### PR TITLE
Add return_embedding parameter for get_all_documents()

### DIFF
--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -31,7 +31,12 @@ class BaseDocumentStore(ABC):
         pass
 
     @abstractmethod
-    def get_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> List[Document]:
+    def get_all_documents(
+            self,
+            index: Optional[str] = None,
+            filters: Optional[Dict[str, List[str]]] = None,
+            return_embedding: Optional[bool] = None
+    ) -> List[Document]:
         pass
 
     @abstractmethod

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -37,6 +37,15 @@ class BaseDocumentStore(ABC):
             filters: Optional[Dict[str, List[str]]] = None,
             return_embedding: Optional[bool] = None
     ) -> List[Document]:
+        """
+        Get documents from the document store.
+
+        :param index: Name of the index to get the documents from. If None, the
+                      DocumentStore's default index (self.index) will be used.
+        :param filters: Optional filters to narrow down the documents to return.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
+        :param return_embedding: Whether to return the document embeddings.
+        """
         pass
 
     @abstractmethod

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -351,6 +351,16 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             filters: Optional[Dict[str, List[str]]] = None,
             return_embedding: Optional[bool] = None
     ) -> List[Document]:
+        """
+        Get documents from the document store.
+
+        :param index: Name of the index to get the documents from. If None, the
+                      DocumentStore's default index (self.index) will be used.
+        :param filters: Optional filters to narrow down the documents to return.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
+        :param return_embedding: Whether to return the document embeddings.
+        """
+
         if index is None:
             index = self.index
 

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -44,7 +44,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         refresh_type: str = "wait_for",
         similarity="dot_product",
         timeout=30,
-        return_embedding: Optional[bool] = True,
+        return_embedding: bool = True,
     ):
         """
         A DocumentStore using Elasticsearch to store and query the documents for our search.

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -44,7 +44,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         refresh_type: str = "wait_for",
         similarity="dot_product",
         timeout=30,
-        return_embedding: bool = True,
+        return_embedding: bool = False,
     ):
         """
         A DocumentStore using Elasticsearch to store and query the documents for our search.

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -77,6 +77,8 @@ class FAISSDocumentStore(SQLDocumentStore):
             self.faiss_index = faiss_index
         else:
             self.faiss_index = self._create_new_index(vector_dim=self.vector_dim, index_factory=faiss_index_factory_str, **kwargs)
+            if "ivf" in faiss_index_factory_str.lower():  # enable reconstruction of vectors for inverted index
+                self.faiss_index.set_direct_map_type(faiss.DirectMap.Hashtable)
 
         self.index_buffer_size = index_buffer_size
         self.return_embedding = return_embedding

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -36,7 +36,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         vector_dim: int = 768,
         faiss_index_factory_str: str = "Flat",
         faiss_index: Optional[faiss.swigfaiss.Index] = None,
-        return_embedding: Optional[bool] = True,
+        return_embedding: bool = True,
         update_existing_documents: bool = False,
         index: str = "document",
         **kwargs,

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -189,6 +189,15 @@ class FAISSDocumentStore(SQLDocumentStore):
             filters: Optional[Dict[str, List[str]]] = None,
             return_embedding: Optional[bool] = None
     ) -> List[Document]:
+        """
+        Get documents from the document store.
+
+        :param index: Name of the index to get the documents from. If None, the
+                      DocumentStore's default index (self.index) will be used.
+        :param filters: Optional filters to narrow down the documents to return.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
+        :param return_embedding: Whether to return the document embeddings.
+        """
         documents = super(FAISSDocumentStore, self).get_all_documents(index=index, filters=filters)
         if return_embedding is None:
             return_embedding = self.return_embedding

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -36,7 +36,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         vector_dim: int = 768,
         faiss_index_factory_str: str = "Flat",
         faiss_index: Optional[faiss.swigfaiss.Index] = None,
-        return_embedding: bool = True,
+        return_embedding: bool = False,
         update_existing_documents: bool = False,
         index: str = "document",
         **kwargs,

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -183,6 +183,20 @@ class FAISSDocumentStore(SQLDocumentStore):
                 vector_id += 1
             self.update_vector_ids(vector_id_map, index=index)
 
