### PR TITLE
Logged warning in Faiss and Milvus for filters

### DIFF
--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -315,7 +315,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         Delete all documents from the document store.
         """
         if filters:
-            raise Exception("filters are supported for deleting documents in FAISSDocumentStore.")
+            logger.warning("Filters are not supported for deleting documents in FAISSDocumentStore.")
         index = index or self.index
         if index in self.faiss_indexes.keys():
             self.faiss_indexes[index].reset()
@@ -341,7 +341,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         :return:
         """
         if filters:
-            raise Exception("Query filters are not implemented for the FAISSDocumentStore.")
+            logger.warning("Query filters are not implemented for the FAISSDocumentStore.")
 
         index = index or self.index
         if not self.faiss_indexes.get(index):

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -298,7 +298,7 @@ class MilvusDocumentStore(SQLDocumentStore):
         :return:
         """
         if filters:
-            raise Exception("Query filters are not implemented for the MilvusDocumentStore.")
+            logger.warning("Query filters are not implemented for the MilvusDocumentStore.")
 
         index = index or self.index
         status, ok = self.milvus_server.has_collection(collection_name=index)


### PR DESCRIPTION
Filters are not (yet) used in FAISS and Milvus: Warning is given, but no exception is raised. After this change filters can be used in a pipeline in other nodes. (see deepset-ai/haystack#912)