### PR TITLE
Fix FARMReader.eval( ) handling of no_answers

### DIFF
--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -478,9 +478,6 @@ class FARMReader(BaseReader):
             # Get rid of the question key again (after we aggregated we don't need it anymore)
             d[str(doc_id)]["qas"] = [v for v in aggregated_per_question.values()]
 
-
-
-
         # Convert input format for FARM
         farm_input = [v for v in d.values()]
         n_queries = len([y for x in farm_input for y in x["qas"]])

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -475,12 +475,6 @@ class FARMReader(BaseReader):
                                 "is_impossible": False
                             }
 
-            # for k, dictionary in aggregated_per_question.items():
-            #     if len(dictionary["answers"]) == 0:
-            #         dictionary["is_impossible"] = True
-            #     else:
-            #         dictionary["is_impossible"] = False
-
             # Get rid of the question key again (after we aggregated we don't need it anymore)
             d[str(doc_id)]["qas"] = [v for v in aggregated_per_question.values()]
 


### PR DESCRIPTION
Previously, Reader.eval( ) was generating dictionaries without the "is_impossible" key, which sometimes contained answer lists populated by empty string span answers. e.g.
```
dictionary = {"answers": [empty_string_span_answer], ...}
```
This PR adds the the "is_impossible" key in the dictionary and represents no_answer dictionaries by setting dictionary
```
dictionary = {"answers": [ ], "is_impossible": True, ...}
```
This solves the drop in haystack/test/benchmarks/reader.py performance that is talked about in [this FARM issue](https://github.com/deepset-ai/FARM/commit/9055094e339285bb47b06a49cfb4589c735dc7b4)