### PR TITLE
Remove column in benchmark website

### DIFF
--- a/docs/_src/benchmarks/retriever_map.json
+++ b/docs/_src/benchmarks/retriever_map.json
@@ -15,42 +15,22 @@
    ],
   "data": [
     {
-        "model": "DPR / ElasticSearch",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 1000,
         "map": 0.929
     },
     {
-        "model": "DPR / ElasticSearch",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 10000,
         "map": 0.898
     },
     {
-        "model": "DPR / ElasticSearch",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 100000,
         "map": 0.863
     },
     {
-        "model": "DPR / ElasticSearch",
-        "n_docs": 500000,
-        "map": 0.805
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 1000,
-        "map": 0.929
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 10000,
-        "map": 0.898
-    },
-    {
-        "model": "DPR / FAISS (flat)",
-        "n_docs": 100000,
-        "map": 0.863
-    },
-    {
-        "model": "DPR / FAISS (flat)",
+        "model": "DPR / ElasticSearch or FAISS (flat)",
         "n_docs": 500000,
         "map": 0.805
     },

--- a/docs/_src/benchmarks/retriever_map.json
+++ b/docs/_src/benchmarks/retriever_map.json
@@ -6,8 +6,7 @@
   "columns": [
     "n_docs",
     "BM25 / ElasticSearch",
-    "DPR / ElasticSearch",
-    "DPR / FAISS (flat)",
+    "DPR / ElasticSearch or FAISS (flat)",
     "DPR / FAISS (HSNW)"
   ],
   "axis": [


### PR DESCRIPTION
An error was being thrown since we had too many columns defined in the chart for retriever mAP. This PR removes it