### PR TITLE
Add filters for delete_all_documents()

### DIFF
--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -121,6 +121,7 @@ class BaseDocumentStore(ABC):
     def add_eval_data(self, filename: str, doc_index: str = "document", label_index: str = "label"):
         pass
 
-    def delete_all_documents(self, index: str):
+    @abstractmethod
+    def delete_all_documents(self, index: str, filters: Optional[Dict[str, List[str]]] = None):
         pass
 

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -618,7 +618,8 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         """
         Delete documents in an index. All documents are deleted if no filters are passed.
 
-        :param index: index name
+        :param index: Index name to delete the document from.
+        :param filters: Optional filters to narrow down the documents to be deleted.
         :return: None
         """
         query: Dict[str, Any] = {"query": {}}

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -621,7 +621,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         :param index: index name
         :return: None
         """
-        query = {"query": {}}
+        query: Dict[str, Any] = {"query": {}}
         if filters:
             filter_clause = []
             for key, values in filters.items():

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -201,7 +201,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         self.write_documents(docs, index=doc_index)
         self.write_labels(labels, index=label_index)
 
-    def delete_all_documents(self, index: Optional[str] = None):
+    def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """
         Delete all documents in a index.
 
@@ -209,5 +209,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         :return: None
         """
 
+        if filters:
+            raise NotImplementedError("Delete by filters is not implemented for InMemoryDocumentStore.")
         index = index or self.index
         self.indexes[index] = {}

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -203,9 +203,10 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """
-        Delete all documents in a index.
+        Delete documents in an index. All documents are deleted if no filters are passed.
 
-        :param index: index name
+        :param index: Index name to delete the document from.
+        :param filters: Optional filters to narrow down the documents to be deleted.
         :return: None
         """
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -248,7 +248,7 @@ class SQLDocumentStore(BaseDocumentStore):
                                   "Change the query type (e.g. by choosing a different retriever) "
                                   "or change the DocumentStore (e.g. to ElasticsearchDocumentStore)")
 
-    def delete_all_documents(self, index: Optional[str], filters: Optional[Dict[str, List[str]]] = None):
+    def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """
         Delete all documents in a index.
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -250,9 +250,10 @@ class SQLDocumentStore(BaseDocumentStore):
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """
-        Delete all documents in a index.
+        Delete documents in an index. All documents are deleted if no filters are passed.
 
-        :param index: index name
+        :param index: Index name to delete the document from.
+        :param filters: Optional filters to narrow down the documents to be deleted.
         :return: None
         """
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -248,7 +248,7 @@ class SQLDocumentStore(BaseDocumentStore):
                                   "Change the query type (e.g. by choosing a different retriever) "
                                   "or change the DocumentStore (e.g. to ElasticsearchDocumentStore)")
 
-    def delete_all_documents(self, index=None):
+    def delete_all_documents(self, index: Optional[str], filters: Optional[Dict[str, List[str]]] = None):
         """
         Delete all documents in a index.
 
@@ -256,6 +256,8 @@ class SQLDocumentStore(BaseDocumentStore):
         :return: None
         """
 
+        if filters:
+            raise NotImplementedError("Delete by filters is not implemented for SQLDocumentStore.")
         index = index or self.index
         documents = self.session.query(DocumentORM).filter_by(index=index)
         documents.delete(synchronize_session=False)

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -134,6 +134,21 @@ def test_write_document_with_embeddings(document_store):
 
 
 @pytest.mark.elasticsearch
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+def test_delete_documents(document_store_with_docs):
+    assert len(document_store_with_docs.get_all_documents()) == 3
+
+    document_store_with_docs.delete_all_documents(index="haystack-test", filters={"meta_field": ["test1", "test2"]})
+    documents = document_store_with_docs.get_all_documents()
+    assert len(documents) == 1
+    assert documents[0].meta["meta_field"] == "test3"
+
+    document_store_with_docs.delete_all_documents(index="haystack-test")
+    documents = document_store_with_docs.get_all_documents()
+    assert len(documents) == 0
+
+
+@pytest.mark.elasticsearch
 def test_labels(document_store):
     label = Label(
         question="question",

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -138,12 +138,12 @@ def test_write_document_with_embeddings(document_store):
 def test_delete_documents(document_store_with_docs):
     assert len(document_store_with_docs.get_all_documents()) == 3
 
-    document_store_with_docs.delete_all_documents(index="haystack-test", filters={"meta_field": ["test1", "test2"]})
+    document_store_with_docs.delete_all_documents(index="haystack_test", filters={"meta_field": ["test1", "test2"]})
     documents = document_store_with_docs.get_all_documents()
     assert len(documents) == 1
     assert documents[0].meta["meta_field"] == "test3"
 
-    document_store_with_docs.delete_all_documents(index="haystack-test")
+    document_store_with_docs.delete_all_documents(index="haystack_test")
     documents = document_store_with_docs.get_all_documents()
     assert len(documents) == 0
 


### PR DESCRIPTION
This PR adds a filters parameter(similar to `get_all_documents()`) to `delete_all_documents()` for `ElasticsearchDocumentStore`.