### PR TITLE
Add support for aggregating scores in JoinDocuments node

### DIFF
--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -298,9 +298,9 @@ class JoinDocuments:
         """
         :param join_mode: `concatenate` to combine documents from multiple retrievers or `merge` to aggregate scores of
                           individual documents.
-        :param weights: A list of weights for adjusting document scores when using the `merge` join_mode. By default,
-                        equal weight is given to each retriever score. This param is not compatible with `concatenate`
-                        join_mode.
+        :param weights: A node-wise list(length of list must be equal to the number of input nodes) of weights for
+                        adjusting document scores when using the `merge` join_mode. By default, equal weight is given
+                        to each retriever score. This param is not compatible with the `concatenate` join_mode.
         :param top_k_join: Limit documents to top_k based on the resulting scores of the join.
         """
         assert join_mode in ["concatenate", "merge"], f"JoinDocuments node does not support '{join_mode}' join_mode."

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -325,7 +325,7 @@ class JoinDocuments:
             if self.weights:
                 weights = self.weights
             else:
-                weights = [1] * len(inputs)
+                weights = [1/len(inputs)] * len(inputs)
             for (input_from_node, _), weight in zip(inputs, weights):
                 for doc in input_from_node["documents"]:
                     if document_map.get(doc.id):  # document already exists; update score

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional, Dict
 
@@ -280,19 +281,63 @@ class QueryNode:
 
 
 class JoinDocuments:
+    """
+    A node to join documents outputted by multiple retriever nodes.
+
+    The node allows multiple join modes:
+    * concatenate: combine the documents from multiple nodes. Any duplicate documents are discarded.
+    * merge: merge scores of documents from multiple nodes. Optionally, each input score can be given a different
+             `weight` & a `top_k` limit can be set. This mode can also be used for "reranking" retrieved documents.
+    """
+
     outgoing_edges = 1
 
-    def __init__(self, join_mode="concatenate"):
-        pass
+    def __init__(
+        self, join_mode: str = "concatenate", weights: Optional[List[float]] = None, top_k_join: Optional[int] = None
+    ):
+        """
+        :param join_mode: `concatenate` to combine documents from multiple retrievers or `merge` to aggregate scores of
+                          individual documents.
+        :param weights: A list of weights for adjusting document scores when using the `merge` join_mode. By default,
+                        equal weight is given to each retriever score. This param is not compatible with `concatenate`
+                        join_mode.
+        :param top_k_join: Limit documents to top_k based on the resulting scores of the join.
+        """
+        assert join_mode in ["concatenate", "merge"], f"JoinDocuments node does not support '{join_mode}' join_mode."
+
+        assert not (
+            weights is not None and join_mode == "concatenate"
+        ), "Weights are not compatible with 'concatenate' join_mode."
+        self.join_mode = join_mode
+        self.weights = weights
+        self.top_k = top_k_join
 
     def run(self, **kwargs):
         inputs = kwargs["inputs"]
 
-        documents = []
-        for i, _ in inputs:
-            documents.extend(i["documents"])
-        output = {
-            "query": inputs[0][0]["query"],
-            "documents": documents
-        }
+        if self.join_mode == "concatenate":
+            document_map = {}
+            for input_from_node, _ in inputs:
+                for doc in input_from_node["documents"]:
+                    document_map[doc.id] = doc
+        elif self.join_mode == "merge":
+            document_map = {}
+            if self.weights:
+                weights = self.weights
+            else:
+                weights = [1] * len(inputs)
+            for (input_from_node, _), weight in zip(inputs, weights):
+                for doc in input_from_node["documents"]:
+                    if document_map.get(doc.id):  # document already exists; update score
+                        document_map[doc.id].score += doc.score * weight
+                    else:  # add the document in map
+                        document_map[doc.id] = deepcopy(doc)
+                        document_map[doc.id].score *= weight
+        else:
+            raise Exception(f"Invalid join_mode: {self.join_mode}")
+
+        documents = sorted(document_map.values(), key=lambda d: d.score, reverse=True)
+        if self.top_k:
+            documents = documents[: self.top_k]
+        output = {"query": inputs[0][0]["query"], "documents": documents}
         return output, "output_1"


### PR DESCRIPTION
With the new `Pipeline` class, a new node `JoinDocuments` was added to support combining results from multiple retrievers. By default, a `join_mode` called `concatenate` was implemented to collect documents retrieved by multiple retrievers. 

This PR adds a new `join_mode` called `merge` that can aggregate (weighted) scores for documents returned by multiple retrievers and return the top_k documents.

Resolves #125 