### PR TITLE
Using Columns names instead of ORM to get all documents

### DIFF
--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -75,7 +75,7 @@ class SQLDocumentStore(BaseDocumentStore):
         index: str = "document",
         label_index: str = "label",
         update_existing_documents: bool = False,
-        batch_size: int = 999,
+        batch_size: int = 32766,
     ):
         """
         An SQL backed DocumentStore. Currently supports SQLite, PostgreSQL and MySQL backends.
@@ -89,8 +89,9 @@ class SQLDocumentStore(BaseDocumentStore):
                                           If set to False, an error is raised if the document ID of the document being
                                           added already exists. Using this parameter could cause performance degradation
                                           for document insertion.
-        :param batch_size: Maximum number of host parameters in a single SQL statement.
-                           To help in excessive memory allocations.
+        :param batch_size: Maximum the number of variable parameters and rows fetched in a single SQL statement,
+                           to help in excessive memory allocations. Tune this value based on host machine main memory.
+                           For SQLite versions prior to v3.32.0 keep this value less than 1000.
                            More info refer: https://www.sqlite.org/limits.html
         """
         engine = create_engine(url)

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -157,7 +157,7 @@ class SQLDocumentStore(BaseDocumentStore):
             documents_map[row.id] = Document(
                 id=row.id,
                 text=row.text,
-                meta=None if row.vector_id is None else {"vector_id": row.vector_id}
+                meta=None if row.vector_id is None else {"vector_id": row.vector_id} # type: ignore
             )
 
         if len(documents_map) > 0:
@@ -170,7 +170,7 @@ class SQLDocumentStore(BaseDocumentStore):
             for row in meta_query.all():
                 if documents_map[row.document_id].meta is None:
                     documents_map[row.document_id].meta = {}
-                documents_map[row.document_id].meta[row.name] = row.value
+                documents_map[row.document_id].meta[row.name] = row.value # type: ignore
 
         return list(documents_map.values())
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -283,7 +283,7 @@ class SQLDocumentStore(BaseDocumentStore):
         :param index: filter documents by the optional index attribute for documents in database.
         """
         index = index or self.index
-        for chunk_map in self.chunked_iterable(vector_id_map.items(), size=self.batch_size):
+        for chunk_map in self.chunked_dict(vector_id_map, size=self.batch_size):
             self.session.query(DocumentORM).filter(
                 DocumentORM.id.in_(chunk_map),
                 DocumentORM.index == index
@@ -416,3 +416,8 @@ class SQLDocumentStore(BaseDocumentStore):
             if not chunk:
                 break
             yield chunk
+
+    def chunked_dict(self, dictionary, size):
+        it = iter(dictionary)
+        for i in range(0, len(dictionary), size):
+            yield {k: dictionary[k] for k in itertools.islice(it, size)}

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -134,7 +134,14 @@ class SQLDocumentStore(BaseDocumentStore):
         """
 
         index = index or self.index
-        query = self.session.query(DocumentORM).filter_by(index=index)
+        # Generally ORM objects kept in memory cause performance issue
+        # Hence using directly column name improve memory and performance.
+        # Refer https://stackoverflow.com/questions/23185319/why-is-loading-sqlalchemy-objects-via-the-orm-5-8x-slower-than-rows-via-a-raw-my
+        query = self.session.query(
+            DocumentORM.id,
+            DocumentORM.text,
+            DocumentORM.meta
+        ).filter_by(index=index)
 
         if filters:
             query = query.join(MetaORM)

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -42,7 +42,12 @@ class MetaORM(ORMBase):
 
     name = Column(String(100), index=True)
     value = Column(String(1000), index=True)
