### PR TITLE
Adding a guard that prevents the tutorial from being executed in every subprocess on windows

### DIFF
--- a/tutorials/Tutorial1_Basic_QA_Pipeline.py
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.py
@@ -22,133 +22,139 @@ from haystack.reader.transformers import TransformersReader
 from haystack.utils import print_answers
 from haystack.retriever.sparse import ElasticsearchRetriever
 
-logger = logging.getLogger(__name__)
 
-LAUNCH_ELASTICSEARCH = True
+def tutorial1_basic_qa_pipeline():
+    logger = logging.getLogger(__name__)
 
-# ## Document Store
-#
-# Haystack finds answers to queries within the documents stored in a `DocumentStore`. The current implementations of
-# `DocumentStore` include `ElasticsearchDocumentStore`, `FAISSDocumentStore`, `SQLDocumentStore`, and `InMemoryDocumentStore`.
-#
-# **Here:** We recommended Elasticsearch as it comes preloaded with features like full-text queries, BM25 retrieval,
-# and vector storage for text embeddings.
-# **Alternatives:** If you are unable to setup an Elasticsearch instance, then follow the Tutorial 3
-# for using SQL/InMemory document stores.
-# **Hint**:
-# This tutorial creates a new document store instance with Wikipedia articles on Game of Thrones. However, you can
-# configure Haystack to work with your existing document stores.
-#
-# Start an Elasticsearch server
-# You can start Elasticsearch on your local machine instance using Docker. If Docker is not readily available in
-# your environment (eg., in Colab notebooks), then you can manually download and execute Elasticsearch from source.
+    LAUNCH_ELASTICSEARCH = True
 
-if LAUNCH_ELASTICSEARCH:
-    logging.info("Starting Elasticsearch ...")
-    status = subprocess.run(
-        ['docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.6.2'], shell=True
-    )
-    if status.returncode:
-        raise Exception("Failed to launch Elasticsearch. If you want to connect to an existing Elasticsearch instance"
-                        "then set LAUNCH_ELASTICSEARCH in the script to False.")
-    time.sleep(15)
+    # ## Document Store
+    #
+    # Haystack finds answers to queries within the documents stored in a `DocumentStore`. The current implementations of
+    # `DocumentStore` include `ElasticsearchDocumentStore`, `FAISSDocumentStore`, `SQLDocumentStore`, and `InMemoryDocumentStore`.
+    #
+    # **Here:** We recommended Elasticsearch as it comes preloaded with features like full-text queries, BM25 retrieval,
+    # and vector storage for text embeddings.
+    # **Alternatives:** If you are unable to setup an Elasticsearch instance, then follow the Tutorial 3
+    # for using SQL/InMemory document stores.
+    # **Hint**:
+    # This tutorial creates a new document store instance with Wikipedia articles on Game of Thrones. However, you can
+    # configure Haystack to work with your existing document stores.
+    #
+    # Start an Elasticsearch server
+    # You can start Elasticsearch on your local machine instance using Docker. If Docker is not readily available in
+    # your environment (eg., in Colab notebooks), then you can manually download and execute Elasticsearch from source.
 
-# Connect to Elasticsearch
-document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
+    if LAUNCH_ELASTICSEARCH:
+        logging.info("Starting Elasticsearch ...")
+        status = subprocess.run(
+            ['docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.6.2'], shell=True
+        )
+        if status.returncode:
+            raise Exception("Failed to launch Elasticsearch. If you want to connect to an existing Elasticsearch instance"
+                            "then set LAUNCH_ELASTICSEARCH in the script to False.")
+        time.sleep(15)
 
-# ## Preprocessing of documents
-#
-# Haystack provides a customizable pipeline for:
-# - converting files into texts
-# - cleaning texts
-# - splitting texts
-# - writing them to a Document Store
+    # Connect to Elasticsearch
+    document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
 
-# In this tutorial, we download Wikipedia articles about Game of Thrones, apply a basic cleaning function, and add
-# them in Elasticsearch.
+    # ## Preprocessing of documents
+    #
+    # Haystack provides a customizable pipeline for:
+    # - converting files into texts
+    # - cleaning texts
+    # - splitting texts
+    # - writing them to a Document Store
 
-
-# Let's first fetch some documents that we want to query
-# Here: 517 Wikipedia articles for Game of Thrones
-doc_dir = "data/article_txt_got"
-s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
-fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
-
-# convert files to dicts containing documents that can be indexed to our datastore
-dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
-# You can optionally supply a cleaning function that is applied to each doc (e.g. to remove footers)
-# It must take a str as input, and return a str.
-
-# Now, let's write the docs to our DB.
-if LAUNCH_ELASTICSEARCH:
-    document_store.write_documents(dicts)
-else:
-    logger.warning("Since we already have a running ES instance we should not index the same documents again. \n"
-                   "If you still want to do this call: document_store.write_documents(dicts) manually ")
-
-# ## Initalize Retriever, Reader,  & Finder
-#
-# ### Retriever
-#
-# Retrievers help narrowing down the scope for the Reader to smaller units of text where a given question
-# could be answered.
-#
-# They use some simple but fast algorithm.
-# **Here:** We use Elasticsearch's default BM25 algorithm
-# **Alternatives:**
-# - Customize the `ElasticsearchRetriever`with custom queries (e.g. boosting) and filters
-# - Use `EmbeddingRetriever` to find candidate documents based on the similarity of
-#   embeddings (e.g. created via Sentence-BERT)
-# - Use `TfidfRetriever` in combination with a SQL or InMemory Document store for simple prototyping and debugging
-
-retriever = ElasticsearchRetriever(document_store=document_store)
-
-# Alternative: An in-memory TfidfRetriever based on Pandas dataframes for building quick-prototypes
-# with SQLite document store.
-#
-# from haystack.retriever.tfidf import TfidfRetriever
-# retriever = TfidfRetriever(document_store=document_store)
-
-# ### Reader
-#
-# A Reader scans the texts returned by retrievers in detail and extracts the k best answers. They are based
-# on powerful, but slower deep learning models.
-#
-# Haystack currently supports Readers based on the frameworks FARM and Transformers.
-# With both you can either load a local model or one from Hugging Face's model hub (https://huggingface.co/models).
-# **Here:** a medium sized RoBERTa QA model using a Reader based on
-#           FARM (https://huggingface.co/deepset/roberta-base-squad2)
-# **Alternatives (Reader):** TransformersReader (leveraging the `pipeline` of the Transformers package)
-# **Alternatives (Models):** e.g. "distilbert-base-uncased-distilled-squad" (fast) or
-#                            "deepset/bert-large-uncased-whole-word-masking-squad2" (good accuracy)
-# **Hint:** You can adjust the model to return "no answer possible" with the no_ans_boost. Higher values mean
-#           the model prefers "no answer possible"
-#
-# #### FARMReader
-
-# Load a  local model or any of the QA models on
-# Hugging Face's model hub (https://huggingface.co/models)
-reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
-
-# #### TransformersReader
-
-# Alternative:
-# reader = TransformersReader(
-#    model_name_or_path="distilbert-base-uncased-distilled-squad", tokenizer="distilbert-base-uncased", use_gpu=-1)
-
-# ### Finder
-#
-# The Finder sticks together reader and retriever in a pipeline to answer our actual questions.
-
-finder = Finder(reader, retriever)
-
-# ## Voilà! Ask a question!
-# You can configure how many candidates the reader and retriever shall return
-# The higher top_k_retriever, the better (but also the slower) your answers.
-prediction = finder.get_answers(question="Who is the father of Sansa Stark?", top_k_retriever=10, top_k_reader=5)
+    # In this tutorial, we download Wikipedia articles about Game of Thrones, apply a basic cleaning function, and add
+    # them in Elasticsearch.
 
 
-# prediction = finder.get_answers(question="Who created the Dothraki vocabulary?", top_k_reader=5)
-# prediction = finder.get_answers(question="Who is the sister of Sansa?", top_k_reader=5)
+    # Let's first fetch some documents that we want to query
+    # Here: 517 Wikipedia articles for Game of Thrones
+    doc_dir = "data/article_txt_got"
+    s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
+    fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
 
