### PR TITLE
Add Docker Images for running Haystack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   haystack-api:
-    image: "deepset/haystack-api-cpu:0.2.0"
+    image: "deepset/haystack-cpu:0.2.0"
     ports:
       - 8000:8000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  haystack-api:
+    image: "deepset/haystack-api-cpu:0.2.0"
+    ports:
+      - 8000:8000
+    environment:
+      # see haystack/api/config.py for additional variables to configure.
+      # load reader model from transformers' model hub.
+      - READER_MODEL_PATH=deepset/roberta-base-squad2
+      - DB_HOST=elasticsearch
+    restart: always
+
+  elasticsearch:
+    # This demo image contains Game of Thrones Wikipedia articles indexed.
+    # For starting a new Elasticsearch instance, replace image with "elasticsearch:7.6.1".
+    image: "deepset/elasticsearch-game-of-thrones"
+    environment:
+      - discovery.type=single-node

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# FARM pre-0.4.3
--e git://github.com/deepset-ai/FARM.git@ecee40e34781394a805c7dde14e6cc2570372798#egg=farm
+farm==0.4.3
 fastapi
 uvicorn
 gunicorn

--- a/run_docker_gpu.sh
+++ b/run_docker_gpu.sh
@@ -8,4 +8,4 @@
 docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.6.1
 # wait for Elasticsearch server to start
 sleep 30
-docker run --net=host --gpus all -e READER_MODEL_PATH=deepset/roberta-base-squad2 -d deepset/haystack-api-gpu:0.2.0
+docker run --net=host --gpus all -e READER_MODEL_PATH=deepset/roberta-base-squad2 -d deepset/haystack-gpu:0.2.0

--- a/run_docker_gpu.sh
+++ b/run_docker_gpu.sh
@@ -1,0 +1,11 @@
+# Run Haystack API(on GPU) and Elasticsearch using Docker.
+#
+# docker-compose doesn't support GPUs in the current version. As a workaround,
+# this script runs haystack-api and Elasticsearch Docker Images separately.
+#
+# To use GPU with Docker, ensure nvidia-docker(https://github.com/NVIDIA/nvidia-docker) is installed.
+
+docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.6.1
+# wait for Elasticsearch server to start
+sleep 30
+docker run --net=host --gpus all -e READER_MODEL_PATH=deepset/roberta-base-squad2 -d deepset/haystack-api-gpu:0.2.0


### PR DESCRIPTION
This PR adds a docker-compose file for running Haystack on CPU and a shell script to run on GPU.