### PR TITLE
Make doc name optional

### DIFF
--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -189,7 +189,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
     def _convert_es_hit_to_document(self, hit, score_adjustment=0) -> Document:
         # We put all additional data of the doc into meta_data and return it in the API
         meta_data = {k:v for k,v in hit["_source"].items() if k not in (self.text_field, self.external_source_id_field)}
-        meta_data["name"] = meta_data.pop(self.name_field)
+        meta_data["name"] = meta_data.pop(self.name_field, None)
 
         document = Document(
             id=hit["_id"],


### PR DESCRIPTION
We currently require a document "name" field in the elastic index (`ElasticsearchDocumentStore.name_field`). Conversion from a ES hit to Doc will fail otherwise as reported in #99 and #97. 

While the name is helpful in many deployments (e.g. to display the origin of answers in a UI), I don't see a reason why it must be mandatory.

FYI @predoctech