### PR TITLE
Improvements in FaissDocumentStore: Abstracting out FAISS index related customisation to another class

### DIFF
--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -4,13 +4,93 @@ from typing import Union, List, Optional, Dict
 
 import faiss
 import numpy as np
-from faiss.swigfaiss import IndexHNSWFlat
+from faiss import Index
 
 from haystack import Document
 from haystack.document_store.sql import SQLDocumentStore
 from haystack.retriever.base import BaseRetriever
 
 logger = logging.getLogger(__name__)
+
+
+class FaissIndexStore:
+    def __init__(
+            self,
+            faiss_index: Optional[Index] = None,
+            # https://github.com/facebookresearch/faiss/wiki/Faiss-indexes
+            # https://github.com/facebookresearch/faiss/wiki/The-index-factory
+            **kwargs
+    ):
+        self.dimension = kwargs.get('dimension', 768)
+        self.allow_training = kwargs.get('allow_training', False)
+        self.convert_l2_to_ip = kwargs.get('convert_l2_to_ip', True)
+        self.index_factory = kwargs.get('index_factory', 'HNSW4')
+        metric_type = kwargs.get('metric_type', None)
+
+        if faiss_index:
+            self.faiss_index = faiss_index
+        else:
+            new_dimension = self.dimension
+            if self.convert_l2_to_ip:
+                new_dimension = self.dimension + 1
+
+            if metric_type is not None:
+                self.faiss_index = faiss.index_factory(new_dimension, self.index_factory, metric_type)
+            else:
+                self.faiss_index = faiss.index_factory(new_dimension, self.index_factory)
+
+    @staticmethod
+    def _get_phi(embeddings: List[np.array]) -> int:
+        phi = 0
+        for embedding in embeddings:
+            norms = (embedding ** 2).sum()  # type: ignore
+            phi = max(phi, norms)
+        return phi
+
+    @staticmethod
+    def _get_hnsw_vectors(embeddings: List[np.array], phi: int) -> np.array:
+        """
+        HNSW indices in FAISS only support L2 distance. This transformation adds an additional dimension to obtain
+        corresponding inner products.
+
+        You can read ore details here:
+        https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#how-can-i-do-max-inner-product-search-on-indexes-that-support-only-l2
+        """
+        vectors = [np.reshape(emb, (1, -1)) for emb in embeddings]
+        norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
+        aux_dims = [np.sqrt(phi - norm) for norm in norms]
+        hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in enumerate(vectors)]
+        hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
+        return hnsw_vectors
+
+    def add_vectors(self, embeddings: List[np.array]):
+        if self.convert_l2_to_ip:
+            vectors_to_add = self._get_hnsw_vectors(embeddings, self._get_phi(embeddings))
+        else:
+            vectors_to_add = np.ascontiguousarray([emb.tolist() for emb in embeddings], dtype=np.float32)
+
+        # Refer https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#how-can-i-index-vectors-for-cosine-similarity
+        if self.faiss_index.metric_type == faiss.METRIC_INNER_PRODUCT:
+            faiss.normalize_L2(vectors_to_add)
+
+        if not self.faiss_index.is_trained and self.allow_training:
+            self.faiss_index.train(vectors_to_add)
+
+        return self.faiss_index.add(vectors_to_add)
+
+    def search_vectors(self, embeddings: List[np.array], top_k: int):
+        vectors = embeddings
+        if self.convert_l2_to_ip:
+            aux_dim = np.zeros(len(embeddings), dtype="float32")
+            vectors = np.hstack((embeddings, aux_dim.reshape(-1, 1)))
+
+        return self.faiss_index.search(vectors, top_k)
+
+    def size(self):
+        return self.faiss_index.ntotal
+
+    def reset(self):
+        return self.faiss_index.reset()
 
 
 class FAISSDocumentStore(SQLDocumentStore):
@@ -26,11 +106,13 @@ class FAISSDocumentStore(SQLDocumentStore):
     """
 
     def __init__(
-        self,
-        sql_url: str = "sqlite:///",
-        index_buffer_size: int = 10_000,
-        vector_size: int = 768,
-        faiss_index: Optional[IndexHNSWFlat] = None,
+            self,
+            sql_url: str = "sqlite:///",
+            index_buffer_size: int = 10_000,
+            vector_size: int = 768,
+            faiss_index: Optional[Index] = None,
+            index_factory: str = "HNSW4",
+            index: str = "document"
     ):
         """
         :param sql_url: SQL connection URL for database. It defaults to local file based SQLite DB. For large scale
