### PR TITLE
Load Pipeline with YAML config file

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -5,7 +5,7 @@
 ## BaseDocumentStore Objects
 
 ```python
-class BaseDocumentStore(ABC)
+class BaseDocumentStore(BaseComponent)
 ```
 
 Base class for implementing Document Stores.

--- a/docs/_src/api/api/generator.md
+++ b/docs/_src/api/api/generator.md
@@ -5,7 +5,7 @@
 ## BaseGenerator Objects
 
 ```python
-class BaseGenerator(ABC)
+class BaseGenerator(BaseComponent)
 ```
 
 Abstract class for Generators

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -76,6 +76,57 @@ Create a Graphviz visualization of the pipeline.
 
 - `path`: the path to save the image.
 
+<a name="pipeline.Pipeline.load_from_yaml"></a>
+#### load\_from\_yaml
+
+```python
+ | @classmethod
+ | load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True)
+```
+
+Load Pipeline from a YAML file defining the individual components and how they're tied together to form
+a Pipeline. A single YAML can declare multiple Pipelines, in which case an explicit `pipeline_name` must
+be passed.
+
+Here's a sample configuration:
+
+```yaml
+|   version: '0.7'
+|
+|    components:    # define all the building-blocks for Pipeline
+|    - name: MyReader       # custom-name for the component; helpful for visualization & debugging
+|      type: FARMReader    # Haystack Class name for the component
+|      params:
+|        no_ans_boost: -10
+|        model_name_or_path: deepset/roberta-base-squad2
+|    - name: MyESRetriever
+|      type: ElasticsearchRetriever
+|      params:
+|        document_store: MyDocumentStore    # params can reference other components defined in the YAML
+|        custom_query: null
+|    - name: MyDocumentStore
+|      type: ElasticsearchDocumentStore
+|      params:
+|        index: haystack_test
+|
+|    pipelines:    # multiple Pipelines can be defined using the components from above
+|    - name: my_query_pipeline    # a simple extractive-qa Pipeline
+|      nodes:
+|      - name: MyESRetriever
+|        inputs: [Query]
+|      - name: MyReader
+|        inputs: [MyESRetriever]
+```
+
+**Arguments**:
+
+- `path`: path of the YAML file.
+- `pipeline_name`: if the YAML contains multiple pipelines, the pipeline_name to load must be set.
+- `overwrite_with_env_variables`: Overwrite the YAML configuration with environment variables. For example,
+to change index name param for an ElasticsearchDocumentStore, an env
+variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
+`_` sign must be used to specify nested hierarchical properties.
+
 <a name="pipeline.BaseStandardPipeline"></a>
 ## BaseStandardPipeline Objects
 

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -5,7 +5,7 @@
 ## BaseRetriever Objects
 
 ```python
-class BaseRetriever(ABC)
+class BaseRetriever(BaseComponent)
 ```
 
 <a name="base.BaseRetriever.retrieve"></a>

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 import pandas as pd
-from haystack.schema import Document, Label, MultiLabel
+from haystack.schema import Document, Label, MultiLabel, BaseComponent
 from haystack.finder import Finder
 from haystack.pipeline import Pipeline
 

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -1,18 +1,18 @@
 import logging
-from abc import abstractmethod, ABC
+from abc import abstractmethod
 from pathlib import Path
 from typing import Optional, Dict, List, Union
 
 import numpy as np
 
-from haystack import Document, Label, MultiLabel
+from haystack import Document, Label, MultiLabel, BaseComponent
 from haystack.preprocessor.preprocessor import PreProcessor
 from haystack.preprocessor.utils import eval_data_from_json, eval_data_from_jsonl, squad_json_to_jsonl
 
 logger = logging.getLogger(__name__)
 
 
-class BaseDocumentStore(ABC):
+class BaseDocumentStore(BaseComponent):
     """
     Base class for implementing Document Stores.
     """
@@ -203,3 +203,5 @@ class BaseDocumentStore(ABC):
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         pass
 
+    def run(self, **kwargs):
+        raise NotImplementedError

--- a/haystack/generator/base.py
+++ b/haystack/generator/base.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict
 
-from haystack import Document
+from haystack import Document, BaseComponent
 
 
-class BaseGenerator(ABC):
+class BaseGenerator(BaseComponent):
     """
     Abstract class for Generators
     """

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -150,31 +150,33 @@ class Pipeline:
 
         Here's a sample configuration:
 
