### PR TITLE
Add document metadata for FAQ style QA

### DIFF
--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -86,7 +86,7 @@ class Finder:
         for doc in documents:
             #TODO proper calibratation of pseudo probabilities
             cur_answer = {"question": doc.meta["question"], "answer": doc.text, "context": doc.text,
-                          "score": doc.query_score, "offset_start": 0, "offset_end": len(doc.text),
+                          "score": doc.query_score, "offset_start": 0, "offset_end": len(doc.text), "meta": doc.meta
                           }
             if self.retriever.embedding_model:
                 probability = (doc.query_score + 1) / 2


### PR DESCRIPTION
Add document metadata for results of `Finder.get_answers_via_similar_questions()`.

This PR fixes #105.