### PR TITLE
Fix validation for `split_respect_sentence_boundary` in Preprocessor

### DIFF
--- a/haystack/preprocessor/preprocessor.py
+++ b/haystack/preprocessor/preprocessor.py
@@ -151,9 +151,8 @@ class PreProcessor(BasePreProcessor):
         if not split_length:
             raise Exception("split_length needs be set when using split_by.")
 
-        if split_respect_sentence_boundary and split_by not in("word","sentence"):
-            raise NotImplementedError("'split_respect_sentence_boundary=True' is only compatible with"
-                                      " split_by='word' or split_by='sentence'.")
+        if split_respect_sentence_boundary and split_by is not "word":
+            raise NotImplementedError("'split_respect_sentence_boundary=True' is only compatible with split_by='word'.")
 
         text = document["text"]
 

--- a/test/test_preprocessor.py
+++ b/test/test_preprocessor.py
@@ -21,12 +21,12 @@ in the sentence.
 @pytest.mark.tika
 def test_preprocess_sentence_split():
     document = {"text": TEXT}
-    preprocessor = PreProcessor(split_length=1, split_overlap=0, split_by="sentence")
+    preprocessor = PreProcessor(split_length=1, split_overlap=0, split_by="sentence", split_respect_sentence_boundary=False)
     documents = preprocessor.process(document)
     assert len(documents) == 15
 
     preprocessor = PreProcessor(
-        split_length=10, split_overlap=0, split_by="sentence"
+        split_length=10, split_overlap=0, split_by="sentence", split_respect_sentence_boundary=False,
     )
     documents = preprocessor.process(document)
     assert len(documents) == 2


### PR DESCRIPTION
The `split_respect_sentence_boundary` should only be applicable when the `split_by` parameter is set to `word.`