-        version: '0.7'
-
-        components:    # define all the building-blocks for Pipeline
-          - name: MyReader       # custom-name for the component; helpful for visualization & debugging
-            type: FARMReader    # Haystack Class name for the component
-            params:
-              no_ans_boost: -10
-              model_name_or_path: deepset/roberta-base-squad2
-          - name: MyESRetriever
-            type: ElasticsearchRetriever
-            params:
-              document_store: MyDocumentStore    # params can reference other components defined in the YAML
-              custom_query: null
-          - name: MyDocumentStore
-            type: ElasticsearchDocumentStore
-            params:
-              index: haystack_test
-
-        pipelines:    # multiple Pipelines can be defined using the components from above
-          - name: my_query_pipeline    # a simple extractive-qa Pipeline
-            nodes:
-              - name: MyESRetriever
-                inputs: [Query]
-              - name: MyReader
-                inputs: [MyESRetriever]
+            ```yaml
+            |   version: '0.7'
+            |
+            |    components:    # define all the building-blocks for Pipeline
+            |    - name: MyReader       # custom-name for the component; helpful for visualization & debugging
+            |      type: FARMReader    # Haystack Class name for the component
+            |      params:
+            |        no_ans_boost: -10
+            |        model_name_or_path: deepset/roberta-base-squad2
+            |    - name: MyESRetriever
+            |      type: ElasticsearchRetriever
+            |      params:
+            |        document_store: MyDocumentStore    # params can reference other components defined in the YAML
+            |        custom_query: null
+            |    - name: MyDocumentStore
+            |      type: ElasticsearchDocumentStore
+            |      params:
+            |        index: haystack_test
+            |
+            |    pipelines:    # multiple Pipelines can be defined using the components from above
+            |    - name: my_query_pipeline    # a simple extractive-qa Pipeline
+            |      nodes:
+            |      - name: MyESRetriever
+            |        inputs: [Query]
+            |      - name: MyReader
+            |        inputs: [MyESRetriever]
+            ```
 
         :param path: path of the YAML file.
         :param pipeline_name: if the YAML contains multiple pipelines, the pipeline_name to load must be set.

--- a/haystack/reader/base.py
+++ b/haystack/reader/base.py
@@ -4,10 +4,10 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import List, Optional, Sequence
 
-from haystack import Document
+from haystack import Document, BaseComponent
 
 
-class BaseReader(ABC):
+class BaseReader(BaseComponent):
     return_no_answers: bool
     outgoing_edges = 1
 
@@ -61,3 +61,5 @@ class BaseReader(ABC):
 
         results.update(**kwargs)
         return results, "output_1"
+
+

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -5,13 +5,13 @@ from time import perf_counter
 from functools import wraps
 from tqdm import tqdm
 
-from haystack import Document
+from haystack import Document, BaseComponent
 from haystack.document_store.base import BaseDocumentStore
 
 logger = logging.getLogger(__name__)
 
 
-class BaseRetriever(ABC):
+class BaseRetriever(BaseComponent):
     document_store: BaseDocumentStore
     outgoing_edges = 1
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Any, Optional, Dict, List
 from uuid import uuid4
 
@@ -207,3 +208,24 @@ class MultiLabel:
 
     def __str__(self):
         return str(self.to_dict())
+
+
+class BaseComponent:
+    outgoing_edges: int
+    subclasses: dict = {}
+
+    def __init_subclass__(cls, **kwargs):
+        """ This automatically keeps track of all available subclasses.
+        Enables generic load() for all specific component implementations.
+        """
+        super().__init_subclass__(**kwargs)
+        cls.subclasses[cls.__name__] = cls
+
+    @classmethod
+    def load_from_args(cls, instance_type: str, **kwargs):
+        instance = cls.subclasses[instance_type](**kwargs)
+        return instance
+
+    @abstractmethod
+    def run(self, **kwargs):
+        pass

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -211,6 +211,10 @@ class MultiLabel:
 
 
 class BaseComponent:
+    """
+    A base class for implementing nodes in a Pipeline.
+    """
+
     outgoing_edges: int
     subclasses: dict = {}
 
@@ -222,10 +226,12 @@ class BaseComponent:
         cls.subclasses[cls.__name__] = cls
 
     @classmethod
