### PR TITLE
Scale dot product into probabilities

### DIFF
--- a/docs/_src/usage/usage/retriever.md
+++ b/docs/_src/usage/usage/retriever.md
@@ -127,6 +127,8 @@ DPR can also work with the ElasticsearchDocumentStore or the InMemoryDocumentSto
 **Tip**
 
 When using DPR, it is recommended that you use the dot product similarity function since that is how it is trained.
+To do so, simply provide `similarity="dot_product"` when initializing the DocumentStore 
+as is done in the code example below.
 
 </div>
 
@@ -144,7 +146,7 @@ If you’d like to learn how to set up a DPR based system, have a look at our tu
 ### Initialisation
 
 ```python
-document_store = FAISSDocumentStore()
+document_store = FAISSDocumentStore(similarity="dot_product")
 ...
 retriever = DensePassageRetriever(
     document_store=document_store,
@@ -173,7 +175,9 @@ This is not inherently suited to query based search where the length, language a
 
 **Tip**
 
-When using Sentence Transformer models, we recommend that you use a cosine similarity function.
+When using Sentence Transformer models, we recommend that you use a cosine similarity function. 
+To do so, simply provide `similarity="cosine"` when initializing the DocumentStore 
+as is done in the code example below.
 
 </div>
 

--- a/docs/_src/usage/usage/retriever.md
+++ b/docs/_src/usage/usage/retriever.md
@@ -121,6 +121,7 @@ Key features:
 Indexing using DPR is comparatively expensive in terms of required computation since all documents in the database need to be processed through the transformer.
 The embeddings that are created in this step can be stored in FAISS, a database optimized for vector similarity.
 DPR can also work with the ElasticsearchDocumentStore or the InMemoryDocumentStore.
+When using DPR, it is recommended that you use the dot product similarity function since that is how it is trained.
 
 There are two design decisions that have made DPR particularly performant.
 
@@ -160,11 +161,12 @@ These models are trained in Siamese Networks and use triplet loss such that they
 They are particular suited to cases where your query input is similar in style to that of the documents in your database
 i.e. when you are searching for most similar documents.
 This is not inherently suited to query based search where the length, language and format of the query usually significantly differs from the searched for text.
+When using them, we recommend that you use a cosine similarity function.
 
 ### Initialisation
 
 ```python
-document_store = ElasticsearchDocumentStore()
+document_store = ElasticsearchDocumentStore(similarity="cosine")
 ...
 retriever = EmbeddingRetriever(document_store=document_store,
                                embedding_model="deepset/sentence_bert")

--- a/docs/_src/usage/usage/retriever.md
+++ b/docs/_src/usage/usage/retriever.md
@@ -121,7 +121,14 @@ Key features:
 Indexing using DPR is comparatively expensive in terms of required computation since all documents in the database need to be processed through the transformer.
 The embeddings that are created in this step can be stored in FAISS, a database optimized for vector similarity.
 DPR can also work with the ElasticsearchDocumentStore or the InMemoryDocumentStore.
+
+<div class="recommendation">
+
+**Tip**
+
 When using DPR, it is recommended that you use the dot product similarity function since that is how it is trained.
+
+</div>
 
 There are two design decisions that have made DPR particularly performant.
 
@@ -161,7 +168,14 @@ These models are trained in Siamese Networks and use triplet loss such that they
 They are particular suited to cases where your query input is similar in style to that of the documents in your database
 i.e. when you are searching for most similar documents.
 This is not inherently suited to query based search where the length, language and format of the query usually significantly differs from the searched for text.
