### PR TITLE
added option for custom elasticsearch queries and filters

### DIFF
--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -25,7 +25,8 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         excluded_meta_data=None,
         scheme="http",
         ca_certs=False,
-        verify_certs=True
+        verify_certs=True,
+        create_index=True
     ):
         self.client = Elasticsearch(hosts=[{"host": host}], http_auth=(username, password),
                                     scheme=scheme, ca_certs=ca_certs, verify_certs=verify_certs)
@@ -45,7 +46,8 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                 custom_mapping["mappings"]["properties"][embedding_field] = {"type": "dense_vector",
                                                                              "dims": embedding_dim}
         # create an index if not exists
-        self.client.indices.create(index=index, ignore=400, body=custom_mapping)
+        if create_index:
+            self.client.indices.create(index=index, ignore=400, body=custom_mapping)
         self.index = index
 
         # configure mappings to ES fields that will be used for querying / displaying results
@@ -89,7 +91,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         return document
 
     def get_document_ids_by_tags(self, tags):
-        term_queries = [{"terms": {key: value}} for key, value in tags.items()]
+        term_queries = [{"term": {key: value}} for key, value in tags.items()]
         query = {"query": {"bool": {"must": term_queries}}}
         logger.debug(f"Tag filter query: {query}")
         result = self.client.search(index=self.index, body=query, size=10000)["hits"]["hits"]
@@ -123,19 +125,35 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             )
         return documents
 
-    def query(self, query, top_k=10, candidate_doc_ids=None):
+    def query(self, query, top_k=10, candidate_doc_ids=None, direct_filters=None, custom_query=None):
         # TODO:
         # for now: we keep the current structure of candidate_doc_ids for compatibility with SQL documentstores
         # midterm: get rid of it and do filtering with tags directly in this query
 
-        body = {
-            "size": top_k,
-            "query": {
-                "bool": {
-                    "should": [{"multi_match": {"query": query, "type": "most_fields", "fields": self.search_fields}}]
+        # if a custom search query is provided then use it
+        if custom_query:
+            body = {
+                "size": top_k,
+                "query": {
+                    "bool": custom_query
                 }
-            },
-        }
+            }
+        # else use standard search query for provided search fields
+        else:
+            body = {
+                "size": top_k,
+                "query": {
+                    "bool": {
+                        "should": [{"multi_match": {"query": query, "type": "most_fields", "fields": self.search_fields}}]
+                    }
+                },
+            }
+
+        # use other filters directly with query, if provided
+        if direct_filters:
+            # filter types are must, should, etc.
+            for filter_type, filter_dict in direct_filters.items():
+                body["query"]["bool"][filter_type] = filter_dict
 
         if candidate_doc_ids:
             body["query"]["bool"]["filter"] = [{"terms": {"_id": candidate_doc_ids}}]

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -91,7 +91,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         return document
 
     def get_document_ids_by_tags(self, tags):
-        term_queries = [{"term": {key: value}} for key, value in tags.items()]
+        term_queries = [{"terms": {key: value}} for key, value in tags.items()]
         query = {"query": {"bool": {"must": term_queries}}}
         logger.debug(f"Tag filter query: {query}")
         result = self.client.search(index=self.index, body=query, size=10000)["hits"]["hits"]

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -25,7 +25,7 @@ class Finder:
         :param top_k_reader: number of answers returned by the reader
         :param top_k_retriever: number of text units to be retrieved
         :param filters: limit scope to documents having the given tags and their corresponding values.
-            The format for the dict is {"tag-1": "value-1", "tag-2": "value-2" ...}
+            The format for the dict is {"tag-1": ["value-1","value-2"], "tag-2": ["value-3]" ...}
         :return:
         """
 

--- a/haystack/retriever/elasticsearch.py
+++ b/haystack/retriever/elasticsearch.py
@@ -8,7 +8,8 @@ logger = logging.getLogger(__name__)
 
 class ElasticsearchRetriever(BaseRetriever):
     def __init__(self, document_store, embedding_model=None, gpu=True, model_format="farm",
-                 pooling_strategy="reduce_mean", emb_extraction_layer=-1):
+                 pooling_strategy="reduce_mean", emb_extraction_layer=-1, direct_filters=None,
+                 custom_query=None):
         """
         TODO
         :param document_store:
@@ -21,6 +22,8 @@ class ElasticsearchRetriever(BaseRetriever):
         self.embedding_model = None
         self.pooling_strategy = pooling_strategy
         self.emb_extraction_layer = emb_extraction_layer
+        self.direct_filters = direct_filters
+        self.custom_query = custom_query
 
         # only needed if you want to retrieve via cosinge similarity of embeddings
         if embedding_model:
@@ -44,7 +47,8 @@ class ElasticsearchRetriever(BaseRetriever):
             paragraphs, meta_data = self.document_store.query_by_embedding(query_emb, top_k, candidate_doc_ids)
         else:
             # regular ES query (e.g. BM25)
-            paragraphs, meta_data = self.document_store.query(query, top_k, candidate_doc_ids)
+            paragraphs, meta_data = self.document_store.query(query, top_k, candidate_doc_ids,
+                                                              self.direct_filters, self.custom_query)
         logger.info(f"Got {len(paragraphs)} candidates from retriever: {meta_data}")
         return paragraphs, meta_data
 


### PR DESCRIPTION
Added an option for custom queries and filters for elasticsearch.

An example filter can look like this:
```
filter = {"must": [{"term": {"tag": "irgendwas"}}, 
                   {"range": {"date": {"gte": "2020-01-01T00:00:00+0200"}}}]}
```

An example custom text query can look like this:
```
query = {"should": [{"match": {"text1": {"query": question, "boost": 2}}},
                    {"match": {"text2": question}}]}
```