### PR TITLE
Add FAISS Document Store

### DIFF
--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -1,10 +1,11 @@
-from abc import abstractmethod, ABC
 import logging
-from typing import Any, Optional, Dict, List
+from abc import abstractmethod, ABC
+from typing import Any, Optional, Dict, List, Union
 from uuid import uuid4
 
 
 logger = logging.getLogger(__name__)
+
 
 class Document:
     def __init__(self, text: str,
@@ -180,7 +181,7 @@ class BaseDocumentStore(ABC):
     label_index: Optional[str]
 
     @abstractmethod
-    def write_documents(self, documents: List[dict], index: Optional[str] = None):
+    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):
         """
         Indexes documents for later queries.
 

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -3,6 +3,8 @@ from abc import abstractmethod, ABC
 from typing import Any, Optional, Dict, List, Union
 from uuid import uuid4
 
+import numpy as np
+
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ class Document:
                  query_score: Optional[float] = None,
                  question: Optional[str] = None,
                  meta: Dict[str, Any] = None,
-                 embedding: Optional[List[float]] = None):
+                 embedding: Optional[np.array] = None):
         """
         Object used to represent documents / passages in a standardized way within Haystack.
         For example, this is what the retriever will return from the DocumentStore,

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -129,17 +129,15 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         self.client.indices.create(index=index_name, ignore=400, body=mapping)
 
     def get_document_by_id(self, id: str, index=None) -> Optional[Document]:
-        if index is None:
-            index = self.index
+        index = index or self.index
         documents = self.get_documents_by_id([id], index=index)
         if documents:
             return documents[0]
         else:
             return None
 
-    def get_documents_by_id(self, ids: Union[List[str], List[UUID]], index=None) -> List[Document]:
-        if index is None:
-            index = self.index
+    def get_documents_by_id(self, ids: List[str], index=None) -> List[Document]:
+        index = index or self.index
         query = {"query": {"ids": {"values": ids}}}
         result = self.client.search(index=index, body=query)["hits"]["hits"]
         documents = [self._convert_es_hit_to_document(hit) for hit in result]

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -131,11 +131,19 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
     def get_document_by_id(self, id: str, index=None) -> Optional[Document]:
         if index is None:
             index = self.index
-        query = {"query": {"ids": {"values": [id]}}}
-        result = self.client.search(index=index, body=query)["hits"]["hits"]
+        documents = self.get_documents_by_id([id], index=index)
+        if documents:
+            return documents[0]
+        else:
+            return None
 