-    document_id = Column(String(100), ForeignKey("document.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False)
+    document_id = Column(
+        String(100),
+        ForeignKey("document.id", ondelete="CASCADE", onupdate="CASCADE"),
+        nullable=False,
+        index=True
+    )
 
     documents = relationship(DocumentORM, backref="Meta")
 
@@ -69,6 +74,7 @@ class SQLDocumentStore(BaseDocumentStore):
         index: str = "document",
         label_index: str = "label",
         update_existing_documents: bool = False,
+        max_variable_number: int = 999,
     ):
         """
         An SQL backed DocumentStore. Currently supports SQLite, PostgreSQL and MySQL backends.
@@ -80,7 +86,11 @@ class SQLDocumentStore(BaseDocumentStore):
         :param update_existing_documents: Whether to update any existing documents with the same ID when adding
                                           documents. When set as True, any document with an existing ID gets updated.
                                           If set to False, an error is raised if the document ID of the document being
-                                          added already exists. Using this parameter coud cause performance degradation for document insertion. 
+                                          added already exists. Using this parameter could cause performance degradation
+                                          for document insertion.
+        :param max_variable_number: Maximum number of host parameters in a single SQL statement.
+                                    To help in excessive memory allocations.
+                                    More info refer: https://www.sqlite.org/limits.html
         """
         engine = create_engine(url)
         ORMBase.metadata.create_all(engine)
@@ -91,6 +101,7 @@ class SQLDocumentStore(BaseDocumentStore):
         self.update_existing_documents = update_existing_documents
         if getattr(self, "similarity", None) is None:
             self.similarity = None
+        self.max_variable_number = max_variable_number
 
     def get_document_by_id(self, id: str, index: Optional[str] = None) -> Optional[Document]:
         """Fetch a document by specifying its text id string"""
@@ -160,12 +171,12 @@ class SQLDocumentStore(BaseDocumentStore):
                 meta=None if row.vector_id is None else {"vector_id": row.vector_id} # type: ignore
             )
 
-        if len(documents_map) > 0:
+        for i in range(0, len(documents_map), self.max_variable_number):
             meta_query = self.session.query(
                 MetaORM.document_id,
                 MetaORM.name,
                 MetaORM.value
-            ).filter(MetaORM.document_id.in_(documents_map.keys()))
+            ).filter(MetaORM.document_id.in_(documents_map.keys()[i: i + self.max_variable_number]))
 
             for row in meta_query.all():
                 if documents_map[row.document_id].meta is None:

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -89,8 +89,9 @@ class SQLDocumentStore(BaseDocumentStore):
                                           If set to False, an error is raised if the document ID of the document being
                                           added already exists. Using this parameter could cause performance degradation
                                           for document insertion.
