### PR TITLE
Update docstring for embedding_field and embedding_dim

### DIFF
--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -49,8 +49,8 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                            If no Reader is used (e.g. in FAQ-Style QA) the plain content of this field will just be returned.
         :param name_field: Name of field that contains the title of the the doc
         :param external_source_id_field: If you have an external id (= non-elasticsearch) that identifies your documents, you can specify it here.
-        :param embedding_field: Name of field containing an embedding vector (Only needed when using the EmbeddingRetriever on top)
-        :param embedding_dim: Dimensionality of embedding vector (Only needed when using the EmbeddingRetriever on top)
+        :param embedding_field: Name of field containing an embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
+        :param embedding_dim: Dimensionality of embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
         :param custom_mapping: If you want to use your own custom mapping for creating a new index in Elasticsearch, you can supply it here as a dictionary.
         :param excluded_meta_data: Name of fields in Elasticsearch that should not be returned (e.g. [field_one, field_two]).
                                    Helpful if you have fields with long, irrelevant content that you don't want to display in results (e.g. embedding vectors).


### PR DESCRIPTION
'embedding_field' and 'embedding_dim' are useful not only for EmbeddingRetriever but also for DensePassageRetriever. Hence, could be good if you generalise as "dense retriever" in the comment.