@@ -40,36 +122,45 @@ class FAISSDocumentStore(SQLDocumentStore):
         :param vector_size: the embedding vector size.
         :param faiss_index: load an existing FAISS Index.
         """
+        self.index = index
         self.vector_size = vector_size
-        self.faiss_index = faiss_index
+        self.index_factory = index_factory
+        self.faiss_indexes = {}
         self.index_buffer_size = index_buffer_size
+
+        if faiss_index:
+            self.get_or_create_fiass_index(index_name=index, faiss_index=faiss_index)
+
         super().__init__(url=sql_url)
 
-    def _create_new_index(self, vector_size: int, index_factory: str = "HNSW4"):
-        index = faiss.index_factory(vector_size + 1, index_factory)
-        return index
+    def get_or_create_fiass_index(self, index: Optional[str] = None, faiss_index: Optional[Index] = None, **kwargs):
+        index = index or self.index
+        if not self.faiss_indexes or not self.faiss_indexes[index]:
+            if kwargs and kwargs.get('index_factory') is None:
+                kwargs['index_factory'] = self.index_factory
 
-    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):
+            if kwargs and kwargs.get('dimension') is None:
+                kwargs['dimension'] = self.vector_size
 
-        self.faiss_index = self.faiss_index or self._create_new_index(vector_size=self.vector_size)
+            self.faiss_indexes[index] = FaissIndexStore(faiss_index=faiss_index, **kwargs)
+        return self.faiss_indexes[index]
+
+    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None, **kwargs):
+
         index = index or self.index
         document_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
-
         add_vectors = False if document_objects[0].embedding is None else True
 
+        vector_id = 0
         if add_vectors:
-            phi = self._get_phi(document_objects)
+            faiss_index = self.get_or_create_fiass_index(index=index, **kwargs)
+            vector_id = faiss_index.size()
+            embeddings = [doc.embedding for doc in document_objects]
+            faiss_index.add_vectors(embeddings=embeddings)
 
         for i in range(0, len(document_objects), self.index_buffer_size):
-            vector_id = self.faiss_index.ntotal
-            if add_vectors:
-                embeddings = [doc.embedding for doc in document_objects[i: i + self.index_buffer_size]]
-                hnsw_vectors = self._get_hnsw_vectors(embeddings=embeddings, phi=phi)
-                hnsw_vectors = hnsw_vectors.astype(np.float32)
-                self.faiss_index.add(hnsw_vectors)
-
             docs_to_write_in_sql = []
-            for doc in document_objects[i : i + self.index_buffer_size]:
+            for doc in document_objects[i: i + self.index_buffer_size]:
                 meta = doc.meta
                 if add_vectors:
                     meta["vector_id"] = vector_id
@@ -78,29 +169,7 @@ class FAISSDocumentStore(SQLDocumentStore):
 
             super(FAISSDocumentStore, self).write_documents(docs_to_write_in_sql, index=index)
 
-    def _get_hnsw_vectors(self, embeddings: List[np.array], phi: int) -> np.array:
-        """
-        HNSW indices in FAISS only support L2 distance. This transformation adds an additional dimension to obtain
-        corresponding inner products.
-
-        You can read ore details here:
-        https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#how-can-i-do-max-inner-product-search-on-indexes-that-support-only-l2
-        """
-        vectors = [np.reshape(emb, (1, -1)) for emb in embeddings]
-        norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
-        aux_dims = [np.sqrt(phi - norm) for norm in norms]
-        hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in enumerate(vectors)]
-        hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
-        return hnsw_vectors
-
-    def _get_phi(self, documents: List[Document]) -> int:
-        phi = 0
-        for doc in documents:
-            norms = (doc.embedding ** 2).sum()  # type: ignore
-            phi = max(phi, norms)
-        return phi
-
-    def update_embeddings(self, retriever: BaseRetriever, index: Optional[str] = None):
+    def update_embeddings(self, retriever: BaseRetriever, index: Optional[str] = None, **kwargs):
         """
         Updates the embeddings in the the document store using the encoding model specified in the retriever.
         This can be useful if want to add or change the embeddings for your documents (e.g. after changing the retriever config).