-When using them, we recommend that you use a cosine similarity function.
+
+<div class="recommendation">
+
+**Tip**
+
+When using Sentence Transformer models, we recommend that you use a cosine similarity function.
+
+</div>
 
 ### Initialisation
 

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -12,6 +12,7 @@ class BaseDocumentStore(ABC):
     """
     index: Optional[str]
     label_index: Optional[str]
+    similarity: Optional[str]
 
     @abstractmethod
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -117,6 +117,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
         self.update_existing_documents = update_existing_documents
         self.refresh_type = refresh_type
+        self.similarity = similarity
         if similarity == "cosine":
             self.similarity_fn_name = "cosineSimilarity"
         elif similarity == "dot_product":
@@ -596,9 +597,9 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         if score:
             if adapt_score_for_embedding:
                 score -= 1000
-                if self.similarity_fn_name == "cosineSimilarity":
+                if self.similarity == "cosine":
                     probability = (score + 1) / 2  # scaling probability from cosine similarity
-                elif self.similarity_fn_name == "dotProduct":
+                elif self.similarity == "dot_product":
                     probability = float(expit(np.asarray(score / 100)))  # scaling probability from dot product
             else:
                 probability = float(expit(np.asarray(score / 8)))  # scaling probability from TFIDF/BM25

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -596,7 +596,10 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         if score:
             if adapt_score_for_embedding:
                 score -= 1000
-                probability = (score + 1) / 2  # scaling probability from cosine similarity
+                if self.similarity_fn_name == "cosineSimilarity":
+                    probability = (score + 1) / 2  # scaling probability from cosine similarity
+                elif self.similarity_fn_name == "dotProduct":
+                    probability = float(expit(np.asarray(score / 100)))  # scaling probability from dot product
             else:
                 probability = float(expit(np.asarray(score / 8)))  # scaling probability from TFIDF/BM25
         else:

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -127,11 +127,9 @@ class FAISSDocumentStore(SQLDocumentStore):
         document_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
 
         def move_embeds(do, embedding_field):
-            try:
+            if embedding_field in do.meta:
                 do.embedding = do.meta[embedding_field]
                 del do.meta[embedding_field]
-            except:
-                pass
             return do
 
         document_objects = [move_embeds(do, self.index) for do in document_objects]

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -47,8 +47,11 @@ class InMemoryDocumentStore(BaseDocumentStore):
         documents_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
 
         def move_embeds(do, embedding_field):
-            do.embedding = do.meta[embedding_field]
-            del do.meta[embedding_field]
+            try:
+                do.embedding = do.meta[embedding_field]
+                del do.meta[embedding_field]
+            except:
+                pass
             return do
 
         documents_objects = [move_embeds(do, self.embedding_field) for do in documents_objects]

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -17,13 +17,14 @@ class InMemoryDocumentStore(BaseDocumentStore):
         In-memory document store
     """
 
-    def __init__(self, embedding_field: Optional[str] = "embedding", return_embedding: bool = False):
+    def __init__(self, embedding_field: Optional[str] = "embedding", return_embedding: bool = False, similarity="dot_product"):
         self.indexes: Dict[str, Dict] = defaultdict(dict)
         self.index: str = "document"
         self.label_index: str = "label"
         self.embedding_field: str = embedding_field if embedding_field is not None else "embedding"
         self.embedding_dim: int = 768
         self.return_embedding: bool = return_embedding
+        self.similarity: str = similarity
 
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):
         """
@@ -115,6 +116,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
             score = dot(query_emb, doc.embedding) / (
                 norm(query_emb) * norm(doc.embedding)
             )
+
             new_document.score = score
             new_document.probability = (score + 1) / 2
 

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -44,18 +44,16 @@ class InMemoryDocumentStore(BaseDocumentStore):
         """
         index = index or self.index
 
-        documents_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
-
-        def move_embeds(do, embedding_field):
-            if embedding_field in do.meta:
-                do.embedding = do.meta[embedding_field]
-                del do.meta[embedding_field]
-            return do
-
-        documents_objects = [move_embeds(do, self.embedding_field) for do in documents_objects]
+        field_map = self._create_document_field_map()
+        documents_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
 
         for document in documents_objects:
             self.indexes[index][document.id] = document
+
+    def _create_document_field_map(self):
+        return {
+            self.embedding_field: "embedding",
+        }
 
     def write_labels(self, labels: Union[List[dict], List[Label]], index: Optional[str] = None):
         """Write annotation labels into document store."""

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -47,11 +47,9 @@ class InMemoryDocumentStore(BaseDocumentStore):
         documents_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
 
         def move_embeds(do, embedding_field):
