### PR TITLE
Fix SQLite errors in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import time
 from subprocess import run
@@ -247,8 +246,6 @@ def document_store(request, test_docs_xs):
 
 def get_document_store(document_store_type, embedding_field="embedding"):
     if document_store_type == "sql":
-        if os.path.exists("haystack_test.db"):
-            os.remove("haystack_test.db")
         document_store = SQLDocumentStore(url="sqlite://")
     elif document_store_type == "memory":
         document_store = InMemoryDocumentStore(return_embedding=True, embedding_field=embedding_field)
@@ -260,8 +257,6 @@ def get_document_store(document_store_type, embedding_field="embedding"):
             index="haystack_test", return_embedding=True, embedding_field=embedding_field
         )
     elif document_store_type == "faiss":
-        if os.path.exists("haystack_test_faiss.db"):
-            os.remove("haystack_test_faiss.db")
         document_store = FAISSDocumentStore(
             sql_url="sqlite://", return_embedding=True, embedding_field=embedding_field
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -249,7 +249,7 @@ def get_document_store(document_store_type, embedding_field="embedding"):
     if document_store_type == "sql":
         if os.path.exists("haystack_test.db"):
             os.remove("haystack_test.db")
-        document_store = SQLDocumentStore(url="sqlite:///haystack_test.db")
+        document_store = SQLDocumentStore(url="sqlite://")
     elif document_store_type == "memory":
         document_store = InMemoryDocumentStore(return_embedding=True, embedding_field=embedding_field)
     elif document_store_type == "elasticsearch":
@@ -263,7 +263,7 @@ def get_document_store(document_store_type, embedding_field="embedding"):
         if os.path.exists("haystack_test_faiss.db"):
             os.remove("haystack_test_faiss.db")
         document_store = FAISSDocumentStore(
-            sql_url="sqlite:///haystack_test_faiss.db", return_embedding=True, embedding_field=embedding_field
+            sql_url="sqlite://", return_embedding=True, embedding_field=embedding_field
         )
         return document_store
     else:

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -36,8 +36,6 @@ def check_data_correctness(documents_indexed, documents_inserted):
 
 @pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
 def test_faiss_index_save_and_load(document_store):
-    import os
-    files = os.listdir(os.curdir)
     document_store.write_documents(DOCUMENTS)
 
     # test saving the index
@@ -50,8 +48,7 @@ def test_faiss_index_save_and_load(document_store):
     assert document_store.faiss_index.ntotal == 0
 
     # test loading the index
-    new_document_store = FAISSDocumentStore.load(sql_url="sqlite:///haystack_test_faiss.db",
-                                                 faiss_file_path="haystack_test_faiss")
+    new_document_store = FAISSDocumentStore.load(sql_url="sqlite://", faiss_file_path="haystack_test_faiss")
 
     # check faiss index is restored
     assert new_document_store.faiss_index.ntotal == len(DOCUMENTS)

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -38,7 +38,6 @@ def check_data_correctness(documents_indexed, documents_inserted):
 def test_faiss_index_save_and_load(document_store):
     import os
     files = os.listdir(os.curdir)
-    print(f"Files in Directory: {files}")
     document_store.write_documents(DOCUMENTS)
 
     # test saving the index
@@ -51,8 +50,8 @@ def test_faiss_index_save_and_load(document_store):
     assert document_store.faiss_index.ntotal == 0
 
     # test loading the index
-    new_document_store = document_store.load(sql_url="sqlite:///haystack_test.db",
-                                             faiss_file_path="haystack_test_faiss")
+    new_document_store = FAISSDocumentStore.load(sql_url="sqlite:///haystack_test_faiss.db",
+                                                 faiss_file_path="haystack_test_faiss")
 
     # check faiss index is restored
     assert new_document_store.faiss_index.ntotal == len(DOCUMENTS)

--- a/test/test_faiss.py
+++ b/test/test_faiss.py
@@ -33,31 +33,29 @@ def check_data_correctness(documents_indexed, documents_inserted):
         vector_ids.add(doc.meta["vector_id"])
     assert len(vector_ids) == len(documents_inserted)
 
-#TODO Test is failing in the CI all of sudden while running smoothly locally. Fix it in a separate PR
-# (sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) disk I/O error)
 
-# @pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
-# def test_faiss_index_save_and_load(document_store):
-#     import os
-#     files = os.listdir(os.curdir)
-#     print(f"Files in Directory: {files}")
-#     document_store.write_documents(DOCUMENTS)
-#
-#     # test saving the index
-#     document_store.save("haystack_test_faiss")
-#
-#     # clear existing faiss_index
-#     document_store.faiss_index.reset()
-#
-#     # test faiss index is cleared
-#     assert document_store.faiss_index.ntotal == 0
-#
-#     # test loading the index
-#     new_document_store = document_store.load(sql_url="sqlite:///haystack_test.db",
-#                                              faiss_file_path="haystack_test_faiss")
-#
-#     # check faiss index is restored
-#     assert new_document_store.faiss_index.ntotal == len(DOCUMENTS)
+@pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
+def test_faiss_index_save_and_load(document_store):
+    import os
+    files = os.listdir(os.curdir)
+    print(f"Files in Directory: {files}")
+    document_store.write_documents(DOCUMENTS)
+
+    # test saving the index
+    document_store.save("haystack_test_faiss")
+
+    # clear existing faiss_index
+    document_store.faiss_index.reset()
+
+    # test faiss index is cleared
+    assert document_store.faiss_index.ntotal == 0
+
+    # test loading the index
+    new_document_store = document_store.load(sql_url="sqlite:///haystack_test.db",
+                                             faiss_file_path="haystack_test_faiss")
+
+    # check faiss index is restored
+    assert new_document_store.faiss_index.ntotal == len(DOCUMENTS)
 
 
 @pytest.mark.parametrize("document_store", ["faiss"], indirect=True)


### PR DESCRIPTION
This PR changes Pytest fixtures for `FAISSDocumentStore` & `SQLDocumentStore` to use in-memory SQLite. This avoids disk-IO related errors in tests running on Github Actions.