@@ -109,64 +178,70 @@ class FAISSDocumentStore(SQLDocumentStore):
         :param index: Index name to update
         :return: None
         """
-        self.faiss_index = self.faiss_index or self._create_new_index(vector_size=self.vector_size)
-        # To clear out the FAISS index contents and frees all memory immediately that is in use by the index
-        self.faiss_index.reset()
-
         index = index or self.index
+        faiss_index = self.get_or_create_fiass_index(index=index, **kwargs)
+        # Some FAISS indexes(like the default HNSWx) do not support removing vectors, so a new index is created.
+        faiss_index.reset()
+        vector_id = faiss_index.size()
 
         documents = self.get_all_documents(index=index)
         logger.info(f"Updating embeddings for {len(documents)} docs ...")
         embeddings = retriever.embed_passages(documents)  # type: ignore
         assert len(documents) == len(embeddings)
-        for i, doc in enumerate(documents):
-            doc.embedding = embeddings[i]
-
-        phi = self._get_phi(documents)
 
         vector_id_map = {}
         for i in range(0, len(documents), self.index_buffer_size):
-            vector_id = self.faiss_index.ntotal
-            embeddings = [doc.embedding for doc in documents[i: i + self.index_buffer_size]]
-            hnsw_vectors = self._get_hnsw_vectors(embeddings=embeddings, phi=phi)
-            hnsw_vectors = hnsw_vectors.astype(np.float32)
-            self.faiss_index.add(hnsw_vectors)
+            embeddings_batch = [embedding for embedding in embeddings[i: i + self.index_buffer_size]]
+            faiss_index.add_vectors(embeddings=embeddings_batch)
 
             for doc in documents[i: i + self.index_buffer_size]:
                 vector_id_map[doc.id] = vector_id
                 vector_id += 1
-                
+
         self.update_vector_ids(vector_id_map, index=index)
 
     def query_by_embedding(
-        self, query_emb: np.array, filters: Optional[dict] = None, top_k: int = 10, index: Optional[str] = None
+            self, query_emb: np.array, filters: Optional[dict] = None, top_k: int = 10,
+            index: Optional[str] = None
     ) -> List[Document]:
+
+        index = index or self.index
+        if not self.faiss_indexes[index]:
+            raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
+
         if filters:
             raise Exception("Query filters are not implemented for the FAISSDocumentStore.")
-        if not self.faiss_index:
-            raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
-        query_emb = query_emb.reshape(1, -1).astype(np.float32)
 
-        aux_dim = np.zeros(len(query_emb), dtype="float32")
-        hnsw_vectors = np.hstack((query_emb, aux_dim.reshape(-1, 1)))
-        score_matrix, vector_id_matrix = self.faiss_index.search(hnsw_vectors, top_k)
+        faiss_index = self.faiss_indexes[index]
+        query_emb = query_emb.reshape(1, -1)
+
+        score_matrix, vector_id_matrix = faiss_index.search_vectors(embeddings=query_emb, top_k=top_k)
         vector_ids_for_query = [str(vector_id) for vector_id in vector_id_matrix[0] if vector_id != -1]
 
         documents = self.get_documents_by_vector_ids(vector_ids_for_query, index=index)
 
         # assign query score to each document
-        scores_for_vector_ids: Dict[str, float] = {str(v_id): s for v_id, s in zip(vector_id_matrix[0], score_matrix[0])}
+        scores_for_vector_ids: Dict[str, float] = {str(v_id): s for v_id, s in
+                                                   zip(vector_id_matrix[0], score_matrix[0])}
         for doc in documents:
             doc.score = scores_for_vector_ids[doc.meta["vector_id"]]  # type: ignore
             doc.probability = (doc.score + 1) / 2
 
         return documents
 
+    def delete_all_documents(self, index=None):
+        index = index or self.index
+        super(FAISSDocumentStore, self).delete_all_documents(index=index)
+        if self.faiss_indexes and self.faiss_indexes[index] is not None:
+            self.faiss_indexes[index].reset()
+
     def save(self, file_path: Union[str, Path]):
         """
         Save FAISS Index to the specified file.
         """
-        faiss.write_index(self.faiss_index, str(file_path))
+        if self.index:
+            faise_index_store = self.faiss_indexes.get(self.index)
+            faiss.write_index(faise_index_store.faiss_index, str(file_path))
 
     @classmethod
     def load(
@@ -174,16 +249,19 @@ class FAISSDocumentStore(SQLDocumentStore):
             faiss_file_path: Union[str, Path],
             sql_url: str,
             index_buffer_size: int = 10_000,
-            vector_size: int = 768
+            vector_size: int = 768,
+            index: str = "document",
+            index_factory: str = "HNSW4"
     ):
         """
         Load a saved FAISS index from a file and connect to the SQL database.
         """
         faiss_index = faiss.read_index(str(faiss_file_path))
         return cls(
+            index=index,
+            index_factory=index_factory,
             faiss_index=faiss_index,
             sql_url=sql_url,
             index_buffer_size=index_buffer_size,
             vector_size=vector_size
         )
-

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -14,37 +14,70 @@ logger = logging.getLogger(__name__)
 
 
 class FaissIndexStore:
+    """
+    Index Store to keep all meta information about FAISS index. It abstract out vector transformation capability from
+    FAISSDocumentStore. It perform L2 to IP transformation, L2 normalization for IP and perform index training if
+    required.
+
+    For details about indexes refer: https://github.com/facebookresearch/faiss/wiki/Faiss-indexes
+    Guideline to choose index refer: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
+    """
     def __init__(
             self,
             faiss_index: Optional[Index] = None,
-            # https://github.com/facebookresearch/faiss/wiki/Faiss-indexes
-            # https://github.com/facebookresearch/faiss/wiki/The-index-factory
-            **kwargs
+            allow_training: bool = False,
+            convert_l2_to_ip: bool = True,
+            index_factory: Optional[str] = "HNSW4",
+            dimension: Optional[int] = 768,
+            metric_type: Optional[int] = None
     ):
-
-        self.allow_training = kwargs.get('allow_training', False)
-        self.convert_l2_to_ip = kwargs.get('convert_l2_to_ip', True)
+        """
+        :param faiss_index: Customized FAISS Index, useful if user want to customize index params like `nlists`,
+                            `nbits`, `efSearch` etc instead of using default params.
+        :param allow_training: Some IVF vector require training on GPU and some not as training is time consuming so
+                               This flag determine whether to allow training even index's `is_trained` flag is `False`.
+        :param convert_l2_to_ip: Mostly indexes on FAISS only support L2 distance hence this flag allow transformation
+                                 to adds an additional dimension to obtain corresponding inner products.
+                                 For more details refer:
+        https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#how-can-i-do-max-inner-product-search-on-indexes-that-support-only-l2
+        :param index_factory: String name to produce composite FAISS index. For more details refer:
+        https://github.com/facebookresearch/faiss/wiki/The-index-factory
+        :param dimension: The embedding vector size.
+        :param metric_type: FAISS support Lx (L1, L2, Lp, LInf) and Inner Product metric type for indexes.
+        """
+        self.allow_training = allow_training
+        self.convert_l2_to_ip = convert_l2_to_ip
 
         if faiss_index:
             self.faiss_index = faiss_index
             self.dimension = None
             self.index_factory = None
         else:
-            self.index_factory = kwargs.get('index_factory', 'HNSW4')
-            metric_type = kwargs.get('metric_type', None)
-            self.dimension = kwargs.get('dimension', 768)
+            self.index_factory = index_factory
+            assert self.index_factory is not None
 
-            new_dimension = self.dimension
+            metric_type = metric_type
+
+            self.dimension = dimension
+            assert self.dimension is not None
+
+            # To adds an additional dimension to obtain corresponding inner products
             if self.convert_l2_to_ip:
-                new_dimension = self.dimension + 1
+                self.dimension += 1
 
             if metric_type is not None:
-                self.faiss_index = faiss.index_factory(new_dimension, self.index_factory, metric_type)
+                self.faiss_index = faiss.index_factory(self.dimension, self.index_factory, metric_type)
             else:
-                self.faiss_index = faiss.index_factory(new_dimension, self.index_factory)
+                self.faiss_index = faiss.index_factory(self.dimension, self.index_factory)
 
     @staticmethod
     def _get_phi(embeddings: List[np.array]) -> int:
+        """
+        This will generate phi for vectors
+
+        :param embeddings: List of vectors
+        :return: phi value
+        """
         phi = 0
         for embedding in embeddings:
             norms = (embedding ** 2).sum()  # type: ignore
@@ -67,13 +100,24 @@ class FaissIndexStore:
         hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
         return hnsw_vectors
 
-    def add_vectors(self, embeddings: List[np.array]) -> List[np.int64]:
+    def add_vectors(self, embeddings: List[np.array]) -> np.ndarray:
+        """
+        This add embeddings to FAISS index. Before adding embeddings to the index it perform following task -
+         - L2 to IP transformation if `convert_l2_to_ip` flag is enabled.
+         - Create contiguous array form embeddings.
+         - Normalize vector via `normalize_L2` if metric of index is inner product. For more details refer:
+         https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#how-can-i-index-vectors-for-cosine-similarity
+         - Train index if index need training and `allow_training` is set
+         - Generate vector ids to return them to caller and also to pass to index if index is IndexIDMap type
+
+        :param embeddings: List of vectors
+        :return: Vector ids
+        """
         if self.convert_l2_to_ip:
             vectors_to_add = self._get_hnsw_vectors(embeddings, self._get_phi(embeddings))
         else:
             vectors_to_add = np.ascontiguousarray([emb.tolist() for emb in embeddings], dtype=np.float32)
 
-        # Refer https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#how-can-i-index-vectors-for-cosine-similarity
         if self.faiss_index.metric_type == faiss.METRIC_INNER_PRODUCT:
             faiss.normalize_L2(vectors_to_add)
 
@@ -90,6 +134,14 @@ class FaissIndexStore:
         return ids
 
     def search_vectors(self, embeddings: List[np.array], top_k: int):
+        """
+        This perform similarity search of given vectors and return vector_ids and corresponding score. If
+        `convert_l2_to_ip` flag is set then it perform transformation add an dimension.
+
+        :param embeddings: List of search vectors
+        :param top_k: How many search result required
+        :return: vector_ids and corresponding score
+        """
         vectors = embeddings
         if self.convert_l2_to_ip:
             aux_dim = np.zeros(len(embeddings), dtype="float32")
@@ -98,10 +150,17 @@ class FaissIndexStore:
         return self.faiss_index.search(vectors, top_k)
 
     def size(self):
+        """
+        :return: Number of embeddings stored in the index
+        """
         return self.faiss_index.ntotal
 
     def reset(self):
-        return self.faiss_index.reset()
+        """
+        This delete the all stored embeddings from the index
+        :return: None
+        """
+        self.faiss_index.reset()
 
 
 class FAISSDocumentStore(SQLDocumentStore):
@@ -121,51 +180,72 @@ class FAISSDocumentStore(SQLDocumentStore):
             sql_url: str = "sqlite:///",
             index_buffer_size: int = 10_000,
             vector_size: int = 768,
-            index_store: Optional[FaissIndexStore] = None,
-            index_factory: Optional[str] = "HNSW4",
-            index: Optional[str] = "document",
-            faiss_indexes: Optional[Dict[str, FaissIndexStore]] = {}
+            custom_index_store: Optional[FaissIndexStore] = None,
+            index_factory: str = "HNSW4",
+            index: str = "document"
     ):
         """