-print_answers(prediction, details="minimal")
+    # convert files to dicts containing documents that can be indexed to our datastore
+    dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
+    # You can optionally supply a cleaning function that is applied to each doc (e.g. to remove footers)
+    # It must take a str as input, and return a str.
+
+    # Now, let's write the docs to our DB.
+    if LAUNCH_ELASTICSEARCH:
+        document_store.write_documents(dicts)
+    else:
+        logger.warning("Since we already have a running ES instance we should not index the same documents again. \n"
+                       "If you still want to do this call: document_store.write_documents(dicts) manually ")
+
+    # ## Initalize Retriever, Reader,  & Finder
+    #
+    # ### Retriever
+    #
+    # Retrievers help narrowing down the scope for the Reader to smaller units of text where a given question
+    # could be answered.
+    #
+    # They use some simple but fast algorithm.
+    # **Here:** We use Elasticsearch's default BM25 algorithm
+    # **Alternatives:**
+    # - Customize the `ElasticsearchRetriever`with custom queries (e.g. boosting) and filters
+    # - Use `EmbeddingRetriever` to find candidate documents based on the similarity of
+    #   embeddings (e.g. created via Sentence-BERT)
+    # - Use `TfidfRetriever` in combination with a SQL or InMemory Document store for simple prototyping and debugging
+
+    retriever = ElasticsearchRetriever(document_store=document_store)
+
+    # Alternative: An in-memory TfidfRetriever based on Pandas dataframes for building quick-prototypes
+    # with SQLite document store.
+    #
+    # from haystack.retriever.tfidf import TfidfRetriever
+    # retriever = TfidfRetriever(document_store=document_store)
+
+    # ### Reader
+    #
+    # A Reader scans the texts returned by retrievers in detail and extracts the k best answers. They are based
+    # on powerful, but slower deep learning models.
+    #
+    # Haystack currently supports Readers based on the frameworks FARM and Transformers.
+    # With both you can either load a local model or one from Hugging Face's model hub (https://huggingface.co/models).
+    # **Here:** a medium sized RoBERTa QA model using a Reader based on
+    #           FARM (https://huggingface.co/deepset/roberta-base-squad2)
+    # **Alternatives (Reader):** TransformersReader (leveraging the `pipeline` of the Transformers package)
+    # **Alternatives (Models):** e.g. "distilbert-base-uncased-distilled-squad" (fast) or
+    #                            "deepset/bert-large-uncased-whole-word-masking-squad2" (good accuracy)
+    # **Hint:** You can adjust the model to return "no answer possible" with the no_ans_boost. Higher values mean
+    #           the model prefers "no answer possible"
+    #
+    # #### FARMReader
+
+    # Load a  local model or any of the QA models on
+    # Hugging Face's model hub (https://huggingface.co/models)
+    reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+
+    # #### TransformersReader
+
+    # Alternative:
+    # reader = TransformersReader(
+    #    model_name_or_path="distilbert-base-uncased-distilled-squad", tokenizer="distilbert-base-uncased", use_gpu=-1)
+
+    # ### Finder
+    #
+    # The Finder sticks together reader and retriever in a pipeline to answer our actual questions.
+
+    finder = Finder(reader, retriever)
+
+    # ## Voilà! Ask a question!
+    # You can configure how many candidates the reader and retriever shall return
+    # The higher top_k_retriever, the better (but also the slower) your answers.
+    prediction = finder.get_answers(question="Who is the father of Sansa Stark?", top_k_retriever=10, top_k_reader=5)
+
+
+    # prediction = finder.get_answers(question="Who created the Dothraki vocabulary?", top_k_reader=5)
+    # prediction = finder.get_answers(question="Who is the sister of Sansa?", top_k_reader=5)
+
+    print_answers(prediction, details="minimal")
+
+
+if __name__ == "__main__":
+    tutorial1_basic_qa_pipeline()

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.py
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.py
@@ -10,38 +10,43 @@
 from haystack.reader.farm import FARMReader
 
 
-# ## Create Training Data
-# 
-# There are two ways to generate training data
-# 
-# 1. **Annotation**: You can use the annotation tool(https://github.com/deepset-ai/haystack#labeling-tool) to label
-#                    your data, i.e. highlighting answers to your questions in a document. The tool supports structuring
-#                   your workflow with organizations, projects, and users. The labels can be exported in SQuAD format
-#                    that is compatible for training with Haystack.
-# 
-# 2. **Feedback**:   For production systems, you can collect training data from direct user feedback via Haystack's
-#                    REST API interface. This includes a customizable user feedback API for providing feedback on the
-#                    answer returned by the API. The API provides a feedback export endpoint to obtain the feedback data
-#                    for fine-tuning your model further.
-# 
-# 
-# ## Fine-tune your model
-# 
-# Once you have collected training data, you can fine-tune your base models.
-# We initialize a reader as a base model and fine-tune it on our own custom dataset (should be in SQuAD-like format).
-# We recommend using a base model that was trained on SQuAD or a similar QA dataset before to benefit from Transfer
-# Learning effects.
+def tutorial2_finetune_a_model_on_your_data():
+    # ## Create Training Data
+    #
+    # There are two ways to generate training data
+    #
+    # 1. **Annotation**: You can use the annotation tool(https://github.com/deepset-ai/haystack#labeling-tool) to label
+    #                    your data, i.e. highlighting answers to your questions in a document. The tool supports structuring
+    #                   your workflow with organizations, projects, and users. The labels can be exported in SQuAD format
+    #                    that is compatible for training with Haystack.
+    #
+    # 2. **Feedback**:   For production systems, you can collect training data from direct user feedback via Haystack's
+    #                    REST API interface. This includes a customizable user feedback API for providing feedback on the
+    #                    answer returned by the API. The API provides a feedback export endpoint to obtain the feedback data
+    #                    for fine-tuning your model further.
+    #
+    #
+    # ## Fine-tune your model
+    #
+    # Once you have collected training data, you can fine-tune your base models.
+    # We initialize a reader as a base model and fine-tune it on our own custom dataset (should be in SQuAD-like format).
+    # We recommend using a base model that was trained on SQuAD or a similar QA dataset before to benefit from Transfer
+    # Learning effects.
 
-#**Recommendation: Run training on a GPU. To do so change the `use_gpu` arguments below to `True`
+    #**Recommendation: Run training on a GPU. To do so change the `use_gpu` arguments below to `True`
 
-reader = FARMReader(model_name_or_path="distilbert-base-uncased-distilled-squad", use_gpu=True)
-train_data = "data/squad20"
-# train_data = "PATH/TO_YOUR/TRAIN_DATA" 
-reader.train(data_dir=train_data, train_filename="dev-v2.0.json", use_gpu=True, n_epochs=1, save_dir="my_model")
+    reader = FARMReader(model_name_or_path="distilbert-base-uncased-distilled-squad", use_gpu=True)
+    train_data = "data/squad20"
+    # train_data = "PATH/TO_YOUR/TRAIN_DATA"
+    reader.train(data_dir=train_data, train_filename="dev-v2.0.json", use_gpu=True, n_epochs=1, save_dir="my_model")
 
