### PR TITLE
Refactor ElasticsearchRetriever into separate class

### DIFF
--- a/haystack/api/controller/query.py
+++ b/haystack/api/controller/query.py
@@ -15,7 +15,7 @@ from haystack.api.config import DB_HOST, DB_USER, DB_PW, DB_INDEX, ES_CONN_SCHEM
 from haystack.api.controller.utils import RequestLimiter
 from haystack.database.elasticsearch import ElasticsearchDocumentStore
 from haystack.reader.farm import FARMReader
-from haystack.retriever.elasticsearch import ElasticsearchRetriever
+from haystack.retriever.elasticsearch import ElasticsearchRetriever, EmbeddingRetriever
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -36,10 +36,13 @@ document_store = ElasticsearchDocumentStore(
     excluded_meta_data=EXCLUDE_META_DATA_FIELDS,
 )
 
-retriever = ElasticsearchRetriever(document_store=document_store, embedding_model=EMBEDDING_MODEL_PATH, gpu=USE_GPU)
 
-if READER_MODEL_PATH:
-    # needed for extractive QA
+if EMBEDDING_MODEL_PATH:
+    retriever = EmbeddingRetriever(document_store=document_store, embedding_model=EMBEDDING_MODEL_PATH, gpu=USE_GPU)
+else:
+    retriever = ElasticsearchRetriever(document_store=document_store)
+
+if READER_MODEL_PATH:  # for extractive doc-qa
     reader = FARMReader(
         model_name_or_path=str(READER_MODEL_PATH),
         batch_size=BATCHSIZE,
@@ -52,8 +55,7 @@ if READER_MODEL_PATH:
         doc_stride=DOC_STRIDE,
     )
 else:
-    # don't need one for pure FAQ matching
-    reader = None
+    reader = None  # don't need one for pure FAQ matching
 
 FINDERS = {1: Finder(reader=reader, retriever=retriever)}
 

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -1,7 +1,7 @@
 import logging
 
 from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan
+from elasticsearch.helpers import bulk, scan
 
 from haystack.database.base import BaseDocumentStore, Document
 
@@ -83,11 +83,11 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         return doc_ids
 
     def write_documents(self, documents):
-        for d in documents:
-            try:
-                self.client.index(index=self.index, body=d)
-            except Exception as e:
-                logger.error(f"Failed to index doc ({e}): {d}")
+        for doc in documents:
+            doc["_op_type"] = "create"
+            doc["_index"] = self.index
+
+        bulk(self.client, documents)
 
     def get_document_count(self):
         result = self.client.count()

--- a/haystack/retriever/elasticsearch.py
+++ b/haystack/retriever/elasticsearch.py
@@ -1,17 +1,38 @@
 import logging
-
+from typing import Type
 from farm.infer import Inferencer
 
-from haystack.database.base import Document
+from haystack.database.base import Document, BaseDocumentStore
 from haystack.retriever.base import BaseRetriever
 
 logger = logging.getLogger(__name__)
 
 
 class ElasticsearchRetriever(BaseRetriever):
-    def __init__(self, document_store, embedding_model=None, gpu=True, model_format="farm",
-                 pooling_strategy="reduce_mean", emb_extraction_layer=-1, direct_filters=None,
-                 custom_query=None):
+    def __init__(self, document_store: Type[BaseDocumentStore], direct_filters=None, custom_query=None):
+        self.document_store = document_store
+        self.direct_filters = direct_filters
+        self.custom_query = custom_query
+
+    def retrieve(self, query: str, candidate_doc_ids: [str] = None, top_k: int = 10) -> [Document]:
+        documents = self.document_store.query(query, top_k, candidate_doc_ids, self.direct_filters, self.custom_query)
+        logger.info(f"Got {len(documents)} candidates from retriever")
+
+        return documents
+
+
+class EmbeddingRetriever(BaseRetriever):
+    def __init__(
+        self,
+        document_store: Type[BaseDocumentStore],
+        embedding_model: str,
+        gpu: bool = True,
+        model_format: str = "farm",
+        pooling_strategy: str = "reduce_mean",
+        emb_extraction_layer: int = -1,
+        direct_filters=None,
+        custom_query=None,
+    ):
         """
         TODO
         :param document_store:
@@ -21,46 +42,43 @@ class ElasticsearchRetriever(BaseRetriever):
         """
         self.document_store = document_store
         self.model_format = model_format
