### PR TITLE
bug: filters on a query_by_embedding

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -437,14 +437,13 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             }  # type: Dict[str,Any]
 
             if filters:
-                filter_clause = []
                 for key, values in filters.items():
-                    filter_clause.append(
-                        {
-                            "terms": {key: values}
-                        }
-                    )
-                body["query"]["bool"]["filter"] = filter_clause
+                    if type(values) != list:
+                        raise ValueError(f'Wrong filter format for key "{key}": Please provide a list of allowed values for each key. '
+                                         'Example: {"name": ["some", "more"], "category": ["only_one"]} ')
+                body["query"]["script_score"]["query"] = {
+                    "terms": filters
+                }
 
             if self.excluded_meta_data:
                 body["_source"] = {"excludes": self.excluded_meta_data}


### PR DESCRIPTION
For the ElasticSearch's document_store, the filters are not working properly when using the query_by_embedding function.
I fixed the ElasticSearch query.