### PR TITLE
Remove phi normalization from FAISS & support more index types

### DIFF
--- a/docs/document_store.md
+++ b/docs/document_store.md
@@ -359,7 +359,7 @@ the vector embeddings are indexed in a FAISS Index.
 deployment, Postgres is recommended.
 - `index_buffer_size`: When working with large datasets, the ingestion process(FAISS + SQL) can be buffered in
 smaller chunks to reduce memory footprint.
-- `vector_size`: the embedding vector size.
+- `vector_dim`: the dimensionality of the embedding vector .
 - `faiss_index`: load an existing FAISS Index.
 
 <a name="faiss.FAISSDocumentStore.update_embeddings"></a>

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -427,7 +427,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                     "script_score": {
                         "query": {"match_all": {}},
                         "script": {
-                            "source": f"cosineSimilarity(params.query_vector,doc['{self.embedding_field}']) + 1.0",
+                            "source": f"cosineSimilarity(params.query_vector,'{self.embedding_field}') + 1.0",
                             "params": {
                                 "query_vector": query_emb.tolist()
                             }

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -165,6 +165,10 @@ class FAISSDocumentStore(SQLDocumentStore):
             embeddings = np.array(embeddings, dtype="float32")
         self.faiss_index.train(embeddings)
 
+    def delete_all_documents(self, index=None):
+        self.faiss_index.reset()
+        super().delete_all_documents(index=index)
+
     def query_by_embedding(
         self, query_emb: np.array, filters: Optional[dict] = None, top_k: int = 10, index: Optional[str] = None
     ) -> List[Document]:

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -166,6 +166,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         self.faiss_index.train(embeddings)
 
     def delete_all_documents(self, index=None):
+        index = index or self.index
         self.faiss_index.reset()
         super().delete_all_documents(index=index)
 

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -155,7 +155,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             faiss_file_path: Union[str, Path],
             sql_url: str,
             index_buffer_size: int = 10_000,
-            vector_size: int = 768
+            vector_dim: int = 768
     ):
         """
         Load a saved FAISS index from a file and connect to the SQL database.
@@ -165,6 +165,6 @@ class FAISSDocumentStore(SQLDocumentStore):
             faiss_index=faiss_index,
             sql_url=sql_url,
             index_buffer_size=index_buffer_size,
-            vector_size=vector_size
+            vector_dim=vector_dim
         )
 

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -123,6 +123,15 @@ class FAISSDocumentStore(SQLDocumentStore):
                 
         self.update_vector_ids(vector_id_map, index=index)
 
+    def train_index(self, documents: Optional[Union[List[dict], List[Document]]], embeddings: Optional[np.array] = None):
+        if embeddings and documents:
+            raise ValueError("Either pass `documents` or `embeddings`. You passed both.")
+        if documents:
+            document_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
+            embeddings = [doc.embedding for doc in document_objects]
+            embeddings = np.array(embeddings, dtype="float32")
+        self.faiss_index.train(embeddings)
+
     def query_by_embedding(
         self, query_emb: np.array, filters: Optional[dict] = None, top_k: int = 10, index: Optional[str] = None
     ) -> List[Document]:

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -4,7 +4,6 @@ from typing import Union, List, Optional, Dict
 
 import faiss
 import numpy as np
-from faiss.swigfaiss import IndexHNSWFlat
 
 from haystack import Document
 from haystack.document_store.sql import SQLDocumentStore
@@ -30,7 +29,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         index_buffer_size: int = 10_000,
         vector_dim: int = 768,
         faiss_index_factory_str: str = "Flat",
-        faiss_index: Optional[IndexHNSWFlat] = None,
+        faiss_index: Optional[faiss.swigfaiss.Index] = None,
         **kwargs,
     ):
         """

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -43,7 +43,9 @@ class FAISSDocumentStore(SQLDocumentStore):
         """
         self.vector_dim = vector_dim
 
-        if not faiss_index:
+        if faiss_index:
+            self.faiss_index = faiss_index
+        else:
             self.faiss_index = self._create_new_index(vector_dim=self.vector_dim, index_factory=faiss_index_factory_str, **kwargs)
 
         self.index_buffer_size = index_buffer_size

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -66,16 +66,16 @@ class FAISSDocumentStore(SQLDocumentStore):
         self.index_buffer_size = index_buffer_size
         super().__init__(url=sql_url)
 
-    def _create_new_index(self, vector_dim: int, index_factory: str = "Flat", metric=faiss.METRIC_INNER_PRODUCT, **kwargs):
-        if index_factory == "HNSW" and metric == faiss.METRIC_INNER_PRODUCT:
+    def _create_new_index(self, vector_dim: int, index_factory: str = "Flat", metric_type=faiss.METRIC_INNER_PRODUCT, **kwargs):
+        if index_factory == "HNSW" and metric_type == faiss.METRIC_INNER_PRODUCT:
             # faiss index factory doesn't give the same results for HNSW IP, therefore direct init.
             # defaults here are similar to DPR codebase (good accuracy, but very high RAM consumption)
             n_links = kwargs.get("n_links", 256)
-            index = faiss.IndexHNSWFlat(vector_dim, n_links, metric)
+            index = faiss.IndexHNSWFlat(vector_dim, n_links, metric_type)
             index.hnsw.efSearch = kwargs.get("efSearch", 256)
             index.hnsw.efConstruction = kwargs.get("efConstruction", 256)
         else:
-            index = faiss.index_factory(vector_dim, index_factory, metric)
+            index = faiss.index_factory(vector_dim, index_factory, metric_type)
         return index
 
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -28,15 +28,15 @@ class DocumentORM(ORMBase):
     index = Column(String, nullable=False)
     vector_id = Column(String, unique=True, nullable=True)
 
-    meta = relationship("MetaORM", backref="Document")
-
+    # speeds up queries for get_documents_by_vector_ids() by having a single query that returns joined metadata
+    meta = relationship("MetaORM", backref="Document", lazy="joined")
 
 class MetaORM(ORMBase):
     __tablename__ = "meta"
 
     name = Column(String, index=True)
     value = Column(String, index=True)
-    document_id = Column(String, ForeignKey("document.id"), nullable=False)
+    document_id = Column(String, ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
 
     documents = relationship(DocumentORM, backref="Meta")
 
@@ -44,7 +44,7 @@ class MetaORM(ORMBase):
 class LabelORM(ORMBase):
     __tablename__ = "label"
 
-    document_id = Column(String, ForeignKey("document.id"), nullable=False)
+    document_id = Column(String, ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
     index = Column(String, nullable=False)
     no_answer = Column(Boolean, nullable=False)
     origin = Column(String, nullable=False)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,7 +26,11 @@ def elasticsearch_fixture():
     except:
         print("Starting Elasticsearch ...")
         status = subprocess.run(
-            ['docker run -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.9.1'],
+            ['docker rm haystack_test_elastic'],
+            shell=True
+        )
+        status = subprocess.run(
+            ['docker run -d --name haystack_test_elastic -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.9.1'],
             shell=True
         )
         if status.returncode:

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -140,10 +140,10 @@ def test_faiss_passing_index_from_outside():
     document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", faiss_index=faiss_index,
                                         index="index_from_outside")
 
+    document_store.delete_all_documents(index="index_from_outside")
     # as it is a IVF index we need to train it before adding docs
     document_store.train_index(DOCUMENTS)
 
-    document_store.delete_all_documents(index="index_from_outside")
     document_store.write_documents(documents=DOCUMENTS, index="index_from_outside")
     documents_indexed = document_store.get_all_documents(index="index_from_outside")
 

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -137,15 +137,14 @@ def test_faiss_passing_index_from_outside():
     quantizer = faiss.IndexFlatIP(d)
     faiss_index = faiss.IndexIVFFlat(quantizer, d, nlist, faiss.METRIC_INNER_PRODUCT)
     faiss_index.nprobe = 2
-    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", faiss_index=faiss_index,
-                                        index="index_from_outside")
+    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", faiss_index=faiss_index)
 
-    document_store.delete_all_documents(index="index_from_outside")
+    document_store.delete_all_documents(index="document")
     # as it is a IVF index we need to train it before adding docs
     document_store.train_index(DOCUMENTS)
 
-    document_store.write_documents(documents=DOCUMENTS, index="index_from_outside")
-    documents_indexed = document_store.get_all_documents(index="index_from_outside")
+    document_store.write_documents(documents=DOCUMENTS, index="document")
+    documents_indexed = document_store.get_all_documents(index="document")
 
     # test document correctness
     check_data_correctness(documents_indexed, DOCUMENTS)

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -69,7 +69,7 @@ def test_faiss_write_docs(document_store, index_buffer_size, batch_size):
         original_doc = [d for d in DOCUMENTS if d["text"] == doc.text][0]
         stored_emb = document_store.faiss_index.reconstruct(int(doc.meta["vector_id"]))
         # compare original input vec with stored one (ignore extra dim added by hnsw)
-        assert np.allclose(original_doc["embedding"], stored_emb[:-1], rtol=0.01)
+        assert np.allclose(original_doc["embedding"], stored_emb, rtol=0.01)
 
     # test document correctness
     check_data_correctness(documents_indexed, DOCUMENTS)
@@ -100,7 +100,7 @@ def test_faiss_update_docs(document_store, index_buffer_size):
         updated_embedding = retriever.embed_passages([Document.from_dict(original_doc)])
         stored_emb = document_store.faiss_index.reconstruct(int(doc.meta["vector_id"]))
         # compare original input vec with stored one (ignore extra dim added by hnsw)
-        assert np.allclose(updated_embedding, stored_emb[:-1], rtol=0.01)
+        assert np.allclose(updated_embedding, stored_emb, rtol=0.01)
 
     # test document correctness
     check_data_correctness(documents_indexed, DOCUMENTS)


### PR DESCRIPTION
As described in https://github.com/deepset-ai/haystack/pull/422 we don't need the phi normalization trick anymore as HNSW supports the inner product metric. This will simplify the code a lot - especially for multiple subsequent writes of documents. 

- [x] Remove Phi normalization from FaissDocumentStore
- [x] Set good default index type
- [x] Allow custom index types via FAISS index factory
- [x] Allow direct init of HNSW index as initi via faiss index factory gives different results (https://github.com/facebookresearch/faiss/issues/1434)  
- [x] Improve SQL speed by 3x by optimizing joins

#### Breaking changes: 

`vector_size` -> `vector_dim`

Old:
`FAISSDocumentStore(...vector_size=768)`

New: 
`FAISSDocumentStore(...vector_dim=768)`

### Limitations / Future improvements
- There are more potential customizations for FAISS index types that we could make accessible for the end user. Some of them were proposed by @lalitpagaria in #385 . As of now most of them don't seem very relevant and rather blow up complexity, but we should re-evaluate when we did more experiments on diff. index types and models
- Currently we don't expose the metric type to the end user. This would be a simple addition, but at this point I believe limiting it to inner product should be ok.