### PR TITLE
fixing ElasticsearchDocumentStore initialisation

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -104,6 +104,10 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
     def _create_document_index(self, index_name):
         if self.client.indices.exists(index=index_name):
+            if self.embedding_field:
+                mapping = self.client.indices.get(index_name)[index_name]["mappings"]
+                mapping["properties"][self.embedding_field] = {"type": "dense_vector", "dims": self.embedding_dim}
+                self.client.indices.put_mapping(index=index_name, body=mapping)
             return
 
         if self.custom_mapping:


### PR DESCRIPTION
By default, Elasticsearch creates an index called document. That's the biggest problem when initializing ElasticsearchDocumentStore through Haystack. Because when calling `_create_document_index`, you may end up doing nothing since `document` index is already created. This is not a problem for non-vector Retriever. 

But Embeddings needs special type "dense_vector" into Elasticsearch mapping definition. That's why it is important to update the default 'document' index in this case.