### PR TITLE
Fixes elasticsearch auth

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -154,13 +154,13 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
         if api_key:
             # api key authentication
+            client = Elasticsearch(hosts=hosts, api_key=(api_key_id, api_key),
+                                        scheme=scheme, ca_certs=ca_certs, verify_certs=verify_certs, timeout=timeout)
+        else:
+            # standard http_auth
             client = Elasticsearch(hosts=hosts, http_auth=(username, password),
                                         scheme=scheme, ca_certs=ca_certs, verify_certs=verify_certs,
                                         timeout=timeout)
-        else:
-            # standard http_auth
-            client = Elasticsearch(hosts=hosts, api_key=(api_key_id, api_key),
-                                        scheme=scheme, ca_certs=ca_certs, verify_certs=verify_certs, timeout=timeout)
 
             # Test connection
         try:


### PR DESCRIPTION
There was a mixup in https://github.com/deepset-ai/haystack/commit/e641bff7a6f7e8e8154efd6bf561de39d6c9bf6b
This fixes the api key auth and http auth for elasticsearch 