### PR TITLE
Fix encoding for pdftotext (Russian characters, German umlauts etc). Fix version in download instructions

### DIFF
--- a/docs/_src/api/api/file_converter.md
+++ b/docs/_src/api/api/file_converter.md
@@ -211,16 +211,20 @@ in garbled text.
 #### convert
 
 ```python
- | convert(file_path: Path, meta: Optional[Dict[str, str]] = None, encoding: str = "UTF-8") -> Dict[str, Any]
+ | convert(file_path: Path, meta: Optional[Dict[str, str]] = None, encoding: str = "Latin1") -> Dict[str, Any]
 ```
 
-Extract text from a .pdf file.
+Extract text from a .pdf file using the pdftotext library (https://www.xpdfreader.com/pdftotext-man.html)
 
 **Arguments**:
 
 - `file_path`: Path to the .pdf file you want to convert
 - `meta`: Optional dictionary with metadata that shall be attached to all resulting documents.
 Can be any custom keys and values.
-- `encoding`: Encoding that will be passed as -enc parameter to pdftotext
-(see: https://www.xpdfreader.com/pdftotext-man.html)
+- `encoding`: Encoding that will be passed as -enc parameter to pdftotext. "Latin 1" is the default encoding
+of pdftotext. While this works well on many PDFs, it might be needed to switch to "UTF-8" or
+others if your doc contains special characters (e.g. German Umlauts, Cyrillic characters ...).
+Note: With "UTF-8" we experienced cases, where a simple "fi" gets wrongly parsed as
+"xef\xac\x81c" (see test cases). That's why we keep "Latin 1" as default here.
+(See list of available encodings by running `pdftotext -listencodings` in the terminal)
 

--- a/haystack/file_converter/pdf.py
+++ b/haystack/file_converter/pdf.py
@@ -28,8 +28,8 @@ class PDFToTextConverter(BaseConverter):
                 """pdftotext is not installed. It is part of xpdf or poppler-utils software suite.
                 
                    Installation on Linux:
-                   wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.02.tar.gz &&
-                   tar -xvf xpdf-tools-linux-4.02.tar.gz && sudo cp xpdf-tools-linux-4.02/bin64/pdftotext /usr/local/bin
+                   wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz &&
+                   tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
                    
                    Installation on MacOS:
                    brew install xpdf
@@ -40,14 +40,18 @@ class PDFToTextConverter(BaseConverter):
 
         super().__init__(remove_numeric_tables=remove_numeric_tables, valid_languages=valid_languages)
 
-    def convert(self, file_path: Path, meta: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    def convert(self, file_path: Path, meta: Optional[Dict[str, str]] = None, encoding: str = "UTF-8") -> Dict[str, Any]:
         """
         Extract text from a .pdf file.
 
         :param file_path: Path to the .pdf file you want to convert
+        :param meta: Optional dictionary with metadata that shall be attached to all resulting documents.
+                     Can be any custom keys and values.
+        :param encoding: Encoding that will be passed as -enc parameter to pdftotext
+                        (see: https://www.xpdfreader.com/pdftotext-man.html)
         """
 
-        pages = self._read_pdf(file_path, layout=False)
+        pages = self._read_pdf(file_path, layout=False, encoding=encoding)
 
         cleaned_pages = []
         for page in pages:
@@ -89,7 +93,7 @@ class PDFToTextConverter(BaseConverter):
         document = {"text": text, "meta": meta}
         return document
 
-    def _read_pdf(self, file_path: Path, layout: bool) -> List[str]:
+    def _read_pdf(self, file_path: Path, layout: bool, encoding: str) -> List[str]:
         """
         Extract pages from the pdf file at file_path.
 
@@ -98,9 +102,9 @@ class PDFToTextConverter(BaseConverter):
                        the content stream order.
         """
         if layout:
-            command = ["pdftotext", "-layout", str(file_path), "-"]
+            command = ["pdftotext", "-enc", encoding, "-layout", str(file_path), "-"]
         else:
-            command = ["pdftotext", str(file_path), "-"]
+            command = ["pdftotext", "-enc", encoding, str(file_path), "-"]
         output = subprocess.run(command, stdout=subprocess.PIPE, shell=False)
         document = output.stdout.decode(errors="ignore")
         pages = document.split("\f")

--- a/haystack/file_converter/pdf.py
+++ b/haystack/file_converter/pdf.py
@@ -40,15 +40,19 @@ class PDFToTextConverter(BaseConverter):
 
         super().__init__(remove_numeric_tables=remove_numeric_tables, valid_languages=valid_languages)
 
-    def convert(self, file_path: Path, meta: Optional[Dict[str, str]] = None, encoding: str = "UTF-8") -> Dict[str, Any]:
+    def convert(self, file_path: Path, meta: Optional[Dict[str, str]] = None, encoding: str = "Latin1") -> Dict[str, Any]:
         """
-        Extract text from a .pdf file.
+        Extract text from a .pdf file using the pdftotext library (https://www.xpdfreader.com/pdftotext-man.html)
 
         :param file_path: Path to the .pdf file you want to convert
         :param meta: Optional dictionary with metadata that shall be attached to all resulting documents.
                      Can be any custom keys and values.
-        :param encoding: Encoding that will be passed as -enc parameter to pdftotext
-                        (see: https://www.xpdfreader.com/pdftotext-man.html)
+        :param encoding: Encoding that will be passed as -enc parameter to pdftotext. "Latin 1" is the default encoding
+                         of pdftotext. While this works well on many PDFs, it might be needed to switch to "UTF-8" or
+                         others if your doc contains special characters (e.g. German Umlauts, Cyrillic characters ...).
+                         Note: With "UTF-8" we experienced cases, where a simple "fi" gets wrongly parsed as
+                         "xef\xac\x81c" (see test cases). That's why we keep "Latin 1" as default here.
+                         (See list of available encodings by running `pdftotext -listencodings` in the terminal)
         """
 
         pages = self._read_pdf(file_path, layout=False, encoding=encoding)

--- a/test/test_pdf_conversion.py
+++ b/test/test_pdf_conversion.py
@@ -18,7 +18,8 @@ def test_convert(Converter, xpdf_fixture):
 
 
 @pytest.mark.tika
-@pytest.mark.parametrize("Converter", [PDFToTextConverter, TikaConverter])
+# @pytest.mark.parametrize("Converter", [PDFToTextConverter, TikaConverter])
+@pytest.mark.parametrize("Converter", [PDFToTextConverter])
 def test_table_removal(Converter, xpdf_fixture):
     converter = Converter(remove_numeric_tables=True)
     document = converter.convert(file_path=Path("samples/pdf/sample_pdf_1.pdf"))
@@ -28,7 +29,9 @@ def test_table_removal(Converter, xpdf_fixture):
     assert "54x growth" not in pages[0]
 
     # assert text is retained from the document.
-    assert "Adobe Systems made the PDF specification available free of charge in 1993." in pages[0].replace("\n", "")
+    # As whitespace can differ (\n," ", etc.), we standardize all to simple whitespace
+    page_standard_whitespace = " ".join(pages[0].split())
+    assert"Adobe Systems made the PDF specification available free of charge in 1993." in page_standard_whitespace
 
 
 @pytest.mark.tika

--- a/test/test_pdf_conversion.py
+++ b/test/test_pdf_conversion.py
@@ -18,8 +18,7 @@ def test_convert(Converter, xpdf_fixture):
 
 
 @pytest.mark.tika
-# @pytest.mark.parametrize("Converter", [PDFToTextConverter, TikaConverter])
-@pytest.mark.parametrize("Converter", [PDFToTextConverter])
+@pytest.mark.parametrize("Converter", [PDFToTextConverter, TikaConverter])
 def test_table_removal(Converter, xpdf_fixture):
     converter = Converter(remove_numeric_tables=True)
     document = converter.convert(file_path=Path("samples/pdf/sample_pdf_1.pdf"))
@@ -31,7 +30,7 @@ def test_table_removal(Converter, xpdf_fixture):
     # assert text is retained from the document.
     # As whitespace can differ (\n," ", etc.), we standardize all to simple whitespace
     page_standard_whitespace = " ".join(pages[0].split())
-    assert"Adobe Systems made the PDF specification available free of charge in 1993." in page_standard_whitespace
+    assert "Adobe Systems made the PDF specification available free of charge in 1993." in page_standard_whitespace
 
 
 @pytest.mark.tika


### PR DESCRIPTION
Fixes #805 

It seems that pdftotext uses different default encodings depending on the host machine. While on my machine all pdfs in #805 get converted correctly, the converter on a Google Colab notebook just produced gibberish.
It might be related to environment variables on the host like `LC_ALL` or `LANG`. 

With this PR we are enabling users to pass a custom `encoding` to `PDFToTextConverter.convert()`.

"Latin 1" is the default encoding of pdftotext. While this works well on many PDFs, it might be needed to switch to "UTF-8" or
others if your doc contains special characters (e.g. German Umlauts, Cyrillic characters ...).

Note: With "UTF-8" we experienced cases, where a simple "fi" gets wrongly parsed as "xef\xac\x81c" which is a [latin small ligature](https://utf8-chartable.de/unicode-utf8-table.pl?start=64256&utf8=string-literal) (see test cases). That's why we keep "Latin 1" as the default here. (See the list of available encodings by running `pdftotext -listencodings` in the terminal)

Also fixing the pdftotext install instructions from 4.02 to 4.03 (thanks for the pointer @m1kol)