### PR TITLE
Aggregate label objects for same questions

### DIFF
--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -84,13 +84,79 @@ class Label:
         :param no_answer: whether the question in unanswerable.
         :param model_id: model_id used for prediction(in-case of user feedback).
         """
+        self.question = question
+        self.answer = answer
+        self.is_correct_answer = is_correct_answer
+        self.is_correct_document = is_correct_document
+        self.origin = origin
+        self.document_id = document_id
+        self.offset_start_in_doc = offset_start_in_doc
+        self.no_answer = no_answer
+        self.model_id = model_id
+
+    @classmethod
+    def from_dict(cls, dict):
+        return cls(**dict)
+
+    def to_dict(self):
+        return self.__dict__
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__) and
+                getattr(other, 'question', None) == self.question and
+                getattr(other, 'answer', None) == self.answer and
+                getattr(other, 'is_correct_answer', None) == self.is_correct_answer and
+                getattr(other, 'is_correct_document', None) == self.is_correct_document and
+                getattr(other, 'origin', None) == self.origin and
+                getattr(other, 'document_id', None) == self.document_id and
+                getattr(other, 'offset_start_in_doc', None) == self.offset_start_in_doc and
+                getattr(other, 'no_answer', None) == self.no_answer and
+                getattr(other, 'model_id', None) == self.model_id)
+
+    def __hash__(self):
+        return hash(self.question +
+                    self.answer +
+                    str(self.is_correct_answer) +
+                    str(self.is_correct_document) +
+                    str(self.origin) +
+                    str(self.document_id) +
+                    str(self.offset_start_in_doc) +
+                    str(self.no_answer) +
+                    str(self.model_id))
+
+
+class Aggregated_Label:
+    def __init__(self, question: str,
+                 multiple_answers: List[str],
+                 is_correct_answer: bool,
+                 is_correct_document: bool,
+                 origin: str,
+                 document_id: Optional[List[str]] = None,
+                 offset_start_in_doc: Optional[List[int]] = None,
+                 no_answer: Optional[bool] = None,
+                 model_id: Optional[int] = None):
+        """
+        Object used to aggregate multiple possible answers for the same question
+
+        :param question: the question(or query) for finding answers.
+        :param multiple_answers: list of possible answer strings
+        :param is_correct_answer: whether the sample is positive or negative.
+        :param is_correct_document: in case of negative sample(is_correct_answer is False), there could be two cases;
+                                    incorrect answer but correct document & incorrect document. This flag denotes if
+                                    the returned document was correct.
+        :param origin: the source for the labels. It can be used to later for filtering.
+        :param document_id: the document_store's ID for the returned answer document.
+        :param offset_start_in_doc: the answer start offset in the document.
+        :param no_answer: whether the question in unanswerable.
+        :param model_id: model_id used for prediction(in-case of user feedback).
+        """
         self.no_answer = no_answer
         self.origin = origin
         self.question = question
         self.is_correct_answer = is_correct_answer
         self.is_correct_document = is_correct_document
         self.document_id = document_id
-        self.answer = answer
+        self.multiple_answers = multiple_answers
         self.offset_start_in_doc = offset_start_in_doc
         self.model_id = model_id
 
@@ -131,7 +197,11 @@ class BaseDocumentStore(ABC):
         pass
 
     @abstractmethod
-    def get_all_labels(self, index: str = "label", filters: Optional[Optional[Dict[str, List[str]]]] = None) -> List[Label]:
+    def get_all_labels(self, index: str = "label", filters: Optional[Dict[str, List[str]]] = None) -> List[Label]:
+        pass
+
+    @abstractmethod
+    def get_all_labels_aggregated(self, index: str = "label", filters: Optional[Dict[str, List[str]]] = None) -> List[Aggregated_Label]:
         pass
 
     @abstractmethod

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -135,8 +135,8 @@ class MultiLabel:
                  is_correct_answer: bool,
                  is_correct_document: bool,
                  origin: str,
-                 multiple_document_ids: Optional[List[str]] = None,
-                 multiple_offset_start_in_docs: Optional[List[int]] = None,
+                 multiple_document_ids: List[Optional[str]] = None,
+                 multiple_offset_start_in_docs: List[Optional[int]] = None,
                  no_answer: Optional[bool] = None,
                  model_id: Optional[int] = None):
         """
@@ -236,7 +236,7 @@ class BaseDocumentStore(ABC):
                 logger.warning(
                     f"Both text label and 'no answer possible' label is present for question: {ls[0].question}")
                 for remove_idx in no_idx[::-1]:
