### PR TITLE
Add ONNXRuntime support

### DIFF
--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -242,7 +242,7 @@ class FARMReader(BaseReader):
 
         # get answers from QA model
         predictions = self.inferencer.inference_from_dicts(
-            dicts=input_dicts, rest_api_schema=True, multiprocessing_chunksize=1
+            dicts=input_dicts, return_json=True, multiprocessing_chunksize=1
         )
         # assemble answers from all the different documents & format them.
         # For the "no answer" option, we collect all no_ans_gaps and decide how likely
@@ -442,3 +442,16 @@ class FARMReader(BaseReader):
             )
         predictions = self.predict(question, documents, top_k)
         return predictions
+
+    def convert_to_onnx(self, output_path: Path, opset_version: int = 11, optimize_for: Optional[str] = None):
+        """
+        Convert a PyTorch BERT model to ONNX format and write to the supplied output_path. The converted ONNX model
+        can be loaded with in the `FARMReader` using the export path as `model_name_or_path` param.
+
+        :param output_path: model dir to write the model and config files
+        :param opset_version: ONNX opset version
+        :param optimize_for: optimize the exported model for a target device. Available options
+                             are "gpu_tensor_core" (GPUs with tensor core like V100 or T4),
+                             "gpu_without_tensor_core" (most other GPUs), and "cpu".
+        """
+        self.inferencer.model.convert_to_onnx(output_path=output_path, opset_version=opset_version, optimize_for=optimize_for)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-farm==0.4.3
+farm==0.4.4
 fastapi
 uvicorn
 gunicorn


### PR DESCRIPTION
This PR adds the conversion of PyTorch BERT models to ONNX format for inference with [ONNXRuntime](https://github.com/microsoft/onnxruntime).

Speed benchmarks: https://docs.google.com/spreadsheets/d/1ak9Cxj1zcNBDtjf7qn2j_ydKDDzpBgWiyJ7cO-7BPvA/edit#gid=0

Usage: 
```python
from haystack.reader.farm import FARMReader
from pathlib import Path

FARMReader.convert_to_onnx(
    model_name_or_path="deepset/bert-base-cased-squad2", optimize_for="gpu_tensor_core"
)  # exports the model to ./onnx-export dir
FARMReader(model_name_or_path=Path("onnx-export"))  # load the ONNX model
```