+        Constructor for FAISSDocumentStore
+
         :param sql_url: SQL connection URL for database. It defaults to local file based SQLite DB. For large scale
                         deployment, Postgres is recommended.
-        :param index_buffer_size: When working with large datasets, the ingestion process(FAISS + SQL) can be buffered in
-                                  smaller chunks to reduce memory footprint.
-        :param vector_size: the embedding vector size.
-        :param faiss_index: load an existing FAISS Index.
+        :param index_buffer_size: When working with large datasets, the ingestion process(FAISS + SQL) can be buffered
+                                  in smaller chunks to reduce memory footprint.
+        :param vector_size: The embedding vector size.
+        :param custom_index_store: Customized FaissIndexStore, useful if user want to customize index params like
+                                   `nlists`, `nbits`, `efSearch` etc instead of using default params.
+        :param index_factory: String name to produce composite FAISS index. For more details refer:
+        https://github.com/facebookresearch/faiss/wiki/The-index-factory
+        :param index: Index name.
         """
         self.index = index
         self.vector_size = vector_size
         self.index_factory = index_factory
-        self.faiss_indexes = faiss_indexes
+        self.index_dict: Dict[str, FaissIndexStore] = {}
         self.index_buffer_size = index_buffer_size
 
-        if index_store:
-            self.get_or_create_fiass_index(index=index, index_store=index_store)
+        if custom_index_store:
+            self.get_or_create_index_store(index=self.index, index_store=custom_index_store)
 
         super().__init__(url=sql_url, index=index)
 
-    def get_or_create_fiass_index(self, index: Optional[str] = None, index_store: Optional[FaissIndexStore] = None,
-                                  **kwargs):
+    def get_or_create_index_store(self, index: Optional[str] = None, index_store: Optional[FaissIndexStore] = None,
+                                  **kwargs) -> FaissIndexStore:
+        """
+        This return FaissIndexStore associated with index, and if not exist then create it from provided parameters.
+        Externally this function can be used to get existing index store to configure various FAISS index params like
+        `nlists`, `nbits`, `efSearch` etc before performing write, update or query operation.
+
+        :param index: Index name.
+        :param index_store: If passed it will replace existing index store corresponding to index.
+        :param kwargs: To pass parameters to FaissIndexStore for index creation.
+        :return: Index store.
+        """
         index = index or self.index
+        assert index is not None
+
         if index_store:
-            self.faiss_indexes[index] = index_store
-        elif not self.faiss_indexes or index not in self.faiss_indexes:
+            if self.index_dict and index in self.index_dict:
+                # Clear old index before re-assignment
+                self.index_dict[index].reset()
+            self.index_dict[index] = index_store
+        elif not self.index_dict or index not in self.index_dict:
+            # Add important params like `index_factory` and `dimension` if not exist in kwargs.
             if kwargs and kwargs.get('index_factory') is None:
                 kwargs['index_factory'] = self.index_factory
 
             if kwargs and kwargs.get('dimension') is None:
                 kwargs['dimension'] = self.vector_size
 
-            self.faiss_indexes[index] = FaissIndexStore(**kwargs)
-        return self.faiss_indexes[index]
+            self.index_dict[index] = FaissIndexStore(**kwargs)
+        return self.index_dict[index]
 
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None, **kwargs):
 
         index = index or self.index
         document_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
         add_vectors = False if document_objects[0].embedding is None else True
-        faiss_index = self.get_or_create_fiass_index(index=index, **kwargs)
+        faiss_index = self.get_or_create_index_store(index=index, **kwargs)
 
         for i in range(0, len(document_objects), self.index_buffer_size):
             vector_ids = []
@@ -185,14 +265,15 @@ class FAISSDocumentStore(SQLDocumentStore):
     def update_embeddings(self, retriever: BaseRetriever, index: Optional[str] = None, **kwargs):
         """
         Updates the embeddings in the the document store using the encoding model specified in the retriever.
