### PR TITLE
Make batchwise adding of evaluation data possible

### DIFF
--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -134,10 +134,16 @@ class BaseDocumentStore(ABC):
     def get_label_count(self, index: Optional[str] = None) -> int:
         pass
 
+    @abstractmethod
+    def write_labels(self, labels: Union[List[Label], List[dict]], index: Optional[str] = None):
+        pass
+
     def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
                       batch_size: Optional[int] = None):
         """
         Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
+        If a jsonl file and a batch size is passed to the function, documents are loaded batch by batch
+        in order to prevent out of memory errors.
 
         :param filename: Name of the file containing evaluation data (json or jsonl)
         :type filename: str
@@ -145,6 +151,11 @@ class BaseDocumentStore(ABC):
         :type doc_index: str
         :param label_index: Elasticsearch index where labeled questions should be stored
         :type label_index: str
+        :param batch_size: Number of documents that are loaded and processed at a time.
+                           Only works with jsonl formatted files. Setting batch_size and
+                           using a json formatted file will convert the json to jsonl prior
+                           to adding eval data.
+        :type batch_size: int
         """
         if filename.endswith(".json"):
             if batch_size is None:

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -142,8 +142,8 @@ class BaseDocumentStore(ABC):
                       batch_size: Optional[int] = None):
         """
         Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
-        If a jsonl file and a batch size is passed to the function, documents are loaded batch by batch
-        in order to prevent out of memory errors.
+        If a jsonl file and a batch_size is passed to the function, documents are loaded batchwise
+        from disk and also indexed batchwise to the DocumentStore in order to prevent out of memory errors.
 
         :param filename: Name of the file containing evaluation data (json or jsonl)
         :type filename: str

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -2,6 +2,8 @@ import logging
 from abc import abstractmethod, ABC
 from typing import Any, Optional, Dict, List, Union
 from haystack import Document, Label, MultiLabel
+from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
+
 
 logger = logging.getLogger(__name__)
 
@@ -132,10 +134,39 @@ class BaseDocumentStore(ABC):
     def get_label_count(self, index: Optional[str] = None) -> int:
         pass
 
-    @abstractmethod
-    def add_eval_data(self, filename: str, doc_index: str = "document", label_index: str = "label",
+    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
                       batch_size: Optional[int] = None):
-        pass
+        """
+        Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
+
+        :param filename: Name of the file containing evaluation data (json or jsonl)
+        :type filename: str
+        :param doc_index: Elasticsearch index where evaluation documents should be stored
+        :type doc_index: str
+        :param label_index: Elasticsearch index where labeled questions should be stored
+        :type label_index: str
+        """
+        if filename.endswith(".json"):
+            if batch_size is None:
+                docs, labels = eval_data_from_json(filename)
+                self.write_documents(docs, index=doc_index)
+                self.write_labels(labels, index=label_index)
+            else:
+                jsonl_filename = filename + "l"
+                logger.info(f"Adding evaluation data batch-wise is not compatible with json-formatted SQuAD files. "
+                            f"Converting json to jsonl to: {jsonl_filename}")
+                squad_json_to_jsonl(filename, jsonl_filename)
+                self.add_eval_data(jsonl_filename, doc_index, label_index, batch_size)
+
+        elif filename.endswith(".jsonl"):
+            for docs, labels in eval_data_from_jsonl(filename, batch_size):
+                if docs:
+                    self.write_documents(docs, index=doc_index)
+                if labels:
+                    self.write_labels(labels, index=label_index)
+
+        else:
+            logger.error("File needs to be in json or jsonl format.")
 
     @abstractmethod
     def delete_all_documents(self, index: str, filters: Optional[Dict[str, List[str]]] = None):

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -133,7 +133,8 @@ class BaseDocumentStore(ABC):
         pass
 
     @abstractmethod
-    def add_eval_data(self, filename: str, doc_index: str = "document", label_index: str = "label"):
+    def add_eval_data(self, filename: str, doc_index: str = "document", label_index: str = "label",
+                      batch_size: Optional[int] = None):
         pass
 
     @abstractmethod

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -710,7 +710,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
         with one document per line.
 
-        `utils.py` contains a methods `squad_json_to_jsonl` to convert a standard
+        `utils.py` contains a method `squad_json_to_jsonl` to convert a standard
         SQuAD-file to .jsonl format.
 
         :param filename: Name of the file containing evaluation data

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -12,9 +12,8 @@ from scipy.special import expit
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl
+from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 from haystack.retriever.base import BaseRetriever
-from haystack.preprocessor.utils import squad_json_to_jsonl
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -3,7 +3,7 @@ import logging
 import time
 from copy import deepcopy
 from string import Template
-from typing import List, Optional, Union, Dict, Any
+from typing import List, Optional, Union, Dict, Any, Generator
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk, scan
 from elasticsearch.exceptions import RequestError
@@ -14,6 +14,7 @@ from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
 from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl
 from haystack.retriever.base import BaseRetriever
+from haystack.preprocessor.utils import squad_json_to_jsonl
 
 logger = logging.getLogger(__name__)
 
@@ -687,47 +688,39 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
         bulk(self.client, doc_updates, request_timeout=300, refresh=self.refresh_type)
 
-    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label"):
+    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
+                      batch_size: Optional[int] = None):
         """
         Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
 
