### PR TITLE
[WiP] FAISSDocumentStore with Finder and EmbeddingRetriever

### DIFF
--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -104,10 +104,11 @@ class Finder:
                 "offset_end": len(doc.text),
                 "meta": doc.meta
              }
+            query_score = doc.query_score or np.nan
             if self.retriever.embedding_model:  # type: ignore
-                probability = (doc.query_score + 1) / 2  # type: ignore
+                probability = (query_score + 1) / 2  # type: ignore
             else:
-                probability = float(expit(np.asarray(doc.query_score / 8)))  # type: ignore
+                probability = float(expit(np.asarray(query_score / 8)))  # type: ignore
 
             cur_answer["probability"] = probability
             results["answers"].append(cur_answer)

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -104,7 +104,7 @@ class Finder:
                 "offset_end": len(doc.text),
                 "meta": doc.meta
              }
-            query_score = doc.query_score or np.nan
+            query_score = np.nan if doc.query_score is None else doc.query_score
             if self.retriever.embedding_model:  # type: ignore
                 probability = (query_score + 1) / 2  # type: ignore
             else:

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -345,7 +345,7 @@ class EmbeddingRetriever(BaseRetriever):
             emb = [(r.astype('float64')) for r in emb]
 
         if isinstance(self.document_store, FAISSDocumentStore):
-                        emb = [(r.astype('float32')) for r in emb]
+            emb = [(r.astype('float32')) for r in emb]
 
         return emb
 

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -8,6 +8,7 @@ from farm.infer import Inferencer
 
 from haystack.database.base import Document, BaseDocumentStore
 from haystack.database.elasticsearch import ElasticsearchDocumentStore
+from haystack.database.faiss import FAISSDocumentStore
 from haystack.retriever.base import BaseRetriever
 from haystack.retriever.sparse import logger
 
@@ -342,6 +343,10 @@ class EmbeddingRetriever(BaseRetriever):
             emb = self.embedding_model.encode(texts)  # type: ignore
             # cast to float64 as float32 can cause trouble when serializing for ES
             emb = [(r.astype('float64')) for r in emb]
+
+        if isinstance(self.document_store, FAISSDocumentStore):
+                        emb = [(r.astype('float32')) for r in emb]
+
         return emb
 
     def embed_queries(self, texts: List[str]) -> List[np.array]:

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -1,16 +1,21 @@
 import numpy as np
 import pytest
 
+from haystack.retriever.dense import EmbeddingRetriever
+from haystack import Finder
+
+
+DOCUMENTS = [
+    {"name": "name_1", "text": "text_1", "embedding": np.random.rand(768).astype(np.float32)},
+    {"name": "name_2", "text": "text_2", "embedding": np.random.rand(768).astype(np.float32)},
+    {"name": "name_3", "text": "text_3", "embedding": np.random.rand(768).astype(np.float32)},
+]
+
 
 @pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
 def test_faiss_indexing(document_store):
-    documents = [
-        {"name": "name_1", "text": "text_1", "embedding": np.random.rand(768).astype(np.float32)},
-        {"name": "name_2", "text": "text_2", "embedding": np.random.rand(768).astype(np.float32)},
-        {"name": "name_3", "text": "text_3", "embedding": np.random.rand(768).astype(np.float32)},
-    ]
 
-    document_store.write_documents(documents)
+    document_store.write_documents(DOCUMENTS)
     documents_indexed = document_store.get_all_documents()
 
     # test if correct vector_ids are assigned
@@ -19,10 +24,32 @@ def test_faiss_indexing(document_store):
 
     # test insertion of documents in an existing index fails
     with pytest.raises(Exception):
-        document_store.write_documents(documents)
+        document_store.write_documents(DOCUMENTS)
 
     # test saving the index
     document_store.save("haystack_test_faiss")
 
     # test loading the index
     document_store.load(sql_url="sqlite:///haystack_test.db", faiss_file_path="haystack_test_faiss")
+
+
+@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
+def test_faiss_retrieving(document_store):
+
+    document_store.write_documents(DOCUMENTS)
+
+    retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", use_gpu=False)
+    embedding = retriever.retrieve(query="How to test this?")
+
+
+@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
+def test_faiss_finding(document_store):
+
+    document_store.write_documents(DOCUMENTS)
+
+    retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", use_gpu=False)
+    finder = Finder(reader=None, retriever=retriever)
+
+    prediction = finder.get_answers_via_similar_questions(question="How to test this?", top_k_retriever=1)
+
+    assert len(prediction.get('answers', [])) == 1


### PR DESCRIPTION
Hi folks,
thanks for the work you've put into this framework - it's a really nice way to bring some structure into a QA pipeline.

I've recently tried to replace an `ElasticsearchDocumentStore` with the newly added `FAISSDocumentStore`  on the latest master and ran into two issues when using it together with `Finder` and the `EmbeddingRetriever`.

-------
The first issue was an exception thrown by `faiss-cpu` when trying to call `EmbeddingRetriever.retrieve`:
```
TypeError: in method 'IndexHNSW_search', argument 3 of type 'float const *'`
```
A quick search turned up https://github.com/facebookresearch/faiss/issues/461, suggesting to pass float32 arrays instead of float64 to the method, and sure enough updating the datatype helped out.
I've added a test `test_faiss_retrieving` to reproduce this error, however, this only seems to show up under MacOS.

Do you guys think a check in `embed` is the proper way to handle this, or would there be a better approach?

------

The second issue was the `Finder` handling documents where query_score is `None`, as the probability calculation throws an exception. This might also be affect other document stores, but I haven't checked yet. The issue can be reproduced with `test_faiss_finding`.

Happy to hear any comments, especially if these tests belong somewhere else.