-    def load_from_args(cls, instance_type: str, **kwargs):
-        instance = cls.subclasses[instance_type](**kwargs)
+    def load_from_args(cls, component_type: str, **kwargs):
+        """
+        Load a component instance of the given type using the kwargs.
+        
+        :param component_type: name of the component class to load.
+        :param kwargs: parameters to pass to the __init__() for the component. 
+        """
+        instance = cls.subclasses[component_type](**kwargs)
         return instance
-
-    @abstractmethod
-    def run(self, **kwargs):
-        pass

--- a/haystack/summarizer/base.py
+++ b/haystack/summarizer/base.py
@@ -1,10 +1,10 @@
-from abc import ABC, abstractmethod
-from typing import List, Optional, Dict
+from abc import abstractmethod
+from typing import List, Dict
 
-from haystack import Document
+from haystack import Document, BaseComponent
 
 
-class BaseSummarizer(ABC):
+class BaseSummarizer(BaseComponent):
     """
     Abstract class for Summarizer
     """

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -1,0 +1,25 @@
+version: '0.7'
+
+components:
+  - name: TestReader
+    type: FARMReader
+    params:
+      no_ans_boost: -10
+      model_name_or_path: deepset/roberta-base-squad2
+  - name: TestESRetriever
+    type: ElasticsearchRetriever
+    params:
+      document_store: TestDocumentStore
+      custom_query: null
+  - name: TestDocumentStore
+    type: ElasticsearchDocumentStore
+    params:
+      index: haystack_test
+
+pipelines:
+  - name: test_query_pipeline
+    nodes:
+      - name: TestESRetriever
+        inputs: [Query]
+      - name: TestReader
+        inputs: [TestESRetriever]

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -1,9 +1,26 @@
+from pathlib import Path
+
 import pytest
 
 from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
 from haystack.pipeline import JoinDocuments, ExtractiveQAPipeline, Pipeline, FAQPipeline, DocumentSearchPipeline
 from haystack.retriever.dense import DensePassageRetriever
 from haystack.retriever.sparse import ElasticsearchRetriever
+
+
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+def test_load_yaml(document_store_with_docs):
+    pipeline = Pipeline()
+
+    # # test correct load from yaml
+    pipeline.load_from_yaml(Path("samples/pipeline/test_pipeline.yaml", pipeline_name="my_query"))
+    prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
+    assert prediction["query"] == "Who lives in Berlin?"
+    assert prediction["answers"][0]["answer"] == "Carla"
+
+    # test invalid pipeline name
+    with pytest.raises(Exception):
+        pipeline.load_from_yaml(path=Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="invalid")
 
 
 @pytest.mark.slow

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -10,17 +10,16 @@ from haystack.retriever.sparse import ElasticsearchRetriever
 
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_yaml(document_store_with_docs):
-    pipeline = Pipeline()
 
     # # test correct load from yaml
-    pipeline.load_from_yaml(Path("samples/pipeline/test_pipeline.yaml", pipeline_name="my_query"))
+    pipeline = Pipeline.load_from_yaml(Path("samples/pipeline/test_pipeline.yaml", pipeline_name="my_query"))
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"
     assert prediction["answers"][0]["answer"] == "Carla"
 
     # test invalid pipeline name
     with pytest.raises(Exception):
-        pipeline.load_from_yaml(path=Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="invalid")
+        Pipeline.load_from_yaml(path=Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="invalid")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This PR adds support to load a Pipeline with a YAML configuration file.

Here's a sample Pipeline YAML:
```yaml
version: '0.7'

components:    # define all the building-blocks for Pipeline
  - name: MyReader       # custom-name for the component; helpful for visualization & debugging
    type: FARMReader    # Haystack Class name for the component
    params:
      no_ans_boost: -10
      model_name_or_path: deepset/roberta-base-squad2
  - name: MyESRetriever
    type: ElasticsearchRetriever
    params:
      document_store: MyDocumentStore    # params can reference other components defined in the YAML
      custom_query: null
  - name: MyDocumentStore
    type: ElasticsearchDocumentStore
    params:
      index: haystack_test

pipelines:    # multiple Pipelines can be defined using the components from above
  - name: my_query_pipeline    # a simple extractive-qa Pipeline
    nodes:
      - name: MyESRetriever
        inputs: [Query]
      - name: MyReader
        inputs: [MyESRetriever]
```

To load a Pipeline:

```python
from pathlib import Path
from haystack import Pipeline

pipeline = Pipeline.load_from_yaml(Path("sample.yaml"))
prediction = pipeline.run(query="What is the capital of Germany?", top_k_retriever=10, top_k_reader=3)
```