-        :param filename: Name of the file containing evaluation data
+        :param filename: Name of the file containing evaluation data (json or jsonl)
         :type filename: str
         :param doc_index: Elasticsearch index where evaluation documents should be stored
         :type doc_index: str
         :param label_index: Elasticsearch index where labeled questions should be stored
         :type label_index: str
         """
-
-        docs, labels = eval_data_from_json(filename)
-        self.write_documents(docs, index=doc_index)
-        self.write_labels(labels, index=label_index)
-
-    def add_eval_data_batchwise(self, filename: str, doc_index: str = "eval_document",
-                                label_index: str = "label", batch_size: int = 50000):
-        """
-        Adds a SQuAD-formatted .jsonl file to the DocumentStore in order to be
-        able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
-        with one document per line.
-
-        `utils.py` contains a method `squad_json_to_jsonl` to convert a standard
-        SQuAD-file to .jsonl format.
-
-        :param filename: Name of the file containing evaluation data
-        :type filename: str
-        :param doc_index: Elasticsearch index where evaluation documents should be stored
-        :type doc_index: str
-        :param label_index: Elasticsearch index where labeled questions should be stored
-        :type label_index: str
-        :param batch_size: Number of documents to be processed at once
-        :type batch_size: int
-        """
-
-        for docs, labels in eval_data_from_jsonl(filename, batch_size):
-            if docs:
+        if filename.endswith(".json"):
+            if batch_size is None:
+                docs, labels = eval_data_from_json(filename)
                 self.write_documents(docs, index=doc_index)
-            if labels:
                 self.write_labels(labels, index=label_index)
+            else:
+                jsonl_filename = filename + "l"
+                logger.info(f"Adding evaluation data batch-wise is not compatible with json-formatted SQuAD files. "
+                            f"Converting json to jsonl to: {jsonl_filename}")
+                squad_json_to_jsonl(filename, jsonl_filename)
+                self.add_eval_data(jsonl_filename, doc_index, label_index, batch_size)
+
+        elif filename.endswith(".jsonl"):
+            for docs, labels in eval_data_from_jsonl(filename, batch_size):
+                if docs:
+                    self.write_documents(docs, index=doc_index)
+                if labels:
+                    self.write_labels(labels, index=label_index)
+
+        else:
+            logger.error("File needs to be in json or jsonl format.")
 
     def delete_all_documents(self, index: str, filters: Optional[Dict[str, List[str]]] = None):
         """

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -12,7 +12,6 @@ from scipy.special import expit
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 from haystack.retriever.base import BaseRetriever
 
 logger = logging.getLogger(__name__)
@@ -686,40 +685,6 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             doc_updates.append(update)
 
         bulk(self.client, doc_updates, request_timeout=300, refresh=self.refresh_type)
