### PR TITLE
Align TransformersReader with FARMReader

### DIFF
--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -20,7 +20,7 @@ class TransformersReader(BaseReader):
         self,
         model: str = "distilbert-base-uncased-distilled-squad",
         tokenizer: Optional[str] = None,
-        context_window_size: int = 150,
+        context_window_size: int = 70,
         use_gpu: int = 0,
         top_k_per_candidate: int = 4,
         return_no_answers: bool = True,

--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -20,11 +20,11 @@ class TransformersReader(BaseReader):
         self,
         model: str = "distilbert-base-uncased-distilled-squad",
         tokenizer: Optional[str] = None,
-        context_window_size: int = 30,
+        context_window_size: int = 150,
         use_gpu: int = 0,
         top_k_per_candidate: int = 4,
-        no_answer: bool = True,
-        max_seq_len: int = 384,
+        return_no_answers: bool = True,
+        max_seq_len: int = 256,
         doc_stride: int = 128
     ):
         """
@@ -46,10 +46,10 @@ class TransformersReader(BaseReader):
                                            Note: - This is not the number of "final answers" you will receive
                                            (see `top_k` in TransformersReader.predict() or Finder.get_answers() for that)
                                          - Can includes no_answer in the sorted list of predictions
-        :param no_answer: True -> Hugging Face model could return an "impossible"/"empty" answer (i.e. when there is an unanswerable question)
-                          False -> otherwise
-                          no_answer_boost is unfortunately not available with TransformersReader. If you would like to
-                          set no_answer_boost, use a FARMReader
+        :param return_no_answers: True -> Hugging Face model could return an "impossible"/"empty" answer (i.e. when there is an unanswerable question)
+                                  False -> otherwise
+                                  no_answer_boost is unfortunately not available with TransformersReader. If you would like to
+                                  set no_answer_boost, use a FARMReader
         :param max_seq_len: max sequence length of one input text for the model
         :param doc_stride: length of striding window for splitting long texts (used if len(text) > max_seq_len)
 
@@ -57,7 +57,7 @@ class TransformersReader(BaseReader):
         self.model = pipeline('question-answering', model=model, tokenizer=tokenizer, device=use_gpu)
         self.context_window_size = context_window_size
         self.top_k_per_candidate = top_k_per_candidate
-        self.return_no_answers = no_answer
+        self.return_no_answers = return_no_answers
         self.max_seq_len = max_seq_len
         self.doc_stride = doc_stride
 


### PR DESCRIPTION
The TransformersReader is adapted such that there is no need to provide a tokenizer as it can be inferred by the model name. 
Also, max_seq_len and doc_stride can now be set by the user.