### PR TITLE
Fix naming of offset in answers of TransformersReader (for consistency with FARMReader)

### DIFF
--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -84,8 +84,8 @@ class TransformersReader(BaseReader):
                     answers.append({
                         "answer": pred["answer"],
                         "context": doc.text[context_start:context_end],
-                        "offset_answer_start": pred["start"],
-                        "offset_answer_end": pred["end"],
+                        "offset_start": pred["start"],
+                        "offset_end": pred["end"],
                         "probability": pred["score"],
                         "score": None,
                         "document_id": doc.id,


### PR DESCRIPTION
the Bug I had was:

```
pydantic.error_wrappers.ValidationError: 8 validation errors for Answers
haystack-api_1   | response -> results -> 0 -> answers -> 0 -> offset_start
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 0 -> offset_end
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 1 -> offset_start
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 1 -> offset_end
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 2 -> offset_start
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 2 -> offset_end
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 3 -> offset_start
haystack-api_1   |   field required (type=value_error.missing)
haystack-api_1   | response -> results -> 0 -> answers -> 3 -> offset_end
haystack-api_1   |   field required (type=value_error.missing)```