### PR TITLE
[RAG] Fix various generator issues

### DIFF
--- a/haystack/generator/transformers.py
+++ b/haystack/generator/transformers.py
@@ -106,6 +106,7 @@ class RAGenerator(BaseGenerator):
 
         if use_gpu and torch.cuda.is_available():
             self.device = torch.device("cuda")
+            raise AttributeError("Currently RAGenerator does not support GPU, try with use_gpu=False")
         else:
             self.device = torch.device("cpu")
 
@@ -158,7 +159,8 @@ class RAGenerator(BaseGenerator):
             truncation=True,
         )
 
-        return contextualized_inputs["input_ids"], contextualized_inputs["attention_mask"]
+        return contextualized_inputs["input_ids"].to(self.device), \
+               contextualized_inputs["attention_mask"].to(self.device)
 
     def _prepare_passage_embeddings(self, docs: List[Document], embeddings: List[Optional[numpy.ndarray]]) -> torch.Tensor:
 
@@ -174,7 +176,7 @@ class RAGenerator(BaseGenerator):
         embeddings_in_tensor = torch.cat(
             [torch.from_numpy(embedding).unsqueeze(0) for embedding in embeddings],
             dim=0
-        )
+        ).to(self.device)
 
         return embeddings_in_tensor
 

--- a/haystack/generator/transformers.py
+++ b/haystack/generator/transformers.py
@@ -90,7 +90,6 @@ class RAGenerator(BaseGenerator):
         """
 
         self.model_name_or_path = model_name_or_path
-        self.top_k_answers = top_k_answers
         self.max_length = max_length
         self.min_length = min_length
         self.generator_type = generator_type
@@ -98,6 +97,12 @@ class RAGenerator(BaseGenerator):
         self.embed_title = embed_title
         self.prefix = prefix
         self.retriever = retriever
+
+        if top_k_answers > self.num_beams:
+            top_k_answers = self.num_beams
+            logger.warning(f'top_k_answers value should not be greater than num_beams, hence setting it to {num_beams}')
+
+        self.top_k_answers = top_k_answers
 
         if use_gpu and torch.cuda.is_available():
             self.device = torch.device("cuda")
@@ -200,6 +205,11 @@ class RAGenerator(BaseGenerator):
             raise AttributeError("generator need documents to predict the answer")
 
         top_k_answers = top_k if top_k is not None else self.top_k_answers
+
+        if top_k_answers > self.num_beams:
+            top_k_answers = self.num_beams
+            logger.warning(f'top_k_answers value should not be greater than num_beams, '
+                           f'hence setting it to {top_k_answers}')
 
         # Flatten the documents so easy to reference
         flat_docs_dict: Dict[str, Any] = {}

--- a/haystack/generator/transformers.py
+++ b/haystack/generator/transformers.py
@@ -153,8 +153,7 @@ class RAGenerator(BaseGenerator):
             truncation=True,
         )
 
-        return contextualized_inputs["input_ids"].to(self.device), \
-               contextualized_inputs["attention_mask"].to(self.device)
+        return contextualized_inputs["input_ids"], contextualized_inputs["attention_mask"]
 
     def _prepare_passage_embeddings(self, docs: List[Document], embeddings: List[Optional[numpy.ndarray]]) -> torch.Tensor:
 
@@ -170,7 +169,7 @@ class RAGenerator(BaseGenerator):
         embeddings_in_tensor = torch.cat(
             [torch.from_numpy(embedding).unsqueeze(0) for embedding in embeddings],
             dim=0
-        ).to(self.device)
+        )
 
         return embeddings_in_tensor
 


### PR DESCRIPTION
Resolve #587 and #585 

for `num_return_sequences` refer.
https://github.com/huggingface/transformers/blob/a1bbcf3f6c20e15fe799a8659d6b7bd36fdf11ed/src/transformers/modeling_rag.py#L852
This should not be greater than `num_beams`  hence when use pass `top_k` value greater than `num_beams` we reset it to `num_beams` and print warning.