### PR TITLE
Add model versioning support

### DIFF
--- a/docs/_src/api/api/generator.md
+++ b/docs/_src/api/api/generator.md
@@ -84,7 +84,7 @@ i.e. the model can easily adjust to domain documents even after training has fin
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str = "facebook/rag-token-nq", retriever: Optional[DensePassageRetriever] = None, generator_type: RAGeneratorType = RAGeneratorType.TOKEN, top_k_answers: int = 2, max_length: int = 200, min_length: int = 2, num_beams: int = 2, embed_title: bool = True, prefix: Optional[str] = None, use_gpu: bool = True)
+ | __init__(model_name_or_path: str = "facebook/rag-token-nq", model_version: Optional[str] = None, retriever: Optional[DensePassageRetriever] = None, generator_type: RAGeneratorType = RAGeneratorType.TOKEN, top_k_answers: int = 2, max_length: int = 200, min_length: int = 2, num_beams: int = 2, embed_title: bool = True, prefix: Optional[str] = None, use_gpu: bool = True)
 ```
 
 Load a RAG model from Transformers along with passage_embedding_model.
@@ -95,6 +95,7 @@ See https://huggingface.co/transformers/model_doc/rag.html for more details
 - `model_name_or_path`: Directory of a saved model or the name of a public model e.g.
 'facebook/rag-token-nq', 'facebook/rag-sequence-nq'.
 See https://huggingface.co/models for full list of available models.
+- `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `retriever`: `DensePassageRetriever` used to embedded passage
 - `generator_type`: Which RAG generator implementation to use? RAG-TOKEN or RAG-SEQUENCE
 - `top_k_answers`: Number of independently generated text to return

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -23,7 +23,7 @@ While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interf
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: Union[str, Path], context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128)
+ | __init__(model_name_or_path: Union[str, Path], model_version: str = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128)
 ```
 
 **Arguments**:
@@ -31,6 +31,7 @@ While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interf
 - `model_name_or_path`: Directory of a saved model or the name of a public model e.g. 'bert-base-cased',
 'deepset/bert-base-cased-squad2', 'deepset/bert-base-cased-squad2', 'distilbert-base-uncased-distilled-squad'.
 See https://huggingface.co/models for full list of available models.
+- `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `context_window_size`: The size, in characters, of the window around the answer span that is used when
 displaying the context around the answer.
 - `batch_size`: Number of samples the model receives in one batch for inference.
@@ -312,7 +313,7 @@ With this reader, you can directly get predictions via predict()
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: int = 0, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
+ | __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: str = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: int = 0, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
 ```
 
 Load a QA model from Transformers.
@@ -329,6 +330,7 @@ See https://huggingface.co/models for full list of available QA models
 - `model_name_or_path`: Directory of a saved model or the name of a public model e.g. 'bert-base-cased',
 'deepset/bert-base-cased-squad2', 'deepset/bert-base-cased-squad2', 'distilbert-base-uncased-distilled-squad'.
 See https://huggingface.co/models for full list of available models.
+- `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `tokenizer`: Name of the tokenizer (usually the same as model)
 - `context_window_size`: Num of chars (before and after the answer) to return as "context" for each answer.
 The context usually helps users to understand if the answer really makes sense.

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -23,7 +23,7 @@ While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interf
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: Union[str, Path], model_version: str = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128)
+ | __init__(model_name_or_path: Union[str, Path], model_version: Optional[str] = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128)
 ```
 
 **Arguments**:
@@ -313,7 +313,7 @@ With this reader, you can directly get predictions via predict()
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: str = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: int = 0, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
+ | __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: Optional[str] = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: int = 0, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
 ```
 
 Load a QA model from Transformers.

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -225,7 +225,7 @@ Karpukhin, Vladimir, et al. (2020): "Dense Passage Retrieval for Open-Domain Que
 #### \_\_init\_\_
 
 ```python
- | __init__(document_store: BaseDocumentStore, query_embedding_model: Union[Path, str] = "facebook/dpr-question_encoder-single-nq-base", passage_embedding_model: Union[Path, str] = "facebook/dpr-ctx_encoder-single-nq-base", max_seq_len_query: int = 64, max_seq_len_passage: int = 256, use_gpu: bool = True, batch_size: int = 16, embed_title: bool = True, use_fast_tokenizers: bool = True, similarity_function: str = "dot_product")
+ | __init__(document_store: BaseDocumentStore, query_embedding_model: Union[Path, str] = "facebook/dpr-question_encoder-single-nq-base", passage_embedding_model: Union[Path, str] = "facebook/dpr-ctx_encoder-single-nq-base", model_version: Optional[str] = None, max_seq_len_query: int = 64, max_seq_len_passage: int = 256, use_gpu: bool = True, batch_size: int = 16, embed_title: bool = True, use_fast_tokenizers: bool = True, similarity_function: str = "dot_product")
 ```
 
 Init the Retriever incl. the two encoder models from a local or remote model checkpoint.