-                    ls.delete(remove_idx)
+                    ls.pop(remove_idx)
             # when all labels to a question say "no answer" we just need the first occurence
             elif no_present and not t_present:
                 ls = ls[:1]

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -82,7 +82,7 @@ class Label:
         :param document_id: the document_store's ID for the returned answer document.
         :param offset_start_in_doc: the answer start offset in the document.
         :param no_answer: whether the question in unanswerable.
-        :param model_id: model_id used for prediction(in-case of user feedback).
+        :param model_id: model_id used for prediction (in-case of user feedback).
         """
         self.question = question
         self.answer = answer
@@ -101,6 +101,7 @@ class Label:
     def to_dict(self):
         return self.__dict__
 
+    # define __eq__ and __hash__ functions to deduplicate Label Objects
     def __eq__(self, other):
         return (isinstance(other, self.__class__) and
                 getattr(other, 'question', None) == self.question and
@@ -131,8 +132,8 @@ class Aggregated_Label:
                  is_correct_answer: bool,
                  is_correct_document: bool,
                  origin: str,
-                 document_id: Optional[List[str]] = None,
-                 offset_start_in_doc: Optional[List[int]] = None,
+                 multiple_document_ids: Optional[List[str]] = None,
+                 multiple_offset_start_in_docs: Optional[List[int]] = None,
                  no_answer: Optional[bool] = None,
                  model_id: Optional[int] = None):
         """
@@ -145,19 +146,19 @@ class Aggregated_Label:
                                     incorrect answer but correct document & incorrect document. This flag denotes if
                                     the returned document was correct.
         :param origin: the source for the labels. It can be used to later for filtering.
-        :param document_id: the document_store's ID for the returned answer document.
-        :param offset_start_in_doc: the answer start offset in the document.
+        :param multiple_document_ids: the document_store's IDs for the returned answer documents.
+        :param multiple_offset_start_in_docs: the answer start offsets in the document.
         :param no_answer: whether the question in unanswerable.
-        :param model_id: model_id used for prediction(in-case of user feedback).
+        :param model_id: model_id used for prediction (in-case of user feedback).
         """
-        self.no_answer = no_answer
-        self.origin = origin
         self.question = question
+        self.multiple_answers = multiple_answers
         self.is_correct_answer = is_correct_answer
         self.is_correct_document = is_correct_document
-        self.document_id = document_id
-        self.multiple_answers = multiple_answers
-        self.offset_start_in_doc = offset_start_in_doc
+        self.origin = origin
+        self.multiple_document_ids = multiple_document_ids
+        self.multiple_offset_start_in_docs = multiple_offset_start_in_docs
+        self.no_answer = no_answer
         self.model_id = model_id
 
     @classmethod

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -135,8 +135,8 @@ class MultiLabel:
                  is_correct_answer: bool,
                  is_correct_document: bool,
                  origin: str,
-                 multiple_document_ids: List[Optional[str]] = None,
-                 multiple_offset_start_in_docs: List[Optional[int]] = None,
+                 multiple_document_ids: List[Any] = None,
+                 multiple_offset_start_in_docs: List[Any] = None,
                  no_answer: Optional[bool] = None,
                  model_id: Optional[int] = None):
         """
@@ -201,7 +201,7 @@ class BaseDocumentStore(ABC):
         pass
 
     @abstractmethod
