### PR TITLE
README: Fix link to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Haystack is an end-to-end framework for Question Answering & Neural search that 
 | :eyes: [Quick Tour](https://github.com/deepset-ai/haystack/#quick-tour) | Basic explanation of concepts, options and usage |
 | :mortar_board: [Tutorials](https://github.com/deepset-ai/haystack/#tutorials) | Jupyter/Colab Notebooks & Scripts |
 | :bar_chart: [Benchmarks](https://haystack.deepset.ai/bm/benchmarks) | Speed & Accuracy of Retriever, Readers and DocumentStores |
-| :telescope: [Roadmap](https://haystack.deepset.ai/en/docs/roadmapmd) | Public roadmap of Haystack |
+| :telescope: [Roadmap](https://haystack.deepset.ai/docs/latest/roadmapmd) | Public roadmap of Haystack |
 | :heart: [Contributing](https://github.com/deepset-ai/haystack/#heart-contributing) | We welcome all contributions! |
 
 ## Core Features


### PR DESCRIPTION
Just give a small fix to Roadmap in the home page.

My editor (geany) clears out all leading spaces hope that's fine ;)