-# Saving the model happens automatically at the end of training into the `save_dir` you specified
-# However, you could also save a reader manually again via:
-reader.save(directory="my_model")
+    # Saving the model happens automatically at the end of training into the `save_dir` you specified
+    # However, you could also save a reader manually again via:
+    reader.save(directory="my_model")
 
-# If you want to load it at a later point, just do:
-new_reader = FARMReader(model_name_or_path="my_model")
+    # If you want to load it at a later point, just do:
+    new_reader = FARMReader(model_name_or_path="my_model")
+
+
+if __name__ == "__main__":
+    tutorial2_finetune_a_model_on_your_data()

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.py
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.py
@@ -18,89 +18,94 @@ from haystack.retriever.sparse import TfidfRetriever
 from haystack.utils import print_answers
 
 
-# In-Memory Document Store
-document_store = InMemoryDocumentStore()
+def tutorial3_basic_qa_pipeline_without_elasticsearch():
+    # In-Memory Document Store
+    document_store = InMemoryDocumentStore()
 
-# or, alternatively, SQLite Document Store
-# document_store = SQLDocumentStore(url="sqlite:///qa.db")
-
-
-# ## Preprocessing of documents
-#
-# Haystack provides a customizable pipeline for:
-# - converting files into texts
-# - cleaning texts
-# - splitting texts
-# - writing them to a Document Store
-
-# In this tutorial, we download Wikipedia articles on Game of Thrones, apply a basic cleaning function, and index
-# them in Elasticsearch.
-# Let's first get some documents that we want to query
-# Here: 517 Wikipedia articles for Game of Thrones
-doc_dir = "data/article_txt_got"
-s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
-fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
-
-# convert files to dicts containing documents that can be indexed to our datastore
-dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
-# You can optionally supply a cleaning function that is applied to each doc (e.g. to remove footers)
-# It must take a str as input, and return a str.
-
-# Now, let's write the docs to our DB.
-document_store.write_documents(dicts)
+    # or, alternatively, SQLite Document Store
+    # document_store = SQLDocumentStore(url="sqlite:///qa.db")
 
 
-# ## Initalize Retriever, Reader,  & Finder
-#
-# ### Retriever
-#
-# Retrievers help narrowing down the scope for the Reader to smaller units of text where
-# a given question could be answered.
-#
-# With InMemoryDocumentStore or SQLDocumentStore, you can use the TfidfRetriever. For more
-# retrievers, please refer to the tutorial-1.
+    # ## Preprocessing of documents
+    #
+    # Haystack provides a customizable pipeline for:
+    # - converting files into texts
+    # - cleaning texts
+    # - splitting texts
+    # - writing them to a Document Store
 
-# An in-memory TfidfRetriever based on Pandas dataframes
-retriever = TfidfRetriever(document_store=document_store)
+    # In this tutorial, we download Wikipedia articles on Game of Thrones, apply a basic cleaning function, and index
+    # them in Elasticsearch.
+    # Let's first get some documents that we want to query
+    # Here: 517 Wikipedia articles for Game of Thrones
+    doc_dir = "data/article_txt_got"
+    s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
+    fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
 
-# ### Reader
-#
-# A Reader scans the texts returned by retrievers in detail and extracts the k best answers. They are based
-# on powerful, but slower deep learning models.
-#
-# Haystack currently supports Readers based on the frameworks FARM and Transformers.
-# With both you can either load a local model or one from Hugging Face's model hub (https://huggingface.co/models).
+    # convert files to dicts containing documents that can be indexed to our datastore
+    dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
+    # You can optionally supply a cleaning function that is applied to each doc (e.g. to remove footers)
+    # It must take a str as input, and return a str.
 
-# **Here:**                   a medium sized RoBERTa QA model using a Reader based on
-#                             FARM (https://huggingface.co/deepset/roberta-base-squad2)
-# **Alternatives (Reader):**  TransformersReader (leveraging the `pipeline` of the Transformers package)
-# **Alternatives (Models):**  e.g. "distilbert-base-uncased-distilled-squad" (fast) or
-#                             "deepset/bert-large-uncased-whole-word-masking-squad2" (good accuracy)
-# **Hint:**                   You can adjust the model to return "no answer possible" with the no_ans_boost.
-#                             Higher values mean the model prefers "no answer possible".
-
-# #### FARMReader
-#
-# Load a  local model or any of the QA models on
-# Hugging Face's model hub (https://huggingface.co/models)
-reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+    # Now, let's write the docs to our DB.
+    document_store.write_documents(dicts)
 
 
-# #### TransformersReader
-# Alternative:
-# reader = TransformersReader(model_name_or_path="distilbert-base-uncased-distilled-squad", tokenizer="distilbert-base-uncased", use_gpu=-1)
+    # ## Initalize Retriever, Reader,  & Finder
+    #
+    # ### Retriever
+    #
+    # Retrievers help narrowing down the scope for the Reader to smaller units of text where
+    # a given question could be answered.
+    #
+    # With InMemoryDocumentStore or SQLDocumentStore, you can use the TfidfRetriever. For more
+    # retrievers, please refer to the tutorial-1.
 
-# ### Finder
-#
-# The Finder sticks together reader and retriever in a pipeline to answer our actual questions.
-finder = Finder(reader, retriever)
+    # An in-memory TfidfRetriever based on Pandas dataframes
+    retriever = TfidfRetriever(document_store=document_store)
 
-# ## Voilà! Ask a question!
+    # ### Reader
+    #
+    # A Reader scans the texts returned by retrievers in detail and extracts the k best answers. They are based
+    # on powerful, but slower deep learning models.
+    #
+    # Haystack currently supports Readers based on the frameworks FARM and Transformers.
+    # With both you can either load a local model or one from Hugging Face's model hub (https://huggingface.co/models).
 
-# You can configure how many candidates the reader and retriever shall return
-# The higher top_k_retriever, the better (but also the slower) your answers.
-prediction = finder.get_answers(question="Who is the father of Arya Stark?", top_k_retriever=10, top_k_reader=5)
-# prediction = finder.get_answers(question="Who created the Dothraki vocabulary?", top_k_reader=5)
-# prediction = finder.get_answers(question="Who is the sister of Sansa?", top_k_reader=5)
+    # **Here:**                   a medium sized RoBERTa QA model using a Reader based on
+    #                             FARM (https://huggingface.co/deepset/roberta-base-squad2)
+    # **Alternatives (Reader):**  TransformersReader (leveraging the `pipeline` of the Transformers package)
+    # **Alternatives (Models):**  e.g. "distilbert-base-uncased-distilled-squad" (fast) or
+    #                             "deepset/bert-large-uncased-whole-word-masking-squad2" (good accuracy)
+    # **Hint:**                   You can adjust the model to return "no answer possible" with the no_ans_boost.
+    #                             Higher values mean the model prefers "no answer possible".
 
-print_answers(prediction, details="minimal")
+    # #### FARMReader
+    #
+    # Load a  local model or any of the QA models on
+    # Hugging Face's model hub (https://huggingface.co/models)
+    reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+
+
+    # #### TransformersReader
+    # Alternative:
+    # reader = TransformersReader(model_name_or_path="distilbert-base-uncased-distilled-squad", tokenizer="distilbert-base-uncased", use_gpu=-1)
+
+    # ### Finder
+    #
+    # The Finder sticks together reader and retriever in a pipeline to answer our actual questions.
+    finder = Finder(reader, retriever)
+
+    # ## Voilà! Ask a question!
+
+    # You can configure how many candidates the reader and retriever shall return
+    # The higher top_k_retriever, the better (but also the slower) your answers.
+    prediction = finder.get_answers(question="Who is the father of Arya Stark?", top_k_retriever=10, top_k_reader=5)
+    # prediction = finder.get_answers(question="Who created the Dothraki vocabulary?", top_k_reader=5)
+    # prediction = finder.get_answers(question="Who is the sister of Sansa?", top_k_reader=5)
+
+    print_answers(prediction, details="minimal")
+
+
+if __name__ == "__main__":
+    tutorial3_basic_qa_pipeline_without_elasticsearch()

