### PR TITLE
Fix format of /export-doc-qa-feedback to comply with SQuAD

### DIFF
--- a/rest_api/controller/feedback.py
+++ b/rest_api/controller/feedback.py
@@ -71,9 +71,10 @@ def faq_qa_feedback(feedback: Feedback):
 def export_doc_qa_feedback():
     """
     SQuAD format JSON export for question/answer pairs that were marked as "relevant".
-
-    #TODO filter out faq-qa feedback.
     """
+    #TODO filter out faq-qa feedback.
+    #TODO Reduce length of context for large documents
+
     relevant_feedback_query = {"query": {"bool": {"must": [{"term": {"label": "relevant"}}]}}}
     result = scan(elasticsearch_client, index=DB_INDEX_FEEDBACK, query=relevant_feedback_query)
 
@@ -94,7 +95,7 @@ def export_doc_qa_feedback():
     for document_id, feedback in per_document_feedback.items():
         document = document_store.get_document_by_id(document_id)
         context = document.text
-        export_data.append({"paragraphs": [{"qas": feedback}], "context": context})
+        export_data.append({"paragraphs": [{"qas": feedback, "context": context}],})
 
     export = {"data": export_data}
 


### PR DESCRIPTION
The "context" was not on the right level of the dict causing trouble in training / preprocessing (see #238).

Note: The context currently contains **all** text of the indexed document. If users index very long texts, they will have very long texts in the SQuAD "context", which will result in many negative training samples (passages with no annotated answer) and can impact training performance. We should address this in a future PR.

