### PR TITLE
Allow configuration of log level in REST API

### DIFF
--- a/haystack/finder.py
+++ b/haystack/finder.py
@@ -51,6 +51,8 @@ class Finder:
 
         # 1) Apply retriever(with optional filters) to get fast candidate documents
         documents = self.retriever.retrieve(question, filters=filters, top_k=top_k_retriever, index=index)
+        logger.info(f"Got {len(documents)} candidates from retriever")
+        logger.debug(f"Retrieved document IDs: {[doc.id for doc in documents]}")
 
         if len(documents) == 0:
             logger.info("Retriever did not return any documents. Skipping reader ...")

--- a/haystack/retriever/sparse.py
+++ b/haystack/retriever/sparse.py
@@ -57,8 +57,6 @@ class ElasticsearchRetriever(BaseRetriever):
             index = self.document_store.index
 
         documents = self.document_store.query(query, filters, top_k, self.custom_query, index)
-        logger.info(f"Got {len(documents)} candidates from retriever")
-
         return documents
 
 
@@ -73,8 +71,6 @@ class ElasticsearchFilterOnlyRetriever(ElasticsearchRetriever):
             index = self.document_store.index
         documents = self.document_store.query(query=None, filters=filters, top_k=top_k,
                                               custom_query=self.custom_query, index=index)
-        logger.info(f"Got {len(documents)} candidates from retriever")
-
         return documents
 
 # TODO make Paragraph generic for configurable units of text eg, pages, paragraphs, or split by a char_limit

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-multipart
 python-docx
 sqlalchemy_utils
 # for using FAISS with GPUs, install faiss-gpu
-faiss-cpu; sys_platform != 'win32' and sys_platform != 'cygwin'
+faiss-cpu==1.6.3; sys_platform != 'win32' and sys_platform != 'cygwin'
 tika
 uvloop; sys_platform != 'win32' and sys_platform != 'cygwin'
 httptools

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -59,5 +59,6 @@ if VALID_LANGUAGES:
     VALID_LANGUAGES = ast.literal_eval(VALID_LANGUAGES)
 
 # Monitoring
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 APM_SERVER = os.getenv("APM_SERVER", None)
 APM_SERVICE_NAME = os.getenv("APM_SERVICE_NAME", "haystack-backend")

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -14,7 +14,7 @@ from rest_api.config import DB_HOST, DB_PORT, DB_USER, DB_PW, DB_INDEX, DEFAULT_
     RETRIEVER_TYPE, EMBEDDING_MODEL_PATH, USE_GPU, READER_MODEL_PATH, BATCHSIZE, CONTEXT_WINDOW_SIZE, \
     TOP_K_PER_CANDIDATE, NO_ANS_BOOST, MAX_PROCESSES, MAX_SEQ_LEN, DOC_STRIDE, CONCURRENT_REQUEST_PER_WORKER, \
     FAQ_QUESTION_FIELD_NAME, EMBEDDING_MODEL_FORMAT, READER_TYPE, READER_TOKENIZER, GPU_NUMBER, NAME_FIELD_NAME, \
-    VECTOR_SIMILARITY_METRIC, CREATE_INDEX
+    VECTOR_SIMILARITY_METRIC, CREATE_INDEX, LOG_LEVEL
 
 from rest_api.controller.request import Question
 from rest_api.controller.response import Answers, AnswersToIndividualQuestion
@@ -28,7 +28,9 @@ from haystack.retriever.base import BaseRetriever
 from haystack.retriever.sparse import ElasticsearchRetriever, ElasticsearchFilterOnlyRetriever
 from haystack.retriever.dense import EmbeddingRetriever
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('haystack')
+logger.setLevel(LOG_LEVEL)
+
 router = APIRouter()
 
 # Init global components: DocumentStore, Retriever, Reader, Finder


### PR DESCRIPTION
If you are running the REST API within a docker container and want to debug, you want an easy way to switch the log level from info to debug.

This PR adds an environment variable `LOG_LEVEL` that you can set to the common python log level strings (INFO, DEBUG ...). It will be applied for all loggers within haystack (but not external ones like FARM or elasticsearch)