### PR TITLE
Make eval during reader.train() more verbose

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger('farm').setLevel(logging.WARNING)
 logging.getLogger('farm.infer').setLevel(logging.INFO)
 logging.getLogger('transformers').setLevel(logging.WARNING)
-
+logging.getLogger('farm.eval').setLevel(logging.INFO)
 
 class Finder:
     """


### PR DESCRIPTION
So far we suppress most of the logging. Let's show the metrics during evaluation. Addressing #27 