-        self.embedding_model = None
+        self.embedding_model = embedding_model
         self.pooling_strategy = pooling_strategy
         self.emb_extraction_layer = emb_extraction_layer
         self.direct_filters = direct_filters
         self.custom_query = custom_query
 
-        # only needed if you want to retrieve via cosinge similarity of embeddings
-        if embedding_model:
-            logger.info(f"Init retriever using embeddings of model {embedding_model}")
-            if model_format == "farm" or model_format == "transformers":
-                self.embedding_model = Inferencer.load(embedding_model, task_type="embeddings",
-                                                   gpu=gpu, batch_size=4, max_seq_len=512)
+        logger.info(f"Init retriever using embeddings of model {embedding_model}")
+        if model_format == "farm" or model_format == "transformers":
+            self.embedding_model = Inferencer.load(
+                embedding_model, task_type="embeddings", gpu=gpu, batch_size=4, max_seq_len=512
+            )
 
-            elif model_format == "sentence_transformers":
-                from sentence_transformers import SentenceTransformer
-                # pretrained embedding models coming from: https://github.com/UKPLab/sentence-transformers#pretrained-models
-                # e.g. 'roberta-base-nli-stsb-mean-tokens'
-                self.embedding_model = SentenceTransformer(embedding_model)
-            else:
-                raise NotImplementedError
+        elif model_format == "sentence_transformers":
+            from sentence_transformers import SentenceTransformer
+
+            # pretrained embedding models coming from: https://github.com/UKPLab/sentence-transformers#pretrained-models
+            # e.g. 'roberta-base-nli-stsb-mean-tokens'
+            self.embedding_model = SentenceTransformer(embedding_model)
+        else:
+            raise NotImplementedError
 
     def retrieve(self, query: str, candidate_doc_ids: [str] = None, top_k: int = 10) -> [Document]:
-        if self.embedding_model:
-            # cos. similarity of embeddings
-            query_emb = self.create_embedding(query)
-            documents = self.document_store.query_by_embedding(query_emb, top_k, candidate_doc_ids)
-        else:
-            # regular ES query (e.g. BM25)
-            documents = self.document_store.query(query, top_k, candidate_doc_ids)
-        logger.info(f"Got {len(documents)} candidates from retriever")
+        query_emb = self.create_embedding(query)
+        documents = self.document_store.query_by_embedding(query_emb, top_k, candidate_doc_ids)
+
         return documents
 
     def create_embedding(self, text):
         if self.model_format == "farm":
-            res = self.embedding_model.extract_vectors(dicts=[{"text": text}],
-                                                       extraction_strategy=self.pooling_strategy,
-                                                       extraction_layer=self.emb_extraction_layer)
+            res = self.embedding_model.extract_vectors(
+                dicts=[{"text": text}],
+                extraction_strategy=self.pooling_strategy,
+                extraction_layer=self.emb_extraction_layer,
+            )
             emb = list(res[0]["vec"])
         elif self.model_format == "sentence_transformers":
             # text is single string, sentence-transformers needs a list of strings
-            res = self.embedding_model.encode([text]) # get back list of numpy embedding vectors
+            res = self.embedding_model.encode([text])  # get back list of numpy embedding vectors
             emb = res[0].tolist()
         return emb


### PR DESCRIPTION
This PR splits the `ElasticsearchRetriever` into separate classes for embeddings based retrieval(`EmbeddingRetriever`) and plain ES retrieval(`ElasticsearchRetriever`). 