--- a/tutorials/Tutorial4_FAQ_style_QA.py
+++ b/tutorials/Tutorial4_FAQ_style_QA.py
@@ -8,74 +8,81 @@ import requests
 import logging
 import subprocess
 import time
-## "FAQ-Style QA": Utilizing existing FAQs for Question Answering
-
-# While *extractive Question Answering* works on pure texts and is therefore more generalizable, there's also a common alternative that utilizes existing FAQ data.
-#
-# Pros:
-# - Very fast at inference time
-# - Utilize existing FAQ data
-# - Quite good control over answers
-#
-# Cons:
-# - Generalizability: We can only answer questions that are similar to existing ones in FAQ
-#
-# In some use cases, a combination of extractive QA and FAQ-style can also be an interesting option.
-LAUNCH_ELASTICSEARCH=True
-
-if LAUNCH_ELASTICSEARCH:
-    logging.info("Starting Elasticsearch ...")
-    status = subprocess.run(
-        ['docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.9.2'], shell=True
-    )
-    if status.returncode:
-        raise Exception("Failed to launch Elasticsearch. If you want to connect to an existing Elasticsearch instance"
-                        "then set LAUNCH_ELASTICSEARCH in the script to False.")
-    time.sleep(15)
-
-### Init the DocumentStore
-# In contrast to Tutorial 1 (extractive QA), we:
-#
-# * specify the name of our `text_field` in Elasticsearch that we want to return as an answer
-# * specify the name of our `embedding_field` in Elasticsearch where we'll store the embedding of our question and that is used later for calculating our similarity to the incoming user question
-# * set `excluded_meta_data=["question_emb"]` so that we don't return the huge embedding vectors in our search results
-
-document_store = ElasticsearchDocumentStore(host="localhost", username="", password="",
-                                            index="document",
-                                            embedding_field="question_emb",
-                                            embedding_dim=768,
-                                            excluded_meta_data=["question_emb"],
-                                            similarity="cosine")
-
-### Create a Retriever using embeddings
-# Instead of retrieving via Elasticsearch's plain BM25, we want to use vector similarity of the questions (user question vs. FAQ ones).
-# We can use the `EmbeddingRetriever` for this purpose and specify a model that we use for the embeddings.
-#
-retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", use_gpu=True)
-
-# Download a csv containing some FAQ data
-# Here: Some question-answer pairs related to COVID-19
-temp = requests.get("https://raw.githubusercontent.com/deepset-ai/COVID-QA/master/data/faqs/faq_covidbert.csv")
-open('small_faq_covid.csv', 'wb').write(temp.content)
-
-# Get dataframe with columns "question", "answer" and some custom metadata
-df = pd.read_csv("small_faq_covid.csv")
-# Minimal cleaning
-df.fillna(value="", inplace=True)
-df["question"] = df["question"].apply(lambda x: x.strip())
-print(df.head())
-
-# Get embeddings for our questions from the FAQs
-questions = list(df["question"].values)
-df["question_emb"] = retriever.embed_queries(texts=questions)
-df = df.rename(columns={"answer": "text"})
-
-# Convert Dataframe to list of dicts and index them in our DocumentStore
-docs_to_index = df.to_dict(orient="records")
-document_store.write_documents(docs_to_index)
 
 
-# Init reader & and use Finder to get answer (same as in Tutorial 1)
-finder = Finder(reader=None, retriever=retriever)
-prediction = finder.get_answers_via_similar_questions(question="How is the virus spreading?", top_k_retriever=10)
-print_answers(prediction, details="all")
+def tutorial4_faq_style_qa():
+    ## "FAQ-Style QA": Utilizing existing FAQs for Question Answering
+
+    # While *extractive Question Answering* works on pure texts and is therefore more generalizable, there's also a common alternative that utilizes existing FAQ data.
+    #
+    # Pros:
+    # - Very fast at inference time
+    # - Utilize existing FAQ data
+    # - Quite good control over answers
+    #
+    # Cons:
+    # - Generalizability: We can only answer questions that are similar to existing ones in FAQ
+    #
+    # In some use cases, a combination of extractive QA and FAQ-style can also be an interesting option.
+    LAUNCH_ELASTICSEARCH=True
+
+    if LAUNCH_ELASTICSEARCH:
+        logging.info("Starting Elasticsearch ...")
+        status = subprocess.run(
+            ['docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.9.2'], shell=True
+        )
+        if status.returncode:
+            raise Exception("Failed to launch Elasticsearch. If you want to connect to an existing Elasticsearch instance"
+                            "then set LAUNCH_ELASTICSEARCH in the script to False.")
+        time.sleep(15)
+
+    ### Init the DocumentStore
+    # In contrast to Tutorial 1 (extractive QA), we:
+    #
+    # * specify the name of our `text_field` in Elasticsearch that we want to return as an answer
+    # * specify the name of our `embedding_field` in Elasticsearch where we'll store the embedding of our question and that is used later for calculating our similarity to the incoming user question
+    # * set `excluded_meta_data=["question_emb"]` so that we don't return the huge embedding vectors in our search results
+
+    document_store = ElasticsearchDocumentStore(host="localhost", username="", password="",
+                                                index="document",
+                                                embedding_field="question_emb",
+                                                embedding_dim=768,
+                                                excluded_meta_data=["question_emb"],
+                                                similarity="cosine")
+
+    ### Create a Retriever using embeddings
+    # Instead of retrieving via Elasticsearch's plain BM25, we want to use vector similarity of the questions (user question vs. FAQ ones).
+    # We can use the `EmbeddingRetriever` for this purpose and specify a model that we use for the embeddings.
+    #
+    retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/sentence_bert", use_gpu=True)
+
+    # Download a csv containing some FAQ data
+    # Here: Some question-answer pairs related to COVID-19
+    temp = requests.get("https://raw.githubusercontent.com/deepset-ai/COVID-QA/master/data/faqs/faq_covidbert.csv")
+    open('small_faq_covid.csv', 'wb').write(temp.content)
+
+    # Get dataframe with columns "question", "answer" and some custom metadata
+    df = pd.read_csv("small_faq_covid.csv")
+    # Minimal cleaning
+    df.fillna(value="", inplace=True)
+    df["question"] = df["question"].apply(lambda x: x.strip())
+    print(df.head())
+
+    # Get embeddings for our questions from the FAQs
+    questions = list(df["question"].values)
+    df["question_emb"] = retriever.embed_queries(texts=questions)
+    df = df.rename(columns={"answer": "text"})
+
+    # Convert Dataframe to list of dicts and index them in our DocumentStore
+    docs_to_index = df.to_dict(orient="records")
+    document_store.write_documents(docs_to_index)
+
+
+    # Init reader & and use Finder to get answer (same as in Tutorial 1)
+    finder = Finder(reader=None, retriever=retriever)
+    prediction = finder.get_answers_via_similar_questions(question="How is the virus spreading?", top_k_retriever=10)
+    print_answers(prediction, details="all")
+
+
+if __name__ == "__main__":
+    tutorial4_faq_style_qa()

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -10,101 +10,107 @@ import logging
 import subprocess
 import time
 
-logger = logging.getLogger(__name__)
 
-##############################################
-# Settings
-##############################################
-LAUNCH_ELASTICSEARCH = True
+def tutorial5_evaluation():
+    logger = logging.getLogger(__name__)
 
-eval_retriever_only = True
-eval_reader_only = False
-eval_both = False
+    ##############################################
+    # Settings
+    ##############################################
+    LAUNCH_ELASTICSEARCH = True
 