-        document = self._convert_es_hit_to_document(result[0]) if result else None
-        return document
+    def get_documents_by_id(self, ids: Union[List[str], List[UUID]], index=None) -> List[Document]:
+        if index is None:
+            index = self.index
+        query = {"query": {"ids": {"values": ids}}}
+        result = self.client.search(index=index, body=query)["hits"]["hits"]
+        documents = [self._convert_es_hit_to_document(hit) for hit in result]
+        return documents
 
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):
         """

--- a/haystack/database/faiss.py
+++ b/haystack/database/faiss.py
@@ -97,7 +97,7 @@ class FAISSDocumentStore(SQLDocumentStore):
     def _get_phi(self, documents: List[Document]) -> int:
         phi = 0
         for doc in documents:
-            norms = (doc.embedding ** 2).sum()
+            norms = (doc.embedding ** 2).sum()  # type: ignore
             phi = max(phi, norms)
         return phi
 

--- a/haystack/database/faiss.py
+++ b/haystack/database/faiss.py
@@ -1,0 +1,94 @@
+import logging
+from pathlib import Path
+from typing import Union, List, Optional, Type
+
+import faiss
+import numpy as np
+from faiss.swigfaiss import IndexHNSWFlat
+
+from haystack.database.base import Document
+from haystack.database.sql import SQLDocumentStore
+from haystack.retriever.base import BaseRetriever
+
+logger = logging.getLogger(__name__)
+
+
+class FAISSDocumentStore(SQLDocumentStore):
+    def __init__(
+        self,
+        sql_url: str = "sqlite:///",
+        index_factory: str = "HNSW4",
+        index_buffer_size: int = 10_000,
+        vector_size: int = 768,
+    ):
+        self.index: IndexHNSWFlat = self._create_new_index(index_factory=index_factory, vector_size=vector_size)
+        self.index_factory = index_factory
+        self.vector_size = vector_size
+        self.index_buffer_size = index_buffer_size
+        super().__init__(url=sql_url)
+
+    def _create_new_index(self, index_factory: str, vector_size: int):
+        index = faiss.index_factory(vector_size, index_factory)
+        return index
+
+    def write_documents(self, documents: List[dict]):
+        for i in range(0, len(documents), self.index_buffer_size):
+            docs_to_write_in_sql = []
+            embeddings = []
+            for doc in documents[i:i+self.index_buffer_size]:
+                meta = doc.get("meta", {})
+                meta["vector_id"] = i
+                docs_to_write_in_sql.append({**meta, **doc})
+                if "embedding" in doc.keys():
+                    embeddings.append(doc["embedding"])
+            if embeddings:
+                vectors = np.asarray(embeddings, dtype=np.float32)
+                self.index.add(vectors)
+            assert not embeddings or (len(docs_to_write_in_sql) == len(embeddings))
+            super(FAISSDocumentStore, self).write_documents(docs_to_write_in_sql)
+        super().get_document_count()
+
+    def update_embeddings(self, retriever: Type[BaseRetriever]):
+        """
+        Updates the embeddings in the the document store using the encoding model specified in the retriever.
+        This can be useful if want to add or change the embeddings for your documents (e.g. after changing the retriever config).
+
+        :param retriever: Retriever
+        :return: None
+        """
+        index = self._create_new_index(index_factory=self.index_factory, vector_size=self.vector_size)
+
+        doc_count = self.get_document_count()
+        for i in range(0, doc_count, self.index_buffer_size):
+            docs = self.get_all_documents(offset=i, limit=self.index_buffer_size)
+
+            passages = [d.text for d in docs]
+            logger.info(f"Updating embeddings for {len(passages)} docs ...")
+            embeddings = retriever.embed_passages(passages)
+
+            assert len(docs) == len(embeddings)
+            index.add(np.asarray(embeddings, dtype=np.float32))
+
+        self.index = index
+        print(type(self.index))
+
+    def query_by_embedding(
+        self, query_emb: List[float], filters: Optional[dict] = None, top_k: int = 10, index: Optional[str] = None
+    ) -> List[Document]:
+        if not self.index:
+            raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
+        query_vector = np.asarray([query_emb], dtype=np.float32)
+
+        _, vector_id_matrix = self.index.search(query_vector, top_k)
+        vector_ids_for_query = vector_id_matrix[0]
+
+        document_ids = [str(v_id + 1) for v_id in vector_ids_for_query if v_id != -1]
+        documents = self.get_documents_by_id(document_ids)
+        # TODO add deprecation warning and use only one under the hood.
+        return documents
+
+    def save(self, file_path: Union[str, Path]):
+        faiss.write_index(self.index, str(file_path))
+
+    def load(self, file_path: Union[str, Path]):
+        self.index = faiss.read_index(str(file_path))

--- a/haystack/database/memory.py
+++ b/haystack/database/memory.py
@@ -55,17 +55,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
     def get_documents_by_id(self, ids: List[str], index: Optional[str] = None) -> List[Document]:
         index = index or self.index
-        documents = [self._convert_memory_hit_to_document(self.indexes[index][id], doc_id=id) for id in ids]
+        documents = [self.indexes[index][id] for id in ids]
         return documents
-
-    def _convert_memory_hit_to_document(self, hit: Dict[str, Any], doc_id: Optional[str] = None) -> Document:
-        document = Document(
-            id=doc_id,
-            text=hit.get("text", None),
-            meta=hit.get("meta", {}),
-            query_score=hit.get("query_score", None),
-        )
-        return document
 
     def query_by_embedding(self,
                            query_emb: List[float],

--- a/haystack/database/memory.py
+++ b/haystack/database/memory.py
@@ -47,7 +47,16 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
     def get_document_by_id(self, id: str, index: Optional[str] = None) -> Document:
         index = index or self.index
-        return self.indexes[index][id]
+        documents = self.get_documents_by_id([id], index=index)
+        if documents:
+            return documents[0]
+        else:
+            return None
+
+    def get_documents_by_id(self, ids: List[str], index: Optional[str] = None) -> List[Document]:
+        index = index or self.index
+        documents = [self._convert_memory_hit_to_document(self.indexes[index][id], doc_id=id) for id in ids]
+        return documents
 
     def _convert_memory_hit_to_document(self, hit: Dict[str, Any], doc_id: Optional[str] = None) -> Document:
         document = Document(

--- a/haystack/database/memory.py
+++ b/haystack/database/memory.py
@@ -45,7 +45,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
             label_id = str(uuid4())
             self.indexes[index][label_id] = label
 
-    def get_document_by_id(self, id: str, index: Optional[str] = None) -> Document:
+    def get_document_by_id(self, id: str, index: Optional[str] = None) -> Optional[Document]:
         index = index or self.index
         documents = self.get_documents_by_id([id], index=index)
         if documents:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ wget
 python-multipart
 python-docx
 sqlalchemy_utils
+faiss-gpu

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -103,14 +103,14 @@ def no_answer_prediction(no_answer_reader, test_docs_xs):
     return prediction
 
 
-@pytest.fixture(params=[ "faiss"])
+@pytest.fixture(params=["elasticsearch", "faiss", "memory", "sql"])
 def document_store_with_docs(request, test_docs_xs, elasticsearch_fixture):
     document_store = get_document_store(request.param)
     document_store.write_documents(test_docs_xs)
     return document_store
 
 
-@pytest.fixture(params=["faiss"])
+@pytest.fixture(params=["elasticsearch", "faiss", "memory", "sql"])
 def document_store(request, test_docs_xs, elasticsearch_fixture):
     return get_document_store(request.param)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -117,20 +117,20 @@ def document_store(request, test_docs_xs, elasticsearch_fixture):
 
 def get_document_store(document_store_type):
     if document_store_type == "sql":
-        if os.path.exists("qa_test.db"):
-            os.remove("qa_test.db")
-        document_store = SQLDocumentStore(url="sqlite:///qa_test.db")
+        if os.path.exists("haystack_test.db"):
+            os.remove("haystack_test.db")
+        document_store = SQLDocumentStore(url="sqlite:///haystack_test.db")
     elif document_store_type == "memory":
         document_store = InMemoryDocumentStore()
     elif document_store_type == "elasticsearch":
         # make sure we start from a fresh index
         client = Elasticsearch()
-        client.indices.delete(index='haystack_test', ignore=[404])
+        client.indices.delete(index='haystack_test*', ignore=[404])
         document_store = ElasticsearchDocumentStore(index="haystack_test")
     elif document_store_type == "faiss":
-        if os.path.exists("qa_test_faiss.db"):
-            os.remove("qa_test_faiss.db")
-        document_store = FAISSDocumentStore(sql_url="sqlite:///qa_test_faiss.db")
+        if os.path.exists("haystack_test_faiss.db"):
+            os.remove("haystack_test_faiss.db")
+        document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db")
     else:
         raise Exception(f"No document store fixture for '{document_store_type}'")
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from haystack.database.base import Document
+from haystack.database.base import Document, Label
 
 
 def test_get_all_documents_without_filters(document_store_with_docs):
@@ -37,6 +37,25 @@ def test_get_documents_by_id(document_store_with_docs):
     doc = document_store_with_docs.get_document_by_id(documents[0].id)
     assert doc.id == documents[0].id
     assert doc.text == documents[0].text
+
+
+def test_labels(document_store):
+    label = Label(
+        question="question",
+        answer="answer",
+        is_correct_answer=True,
+        is_correct_document=True,
+        document_id="123",
+        offset_start_in_doc=12,
+        no_answer=False,
+        origin="gold_label",
+    )
+    document_store.write_labels([label], index="haystack_test_label")
+    labels = document_store.get_all_labels(index="haystack_test_label")
+    assert len(labels) == 1
+
+    labels = document_store.get_all_labels()
+    assert len(labels) == 0
 
 
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)

--- a/test/test_dpr_retriever.py
+++ b/test/test_dpr_retriever.py
@@ -1,10 +1,10 @@
-from haystack.database.memory import InMemoryDocumentStore
+import pytest
+
 from haystack.retriever.dense import DensePassageRetriever
 
 
-def test_dpr_inmemory_retrieval():
-    document_store = InMemoryDocumentStore()
-
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
+def test_dpr_inmemory_retrieval(document_store):
     documents = [
         {'name': '0', 'text': """Aaron Aaron ( or ; ""Ahärôn"") is a prophet, high priest, and the brother of Moses in the Abrahamic religions. Knowledge of Aaron, along with his brother Moses, comes exclusively from religious texts, such as the Bible and Quran. The Hebrew Bible relates that, unlike Moses, who grew up in the Egyptian royal court, Aaron and his elder sister Miriam remained with their kinsmen in the eastern border-land of Egypt (Goshen). When Moses first confronted the Egyptian king about the Israelites, Aaron served as his brother's spokesman (""prophet"") to the Pharaoh. Part of the Law (Torah) that Moses received from"""},
         {'name': '1', 'text': """Schopenhauer, describing him as an ultimately shallow thinker: ""Schopenhauer has quite a crude mind ... where real depth starts, his comes to an end."" His friend Bertrand Russell had a low opinion on the philosopher, and attacked him in his famous ""History of Western Philosophy"" for hypocritically praising asceticism yet not acting upon it. On the opposite isle of Russell on the foundations of mathematics, the Dutch mathematician L. E. J. Brouwer incorporated the ideas of Kant and Schopenhauer in intuitionism, where mathematics is considered a purely mental activity, instead of an analytic activity wherein objective properties of reality are"""},
