### PR TITLE
Update Colab Torch Version

### DIFF
--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -31,7 +31,8 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ]
   },
   {

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -26,7 +26,8 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ]
   },
   {

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -26,7 +26,8 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ]
   },
   {

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -34,7 +34,8 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ]
   },
   {

--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -47,7 +47,8 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ]
   },
   {

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -247,12 +247,12 @@
       "Requirement already satisfied: pyrsistent>=0.14.0 in /home/ubuntu/py3_6/lib/python3.6/site-packages (from jsonschema->flask-restplus->farm==0.4.6->farm-haystack==0.3.0) (0.16.0)\n",
       "Requirement already satisfied: smmap<4,>=3.0.1 in /home/ubuntu/py3_6/lib/python3.6/site-packages (from gitdb<5,>=4.0.1->gitpython>=2.1.0->mlflow==1.0.0->farm==0.4.6->farm-haystack==0.3.0) (3.0.4)\n",
       "Building wheels for collected packages: farm-haystack\n",
-      "  Building wheel for farm-haystack (setup.py) ... \u001B[?25ldone\n",
-      "\u001B[?25h  Created wheel for farm-haystack: filename=farm_haystack-0.3.0-py3-none-any.whl size=99007 sha256=c46bad086db77ddc557d67d6a47b0e8ead6a76c20451e21bd7e56e7b3adf5434\n",
+      "  Building wheel for farm-haystack (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for farm-haystack: filename=farm_haystack-0.3.0-py3-none-any.whl size=99007 sha256=c46bad086db77ddc557d67d6a47b0e8ead6a76c20451e21bd7e56e7b3adf5434\n",
       "  Stored in directory: /tmp/pip-ephem-wheel-cache-s2p1ltpe/wheels/5b/d7/60/7a15bd24f2905dfa70aa762413b9570b9d37add064b151aaf0\n",
       "Successfully built farm-haystack\n",
-      "\u001B[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
-      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001B[0m\n"
+      "\u001b[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
+      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001b[0m\n"
      ]
     },
     {
@@ -262,11 +262,11 @@
       "Looking in links: https://download.pytorch.org/whl/torch_stable.html\n",
       "Collecting torch==1.5.1+cu101\n",
       "  Downloading https://download.pytorch.org/whl/cu101/torch-1.5.1%2Bcu101-cp36-cp36m-linux_x86_64.whl (704.4 MB)\n",
-      "\u001B[K     |████████████████████████████████| 704.4 MB 9.3 kB/s eta 0:00:011\n",
-      "\u001B[?25hCollecting torchvision==0.6.1+cu101\n",
+      "\u001b[K     |████████████████████████████████| 704.4 MB 9.3 kB/s eta 0:00:011\n",
+      "\u001b[?25hCollecting torchvision==0.6.1+cu101\n",
       "  Downloading https://download.pytorch.org/whl/cu101/torchvision-0.6.1%2Bcu101-cp36-cp36m-linux_x86_64.whl (6.6 MB)\n",
-      "\u001B[K     |████████████████████████████████| 6.6 MB 881 kB/s eta 0:00:01\n",
-      "\u001B[?25hRequirement already satisfied: numpy in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torch==1.5.1+cu101) (1.19.0)\n",
+      "\u001b[K     |████████████████████████████████| 6.6 MB 881 kB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: numpy in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torch==1.5.1+cu101) (1.19.0)\n",
       "Requirement already satisfied: future in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torch==1.5.1+cu101) (0.18.2)\n",
       "Requirement already satisfied: pillow>=4.1.1 in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torchvision==0.6.1+cu101) (7.2.0)\n",
       "Installing collected packages: torch, torchvision\n",
@@ -275,8 +275,8 @@
       "    Uninstalling torch-1.5.1:\n",
       "      Successfully uninstalled torch-1.5.1\n",
       "Successfully installed torch-1.5.1+cu101 torchvision-0.6.1+cu101\n",
-      "\u001B[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
-      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001B[0m\n"
+      "\u001b[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
+      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001b[0m\n"
      ]
     }
    ],
@@ -286,7 +286,8 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ]
   },
   {

--- a/tutorials/Tutorial7_RAG_Generator.ipynb
+++ b/tutorials/Tutorial7_RAG_Generator.ipynb
@@ -1,17 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "Tutorial7_RAG_Generator.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
  "cells": [
   {
    "cell_type": "code",
@@ -20,7 +7,8 @@
    },
    "source": [
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
-    "!pip install urllib3==1.25.4"
+    "!pip install urllib3==1.25.4\n",
+    "!pip install torch==1.6.0+cu101 torchvision==0.6.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html\n"
    ],
    "execution_count": null,
    "outputs": []
@@ -191,5 +179,18 @@
    "execution_count": null,
    "outputs": []
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "name": "Tutorial7_RAG_Generator.ipynb",
+   "provenance": [],
+   "collapsed_sections": []
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Google colab updated to Torch 1.7+cu101. However, Haystack requires FARM 0.5.0 which requires Torch>1.5 and Torch<1.7. When Haystack runs in Colab, it uninstalls Torch 1.7+cu101 for Torch 1.5.1 but without the appropriate Cuda version. The added lines here ensure that that Torch1.6+cu101 is installed