-# make sure these indices do not collide with existing ones, the indices will be wiped clean before data is inserted
-doc_index = "tutorial5_docs"
-label_index = "tutorial5_labels"
-##############################################
-# Code
-##############################################
-device, n_gpu = initialize_device_settings(use_cuda=True)
-# Start an Elasticsearch server
-# You can start Elasticsearch on your local machine instance using Docker. If Docker is not readily available in
-# your environment (eg., in Colab notebooks), then you can manually download and execute Elasticsearch from source.
-if LAUNCH_ELASTICSEARCH:
-    logging.info("Starting Elasticsearch ...")
-    status = subprocess.run(
-        ['docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.9.2'], shell=True
-    )
-    if status.returncode:
-        raise Exception("Failed to launch Elasticsearch. If you want to connect to an existing Elasticsearch instance"
-                        "then set LAUNCH_ELASTICSEARCH in the script to False.")
-    time.sleep(30)
+    eval_retriever_only = True
+    eval_reader_only = False
+    eval_both = False
 
-# Download evaluation data, which is a subset of Natural Questions development set containing 50 documents
-doc_dir = "../data/nq"
-s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/nq_dev_subset_v2.json.zip"
-fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
+    # make sure these indices do not collide with existing ones, the indices will be wiped clean before data is inserted
+    doc_index = "tutorial5_docs"
+    label_index = "tutorial5_labels"
+    ##############################################
+    # Code
+    ##############################################
+    device, n_gpu = initialize_device_settings(use_cuda=True)
+    # Start an Elasticsearch server
+    # You can start Elasticsearch on your local machine instance using Docker. If Docker is not readily available in
+    # your environment (eg., in Colab notebooks), then you can manually download and execute Elasticsearch from source.
+    if LAUNCH_ELASTICSEARCH:
+        logging.info("Starting Elasticsearch ...")
+        status = subprocess.run(
+            ['docker run -d -p 9200:9200 -e "discovery.type=single-node" elasticsearch:7.9.2'], shell=True
+        )
+        if status.returncode:
+            raise Exception("Failed to launch Elasticsearch. If you want to connect to an existing Elasticsearch instance"
+                            "then set LAUNCH_ELASTICSEARCH in the script to False.")
+        time.sleep(30)
 
-# Connect to Elasticsearch
-document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document",
-                                            create_index=False, embedding_field="emb",
-                                            embedding_dim=768, excluded_meta_data=["emb"])
+    # Download evaluation data, which is a subset of Natural Questions development set containing 50 documents
+    doc_dir = "../data/nq"
+    s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/nq_dev_subset_v2.json.zip"
+    fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
 
-
-# Add evaluation data to Elasticsearch document store
-# We first delete the custom tutorial indices to not have duplicate elements
-document_store.delete_all_documents(index=doc_index)
-document_store.delete_all_documents(index=label_index)
-document_store.add_eval_data(filename="../data/nq/nq_dev_subset_v2.json", doc_index=doc_index, label_index=label_index)
-
-# Initialize Retriever
-retriever = ElasticsearchRetriever(document_store=document_store)
-
-# Alternative: Evaluate DensePassageRetriever
-# Note, that DPR works best when you index short passages < 512 tokens as only those tokens will be used for the embedding.
-# Here, for nq_dev_subset_v2.json we have avg. num of tokens = 5220(!).
-# DPR still outperforms Elastic's BM25 by a small margin here.
-# retriever = DensePassageRetriever(document_store=document_store,
-#                                   query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
-#                                   passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
-#                                   use_gpu=True,
-#                                   embed_title=True,
-#                                   remove_sep_tok_from_untitled_passages=True)
-# document_store.update_embeddings(retriever, index=doc_index)
+    # Connect to Elasticsearch
+    document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document",
+                                                create_index=False, embedding_field="emb",
+                                                embedding_dim=768, excluded_meta_data=["emb"])
 
 
-# Initialize Reader
-reader = FARMReader("deepset/roberta-base-squad2", top_k_per_candidate=4)
+    # Add evaluation data to Elasticsearch document store
+    # We first delete the custom tutorial indices to not have duplicate elements
+    document_store.delete_all_documents(index=doc_index)
+    document_store.delete_all_documents(index=label_index)
+    document_store.add_eval_data(filename="../data/nq/nq_dev_subset_v2.json", doc_index=doc_index, label_index=label_index)
 
-# Initialize Finder which sticks together Reader and Retriever
-finder = Finder(reader, retriever)
+    # Initialize Retriever
+    retriever = ElasticsearchRetriever(document_store=document_store)
 
-
-## Evaluate Retriever on its own
-if eval_retriever_only:
-    retriever_eval_results = retriever.eval(top_k=10, label_index=label_index, doc_index=doc_index)
-    ## Retriever Recall is the proportion of questions for which the correct document containing the answer is
-    ## among the correct documents
-    print("Retriever Recall:", retriever_eval_results["recall"])
-    ## Retriever Mean Avg Precision rewards retrievers that give relevant documents a higher rank
-    print("Retriever Mean Avg Precision:", retriever_eval_results["map"])
-
-# Evaluate Reader on its own
-if eval_reader_only:
-    reader_eval_results = reader.eval(document_store=document_store, device=device, label_index=label_index, doc_index=doc_index)
-    # Evaluation of Reader can also be done directly on a SQuAD-formatted file without passing the data to Elasticsearch
-    #reader_eval_results = reader.eval_on_file("../data/nq", "nq_dev_subset_v2.json", device=device)
-
-    ## Reader Top-N-Accuracy is the proportion of predicted answers that match with their corresponding correct answer
-    print("Reader Top-N-Accuracy:", reader_eval_results["top_n_accuracy"])
-    ## Reader Exact Match is the proportion of questions where the predicted answer is exactly the same as the correct answer
-    print("Reader Exact Match:", reader_eval_results["EM"])
-    ## Reader F1-Score is the average overlap between the predicted answers and the correct answers
-    print("Reader F1-Score:", reader_eval_results["f1"])
+    # Alternative: Evaluate DensePassageRetriever
+    # Note, that DPR works best when you index short passages < 512 tokens as only those tokens will be used for the embedding.
+    # Here, for nq_dev_subset_v2.json we have avg. num of tokens = 5220(!).
+    # DPR still outperforms Elastic's BM25 by a small margin here.
+    # retriever = DensePassageRetriever(document_store=document_store,
+    #                                   query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
+    #                                   passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
+    #                                   use_gpu=True,
+    #                                   embed_title=True,
+    #                                   remove_sep_tok_from_untitled_passages=True)
+    # document_store.update_embeddings(retriever, index=doc_index)
 
 
-# Evaluate combination of Reader and Retriever through Finder
-if eval_both:
-    finder_eval_results = finder.eval(top_k_retriever=1, top_k_reader=10, label_index=label_index, doc_index=doc_index)
-    finder.print_eval_results(finder_eval_results)
+    # Initialize Reader
+    reader = FARMReader("deepset/roberta-base-squad2", top_k_per_candidate=4)
+
+    # Initialize Finder which sticks together Reader and Retriever
+    finder = Finder(reader, retriever)
+
+
+    ## Evaluate Retriever on its own
+    if eval_retriever_only:
+        retriever_eval_results = retriever.eval(top_k=10, label_index=label_index, doc_index=doc_index)
+        ## Retriever Recall is the proportion of questions for which the correct document containing the answer is
+        ## among the correct documents
+        print("Retriever Recall:", retriever_eval_results["recall"])
+        ## Retriever Mean Avg Precision rewards retrievers that give relevant documents a higher rank
+        print("Retriever Mean Avg Precision:", retriever_eval_results["map"])
+
+    # Evaluate Reader on its own
+    if eval_reader_only:
+        reader_eval_results = reader.eval(document_store=document_store, device=device, label_index=label_index, doc_index=doc_index)
+        # Evaluation of Reader can also be done directly on a SQuAD-formatted file without passing the data to Elasticsearch
+        #reader_eval_results = reader.eval_on_file("../data/nq", "nq_dev_subset_v2.json", device=device)
+
+        ## Reader Top-N-Accuracy is the proportion of predicted answers that match with their corresponding correct answer
+        print("Reader Top-N-Accuracy:", reader_eval_results["top_n_accuracy"])
+        ## Reader Exact Match is the proportion of questions where the predicted answer is exactly the same as the correct answer
+        print("Reader Exact Match:", reader_eval_results["EM"])
+        ## Reader F1-Score is the average overlap between the predicted answers and the correct answers
+        print("Reader F1-Score:", reader_eval_results["f1"])
+
+
+    # Evaluate combination of Reader and Retriever through Finder
+    if eval_both:
+        finder_eval_results = finder.eval(top_k_retriever=1, top_k_reader=10, label_index=label_index, doc_index=doc_index)
+        finder.print_eval_results(finder_eval_results)
+
+
+if __name__ == "__main__":
+    tutorial5_evaluation()

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -6,63 +6,67 @@ from haystack.reader.farm import FARMReader
 from haystack.utils import print_answers
 from haystack.retriever.dense import DensePassageRetriever
 