-
-    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
-                      batch_size: Optional[int] = None):
-        """
-        Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
-
-        :param filename: Name of the file containing evaluation data (json or jsonl)
-        :type filename: str
-        :param doc_index: Elasticsearch index where evaluation documents should be stored
-        :type doc_index: str
-        :param label_index: Elasticsearch index where labeled questions should be stored
-        :type label_index: str
-        """
-        if filename.endswith(".json"):
-            if batch_size is None:
-                docs, labels = eval_data_from_json(filename)
-                self.write_documents(docs, index=doc_index)
-                self.write_labels(labels, index=label_index)
-            else:
-                jsonl_filename = filename + "l"
-                logger.info(f"Adding evaluation data batch-wise is not compatible with json-formatted SQuAD files. "
-                            f"Converting json to jsonl to: {jsonl_filename}")
-                squad_json_to_jsonl(filename, jsonl_filename)
-                self.add_eval_data(jsonl_filename, doc_index, label_index, batch_size)
-
-        elif filename.endswith(".jsonl"):
-            for docs, labels in eval_data_from_jsonl(filename, batch_size):
-                if docs:
-                    self.write_documents(docs, index=doc_index)
-                if labels:
-                    self.write_labels(labels, index=label_index)
-
-        else:
-            logger.error("File needs to be in json or jsonl format.")
 
     def delete_all_documents(self, index: str, filters: Optional[Dict[str, List[str]]] = None):
         """

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -5,14 +5,12 @@ from collections import defaultdict
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl
+from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 from haystack.retriever.base import BaseRetriever
 
 from scipy.spatial.distance import cosine
 
 import logging
-
-from haystack.preprocessor.utils import squad_json_to_jsonl
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -275,7 +275,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
         with one document per line.
 
-        `utils.py` contains a methods `squad_json_to_jsonl` to convert a standard
+        `utils.py` contains a method `squad_json_to_jsonl` to convert a standard
         SQuAD-file to .jsonl format.
 
         :param filename: Name of the file containing evaluation data

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_file
+from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl
 from haystack.retriever.base import BaseRetriever
 
 from scipy.spatial.distance import cosine
@@ -262,11 +262,39 @@ class InMemoryDocumentStore(BaseDocumentStore):
         :type label_index: str
         """
 
-        docs, labels = eval_data_from_file(filename)
+        docs, labels = eval_data_from_json(filename)
         doc_index = doc_index or self.index
         label_index = label_index or self.label_index
         self.write_documents(docs, index=doc_index)
         self.write_labels(labels, index=label_index)
+
+    def add_eval_data_batchwise(self, filename: str, doc_index: str = "eval_document",
+                                label_index: str = "label", batch_size: int = 50000):
+        """
+        Adds a SQuAD-formatted .jsonl file to the DocumentStore in order to be
+        able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
+        with one document per line.
+
+        `utils.py` contains a methods `squad_json_to_jsonl` to convert a standard
+        SQuAD-file to .jsonl format.
+
+        :param filename: Name of the file containing evaluation data
+        :type filename: str
+        :param doc_index: Elasticsearch index where evaluation documents should be stored
+        :type doc_index: str
+        :param label_index: Elasticsearch index where labeled questions should be stored
+        :type label_index: str
+        :param batch_size: Number of documents to be processed at once
+        :type batch_size: int
+        """
+
+        doc_index = doc_index or self.index
+        label_index = label_index or self.label_index
+        for docs, labels in eval_data_from_jsonl(filename, batch_size):
+            if docs:
+                self.write_documents(docs, index=doc_index)
+            if labels:
+                self.write_labels(labels, index=label_index)
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -11,6 +11,9 @@ from haystack.retriever.base import BaseRetriever
 from scipy.spatial.distance import cosine
 
 import logging
+
+from haystack.preprocessor.utils import squad_json_to_jsonl
+
 logger = logging.getLogger(__name__)
 
 
@@ -250,51 +253,39 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
         return result
 
