### PR TITLE
Make benchmarks clearer

### DIFF
--- a/docs/_src/benchmarks/retriever_map.json
+++ b/docs/_src/benchmarks/retriever_map.json
@@ -15,42 +15,22 @@
    ],
   "data": [
     {
-        "model": "DPR / ElasticSearch",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 1000,
         "map": 0.929
     },
     {
-        "model": "DPR / ElasticSearch",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 10000,
         "map": 0.898
     },
     {
-        "model": "DPR / ElasticSearch",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 100000,
         "map": 0.863
     },
     {
-        "model": "DPR / ElasticSearch",
-        "n_docs": 500000,
-        "map": 0.805
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 1000,
-        "map": 0.929
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 10000,
-        "map": 0.898
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 100000,
-        "map": 0.863
-    },
-    {
-        "model": "DPR / FAISS (flat)",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 500000,
         "map": 0.805
     },


### PR DESCRIPTION
Merge two lines in Retriever Accuracy benchmark graph since their performance is exactly the same