### PR TITLE
Remove quotes around placeholders in Elasticsearch custom query

### DIFF
--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -103,13 +103,13 @@ names must match with the filters dict supplied in self.retrieve().
 |        "query": {
 |            "bool": {
 |                "should": [{"multi_match": {
-|                    "query": "${query}",                 // mandatory query placeholder
+|                    "query": ${query},                 // mandatory query placeholder
 |                    "type": "most_fields",
 |                    "fields": ["text", "title"]}}],
 |                "filter": [                                 // optional custom filters
-|                    {"terms": {"year": "${years}"}},
-|                    {"terms": {"quarter": "${quarters}"}},
-|                    {"range": {"date": {"gte": "${date}"}}}
+|                    {"terms": {"year": ${years}}},
+|                    {"terms": {"quarter": ${quarters}}},
+|                    {"range": {"date": {"gte": ${date}}}}
 |                    ],
 |            }
 |        },

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -522,7 +522,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         elif custom_query:  # substitute placeholder for query and filters for the custom_query template string
             template = Template(custom_query)
             # replace all "${query}" placeholder(s) with query
-            substitutions = {"query": query}
+            substitutions = {"query": f'"{query}"'}
             # For each filter we got passed, we'll try to find & replace the corresponding placeholder in the template
             # Example: filters={"years":[2018]} => replaces {$years} in custom_query with '[2018]'
             if filters:

--- a/haystack/retriever/sparse.py
+++ b/haystack/retriever/sparse.py
@@ -32,7 +32,7 @@ class ElasticsearchRetriever(BaseRetriever):
                                 |        "query": {
                                 |            "bool": {
                                 |                "should": [{"multi_match": {
-                                |                    "query": "${query}",                 // mandatory query placeholder
+                                |                    "query": ${query},                 // mandatory query placeholder
                                 |                    "type": "most_fields",
                                 |                    "fields": ["text", "title"]}}],
                                 |                "filter": [                                 // optional custom filters

--- a/haystack/retriever/sparse.py
+++ b/haystack/retriever/sparse.py
@@ -36,9 +36,9 @@ class ElasticsearchRetriever(BaseRetriever):
                                 |                    "type": "most_fields",
                                 |                    "fields": ["text", "title"]}}],
                                 |                "filter": [                                 // optional custom filters
-                                |                    {"terms": {"year": "${years}"}},
-                                |                    {"terms": {"quarter": "${quarters}"}},
-                                |                    {"range": {"date": {"gte": "${date}"}}}
+                                |                    {"terms": {"year": ${years}}},
+                                |                    {"terms": {"quarter": ${quarters}}},
+                                |                    {"range": {"date": {"gte": ${date}}}}
                                 |                    ],
                                 |            }
                                 |        },

--- a/test/test_elastic_retriever.py
+++ b/test/test_elastic_retriever.py
@@ -63,7 +63,7 @@ def test_elasticsearch_custom_query(elasticsearch_fixture):
                 "query": {
                     "bool": {
                         "should": [{
-                            "multi_match": {"query": "${query}", "type": "most_fields", "fields": ["text"]}}],
+                            "multi_match": {"query": ${query}, "type": "most_fields", "fields": ["text"]}}],
                             "filter": [{"terms": {"year": ${years}}}]}}}"""
     )
     results = retriever.run(query="test", filters={"years": ["2020", "2021"]})[0]["documents"]
@@ -78,7 +78,7 @@ def test_elasticsearch_custom_query(elasticsearch_fixture):
                     "query": {
                         "bool": {
                             "should": [{
-                                "multi_match": {"query": "${query}", "type": "most_fields", "fields": ["text"]}}],
+                                "multi_match": {"query": ${query}, "type": "most_fields", "fields": ["text"]}}],
                                 "filter": [{"term": {"year": ${years}}}]}}}"""
     )
     results = retriever.run(query="test", filters={"years": "2021"})[0]["documents"]

--- a/test/test_elastic_retriever.py
+++ b/test/test_elastic_retriever.py
@@ -1,4 +1,8 @@
 import pytest
+from elasticsearch import Elasticsearch
+
+from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
+from haystack.retriever.sparse import ElasticsearchRetriever
 
 
 @pytest.mark.elasticsearch
@@ -33,3 +37,49 @@ def test_elasticsearch_retrieval_filters(retriever_with_docs, document_store_wit
 
     res = retriever_with_docs.retrieve(query="Who lives in Berlin?", filters={"name":["filename1"], "meta_field":["test2"]})
     assert len(res) == 0
+
+
+@pytest.mark.elasticsearch
+def test_elasticsearch_custom_query(elasticsearch_fixture):
+    client = Elasticsearch()
+    client.indices.delete(index='haystack_test_custom', ignore=[404])
+    document_store = ElasticsearchDocumentStore(index="haystack_test_custom", text_field="custom_text_field",
+                                                embedding_field="custom_embedding_field")
+    documents = [
+        {"text": "test_1", "meta": {"year": "2019"}},
+        {"text": "test_2", "meta": {"year": "2020"}},
+        {"text": "test_3", "meta": {"year": "2021"}},
+        {"text": "test_4", "meta": {"year": "2021"}},
+        {"text": "test_5", "meta": {"year": "2021"}},
+    ]
+    document_store.write_documents(documents)
+
+    # test custom "terms" query
+    retriever = ElasticsearchRetriever(
+        document_store=document_store,
+        custom_query="""
+            {
+                "size": 10, 
+                "query": {
+                    "bool": {
+                        "should": [{
+                            "multi_match": {"query": "${query}", "type": "most_fields", "fields": ["text"]}}],
+                            "filter": [{"terms": {"year": ${years}}}]}}}"""
+    )
+    results = retriever.run(query="test", filters={"years": ["2020", "2021"]})[0]["documents"]
+    assert len(results) == 4
+
+    # test custom "term" query
+    retriever = ElasticsearchRetriever(
+        document_store=document_store,
+        custom_query="""
+                {
+                    "size": 10, 
+                    "query": {
+                        "bool": {
+                            "should": [{
+                                "multi_match": {"query": "${query}", "type": "most_fields", "fields": ["text"]}}],
+                                "filter": [{"term": {"year": ${years}}}]}}}"""
+    )
+    results = retriever.run(query="test", filters={"years": "2021"})[0]["documents"]
+    assert len(results) == 3


### PR DESCRIPTION
This PR removes quotes around placeholders in Elasticsearch `custom_query` parameter. 

## Before
The placeholder terms(`$query`, `$years`) had quotes around them. For instance,
```python
retriever = ElasticsearchRetriever(
        document_store=document_store,
        custom_query="""
                {
                    "size": 10, 
                    "query": {
                        "bool": {
                            "should": [{
                                "multi_match": {"query": "${query}", "type": "most_fields", "fields": ["text"]}}],
                                "filter": [{"term": {"year": "${years}"}}]}}}"""
)
```

## Now
The placeholders must be used without quotes. For instance,
```python
retriever = ElasticsearchRetriever(
        document_store=document_store,
        custom_query="""
                {
                    "size": 10, 
                    "query": {
                        "bool": {
                            "should": [{
                                "multi_match": {"query": ${query}, "type": "most_fields", "fields": ["text"]}}],
                                "filter": [{"term": {"year": ${years}}}]}}}"""
)
```