+def tutorial6_better_retrieval_via_dpr():
+    # FAISS is a library for efficient similarity search on a cluster of dense vectors.
+    # The FAISSDocumentStore uses a SQL(SQLite in-memory be default) document store under-the-hood
+    # to store the document text and other meta data. The vector embeddings of the text are
+    # indexed on a FAISS Index that later is queried for searching answers.
+    # The default flavour of FAISSDocumentStore is "Flat" but can also be set to "HNSW" for
+    # faster search at the expense of some accuracy. Just set the faiss_index_factor_str argument in the constructor.
+    # For more info on which suits your use case: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
+    document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
 
-# FAISS is a library for efficient similarity search on a cluster of dense vectors.
-# The FAISSDocumentStore uses a SQL(SQLite in-memory be default) document store under-the-hood
-# to store the document text and other meta data. The vector embeddings of the text are
-# indexed on a FAISS Index that later is queried for searching answers.
-# The default flavour of FAISSDocumentStore is "Flat" but can also be set to "HNSW" for
-# faster search at the expense of some accuracy. Just set the faiss_index_factor_str argument in the constructor.
-# For more info on which suits your use case: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
-document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
+    # ## Preprocessing of documents
+    # Let's first get some documents that we want to query
+    doc_dir = "data/article_txt_got"
+    s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
+    fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
 
-# ## Preprocessing of documents
-# Let's first get some documents that we want to query
-doc_dir = "data/article_txt_got"
-s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
-fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
+    # convert files to dicts containing documents that can be indexed to our datastore
+    dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
 
-# convert files to dicts containing documents that can be indexed to our datastore
-dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
+    # Now, let's write the docs to our DB.
+    document_store.write_documents(dicts)
 
-# Now, let's write the docs to our DB.
-document_store.write_documents(dicts)
+    ### Retriever
+    retriever = DensePassageRetriever(document_store=document_store,
+                                      query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
+                                      passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
+                                      max_seq_len_query=64,
+                                      max_seq_len_passage=256,
+                                      batch_size=2,
+                                      use_gpu=True,
+                                      embed_title=True,
+                                      use_fast_tokenizers=True
+                                      )
 
-### Retriever
-retriever = DensePassageRetriever(document_store=document_store,
-                                  query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
-                                  passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
-                                  max_seq_len_query=64,
-                                  max_seq_len_passage=256,
-                                  batch_size=2,
-                                  use_gpu=True,
-                                  embed_title=True,
-                                  use_fast_tokenizers=True
-                                  )
+    # Important:
+    # Now that after we have the DPR initialized, we need to call update_embeddings() to iterate over all
+    # previously indexed documents and update their embedding representation.
+    # While this can be a time consuming operation (depending on corpus size), it only needs to be done once.
+    # At query time, we only need to embed the query and compare it the existing doc embeddings which is very fast.
+    document_store.update_embeddings(retriever)
 
-# Important:
-# Now that after we have the DPR initialized, we need to call update_embeddings() to iterate over all
-# previously indexed documents and update their embedding representation.
-# While this can be a time consuming operation (depending on corpus size), it only needs to be done once.
-# At query time, we only need to embed the query and compare it the existing doc embeddings which is very fast.
-document_store.update_embeddings(retriever)
+    ### Reader
+    # Load a  local model or any of the QA models on
+    # Hugging Face's model hub (https://huggingface.co/models)
+    reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
 
-### Reader
-# Load a  local model or any of the QA models on
-# Hugging Face's model hub (https://huggingface.co/models)
-reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+    ### Finder
+    # The Finder sticks together reader and retriever in a pipeline to answer our actual questions.
+    finder = Finder(reader, retriever)
 
-### Finder
-# The Finder sticks together reader and retriever in a pipeline to answer our actual questions.
-finder = Finder(reader, retriever)
-
-### Voilà! Ask a question!
-# You can configure how many candidates the reader and retriever shall return
-# The higher top_k_retriever, the better (but also the slower) your answers.
-prediction = finder.get_answers(question="Who is the father of Arya Stark?", top_k_retriever=10, top_k_reader=5)
+    ### Voilà! Ask a question!
+    # You can configure how many candidates the reader and retriever shall return
+    # The higher top_k_retriever, the better (but also the slower) your answers.
+    prediction = finder.get_answers(question="Who is the father of Arya Stark?", top_k_retriever=10, top_k_reader=5)
 
 
-# prediction = finder.get_answers(question="Who created the Dothraki vocabulary?", top_k_reader=5)
-# prediction = finder.get_answers(question="Who is the sister of Sansa?", top_k_reader=5)
+    # prediction = finder.get_answers(question="Who created the Dothraki vocabulary?", top_k_reader=5)
+    # prediction = finder.get_answers(question="Who is the sister of Sansa?", top_k_reader=5)
 
-print_answers(prediction, details="minimal")
+    print_answers(prediction, details="minimal")
+
+
+if __name__ == "__main__":
+    tutorial6_better_retrieval_via_dpr()

--- a/tutorials/Tutorial7_RAG_Generator.py
+++ b/tutorials/Tutorial7_RAG_Generator.py
@@ -7,105 +7,110 @@ from haystack.generator.transformers import RAGenerator
 from haystack.retriever.dense import DensePassageRetriever
 
 
-# Add documents from which you want generate answers
-# Download a csv containing some sample documents data
-# Here some sample documents data
-temp = requests.get("https://raw.githubusercontent.com/deepset-ai/haystack/master/tutorials/small_generator_dataset.csv")
-open('small_generator_dataset.csv', 'wb').write(temp.content)
+def tutorial7_rag_generator():
+    # Add documents from which you want generate answers
+    # Download a csv containing some sample documents data
+    # Here some sample documents data
+    temp = requests.get("https://raw.githubusercontent.com/deepset-ai/haystack/master/tutorials/small_generator_dataset.csv")
+    open('small_generator_dataset.csv', 'wb').write(temp.content)
 
-# Get dataframe with columns "title", and "text"
-df = pd.read_csv("small_generator_dataset.csv", sep=',')
-# Minimal cleaning
-df.fillna(value="", inplace=True)
+    # Get dataframe with columns "title", and "text"
+    df = pd.read_csv("small_generator_dataset.csv", sep=',')
+    # Minimal cleaning
+    df.fillna(value="", inplace=True)
 
