### PR TITLE
Add deepcopy for meta dicts in answers

### DIFF
--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from copy import deepcopy
 from statistics import mean
 from typing import Optional, Dict, Any, List
 from collections import defaultdict
@@ -69,7 +70,7 @@ class Finder:
             ans["meta"] = {}
             for doc in documents:
                 if doc.id == ans["document_id"]:
-                    ans["meta"] = doc.meta
+                    ans["meta"] = deepcopy(doc.meta)
 
         return results
 


### PR DESCRIPTION
In the Finder, for each answer object, the corresponding document's `meta` is added.  In the case of multiple answers from the same document, the answers' `meta` references to the same dictionary in memory. This could lead to unintended behavior where changes to the `meta` of an answer get propagated to the `meta` of others answers.


