### PR TITLE
Add DocumentStore for Open Distro Elasticsearch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         pip install pytest
         pip install -r requirements.txt
         pip install -e .
-    
+
     - name: Run Pytest without generator/pipeline marker
       run: cd test &&  pytest -m "not pipeline and not generator"
 

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -604,7 +604,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         score = hit["_score"] if hit["_score"] else None
         if score:
             if adapt_score_for_embedding:
-                score -= 1000
+                score = self._scale_embedding_score(score)
                 if self.similarity == "cosine":
                     probability = (score + 1) / 2  # scaling probability from cosine similarity
                 elif self.similarity == "dot_product":
@@ -630,6 +630,9 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             embedding=embedding,
         )
         return document
+
+    def _scale_embedding_score(self, score):
+        return score - 1000
 
     def describe_documents(self, index=None):
         """
@@ -797,3 +800,6 @@ class OpenDistroElasticsearchDocumentStore(ElasticsearchDocumentStore):
         """
         query = {"knn": {self.embedding_field: {"vector": query_emb.tolist(), "k": top_k}}}
         return query
+
+    def _scale_embedding_score(self, score):
+        return score

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -179,7 +179,8 @@ class BaseRetriever(ABC):
             documents = self.retrieve(query=query, filters=filters, top_k=top_k_retriever)
         else:
             documents = self.retrieve(query=query, filters=filters)
-
+        document_ids = [doc.id for doc in documents]
+        logger.debug(f"Retrieved documents with IDs: {document_ids}")
         output = {
             "query": query,
             "documents": documents,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-multipart
 python-docx
 sqlalchemy_utils
 # for using FAISS with GPUs, install faiss-gpu
-faiss-cpu; sys_platform != 'win32' and sys_platform != 'cygwin'
+faiss-cpu==1.6.3; sys_platform != 'win32' and sys_platform != 'cygwin'
 tika
 uvloop; sys_platform != 'win32' and sys_platform != 'cygwin'
 httptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-multipart
 python-docx
 sqlalchemy_utils
 # for using FAISS with GPUs, install faiss-gpu
-faiss-cpu==1.6.3; sys_platform != 'win32' and sys_platform != 'cygwin'
+faiss-cpu; sys_platform != 'win32' and sys_platform != 'cygwin'
 tika
 uvloop; sys_platform != 'win32' and sys_platform != 'cygwin'
 httptools


### PR DESCRIPTION
The PR adds a new document store for the [Open Distro Elasticsearch](https://opendistro.github.io/for-elasticsearch/).

In addition to the filtering & query functionality of the `ElasticsearchDocumentStore`, the new document store provides efficient vector similarity implementation for large indices using the [KNN plugin](https://opendistro.github.io/for-elasticsearch/features/knn.html). 

Resolves #665