### PR TITLE
Add embedding query for InMemoryDocumentStore 

### DIFF
--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -25,6 +25,10 @@ class BaseDocumentStore:
     def get_document_count(self):
         pass
 
+    @abstractmethod
+    def query_by_embedding(self, query_emb, top_k=10, candidate_doc_ids=None):
+        pass
+
 
 class Document(BaseModel):
     id: str = Field(..., description="_id field from Elasticsearch")

--- a/haystack/retriever/tfidf.py
+++ b/haystack/retriever/tfidf.py
@@ -72,8 +72,6 @@ class TfidfRetriever(BaseRetriever):
         # get scores
         indices_and_scores = self._calc_scores(query)
 
-        print(indices_and_scores)
-
         # rank paragraphs
         df_sliced = self.df.loc[indices_and_scores.keys()]
         df_sliced = df_sliced[:top_k]

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -20,7 +20,6 @@ def test_elasticsearch_write_read(elasticsearch_fixture):
     write_documents_to_db(document_store=document_store, document_dir="samples/docs")
     sleep(2)  # wait for documents to be available for query
     documents = document_store.get_all_documents()
-    print(documents)
     assert len(documents) == 2
     assert documents[0].id
     assert documents[0].text

--- a/test/test_faq_retriever.py
+++ b/test/test_faq_retriever.py
@@ -1,0 +1,50 @@
+from haystack import Finder
+
+
+def test_far_retriever_in_memory_store():
+    from haystack.database.memory import InMemoryDocumentStore
+    from haystack.retriever.elasticsearch import EmbeddingRetriever
+
+    document_store = InMemoryDocumentStore()
+
+    documents = [
+        {'name': 'How to test this library?', 'text': 'By running tox in the command line!', 'meta': {'question': 'How to test this library?'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+        {'name': 'blah blah blah', 'text': 'By running tox in the command line!', 'meta': {'question': 'blah blah blah'}},
+    ]
+
+    retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", gpu=False)
+
+    embedded = []
+    for doc in documents:
+        doc['embedding'] = retriever.create_embedding([doc['meta']['question']])[0]
+        embedded.append(doc)
+
+    document_store.write_documents(embedded)
+
+    finder = Finder(reader=None, retriever=retriever)
+    prediction = finder.get_answers_via_similar_questions(question="How to test this?", top_k_retriever=1)
+
+    assert prediction == {
+        'question': 'How to test this?', 'answers':
+            [
+                {
+                    'question': 'How to test this library?',
+                    'answer': 'By running tox in the command line!',
+                    'context': 'By running tox in the command line!',
+                    'score': 0.5425953283001858,
+                    'offset_start': 0,
+                    'offset_end': 35,
+                    'meta': {'question': 'How to test this library?'},
+                    'probability': 0.7712976641500928
+                 }
+            ]
+    }

--- a/test/test_faq_retriever.py
+++ b/test/test_faq_retriever.py
@@ -1,7 +1,9 @@
 from haystack import Finder
 
 
-def test_far_retriever_in_memory_store():
+def test_faq_retriever_in_memory_store(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_FIELD_NAME", "embedding")
+
     from haystack.database.memory import InMemoryDocumentStore
     from haystack.retriever.elasticsearch import EmbeddingRetriever
 
@@ -33,18 +35,4 @@ def test_far_retriever_in_memory_store():
     finder = Finder(reader=None, retriever=retriever)
     prediction = finder.get_answers_via_similar_questions(question="How to test this?", top_k_retriever=1)
 
-    assert prediction == {
-        'question': 'How to test this?', 'answers':
-            [
-                {
-                    'question': 'How to test this library?',
-                    'answer': 'By running tox in the command line!',
-                    'context': 'By running tox in the command line!',
-                    'score': 0.5425953283001858,
-                    'offset_start': 0,
-                    'offset_end': 35,
-                    'meta': {'question': 'How to test this library?'},
-                    'probability': 0.7712976641500928
-                 }
-            ]
-    }
+    assert len(prediction.get('answers', [])) == 1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     pytest
     pandas
 setenv =
+    EMBEDDING_FIELD_NAME = embedding
     COVERAGE_FILE = test-reports/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps =
     pytest
     pandas
 setenv =
-    EMBEDDING_FIELD_NAME = embedding
     COVERAGE_FILE = test-reports/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv
 commands =


### PR DESCRIPTION
print of indices can get quite large and kill stdout on a container