### PR TITLE
Add link to FAISS Info in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ We recommend Elasticsearch or FAISS, but have also more light-weight options for
 
 
 ## Quick Tour
-[File Conversion](https://github.com/deepset-ai/haystack/blob/master/README.md#1-file-conversion) | [Preprocessing](https://github.com/deepset-ai/haystack/blob/master/README.md#2-preprocessing) | [DocumentStores](https://github.com/deepset-ai/haystack/blob/master/README.md#3-documentstores) | [Retrievers](https://github.com/deepset-ai/haystack/blob/master/README.md#5-retrievers) | [Readers](https://github.com/deepset-ai/haystack/blob/master/README.md#5-readers) | [REST API](https://github.com/deepset-ai/haystack/blob/master/README.md#6-rest-api) |  [Labeling Tool](https://github.com/deepset-ai/haystack/blob/master/README.md#7-labeling-tool) 
+[File Conversion](https://github.com/deepset-ai/haystack/blob/master/README.md#1-file-conversion) | [Preprocessing](https://github.com/deepset-ai/haystack/blob/master/README.md#2-preprocessing) | [DocumentStores](https://github.com/deepset-ai/haystack/blob/master/README.md#3-documentstores) | [Retrievers](https://github.com/deepset-ai/haystack/blob/master/README.md#4-retrievers) | [Readers](https://github.com/deepset-ai/haystack/blob/master/README.md#5-readers) | [REST API](https://github.com/deepset-ai/haystack/blob/master/README.md#6-rest-api) |  [Labeling Tool](https://github.com/deepset-ai/haystack/blob/master/README.md#7-labeling-tool) 
 
 ### 1) File Conversion
 **What**  

--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -100,12 +100,15 @@ FAISS is a library for efficient similarity search on a cluster of dense vectors
 The `FAISSDocumentStore` uses a SQL(SQLite in-memory be default) database under-the-hood
 to store the document text and other meta data. The vector embeddings of the text are
 indexed on a FAISS Index that later is queried for searching answers.
+The default flavour of FAISSDocumentStore is "Flat" but can also be set to "HNSW" for
+faster search at the expense of some accuracy. Just set the faiss_index_factor_str argument in the constructor.
+For more info on which suits your use case: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
 
 
 ```python
 from haystack.document_store.faiss import FAISSDocumentStore
 
-document_store = FAISSDocumentStore()
+document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
 ```
 
 ### Cleaning & indexing documents

--- a/docs/_src/usage/usage/document_store.md
+++ b/docs/_src/usage/usage/document_store.md
@@ -154,7 +154,7 @@ The Document Stores have different characteristics. You should choose one depend
 **Pros:** 
 - Fast & accurate dense retrieval
 - Highly scalable due to approximate nearest neighbour algorithms (ANN)
-- Many options to tune dense retrieval via different index types ([link](https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index))
+- Many options to tune dense retrieval via different index types (more info [here](https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index))
 
 **Cons:**
 - No efficient sparse retrieval

--- a/docs/_src/usage/usage/document_store.md
+++ b/docs/_src/usage/usage/document_store.md
@@ -40,7 +40,7 @@ document_store = ElasticsearchDocumentStore()
 <div class="tabcontent">
 
 ```python
-document_store = FAISSDocumentStore()
+document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
 ```
 
 </div>
@@ -154,7 +154,7 @@ The Document Stores have different characteristics. You should choose one depend
 **Pros:** 
 - Fast & accurate dense retrieval
 - Highly scalable due to approximate nearest neighbour algorithms (ANN)
-- Many options to tune dense retrieval via different index types 
+- Many options to tune dense retrieval via different index types ([link](https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index))
 
 **Cons:**
 - No efficient sparse retrieval

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -247,12 +247,12 @@
       "Requirement already satisfied: pyrsistent>=0.14.0 in /home/ubuntu/py3_6/lib/python3.6/site-packages (from jsonschema->flask-restplus->farm==0.4.6->farm-haystack==0.3.0) (0.16.0)\n",
       "Requirement already satisfied: smmap<4,>=3.0.1 in /home/ubuntu/py3_6/lib/python3.6/site-packages (from gitdb<5,>=4.0.1->gitpython>=2.1.0->mlflow==1.0.0->farm==0.4.6->farm-haystack==0.3.0) (3.0.4)\n",
       "Building wheels for collected packages: farm-haystack\n",
-      "  Building wheel for farm-haystack (setup.py) ... \u001b[?25ldone\n",
-      "\u001b[?25h  Created wheel for farm-haystack: filename=farm_haystack-0.3.0-py3-none-any.whl size=99007 sha256=c46bad086db77ddc557d67d6a47b0e8ead6a76c20451e21bd7e56e7b3adf5434\n",
+      "  Building wheel for farm-haystack (setup.py) ... \u001B[?25ldone\n",
+      "\u001B[?25h  Created wheel for farm-haystack: filename=farm_haystack-0.3.0-py3-none-any.whl size=99007 sha256=c46bad086db77ddc557d67d6a47b0e8ead6a76c20451e21bd7e56e7b3adf5434\n",
       "  Stored in directory: /tmp/pip-ephem-wheel-cache-s2p1ltpe/wheels/5b/d7/60/7a15bd24f2905dfa70aa762413b9570b9d37add064b151aaf0\n",
       "Successfully built farm-haystack\n",
-      "\u001b[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
-      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001b[0m\n"
+      "\u001B[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
+      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001B[0m\n"
      ]
     },
     {
@@ -262,11 +262,11 @@
       "Looking in links: https://download.pytorch.org/whl/torch_stable.html\n",
       "Collecting torch==1.5.1+cu101\n",
       "  Downloading https://download.pytorch.org/whl/cu101/torch-1.5.1%2Bcu101-cp36-cp36m-linux_x86_64.whl (704.4 MB)\n",
-      "\u001b[K     |████████████████████████████████| 704.4 MB 9.3 kB/s eta 0:00:011\n",
-      "\u001b[?25hCollecting torchvision==0.6.1+cu101\n",
+      "\u001B[K     |████████████████████████████████| 704.4 MB 9.3 kB/s eta 0:00:011\n",
+      "\u001B[?25hCollecting torchvision==0.6.1+cu101\n",
       "  Downloading https://download.pytorch.org/whl/cu101/torchvision-0.6.1%2Bcu101-cp36-cp36m-linux_x86_64.whl (6.6 MB)\n",
-      "\u001b[K     |████████████████████████████████| 6.6 MB 881 kB/s eta 0:00:01\n",
-      "\u001b[?25hRequirement already satisfied: numpy in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torch==1.5.1+cu101) (1.19.0)\n",
+      "\u001B[K     |████████████████████████████████| 6.6 MB 881 kB/s eta 0:00:01\n",
+      "\u001B[?25hRequirement already satisfied: numpy in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torch==1.5.1+cu101) (1.19.0)\n",
       "Requirement already satisfied: future in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torch==1.5.1+cu101) (0.18.2)\n",
       "Requirement already satisfied: pillow>=4.1.1 in /home/ubuntu/py3_6/lib/python3.6/site-packages (from torchvision==0.6.1+cu101) (7.2.0)\n",
       "Installing collected packages: torch, torchvision\n",
@@ -275,8 +275,8 @@
       "    Uninstalling torch-1.5.1:\n",
       "      Successfully uninstalled torch-1.5.1\n",
       "Successfully installed torch-1.5.1+cu101 torchvision-0.6.1+cu101\n",
-      "\u001b[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
-      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001b[0m\n"
+      "\u001B[33mWARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.\n",
+      "You should consider upgrading via the '/home/ubuntu/py3_6/bin/python3.6 -m pip install --upgrade pip' command.\u001B[0m\n"
      ]
     }
    ],
@@ -320,7 +320,10 @@
     "FAISS is a library for efficient similarity search on a cluster of dense vectors.\n",
     "The `FAISSDocumentStore` uses a SQL(SQLite in-memory be default) database under-the-hood\n",
     "to store the document text and other meta data. The vector embeddings of the text are\n",
-    "indexed on a FAISS Index that later is queried for searching answers."
+    "indexed on a FAISS Index that later is queried for searching answers.\n",
+    "The default flavour of FAISSDocumentStore is \"Flat\" but can also be set to \"HNSW\" for\n",
+    "faster search at the expense of some accuracy. Just set the faiss_index_factor_str argument in the constructor.\n",
+    "For more info on which suits your use case: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index"
    ]
   },
   {
@@ -351,7 +354,7 @@
    "source": [
     "from haystack.document_store.faiss import FAISSDocumentStore\n",
     "\n",
-    "document_store = FAISSDocumentStore()"
+    "document_store = FAISSDocumentStore(faiss_index_factory_str=\"Flat\")"
    ]
   },
   {

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -11,7 +11,10 @@ from haystack.retriever.dense import DensePassageRetriever
 # The FAISSDocumentStore uses a SQL(SQLite in-memory be default) document store under-the-hood
 # to store the document text and other meta data. The vector embeddings of the text are
 # indexed on a FAISS Index that later is queried for searching answers.
-document_store = FAISSDocumentStore()
+# The default flavour of FAISSDocumentStore is "Flat" but can also be set to "HNSW" for
+# faster search at the expense of some accuracy. Just set the faiss_index_factor_str argument in the constructor.
+# For more info on which suits your use case: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
+document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
 
 # ## Preprocessing of documents
 # Let's first get some documents that we want to query


### PR DESCRIPTION
Brought up in #634 

This PR makes it clearer how to pick a different flavor of FAISSDocumentStore (e.g. Flat vs HNSW). More information is now given in the tutorials and also on the website documentation.