### PR TITLE
DPR (Dense Retriever) for InMemoryDocumentStore #316

### DIFF
--- a/haystack/database/memory.py
+++ b/haystack/database/memory.py
@@ -118,10 +118,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
                                "Specify the arg `embedding_dim` when initializing InMemoryDocumentStore()")
 
         for doc, emb in zip(docs, embeddings):
-            d = self.indexes[index][doc.id]
-            doc_dict = d.to_dict()
-            doc_dict[self.embedding_field] = emb.tolist()
-            self.indexes[index][doc.id] = Document.from_dict(doc_dict)
+            self.indexes[index][doc.id].embedding = emb
 
     def get_document_count(self, index: Optional[str] = None) -> int:
         index = index or self.index


### PR DESCRIPTION
This is a work in progress pull request for the issue #316 as suggested by @tanaysoni.

Hi @tanaysoni, Implemented the update_embeddings method. Can you please review this? 

Question : Once the embeddings are generated by DPR, logic is to convert every document into dict, add the embedding to it, before converting it back into document to push it in memory store. I understand this is a one time process, is there a better way to handle this?

Do I need to create & run unit tests too?

P.S: This is my first pull request, pls let me know if there is anything amiss. 