### PR TITLE
Fix CI bug due to new Elasticsearch release and new model release

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -380,7 +380,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                     }
                 )
             body["query"]["bool"]["filter"] = filter_clause
-        result = scan(self.client, query=body, index=index)
+        result = list(scan(self.client, query=body, index=index))
 
         return result
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn
 pandas
 sklearn
 psycopg2-binary; sys_platform != 'win32' and sys_platform != 'cygwin'
-elasticsearch
+elasticsearch>=7.7,<7.10
 elastic-apm
 tox
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ gunicorn
 pandas
 sklearn
 psycopg2-binary; sys_platform != 'win32' and sys_platform != 'cygwin'
-elasticsearch>=7.7,<7.10
+elasticsearch>=7.7,<=7.10
 elastic-apm
 tox
 coverage

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -28,7 +28,7 @@ def test_output(prediction):
 def test_no_answer_output(no_answer_prediction):
     assert no_answer_prediction is not None
     assert no_answer_prediction["question"] == "What is the meaning of life?"
-    assert math.isclose(no_answer_prediction["no_ans_gap"], -14.4729533, rel_tol=0.0001)
+    assert math.isclose(no_answer_prediction["no_ans_gap"], -13.048564434051514, rel_tol=0.0001)
     assert no_answer_prediction["answers"][0]["answer"] is None
     assert no_answer_prediction["answers"][0]["offset_start"] == 0
     assert no_answer_prediction["answers"][0]["offset_end"] == 0


### PR DESCRIPTION
Haystack's requirements.txt ask for the latest version of Elasticsearch. A new ES release causes the `elasticsearch.helpers.scan()` function to now return a generator instead of a list. 

This PR casts the output of `scan()` to a list so that CI doesn't fail and restricts ES versioning so new releases won't introduce bugs.

The assert value of a reader test is also changed since the `deepset/roberta-base-squad2 `model was updated to version2. 