-        This can be useful if want to add or change the embeddings for your documents (e.g. after changing the retriever config).
+        This can be useful if want to add or change the embeddings for your documents (e.g. after changing the retriever
+        config).
 
-        :param retriever: Retriever to use to get embeddings for text
-        :param index: Index name to update
+        :param retriever: Retriever to use to get embeddings for text.
+        :param index: Index name to update.
         :return: None
         """
         index = index or self.index
-        faiss_index = self.get_or_create_fiass_index(index=index, **kwargs)
+        faiss_index = self.get_or_create_index_store(index=index, **kwargs)
         # Some FAISS indexes(like the default HNSWx) do not support removing vectors, so a new index is created.
         faiss_index.reset()
 
@@ -218,13 +299,13 @@ class FAISSDocumentStore(SQLDocumentStore):
     ) -> List[Document]:
 
         index = index or self.index
-        if index not in self.faiss_indexes:
+        if index not in self.index_dict:
             raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
 
         if filters:
             raise Exception("Query filters are not implemented for the FAISSDocumentStore.")
 
-        faiss_index = self.faiss_indexes[index]
+        faiss_index = self.index_dict[index]
         query_emb = query_emb.reshape(1, -1)
 
         score_matrix, vector_id_matrix = faiss_index.search_vectors(embeddings=query_emb, top_k=top_k)
@@ -242,17 +323,22 @@ class FAISSDocumentStore(SQLDocumentStore):
         return documents
 
     def delete_all_documents(self, index: Optional[str] = None):
+        """
+        This delete all documents and FAISS index for the corresponding index
+        :param index: Index name.
+        :return: None
+        """
         index = index or self.index
         super(FAISSDocumentStore, self).delete_all_documents(index=index)
-        if self.faiss_indexes and index in self.faiss_indexes:
-            self.faiss_indexes[index].reset()
+        if self.index_dict and index in self.index_dict:
+            self.index_dict[index].reset()
 
     def save(self, file_path: Union[str, Path]):
         """
         Save FAISS Index to the specified file.
         """
         if self.index:
-            faise_index_store = self.faiss_indexes.get(self.index)
+            faise_index_store = self.index_dict[self.index]
             faiss.write_index(faise_index_store.faiss_index, str(file_path))
 
     @classmethod
@@ -272,7 +358,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         return cls(
             index=index,
             index_factory=index_factory,
-            index_store=FaissIndexStore(faiss_index=faiss_index),
+            custom_index_store=FaissIndexStore(faiss_index=faiss_index),
             sql_url=sql_url,
             index_buffer_size=index_buffer_size,
             vector_size=vector_size

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -97,8 +97,7 @@ class FaissIndexStore:
         norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
         aux_dims = [np.sqrt(phi - norm) for norm in norms]
         hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in enumerate(vectors)]
-        hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
-        return hnsw_vectors.astype(np.float32, copy=False)
+        return np.concatenate(hnsw_vectors, axis=0).astype(np.float32)
 
     def add_vectors(self, embeddings: List[np.array]) -> np.ndarray:
         """

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -118,7 +118,7 @@ class FaissIndexStore:
             vectors_to_add = np.ascontiguousarray([emb.tolist() for emb in embeddings], dtype=np.float32)
 
         if self.faiss_index.metric_type == faiss.METRIC_INNER_PRODUCT:
-            faiss.normalize_L2(vectors_to_add)
+            vectors_to_add = faiss.normalize_L2(vectors_to_add)
 
         if not self.faiss_index.is_trained and self.allow_training:
             self.faiss_index.train(vectors_to_add)
@@ -145,6 +145,9 @@ class FaissIndexStore:
         if self.convert_l2_to_ip:
             aux_dim = np.zeros(len(embeddings), dtype="float32")
             vectors = np.hstack((embeddings, aux_dim.reshape(-1, 1)))
+
+        if self.faiss_index.metric_type == faiss.METRIC_INNER_PRODUCT:
+            vectors = faiss.normalize_L2(vectors)
 
         return self.faiss_index.search(vectors, top_k)
 

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -118,7 +118,7 @@ class FaissIndexStore:
             vectors_to_add = np.ascontiguousarray([emb.tolist() for emb in embeddings], dtype=np.float32)
 
         if self.faiss_index.metric_type == faiss.METRIC_INNER_PRODUCT:
-            vectors_to_add = faiss.normalize_L2(vectors_to_add)
+            faiss.normalize_L2(vectors_to_add)
 
         if not self.faiss_index.is_trained and self.allow_training:
             self.faiss_index.train(vectors_to_add)
@@ -147,7 +147,7 @@ class FaissIndexStore:
             vectors = np.hstack((embeddings, aux_dim.reshape(-1, 1)))
 
         if self.faiss_index.metric_type == faiss.METRIC_INNER_PRODUCT:
-            vectors = faiss.normalize_L2(vectors)
+            faiss.normalize_L2(vectors)
 
         return self.faiss_index.search(vectors, top_k)
 

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -123,7 +123,8 @@ class FAISSDocumentStore(SQLDocumentStore):
             vector_size: int = 768,
             index_store: Optional[FaissIndexStore] = None,
             index_factory: Optional[str] = "HNSW4",