-            try:
+            if embedding_field in do.meta:
                 do.embedding = do.meta[embedding_field]
                 del do.meta[embedding_field]
-            except:
-                pass
             return do
 
         documents_objects = [move_embeds(do, self.embedding_field) for do in documents_objects]

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -87,6 +87,8 @@ class SQLDocumentStore(BaseDocumentStore):
         self.index = index
         self.label_index = label_index
         self.update_existing_documents = update_existing_documents
+        if getattr(self, "similarity", None) is None:
+            self.similarity = None
 
     def get_document_by_id(self, id: str, index: Optional[str] = None) -> Optional[Document]:
         """Fetch a document by specifying its text id string"""

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -408,12 +408,12 @@ class EmbeddingRetriever(BaseRetriever):
             # Check that document_store has the right similarity function
             similarity = document_store.similarity
             # If we are using a sentence transformer model
-            if "sentence" in embedding_model.lower() and similarity != "cosineSimilarity":
+            if "sentence" in embedding_model.lower() and similarity != "cosine":
                 logger.warning(f"You seem to be using a Sentence Transformer with the {similarity} function. "
-                               f"We recommend using cosineSimilarity instead")
-            elif "dpr" in embedding_model.lower() and similarity != "dotProduct":
+                               f"We recommend using cosine instead")
+            elif "dpr" in embedding_model.lower() and similarity != "dot_product":
                 logger.warning(f"You seem to be using a DPR model with the {similarity} function. "
-                               f"We recommend using dotProduct instead")
+                               f"We recommend using dot_product instead")
 
 
         elif model_format == "sentence_transformers":
@@ -430,10 +430,10 @@ class EmbeddingRetriever(BaseRetriever):
             else:
                 device = "cpu"
             self.embedding_model = SentenceTransformer(embedding_model, device=device)
-            if document_store.similarity != "cosineSimilarity":
+            if document_store.similarity != "cosine":
                 logger.warning(
                     f"You are using a Sentence Transformer with the {document_store.similarity} function. "
-                    f"We recommend using cosineSimilarity instead")
+                    f"We recommend using cosine instead")
         else:
             raise NotImplementedError
 

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -406,15 +406,14 @@ class EmbeddingRetriever(BaseRetriever):
                 extraction_layer=self.emb_extraction_layer, gpu=use_gpu, batch_size=4, max_seq_len=512, num_processes=0
             )
             # Check that document_store has the right similarity function
-            if type(document_store) == ElasticsearchDocumentStore:
-                similarity_fn = document_store.similarity_fn_name
-                # If we are using a sentence transformer model
-                if "sentence" in embedding_model.lower() and similarity_fn != "cosineSimilarity":
-                    logger.warning(f"You seem to be using a Sentence Transformer with the {document_store.similarity_fn_name} function. "
-                                   f"We recommend using cosineSimilarity instead")
-                elif "dpr" in embedding_model.lower() and similarity_fn != "dotProduct":
-                    logger.warning(f"You seem to be using a DPR model with the {similarity_fn} function. "
-                                   f"We recommend using dotProduct instead")
+            similarity = document_store.similarity
+            # If we are using a sentence transformer model
+            if "sentence" in embedding_model.lower() and similarity != "cosineSimilarity":
+                logger.warning(f"You seem to be using a Sentence Transformer with the {similarity} function. "
+                               f"We recommend using cosineSimilarity instead")
+            elif "dpr" in embedding_model.lower() and similarity != "dotProduct":
+                logger.warning(f"You seem to be using a DPR model with the {similarity} function. "
+                               f"We recommend using dotProduct instead")
 
 
         elif model_format == "sentence_transformers":
@@ -431,11 +430,10 @@ class EmbeddingRetriever(BaseRetriever):
             else:
                 device = "cpu"
             self.embedding_model = SentenceTransformer(embedding_model, device=device)
