### PR TITLE
Move DPR embeddings from GPU to CPU straight away

### DIFF
--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -157,7 +157,7 @@ class DensePassageRetriever(BaseRetriever):
         data_loader = NamedDataLoader(
             dataset=dataset, sampler=SequentialSampler(dataset), batch_size=self.batch_size, tensor_names=tensor_names
         )
-        all_embeddings = {"query": torch.tensor([]).to(self.device), "passages": torch.tensor([]).to(self.device)}
+        all_embeddings = {"query": [], "passages": []}
         self.model.eval()
         for i, batch in enumerate(tqdm(data_loader, desc=f"Inferencing Samples", unit=" Batches", disable=False)):
             batch = {key: batch[key].to(self.device) for key in batch}

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -165,14 +165,15 @@ class DensePassageRetriever(BaseRetriever):
             # get logits
             with torch.no_grad():
                 query_embeddings, passage_embeddings = self.model.forward(**batch)[0]
-                all_embeddings["query"] = torch.cat((all_embeddings["query"], query_embeddings), dim=0) \
-                                                     if isinstance(query_embeddings, torch.Tensor) else None
-                all_embeddings["passages"] = torch.cat((all_embeddings["passages"], passage_embeddings), dim=0) \
-                                                    if isinstance(passage_embeddings, torch.Tensor) else None
+                if query_embeddings is not None:
+                    all_embeddings["query"].append(query_embeddings.cpu().numpy())
+                if passage_embeddings is not None:
+                    all_embeddings["passages"].append(passage_embeddings.cpu().numpy())
 
-        # convert embeddings to numpy array
-        for k, v in all_embeddings.items():
-            all_embeddings[k] = v.cpu().numpy() if v!=None else None
+        if all_embeddings["passages"]:
+            all_embeddings["passages"] = np.concatenate(all_embeddings["passages"])
+        if all_embeddings["query"]:
+            all_embeddings["query"] = np.concatenate(all_embeddings["query"])
         return all_embeddings
 
     def embed_queries(self, texts: List[str]) -> List[np.array]:


### PR DESCRIPTION
This is an idea brought up by @nliu86 in #602.

DPR._get_predictions() aggregates document and query embeddings as tensors stored on GPU. This is usually fine but can become a large amount of GPU memory overhead when datasets get large. This PR aims to move them from GPU to CPU as early as possible in the pipeline.