### PR TITLE
Fix boundary condition in detection of header/footer in file converters

### DIFF
--- a/haystack/indexing/file_converters/base.py
+++ b/haystack/indexing/file_converters/base.py
@@ -130,7 +130,9 @@ class BaseConverter:
         :param min_ngram: minimum length of ngram to consider
         :return: str, common string of all sections
         """
-
+        sequences = [s for s in sequences if s]  # filter empty sequences
+        if not sequences:
+            return None
         seqs_ngrams = map(partial(self._allngram, min_ngram=min_ngram, max_ngram=max_ngram), sequences)
         intersection = reduce(set.intersection, seqs_ngrams)
 


### PR DESCRIPTION
If the `sequences` param is an empty list, it raises an exception: #164.