### PR TITLE
Fix Dockerfile to build successfully without models directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY haystack /home/user/haystack
 COPY rest_api /home/user/rest_api
 
 # copy saved FARM models
-COPY models /home/user/models
+# COPY README.rst models* /home/user/models
 
 # optional : copy sqlite db if needed for testing
 #COPY qa.db /home/user/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY haystack /home/user/haystack
 COPY rest_api /home/user/rest_api
 
 # copy saved FARM models
-# COPY README.rst models* /home/user/models
+COPY README.rst models* /home/user/models
 
 # optional : copy sqlite db if needed for testing
 #COPY qa.db /home/user/


### PR DESCRIPTION
Here is a proposal for this bug during Docker build :
```
Step 8/10 : COPY models /home/user/models
ERROR: Service 'haystack-api' failed to build: COPY failed: stat /var/lib/docker/tmp/docker-builder648491496/models: no such file or directory
```
Problem is since we added **models** to the gitignore (my suggestion) we don't have the folder if we don't create it manually. So my suggestion is : we trick Docker with my suggestion (COPY always requires at least one file, in our case I chose the README)

Another solution would be to ignore everything but a README.md inside the models folder. up to you @tholor 