### PR TITLE
Introduce incremental updates for embeddings in document stores

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -344,7 +344,7 @@ Return a summary of the documents in the document store
 #### update\_embeddings
 
 ```python
- | update_embeddings(retriever, index: Optional[str] = None, batch_size: int = 10_000)
+ | update_embeddings(retriever, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None, update_existing_embeddings: bool = True, batch_size: int = 10_000)
 ```
 
 Updates the embeddings in the the document store using the encoding model specified in the retriever.
@@ -354,6 +354,12 @@ This can be useful if want to add or change the embeddings for your documents (e
 
 - `retriever`: Retriever to use to update the embeddings.
 - `index`: Index name to update
+- `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
+only documents without embeddings are processed. This mode can be used for
+incremental updating of embeddings, wherein, only newly indexed documents
+get processed.
+- `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
+Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
@@ -406,15 +412,21 @@ In-memory document store
 #### \_\_init\_\_
 
 ```python
- | __init__(index: str = "document", label_index: str = "label", embedding_field: Optional[str] = "embedding", embedding_dim: int = 768, return_embedding: bool = False, similarity: str = "dot_product")
+ | __init__(index: str = "document", label_index: str = "label", embedding_field: Optional[str] = "embedding", embedding_dim: int = 768, return_embedding: bool = False, similarity: str = "dot_product", progress_bar: bool = True)
 ```
 
 **Arguments**:
 
+- `index`: The documents are scoped to an index attribute that can be used when writing, querying,
+or deleting documents. This parameter sets the default value for document index.
+- `label_index`: The default value of index attribute for the labels.
 - `embedding_field`: Name of field containing an embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
+- `embedding_dim`: The size of the embedding vector.
 - `return_embedding`: To return document embedding
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default sine it is
 more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
+- `progress_bar`: Whether to show a tqdm progress bar or not.
+Can be helpful to disable in production deployments to keep the logs clean.
 
 <a name="memory.InMemoryDocumentStore.write_documents"></a>
 #### write\_documents
@@ -493,7 +505,7 @@ Example: {"name": ["some", "more"], "category": ["only_one"]}
 #### update\_embeddings
 
 ```python
- | update_embeddings(retriever: BaseRetriever, index: Optional[str] = None)
+ | update_embeddings(retriever: BaseRetriever, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None, update_existing_embeddings: bool = True, batch_size: int = 10_000)
 ```
 
 Updates the embeddings in the the document store using the encoding model specified in the retriever.
@@ -501,8 +513,15 @@ This can be useful if want to add or change the embeddings for your documents (e
 
 **Arguments**:
 
-- `retriever`: Retriever
-- `index`: Index name to update
+- `retriever`: Retriever to use to get embeddings for text
+- `index`: Index name for which embeddings are to be updated. If set to None, the default self.index is used.
+- `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
+only documents without embeddings are processed. This mode can be used for
+incremental updating of embeddings, wherein, only newly indexed documents
+get processed.
+- `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
+Example: {"name": ["some", "more"], "category": ["only_one"]}
+- `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
 
@@ -628,6 +647,13 @@ Fetch documents by specifying a list of text id strings
 ```
 
 Fetch documents by specifying a list of text vector id strings
+
+**Arguments**:
+
+- `vector_ids`: List of vector_id strings.
+- `index`: Name of the index to get the documents from. If None, the
+DocumentStore's default index (self.index) will be used.
+- `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 <a name="sql.SQLDocumentStore.get_all_documents_generator"></a>
 #### get\_all\_documents\_generator
@@ -843,7 +869,7 @@ them right away in FAISS. If not, you can later call update_embeddings() to crea
 #### update\_embeddings
 
 ```python
- | update_embeddings(retriever: BaseRetriever, index: Optional[str] = None, batch_size: int = 10_000)
+ | update_embeddings(retriever: BaseRetriever, index: Optional[str] = None, update_existing_embeddings: bool = True, filters: Optional[Dict[str, List[str]]] = None, batch_size: int = 10_000)
 ```
 
 Updates the embeddings in the the document store using the encoding model specified in the retriever.
@@ -852,7 +878,13 @@ This can be useful if want to add or change the embeddings for your documents (e
 **Arguments**:
 
 - `retriever`: Retriever to use to get embeddings for text
-- `index`: (SQL) index name for storing the docs and metadata
+- `index`: Index name for which embeddings are to be updated. If set to None, the default self.index is used.
+- `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
+only documents without embeddings are processed. This mode can be used for
+incremental updating of embeddings, wherein, only newly indexed documents
+get processed.
+- `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
+Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
@@ -883,7 +915,7 @@ Example: {"name": ["some", "more"], "category": ["only_one"]}
 #### train\_index
 
 ```python
- | train_index(documents: Optional[Union[List[dict], List[Document]]], embeddings: Optional[np.ndarray] = None)
+ | train_index(documents: Optional[Union[List[dict], List[Document]]], embeddings: Optional[np.ndarray] = None, index: Optional[str] = None)
 ```
 
 Some FAISS indices (e.g. IVF) require initial "training" on a sample of vectors before you can add your final vectors.
@@ -894,6 +926,7 @@ You can pass either documents (incl. embeddings) or just the plain embeddings th
 
 - `documents`: Documents (incl. the embeddings)
 - `embeddings`: Plain embeddings
+- `index`: Name of the index to train. If None, the DocumentStore's default index (self.index) will be used.
 
 **Returns**:
 
@@ -912,7 +945,7 @@ Delete all documents from the document store.
 #### query\_by\_embedding
 
 ```python
- | query_by_embedding(query_emb: np.ndarray, filters: Optional[dict] = None, top_k: int = 10, index: Optional[str] = None, return_embedding: Optional[bool] = None) -> List[Document]
+ | query_by_embedding(query_emb: np.ndarray, filters: Optional[Dict[str, List[str]]] = None, top_k: int = 10, index: Optional[str] = None, return_embedding: Optional[bool] = None) -> List[Document]
 ```
 
 Find the document that is most similar to the provided `query_emb` by using a vector similarity metric.
@@ -923,7 +956,7 @@ Find the document that is most similar to the provided `query_emb` by using a ve
 - `filters`: Optional filters to narrow down the search space.
 Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `top_k`: How many documents to return
-- `index`: (SQL) index name for storing the docs and metadata
+- `index`: Index name to query the document from.
 - `return_embedding`: To return document embedding
 
 **Returns**:
@@ -952,7 +985,7 @@ None
 
 ```python
  | @classmethod
- | load(cls, faiss_file_path: Union[str, Path], sql_url: str)
+ | load(cls, faiss_file_path: Union[str, Path], sql_url: str, index: str)
 ```
 
 Load a saved FAISS index from a file and connect to the SQL database.
@@ -963,6 +996,8 @@ make sure to use the same SQL DB that you used when calling `save()`.
 
 - `faiss_file_path`: Stored FAISS index file. Can be created via calling `save()`
 - `sql_url`: Connection string to the SQL database that contains your docs and metadata.
+- `index`: Index name to load the FAISS index as. It must match the index name used for
+when creating the FAISS index.
 
 **Returns**:
 

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -492,7 +492,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         index: str,
         filters: Optional[Dict[str, List[str]]] = None,
         batch_size: int = 10_000,
-        filter_documents_without_embedding: bool = False,
+        only_documents_without_embedding: bool = False,
     ) -> Generator[dict, None, None]:
         """
         Return all documents in a specific index in the document store
@@ -517,7 +517,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                 )
             body["query"]["bool"]["filter"] = filter_clause
 
-        if filter_documents_without_embedding:
+        if only_documents_without_embedding:
             body["query"]["bool"] = {"must_not": {"exists": {"field": self.embedding_field}}}
 
         result = scan(self.client, query=body, index=index, size=batch_size, scroll="1d")
@@ -796,7 +796,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             index=index,
             filters=filters,
             batch_size=batch_size,
-            filter_documents_without_embedding=not update_existing_embeddings
+            only_documents_without_embedding=not update_existing_embeddings
         )
 
         for result_batch in get_batches_from_generator(result, batch_size):

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -322,7 +322,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             raise Exception("filters are supported for deleting documents in FAISSDocumentStore.")
         index = index or self.index
         self.faiss_indexes[index].reset()
-        super().delete_all_documents(index=index, filters=filters)
+        super().delete_all_documents(index=index)
 
     def query_by_embedding(
         self,
@@ -345,12 +345,13 @@ class FAISSDocumentStore(SQLDocumentStore):
         """
         if filters:
             raise Exception("Query filters are not implemented for the FAISSDocumentStore.")
+
+        index = index or self.index
         if not self.faiss_indexes.get(index):
             raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
 
         if return_embedding is None:
             return_embedding = self.return_embedding
-        index = index or self.index
 
         query_emb = query_emb.reshape(1, -1).astype(np.float32)
         score_matrix, vector_id_matrix = self.faiss_indexes[index].search(query_emb, top_k)

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -211,7 +211,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             vector_ids=None,
             batch_size=batch_size,
             filters=filters,
-            filter_documents_without_embeddings=not update_existing_embeddings
+            only_documents_without_embedding=not update_existing_embeddings
         )
         batched_documents = get_batches_from_generator(result, batch_size)
         with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:
@@ -349,7 +349,7 @@ class FAISSDocumentStore(SQLDocumentStore):
 
         index = index or self.index
         if not self.faiss_indexes.get(index):
-            raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
+            raise Exception(f"Index named '{index}' does not exists. Use 'update_embeddings()' to create an index.")
 
         if return_embedding is None:
             return_embedding = self.return_embedding

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -79,13 +79,14 @@ class FAISSDocumentStore(SQLDocumentStore):
                              Can be helpful to disable in production deployments to keep the logs clean.
         """
         self.vector_dim = vector_dim
-
+        self.faiss_index_factory_str = faiss_index_factory_str
+        self.faiss_indexes: Dict[str, faiss.swigfaiss.Index] = {}
         if faiss_index:
-            self.faiss_index = faiss_index
+            self.faiss_indexes[index] = faiss_index
         else:
-            self.faiss_index = self._create_new_index(vector_dim=self.vector_dim, index_factory=faiss_index_factory_str, **kwargs)
-            if "ivf" in faiss_index_factory_str.lower():  # enable reconstruction of vectors for inverted index
-                self.faiss_index.set_direct_map_type(faiss.DirectMap.Hashtable)
+            self.faiss_indexes[index] = self._create_new_index(
+                vector_dim=self.vector_dim, index_factory=faiss_index_factory_str, **kwargs
+            )
 
         self.return_embedding = return_embedding
         self.embedding_field = embedding_field
@@ -110,6 +111,9 @@ class FAISSDocumentStore(SQLDocumentStore):
             index = faiss.IndexHNSWFlat(vector_dim, n_links, metric_type)
             index.hnsw.efSearch = kwargs.get("efSearch", 20)#20
             index.hnsw.efConstruction = kwargs.get("efConstruction", 80)#80
+            if "ivf" in index_factory.lower():  # enable reconstruction of vectors for inverted index
+                self.faiss_indexes[index].set_direct_map_type(faiss.DirectMap.Hashtable)
+
             logger.info(f"HNSW params: n_links: {n_links}, efSearch: {index.hnsw.efSearch}, efConstruction: {index.hnsw.efConstruction}")
         else:
             index = faiss.index_factory(vector_dim, index_factory, metric_type)
@@ -127,12 +131,13 @@ class FAISSDocumentStore(SQLDocumentStore):
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
         :return:
         """
-        # vector index
-        if not self.faiss_index:
-            raise ValueError("Couldn't find a FAISS index. Try to init the FAISSDocumentStore() again ...")
 
-        # doc + metadata index
         index = index or self.index
+        if not self.faiss_indexes.get(index):
+            self.faiss_indexes[index] = self._create_new_index(
+                vector_dim=self.vector_dim, index_factory=self.faiss_index_factory_str
+            )
+
         field_map = self._create_document_field_map()
         document_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
 
@@ -143,12 +148,12 @@ class FAISSDocumentStore(SQLDocumentStore):
                            "`FAISSDocumentStore` does not support update in existing `faiss_index`.\n"
                            "Please call `update_embeddings` method to repopulate `faiss_index`")
 
-        vector_id = self.faiss_index.ntotal
+        vector_id = self.faiss_indexes[index].ntotal
         for i in range(0, len(document_objects), batch_size):
             if add_vectors:
                 embeddings = [doc.embedding for doc in document_objects[i: i + batch_size]]
                 embeddings_to_index = np.array(embeddings, dtype="float32")
-                self.faiss_index.add(embeddings_to_index)
+                self.faiss_indexes[index].add(embeddings_to_index)
 
             docs_to_write_in_sql = []
             for doc in document_objects[i: i + batch_size]:
@@ -165,24 +170,33 @@ class FAISSDocumentStore(SQLDocumentStore):
             self.index: self.embedding_field,
         }
 
-    def update_embeddings(self, retriever: BaseRetriever, index: Optional[str] = None, batch_size: int = 10_000):
+    def update_embeddings(
+        self,
+        retriever: BaseRetriever,
+        index: Optional[str] = None,
+        update_existing_embeddings: bool = True,
+        filters: Optional[Dict[str, List[str]]] = None,
+        batch_size: int = 10_000
+    ):
         """
         Updates the embeddings in the the document store using the encoding model specified in the retriever.
         This can be useful if want to add or change the embeddings for your documents (e.g. after changing the retriever config).
 
         :param retriever: Retriever to use to get embeddings for text
-        :param index: (SQL) index name for storing the docs and metadata
+        :param index: Index name for which embeddings are to be updated. If set to None, the default self.index is used.
+        :param update_existing_embeddings: Whether to update existing embeddings of the documents. If set to False,
+                                           only documents without embeddings are processed. This mode can be used for
+                                           incremental updating of embeddings, wherein, only newly indexed documents
+                                           get processed.
+        :param filters: Optional filters to narrow down the documents for which embeddings are to be updated.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
         :return: None
         """
-        if not self.faiss_index:
-            raise ValueError("Couldn't find a FAISS index. Try to init the FAISSDocumentStore() again ...")
-
-        # Faiss does not support update in existing index data so clear all existing data in it
-        self.faiss_index.reset()
-        self.reset_vector_ids(index=index)
 
         index = index or self.index
+        if not self.faiss_indexes.get(index):
+            raise ValueError("Couldn't find a FAISS index. Try to init the FAISSDocumentStore() again ...")
 
         document_count = self.get_document_count(index=index)
         if document_count == 0:
@@ -190,9 +204,15 @@ class FAISSDocumentStore(SQLDocumentStore):
             return
 
         logger.info(f"Updating embeddings for {document_count} docs...")
-        vector_id = self.faiss_index.ntotal
+        vector_id = self.faiss_indexes[index].ntotal
 
-        result = self.get_all_documents_generator(index=index, batch_size=batch_size, return_embedding=False)
+        result = self._query(
+            index=index,
+            vector_ids=None,
+            batch_size=batch_size,
+            filters=filters,
+            filter_documents_without_embeddings=not update_existing_embeddings
+        )
         batched_documents = get_batches_from_generator(result, batch_size)
         with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:
             for document_batch in batched_documents:
@@ -200,7 +220,7 @@ class FAISSDocumentStore(SQLDocumentStore):
                 assert len(document_batch) == len(embeddings)
 
                 embeddings_to_index = np.array(embeddings, dtype="float32")
-                self.faiss_index.add(embeddings_to_index)
+                self.faiss_indexes[index].add(embeddings_to_index)
 
                 vector_id_map = {}
                 for doc in document_batch:
@@ -242,8 +262,9 @@ class FAISSDocumentStore(SQLDocumentStore):
         :param return_embedding: Whether to return the document embeddings.
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
         """
+        index = index or self.index
         documents = super(FAISSDocumentStore, self).get_all_documents_generator(
-            index=index, filters=filters, batch_size=batch_size
+            index=index, filters=filters, batch_size=batch_size, return_embedding=False,
         )
         if return_embedding is None:
             return_embedding = self.return_embedding
@@ -251,21 +272,25 @@ class FAISSDocumentStore(SQLDocumentStore):
         for doc in documents:
             if return_embedding:
                 if doc.meta and doc.meta.get("vector_id") is not None:
-                    doc.embedding = self.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+                    doc.embedding = self.faiss_indexes[index].reconstruct(int(doc.meta["vector_id"]))
             yield doc
 
     def get_documents_by_id(
         self, ids: List[str], index: Optional[str] = None, batch_size: int = 10_000
     ) -> List[Document]:
+        index = index or self.index
         documents = super(FAISSDocumentStore, self).get_documents_by_id(ids=ids, index=index)
         if self.return_embedding:
             for doc in documents:
                 if doc.meta and doc.meta.get("vector_id") is not None:
-                    doc.embedding = self.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+                    doc.embedding = self.faiss_indexes[index].reconstruct(int(doc.meta["vector_id"]))
         return documents
 
     def train_index(
-            self, documents: Optional[Union[List[dict], List[Document]]], embeddings: Optional[np.ndarray] = None
+        self,
+        documents: Optional[Union[List[dict], List[Document]]],
+        embeddings: Optional[np.ndarray] = None,
+        index: Optional[str] = None,
     ):
         """
         Some FAISS indices (e.g. IVF) require initial "training" on a sample of vectors before you can add your final vectors.
@@ -274,33 +299,39 @@ class FAISSDocumentStore(SQLDocumentStore):
 
         :param documents: Documents (incl. the embeddings)
         :param embeddings: Plain embeddings
+        :param index: Name of the index to train. If None, the DocumentStore's default index (self.index) will be used.
         :return: None
         """
 
+        index = index or self.index
         if embeddings and documents:
             raise ValueError("Either pass `documents` or `embeddings`. You passed both.")
         if documents:
             document_objects = [Document.from_dict(d) if isinstance(d, dict) else d for d in documents]
             doc_embeddings = [doc.embedding for doc in document_objects]
             embeddings_for_train = np.array(doc_embeddings, dtype="float32")
-            self.faiss_index.train(embeddings_for_train)
+            self.faiss_indexes[index].train(embeddings_for_train)
         if embeddings:
-            self.faiss_index.train(embeddings)
+            self.faiss_indexes[index].train(embeddings)
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
         """
         Delete all documents from the document store.
         """
+        if filters:
+            raise Exception("filters are supported for deleting documents in FAISSDocumentStore.")
         index = index or self.index
-        self.faiss_index.reset()
+        self.faiss_indexes[index].reset()
         super().delete_all_documents(index=index, filters=filters)
 
-    def query_by_embedding(self,
-                           query_emb: np.ndarray,
-                           filters: Optional[dict] = None,
-                           top_k: int = 10,
-                           index: Optional[str] = None,
-                           return_embedding: Optional[bool] = None) -> List[Document]:
+    def query_by_embedding(
+        self,
+        query_emb: np.ndarray,
+        filters: Optional[Dict[str, List[str]]] = None,
+        top_k: int = 10,
+        index: Optional[str] = None,
+        return_embedding: Optional[bool] = None
+    ) -> List[Document]:
         """
         Find the document that is most similar to the provided `query_emb` by using a vector similarity metric.
 
@@ -308,13 +339,13 @@ class FAISSDocumentStore(SQLDocumentStore):
         :param filters: Optional filters to narrow down the search space.
                         Example: {"name": ["some", "more"], "category": ["only_one"]}
         :param top_k: How many documents to return
-        :param index: (SQL) index name for storing the docs and metadata
+        :param index: Index name to query the document from.
         :param return_embedding: To return document embedding
         :return:
         """
         if filters:
             raise Exception("Query filters are not implemented for the FAISSDocumentStore.")
-        if not self.faiss_index:
+        if not self.faiss_indexes.get(index):
             raise Exception("No index exists. Use 'update_embeddings()` to create an index.")
 
         if return_embedding is None:
@@ -322,7 +353,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         index = index or self.index
 
         query_emb = query_emb.reshape(1, -1).astype(np.float32)
-        score_matrix, vector_id_matrix = self.faiss_index.search(query_emb, top_k)
+        score_matrix, vector_id_matrix = self.faiss_indexes[index].search(query_emb, top_k)
         vector_ids_for_query = [str(vector_id) for vector_id in vector_id_matrix[0] if vector_id != -1]
 
         documents = self.get_documents_by_vector_ids(vector_ids_for_query, index=index)
@@ -333,7 +364,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             doc.score = scores_for_vector_ids[doc.meta["vector_id"]]
             doc.probability = float(expit(np.asarray(doc.score / 100)))
             if return_embedding is True:
-                doc.embedding = self.faiss_index.reconstruct(int(doc.meta["vector_id"]))
+                doc.embedding = self.faiss_indexes[index].reconstruct(int(doc.meta["vector_id"]))
 
         return documents
 
@@ -344,13 +375,14 @@ class FAISSDocumentStore(SQLDocumentStore):
         :param file_path: Path to save to.
         :return: None
         """
-        faiss.write_index(self.faiss_index, str(file_path))
+        faiss.write_index(self.faiss_indexes[self.index], str(file_path))
 
     @classmethod
     def load(
-            cls,
-            faiss_file_path: Union[str, Path],
-            sql_url: str,
+        cls,
+        faiss_file_path: Union[str, Path],
+        sql_url: str,
+        index: str,
     ):
         """
         Load a saved FAISS index from a file and connect to the SQL database.
@@ -359,6 +391,8 @@ class FAISSDocumentStore(SQLDocumentStore):
 
         :param faiss_file_path: Stored FAISS index file. Can be created via calling `save()`
         :param sql_url: Connection string to the SQL database that contains your docs and metadata.
+        :param index: Index name to load the FAISS index as. It must match the index name used for
+                      when creating the FAISS index.
         :return:
         """
         """
@@ -367,6 +401,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         return cls(
             faiss_index=faiss_index,
             sql_url=sql_url,
-            vector_dim=faiss_index.d
+            vector_dim=faiss_index.d,
+            index=index,
         )
 

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -321,7 +321,8 @@ class FAISSDocumentStore(SQLDocumentStore):
         if filters:
             raise Exception("filters are supported for deleting documents in FAISSDocumentStore.")
         index = index or self.index
-        self.faiss_indexes[index].reset()
+        if index in self.faiss_indexes.keys():
+            self.faiss_indexes[index].reset()
         super().delete_all_documents(index=index)
 
     def query_by_embedding(

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -63,6 +63,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         index = index or self.index
 
         field_map = self._create_document_field_map()
+        documents = deepcopy(documents)
         documents_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
 
         for document in documents_objects:

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -254,7 +254,7 @@ class MilvusDocumentStore(SQLDocumentStore):
             vector_ids=None,
             batch_size=batch_size,
             filters=filters,
-            filter_documents_without_embeddings=not update_existing_embeddings
+            only_documents_without_embedding=not update_existing_embeddings
         )
         batched_documents = get_batches_from_generator(result, batch_size)
         with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -216,7 +216,14 @@ class MilvusDocumentStore(SQLDocumentStore):
         if self.update_existing_documents:
             self.milvus_server.compact(collection_name=index)
 
-    def update_embeddings(self, retriever: BaseRetriever, index: Optional[str] = None, batch_size: int = 10_000):
+    def update_embeddings(
+        self,
+        retriever: BaseRetriever,
+        index: Optional[str] = None,
+        batch_size: int = 10_000,
+        update_existing_embeddings: bool = True,
+        filters: Optional[Dict[str, List[str]]] = None,
+    ):
         """
         Updates the embeddings in the the document store using the encoding model specified in the retriever.
         This can be useful if want to add or change the embeddings for your documents (e.g. after changing the retriever config).
@@ -224,6 +231,12 @@ class MilvusDocumentStore(SQLDocumentStore):
         :param retriever: Retriever to use to get embeddings for text
         :param index: (SQL) index name for storing the docs and metadata
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
+        :param update_existing_embeddings: Whether to update existing embeddings of the documents. If set to False,
+                                           only documents without embeddings are processed. This mode can be used for
+                                           incremental updating of embeddings, wherein, only newly indexed documents
+                                           get processed.
+        :param filters: Optional filters to narrow down the documents for which embeddings are to be updated.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
         :return: None
         """
         index = index or self.index
@@ -236,7 +249,13 @@ class MilvusDocumentStore(SQLDocumentStore):
 
         logger.info(f"Updating embeddings for {document_count} docs...")
 
-        result = self.get_all_documents_generator(index=index, batch_size=batch_size, return_embedding=False)
+        result = self._query(
+            index=index,
+            vector_ids=None,
+            batch_size=batch_size,
+            filters=filters,
+            filter_documents_without_embeddings=not update_existing_embeddings
+        )
         batched_documents = get_batches_from_generator(result, batch_size)
         with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:
             for document_batch in batched_documents:

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -145,7 +145,8 @@ class SQLDocumentStore(BaseDocumentStore):
             batch_size=batch_size
         )
         documents = list(result)
-        return documents
+        sorted_documents = sorted(documents, key=lambda doc: vector_ids.index(doc.meta["vector_id"]))
+        return sorted_documents
 
     def get_all_documents(
         self,

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -92,7 +92,7 @@ class SQLDocumentStore(BaseDocumentStore):
         ORMBase.metadata.create_all(engine)
         Session = sessionmaker(bind=engine)
         self.session = Session()
-        self.index = index
+        self.index: str = index
         self.label_index = label_index
         self.update_existing_documents = update_existing_documents
         if getattr(self, "similarity", None) is None:

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -191,7 +191,7 @@ class SQLDocumentStore(BaseDocumentStore):
         index: Optional[str] = None,
         filters: Optional[Dict[str, List[str]]] = None,
         vector_ids: Optional[List[str]] = None,
-        filter_documents_without_embeddings: bool = False,
+        only_documents_without_embedding: bool = False,
         batch_size: int = 10_000
     ):
         """
@@ -200,7 +200,7 @@ class SQLDocumentStore(BaseDocumentStore):
         :param filters: Optional filters to narrow down the documents to return.
                         Example: {"name": ["some", "more"], "category": ["only_one"]}
         :param vector_ids: List of vector_id strings to filter the documents by.
-        :param filter_documents_without_embeddings: return only documents without an embedding.
+        :param only_documents_without_embedding: return only documents without an embedding.
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
         """
         index = index or self.index
@@ -221,7 +221,7 @@ class SQLDocumentStore(BaseDocumentStore):
                     MetaORM.value.in_(values),
                     DocumentORM.id == MetaORM.document_id
                 )
