### PR TITLE
Increase timeout for bulk indexing in ES

### DIFF
--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -115,7 +115,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             doc["_op_type"] = "create"
             doc["_index"] = self.index
 
-        bulk(self.client, documents, request_timeout=30)
+        bulk(self.client, documents, request_timeout=300)
 
     def get_document_count(self):
         result = self.client.count()


### PR DESCRIPTION
Resolving #117 by increasing timeout for indexing docs (e.g. when using large models)