### PR TITLE
Fix delete_all_documents for the SQLDocumentStore

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -388,7 +388,7 @@ In-memory document store
 #### \_\_init\_\_
 
 ```python
- | __init__(embedding_field: Optional[str] = "embedding", return_embedding: bool = False, similarity="dot_product")
+ | __init__(index: str = "document", label_index: str = "label", embedding_field: Optional[str] = "embedding", embedding_dim: int = 768, return_embedding: bool = False, similarity: str = "dot_product")
 ```
 
 **Arguments**:

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -19,7 +19,15 @@ class InMemoryDocumentStore(BaseDocumentStore):
         In-memory document store
     """
 
-    def __init__(self, embedding_field: Optional[str] = "embedding", return_embedding: bool = False, similarity="dot_product"):
+    def __init__(
+        self,
+        index: str = "document",
+        label_index: str = "label",
+        embedding_field: Optional[str] = "embedding",
+        embedding_dim: int = 768,
+        return_embedding: bool = False,
+        similarity: str = "dot_product",
+    ):
         """
         :param embedding_field: Name of field containing an embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
         :param return_embedding: To return document embedding
@@ -27,12 +35,12 @@ class InMemoryDocumentStore(BaseDocumentStore):
                    more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
         """
         self.indexes: Dict[str, Dict] = defaultdict(dict)
-        self.index: str = "document"
-        self.label_index: str = "label"
-        self.embedding_field: str = embedding_field if embedding_field is not None else "embedding"
-        self.embedding_dim: int = 768
-        self.return_embedding: bool = return_embedding
-        self.similarity: str = similarity
+        self.index: str = index
+        self.label_index: str = label_index
+        self.embedding_field = embedding_field
+        self.embedding_dim = embedding_dim
+        self.return_embedding = return_embedding
+        self.similarity = similarity
 
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):
         """

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -403,6 +403,7 @@ class SQLDocumentStore(BaseDocumentStore):
         index = index or self.index
         documents = self.session.query(DocumentORM).filter_by(index=index)
         documents.delete(synchronize_session=False)
+        self.session.commit()
 
     def _get_or_create(self, session, model, **kwargs):
         instance = session.query(model).filter_by(**kwargs).first()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -1,6 +1,0 @@
-from haystack import Document
-
-
-def test_document_data_access():
-    doc = Document(text="test")
-    assert doc.text == "test"

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -218,18 +218,21 @@ def test_update_embeddings(document_store, retriever):
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_delete_documents(document_store_with_docs):
-    assert len(document_store_with_docs.get_all_documents()) == 3
+def test_delete_all_documents(document_store_with_docs):
+    assert len(document_store_with_docs.get_all_documents(index="haystack_test")) == 3
 
+    document_store_with_docs.delete_all_documents(index="haystack_test")
+    documents = document_store_with_docs.get_all_documents(index="haystack_test")
+    assert len(documents) == 0
+
+
+@pytest.mark.elasticsearch
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+def test_delete_documents_with_filters(document_store_with_docs):
     document_store_with_docs.delete_all_documents(index="haystack_test", filters={"meta_field": ["test1", "test2"]})
     documents = document_store_with_docs.get_all_documents()
     assert len(documents) == 1
     assert documents[0].meta["meta_field"] == "test3"
-
-    document_store_with_docs.delete_all_documents(index="haystack_test")
-    documents = document_store_with_docs.get_all_documents()
-    assert len(documents) == 0
 
 
 @pytest.mark.elasticsearch
@@ -394,8 +397,8 @@ def test_multilabel_no_answer(document_store):
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "sql"], indirect=True)
-def test_elasticsearch_update_meta(document_store):
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "sql"], indirect=True)
+def test_update_meta(document_store):
     documents = [
         Document(
             text="Doc1",


### PR DESCRIPTION
This PR makes the following changes:

- `SQLDocumentStore.delete_all_documents()` was missing a database commit()
- The missing commit would not have been surfaced as an error by the tests. With this PR, the tests now inject a database transaction rollback, so similar issues can be caught by the tests.
- tests for deleting documents are extended to run for all document stores.
- `test_db.py` is renamed to `test_document_store.py`
- `test_document.py` is removed as it had no meaningful test cases

Additionally, the `InMemoryDocument.__init__()` had missing parameters that are now added.