-    def add_eval_data(self, filename: str, doc_index: Optional[str] = None, label_index: Optional[str] = None):
+    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
+                      batch_size: Optional[int] = None):
         """
         Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
 
-        :param filename: Name of the file containing evaluation data
+        :param filename: Name of the file containing evaluation data (json or jsonl)
         :type filename: str
         :param doc_index: Elasticsearch index where evaluation documents should be stored
         :type doc_index: str
         :param label_index: Elasticsearch index where labeled questions should be stored
         :type label_index: str
         """
-
-        docs, labels = eval_data_from_json(filename)
-        doc_index = doc_index or self.index
-        label_index = label_index or self.label_index
-        self.write_documents(docs, index=doc_index)
-        self.write_labels(labels, index=label_index)
-
-    def add_eval_data_batchwise(self, filename: str, doc_index: str = "eval_document",
-                                label_index: str = "label", batch_size: int = 50000):
-        """
-        Adds a SQuAD-formatted .jsonl file to the DocumentStore in order to be
-        able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
-        with one document per line.
-
-        `utils.py` contains a method `squad_json_to_jsonl` to convert a standard
-        SQuAD-file to .jsonl format.
-
-        :param filename: Name of the file containing evaluation data
-        :type filename: str
-        :param doc_index: Elasticsearch index where evaluation documents should be stored
-        :type doc_index: str
-        :param label_index: Elasticsearch index where labeled questions should be stored
-        :type label_index: str
-        :param batch_size: Number of documents to be processed at once
-        :type batch_size: int
-        """
-
-        doc_index = doc_index or self.index
-        label_index = label_index or self.label_index
-        for docs, labels in eval_data_from_jsonl(filename, batch_size):
-            if docs:
+        if filename.endswith(".json"):
+            if batch_size is None:
+                docs, labels = eval_data_from_json(filename)
                 self.write_documents(docs, index=doc_index)
-            if labels:
                 self.write_labels(labels, index=label_index)
+            else:
+                jsonl_filename = filename + "l"
+                logger.info(f"Adding evaluation data batch-wise is not compatible with json-formatted SQuAD files. "
+                            f"Converting json to jsonl to: {jsonl_filename}")
+                squad_json_to_jsonl(filename, jsonl_filename)
+                self.add_eval_data(jsonl_filename, doc_index, label_index, batch_size)
+
+        elif filename.endswith(".jsonl"):
+            for docs, labels in eval_data_from_jsonl(filename, batch_size):
+                if docs:
+                    self.write_documents(docs, index=doc_index)
+                if labels:
+                    self.write_labels(labels, index=label_index)
+
+        else:
+            logger.error("File needs to be in json or jsonl format.")
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 from haystack.retriever.base import BaseRetriever
 
 from scipy.spatial.distance import cosine
@@ -250,40 +249,6 @@ class InMemoryDocumentStore(BaseDocumentStore):
             result = list(self.indexes[index].values())
 
         return result
-
-    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
-                      batch_size: Optional[int] = None):
-        """
-        Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
-
-        :param filename: Name of the file containing evaluation data (json or jsonl)
-        :type filename: str
-        :param doc_index: Elasticsearch index where evaluation documents should be stored
-        :type doc_index: str
-        :param label_index: Elasticsearch index where labeled questions should be stored
-        :type label_index: str
-        """
-        if filename.endswith(".json"):
-            if batch_size is None:
-                docs, labels = eval_data_from_json(filename)
-                self.write_documents(docs, index=doc_index)
-                self.write_labels(labels, index=label_index)
-            else:
-                jsonl_filename = filename + "l"
-                logger.info(f"Adding evaluation data batch-wise is not compatible with json-formatted SQuAD files. "
-                            f"Converting json to jsonl to: {jsonl_filename}")
-                squad_json_to_jsonl(filename, jsonl_filename)
-                self.add_eval_data(jsonl_filename, doc_index, label_index, batch_size)
-
-        elif filename.endswith(".jsonl"):
-            for docs, labels in eval_data_from_jsonl(filename, batch_size):
-                if docs:
-                    self.write_documents(docs, index=doc_index)
-                if labels:
-                    self.write_labels(labels, index=label_index)
-
-        else:
-            logger.error("File needs to be in json or jsonl format.")
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -264,7 +264,7 @@ class SQLDocumentStore(BaseDocumentStore):
         able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
         with one document per line.
 
