### PR TITLE
Standardize Finder, Readers, and Retriever interfaces

### DIFF
--- a/haystack/api/controller/feedback.py
+++ b/haystack/api/controller/feedback.py
@@ -91,7 +91,7 @@ def export_doc_qa_feedback():
     export_data = []
     for document_id, feedback in per_document_feedback.items():
         document = document_store.get_document_by_id(document_id)
-        context = document["text"]
+        context = document.text
         export_data.append({"paragraphs": [{"qas": feedback}], "context": context})
 
     export = {"data": export_data}
@@ -120,7 +120,7 @@ def export_faq_feedback():
     for document_id, feedback in per_document_feedback.items():
         document = document_store.get_document_by_id(document_id)
         export_data.append(
-            {"target_question": document["question"], "target_answer": document["text"], "queries": feedback}
+            {"target_question": document.question, "target_answer": document.text, "queries": feedback}
         )
 
     export = {"data": export_data}

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -1,4 +1,7 @@
 from abc import abstractmethod
+from typing import Optional
+
+from pydantic import BaseModel, Field
 
 
 class BaseDocumentStore:
@@ -23,3 +26,14 @@ class BaseDocumentStore:
         pass
 
 
+class Document(BaseModel):
+    id: str = Field(..., description="_id field from Elasticsearch")
+    text: str = Field(..., description="Text of the document")
+    external_source_id: Optional[str] = Field(
+        None,
+        description="id for the source file the document was created from. In the case when a large file is divided "
+        "across multiple Elasticsearch documents, this id can be used to reference original source file.",
+    )
+    name: Optional[str] = Field(None, description="Title of the document")
+    question: Optional[str] = Field(None, description="Question text for FAQs.")
+    query_score: Optional[int] = Field(None, description="Elasticsearch query score for a retrieved document")

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -66,7 +66,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         self.excluded_meta_data = excluded_meta_data
 
     def get_document_by_id(self, id: str) -> Document:
-        query = {"query": {"bool": {"filter": {"term": {"_id": id}}}}}  # check if simplify?
+        query = {"query": {"ids": {"values": [id]}}}
         result = self.client.search(index=self.index, body=query)["hits"]["hits"]
 
         document = self._convert_es_hit_to_document(result[0]) if result else None

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -57,7 +57,7 @@ class Finder:
         results = self.reader.predict(question=question,
                                       documents=documents,
                                       top_k=top_k_reader)
-        # Add corresponding document_name if an answer contains the document_id (only supported in FARMReader)
+        # Add corresponding document_name if an answer contains the document_id
         for ans in results["answers"]:
             ans["document_name"] = None
             for doc in documents:

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -25,7 +25,7 @@ class Finder:
         :param top_k_reader: number of answers returned by the reader
         :param top_k_retriever: number of text units to be retrieved
         :param filters: limit scope to documents having the given tags and their corresponding values.
-            The format for the dict is {"tag-1": "value-1", "tag-2": "value-2" ...}
+            The format for the dict is {"tag-1": ["value-1","value-2"], "tag-2": ["value-3]" ...}
         :return:
         """
 

--- a/haystack/indexing/io.py
+++ b/haystack/indexing/io.py
@@ -44,8 +44,7 @@ def write_documents_to_db(document_store, document_dir, clean_func=None, only_em
                     docs_to_index.append(
                         {
                             "name": path.name,
-                            "text": para,
-                            "document_id": doc_id
+                            "text": para
                         }
                     )
                     doc_id += 1
@@ -53,8 +52,7 @@ def write_documents_to_db(document_store, document_dir, clean_func=None, only_em
                 docs_to_index.append(
                     {
                         "name": path.name,
-                        "text": text,
-                        "document_id": doc_id
+                        "text": text
                     }
                 )
     document_store.write_documents(docs_to_index)

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -188,7 +188,7 @@ class FARMReader:
 
     def predict(self, question: str, documents: [Document], top_k: int = None):
         """
-        Use loaded QA model to find answers for a question in the supplied documents.
+        Use loaded QA model to find answers for a question in the supplied list of Document.
 
         Returns dictionaries containing answers sorted by (desc.) probability
         Example:
@@ -207,7 +207,7 @@ class FARMReader:
         }
 
         :param question: question string
