### PR TITLE
Enable bulk operations on vector IDs for FAISSDocumentStore

### DIFF
--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, func, ForeignKey, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.sql import case
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
@@ -25,6 +26,7 @@ class DocumentORM(ORMBase):
 
     text = Column(String, nullable=False)
     index = Column(String, nullable=False)
+    vector_id = Column(String, unique=True, nullable=True)
 
     meta = relationship("MetaORM", backref="Document")
 
@@ -75,6 +77,16 @@ class SQLDocumentStore(BaseDocumentStore):
 
         return documents
 
+    def get_documents_by_vector_ids(self, vector_ids: List[str], index: Optional[str] = None):
+        index = index or self.index
+        results = self.session.query(DocumentORM).filter(
+            DocumentORM.vector_id.in_(vector_ids),
+            DocumentORM.index == index
+        ).all()
+        sorted_results = sorted(results, key=lambda doc: vector_ids.index(doc.vector_id))  # type: ignore
+        documents = [self._convert_sql_row_to_document(row) for row in sorted_results]
+        return documents
+
     def get_all_documents(
         self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None
     ) -> List[Document]:
@@ -116,8 +128,9 @@ class SQLDocumentStore(BaseDocumentStore):
         index = index or self.index
         for doc in document_objects:
             meta_fields = doc.meta or {}
+            vector_id = meta_fields.get("vector_id")
             meta_orms = [MetaORM(name=key, value=value) for key, value in meta_fields.items()]
-            doc_orm = DocumentORM(id=doc.id, text=doc.text, meta=meta_orms, index=index)
+            doc_orm = DocumentORM(id=doc.id, text=doc.text, vector_id=vector_id, meta=meta_orms, index=index)
             self.session.add(doc_orm)
         self.session.commit()
 
@@ -139,6 +152,19 @@ class SQLDocumentStore(BaseDocumentStore):
                 index=index,
             )
             self.session.add(label_orm)
+        self.session.commit()
+
+    def update_vector_ids(self, vector_id_map: Dict[str, str], index: Optional[str] = None):
+        index = index or self.index
+        self.session.query(DocumentORM).filter(
+            DocumentORM.id.in_(vector_id_map),
+            DocumentORM.index == index
+        ).update({
+            DocumentORM.vector_id: case(
+                vector_id_map,
+                value=DocumentORM.id,
+            )
+        }, synchronize_session=False)
         self.session.commit()
 
     def update_document_meta(self, id: str, meta: Dict[str, str]):
@@ -178,6 +204,8 @@ class SQLDocumentStore(BaseDocumentStore):
             text=row.text,
             meta={meta.name: meta.value for meta in row.meta}
         )
+        if row.vector_id:
+            document.meta["vector_id"] = row.vector_id
         return document
 
     def _convert_sql_row_to_label(self, row) -> Label:

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -155,6 +155,12 @@ class SQLDocumentStore(BaseDocumentStore):
         self.session.commit()
 
     def update_vector_ids(self, vector_id_map: Dict[str, str], index: Optional[str] = None):
+        """
+        Update vector_ids for given document_ids.
+
+        :param vector_id_map: dict containing mapping of document_id -> vector_id.
+        :param index: filter documents by the optional index attribute for documents in database.
+        """
         index = index or self.index
         self.session.query(DocumentORM).filter(
             DocumentORM.id.in_(vector_id_map),
@@ -205,7 +211,7 @@ class SQLDocumentStore(BaseDocumentStore):
             meta={meta.name: meta.value for meta in row.meta}
         )
         if row.vector_id:
-            document.meta["vector_id"] = row.vector_id
+            document.meta["vector_id"] = row.vector_id  # type: ignore
         return document
 
     def _convert_sql_row_to_label(self, row) -> Label:

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -271,24 +271,24 @@ def test_elasticsearch_update_meta(document_store):
     documents = [
         Document(
             text="Doc1",
-            meta={"vector_id": "1", "meta_key": "1"}
+            meta={"meta_key_1": "1", "meta_key_2": "1"}
         ),
         Document(
             text="Doc2",
-            meta={"vector_id": "2", "meta_key": "2"}
+            meta={"meta_key_1": "2", "meta_key_2": "2"}
         ),
         Document(
             text="Doc3",
-            meta={"vector_id": "3", "meta_key": "3"}
+            meta={"meta_key_1": "3", "meta_key_2": "3"}
         )
     ]
     document_store.write_documents(documents)
-    document_2 = document_store.get_all_documents(filters={"meta_key": ["2"]})[0]
-    document_store.update_document_meta(document_2.id, meta={"vector_id": "99", "meta_key": "2"})
+    document_2 = document_store.get_all_documents(filters={"meta_key_2": ["2"]})[0]
+    document_store.update_document_meta(document_2.id, meta={"meta_key_1": "99", "meta_key_2": "2"})
     updated_document = document_store.get_document_by_id(document_2.id)
     assert len(updated_document.meta.keys()) == 2
-    assert updated_document.meta["vector_id"] == "99"
-    assert updated_document.meta["meta_key"] == "2"
+    assert updated_document.meta["meta_key_1"] == "99"
+    assert updated_document.meta["meta_key_2"] == "2"
 
 
 def test_elasticsearch_custom_fields(elasticsearch_fixture):


### PR DESCRIPTION
With this PR, the `SQLDocumentStore` has a new `vector_id` field in the `document` table. 

The `FAISSDocumentStore` now uses the new methods `get_documents_by_vector_ids()` & `update_vector_ids()` to perform bulk read & writes on vector_ids in the `SQLDocumentStore`.

Resolves #383.