### PR TITLE
Fix UI when API returns fewer answers than expected

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       # See rest_api/config.py for more variables that you can configure here.
       - DB_HOST=elasticsearch
       - USE_GPU=False
+      - TOP_K_PER_SAMPLE=3 # how many answers can come from the same small passage (reduce value for more variety of answers)
       # Load a model from transformers' model hub or a local path into the FARMReader.
       - READER_MODEL_PATH=deepset/roberta-base-squad2
       # - READER_MODEL_PATH=home/user/models/roberta-base-squad2

--- a/docs/_src/tutorials/tutorials/8.md
+++ b/docs/_src/tutorials/tutorials/8.md
@@ -9,7 +9,7 @@ id: "tutorial8md"
 
 # Preprocessing
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial9_DPR_training.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial8_Preprocessing.ipynb)
 
 Haystack includes a suite of tools to extract text from different file types, normalize white space
 and split text into smaller pieces to optimize retrieval.

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -34,8 +34,9 @@ READER_MODEL_PATH = os.getenv("READER_MODEL_PATH", "deepset/roberta-base-squad2"
 READER_TYPE = os.getenv("READER_TYPE", "FARMReader") # alternative: 'TransformersReader'
 READER_TOKENIZER = os.getenv("READER_TOKENIZER", None)
 CONTEXT_WINDOW_SIZE = int(os.getenv("CONTEXT_WINDOW_SIZE", 500))
-DEFAULT_TOP_K_READER = int(os.getenv("DEFAULT_TOP_K_READER", 5))
-TOP_K_PER_CANDIDATE = int(os.getenv("TOP_K_PER_CANDIDATE", 3))
+DEFAULT_TOP_K_READER = int(os.getenv("DEFAULT_TOP_K_READER", 5)) # How many answers to return in total
+TOP_K_PER_CANDIDATE = int(os.getenv("TOP_K_PER_CANDIDATE", 10)) # How many answers can come from one indexed doc
+TOP_K_PER_SAMPLE = int(os.getenv("TOP_K_PER_SAMPLE", 1)) # How many answers can come from one passage that the reader processes at once (i.e. text of max_seq_len from the doc)
 NO_ANS_BOOST = int(os.getenv("NO_ANS_BOOST", -10))
 READER_CAN_HAVE_NO_ANSWER = os.getenv("READER_CAN_HAVE_NO_ANSWER", "True").lower() == "true"
 DOC_STRIDE = int(os.getenv("DOC_STRIDE", 128))

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -14,7 +14,8 @@ from rest_api.config import DB_HOST, DB_PORT, DB_USER, DB_PW, DB_INDEX, DB_INDEX
     RETRIEVER_TYPE, EMBEDDING_MODEL_PATH, USE_GPU, READER_MODEL_PATH, BATCHSIZE, CONTEXT_WINDOW_SIZE, \
     TOP_K_PER_CANDIDATE, NO_ANS_BOOST, READER_CAN_HAVE_NO_ANSWER, MAX_PROCESSES, MAX_SEQ_LEN, DOC_STRIDE, \
     CONCURRENT_REQUEST_PER_WORKER, FAQ_QUESTION_FIELD_NAME, EMBEDDING_MODEL_FORMAT, READER_TYPE, READER_TOKENIZER, \
-    GPU_NUMBER, NAME_FIELD_NAME, VECTOR_SIMILARITY_METRIC, CREATE_INDEX, LOG_LEVEL, UPDATE_EXISTING_DOCUMENTS
+    GPU_NUMBER, NAME_FIELD_NAME, VECTOR_SIMILARITY_METRIC, CREATE_INDEX, LOG_LEVEL, UPDATE_EXISTING_DOCUMENTS, \
+    TOP_K_PER_SAMPLE
 
 from rest_api.controller.request import Question
 from rest_api.controller.response import Answers, AnswersToIndividualQuestion
@@ -75,6 +76,7 @@ else:
                      )
 
 if READER_MODEL_PATH:  # for extractive doc-qa
+    logger.info(f"Loading reader model `{READER_MODEL_PATH}` ...")
     if READER_TYPE == "TransformersReader":
         use_gpu = -1 if not USE_GPU else GPU_NUMBER
         reader = TransformersReader(
@@ -91,6 +93,7 @@ if READER_MODEL_PATH:  # for extractive doc-qa
             use_gpu=USE_GPU,
             context_window_size=CONTEXT_WINDOW_SIZE,
             top_k_per_candidate=TOP_K_PER_CANDIDATE,
+            top_k_per_sample=TOP_K_PER_SAMPLE,
             no_ans_boost=NO_ANS_BOOST,
             num_processes=MAX_PROCESSES,
             max_seq_len=MAX_SEQ_LEN,

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -32,7 +32,7 @@ def retrieve_doc(question,filters=None,top_k_reader=5,top_k_retriever=5):
    # Format response
    result = []
    answers = response_raw['results'][0]['answers']
-   for i in range(top_k_reader):
+   for i in range(len(answers)):
        answer = answers[i]['answer']
        if answer:
            context = '...' + answers[i]['context'] + '...'

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -9,8 +9,8 @@ def annotate_answer(answer,context):
       
 st.write("# Haystack Demo")
 st.sidebar.header("Options")
-top_k_reader = st.sidebar.slider("Number of answers",min_value=1,max_value=10,value=5,step=1)
-top_k_retriever = st.sidebar.slider("Number of documents from retriever",min_value=1,max_value=10,value=3,step=1)
+top_k_reader = st.sidebar.slider("Max. number of answers",min_value=1,max_value=10,value=3,step=1)
+top_k_retriever = st.sidebar.slider("Max. number of documents from retriever",min_value=1,max_value=10,value=3,step=1)
 question = st.text_input("Please provide your query:",value="Who is the father of Arya Starck?")
 run_query = st.button("Run")
 debug = st.sidebar.checkbox("Show debug info")
@@ -22,7 +22,7 @@ if run_query:
     st.write("## Retrieved answers:")
     for result in results:
         annotate_answer(result['answer'],result['context'])
-        '**Relevance:** ', result['relevance'] , '**source:** ' , result['source']
+        '**Relevance:** ', result['relevance'] , '**Source:** ' , result['source']
     if debug:
         st.subheader('REST API JSON response')
         st.write(raw_json)


### PR DESCRIPTION
Problem occured on datasets with short docs. When putting the slider for top_k_reader to a high value (e.g. 10), while keeping top_k_retriever low (e.g. 1) the API returned less than the 10 expected answers and the UI crashed. Handled this case now + exposed a env variable for top_k_per_sample. We should further simplify this handling in #817