### PR TITLE
Add requirement to colab notebooks

### DIFF
--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -30,7 +30,8 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git"
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install urllib3==1.25.4"
    ]
   },
   {

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -25,7 +25,8 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git"
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install urllib3==1.25.4"
    ]
   },
   {

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -25,7 +25,8 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git"
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install urllib3==1.25.4"
    ]
   },
   {

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -33,7 +33,8 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git"
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install urllib3==1.25.4"
    ]
   },
   {

--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -46,7 +46,8 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git"
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install urllib3==1.25.4"
    ]
   },
   {

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -285,7 +285,8 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git"
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install urllib3==1.25.4"
    ]
   },
   {


### PR DESCRIPTION
Fixes #507. 

Google colab environments have preinstalled `urllib3==1.24.3`, but botocore 1.19.0 needs `urllib3<1.26,>=1.25.4`. This PR adds a pip install for `urllib3==1.25.4` on all colab examples.