### PR TITLE
WIP: Cast document_ids as strings

### DIFF
--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -1,11 +1,11 @@
 from abc import abstractmethod, ABC
-from typing import Any, Optional, Dict, List, Union
-from uuid import UUID, uuid4
+from typing import Any, Optional, Dict, List
+from uuid import uuid4
 
 
 class Document:
     def __init__(self, text: str,
-                 id: Optional[Union[str, UUID]] = None,
+                 id: str = None,
                  query_score: Optional[float] = None,
                  question: Optional[str] = None,
                  meta: Dict[str, Any] = None,
@@ -31,12 +31,9 @@ class Document:
         self.text = text
         # Create a unique ID (either new one, or one from user input)
         if id:
-            if isinstance(id, str):
-                self.id = UUID(hex=str(id), version=4)
-            if isinstance(id, UUID):
-                self.id = id
+            self.id = str(id)
         else:
-            self.id = uuid4()
+            self.id = str(uuid4())
 
         self.query_score = query_score
         self.question = question
@@ -69,7 +66,7 @@ class Label:
                  is_correct_answer: bool,
                  is_correct_document: bool,
                  origin: str,
-                 document_id: Optional[UUID] = None,
+                 document_id: Optional[str] = None,
                  offset_start_in_doc: Optional[int] = None,
                  no_answer: Optional[bool] = None,
                  model_id: Optional[int] = None):
@@ -95,13 +92,7 @@ class Label:
         self.question = question
         self.is_correct_answer = is_correct_answer
         self.is_correct_document = is_correct_document
-        if document_id:
-            if isinstance(document_id, str):
-                self.document_id: Optional[UUID] = UUID(hex=str(document_id), version=4)
-            if isinstance(document_id, UUID):
-                self.document_id = document_id
-        else:
-            self.document_id = document_id
+        self.document_id = document_id
         self.answer = answer
         self.offset_start_in_doc = offset_start_in_doc
         self.model_id = model_id
@@ -146,7 +137,7 @@ class BaseDocumentStore(ABC):
         pass
 
     @abstractmethod
-    def get_document_by_id(self, id: UUID, index: Optional[str] = None) -> Optional[Document]:
+    def get_document_by_id(self, id: str, index: Optional[str] = None) -> Optional[Document]:
         pass
 
     @abstractmethod

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -6,7 +6,6 @@ from typing import List, Optional, Union, Dict, Any
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk, scan
 import numpy as np
-from uuid import UUID
 
 from haystack.database.base import BaseDocumentStore, Document, Label
 from haystack.indexing.utils import eval_data_from_file
@@ -122,7 +121,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         }
         self.client.indices.create(index=index_name, ignore=400, body=mapping)
 
-    def get_document_by_id(self, id: Union[UUID, str], index=None) -> Optional[Document]:
+    def get_document_by_id(self, id: str, index=None) -> Optional[Document]:
         if index is None:
             index = self.index
         query = {"query": {"ids": {"values": [id]}}}

--- a/haystack/database/memory.py
+++ b/haystack/database/memory.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
-from uuid import UUID
+from uuid import uuid4
 from collections import defaultdict
-import uuid
+
 from haystack.database.base import BaseDocumentStore, Document, Label
 from haystack.indexing.utils import eval_data_from_file
 
@@ -46,7 +46,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         label_objects = [Label.from_dict(l) if isinstance(l, dict) else l for l in labels]
 
         for label in label_objects:
-            label_id = uuid.uuid4()
+            label_id = str(uuid4())
             self.indexes[index][label_id] = label
 
     def _map_tags_to_ids(self, hash: str, tags: List[str]):
@@ -64,7 +64,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
                                 else:
                                     self.doc_tags[comp_key] = [hash]
 
-    def get_document_by_id(self, id: Union[str, UUID], index: Optional[str] = None) -> Document:
+    def get_document_by_id(self, id: str, index: Optional[str] = None) -> Document:
         index = index or self.index
         return self.indexes[index][id]
 

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -2,7 +2,6 @@ import logging
 import time
 from datetime import datetime
 from typing import List, Dict, Optional
-from uuid import UUID
 
 import elasticapm
 from fastapi import APIRouter
@@ -116,7 +115,7 @@ class Answer(BaseModel):
     offset_end: int
     offset_start_in_doc: Optional[int]
     offset_end_in_doc: Optional[int]
-    document_id: Optional[UUID] = None
+    document_id: Optional[str] = None
     meta: Optional[Dict[str, Optional[str]]]
 
 

--- a/test/test_tfidf_retriever.py
+++ b/test/test_tfidf_retriever.py
@@ -1,6 +1,3 @@
-from haystack.database.base import Document
-from uuid import UUID
-
 def test_tfidf_retriever():
     from haystack.retriever.sparse import TfidfRetriever
 
@@ -17,6 +14,6 @@ def test_tfidf_retriever():
     retriever = TfidfRetriever(document_store)
     retriever.fit()
     doc = retriever.retrieve("godzilla", top_k=1)[0]
-    assert doc.id == UUID("26f84672c6d7aaeb8e2cd53e9c62d62d", version=4)
+    assert doc.id == "26f84672c6d7aaeb8e2cd53e9c62d62d"
     assert doc.text == 'godzilla says hello'
     assert doc.meta == {"name": "testing the finder 1"}


### PR DESCRIPTION
The `Document.id` values are currently expected to be UUIDs. They are either generated automatically by Haystack when indexing in a new document store or get UUIDs assigned from user-supplied hex string when reading from an existing document store.

To support arbitrary IDs(strings/numeric) from existing document stores, this PR refactors IDs to always be strings.

For creating new document stores, the IDs are still UUID strings to prevent duplicates.

Related issue: #278 