-        if filter_documents_without_embeddings:
+        if only_documents_without_embedding:
             documents_query = documents_query.filter(DocumentORM.vector_id.is_(None))
         if vector_ids:
             documents_query = documents_query.filter(DocumentORM.vector_id.in_(vector_ids))

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -199,27 +199,27 @@ def test_document_with_embeddings(document_store):
 @pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus"], indirect=True)
 def test_update_embeddings(document_store, retriever):
     documents = []
-    for i in range(23):
+    for i in range(6):
         documents.append({"text": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
-    documents.append({"text": "text_0", "id": "23", "meta_field": "value_0"})
+    documents.append({"text": "text_0", "id": "6", "meta_field": "value_0"})
 
     document_store.write_documents(documents, index="haystack_test_1")
-    document_store.update_embeddings(retriever, index="haystack_test_1")
+    document_store.update_embeddings(retriever, index="haystack_test_1", batch_size=3)
     documents = document_store.get_all_documents(index="haystack_test_1", return_embedding=True)
-    assert len(documents) == 24
+    assert len(documents) == 7
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
 
     documents = document_store.get_all_documents(
         index="haystack_test_1",
-        filters={"meta_field": ["value_0", "value_23"]},
+        filters={"meta_field": ["value_0", "value_6"]},
         return_embedding=True,
     )
     np.testing.assert_array_equal(documents[0].embedding, documents[1].embedding)
 
     documents = document_store.get_all_documents(
         index="haystack_test_1",
-        filters={"meta_field": ["value_0", "value_10"]},
+        filters={"meta_field": ["value_0", "value_5"]},
         return_embedding=True,
     )
     np.testing.assert_raises(
@@ -228,6 +228,38 @@ def test_update_embeddings(document_store, retriever):
         documents[0].embedding,
         documents[1].embedding
     )
+
+    doc = {"text": "text_7", "id": "7", "meta_field": "value_7",
+           "embedding": retriever.embed_queries(texts=["a random string"])[0]}
+    document_store.write_documents([doc], index="haystack_test_1")
+
+    documents = []
+    for i in range(8, 11):
+        documents.append({"text": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+    document_store.write_documents(documents, index="haystack_test_1")
+
+    doc_before_update = document_store.get_all_documents(index="haystack_test_1", filters={"meta_field": ["value_7"]})[0]
+    embedding_before_update = doc_before_update.embedding
+
+    # test updating only documents without embeddings
+    document_store.update_embeddings(retriever, index="haystack_test_1", batch_size=3, update_existing_embeddings=False)
+    doc_after_update = document_store.get_all_documents(index="haystack_test_1", filters={"meta_field": ["value_7"]})[0]
+    embedding_after_update = doc_after_update.embedding
+    np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
+
+    # test updating with filters
+    document_store.update_embeddings(
+        retriever, index="haystack_test_1", batch_size=3, filters={"meta_field": ["value_0", "value_1"]}
+    )
+    doc_after_update = document_store.get_all_documents(index="haystack_test_1", filters={"meta_field": ["value_7"]})[0]
+    embedding_after_update = doc_after_update.embedding
+    np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
+
+    # test update all embeddings
+    document_store.update_embeddings(retriever, index="haystack_test_1", batch_size=3, update_existing_embeddings=True)
+    doc_after_update = document_store.get_all_documents(index="haystack_test_1", filters={"meta_field": ["value_7"]})[0]
+    embedding_after_update = doc_after_update.embedding
+    np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, embedding_before_update, embedding_after_update)
 
 
 @pytest.mark.elasticsearch

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -1,5 +1,4 @@
 import os
-from copy import deepcopy
 
 import faiss
 import numpy as np


### PR DESCRIPTION
The document stores provide a `update_embedding()` method that takes a retriever instance as an argument to create/update embeddings of all indexed documents. This works well for the creation of new document stores. However, this approach is inefficient when a large document collection is already present and you want to update only the newly added documents that don't have embeddings yet.

This PR introduces a new parameter `update_existing_embeddings` for `update_embeddings()`, which when set to `False`, will only generate embeddings for documents without embeddings. Additionally, `filters` are now also added to update embeddings for a subset of documents.

Resolves #806 