### PR TITLE
WIP: Fix execution of Pipelines with parallel nodes

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -346,7 +346,7 @@ Note that pipelines with split or merge nodes are currently not supported.
 ## JoinDocuments Objects
 
 ```python
-class JoinDocuments()
+class JoinDocuments(BaseComponent)
 ```
 
 A node to join documents outputted by multiple retriever nodes.


### PR DESCRIPTION
With #688, the `Pipeline` was extended to support executing graphs that have parallel nodes.

This worked well until there was a case with a graph having both "branch"(having multiple output streams) node and parallel nodes. In that case, the complete graph did not get executed, resulting in partial results.

Here's the graph:
![image](https://user-images.githubusercontent.com/78848855/111620113-965f7c00-87e6-11eb-9f0d-0e3760baeb86.png)

When the `QueryRouter` returns `output_2`, then the pipeline executed only one of the two graph retriever nodes and returned the results.

This PR refactor the `run()` method which resolves the issue.