### PR TITLE
Return more meta data & restructure reponse format

### DIFF
--- a/haystack/api/controller/feedback.py
+++ b/haystack/api/controller/feedback.py
@@ -45,13 +45,13 @@ class Feedback(BaseModel):
     label: str = Field(..., description="The Label for the feedback, eg, relevant or irrelevant.")
     document_id: str = Field(..., description="The document in the query result for which feedback is given.")
     answer: Optional[str] = Field(None, description="The answer string. Only required for doc-qa feedback.")
-    answer_doc_start: Optional[int] = Field(None, description="The answer start offset in the original doc. Only required for doc-qa feedback.")
+    offset_start_in_doc: Optional[int] = Field(None, description="The answer start offset in the original doc. Only required for doc-qa feedback.")
     model_id: Optional[int] = Field(None, description="The model used for the query.")
 
 
 @router.post("/doc-qa-feedback")
 def feedback(feedback: Feedback):
-    if feedback.answer and feedback.answer_doc_start:
+    if feedback.answer and feedback.offset_start_in_doc:
         elasticsearch_client.index(index=DB_INDEX_FEEDBACK, body=feedback.dict())
     else:
         return JSONResponse(
@@ -83,7 +83,7 @@ def export_doc_qa_feedback():
                 "question": feedback["_source"]["question"],
                 "id": feedback["_id"],
                 "answers": [
-                    {"text": feedback["_source"]["answer"], "answer_start": feedback["_source"]["answer_doc_start"]}
+                    {"text": feedback["_source"]["answer"], "answer_start": feedback["_source"]["offset_start_in_doc"]}
                 ],
             }
         )

--- a/haystack/api/controller/feedback.py
+++ b/haystack/api/controller/feedback.py
@@ -45,18 +45,18 @@ class Feedback(BaseModel):
     label: str = Field(..., description="The Label for the feedback, eg, relevant or irrelevant.")
     document_id: str = Field(..., description="The document in the query result for which feedback is given.")
     answer: Optional[str] = Field(None, description="The answer string. Only required for doc-qa feedback.")
-    answer_start: Optional[int] = Field(None, description="The answer start offset. Only required for doc-qa feedback.")
+    answer_doc_start: Optional[int] = Field(None, description="The answer start offset in the original doc. Only required for doc-qa feedback.")
     model_id: Optional[int] = Field(None, description="The model used for the query.")
 
 
 @router.post("/doc-qa-feedback")
 def feedback(feedback: Feedback):
-    if feedback.answer and feedback.answer_start:
+    if feedback.answer and feedback.answer_doc_start:
         elasticsearch_client.index(index=DB_INDEX_FEEDBACK, body=feedback.dict())
     else:
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content="doc-qa feedback must contain 'answer' and 'answer_start' fields.",
+            content="doc-qa feedback must contain 'answer' and 'answer_doc_start' fields.",
         )
 
 
@@ -83,7 +83,7 @@ def export_doc_qa_feedback():
                 "question": feedback["_source"]["question"],
                 "id": feedback["_id"],
                 "answers": [
-                    {"text": feedback["_source"]["answer"], "answer_start": feedback["_source"]["answer_start"]}
+                    {"text": feedback["_source"]["answer"], "answer_start": feedback["_source"]["answer_doc_start"]}
                 ],
             }
         )

--- a/haystack/api/controller/model.py
+++ b/haystack/api/controller/model.py
@@ -75,10 +75,10 @@ class Answer(BaseModel):
     context: Optional[str]
     offset_start: int
     offset_end: int
+    offset_doc_start: Optional[int]
+    offset_doc_end: Optional[int]
+    document_id: Optional[str] = None
     meta: Optional[Dict[str, Optional[str]]]
-    # document_id: Optional[str] = None
-    # document_name: Optional[str]
-    # TODO move these two into "meta" also for the regular extractive QA
 
 
 class AnswersToIndividualQuestion(BaseModel):