-            index: Optional[str] = "document"
+            index: Optional[str] = "document",
+            faiss_indexes: Optional[Dict[str, FaissIndexStore]] = {}
     ):
         """
         :param sql_url: SQL connection URL for database. It defaults to local file based SQLite DB. For large scale
@@ -136,7 +137,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         self.index = index
         self.vector_size = vector_size
         self.index_factory = index_factory
-        self.faiss_indexes = Dict[str, FaissIndexStore]
+        self.faiss_indexes = faiss_indexes
         self.index_buffer_size = index_buffer_size
 
         if index_store:

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -136,7 +136,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         self.index = index
         self.vector_size = vector_size
         self.index_factory = index_factory
-        self.faiss_indexes = {}
+        self.faiss_indexes = Dict[str, FaissIndexStore]
         self.index_buffer_size = index_buffer_size
 
         if index_store:

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -64,6 +64,8 @@ class SQLDocumentStore(BaseDocumentStore):
         self.session = Session()
         self.index = index
         self.label_index = "label"
+        # To enable foreign key constraint
+        self.session.execute("PRAGMA foreign_keys = ON;")
 
     def get_document_by_id(self, id: str, index: Optional[str] = None) -> Optional[Document]:
         documents = self.get_documents_by_id([id], index)

--- a/test/test_dpr_retriever.py
+++ b/test/test_dpr_retriever.py
@@ -1,4 +1,3 @@
-import faiss
 import pytest
 import time
 
@@ -52,51 +51,6 @@ def test_dpr_inmemory_retrieval(document_store):
         assert (abs(docs_with_emb[2].embedding[0] - (-0.24695)) < 0.001)
         assert (abs(docs_with_emb[3].embedding[0] - (-0.08017)) < 0.001)
         assert (abs(docs_with_emb[4].embedding[0] - (-0.01534)) < 0.001)
-    res = retriever.retrieve(query="Which philosopher attacked Schopenhauer?", index="test_dpr")
-    assert res[0].meta["name"] == "1"
-
-    # clean up
-    document_store.delete_all_documents(index="test_dpr")
-
-@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
-def test_dpr_inmemory_retrieval_with_diff_faiss_index_param(document_store):
-
-    documents = [
-        Document(
-            text="""Aaron Aaron ( or ; ""Ahärôn"") is a prophet, high priest, and the brother of Moses in the Abrahamic religions. Knowledge of Aaron, along with his brother Moses, comes exclusively from religious texts, such as the Bible and Quran. The Hebrew Bible relates that, unlike Moses, who grew up in the Egyptian royal court, Aaron and his elder sister Miriam remained with their kinsmen in the eastern border-land of Egypt (Goshen). When Moses first confronted the Egyptian king about the Israelites, Aaron served as his brother's spokesman (""prophet"") to the Pharaoh. Part of the Law (Torah) that Moses received from""",
-            meta={"name": "0"}
-        ),
-        Document(
-            text="""Democratic Republic of the Congo to the south. Angola's capital, Luanda, lies on the Atlantic coast in the northwest of the country. Angola, although located in a tropical zone, has a climate that is not characterized for this region, due to the confluence of three factors: As a result, Angola's climate is characterized by two seasons: rainfall from October to April and drought, known as ""Cacimbo"", from May to August, drier, as the name implies, and with lower temperatures. On the other hand, while the coastline has high rainfall rates, decreasing from North to South and from to , with""",
-        ),
-        Document(
-            text="""Schopenhauer, describing him as an ultimately shallow thinker: ""Schopenhauer has quite a crude mind ... where real depth starts, his comes to an end."" His friend Bertrand Russell had a low opinion on the philosopher, and attacked him in his famous ""History of Western Philosophy"" for hypocritically praising asceticism yet not acting upon it. On the opposite isle of Russell on the foundations of mathematics, the Dutch mathematician L. E. J. Brouwer incorporated the ideas of Kant and Schopenhauer in intuitionism, where mathematics is considered a purely mental activity, instead of an analytic activity wherein objective properties of reality are""",
-            meta={"name": "1"}
-        ),
-        Document(
-            text="""The Dothraki vocabulary was created by David J. Peterson well in advance of the adaptation. HBO hired the Language Creatio""",
-            meta={"name": "2"}
-        ),
-        Document(
-            text="""The title of the episode refers to the Great Sept of Baelor, the main religious building in King's Landing, where the episode's pivotal scene takes place. In the world created by George R. R. Martin""",
-            meta={}
-        )
-    ]
-
-    document_store.delete_all_documents(index="test_dpr")
-    document_store.write_documents(documents, index="test_dpr", index_factory='IVF4,Flat',
-                                   convert_l2_to_ip=True, metric_type=faiss.METRIC_L2, allow_training=True)
-    retriever = DensePassageRetriever(document_store=document_store,
-                                      query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
-                                      passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
-                                      use_gpu=True, embed_title=True,
-                                      remove_sep_tok_from_untitled_passages=True)
-    document_store.update_embeddings(retriever=retriever, index="test_dpr", index_factory='IVF4,Flat',
-                                     convert_l2_to_ip=True, metric_type=faiss.METRIC_L2, allow_training=True)
-    time.sleep(2)
-
-    docs_with_emb = document_store.get_all_documents(index="test_dpr")
-
     res = retriever.retrieve(query="Which philosopher attacked Schopenhauer?", index="test_dpr")
     assert res[0].meta["name"] == "1"
 

--- a/test/test_dpr_retriever.py
+++ b/test/test_dpr_retriever.py
@@ -1,3 +1,4 @@
+import faiss
 import pytest
 import time
 
@@ -51,6 +52,51 @@ def test_dpr_inmemory_retrieval(document_store):
         assert (abs(docs_with_emb[2].embedding[0] - (-0.24695)) < 0.001)
         assert (abs(docs_with_emb[3].embedding[0] - (-0.08017)) < 0.001)
         assert (abs(docs_with_emb[4].embedding[0] - (-0.01534)) < 0.001)