-print(df.head())
+    print(df.head())
 
-titles = list(df["title"].values)
-texts = list(df["text"].values)
+    titles = list(df["title"].values)
+    texts = list(df["text"].values)
 
-# Create to haystack document format
-documents: List[Document] = []
-for title, text in zip(titles, texts):
-    documents.append(
-        Document(
-            text=text,
-            meta={
-                "name": title or ""
-            }
+    # Create to haystack document format
+    documents: List[Document] = []
+    for title, text in zip(titles, texts):
+        documents.append(
+            Document(
+                text=text,
+                meta={
+                    "name": title or ""
+                }
+            )
         )
+
+
+    # Initialize FAISS document store to documents and corresponding index for embeddings
+    # Set `return_embedding` to `True`, so generator doesn't have to perform re-embedding
+    document_store = FAISSDocumentStore(
+        faiss_index_factory_str="Flat",
+        return_embedding=True
     )
 
-
-# Initialize FAISS document store to documents and corresponding index for embeddings
-# Set `return_embedding` to `True`, so generator doesn't have to perform re-embedding
-document_store = FAISSDocumentStore(
-    faiss_index_factory_str="Flat",
-    return_embedding=True
-)
-
-# Initialize DPR Retriever to encode documents, encode question and query documents
-retriever = DensePassageRetriever(
-    document_store=document_store,
-    query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
-    passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
-    use_gpu=True,
-    embed_title=True,
-)
-
-# Initialize RAG Generator
-generator = RAGenerator(
-    model_name_or_path="facebook/rag-token-nq",
-    use_gpu=True,
-    top_k_answers=1,
-    max_length=200,
-    min_length=2,
-    embed_title=True,
-    num_beams=2,
-)
-
-# Delete existing documents in documents store
-document_store.delete_all_documents()
-# Write documents to document store
-document_store.write_documents(documents)
-# Add documents embeddings to index
-document_store.update_embeddings(
-    retriever=retriever
-)
-
-# Now ask your questions
-# We have some sample questions
-QUESTIONS = [
-    "who got the first nobel prize in physics",
-    "when is the next deadpool movie being released",
-    "which mode is used for short wave broadcast service",
-    "who is the owner of reading football club",
-    "when is the next scandal episode coming out",
-    "when is the last time the philadelphia won the superbowl",
-    "what is the most current adobe flash player version",
-    "how many episodes are there in dragon ball z",
-    "what is the first step in the evolution of the eye",
-    "where is gall bladder situated in human body",
-    "what is the main mineral in lithium batteries",
-    "who is the president of usa right now",
-    "where do the greasers live in the outsiders",
-    "panda is a national animal of which country",
-    "what is the name of manchester united stadium",
-]
-
-# Now generate answer for question
-for question in QUESTIONS:
-    # Retrieve related documents from retriever
-    retriever_results = retriever.retrieve(
-        query=question
+    # Initialize DPR Retriever to encode documents, encode question and query documents
+    retriever = DensePassageRetriever(
+        document_store=document_store,
+        query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
+        passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
+        use_gpu=True,
+        embed_title=True,
     )
 
-    # Now generate answer from question and retrieved documents
-    predicted_result = generator.predict(
-        query=question,
-        documents=retriever_results,
-        top_k=1
+    # Initialize RAG Generator
+    generator = RAGenerator(
+        model_name_or_path="facebook/rag-token-nq",
+        use_gpu=True,
+        top_k_answers=1,
+        max_length=200,
+        min_length=2,
+        embed_title=True,
+        num_beams=2,
     )
 
-    # Print you answer
-    answers = predicted_result["answers"]
-    print(f'Generated answer is \'{answers[0]["answer"]}\' for the question = \'{question}\'')
+    # Delete existing documents in documents store
+    document_store.delete_all_documents()
+    # Write documents to document store
+    document_store.write_documents(documents)
+    # Add documents embeddings to index
+    document_store.update_embeddings(
+        retriever=retriever
+    )
+
+    # Now ask your questions
+    # We have some sample questions
+    QUESTIONS = [
+        "who got the first nobel prize in physics",
+        "when is the next deadpool movie being released",
+        "which mode is used for short wave broadcast service",
+        "who is the owner of reading football club",
+        "when is the next scandal episode coming out",
+        "when is the last time the philadelphia won the superbowl",
+        "what is the most current adobe flash player version",
+        "how many episodes are there in dragon ball z",
+        "what is the first step in the evolution of the eye",
+        "where is gall bladder situated in human body",
+        "what is the main mineral in lithium batteries",
+        "who is the president of usa right now",
+        "where do the greasers live in the outsiders",
+        "panda is a national animal of which country",
+        "what is the name of manchester united stadium",
+    ]
+
+    # Now generate answer for question
+    for question in QUESTIONS:
+        # Retrieve related documents from retriever
+        retriever_results = retriever.retrieve(
+            query=question
+        )
+
+        # Now generate answer from question and retrieved documents
+        predicted_result = generator.predict(
+            query=question,
+            documents=retriever_results,
+            top_k=1
+        )
+
+        # Print you answer
+        answers = predicted_result["answers"]
+        print(f'Generated answer is \'{answers[0]["answer"]}\' for the question = \'{question}\'')
+
+
+if __name__ == "__main__":
+    tutorial7_rag_generator()

--- a/tutorials/Tutorial8_Preprocessing.py
+++ b/tutorials/Tutorial8_Preprocessing.py
@@ -26,117 +26,121 @@ from haystack.file_converter.docx import DocxToTextConverter
 from haystack.preprocessor.utils import convert_files_to_dicts, fetch_archive_from_http
 from haystack.preprocessor.preprocessor import PreProcessor
 
-# This fetches some sample files to work with
 
-doc_dir = "data/preprocessing_tutorial"
-s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/preprocessing_tutorial.zip"
-fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
+def tutorial8_preprocessing():
+    # This fetches some sample files to work with
 
-"""
-## Converters
+    doc_dir = "data/preprocessing_tutorial"
+    s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/preprocessing_tutorial.zip"
+    fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
 
-Haystack's converter classes are designed to help you turn files on your computer into the documents
-that can be processed by the Haystack pipeline.
-There are file converters for txt, pdf, docx files as well as a converter that is powered by Apache Tika.
-"""
+    """
+    ## Converters
+    
+    Haystack's converter classes are designed to help you turn files on your computer into the documents
+    that can be processed by the Haystack pipeline.
+    There are file converters for txt, pdf, docx files as well as a converter that is powered by Apache Tika.
+    """
 
-# Here are some examples of how you would use file converters
+    # Here are some examples of how you would use file converters
 
-converter = TextConverter(remove_numeric_tables=True, valid_languages=["en"])
-doc_txt = converter.convert(file_path="data/preprocessing_tutorial/classics.txt", meta=None)
+    converter = TextConverter(remove_numeric_tables=True, valid_languages=["en"])
+    doc_txt = converter.convert(file_path="data/preprocessing_tutorial/classics.txt", meta=None)
 
-converter = PDFToTextConverter(remove_numeric_tables=True, valid_languages=["en"])
-doc_pdf = converter.convert(file_path="data/preprocessing_tutorial/bert.pdf", meta=None)
+    converter = PDFToTextConverter(remove_numeric_tables=True, valid_languages=["en"])
+    doc_pdf = converter.convert(file_path="data/preprocessing_tutorial/bert.pdf", meta=None)
 
-converter = DocxToTextConverter(remove_numeric_tables=True, valid_languages=["en"])
-doc_docx = converter.convert(file_path="data/preprocessing_tutorial/heavy_metal.docx", meta=None)
+    converter = DocxToTextConverter(remove_numeric_tables=True, valid_languages=["en"])
+    doc_docx = converter.convert(file_path="data/preprocessing_tutorial/heavy_metal.docx", meta=None)
 
-# Haystack also has a convenience function that will automatically apply the right converter to each file in a directory.
+    # Haystack also has a convenience function that will automatically apply the right converter to each file in a directory.
 
-all_docs = convert_files_to_dicts(dir_path="data/preprocessing_tutorial")
+    all_docs = convert_files_to_dicts(dir_path="data/preprocessing_tutorial")
 
-"""
-
-## PreProcessor
-
-The PreProcessor class is designed to help you clean text and split text into sensible units.
-File splitting can have a very significant impact on the system's performance.
-Have a look at the [Preprocessing](https://haystack.deepset.ai/docs/latest/preprocessingmd)
-and [Optimization](https://haystack.deepset.ai/docs/latest/optimizationmd) pages on our website for more details.
-"""
-
-
-# This is a default usage of the PreProcessor.
-# Here, it performs cleaning of consecutive whitespaces
-# and splits a single large document into smaller documents.
-# Each document is up to 1000 words long and document breaks cannot fall in the middle of sentences
-# Note how the single document passed into the document gets split into 5 smaller documents
-
-preprocessor = PreProcessor(
-    clean_empty_lines=True,
-    clean_whitespace=True,
-    clean_header_footer=False,
-    split_by="word",
-    split_length=1000,
-    split_respect_sentence_boundary=True
-)
-docs_default = preprocessor.process(doc_txt)
-print(f"n_docs_input: 1\nn_docs_output: {len(docs_default)}")
-
-"""
-## Cleaning
-
-- `clean_empty_lines` will normalize 3 or more consecutive empty lines to be just a two empty lines
-- `clean_whitespace` will remove any whitespace at the beginning or end of each line in the text
-- `clean_header_footer` will remove any long header or footer texts that are repeated on each page
-
-## Splitting
-By default, the PreProcessor will respect sentence boundaries, meaning that documents will not start or end
-midway through a sentence.
-This will help reduce the possibility of answer phrases being split between two documents.
-This feature can be turned off by setting `split_respect_sentence_boundary=False`.
-"""
-
-# Not respecting sentence boundary vs respecting sentence boundary
-
-preprocessor_nrsb = PreProcessor(split_respect_sentence_boundary=False)
-docs_nrsb = preprocessor_nrsb.process(doc_txt)
-
-print("RESPECTING SENTENCE BOUNDARY")
-end_text = docs_default[0]["text"][-50:]
-print("End of document: \"..." + end_text + "\"")
-print()
-print("NOT RESPECTING SENTENCE BOUNDARY")
-end_text_nrsb = docs_nrsb[0]["text"][-50:]
-print("End of document: \"..." + end_text_nrsb + "\"")
-
-"""
-A commonly used strategy to split long documents, especially in the field of Question Answering,
-is the sliding window approach. If `split_length=10` and `split_overlap=3`, your documents will look like this:
-
-- doc1 = words[0:10]
-- doc2 = words[7:17]
-- doc3 = words[14:24]
-- ...
-
-You can use this strategy by following the code below.
-"""
-
-# Sliding window approach
-
-preprocessor_sliding_window = PreProcessor(
-    split_overlap=3,
-    split_length=10,
-    split_respect_sentence_boundary=False
-)
-docs_sliding_window = preprocessor_sliding_window.process(doc_txt)
-
-doc1 = docs_sliding_window[0]["text"][:200]
-doc2 = docs_sliding_window[1]["text"][:100]
-doc3 = docs_sliding_window[2]["text"][:100]
-
-print("Document 1: \"" + doc1 + "...\"")
-print("Document 2: \"" + doc2 + "...\"")
-print("Document 3: \"" + doc3 + "...\"")
+    """
+    
+    ## PreProcessor
+    
+    The PreProcessor class is designed to help you clean text and split text into sensible units.
+    File splitting can have a very significant impact on the system's performance.
+    Have a look at the [Preprocessing](https://haystack.deepset.ai/docs/latest/preprocessingmd)
+    and [Optimization](https://haystack.deepset.ai/docs/latest/optimizationmd) pages on our website for more details.
+    """
 
 
+    # This is a default usage of the PreProcessor.
+    # Here, it performs cleaning of consecutive whitespaces
+    # and splits a single large document into smaller documents.
+    # Each document is up to 1000 words long and document breaks cannot fall in the middle of sentences
+    # Note how the single document passed into the document gets split into 5 smaller documents
+
+    preprocessor = PreProcessor(
+        clean_empty_lines=True,
+        clean_whitespace=True,
+        clean_header_footer=False,
+        split_by="word",
+        split_length=1000,
+        split_respect_sentence_boundary=True
+    )
+    docs_default = preprocessor.process(doc_txt)
+    print(f"n_docs_input: 1\nn_docs_output: {len(docs_default)}")
+
+    """
+    ## Cleaning
+    
+    - `clean_empty_lines` will normalize 3 or more consecutive empty lines to be just a two empty lines
+    - `clean_whitespace` will remove any whitespace at the beginning or end of each line in the text
+    - `clean_header_footer` will remove any long header or footer texts that are repeated on each page
+    
+    ## Splitting
+    By default, the PreProcessor will respect sentence boundaries, meaning that documents will not start or end
+    midway through a sentence.
+    This will help reduce the possibility of answer phrases being split between two documents.
+    This feature can be turned off by setting `split_respect_sentence_boundary=False`.
+    """
+
+    # Not respecting sentence boundary vs respecting sentence boundary
+
+    preprocessor_nrsb = PreProcessor(split_respect_sentence_boundary=False)
+    docs_nrsb = preprocessor_nrsb.process(doc_txt)
+
+    print("RESPECTING SENTENCE BOUNDARY")
+    end_text = docs_default[0]["text"][-50:]
+    print("End of document: \"..." + end_text + "\"")
+    print()
+    print("NOT RESPECTING SENTENCE BOUNDARY")
+    end_text_nrsb = docs_nrsb[0]["text"][-50:]
+    print("End of document: \"..." + end_text_nrsb + "\"")
+
+    """
+    A commonly used strategy to split long documents, especially in the field of Question Answering,
+    is the sliding window approach. If `split_length=10` and `split_overlap=3`, your documents will look like this:
+    
+    - doc1 = words[0:10]
+    - doc2 = words[7:17]
+    - doc3 = words[14:24]
+    - ...
+    
+    You can use this strategy by following the code below.
+    """
+
+    # Sliding window approach
+
+    preprocessor_sliding_window = PreProcessor(
+        split_overlap=3,
+        split_length=10,
+        split_respect_sentence_boundary=False
+    )
+    docs_sliding_window = preprocessor_sliding_window.process(doc_txt)
+
+    doc1 = docs_sliding_window[0]["text"][:200]
+    doc2 = docs_sliding_window[1]["text"][:100]
+    doc3 = docs_sliding_window[2]["text"][:100]
+
+    print("Document 1: \"" + doc1 + "...\"")
+    print("Document 2: \"" + doc2 + "...\"")
+    print("Document 3: \"" + doc3 + "...\"")
+
+
+if __name__ == "__main__":
+    tutorial8_preprocessing()


### PR DESCRIPTION
The tutorials are now encapsulated in methods and it is checked that the code is executed only by the main process but none of the subprocesses when using multiprocessing. This change only affects Windows users.

On Windows, this check is necessary to prevent the tutorial code from being executed in every subprocess when using multiprocessing. Without the check, every subprocess tries to spawn a new elasticsearch instance, write to the same log file, etc., which leads to "Permission denied" errors or "failed to obtain node locks" exceptions as reported in the following issue

closes #709 