### PR TITLE
Add option to update existing documents when indexing

### DIFF
--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -33,7 +33,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         scheme: str = "http",
         ca_certs: bool = False,
         verify_certs: bool = True,
-        create_index: bool = True
+        create_index: bool = True,
     ):
         """
         A DocumentStore using Elasticsearch to store and query the documents for our search.


### PR DESCRIPTION
This PR adds a `update_existing_documents ` parameter for the `ElasticsearchDocumentStore`. 

When the parameter is set to `True`, indexing new documents with explicit IDs will update any existing documents with the same ID. Otherwise, if set to `False`, the document store throws an error.

By default, the parameter is set to `False` to retain the same behaviour as before.