### PR TITLE
Fix multi gpu training via Dataparallel

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -12,5 +12,6 @@ logging.getLogger('farm.utils').setLevel(logging.INFO)
 logging.getLogger('farm.infer').setLevel(logging.INFO)
 logging.getLogger('transformers').setLevel(logging.WARNING)
 logging.getLogger('farm.eval').setLevel(logging.INFO)
+logging.getLogger('farm.modeling.optimization').setLevel(logging.INFO)
 
 

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -90,10 +90,10 @@
     }
    ],
    "source": [
-    "reader = FARMReader(model_name_or_path=\"distilbert-base-uncased-distilled-squad\", use_gpu=False)\n",
+    "reader = FARMReader(model_name_or_path=\"distilbert-base-uncased-distilled-squad\", use_gpu=True)\n",
     "train_data = \"data/squad20\"\n",
     "# train_data = \"PATH/TO_YOUR/TRAIN_DATA\" \n",
-    "reader.train(data_dir=train_data, train_filename=\"dev-v2.0.json\", use_gpu=False, n_epochs=1, save_dir=\"my_model\")"
+    "reader.train(data_dir=train_data, train_filename=\"dev-v2.0.json\", use_gpu=True, n_epochs=1, save_dir=\"my_model\")"
    ]
   },
   {

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.py
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.py
@@ -34,10 +34,10 @@ from haystack.reader.farm import FARMReader
 
 #**Recommendation: Run training on a GPU. To do so change the `use_gpu` arguments below to `True`
 
-reader = FARMReader(model_name_or_path="distilbert-base-uncased-distilled-squad", use_gpu=False)
+reader = FARMReader(model_name_or_path="distilbert-base-uncased-distilled-squad", use_gpu=True)
 train_data = "data/squad20"
 # train_data = "PATH/TO_YOUR/TRAIN_DATA" 
-reader.train(data_dir=train_data, train_filename="dev-v2.0.json", use_gpu=False, n_epochs=1, save_dir="my_model")
+reader.train(data_dir=train_data, train_filename="dev-v2.0.json", use_gpu=True, n_epochs=1, save_dir="my_model")
 
 # Saving the model happens automatically at the end of training into the `save_dir` you specified
 # However, you could also save a reader manually again via:


### PR DESCRIPTION
When calling FARMReader.train() with multiple GPUs using DataParallel, we were running into an error because we apply DataParallel twice(!). Once when initializing the FARMReader (so that we can use Dataparallel for inference), and then again in train() when we call initialize_optimizer(). 

This is a quick fix, but we should fix it upstream in FARM (e.g. by adding a check in optimize_model() and avoid applying DataParallel there if it was already done before). 

Fixing #224 