--- a/haystack/api/controller/model.py
+++ b/haystack/api/controller/model.py
@@ -75,8 +75,8 @@ class Answer(BaseModel):
     context: Optional[str]
     offset_start: int
     offset_end: int
-    offset_doc_start: Optional[int]
-    offset_doc_end: Optional[int]
+    offset_start_in_doc: Optional[int]
+    offset_end_in_doc: Optional[int]
     document_id: Optional[str] = None
     meta: Optional[Dict[str, Optional[str]]]
 

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional
+from typing import Optional, Dict
 
 from pydantic import BaseModel, Field
 
@@ -34,6 +34,7 @@ class Document(BaseModel):
         description="id for the source file the document was created from. In the case when a large file is divided "
         "across multiple Elasticsearch documents, this id can be used to reference original source file.",
     )
-    name: Optional[str] = Field(None, description="Title of the document")
+    # name: Optional[str] = Field(None, description="Title of the document")
     question: Optional[str] = Field(None, description="Question text for FAQs.")
     query_score: Optional[int] = Field(None, description="Elasticsearch query score for a retrieved document")
+    meta: Optional[Dict[str, Optional[str]]] = Field(None, description="")

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -186,11 +186,15 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             return documents
 
     def _convert_es_hit_to_document(self, hit, score_adjustment=0) -> [Document]:
+        # We put all additional data of the doc into meta_data and return it in the API
+        meta_data = {k:v for k,v in hit["_source"].items() if k not in (self.text_field, self.external_source_id_field)}
+        meta_data["name"] = meta_data.pop(self.name_field)
+
         document = Document(
             id=hit["_id"],
             text=hit["_source"][self.text_field],
             external_source_id=hit["_source"].get(self.external_source_id_field),
-            name=hit["_source"].get(self.name_field),
+            meta=meta_data,
             query_score=hit["_score"] + score_adjustment,
         )
         return document

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -57,12 +57,12 @@ class Finder:
         results = self.reader.predict(question=question,
                                       documents=documents,
                                       top_k=top_k_reader)
-        # Add corresponding document_name if an answer contains the document_id
+        # Add corresponding document_name and more meta data, if an answer contains the document_id
         for ans in results["answers"]:
-            ans["document_name"] = None
+            ans["meta"] = {}
             for doc in documents:
                 if doc.id == ans["document_id"]:
-                    ans["document_name"] = doc.name
+                    ans["meta"] = doc.meta
 
         return results
 

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -247,6 +247,8 @@ class FARMReader:
                            "context": a["context"],
                            "offset_start": a["offset_answer_start"] - a["offset_context_start"],
                            "offset_end": a["offset_answer_end"] - a["offset_context_start"],
+                           "offset_doc_start": a["offset_answer_start"],
+                           "offset_doc_end": a["offset_answer_end"],
                            "document_id": a["document_id"]}
                     answers_per_document.append(cur)
 


### PR DESCRIPTION
Let's return a bit more information from the `Finder` / in the API and adjust the response format: 
- offsets in the original doc (needed for feedback endpoint)
- custom meta data (whatever is available in elasticsearch and is not excluded via `excluded_meta_data`in the `ElasticsearchDocumentStore`
- move `name` into the meta field

```
{
    "results": [
        {
            "question": "Why did revenue increase?",
            "answers": [
                {
                    "answer": "Total revenue for the first quarter of 2017 was approximately $1,437,000,000",
                    "score": 3.589367151260376,
                    "probability": 0.6103231806375512,
                    "context": "<Some context>",
                    "offset_start": 212,
                    "offset_end": 288,
                    "offset_start_in_doc": 5674,
                    "offset_end_in_doc": 5750,
                    "document_id": "cqjbqnABdLrIEs4cBtTh",
                    "meta": {
                        "quarter": "Q1",
                        "year": "2017",
                        "company": "<Some Name>",
                        "name": "<Some File Name>.txt"
                    }
                },
```