### PR TITLE
Removed "document_name" from farm.py

### DIFF
--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -190,8 +190,7 @@ class FARMReader:
         for paragraph, meta_data in zip(paragraphs, meta_data_paragraphs):
             cur = {"text": paragraph,
                    "questions": [question],
-                   "document_id": meta_data["document_id"],
-                   "document_name": meta_data["document_name"],
+                   "document_id": meta_data["document_id"]
             }
             input_dicts.append(cur)
 


### PR DESCRIPTION
Predict method of farm.py was using the assignment of "document_name" but tfidf retriever was not generating that value hence it broke the code and was generating the error.