### PR TITLE
Adjust PDF conversion subprocess for Python v3.6

### DIFF
--- a/haystack/indexing/file_converters/pdf.py
+++ b/haystack/indexing/file_converters/pdf.py
@@ -128,7 +128,7 @@ class PDFToTextConverter(BaseConverter):
             command = ["pdftotext", "-layout", str(file_path), "-"]
         else:
             command = ["pdftotext", str(file_path), "-"]
-        output = subprocess.run(command, capture_output=True, shell=False)
+        output = subprocess.run(command, stdout=subprocess.PIPE, shell=False)
         document = output.stdout.decode(errors="ignore")
         pages = document.split("\f")
         pages = pages[:-1]  # the last page in the split is always empty.


### PR DESCRIPTION
This PR replaces the `capture_output` parameter as it is not supported in Python 3.6(#182).