### PR TITLE
Add limit on concurrent requests for doc-qa

### DIFF
--- a/haystack/api/config.py
+++ b/haystack/api/config.py
@@ -5,6 +5,7 @@ import os
 USE_GPU = os.getenv("USE_GPU", "True").lower() == "true"
 MAX_PROCESSES = int(os.getenv("MAX_PROCESSES", 4))
 BATCHSIZE = int(os.getenv("BATCHSIZE", 50))
+CONCURRENT_REQUEST_PER_WORKER = int(os.getenv("CONCURRENT_REQUEST_PER_WORKER", 4))
 
 # DB
 DB_HOST = os.getenv("DB_HOST", "localhost")

--- a/haystack/api/controller/utils.py
+++ b/haystack/api/controller/utils.py
@@ -12,7 +12,7 @@ class RequestLimiter:
     def run(self):
         acquired = self.semaphore.acquire(blocking=False)
         if not acquired:
-            raise HTTPException(status_code=429, detail="The server is busy processing requests.")
+            raise HTTPException(status_code=503, detail="The server is busy processing requests.")
         try:
             yield acquired
         finally:

--- a/haystack/api/controller/utils.py
+++ b/haystack/api/controller/utils.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+from threading import Semaphore
+
+from fastapi import HTTPException
+
+
+class RequestLimiter:
+    def __init__(self, limit):
+        self.semaphore = Semaphore(limit - 1)
+
+    @contextmanager
+    def run(self):
+        acquired = self.semaphore.acquire(blocking=False)
+        if not acquired:
+            raise HTTPException(status_code=429, detail="The server is busy processing requests.")
+        try:
+            yield acquired
+        finally:
+            self.semaphore.release()


### PR DESCRIPTION
This PR adds a `RequestLimiter` class to limit concurrent requests for a given endpoint.

In the case of question answering on very large documents, the requests can take several seconds. With the default FastAPI/Uvicorn/Gunicorn deployment, the requests get processed concurrently on a GPU, slowing down **all** the requests. To provide consistent user experience, the API can respond with a server-busy error code if the in-process requests exceed the limit threshold.