-        :param batch_size: Maximum the number of variable parameters and rows fetched in a single SQL statement,
-                           to help in excessive memory allocations. Tune this value based on host machine main memory.
+        :param batch_size: Maximum number of variable parameters and rows fetched in a single SQL statement,
+                           to help in excessive memory allocations. In most methods of the DocumentStore this means number of documents fetched in one query.
+                           Tune this value based on host machine main memory.
                            For SQLite versions prior to v3.32.0 keep this value less than 1000.
                            More info refer: https://www.sqlite.org/limits.html
         """

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -151,7 +151,8 @@ class SQLDocumentStore(BaseDocumentStore):
         documents_query = self.session.query(
             DocumentORM.id,
             DocumentORM.text,
-            DocumentORM.vector_id
+            DocumentORM.vector_id,
+            DocumentORM.meta
         ).filter_by(index=index)
 
         if filters:
@@ -164,23 +165,28 @@ class SQLDocumentStore(BaseDocumentStore):
                 )
 
         documents_map = {}
+        doc_ids_with_meta = []
         for row in documents_query.all():
             documents_map[row.id] = Document(
                 id=row.id,
                 text=row.text,
-                meta=None if row.vector_id is None else {"vector_id": row.vector_id} # type: ignore
+                # Initialise meta if row.meta exist so we don't have to do it in other places
+                meta=None if row.vector_id is None and not row.meta else {}
             )
+            if row.vector_id is not None:
+                documents_map[row.id].meta["vector_id"] = row.vector_id # type: ignore
 
-        for i in range(0, len(documents_map), self.max_variable_number):
+            if row.meta:
+                doc_ids_with_meta.append(row.id)
+
+        for i in range(0, len(doc_ids_with_meta), self.max_variable_number):
             meta_query = self.session.query(
                 MetaORM.document_id,
                 MetaORM.name,
                 MetaORM.value
-            ).filter(MetaORM.document_id.in_(documents_map.keys()[i: i + self.max_variable_number]))
+            ).filter(MetaORM.document_id.in_(doc_ids_with_meta[i: i + self.max_variable_number]))
 
             for row in meta_query.all():
-                if documents_map[row.document_id].meta is None:
-                    documents_map[row.document_id].meta = {}
                 documents_map[row.document_id].meta[row.name] = row.value # type: ignore
 
         return list(documents_map.values())

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -164,8 +164,7 @@ class SQLDocumentStore(BaseDocumentStore):
         documents_query = self.session.query(
             DocumentORM.id,
             DocumentORM.text,
-            DocumentORM.vector_id,
-            DocumentORM.meta
+            DocumentORM.vector_id
         ).filter_by(index=index)
 
         if filters:
@@ -178,28 +177,23 @@ class SQLDocumentStore(BaseDocumentStore):
                 )
 
         documents_map = {}
-        doc_ids_with_meta = []
         for row in documents_query.all():
             documents_map[row.id] = Document(
                 id=row.id,
                 text=row.text,
-                # Initialise meta if row.meta exist so we don't have to do it in other places
-                meta=None if row.vector_id is None and not row.meta else {}
+                meta=None if row.vector_id is None else {"vector_id": row.vector_id} # type: ignore
             )
-            if row.vector_id is not None:
-                documents_map[row.id].meta["vector_id"] = row.vector_id # type: ignore
 
-            if row.meta:
-                doc_ids_with_meta.append(row.id)
-
-        for i in range(0, len(doc_ids_with_meta), self.batch_size):
+        for doc_ids in self.chunked_iterable(documents_map.keys(), size=self.batch_size):
             meta_query = self.session.query(
                 MetaORM.document_id,
                 MetaORM.name,
                 MetaORM.value
-            ).filter(MetaORM.document_id.in_(doc_ids_with_meta[i: i + self.batch_size]))
+            ).filter(MetaORM.document_id.in_(doc_ids))
 
             for row in meta_query.all():
+                if documents_map[row.document_id].meta is None:
+                    documents_map[row.document_id].meta = {}
                 documents_map[row.document_id].meta[row.name] = row.value # type: ignore
 
         return list(documents_map.values())

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -408,7 +408,7 @@ class SQLDocumentStore(BaseDocumentStore):
             session.commit()
             return instance
 
-    # Refer https://alexwlchan.net/2018/12/iterating-in-fixed-size-chunks/
+    # Refer: https://alexwlchan.net/2018/12/iterating-in-fixed-size-chunks/
     def chunked_iterable(self, iterable, size):
         it = iter(iterable)
         while True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-multipart
 python-docx
 sqlalchemy_utils
 # for using FAISS with GPUs, install faiss-gpu
-faiss-cpu==1.6.5; sys_platform != 'win32' and sys_platform != 'cygwin'
+faiss-cpu==1.6.3; sys_platform != 'win32' and sys_platform != 'cygwin'
 tika
 uvloop; sys_platform != 'win32' and sys_platform != 'cygwin'
 httptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-multipart
 python-docx
 sqlalchemy_utils
 # for using FAISS with GPUs, install faiss-gpu
-faiss-cpu==1.6.3; sys_platform != 'win32' and sys_platform != 'cygwin'
+faiss-cpu==1.6.5; sys_platform != 'win32' and sys_platform != 'cygwin'
 tika
 uvloop; sys_platform != 'win32' and sys_platform != 'cygwin'
 httptools


### PR DESCRIPTION
To improve #601 

Generally ORM objects kept in memory cause performance issue
Hence using directly column name improve memory and performance.
Refer [StackOverflow](https://stackoverflow.com/questions/23185319/why-is-loading-sqlalchemy-objects-via-the-orm-5-8x-slower-than-rows-via-a-raw-my)