### PR TITLE
Move API from flask to fastAPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,5 @@ Elasticsearch Backend
 
 REST API
 --------
-A Flask based HTTP REST API is included to use the QA Framework with UI or integrating with other systems. To serve the API, run :code:`FLASK_APP=farm_hackstack.api.inference flask run`. 
-
-
+A simple REST API based on `FastAPI <https://fastapi.tiangolo.com/>`_ is included to answer questions at inference time. To serve the API, run :code:`uvicorn haystack.api.inference:app`.
+You will find the Swagger API documentation at http://127.0.0.1:8000/docs

--- a/haystack/api/inference.py
+++ b/haystack/api/inference.py
@@ -22,7 +22,9 @@ BATCH_SIZE = 16
 
 app = FastAPI(title="Haystack API", version="0.1")
 
+#############################################
 # Load all models in memory
+#############################################
 model_paths = []
 for model_dir in MODELS_DIRS:
     path = Path(model_dir)
@@ -40,8 +42,12 @@ for idx, model_dir in enumerate(model_paths, start=1):
     FINDERS[idx] = Finder(reader, retriever)
     logger.info(f"Initialized Finder (ID={idx}) with model '{model_dir}'")
 
+logger.info("Open http://127.0.0.1:8000/docs to see Swagger API Documentation.")
+logger.info(""" Or just try it out directly: curl --request POST --url 'http://127.0.0.1:8000/finders/1/ask' --data '{"question": "Who is the father of Arya Starck?"}'""")
 
-# Basic data models for request & response
+#############################################
+# Basic data schema for request & response
+#############################################
 class Request(BaseModel):
     question: str
     filters: Dict[str, str] = None
@@ -63,16 +69,18 @@ class Response(BaseModel):
     question: str
     answers: List[Answer]
 
-
+#############################################
 # Endpoints
-@app.post("/finders/<int:finder_id>/ask", response_model=Response, response_model_exclude_unset=True)
+#############################################
+@app.post("/finders/{finder_id}/ask", response_model=Response, response_model_exclude_unset=True)
 def ask(finder_id: int, request: Request):
     finder = FINDERS.get(finder_id, None)
     if not finder:
         return "Model not found", 404
 
     results = finder.get_answers(
-        question=request.question, top_k_retriever=request.top_k_retriever, top_k_reader=request.top_k_reader, filters=request.filters
+        question=request.question, top_k_retriever=request.top_k_retriever,
+        top_k_reader=request.top_k_reader, filters=request.filters
     )
 
     return results

--- a/haystack/api/inference.py
+++ b/haystack/api/inference.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 import logging
 
@@ -76,7 +76,7 @@ class Response(BaseModel):
 def ask(finder_id: int, request: Request):
     finder = FINDERS.get(finder_id, None)
     if not finder:
-        return "Model not found", 404
+        raise HTTPException(status_code=404, detail=f"Couldn't get Finder with ID {finder_id}. Available IDs: {list(FINDERS.keys())}")
 
     results = finder.get_answers(
         question=request.question, top_k_retriever=request.top_k_retriever,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 # FARM (incl. transformers 2.3.0 with pipelines)
 #farm -e git+https://github.com/deepset-ai/FARM.git@1d30237b037050ef0ac5516f427443cdd18a4d43
 -e git://github.com/deepset-ai/FARM.git@1d30237b037050ef0ac5516f427443cdd18a4d43#egg=farm
-flask
-flask_cors
-flask_restplus
+fastapi
+uvicorn
 flask_sqlalchemy
 pandas
 psycopg2-binary


### PR DESCRIPTION
Let's move towards FastAPI as it is fast, builds on ASGI rather than WSGI, is user friendly and simplifies our lives in documenting the API schema.