-            if type(document_store) == ElasticsearchDocumentStore:
-                if document_store.similarity_fn_name != "cosineSimilarity":
-                    logger.warning(
-                        f"You are using a Sentence Transformer with the {self.document_store.similarity_fn_name} function. "
-                        f"We recommend using cosineSimilarity instead")
+            if document_store.similarity != "cosineSimilarity":
+                logger.warning(
+                    f"You are using a Sentence Transformer with the {document_store.similarity} function. "
+                    f"We recommend using cosineSimilarity instead")
         else:
             raise NotImplementedError
 

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -87,10 +87,10 @@ class DensePassageRetriever(BaseRetriever):
         self.max_seq_len_passage = max_seq_len_passage
         self.max_seq_len_query = max_seq_len_query
 
-        if type(document_store) == ElasticsearchDocumentStore:
-            if document_store.similarity_fn_name != "dotProduct":
-                logger.warning(f"You are using a Dense Passage Retriever model with the {document_store.similarity_fn_name} function. "
-                               "We recommend you use dotProduct instead")
+        if document_store.similarity != "dot_product":
+            logger.warning(f"You are using a Dense Passage Retriever model with the {document_store.similarity} function. "
+                           "We recommend you use dot_product instead. "
+                           "This can be set when initializing the DocumentStore")
 
         if use_gpu and torch.cuda.is_available():
             self.device = torch.device("cuda")
@@ -410,10 +410,12 @@ class EmbeddingRetriever(BaseRetriever):
             # If we are using a sentence transformer model
             if "sentence" in embedding_model.lower() and similarity != "cosine":
                 logger.warning(f"You seem to be using a Sentence Transformer with the {similarity} function. "
-                               f"We recommend using cosine instead")
+                               f"We recommend using cosine instead. "
+                               f"This can be set when initializing the DocumentStore")
             elif "dpr" in embedding_model.lower() and similarity != "dot_product":
                 logger.warning(f"You seem to be using a DPR model with the {similarity} function. "
-                               f"We recommend using dot_product instead")
+                               f"We recommend using dot_product instead. "
+                               f"This can be set when initializing the DocumentStore")
 
 
         elif model_format == "sentence_transformers":
@@ -433,7 +435,8 @@ class EmbeddingRetriever(BaseRetriever):
             if document_store.similarity != "cosine":
                 logger.warning(
                     f"You are using a Sentence Transformer with the {document_store.similarity} function. "
-                    f"We recommend using cosine instead")
+                    f"We recommend using cosine instead. "
+                    f"This can be set when initializing the DocumentStore")
         else:
             raise NotImplementedError
 

--- a/tutorials/Tutorial4_FAQ_style_QA.py
+++ b/tutorials/Tutorial4_FAQ_style_QA.py
@@ -44,7 +44,8 @@ document_store = ElasticsearchDocumentStore(host="localhost", username="", passw
                                             index="document",
                                             embedding_field="question_emb",
                                             embedding_dim=768,
-                                            excluded_meta_data=["question_emb"])
+                                            excluded_meta_data=["question_emb"],
+                                            similarity="cosine")
 
 ### Create a Retriever using embeddings
 # Instead of retrieving via Elasticsearch's plain BM25, we want to use vector similarity of the questions (user question vs. FAQ ones).


### PR DESCRIPTION
This PR makes improvements and fixes around the similarity functions used in embedding based retrieval. 

A warning will be logged in cases where there is a non-recommended Dense Retrieval Model / similarity function pairing. 

Scaling of dot product scores into probabilities is now also supported.

This addresses #661

TODO:
- [x] Raise warning with bad pairing (ES)
- [x] Scale dot product properly
- [x] Add similarity as attribute of DocumentStore mother class
- [x] Implement both similarity fns in InMemoryDocumentStore
- [x] Implement dot product in FAISSDocumentStore
- [x] Implement neither in SQLDocumentStore (But raise warning?)
- [x] Give each document store its own `_create_document_field_map()` method
- [ ] Compare numbers across doc stores (To be addressed in #672)