### PR TITLE
Add support for parallel paths in Pipeline

### DIFF
--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -561,7 +561,7 @@ class JoinDocuments:
 
         if self.join_mode == "concatenate":
             document_map = {}
-            for input_from_node, _ in inputs:
+            for input_from_node in inputs:
                 for doc in input_from_node["documents"]:
                     document_map[doc.id] = doc
         elif self.join_mode == "merge":
@@ -570,7 +570,7 @@ class JoinDocuments:
                 weights = self.weights
             else:
                 weights = [1/len(inputs)] * len(inputs)
-            for (input_from_node, _), weight in zip(inputs, weights):
+            for input_from_node, weight in zip(inputs, weights):
                 for doc in input_from_node["documents"]:
                     if document_map.get(doc.id):  # document already exists; update score
                         document_map[doc.id].score += doc.score * weight
@@ -583,5 +583,5 @@ class JoinDocuments:
         documents = sorted(document_map.values(), key=lambda d: d.score, reverse=True)
         if self.top_k:
             documents = documents[: self.top_k]
-        output = {"query": inputs[0][0]["query"], "documents": documents}
+        output = {"query": inputs[0]["query"], "documents": documents}
         return output, "output_1"

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -100,7 +100,9 @@ class Pipeline(ABC):
 
     def run(self, **kwargs):
         node_output = None
-        stack = {self.root_node_id: kwargs}  # ordered dict with "node_id" -> "input" mapping that acts as a FIFO stack
+        stack = {
+            self.root_node_id: {"pipeline_type": self.pipeline_type, **kwargs}
+        }  # ordered dict with "node_id" -> "input" mapping that acts as a FIFO stack
         nodes_executed = set()
         i = -1  # the last item is popped off the stack unless it is a join node with unprocessed predecessors
         while stack:
@@ -123,7 +125,7 @@ class Pipeline(ABC):
                     else:
                         stack[n] = node_output
                 i = -1
-            else:  # execute lower nodes in the stack
+            else:  # attempt executing lower nodes in the stack as `node_id` has unprocessed predecessors
                 i -= 1
         return node_output
 


### PR DESCRIPTION
The current `Pipeline` supports parallel paths having exactly one node. For instance, the following graph will work with the existing `Pipeline` where nodes `C` and `D` are parallel paths.

![pipeline copy](https://user-images.githubusercontent.com/78848855/110654287-4bc67a00-81be-11eb-8efa-42ef5f55f874.png)


However, when having more than 1 node in a parallel path is not supported. For instance, in the following graph, where `C`/`E` and `D` are in separate parallel paths.

![pipeline](https://user-images.githubusercontent.com/78848855/110654691-a95ac680-81be-11eb-8257-d71c6dd2e164.png)


This PR adds supports for the second type of graphs with multiple nodes in a parallel path.