### PR TITLE
Make creation of label index optional

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -101,12 +101,12 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         self.faq_question_field = faq_question_field
 
         self.custom_mapping = custom_mapping
+        self.index: str = index
+        self.label_index: str = label_index
         if create_index:
             self._create_document_index(index)
-        self.index: str = index
+            self._create_label_index(label_index)
 
-        self._create_label_index(label_index)
-        self.label_index: str = label_index
         self.update_existing_documents = update_existing_documents
         self.refresh_type = refresh_type
         if similarity == "cosine":


### PR DESCRIPTION
Currently, we always try to create a label index if it does not exist yet. 
In some deployment scenarios this is not wanted (e.g. when no labels / eval is planned or the elasticsearch cluster is not managed by the user and he/she cannot easily create indices). 

With this PR we can disable all index creation by setting `create_index=False`  when initializting the `ElasticearchDocumentStore`