@@ -25,4 +25,4 @@ def test_dpr_inmemory_retrieval():
     document_store.write_documents(embedded)
 
     res = retriever.retrieve(query="Which philosopher attacked Schopenhauer?")
-    assert res[0].text == documents[1]["text"]
+    assert res[0].meta["name"] == "1"

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
+def test_faiss_indexing(document_store):
+    documents = [
+        {"name": "name_1", "text": "text_1", "embedding": np.random.rand(768).astype(np.float32)},
+        {"name": "name_2", "text": "text_2", "embedding": np.random.rand(768).astype(np.float32)},
+        {"name": "name_3", "text": "text_3", "embedding": np.random.rand(768).astype(np.float32)},
+    ]
+
+    document_store.write_documents(documents)
+    documents_indexed = document_store.get_all_documents()
+
+    # test if correct vector_ids are assigned
+    for i, doc in enumerate(documents_indexed):
+        assert doc.meta["vector_id"] == str(i)
+
+    # test insertion of documents in an existing index fails
+    with pytest.raises(Exception):
+        document_store.write_documents(documents)

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -20,3 +20,9 @@ def test_faiss_indexing(document_store):
     # test insertion of documents in an existing index fails
     with pytest.raises(Exception):
         document_store.write_documents(documents)
+
+    # test saving the index
+    document_store.save("haystack_test_faiss")
+
+    # test loading the index
+    document_store.load(sql_url="sqlite:///haystack_test.db", faiss_file_path="haystack_test_faiss")


### PR DESCRIPTION
This PR adds a document store for very large scale embedding based dense retrievers like the [DPR](https://github.com/deepset-ai/haystack#densepassageretriever). It uses the [FAISS](https://github.com/facebookresearch/faiss) library for computing similarity between vector embeddings.