### PR TITLE
Suggestion for default settings

### DIFF
--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -14,6 +14,7 @@ from haystack.retriever.sparse import logger
 
 from transformers.modeling_dpr import DPRContextEncoder, DPRQuestionEncoder
 from transformers.tokenization_dpr import DPRContextEncoderTokenizer, DPRQuestionEncoderTokenizer
+from sentence_transformers import SentenceTransformer
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ elastic-apm
 tox
 coverage
 langdetect # for PDF conversions
-# optional: sentence-transformers
+sentence-transformers # for sentence_transformers retriever type
 #temporarily (used for DPR downloads)
 wget
 python-multipart


### PR DESCRIPTION
Hello @tholor 

When trying to get sentence_transformers based retriever working using Haystack, I came across a configuration which wasn't well documented : 
- you need to uncomment `sentence-transformers` in the requirements
- you need to add new line in the `retriever/dense.py` code to import it

I would say this **could discourage people trying to make this work**. I understand however, that it consumes way more space to require the `sentence-transformers` to be installed by default.

That's why I quote this PR as a suggestion, not an actual request as such.

Cheers