+    res = retriever.retrieve(query="Which philosopher attacked Schopenhauer?", index="test_dpr")
+    assert res[0].meta["name"] == "1"
+
+    # clean up
+    document_store.delete_all_documents(index="test_dpr")
+
+@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
+def test_dpr_inmemory_retrieval_with_diff_faiss_index_param(document_store):
+
+    documents = [
+        Document(
+            text="""Aaron Aaron ( or ; ""Ahärôn"") is a prophet, high priest, and the brother of Moses in the Abrahamic religions. Knowledge of Aaron, along with his brother Moses, comes exclusively from religious texts, such as the Bible and Quran. The Hebrew Bible relates that, unlike Moses, who grew up in the Egyptian royal court, Aaron and his elder sister Miriam remained with their kinsmen in the eastern border-land of Egypt (Goshen). When Moses first confronted the Egyptian king about the Israelites, Aaron served as his brother's spokesman (""prophet"") to the Pharaoh. Part of the Law (Torah) that Moses received from""",
+            meta={"name": "0"}
+        ),
+        Document(
+            text="""Democratic Republic of the Congo to the south. Angola's capital, Luanda, lies on the Atlantic coast in the northwest of the country. Angola, although located in a tropical zone, has a climate that is not characterized for this region, due to the confluence of three factors: As a result, Angola's climate is characterized by two seasons: rainfall from October to April and drought, known as ""Cacimbo"", from May to August, drier, as the name implies, and with lower temperatures. On the other hand, while the coastline has high rainfall rates, decreasing from North to South and from to , with""",
+        ),
+        Document(
+            text="""Schopenhauer, describing him as an ultimately shallow thinker: ""Schopenhauer has quite a crude mind ... where real depth starts, his comes to an end."" His friend Bertrand Russell had a low opinion on the philosopher, and attacked him in his famous ""History of Western Philosophy"" for hypocritically praising asceticism yet not acting upon it. On the opposite isle of Russell on the foundations of mathematics, the Dutch mathematician L. E. J. Brouwer incorporated the ideas of Kant and Schopenhauer in intuitionism, where mathematics is considered a purely mental activity, instead of an analytic activity wherein objective properties of reality are""",
+            meta={"name": "1"}
+        ),
+        Document(
+            text="""The Dothraki vocabulary was created by David J. Peterson well in advance of the adaptation. HBO hired the Language Creatio""",
+            meta={"name": "2"}
+        ),
+        Document(
+            text="""The title of the episode refers to the Great Sept of Baelor, the main religious building in King's Landing, where the episode's pivotal scene takes place. In the world created by George R. R. Martin""",
+            meta={}
+        )
+    ]
+
+    document_store.delete_all_documents(index="test_dpr")
+    document_store.write_documents(documents, index="test_dpr", index_factory='IVF4,Flat',
+                                   convert_l2_to_ip=True, metric_type=faiss.METRIC_L2, allow_training=True)
+    retriever = DensePassageRetriever(document_store=document_store,
+                                      query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
+                                      passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
+                                      use_gpu=True, embed_title=True,
+                                      remove_sep_tok_from_untitled_passages=True)
+    document_store.update_embeddings(retriever=retriever, index="test_dpr", index_factory='IVF4,Flat',
+                                     convert_l2_to_ip=True, metric_type=faiss.METRIC_L2, allow_training=True)
+    time.sleep(2)
+
+    docs_with_emb = document_store.get_all_documents(index="test_dpr")
+
     res = retriever.retrieve(query="Which philosopher attacked Schopenhauer?", index="test_dpr")
     assert res[0].meta["name"] == "1"
 

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -70,7 +70,7 @@ def test_faiss_write_docs(document_store, index_buffer_size, batch_size):
     for i, doc in enumerate(documents_indexed):
         # we currently don't get the embeddings back when we call document_store.get_all_documents()
         original_doc = [d for d in DOCUMENTS if d["text"] == doc.text][0]
-        stored_emb = document_store.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+        stored_emb = document_store.get_faiss_index().reconstruct(int(doc.meta["vector_id"]))
         # compare original input vec with stored one (ignore extra dim added by hnsw)
         assert np.allclose(original_doc["embedding"], stored_emb[:-1], rtol=0.01)
 
@@ -101,7 +101,7 @@ def test_faiss_update_docs(document_store, index_buffer_size):
     for i, doc in enumerate(documents_indexed):
         original_doc = [d for d in DOCUMENTS if d["text"] == doc.text][0]
         updated_embedding = retriever.embed_passages([Document.from_dict(original_doc)])
-        stored_emb = document_store.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+        stored_emb = document_store.get_faiss_index().reconstruct(int(doc.meta["vector_id"]))
         # compare original input vec with stored one (ignore extra dim added by hnsw)
         assert np.allclose(updated_embedding, stored_emb[:-1], rtol=0.01)
 
@@ -131,109 +131,6 @@ def test_faiss_finding(document_store):
     prediction = finder.get_answers_via_similar_questions(question="How to test this?", top_k_retriever=1)
 
     assert len(prediction.get('answers', [])) == 1
