### PR TITLE
Exclude embedding fields from the REST API

### DIFF
--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -40,7 +40,7 @@ MAX_SEQ_LEN = int(os.getenv("MAX_SEQ_LEN", 256))
 # Retriever
 RETRIEVER_TYPE = os.getenv("RETRIEVER_TYPE", "ElasticsearchRetriever") # alternatives: 'EmbeddingRetriever', 'ElasticsearchRetriever', 'ElasticsearchFilterOnlyRetriever', None
 DEFAULT_TOP_K_RETRIEVER = int(os.getenv("DEFAULT_TOP_K_RETRIEVER", 10))
-EXCLUDE_META_DATA_FIELDS = os.getenv("EXCLUDE_META_DATA_FIELDS", None)
+EXCLUDE_META_DATA_FIELDS = os.getenv("EXCLUDE_META_DATA_FIELDS", f"['question_emb','embedding']")
 if EXCLUDE_META_DATA_FIELDS:
     EXCLUDE_META_DATA_FIELDS = ast.literal_eval(EXCLUDE_META_DATA_FIELDS)
 EMBEDDING_MODEL_PATH = os.getenv("EMBEDDING_MODEL_PATH", None)

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -102,7 +102,7 @@ FINDERS = {1: Finder(reader=reader, retriever=retriever)}
 #############################################
 class Question(BaseModel):
     questions: List[str]
-    filters: Optional[Dict[str, Optional[str]]] = None
+    filters: Optional[Dict[str, str]] = None
     top_k_reader: int = DEFAULT_TOP_K_READER
     top_k_retriever: int = DEFAULT_TOP_K_RETRIEVER
 
@@ -118,7 +118,7 @@ class Answer(BaseModel):
     offset_start_in_doc: Optional[int]
     offset_end_in_doc: Optional[int]
     document_id: Optional[str] = None
-    meta: Optional[Dict[str, Optional[str]]]
+    meta: Optional[Dict[str, str]]
 
 
 class AnswersToIndividualQuestion(BaseModel):


### PR DESCRIPTION
This PR removes embeddings from the metadata of the returned documents by the `/doc-qa` & `/faq-qa` REST APIs.  This resolves failure in schema validation(#387) of answers and reduces the payload size.