-        :param documents: list of strings in which to search for the answer
+        :param documents: list of Document in which to search for the answer
         :param top_k: the maximum number of answers to return
         :return: dict containing question and answers
         """

--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -46,7 +46,7 @@ class TransformersReader:
 
     def predict(self, question: str, documents: [Document], top_k: int = None):
         """
-        Use loaded QA model to find answers for a question in the supplied paragraphs.
+        Use loaded QA model to find answers for a question in the supplied list of Document.
 
         Returns dictionaries containing answers sorted by (desc.) probability
         Example:
@@ -65,7 +65,7 @@ class TransformersReader:
         }
 
         :param question: question string
-        :param documents: list of strings in which to search for the answer
+        :param documents: list of Document in which to search for the answer
         :param top_k: the maximum number of answers to return
         :return: dict containing question and answers
 

--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -1,5 +1,7 @@
 from transformers import pipeline
 
+from haystack.database.base import Document
+
 
 class TransformersReader:
     """
@@ -42,8 +44,7 @@ class TransformersReader:
         self.n_best_per_passage = n_best_per_passage
         #TODO param to modify bias for no_answer
 
-
-    def predict(self, question, paragraphs, meta_data_paragraphs=None, top_k=None):
+    def predict(self, question: str, documents: [Document], top_k: int = None):
         """
         Use loaded QA model to find answers for a question in the supplied paragraphs.
 
@@ -64,34 +65,29 @@ class TransformersReader:
         }
 
         :param question: question string
-        :param paragraphs: list of strings in which to search for the answer
-        :param meta_data_paragraphs: list of dicts containing meta data for the paragraphs.
-                                     len(paragraphs) == len(meta_data_paragraphs)
+        :param documents: list of strings in which to search for the answer
         :param top_k: the maximum number of answers to return
-        :param max_processes: max number of parallel processes
         :return: dict containing question and answers
 
         """
-        #TODO pass metadata
-
         # get top-answers for each candidate passage
         answers = []
-        for para, meta in zip(paragraphs, meta_data_paragraphs):
-            query = {"context": para, "question": question}
+        for doc in documents:
+            query = {"context": doc.text, "question": question}
             predictions = self.model(query, topk=self.n_best_per_passage)
             # assemble and format all answers
             for pred in predictions:
                 if pred["answer"]:
                     context_start = max(0, pred["start"] - self.context_size)
-                    context_end = min(len(para), pred["end"] + self.context_size)
+                    context_end = min(len(doc.text), pred["end"] + self.context_size)
                     answers.append({
                         "answer": pred["answer"],
-                        "context": para[context_start:context_end],
+                        "context": doc.text[context_start:context_end],
                         "offset_answer_start": pred["start"],
                         "offset_answer_end": pred["end"],
-                        "probability": pred["score"],  
+                        "probability": pred["score"],
                         "score": None,
-                        "document_id": meta["document_id"]
+                        "document_id": None
                     })
 
         # sort answers by their `probability` and select top-k

--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -87,7 +87,7 @@ class TransformersReader:
                         "offset_answer_end": pred["end"],
                         "probability": pred["score"],
                         "score": None,
-                        "document_id": None
+                        "document_id": doc.id
                     })
 
         # sort answers by their `probability` and select top-k


### PR DESCRIPTION
This PR makes the following changes:

#### Retriever-Reader Interface
- in the current implementation, Retrievers return a list of texts and their associated `meta_data`. This PR introduces a `Document` schema that encapsulates documents and their `meta_data`. It simplifies the Retriever-Reader pipeline since now Retrievers only need to return a list of `Document`.
#### Simplify IDs
- the document_id field(`Document.id`) is now the `_id` field from ES
- `external_source_id ` is added to identify the source file for the case when a large file is split across multiple ES documents.

#### Code Style
- introduce Pydantic and Python type hints
