### PR TITLE
Add success response for successful file upload API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ langdetect # for PDF conversions
 # optional: sentence-transformers
 #temporarily (used for DPR downloads)
 wget
+python-multipart

--- a/rest_api/controller/file_upload.py
+++ b/rest_api/controller/file_upload.py
@@ -49,7 +49,7 @@ def upload_file_to_document_store(
     remove_empty_lines: Optional[bool] = Form(REMOVE_EMPTY_LINES),
     remove_header_footer: Optional[bool] = Form(REMOVE_HEADER_FOOTER),
     valid_languages: Optional[List[str]] = Form(VALID_LANGUAGES),
-) -> None:
+):
     try:
         file_path = Path(FILE_UPLOAD_PATH) / f"{uuid.uuid4().hex}_{file.filename}"
         with file_path.open("wb") as buffer:
@@ -78,6 +78,6 @@ def upload_file_to_document_store(
 
         document = {TEXT_FIELD_NAME: "\n".join(pages), "name": file.filename}
         document_store.write_documents([document])
-
+        return "File upload was successful."
     finally:
         file.file.close()


### PR DESCRIPTION
This PR adds a message in the HTTP response body when a file upload is successful. Additionally, `python-multipart` is added in requirements to support multipart/form-data enctype for file uploads.

Related issue: #183.