+    def get_all_documents(
+            self,
+            index: Optional[str] = None,
+            filters: Optional[Dict[str, List[str]]] = None,
+            return_embedding: Optional[bool] = None
+    ) -> List[Document]:
+        documents = super(FAISSDocumentStore, self).get_all_documents(index=index, filters=filters)
+        if return_embedding is None:
+            return_embedding = self.return_embedding
+        if return_embedding:
+            for doc in documents:
+                doc.embedding = self.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+        return documents
+
     def train_index(self, documents: Optional[Union[List[dict], List[Document]]], embeddings: Optional[np.array] = None):
         """
         Some FAISS indices (e.g. IVF) require initial "training" on a sample of vectors before you can add your final vectors.

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -203,7 +203,8 @@ class FAISSDocumentStore(SQLDocumentStore):
             return_embedding = self.return_embedding
         if return_embedding:
             for doc in documents:
-                doc.embedding = self.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+                if doc.meta and doc.meta.get("vector_id") is not None:
+                    doc.embedding = self.faiss_index.reconstruct(int(doc.meta["vector_id"]))
         return documents
 
     def train_index(self, documents: Optional[Union[List[dict], List[Document]]], embeddings: Optional[np.array] = None):

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -243,7 +243,8 @@ class FAISSDocumentStore(SQLDocumentStore):
         if not self.faiss_index:
             raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
 
-        return_embedding = return_embedding or self.return_embedding
+        if return_embedding is None:
+            return_embedding = self.return_embedding
         index = index or self.index
 
         query_emb = query_emb.reshape(1, -1).astype(np.float32)

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -83,7 +83,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
                                       "use a different DocumentStore (e.g. ElasticsearchDocumentStore).")
 
         index = index or self.index
-        return_embedding = return_embedding or self.return_embedding
+        if return_embedding is None:
+            return_embedding = self.return_embedding
 
         if query_emb is None:
             return []
@@ -143,10 +144,22 @@ class InMemoryDocumentStore(BaseDocumentStore):
         index = index or self.label_index
         return len(self.indexes[index].items())
 
-    def get_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> List[Document]:
+    def get_all_documents(
+            self,
+            index: Optional[str] = None,
+            filters: Optional[Dict[str, List[str]]] = None,
+            return_embedding: Optional[bool] = None
+    ) -> List[Document]:
         index = index or self.index
-        documents = list(self.indexes[index].values())
+        documents = deepcopy(list(self.indexes[index].values()))
+
         filtered_documents = []
+
+        if return_embedding is None:
+            return_embedding = self.return_embedding
+        if return_embedding is False:
+            for doc in documents:
+                doc.embedding = None
 
         if filters:
             for doc in documents:

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -150,6 +150,15 @@ class InMemoryDocumentStore(BaseDocumentStore):
             filters: Optional[Dict[str, List[str]]] = None,
             return_embedding: Optional[bool] = None
     ) -> List[Document]:
+        """
+        Get documents from the document store.
+
+        :param index: Name of the index to get the documents from. If None, the
+                      DocumentStore's default index (self.index) will be used.
+        :param filters: Optional filters to narrow down the documents to return.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
+        :param return_embedding: Whether to return the document embeddings.
+        """
         index = index or self.index
         documents = deepcopy(list(self.indexes[index].values()))
 

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -17,7 +17,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         In-memory document store
     """
 
-    def __init__(self, embedding_field: Optional[str] = "embedding", return_embedding: bool = True):
+    def __init__(self, embedding_field: Optional[str] = "embedding", return_embedding: bool = False):
         self.indexes: Dict[str, Dict] = defaultdict(dict)
         self.index: str = "document"
         self.label_index: str = "label"

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -116,6 +116,16 @@ class SQLDocumentStore(BaseDocumentStore):
             filters: Optional[Dict[str, List[str]]] = None,
             return_embedding: Optional[bool] = None
     ) -> List[Document]:
+        """
+        Get documents from the document store.
+
+        :param index: Name of the index to get the documents from. If None, the
+                      DocumentStore's default index (self.index) will be used.
+        :param filters: Optional filters to narrow down the documents to return.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
+        :param return_embedding: Whether to return the document embeddings.
+        """
+
         index = index or self.index
         query = self.session.query(DocumentORM).filter_by(index=index)
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -111,7 +111,10 @@ class SQLDocumentStore(BaseDocumentStore):
         return documents
 
     def get_all_documents(
-        self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None
+            self,
+            index: Optional[str] = None,
+            filters: Optional[Dict[str, List[str]]] = None,
+            return_embedding: Optional[bool] = None
     ) -> List[Document]:
         index = index or self.index
         query = self.session.query(DocumentORM).filter_by(index=index)

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -149,16 +149,22 @@ def test_write_document_index(document_store):
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
-def test_write_document_with_embeddings(document_store):
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+def test_document_with_embeddings(document_store):
     documents = [
         {"text": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
         {"text": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
-        {"text": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
-        {"text": "text4", "id": "4", "embedding": None},
+        {"text": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32)},
+        {"text": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
     document_store.write_documents(documents, index="haystack_test_1")
     assert len(document_store.get_all_documents(index="haystack_test_1")) == 4
+
+    documents_without_embedding = document_store.get_all_documents(index="haystack_test_1", return_embedding=False)
+    assert documents_without_embedding[0].embedding is None
+
+    documents_with_embedding = document_store.get_all_documents(index="haystack_test_1", return_embedding=True)
+    assert isinstance(documents_with_embedding[0].embedding, (list, np.ndarray))
 
 
 @pytest.mark.elasticsearch
@@ -376,3 +382,5 @@ def test_elasticsearch_custom_fields(elasticsearch_fixture):
     assert len(documents) == 1
     assert documents[0].text == "test"
     np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
+
+

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -378,7 +378,7 @@ def test_elasticsearch_custom_fields(elasticsearch_fixture):
 
     doc_to_write = {"custom_text_field": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
     document_store.write_documents([doc_to_write])
-    documents = document_store.get_all_documents()
+    documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 1
     assert documents[0].text == "test"
     np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -154,7 +154,7 @@ def test_document_with_embeddings(document_store):
     documents = [
         {"text": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
         {"text": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
-        {"text": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32)},
+        {"text": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
         {"text": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
     document_store.write_documents(documents, index="haystack_test_1")

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -149,7 +149,7 @@ def test_write_document_index(document_store):
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
 def test_document_with_embeddings(document_store):
     documents = [
         {"text": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
@@ -382,5 +382,3 @@ def test_elasticsearch_custom_fields(elasticsearch_fixture):
     assert len(documents) == 1
     assert documents[0].text == "test"
     np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
-
-

--- a/test/test_dpr_retriever.py
+++ b/test/test_dpr_retriever.py
@@ -3,7 +3,6 @@ import time
 import numpy as np
 
 from haystack import Document
-from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
 from haystack.retriever.dense import DensePassageRetriever
 
 from transformers import DPRContextEncoderTokenizerFast, DPRQuestionEncoderTokenizerFast
@@ -45,8 +44,7 @@ def test_dpr_retrieval(document_store, retriever, return_embedding):
 
     docs_with_emb = document_store.get_all_documents()
 
-    # FAISSDocumentStore doesn't return embeddings, so these tests only work with ElasticsearchDocumentStore
-    if isinstance(document_store, ElasticsearchDocumentStore):
+    if return_embedding is True:
         assert (len(docs_with_emb[0].embedding) == 768)
         assert (abs(docs_with_emb[0].embedding[0] - (-0.3063)) < 0.001)
         assert (abs(docs_with_emb[1].embedding[0] - (-0.3914)) < 0.001)


### PR DESCRIPTION
This PR adds a `return_embedding` parameter for `DocumentStore.get_all_document()` methods. 

Additionally, the default `return_embedding` parameters are set to `False`.