-        `utils.py` contains a methods `squad_json_to_jsonl` to convert a standard
+        `utils.py` contains a method `squad_json_to_jsonl` to convert a standard
         SQuAD-file to .jsonl format.
 
         :param filename: Name of the file containing evaluation data

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -10,8 +10,7 @@ from sqlalchemy.sql import case
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl
-from haystack.preprocessor.utils import squad_json_to_jsonl
+from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import case
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_file
+from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl
 
 
 logger = logging.getLogger(__name__)
@@ -253,9 +253,35 @@ class SQLDocumentStore(BaseDocumentStore):
         :type label_index: str
         """
 
-        docs, labels = eval_data_from_file(filename)
+        docs, labels = eval_data_from_json(filename)
         self.write_documents(docs, index=doc_index)
         self.write_labels(labels, index=label_index)
+
+    def add_eval_data_batchwise(self, filename: str, doc_index: str = "eval_document",
+                                label_index: str = "label", batch_size: int = 50000):
+        """
+        Adds a SQuAD-formatted .jsonl file to the DocumentStore in order to be
+        able to perform evaluation on it. The SQuAD file needs to be in jsonl-format
+        with one document per line.
+
+        `utils.py` contains a methods `squad_json_to_jsonl` to convert a standard
+        SQuAD-file to .jsonl format.
+
+        :param filename: Name of the file containing evaluation data
+        :type filename: str
+        :param doc_index: Elasticsearch index where evaluation documents should be stored
+        :type doc_index: str
+        :param label_index: Elasticsearch index where labeled questions should be stored
+        :type label_index: str
+        :param batch_size: Number of documents to be processed at once
+        :type batch_size: int
+        """
+
+        for docs, labels in eval_data_from_jsonl(filename, batch_size):
+            if docs:
+                self.write_documents(docs, index=doc_index)
+            if labels:
+                self.write_labels(labels, index=label_index)
 
     def get_document_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
         """

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -10,7 +10,6 @@ from sqlalchemy.sql import case
 
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document, Label
-from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 
 logger = logging.getLogger(__name__)
 
@@ -310,40 +309,6 @@ class SQLDocumentStore(BaseDocumentStore):
         for m in meta_orms:
             self.session.add(m)
         self.session.commit()
-
-    def add_eval_data(self, filename: str, doc_index: str = "eval_document", label_index: str = "label",
-                      batch_size: Optional[int] = None):
-        """
-        Adds a SQuAD-formatted file to the DocumentStore in order to be able to perform evaluation on it.
-
-        :param filename: Name of the file containing evaluation data (json or jsonl)
-        :type filename: str
-        :param doc_index: Elasticsearch index where evaluation documents should be stored
-        :type doc_index: str
-        :param label_index: Elasticsearch index where labeled questions should be stored
-        :type label_index: str
-        """
-        if filename.endswith(".json"):
-            if batch_size is None:
-                docs, labels = eval_data_from_json(filename)
-                self.write_documents(docs, index=doc_index)
-                self.write_labels(labels, index=label_index)
-            else:
-                jsonl_filename = filename + "l"
-                logger.info(f"Adding evaluation data batch-wise is not compatible with json-formatted SQuAD files. "
-                            f"Converting json to jsonl to: {jsonl_filename}")
-                squad_json_to_jsonl(filename, jsonl_filename)
-                self.add_eval_data(jsonl_filename, doc_index, label_index, batch_size)
-
-        elif filename.endswith(".jsonl"):
-            for docs, labels in eval_data_from_jsonl(filename, batch_size):
-                if docs:
-                    self.write_documents(docs, index=doc_index)
-                if labels:
-                    self.write_labels(labels, index=label_index)
-
-        else:
-            logger.error("File needs to be in json or jsonl format.")
 
     def get_document_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
         """

--- a/haystack/preprocessor/utils.py
+++ b/haystack/preprocessor/utils.py
@@ -56,7 +56,8 @@ def eval_data_from_jsonl(filename: str, batch_size: Union[int, bool] = None,
     Read Documents + Labels from a SQuAD-style file in jsonl format, i.e. one document per line.
     Document and Labels can then be indexed to the DocumentStore and be used for evaluation.
 
-    This is a generator and will yield batch_size documents per iteration.
+    This is a generator which will yield one tuple per iteration containing a list
+    of batch_size documents and a list with the documents' labels.
     If batch_size is set to None, this method will yield all documents and labels.
 
     :param filename: Path to file in SQuAD format

--- a/haystack/preprocessor/utils.py
+++ b/haystack/preprocessor/utils.py
@@ -50,7 +50,7 @@ def eval_data_from_json(filename: str, max_docs: Union[int, bool] = None) -> Tup
     return docs, labels
 
 
-def eval_data_from_jsonl(filename: str, batch_size: Union[int, bool] = None,
+def eval_data_from_jsonl(filename: str, batch_size: Optional[int] = None,
                          max_docs: Union[int, bool] = None) -> Generator[Tuple[List[Document], List[Label]], None, None]:
     """
     Read Documents + Labels from a SQuAD-style file in jsonl format, i.e. one document per line.
