### PR TITLE
Refactor DPR for latest transformers version & change init arg `gpu` -> `use_gpu` for DPR and EmbeddingRetriever

### DIFF
--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -28,7 +28,7 @@ class DensePassageRetriever(BaseRetriever):
     def __init__(self,
                  document_store: BaseDocumentStore,
                  embedding_model: str,
-                 gpu: bool = True,
+                 use_gpu: bool = True,
                  batch_size: int = 16,
                  do_lower_case: bool = False,
                  use_amp: str = None,
@@ -41,15 +41,15 @@ class DensePassageRetriever(BaseRetriever):
         :Example:
 
             # remote model from FAIR
-            >>> DensePassageRetriever(document_store=your_doc_store, embedding_model="dpr-bert-base-nq", gpu=True)
+            >>> DensePassageRetriever(document_store=your_doc_store, embedding_model="dpr-bert-base-nq", use_gpu=True)
             # or from local path
-            >>> DensePassageRetriever(document_store=your_doc_store, embedding_model="some_path/ber-base-encoder.cp", gpu=True)
+            >>> DensePassageRetriever(document_store=your_doc_store, embedding_model="some_path/ber-base-encoder.cp", use_gpu=True)
 
         :param document_store: An instance of DocumentStore from which to retrieve documents.
         :param embedding_model: Local path or remote name of model checkpoint. The format equals the 
                                 one used by original author's in https://github.com/facebookresearch/DPR. 
                                 Currently available remote names: "dpr-bert-base-nq" 
-        :param gpu: Whether to use gpu or not
+        :param use_gpu: Whether to use gpu or not
         :param batch_size: Number of questions or passages to encode at once
         :param do_lower_case: Whether to lower case the text input in the tokenizer
         :param encoder_model_type: 
@@ -71,7 +71,7 @@ class DensePassageRetriever(BaseRetriever):
                 download_dpr(resource_key="checkpoint.retriever.single.nq.bert-base-encoder", out_dir="models/dpr")
             self.embedding_model = "models/dpr/checkpoint/retriever/single/nq/bert-base-encoder.cp"
 
-        if gpu and torch.cuda.is_available():
+        if use_gpu and torch.cuda.is_available():
             self.device = torch.device("cuda")
         else:
             self.device = torch.device("cpu")

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -196,7 +196,7 @@ class EmbeddingRetriever(BaseRetriever):
         self,
         document_store: ElasticsearchDocumentStore,
         embedding_model: str,
-        gpu: bool = True,
+        use_gpu: bool = True,
         model_format: str = "farm",
         pooling_strategy: str = "reduce_mean",
         emb_extraction_layer: int = -1,
@@ -204,7 +204,7 @@ class EmbeddingRetriever(BaseRetriever):
         """
         :param document_store: An instance of DocumentStore from which to retrieve documents.
         :param embedding_model: Local path or name of model in Hugging Face's model hub. Example: 'deepset/sentence_bert'
-        :param gpu: Whether to use gpu or not
+        :param use_gpu: Whether to use gpu or not
         :param model_format: Name of framework that was used for saving the model. Options: 'farm', 'transformers', 'sentence_transformers'
         :param pooling_strategy: Strategy for combining the embeddings from the model (for farm / transformers models only).
                                  Options: 'cls_token' (sentence vector), 'reduce_mean' (sentence vector),
@@ -222,7 +222,7 @@ class EmbeddingRetriever(BaseRetriever):
         if model_format == "farm" or model_format == "transformers":
             self.embedding_model = Inferencer.load(
                 embedding_model, task_type="embeddings", extraction_strategy=self.pooling_strategy,
-                extraction_layer=self.emb_extraction_layer, gpu=gpu, batch_size=4, max_seq_len=512, num_processes=0
+                extraction_layer=self.emb_extraction_layer, gpu=use_gpu, batch_size=4, max_seq_len=512, num_processes=0
             )
 
         elif model_format == "sentence_transformers":
@@ -230,7 +230,7 @@ class EmbeddingRetriever(BaseRetriever):
 
             # pretrained embedding models coming from: https://github.com/UKPLab/sentence-transformers#pretrained-models
             # e.g. 'roberta-base-nli-stsb-mean-tokens'
-            if gpu:
+            if use_gpu:
                 device = "cuda"
             else:
                 device = "cpu"

--- a/haystack/retriever/dpr_utils.py
+++ b/haystack/retriever/dpr_utils.py
@@ -109,11 +109,12 @@ class BertTensorizer(Tensorizer):
 
         # tokenizer automatic padding is explicitly disabled since its inconsistent behavior
         if title:
-            token_ids = self.tokenizer.encode(title, text_pair=text, add_special_tokens=add_special_tokens,
+            token_ids = self.tokenizer.encode(title, text_pair=text, truncation=True, add_special_tokens=add_special_tokens,
                                               max_length=self.max_length,
                                               pad_to_max_length=False)
         else:
-            token_ids = self.tokenizer.encode(text, add_special_tokens=add_special_tokens, max_length=self.max_length,
+            token_ids = self.tokenizer.encode(text, add_special_tokens=add_special_tokens, truncation=True,
+                                              max_length=self.max_length,
                                               pad_to_max_length=False)
 
         seq_len = self.max_length

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -49,7 +49,7 @@ if RETRIEVER_TYPE == "EmbeddingRetriever":
         document_store=document_store,
         embedding_model=EMBEDDING_MODEL_PATH,
         model_format=EMBEDDING_MODEL_FORMAT,
-        gpu=USE_GPU
+        use_gpu=USE_GPU
     )  # type: BaseRetriever
 elif RETRIEVER_TYPE == "ElasticsearchRetriever":
     retriever = ElasticsearchRetriever(document_store=document_store)

--- a/test/test_dpr_retriever.py
+++ b/test/test_dpr_retriever.py
@@ -11,7 +11,7 @@ def test_dpr_inmemory_retrieval():
         {'name': '2', 'text': """Democratic Republic of the Congo to the south. Angola's capital, Luanda, lies on the Atlantic coast in the northwest of the country. Angola, although located in a tropical zone, has a climate that is not characterized for this region, due to the confluence of three factors: As a result, Angola's climate is characterized by two seasons: rainfall from October to April and drought, known as ""Cacimbo"", from May to August, drier, as the name implies, and with lower temperatures. On the other hand, while the coastline has high rainfall rates, decreasing from North to South and from to , with"""},
     ]
 
-    retriever = DensePassageRetriever(document_store=document_store, embedding_model="dpr-bert-base-nq", gpu=False)
+    retriever = DensePassageRetriever(document_store=document_store, embedding_model="dpr-bert-base-nq", use_gpu=False)
 
     embedded = []
     for doc in documents:

--- a/test/test_faq_retriever.py
+++ b/test/test_faq_retriever.py
@@ -22,7 +22,7 @@ def test_faq_retriever_in_memory_store():
         {'text': 'By running tox in the command line!', 'meta': {'name': 'blah blah blah', 'question': 'blah blah blah'}},
     ]
 
-    retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", gpu=False)
+    retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", use_gpu=False)
 
     embedded = []
     for doc in documents:

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -147,7 +147,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "retriever = EmbeddingRetriever(document_store=document_store, embedding_model=\"deepset/sentence_bert\", gpu=False)"
+    "retriever = EmbeddingRetriever(document_store=document_store, embedding_model=\"deepset/sentence_bert\", use_gpu=False)"
    ],
    "metadata": {
     "collapsed": false,

--- a/tutorials/Tutorial4_FAQ_style_QA.py
+++ b/tutorials/Tutorial4_FAQ_style_QA.py
@@ -51,7 +51,7 @@ document_store = ElasticsearchDocumentStore(host="localhost", username="", passw
 # Instead of retrieving via Elasticsearch's plain BM25, we want to use vector similarity of the questions (user question vs. FAQ ones).
 # We can use the `EmbeddingRetriever` for this purpose and specify a model that we use for the embeddings.
 #
-retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", gpu=False)
+retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", use_gpu=False)
 
 # Download a csv containing some FAQ data
 # Here: Some question-answer pairs related to COVID-19

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -309,7 +309,7 @@
    "source": [
     "from haystack.retriever.dense import DensePassageRetriever\n",
     "retriever = DensePassageRetriever(document_store=document_store, embedding_model=\"dpr-bert-base-nq\",\n",
-    "                                  do_lower_case=True, gpu=True)\n",
+    "                                  do_lower_case=True, use_gpu=True)\n",
     "\n",
     "# Important: \n",
     "# Now that after we have the DPR initialized, we need to call update_embeddings() to iterate over all\n",

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -12,7 +12,7 @@ from haystack.utils import print_answers
 from haystack.retriever.sparse import ElasticsearchRetriever
 from haystack.retriever.dense import DensePassageRetriever
 
-LAUNCH_ELASTICSEARCH = False
+LAUNCH_ELASTICSEARCH = True
 
 # Start an Elasticsearch server
 # You can start Elasticsearch on your local machine instance using Docker. If Docker is not readily available in
@@ -47,7 +47,7 @@ document_store.write_documents(dicts[:16])
 
 ### Retriever
 retriever = DensePassageRetriever(document_store=document_store, embedding_model="dpr-bert-base-nq",
-                                  do_lower_case=True, gpu=True)
+                                  do_lower_case=True, use_gpu=True)
 # Important:
 # Now that after we have the DPR initialized, we need to call update_embeddings() to iterate over all
 # previously indexed documents and update their embedding representation.


### PR DESCRIPTION
- Add `truncation=True` in the calls to transformers from Dense Passage Retriever to avoid new warnings in transformers 3.0.2
- Change arg `gpu` -> `use_gpu` in init of DPR and EmbeddingRetriever to be more compliant with Readers

Fixing #237 