-    def get_all_labels(self, index: str = "label", filters: Optional[Dict[str, List[str]]] = None) -> List[Label]:
+    def get_all_labels(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> List[Label]:
         pass
 
     def get_all_labels_aggregated(self,
@@ -211,7 +211,7 @@ class BaseDocumentStore(ABC):
         all_labels = self.get_all_labels(index=index, filters=filters)
 
         # Collect all answers to a question in a dict
-        question_ans_dict = {}
+        question_ans_dict = {} # type: Dict[str,List[str]]
         for l in all_labels:
             if l.question in question_ans_dict:
                 question_ans_dict[l.question].append(l)

--- a/haystack/database/base.py
+++ b/haystack/database/base.py
@@ -135,8 +135,8 @@ class MultiLabel:
                  is_correct_answer: bool,
                  is_correct_document: bool,
                  origin: str,
-                 multiple_document_ids: List[Any] = None,
-                 multiple_offset_start_in_docs: List[Any] = None,
+                 multiple_document_ids: List[Any],
+                 multiple_offset_start_in_docs: List[Any],
                  no_answer: Optional[bool] = None,
                  model_id: Optional[int] = None):
         """
@@ -211,7 +211,7 @@ class BaseDocumentStore(ABC):
         all_labels = self.get_all_labels(index=index, filters=filters)
 
         # Collect all answers to a question in a dict
-        question_ans_dict = {} # type: Dict[str,List[str]]
+        question_ans_dict = {} # type: ignore
         for l in all_labels:
             if l.question in question_ans_dict:
                 question_ans_dict[l.question].append(l)

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -237,15 +237,18 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         return labels
 
     def get_all_labels_aggregated(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> List[Aggregated_Label]:
+        aggregated_labels = []
         all_labels = self.get_all_labels(index=index, filters=filters)
+        # Collect all answers to a question in a dict
         question_ans_dict = {}
         for l in all_labels:
             if l.question in question_ans_dict:
                 question_ans_dict[l.question].append(l)
             else:
                 question_ans_dict[l.question] = [l]
-        aggregated_labels = []
-        for q,ls in question_ans_dict.item():
+
+        # Aggregate labels
+        for q,ls in question_ans_dict.items():
             ls = list(set(ls)) #get rid of exact duplicates
             # check if there are both text answer and "no answer" present
             t_present = False
@@ -262,13 +265,32 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                 logger.warning(f"Both text label and 'no answer possible' label is present for question: {ls[0].question}")
                 for remove_idx in no_idx[::-1]:
                     ls.delete(remove_idx)
+            # when all labels to a question say "no answer" we just need the first occurence
+            elif no_present and not t_present:
+                ls = ls[:1]
+
+            # construct Aggregated_label
+            for i,l in enumerate(ls):
+                if i == 0:
+                    agg_label = Aggregated_Label(question=l.question,
+                                             multiple_answers=[l.answer],
+                                             is_correct_answer=l.is_correct_answer,
+                                             is_correct_document=l.is_correct_document,
+                                             origin=l.origin,
+                                             multiple_document_ids=[l.document_id] if l.document_id else [],
+                                             multiple_offset_start_in_docs=[l.offset_start_in_doc] if l.offset_start_in_doc else [],
+                                             no_answer=l.no_answer,
+                                             model_id=l.model_id,
+                                             )
+                else:
+                    agg_label.multiple_answers.append(l.answer)
+                    agg_label.multiple_document_ids.append(l.document_id)
+                    agg_label.multiple_offset_start_in_docs.append(l.offset_start_in_doc)
+            aggregated_labels.append(agg_label)
+
             
-        return None
+        return aggregated_labels
 
-    @staticmethod
-    def deduplicate_labels(labels: List[Label]) -> Aggregated_Label:
-
-        return None
 
     def get_all_documents_in_index(self, index: str, filters: Optional[Dict[str, List[str]]] = None) -> List[dict]:
         body = {

--- a/haystack/database/elasticsearch.py
+++ b/haystack/database/elasticsearch.py
@@ -7,7 +7,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk, scan
 import numpy as np
 
-from haystack.database.base import BaseDocumentStore, Document, Label, Aggregated_Label
+from haystack.database.base import BaseDocumentStore, Document, Label
 from haystack.indexing.utils import eval_data_from_file
 from haystack.retriever.base import BaseRetriever
 
@@ -235,62 +235,6 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         result = self.get_all_documents_in_index(index=index, filters=filters)
         labels = [Label.from_dict(hit["_source"]) for hit in result]
         return labels
-
-    def get_all_labels_aggregated(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> List[Aggregated_Label]:
-        aggregated_labels = []
-        all_labels = self.get_all_labels(index=index, filters=filters)
-        # Collect all answers to a question in a dict
-        question_ans_dict = {}
-        for l in all_labels:
-            if l.question in question_ans_dict:
-                question_ans_dict[l.question].append(l)
-            else:
-                question_ans_dict[l.question] = [l]
-
-        # Aggregate labels
-        for q,ls in question_ans_dict.items():
-            ls = list(set(ls)) #get rid of exact duplicates
-            # check if there are both text answer and "no answer" present
-            t_present = False
-            no_present = False
-            no_idx = []
-            for idx,l in enumerate(ls):
-                if len(l.answer) == 0:
-                    no_present = True
-                else:
-                    t_present = True
-                    no_idx.append(idx)
-            # if both text and no answer are present, remove no answer labels
-            if t_present and no_present:
-                logger.warning(f"Both text label and 'no answer possible' label is present for question: {ls[0].question}")
-                for remove_idx in no_idx[::-1]:
-                    ls.delete(remove_idx)
-            # when all labels to a question say "no answer" we just need the first occurence
-            elif no_present and not t_present:
-                ls = ls[:1]
-
-            # construct Aggregated_label
-            for i,l in enumerate(ls):
-                if i == 0:
-                    agg_label = Aggregated_Label(question=l.question,
-                                             multiple_answers=[l.answer],
-                                             is_correct_answer=l.is_correct_answer,
-                                             is_correct_document=l.is_correct_document,
-                                             origin=l.origin,
-                                             multiple_document_ids=[l.document_id] if l.document_id else [],
-                                             multiple_offset_start_in_docs=[l.offset_start_in_doc] if l.offset_start_in_doc else [],
-                                             no_answer=l.no_answer,
-                                             model_id=l.model_id,
-                                             )
-                else:
-                    agg_label.multiple_answers.append(l.answer)
-                    agg_label.multiple_document_ids.append(l.document_id)
-                    agg_label.multiple_offset_start_in_docs.append(l.offset_start_in_doc)
-            aggregated_labels.append(agg_label)
-
-            
-        return aggregated_labels
-
 
     def get_all_documents_in_index(self, index: str, filters: Optional[Dict[str, List[str]]] = None) -> List[dict]:
         body = {

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -46,7 +46,7 @@ class BaseRetriever(ABC):
         # Extract all questions for evaluation
         filters = {"origin": [label_origin]}
 
-        labels = self.document_store.get_all_labels(index=label_index, filters=filters)
+        labels = self.document_store.get_all_labels_aggregated(index=label_index, filters=filters)
 
         correct_retrievals = 0
         summed_avg_precision = 0

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List
 import logging
-from collections import defaultdict
 
 from haystack.database.base import Document
 from haystack.database.base import BaseDocumentStore
@@ -57,7 +56,7 @@ class BaseRetriever(ABC):
             if open_domain:
                 question_label_dict[label.question] = label.multiple_answers
             else:
-                deduplicated_doc_ids = set([str(x) for x in label.multiple_document_ids])
+                deduplicated_doc_ids = list(set([str(x) for x in label.multiple_document_ids]))
                 question_label_dict[label.question] = deduplicated_doc_ids
 
         # Option 1: Open-domain evaluation by checking if the answer string is in the retrieved docs

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -51,17 +51,18 @@ class BaseRetriever(ABC):
         correct_retrievals = 0
         summed_avg_precision = 0
 
-        # Aggregate all positive document ids / answers per question
-        aggregated_labels = defaultdict(set)
+        # Collect questions and corresponding answers/document_ids in a dict
+        question_label_dict = {}
         for label in labels:
             if open_domain:
-                aggregated_labels[label.question].add(label.answer)
+                question_label_dict[label.question] = label.multiple_answers
             else:
-                aggregated_labels[label.question].add(str(label.document_id))
+                deduplicated_doc_ids = set([str(x) for x in label.multiple_document_ids])
+                question_label_dict[label.question] = deduplicated_doc_ids
 
         # Option 1: Open-domain evaluation by checking if the answer string is in the retrieved docs
         if open_domain:
-            for question, gold_answers in aggregated_labels.items():
+            for question, gold_answers in question_label_dict.items():
                 retrieved_docs = self.retrieve(question, top_k=top_k, index=doc_index)
                 # check if correct doc in retrieved docs
                 for doc_idx, doc in enumerate(retrieved_docs):
@@ -72,16 +73,17 @@ class BaseRetriever(ABC):
                             break
         # Option 2: Strict evaluation by document ids that are listed in the labels
         else:
-            for question, gold_ids in aggregated_labels.items():
+            for question, gold_ids in question_label_dict.items():
                 retrieved_docs = self.retrieve(question, top_k=top_k, index=doc_index)
                 # check if correct doc in retrieved docs
                 for doc_idx, doc in enumerate(retrieved_docs):
-                    if str(doc.id) in gold_ids:
-                        correct_retrievals += 1
-                        summed_avg_precision += 1 / (doc_idx + 1)  # type: ignore
-                        break
+                    for gold_id in gold_ids:
+                        if str(doc.id) == gold_id:
+                            correct_retrievals += 1
+                            summed_avg_precision += 1 / (doc_idx + 1)  # type: ignore
+                            break
         # Metrics
-        number_of_questions = len(aggregated_labels)
+        number_of_questions = len(question_label_dict)
         recall = correct_retrievals / number_of_questions
         mean_avg_precision = summed_avg_precision / number_of_questions
 

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -20,7 +20,8 @@ eval_retriever_only = True
 eval_reader_only = False
 eval_both = False
 
-doc_index = "tutorial5_docs" # make sure these indices do not collide with existing ones
+# make sure these indices do not collide with existing ones, the indices will be wiped clean before data is inserted
+doc_index = "tutorial5_docs"
 label_index = "tutorial5_labels"
 ##############################################
 # Code

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 ##############################################
 # Settings
 ##############################################
-LAUNCH_ELASTICSEARCH = False
+LAUNCH_ELASTICSEARCH = True
 
 eval_retriever_only = True
 eval_reader_only = False


### PR DESCRIPTION
This PR adds functionality to aggregate Label Objects into an Aggregated_Label Object.

The Aggregated_Label differs from a normal Label in 
- multiple_answers
- multiple_document_ids
- multiple_offset_start_in_docs

I am unsure how to aggregating values for is_correct_answer/document. I think for the use case of evaluating on QA datasets those fields are not needed