### PR TITLE
Remove conditional import of FAISS for Windows

### DIFF
--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -9,6 +9,8 @@ from haystack import Document
 from haystack.document_store.sql import SQLDocumentStore
 from haystack.retriever.base import BaseRetriever
 from haystack.utils import get_batches_from_generator
+from scipy.special import expit
+
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -1,20 +1,14 @@
 import logging
-from sys import platform
 from pathlib import Path
 from typing import Union, List, Optional, Dict, Generator
 from tqdm import tqdm
+import faiss
 import numpy as np
 
 from haystack import Document
 from haystack.document_store.sql import SQLDocumentStore
 from haystack.retriever.base import BaseRetriever
 from haystack.utils import get_batches_from_generator
-from scipy.special import expit
-
-if platform != 'win32' and platform != 'cygwin':
-    import faiss
-else:
-    raise ModuleNotFoundError("FAISSDocumentStore on windows platform is not supported")
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ python-multipart
 python-docx
 sqlalchemy_utils
 # for using FAISS with GPUs, install faiss-gpu
-faiss-cpu==1.6.3; sys_platform != 'win32' and sys_platform != 'cygwin'
+faiss-cpu==1.6.3
 tika
 uvloop; sys_platform != 'win32' and sys_platform != 'cygwin'
 httptools


### PR DESCRIPTION
Since FAISS is now supported on Windows, we can remove the conditional import of `faiss` in the `FAISSDocumentDocumentStore`.

Resolves #817 