-
-
-@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
-def test_faiss_indexing_with_different_params(document_store):
-
-    document_store.write_documents(DOCUMENTS, index_factory='IVF4,Flat',
-                                   convert_l2_to_ip=False, metric_type=faiss.METRIC_L2, allow_training=True)
-    documents_indexed = document_store.get_all_documents()
-
-    # test if number of documents is correct
-    assert len(documents_indexed) == len(DOCUMENTS)
-
-    # test if correct vector_ids are assigned
-    for i, doc in enumerate(documents_indexed):
-        assert doc.meta["vector_id"] == str(i)
-
-    # test insertion of documents in an existing index should pass
-    document_store.write_documents(DOCUMENTS, index_factory='IVF4,Flat',
-                                   convert_l2_to_ip=False, metric_type=faiss.METRIC_L2, allow_training=True)
-    documents_indexed = document_store.get_all_documents()
-
-    # test if number of documents is correct
-    assert len(documents_indexed) == 2 * len(DOCUMENTS)
-
-    # test if correct vector_ids are assigned
-    for i, doc in enumerate(documents_indexed):
-        assert doc.meta["vector_id"] == str(i)
-
-    # test saving the index
-    document_store.save("haystack_test_faiss")
-
-    # test loading the index
-    document_store.load(sql_url="sqlite:///haystack_test.db", faiss_file_path="haystack_test_faiss")
-
-
-def test_faiss_write_docs_with_small_buffer_size():
-    documents = [
-        {"name": "name_1", "text": "text_1", "embedding": np.random.rand(768).astype(np.float32)},
-        {"name": "name_2", "text": "text_2", "embedding": np.random.rand(768).astype(np.float32)},
-        {"name": "name_3", "text": "text_3", "embedding": np.random.rand(768).astype(np.float32)},
-    ]
-
-    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db",
-                                        index_buffer_size=2, index="small_buffer_size")
-    document_store.delete_all_documents()
-    document_store.write_documents(documents)
-    documents_indexed = document_store.get_all_documents()
-
-    # test if number of documents is correct
-    assert len(documents_indexed) == len(documents)
-
-    # test if two docs have same vector_is assigned
-    vector_ids = set()
-    for i, doc in enumerate(documents_indexed):
-        vector_ids.add(doc.meta["vector_id"])
-    assert len(vector_ids) == len(documents)
-
-
-def test_faiss_write_and_update_docs_with_small_buffer_size():
-    documents = [
-        Document(
-            text="""Aaron Aaron ( or ; ""Ahärôn"") is a prophet, high priest, and the brother of Moses in the Abrahamic religions. Knowledge of Aaron, along with his brother Moses, comes exclusively from religious texts, such as the Bible and Quran. The Hebrew Bible relates that, unlike Moses, who grew up in the Egyptian royal court, Aaron and his elder sister Miriam remained with their kinsmen in the eastern border-land of Egypt (Goshen). When Moses first confronted the Egyptian king about the Israelites, Aaron served as his brother's spokesman (""prophet"") to the Pharaoh. Part of the Law (Torah) that Moses received from""",
-            meta={"name": "0"}
-        ),
-        Document(
-            text="""Democratic Republic of the Congo to the south. Angola's capital, Luanda, lies on the Atlantic coast in the northwest of the country. Angola, although located in a tropical zone, has a climate that is not characterized for this region, due to the confluence of three factors: As a result, Angola's climate is characterized by two seasons: rainfall from October to April and drought, known as ""Cacimbo"", from May to August, drier, as the name implies, and with lower temperatures. On the other hand, while the coastline has high rainfall rates, decreasing from North to South and from to , with""",
-        ),
-        Document(
-            text="""Schopenhauer, describing him as an ultimately shallow thinker: ""Schopenhauer has quite a crude mind ... where real depth starts, his comes to an end."" His friend Bertrand Russell had a low opinion on the philosopher, and attacked him in his famous ""History of Western Philosophy"" for hypocritically praising asceticism yet not acting upon it. On the opposite isle of Russell on the foundations of mathematics, the Dutch mathematician L. E. J. Brouwer incorporated the ideas of Kant and Schopenhauer in intuitionism, where mathematics is considered a purely mental activity, instead of an analytic activity wherein objective properties of reality are""",
-            meta={"name": "1"}
-        ),
-        Document(
-            text="""The Dothraki vocabulary was created by David J. Peterson well in advance of the adaptation. HBO hired the Language Creatio""",
-            meta={"name": "2"}
-        ),
-        Document(
-            text="""The title of the episode refers to the Great Sept of Baelor, the main religious building in King's Landing, where the episode's pivotal scene takes place. In the world created by George R. R. Martin""",
-            meta={}
-        )
-    ]
-
-    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db",
-                                        index_buffer_size=2, index="small_buffer_size")
-    document_store.delete_all_documents()
-    document_store.write_documents(documents)
-
-    retriever = DensePassageRetriever(document_store=document_store,
-                                      query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
-                                      passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
-                                      use_gpu=True, embed_title=True,
-                                      remove_sep_tok_from_untitled_passages=True)
-
-    document_store.update_embeddings(retriever=retriever)
-    documents_indexed = document_store.get_all_documents()
-
-    # test if number of documents is correct
-    assert len(documents_indexed) == len(documents)
-
-    # test if two docs have same vector_is assigned
-    vector_ids = set()
-    for i, doc in enumerate(documents_indexed):
-        vector_ids.add(doc.meta["vector_id"])
-    assert len(vector_ids) == len(documents)
 
 
 def test_faiss_passing_index_from_outside():

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -42,16 +42,16 @@ def test_faiss_index_save_and_load(document_store):
     document_store.save("haystack_test_faiss")
 
     # clear existing faiss_index
-    document_store.faiss_index.reset()
+    document_store.get_faiss_index().reset()
 
     # test faiss index is cleared
-    assert document_store.faiss_index.ntotal == 0
+    assert document_store.get_faiss_index().ntotal == 0
 
     # test loading the index
     new_document_store = document_store.load(sql_url="sqlite:///haystack_test.db", faiss_file_path="haystack_test_faiss")
 
     # check faiss index is restored
-    assert new_document_store.faiss_index.ntotal == len(DOCUMENTS)
+    assert new_document_store.get_faiss_index().ntotal == len(DOCUMENTS)
 
 
 @pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
@@ -142,9 +142,9 @@ def test_faiss_passing_index_from_outside(dimension, index_factory, metric_type)
     document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", custom_index_store=index_store,
                                         index="index_from_outside")
 
-    document_store.delete_all_documents()
-    document_store.write_documents(DOCUMENTS)
-    documents_indexed = document_store.get_all_documents()
+    document_store.delete_all_documents(index="index_from_outside")
+    document_store.write_documents(documents=DOCUMENTS, index="index_from_outside")
+    documents_indexed = document_store.get_all_documents(index="index_from_outside")
 
     # test document correctness
     check_data_correctness(documents_indexed, DOCUMENTS)

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -241,7 +241,7 @@ def test_faiss_passing_index_from_outside():
     faiss_index = faiss.index_factory(768, 'IDMap,Flat', faiss.METRIC_L2)
     index_store = FaissIndexStore(faiss_index=faiss_index, convert_l2_to_ip=False)
 
-    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", index_store=index_store,
+    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", custom_index_store=index_store,
                                         index="index_from_outside")
     document_store.delete_all_documents()
     document_store.write_documents(DOCUMENTS)


### PR DESCRIPTION
* Creating FaissIndexStore to abstract out vector transformation capability from FAISSDocumentStore and it will handle FAISS Index operation like add, search or delete embeddings.
* FaissIndexStore will also perform L2 to IP transformation, L2 normalization for IP and perform index training if required.
* Allow user to customize index params like `nlists`, `nbits`, `efSearch` etc instead of using default params. Refer `test_faiss_passing_index_from_outside` function.
* Allow multiple `write_documents` calls to allow user to add more documents to existing storage
* Fix for bug when `index_buffer_size` is smaller than number of documents. #392 
