### PR TITLE
gitignore fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,6 @@ src
 tutorials/cache
 tutorials/mlruns
 tutorials/model
-model
+models
 
 .DS_Store


### PR DESCRIPTION
While the API and docker files mention "**models**", the .gitignore still reference "**model**". If I am correct, it refers to the same thing :  the folder where we store local models. Since we don't want git to interact with them, I suggest this modification