### PR TITLE
Add support for MySQL database

### DIFF
--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -5,7 +5,6 @@ from sqlalchemy import create_engine, Column, Integer, String, DateTime, func, F
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.sql import case
-from sqlalchemy_utils import UUIDType
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
@@ -17,7 +16,7 @@ Base = declarative_base()  # type: Any
 class ORMBase(Base):
     __abstract__ = True
 
-    id = Column(UUIDType(binary=False), default=lambda: uuid4(), primary_key=True)
+    id = Column(String(100), default=lambda: str(uuid4()), primary_key=True)
     created = Column(DateTime, server_default=func.now())
     updated = Column(DateTime, server_default=func.now(), server_onupdate=func.now())
 
@@ -26,8 +25,8 @@ class DocumentORM(ORMBase):
     __tablename__ = "document"
 
     text = Column(Text, nullable=False)
-    index = Column(String(50), nullable=False)
-    vector_id = Column(String(50), unique=True, nullable=True)
+    index = Column(String(100), nullable=False)
+    vector_id = Column(String(100), unique=True, nullable=True)
 
     # speeds up queries for get_documents_by_vector_ids() by having a single query that returns joined metadata
     meta = relationship("MetaORM", backref="Document", lazy="joined")
@@ -36,9 +35,9 @@ class DocumentORM(ORMBase):
 class MetaORM(ORMBase):
     __tablename__ = "meta"
 
-    name = Column(String(50), index=True)
-    value = Column(String(50), index=True)
-    document_id = Column(UUIDType(binary=False), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
+    name = Column(String(100), index=True)
+    value = Column(String(100), index=True)
+    document_id = Column(String(100), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
 
     documents = relationship(DocumentORM, backref="Meta")
 
@@ -46,10 +45,10 @@ class MetaORM(ORMBase):
 class LabelORM(ORMBase):
     __tablename__ = "label"
 
-    document_id = Column(UUIDType(binary=False), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
-    index = Column(String(50), nullable=False)
+    document_id = Column(String(100), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
+    index = Column(String(100), nullable=False)
     no_answer = Column(Boolean, nullable=False)
-    origin = Column(String(50), nullable=False)
+    origin = Column(String(100), nullable=False)
     question = Column(Text, nullable=False)
     is_correct_answer = Column(Boolean, nullable=False)
     is_correct_document = Column(Boolean, nullable=False)

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -36,7 +36,7 @@ class MetaORM(ORMBase):
     __tablename__ = "meta"
 
     name = Column(String(100), index=True)
-    value = Column(Text, index=True)
+    value = Column(String(1000), index=True)
     document_id = Column(String(100), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
 
     documents = relationship(DocumentORM, backref="Meta")

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, Union, List, Optional
 from uuid import uuid4
 
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, func, ForeignKey, Boolean
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, func, ForeignKey, Boolean, Text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.sql import case
+from sqlalchemy_utils import UUIDType
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
@@ -16,7 +17,7 @@ Base = declarative_base()  # type: Any
 class ORMBase(Base):
     __abstract__ = True
 
-    id = Column(String, default=lambda: str(uuid4()), primary_key=True)
+    id = Column(UUIDType(binary=False), default=lambda: uuid4(), primary_key=True)
     created = Column(DateTime, server_default=func.now())
     updated = Column(DateTime, server_default=func.now(), server_onupdate=func.now())
 
@@ -24,19 +25,20 @@ class ORMBase(Base):
 class DocumentORM(ORMBase):
     __tablename__ = "document"
 
-    text = Column(String, nullable=False)
-    index = Column(String, nullable=False)
-    vector_id = Column(String, unique=True, nullable=True)
+    text = Column(Text, nullable=False)
+    index = Column(String(50), nullable=False)
+    vector_id = Column(String(50), unique=True, nullable=True)
 
     # speeds up queries for get_documents_by_vector_ids() by having a single query that returns joined metadata
     meta = relationship("MetaORM", backref="Document", lazy="joined")
 
+
 class MetaORM(ORMBase):
     __tablename__ = "meta"
 
-    name = Column(String, index=True)
-    value = Column(String, index=True)
-    document_id = Column(String, ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
+    name = Column(String(50), index=True)
+    value = Column(String(50), index=True)
+    document_id = Column(UUIDType(binary=False), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
 
     documents = relationship(DocumentORM, backref="Meta")
 
@@ -44,14 +46,14 @@ class MetaORM(ORMBase):
 class LabelORM(ORMBase):
     __tablename__ = "label"
 
-    document_id = Column(String, ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
-    index = Column(String, nullable=False)
+    document_id = Column(UUIDType(binary=False), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
+    index = Column(String(50), nullable=False)
     no_answer = Column(Boolean, nullable=False)
-    origin = Column(String, nullable=False)
-    question = Column(String, nullable=False)
+    origin = Column(String(50), nullable=False)
+    question = Column(Text, nullable=False)
     is_correct_answer = Column(Boolean, nullable=False)
     is_correct_document = Column(Boolean, nullable=False)
-    answer = Column(String, nullable=False)
+    answer = Column(Text, nullable=False)
     offset_start_in_doc = Column(Integer, nullable=False)
     model_id = Column(Integer, nullable=True)
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -36,7 +36,7 @@ class MetaORM(ORMBase):
     __tablename__ = "meta"
 
     name = Column(String(100), index=True)
-    value = Column(String(100), index=True)
+    value = Column(Text, index=True)
     document_id = Column(String(100), ForeignKey("document.id", ondelete="CASCADE"), nullable=False)
 
     documents = relationship(DocumentORM, backref="Meta")


### PR DESCRIPTION
This PR adds makes the `SQLDocumentStore` more generic to work with MySQL database.

Resolves #543.