@@ -320,3 +320,20 @@ def fetch_archive_from_http(url: str, output_dir: str, proxies: Optional[dict] =
                                'See haystack documentation for support of more file types'.format(url))
             # temp_file gets deleted here
         return True
+
+
+def squad_json_to_jsonl(squad_file: str, output_file: str):
+    """
+    Converts a SQuAD-json-file into jsonl format with one document per line.
+
+    :param squad_file: SQuAD-file in json format.
+    :type squad_file: str
+    :param output_file: Name of output file (SQuAD in jsonl format)
+    :type output_file: str
+    """
+    with open(squad_file) as json_file, open(output_file, "w") as jsonl_file:
+        squad_json = json.load(json_file)
+
+        for doc in squad_json["data"]:
+            json.dump(doc, jsonl_file)
+            jsonl_file.write("\n")

--- a/haystack/utils.py
+++ b/haystack/utils.py
@@ -113,3 +113,20 @@ def convert_labels_to_squad(labels_file: str):
 
     with open("labels_in_squad_format.json", "w+") as outfile:
         json.dump(labels_in_squad_format, outfile)
+
+
+def squad_json_to_jsonl(squad_file: str, output_file: str):
+    """
+    Converts a SQuAD-json-file into jsonl format with one document per line.
+
+    :param squad_file: SQuAD-file in json format.
+    :type squad_file: str
+    :param output_file: Name of output file (SQuAD in jsonl format)
+    :type output_file: str
+    """
+    with open(squad_file) as json_file, open(output_file, "w") as jsonl_file:
+        squad_json = json.load(json_file)
+
+        for doc in squad_json["data"]:
+            json.dump(doc, jsonl_file)
+            jsonl_file.write("\n")

--- a/haystack/utils.py
+++ b/haystack/utils.py
@@ -113,20 +113,3 @@ def convert_labels_to_squad(labels_file: str):
 
     with open("labels_in_squad_format.json", "w+") as outfile:
         json.dump(labels_in_squad_format, outfile)
-
-
-def squad_json_to_jsonl(squad_file: str, output_file: str):
-    """
-    Converts a SQuAD-json-file into jsonl format with one document per line.
-
-    :param squad_file: SQuAD-file in json format.
-    :type squad_file: str
-    :param output_file: Name of output file (SQuAD in jsonl format)
-    :type output_file: str
-    """
-    with open(squad_file) as json_file, open(output_file, "w") as jsonl_file:
-        squad_json = json.load(json_file)
-
-        for doc in squad_json["data"]:
-            json.dump(doc, jsonl_file)
-            jsonl_file.write("\n")

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -1,7 +1,6 @@
 import pytest
 from haystack.document_store.base import BaseDocumentStore
 from haystack.finder import Finder
