### PR TITLE
Add a document offset correction for documents that were segmented by TfidfRetriever

### DIFF
--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -9,6 +9,7 @@ from scipy.special import expit
 
 from haystack.reader.base import BaseReader
 from haystack.retriever.base import BaseRetriever
+from haystack.retriever.sparse import TfidfRetriever
 from haystack.database.base import MultiLabel, Document
 from haystack.eval import calculate_average_precision, eval_counts_reader_batch, calculate_reader_metrics, \
     eval_counts_reader
@@ -68,7 +69,7 @@ class Finder:
                 if doc.id == ans["document_id"]:
                     ans["meta"] = doc.meta
                     # correct document offsets for auto-segmented documents from tfidf retriever
-                    if "document_offset" in ans["meta"].keys():
+                    if isinstance(self.retriever, TfidfRetriever):
                         doc_offset = ans["meta"].pop("document_offset")
                         ans["offset_start_in_doc"] += doc_offset
                         ans["offset_end_in_doc"] += doc_offset

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -67,6 +67,10 @@ class Finder:
             for doc in documents:
                 if doc.id == ans["document_id"]:
                     ans["meta"] = doc.meta
+                    # correct document offsets for auto-segmented documents
+                    doc_offset = ans["meta"].pop("document_offset", 0)
+                    ans["offset_start_in_doc"] += doc_offset
+                    ans["offset_end_in_doc"] += doc_offset
 
         return results
 

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -67,10 +67,11 @@ class Finder:
             for doc in documents:
                 if doc.id == ans["document_id"]:
                     ans["meta"] = doc.meta
-                    # correct document offsets for auto-segmented documents
-                    doc_offset = ans["meta"].pop("document_offset", 0)
-                    ans["offset_start_in_doc"] += doc_offset
-                    ans["offset_end_in_doc"] += doc_offset
+                    # correct document offsets for auto-segmented documents from tfidf retriever
+                    if "document_offset" in ans["meta"].keys():
+                        doc_offset = ans["meta"].pop("document_offset")
+                        ans["offset_start_in_doc"] += doc_offset
+                        ans["offset_end_in_doc"] += doc_offset
 
         return results
 


### PR DESCRIPTION
As I mentioned in https://github.com/deepset-ai/haystack/issues/369 the document offset values are incorrect in the case that the TfIdf Retriever splits up the document at "\n\n".

I fixed this by adding a document_offset value to the document's meta field once it is split up into paragraphs.
These offset values are added to the document start/end values when the final answers are constructed.

From what I've seen, the tfidf is the sole retriever to perform additional segmentation, so as an alternative to my workaround I'd suggest just getting rid of that, since it breaks consistency anyway.

TODO: This warrants a test, but I haven't added one since I'm unsure where it would fit best, I'm thinking `test_finder.py`.