### PR TITLE
Remove Literal type hint

### DIFF
--- a/haystack/api/controller/search.py
+++ b/haystack/api/controller/search.py
@@ -45,7 +45,7 @@ if EMBEDDING_MODEL_PATH:
     retriever = EmbeddingRetriever(
         document_store=document_store,
         embedding_model=EMBEDDING_MODEL_PATH,
-        model_format=EMBEDDING_MODEL_FORMAT,  # type: ignore
+        model_format=EMBEDDING_MODEL_FORMAT,
         gpu=USE_GPU
     )  # type: BaseRetriever
 else:

--- a/haystack/retriever/elasticsearch.py
+++ b/haystack/retriever/elasticsearch.py
@@ -2,7 +2,6 @@ import logging
 from typing import List, Union
 
 from farm.infer import Inferencer
-from typing_extensions import Literal
 
 from haystack.database.base import Document
 from haystack.database.elasticsearch import ElasticsearchDocumentStore
@@ -108,8 +107,8 @@ class EmbeddingRetriever(BaseRetriever):
         document_store: ElasticsearchDocumentStore,
         embedding_model: str,
         gpu: bool = True,
-        model_format: Literal["farm", "transformers", "sentence_transformers"] = "farm",
-        pooling_strategy: Literal["cls_token", "reduce_mean", "reduce_max", "per_token", "s3e"] = "reduce_mean",
+        model_format: str = "farm",
+        pooling_strategy: str = "reduce_mean",
         emb_extraction_layer: int = -1,
     ):
         """


### PR DESCRIPTION
Google Colab Notebooks currently support Python v3.6.9 which does not have the `Literal` type.

This PR fixes #155.