### PR TITLE
Make filter value optional in REST API

### DIFF
--- a/rest_api/controller/request.py
+++ b/rest_api/controller/request.py
@@ -10,7 +10,7 @@ MAX_RECURSION_DEPTH = sys.getrecursionlimit() - 1
 
 class Question(BaseModel):
     questions: List[str]
-    filters: Optional[Dict[str, str]] = None
+    filters: Optional[Dict[str, Optional[str]]] = None
     top_k_reader: int = DEFAULT_TOP_K_READER
     top_k_retriever: int = DEFAULT_TOP_K_RETRIEVER
 


### PR DESCRIPTION
Let's allow again `null` as filter value (for backward compatibility).

Example: 
``` 
{
    "questions": [
        "Who is the father of Arya?"
    ],
    "filters": {"test":null},
    "top_k_retriever": 2
}

```

Currently, this is failing and causes trouble with older integrations.