@@ -253,6 +253,7 @@ Currently available remote names: ``"facebook/dpr-question_encoder-single-nq-bas
 - `passage_embedding_model`: Local path or remote name of passage encoder checkpoint. The format equals the
 one used by hugging-face transformers' modelhub models
 Currently available remote names: ``"facebook/dpr-ctx_encoder-single-nq-base"``
+- `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `max_seq_len_query`: Longest length of each query sequence. Maximum number of tokens for the query text. Longer ones will be cut down."
 - `max_seq_len_passage`: Longest length of each passage/context sequence. Maximum number of tokens for the passage text. Longer ones will be cut down."
 - `use_gpu`: Whether to use gpu or not

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -389,13 +389,14 @@ class EmbeddingRetriever(BaseRetriever)
 #### \_\_init\_\_
 
 ```python
- | __init__(document_store: BaseDocumentStore, embedding_model: str, use_gpu: bool = True, model_format: str = "farm", pooling_strategy: str = "reduce_mean", emb_extraction_layer: int = -1)
+ | __init__(document_store: BaseDocumentStore, embedding_model: str, model_version: Optional[str] = None, use_gpu: bool = True, model_format: str = "farm", pooling_strategy: str = "reduce_mean", emb_extraction_layer: int = -1)
 ```
 
 **Arguments**:
 
 - `document_store`: An instance of DocumentStore from which to retrieve documents.
 - `embedding_model`: Local path or name of model in Hugging Face's model hub such as ``'deepset/sentence_bert'``
+- `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `use_gpu`: Whether to use gpu or not
 - `model_format`: Name of framework that was used for saving the model. Options:
 

