### PR TITLE
Fix document filtering in SQLDocumentStore

### DIFF
--- a/test/test_db.py
+++ b/test/test_db.py
@@ -15,6 +15,28 @@ def test_get_all_documents_without_filters(document_store_with_docs):
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test2", "test3"}
 
 
+def test_get_all_document_filter_duplicate_value(document_store):
+    documents = [
+        Document(
+            text="Doc1",
+            meta={"f1": "0"}
+        ),
+        Document(
+            text="Doc1",
+            meta={"f1": "1", "vector_id": "0"}
+        ),
+        Document(
+            text="Doc2",
+            meta={"f3": "0"}
+        )
+    ]
+    document_store.write_documents(documents)
+    documents = document_store.get_all_documents(filters={"f1": ["1"]})
+    assert documents[0].text == "Doc1"
+    assert len(documents) == 1
+    assert {d.meta["vector_id"] for d in documents} == {"0"}
+
+
 def test_get_all_documents_with_correct_filters(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
     assert len(documents) == 1
@@ -234,12 +256,29 @@ def test_multilabel_no_answer(document_store):
     document_store.delete_all_documents(index="haystack_test_multilabel_no_answer")
 
 
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_elasticsearch_update_meta(document_store_with_docs):
-    document = document_store_with_docs.query(query=None, filters={"name": ["filename1"]})[0]
-    document_store_with_docs.update_document_meta(document.id, meta={"meta_field": "updated_meta"})
-    updated_document = document_store_with_docs.query(query=None, filters={"name": ["filename1"]})[0]
-    assert updated_document.meta["meta_field"] == "updated_meta"
+@pytest.mark.parametrize("document_store", ["elasticsearch", "sql"], indirect=True)
+def test_elasticsearch_update_meta(document_store):
+    documents = [
+        Document(
+            text="Doc1",
+            meta={"vector_id": "1", "meta_key": "1"}
+        ),
+        Document(
+            text="Doc2",
+            meta={"vector_id": "2", "meta_key": "2"}
+        ),
+        Document(
+            text="Doc3",
+            meta={"vector_id": "3", "meta_key": "3"}
+        )
+    ]
+    document_store.write_documents(documents)
+    document_2 = document_store.get_all_documents(filters={"meta_key": ["2"]})[0]
+    document_store.update_document_meta(document_2.id, meta={"vector_id": "99", "meta_key": "2"})
+    updated_document = document_store.get_document_by_id(document_2.id)
+    assert len(updated_document.meta.keys()) == 2
+    assert updated_document.meta["vector_id"] == "99"
+    assert updated_document.meta["meta_key"] == "2"
 
 
 def test_elasticsearch_custom_fields(elasticsearch_fixture):


### PR DESCRIPTION
This PR refactors the SQLDocumentStore table schema. 

- many-to-many mapping table between `document` & `meta` table is removed
- `meta` table now has `document_id` as a foreign key
- filtering of documents by meta data key-value pairs is fixed 
- added more tests for filtering & updating meta data

Resolves #391.