### PR TITLE
Fix boolean `progress_bar` for disabling tqdm progressbar

### DIFF
--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -210,7 +210,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             only_documents_without_embedding=not update_existing_embeddings
         )
         batched_documents = get_batches_from_generator(result, batch_size)
-        with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:
+        with tqdm(total=document_count, disable=not self.progress_bar) as progress_bar:
             for document_batch in batched_documents:
                 embeddings = retriever.embed_passages(document_batch)  # type: ignore
                 assert len(document_batch) == len(embeddings)

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -200,7 +200,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         document_count = len(result)
         logger.info(f"Updating embeddings for {document_count} docs ...")
         batched_documents = get_batches_from_generator(result, batch_size)
-        with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:
+        with tqdm(total=document_count, disable=not self.progress_bar) as progress_bar:
             for document_batch in batched_documents:
                 embeddings = retriever.embed_passages(document_batch)  # type: ignore
                 assert len(document_batch) == len(embeddings)

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -177,7 +177,7 @@ class MilvusDocumentStore(SQLDocumentStore):
         add_vectors = False if document_objects[0].embedding is None else True
 
         batched_documents = get_batches_from_generator(document_objects, batch_size)
-        with tqdm(total=len(document_objects), disable=self.progress_bar) as progress_bar:
+        with tqdm(total=len(document_objects), disable=not self.progress_bar) as progress_bar:
             for document_batch in batched_documents:
                 vector_ids = []
                 if add_vectors:
@@ -257,7 +257,7 @@ class MilvusDocumentStore(SQLDocumentStore):
             only_documents_without_embedding=not update_existing_embeddings
         )
         batched_documents = get_batches_from_generator(result, batch_size)
-        with tqdm(total=document_count, disable=self.progress_bar) as progress_bar:
+        with tqdm(total=document_count, disable=not self.progress_bar) as progress_bar:
             for document_batch in batched_documents:
                 self._delete_vector_ids_from_milvus(documents=document_batch, index=index)
 

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -96,7 +96,7 @@ class FARMReader(BaseReader):
         self.inferencer = QAInferencer.load(model_name_or_path, batch_size=batch_size, gpu=use_gpu,
                                             task_type="question_answering", max_seq_len=max_seq_len,
                                             doc_stride=doc_stride, num_processes=num_processes, revision=model_version,
-                                            disable_tqdm=progress_bar)
+                                            disable_tqdm=not progress_bar)
         self.inferencer.model.prediction_heads[0].context_window_size = context_window_size
         self.inferencer.model.prediction_heads[0].no_ans_boost = no_ans_boost
         self.inferencer.model.prediction_heads[0].n_best = top_k_per_candidate + 1 # including possible no_answer
@@ -230,7 +230,7 @@ class FARMReader(BaseReader):
             evaluate_every=evaluate_every,
             device=device,
             use_amp=use_amp,
-            disable_tqdm=self.progress_bar
+            disable_tqdm=not self.progress_bar
         )
 
 

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -213,7 +213,7 @@ class DensePassageRetriever(BaseRetriever):
         if len(dataset) == 1:
             disable_tqdm=True
         else:
-            disable_tqdm = self.progress_bar
+            disable_tqdm = not self.progress_bar
 
         for i, batch in enumerate(tqdm(data_loader, desc=f"Creating Embeddings", unit=" Batches", disable=disable_tqdm)):
             batch = {key: batch[key].to(self.device) for key in batch}


### PR DESCRIPTION
We recently introduced the boolean argument `progress_bar` in various Haystack components to disable tqdm progress bars. However, the behavior was the opposite of the expected, i.e. `progress_bar=True` resulted in **not** showing the bar. Fixing this now.

Fixing #835