### PR TITLE
Fix cyclic import of Elasticsearch client

### DIFF
--- a/haystack/api/elasticsearch_client.py
+++ b/haystack/api/elasticsearch_client.py
@@ -1,0 +1,7 @@
+from elasticsearch import Elasticsearch
+
+from haystack.api.config import DB_HOST, DB_USER, DB_PW
+
+elasticsearch_client = Elasticsearch(
+    hosts=[{"host": DB_HOST}], http_auth=(DB_USER, DB_PW), scheme="http", ca_certs=False, verify_certs=False
+)


### PR DESCRIPTION
This PR moves Elasticsearch connection out of the `application.py`. It fixes a cyclic import issue that prevented running the `application.py` as a Python script for debugging.