--- a/haystack/generator/transformers.py
+++ b/haystack/generator/transformers.py
@@ -64,6 +64,7 @@ class RAGenerator(BaseGenerator):
     def __init__(
             self,
             model_name_or_path: str = "facebook/rag-token-nq",
+            model_version: Optional[str] = None,
             retriever: Optional[DensePassageRetriever] = None,
             generator_type: RAGeneratorType = RAGeneratorType.TOKEN,
             top_k_answers: int = 2,
@@ -81,6 +82,7 @@ class RAGenerator(BaseGenerator):
         :param model_name_or_path: Directory of a saved model or the name of a public model e.g.
                                    'facebook/rag-token-nq', 'facebook/rag-sequence-nq'.
                                    See https://huggingface.co/models for full list of available models.
+        :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param retriever: `DensePassageRetriever` used to embedded passage
         :param generator_type: Which RAG generator implementation to use? RAG-TOKEN or RAG-SEQUENCE
         :param top_k_answers: Number of independently generated text to return
@@ -120,7 +122,7 @@ class RAGenerator(BaseGenerator):
             # Also refer refer https://github.com/huggingface/transformers/issues/7829
             # self.model = RagSequenceForGeneration.from_pretrained(model_name_or_path)
         else:
-            self.model = RagTokenForGeneration.from_pretrained(model_name_or_path).to(self.device)
+            self.model = RagTokenForGeneration.from_pretrained(model_name_or_path, revision=model_version).to(self.device)
 
     # Copied cat_input_and_doc method from transformers.RagRetriever
     # Refer section 2.3 of https://arxiv.org/abs/2005.11401

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -41,7 +41,7 @@ class FARMReader(BaseReader):
     def __init__(
         self,
         model_name_or_path: Union[str, Path],
-        model_version: str = None,
+        model_version: Optional[str] = None,
         context_window_size: int = 150,
         batch_size: int = 50,
         use_gpu: bool = True,

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -41,6 +41,7 @@ class FARMReader(BaseReader):
     def __init__(
         self,
         model_name_or_path: Union[str, Path],
+        model_version: str = None,
         context_window_size: int = 150,
         batch_size: int = 50,
         use_gpu: bool = True,
@@ -57,6 +58,7 @@ class FARMReader(BaseReader):
         :param model_name_or_path: Directory of a saved model or the name of a public model e.g. 'bert-base-cased',
         'deepset/bert-base-cased-squad2', 'deepset/bert-base-cased-squad2', 'distilbert-base-uncased-distilled-squad'.
         See https://huggingface.co/models for full list of available models.
+        :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param context_window_size: The size, in characters, of the window around the answer span that is used when
                                     displaying the context around the answer.
         :param batch_size: Number of samples the model receives in one batch for inference.
@@ -91,7 +93,7 @@ class FARMReader(BaseReader):
         self.top_k_per_candidate = top_k_per_candidate
         self.inferencer = QAInferencer.load(model_name_or_path, batch_size=batch_size, gpu=use_gpu,
                                           task_type="question_answering", max_seq_len=max_seq_len,
-                                          doc_stride=doc_stride, num_processes=num_processes)
+                                          doc_stride=doc_stride, num_processes=num_processes, revision=model_version)
         self.inferencer.model.prediction_heads[0].context_window_size = context_window_size
         self.inferencer.model.prediction_heads[0].no_ans_boost = no_ans_boost
         self.inferencer.model.prediction_heads[0].n_best = top_k_per_candidate + 1 # including possible no_answer

--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -17,6 +17,7 @@ class TransformersReader(BaseReader):
     def __init__(
         self,
         model_name_or_path: str = "distilbert-base-uncased-distilled-squad",
+        model_version: str = None,
         tokenizer: Optional[str] = None,
         context_window_size: int = 70,
         use_gpu: int = 0,
@@ -38,6 +39,7 @@ class TransformersReader(BaseReader):
         :param model_name_or_path: Directory of a saved model or the name of a public model e.g. 'bert-base-cased',
         'deepset/bert-base-cased-squad2', 'deepset/bert-base-cased-squad2', 'distilbert-base-uncased-distilled-squad'.
         See https://huggingface.co/models for full list of available models.
+        :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param tokenizer: Name of the tokenizer (usually the same as model)
         :param context_window_size: Num of chars (before and after the answer) to return as "context" for each answer.
                                     The context usually helps users to understand if the answer really makes sense.
@@ -53,7 +55,7 @@ class TransformersReader(BaseReader):
         :param doc_stride: length of striding window for splitting long texts (used if len(text) > max_seq_len)
 
         """
-        self.model = pipeline('question-answering', model=model_name_or_path, tokenizer=tokenizer, device=use_gpu)
+        self.model = pipeline('question-answering', model=model_name_or_path, tokenizer=tokenizer, device=use_gpu, revision=model_version)
         self.context_window_size = context_window_size
         self.top_k_per_candidate = top_k_per_candidate
         self.return_no_answers = return_no_answers

--- a/haystack/reader/transformers.py
+++ b/haystack/reader/transformers.py
@@ -17,7 +17,7 @@ class TransformersReader(BaseReader):
     def __init__(
         self,
         model_name_or_path: str = "distilbert-base-uncased-distilled-squad",
-        model_version: str = None,
+        model_version: Optional[str] = None,
         tokenizer: Optional[str] = None,
         context_window_size: int = 70,
         use_gpu: int = 0,

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -394,6 +394,7 @@ class EmbeddingRetriever(BaseRetriever):
         self,
         document_store: BaseDocumentStore,
         embedding_model: str,
+        model_version: Optional[str] = None,
         use_gpu: bool = True,
         model_format: str = "farm",
         pooling_strategy: str = "reduce_mean",
@@ -402,6 +403,7 @@ class EmbeddingRetriever(BaseRetriever):
         """
         :param document_store: An instance of DocumentStore from which to retrieve documents.
         :param embedding_model: Local path or name of model in Hugging Face's model hub such as ``'deepset/sentence_bert'``
+        :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param use_gpu: Whether to use gpu or not
         :param model_format: Name of framework that was used for saving the model. Options:
 
@@ -426,7 +428,7 @@ class EmbeddingRetriever(BaseRetriever):
         logger.info(f"Init retriever using embeddings of model {embedding_model}")
         if model_format == "farm" or model_format == "transformers":
             self.embedding_model = Inferencer.load(
-                embedding_model, task_type="embeddings", extraction_strategy=self.pooling_strategy,
+                embedding_model, revision=model_version, task_type="embeddings", extraction_strategy=self.pooling_strategy,
                 extraction_layer=self.emb_extraction_layer, gpu=use_gpu, batch_size=4, max_seq_len=512, num_processes=0
             )
             # Check that document_store has the right similarity function

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -39,6 +39,7 @@ class DensePassageRetriever(BaseRetriever):
                  document_store: BaseDocumentStore,
                  query_embedding_model: Union[Path, str] = "facebook/dpr-question_encoder-single-nq-base",
                  passage_embedding_model: Union[Path, str] = "facebook/dpr-ctx_encoder-single-nq-base",
+                 model_version: Optional[str] = None,
                  max_seq_len_query: int = 64,
                  max_seq_len_passage: int = 256,
                  use_gpu: bool = True,
@@ -71,6 +72,7 @@ class DensePassageRetriever(BaseRetriever):
         :param passage_embedding_model: Local path or remote name of passage encoder checkpoint. The format equals the
                                         one used by hugging-face transformers' modelhub models
                                         Currently available remote names: ``"facebook/dpr-ctx_encoder-single-nq-base"``
+        :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param max_seq_len_query: Longest length of each query sequence. Maximum number of tokens for the query text. Longer ones will be cut down."
         :param max_seq_len_passage: Longest length of each passage/context sequence. Maximum number of tokens for the passage text. Longer ones will be cut down."
         :param use_gpu: Whether to use gpu or not
@@ -106,17 +108,20 @@ class DensePassageRetriever(BaseRetriever):
 
         # Init & Load Encoders
         self.query_tokenizer = Tokenizer.load(pretrained_model_name_or_path=query_embedding_model,
+                                              revision=model_version,
                                               do_lower_case=True,
                                               use_fast=use_fast_tokenizers,
                                               tokenizer_class="DPRQuestionEncoderTokenizer")
         self.query_encoder = LanguageModel.load(pretrained_model_name_or_path=query_embedding_model,
+                                                revision=model_version,
                                                 language_model_class="DPRQuestionEncoder")
-
         self.passage_tokenizer = Tokenizer.load(pretrained_model_name_or_path=passage_embedding_model,
+                                                revision=model_version,
                                                 do_lower_case=True,
                                                 use_fast=use_fast_tokenizers,
                                                 tokenizer_class="DPRContextEncoderTokenizer")
         self.passage_encoder = LanguageModel.load(pretrained_model_name_or_path=passage_embedding_model,
+                                                  revision=model_version,
                                                   language_model_class="DPRContextEncoder")
 
         self.processor = TextSimilarityProcessor(tokenizer=self.query_tokenizer,

--- a/haystack/summarizer/transformers.py
+++ b/haystack/summarizer/transformers.py
@@ -51,6 +51,7 @@ class TransformersSummarizer(BaseSummarizer):
     def __init__(
             self,
             model_name_or_path: str = "google/pegasus-xsum",
+            model_version: Optional[str] = None,
             tokenizer: Optional[str] = None,
             max_length: int = 200,
             min_length: int = 5,
@@ -66,6 +67,7 @@ class TransformersSummarizer(BaseSummarizer):
         :param model_name_or_path: Directory of a saved model or the name of a public model e.g.
                                    'facebook/rag-token-nq', 'facebook/rag-sequence-nq'.
                                    See https://huggingface.co/models?filter=summarization for full list of available models.
+        :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param tokenizer: Name of the tokenizer (usually the same as model)
         :param max_length: Maximum length of summarized text
         :param min_length: Minimum length of summarized text
@@ -78,7 +80,7 @@ class TransformersSummarizer(BaseSummarizer):
         # TODO AutoModelForSeq2SeqLM is only necessary with transformers==4.1.1, with newer versions use the pipeline directly
         if tokenizer is None:
             tokenizer = model_name_or_path
-        model = AutoModelForSeq2SeqLM.from_pretrained(pretrained_model_name_or_path=model_name_or_path)
+        model = AutoModelForSeq2SeqLM.from_pretrained(pretrained_model_name_or_path=model_name_or_path, revision=model_version)
         self.summarizer = pipeline("summarization", model=model, tokenizer=tokenizer, device=use_gpu)
         self.max_length = max_length
         self.min_length = min_length


### PR DESCRIPTION
The latest FARM version allows for specifying the model version when downloading a model from HuggingFace's Model Hub. This allows for the same model versioning to be done when initializing a FARM or Transformers Reader. Solves #712 