-from haystack.utils import squad_json_to_jsonl
 
 
 @pytest.mark.elasticsearch
@@ -43,16 +42,13 @@ def test_add_eval_data(document_store):
 
 @pytest.mark.elasticsearch
 def test_add_eval_data_batchwise(document_store):
-    # create SQuAD jsonl from SQuAD json
-    squad_json_to_jsonl(squad_file="samples/squad/small.json", output_file="samples/squad/small.jsonl")
-
     # add eval data (SQUAD format in jsonl)
     document_store.delete_all_documents(index="test_eval_document")
     document_store.delete_all_documents(index="test_feedback")
-    document_store.add_eval_data_batchwise(filename="samples/squad/small.jsonl",
-                                           doc_index="test_eval_document",
-                                           label_index="test_feedback",
-                                           batch_size=20)
+    document_store.add_eval_data(filename="samples/squad/small.json",
+                                 doc_index="test_eval_document",
+                                 label_index="test_feedback",
+                                 batch_size=20)
 
     assert document_store.get_document_count(index="test_eval_document") == 87
     assert document_store.get_label_count(index="test_feedback") == 1214

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -1,6 +1,7 @@
 import pytest
 from haystack.document_store.base import BaseDocumentStore
 from haystack.finder import Finder
+from haystack.utils import squad_json_to_jsonl
 
 
 @pytest.mark.elasticsearch
@@ -9,6 +10,49 @@ def test_add_eval_data(document_store):
     document_store.delete_all_documents(index="test_eval_document")
     document_store.delete_all_documents(index="test_feedback")
     document_store.add_eval_data(filename="samples/squad/small.json", doc_index="test_eval_document", label_index="test_feedback")
+
+    assert document_store.get_document_count(index="test_eval_document") == 87
+    assert document_store.get_label_count(index="test_feedback") == 1214
+
+    # test documents
+    docs = document_store.get_all_documents(index="test_eval_document")
+    assert docs[0].text[:10] == "The Norman"
+    assert docs[0].meta["name"] == "Normans"
+    assert len(docs[0].meta.keys()) == 1
+
+    # test labels
+    labels = document_store.get_all_labels(index="test_feedback")
+    assert labels[0].answer == "France"
+    assert labels[0].no_answer == False
+    assert labels[0].is_correct_answer == True
+    assert labels[0].is_correct_document == True
+    assert labels[0].question == 'In what country is Normandy located?'
+    assert labels[0].origin == "gold_label"
+    assert labels[0].offset_start_in_doc == 159
+
+    # check combination
+    assert labels[0].document_id == docs[0].id
+    start = labels[0].offset_start_in_doc
+    end = start+len(labels[0].answer)
+    assert docs[0].text[start:end] == "France"
+
+    # clean up
+    document_store.delete_all_documents(index="test_eval_document")
+    document_store.delete_all_documents(index="test_feedback")
+
+
+@pytest.mark.elasticsearch
+def test_add_eval_data_batchwise(document_store):
+    # create SQuAD jsonl from SQuAD json
+    squad_json_to_jsonl(squad_file="samples/squad/small.json", output_file="samples/squad/small.jsonl")
+
+    # add eval data (SQUAD format in jsonl)
+    document_store.delete_all_documents(index="test_eval_document")
+    document_store.delete_all_documents(index="test_feedback")
+    document_store.add_eval_data_batchwise(filename="samples/squad/small.jsonl",
+                                           doc_index="test_eval_document",
+                                           label_index="test_feedback",
+                                           batch_size=20)
 
     assert document_store.get_document_count(index="test_eval_document") == 87
     assert document_store.get_label_count(index="test_feedback") == 1214


### PR DESCRIPTION
When trying to add evaluation data containing millions of documents, my computer ran out of memory.

To solve this problem, this PR adds a method to add eval docs batch-wise so that not all eval docs have to be loaded to memory at once. Furthermore, this PR introduces the method `squad_json_to_jsonl` as the required format for `add_eval_data_batchwise` is jsonl.