### PR TITLE
Fix type of query_emb in DPR.retrieve()

### DIFF
--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -107,8 +107,8 @@ class DensePassageRetriever(BaseRetriever):
     def retrieve(self, query: str, filters: dict = None, top_k: int = 10, index: str = None) -> List[Document]:
         if index is None:
             index = self.document_store.index
-        query_emb: List[float] = self.embed_queries(texts=[query])[0].tolist()
-        documents = self.document_store.query_by_embedding(query_emb=query_emb, top_k=top_k, filters=filters, index=index)
+        query_emb = self.embed_queries(texts=[query])
+        documents = self.document_store.query_by_embedding(query_emb=query_emb[0], top_k=top_k, filters=filters, index=index)
         return documents
 
     def embed_queries(self, texts: List[str]) -> List[np.array]:


### PR DESCRIPTION
After refactoring of query_by_embedding function in the commit 355be293b6ee17f4305aef66bffbf2ba052db327, DPR has stopped to work. 
According to your EmbeddingRetriever retrieve function implementation, I have fixed DPR retrieve function. Hope it helps.