### PR TITLE
Move retriever probability calculations to document_store

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -212,7 +212,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             _doc["_id"] = str(_doc.pop("id"))
 
             # don't index query score and empty fields
-            _ = _doc.pop("query_score", None)
+            _ = _doc.pop("score", None)
             _ = _doc.pop("probability", None)
             _doc = {k:v for k,v in _doc.items() if v is not None}
 
@@ -426,20 +426,20 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         if name:
             meta_data["name"] = name
 
-        query_score = hit["_score"] if hit["_score"] else None
-        if query_score:
+        score = hit["_score"] if hit["_score"] else None
+        if score:
             if adapt_score_for_embedding:
-                query_score -= 1
-                probability = (query_score + 1) / 2  # scaling probability from cosine similarity
+                score -= 1
+                probability = (score + 1) / 2  # scaling probability from cosine similarity
             else:
-                probability = float(expit(np.asarray(query_score / 8)))  # scaling probability from TFIDF/BM25
+                probability = float(expit(np.asarray(score / 8)))  # scaling probability from TFIDF/BM25
         else:
             probability = None
         document = Document(
             id=hit["_id"],
             text=hit["_source"].get(self.text_field),
             meta=meta_data,
-            query_score=query_score,
+            score=score,
             probability=probability,
             question=hit["_source"].get(self.faq_question_field),
             embedding=hit["_source"].get(self.embedding_field)

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -160,7 +160,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         scores_for_vector_ids: Dict[str, float] = {str(v_id): s for v_id, s in zip(vector_id_matrix[0], score_matrix[0])}
         for doc in documents:
             doc.query_score = scores_for_vector_ids[doc.meta["vector_id"]]  # type: ignore
-
+            doc.probability = (doc.query_score + 1) / 2
         return documents
 
     def save(self, file_path: Union[str, Path]):

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -159,8 +159,8 @@ class FAISSDocumentStore(SQLDocumentStore):
         # assign query score to each document
         scores_for_vector_ids: Dict[str, float] = {str(v_id): s for v_id, s in zip(vector_id_matrix[0], score_matrix[0])}
         for doc in documents:
-            doc.query_score = scores_for_vector_ids[doc.meta["vector_id"]]  # type: ignore
-            doc.probability = (doc.query_score + 1) / 2
+            doc.score = scores_for_vector_ids[doc.meta["vector_id"]]  # type: ignore
+            doc.probability = (doc.score + 1) / 2
         return documents
 
     def save(self, file_path: Union[str, Path]):

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -88,6 +88,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
             doc.query_score = dot(query_emb, doc.embedding) / (
                 norm(query_emb) * norm(doc.embedding)
             )
+            doc.probability = (doc.query_score + 1) / 2
             candidate_docs.append(doc)
 
         return sorted(candidate_docs, key=lambda x: x.query_score, reverse=True)[0:top_k]

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -85,10 +85,10 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
         candidate_docs = []
         for idx, doc in self.indexes[index].items():
-            doc.query_score = dot(query_emb, doc.embedding) / (
+            doc.score = dot(query_emb, doc.embedding) / (
                 norm(query_emb) * norm(doc.embedding)
             )
-            doc.probability = (doc.query_score + 1) / 2
+            doc.probability = (doc.score + 1) / 2
             candidate_docs.append(doc)
 
         return sorted(candidate_docs, key=lambda x: x.query_score, reverse=True)[0:top_k]

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -91,7 +91,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
             doc.probability = (doc.score + 1) / 2
             candidate_docs.append(doc)
 
-        return sorted(candidate_docs, key=lambda x: x.query_score, reverse=True)[0:top_k]
+        return sorted(candidate_docs, key=lambda x: x.score, reverse=True)[0:top_k]
 
     def update_embeddings(self, retriever: BaseRetriever, index: Optional[str] = None):
         """

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -96,7 +96,7 @@ class Finder:
                 "answer": doc.text,
                 "document_id": doc.id,
                 "context": doc.text,
-                "score": doc.query_score,
+                "score": doc.score,
                 "probability": doc.probability,
                 "offset_start": 0,
                 "offset_end": len(doc.text),

--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -4,12 +4,9 @@ from statistics import mean
 from typing import Optional, Dict, Any, List
 from collections import defaultdict
 
-import numpy as np
-from scipy.special import expit
-
 from haystack.reader.base import BaseReader
 from haystack.retriever.base import BaseRetriever
-from haystack import MultiLabel, Document
+from haystack import MultiLabel
 from haystack.eval import calculate_average_precision, eval_counts_reader_batch, calculate_reader_metrics, \
     eval_counts_reader
 
@@ -100,16 +97,12 @@ class Finder:
                 "document_id": doc.id,
                 "context": doc.text,
                 "score": doc.query_score,
+                "probability": doc.probability,
                 "offset_start": 0,
                 "offset_end": len(doc.text),
                 "meta": doc.meta
              }
-            if self.retriever.embedding_model:  # type: ignore
-                probability = (doc.query_score + 1) / 2  # type: ignore
-            else:
-                probability = float(expit(np.asarray(doc.query_score / 8)))  # type: ignore
 
-            cur_answer["probability"] = probability
             results["answers"].append(cur_answer)
 
         return results

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -7,7 +7,7 @@ import numpy as np
 class Document:
     def __init__(self, text: str,
                  id: str = None,
-                 query_score: Optional[float] = None,
+                 score: Optional[float] = None,
                  probability: Optional[float] = None,
                  question: Optional[str] = None,
                  meta: Optional[Dict[str, Any]] = None,
@@ -22,8 +22,8 @@ class Document:
 
         :param id: ID used within the DocumentStore
         :param text: Text of the document
-        :param query_score: Retriever's query score for a retrieved document
-        :param probability: a psuedo probability by scaling query_score in the range 0 to 1
+        :param score: Retriever's query score for a retrieved document
+        :param probability: a psuedo probability by scaling score in the range 0 to 1
         :param question: Question text for FAQs.
         :param meta: Meta fields for a document like name, url, or author.
         :param embedding: Vector encoding of the text
@@ -36,7 +36,7 @@ class Document:
         else:
             self.id = str(uuid4())
 
-        self.query_score = query_score
+        self.score = score
         self.probability = probability
         self.question = question
         self.meta = meta
@@ -53,7 +53,7 @@ class Document:
     @classmethod
     def from_dict(cls, dict, field_map={}):
         _doc = dict.copy()
-        init_args = ["text", "id", "query_score", "probability", "question", "meta", "embedding"]
+        init_args = ["text", "id", "score", "probability", "question", "meta", "embedding"]
         if "meta" not in _doc.keys():
             _doc["meta"] = {}
         # copy additional fields into "meta"

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -8,6 +8,7 @@ class Document:
     def __init__(self, text: str,
                  id: str = None,
                  query_score: Optional[float] = None,
+                 probability: Optional[float] = None,
                  question: Optional[str] = None,
                  meta: Optional[Dict[str, Any]] = None,
                  embedding: Optional[np.array] = None):
@@ -22,6 +23,7 @@ class Document:
         :param id: ID used within the DocumentStore
         :param text: Text of the document
         :param query_score: Retriever's query score for a retrieved document
+        :param probability: a psuedo probability by scaling query_score in the range 0 to 1
         :param question: Question text for FAQs.
         :param meta: Meta fields for a document like name, url, or author.
         :param embedding: Vector encoding of the text
@@ -35,6 +37,7 @@ class Document:
             self.id = str(uuid4())
 
         self.query_score = query_score
+        self.probability = probability
         self.question = question
         self.meta = meta
         self.embedding = embedding
@@ -50,7 +53,7 @@ class Document:
     @classmethod
     def from_dict(cls, dict, field_map={}):
         _doc = dict.copy()
-        init_args = ["text", "id", "query_score", "question", "meta", "embedding"]
+        init_args = ["text", "id", "query_score", "probability", "question", "meta", "embedding"]
         if "meta" not in _doc.keys():
             _doc["meta"] = {}
         # copy additional fields into "meta"


### PR DESCRIPTION
This PR moves the retrieval probability(pseudo probability by scaling query scores) calculations to the respective document stores.

It simplifies the similarity matching method(`get_answers_via_similar_questions()`) in the `Finder`. Additionally, now the retrieved documents have an explicit probability field that could be useful in the future.