### PR TITLE
Rest API update with pipeline

### DIFF
--- a/rest_api/controller/response.py
+++ b/rest_api/controller/response.py
@@ -18,7 +18,7 @@ class Answer(BaseModel):
 
 
 class AnswersToIndividualQuestion(BaseModel):
-    question: str
+    question: Optional[str]
     answers: List[Optional[Answer]]
 
     @staticmethod


### PR DESCRIPTION
1. What is changing?
We update the **rest API** to make it compatible with the new "_pipeline_". I did this for two endpoints :

> /models/{model_id}/query
> /models/{model_id}/doc-qa
> 

2. Why?
Get rid of the _"finder"_ for these endpoints

3. What are limitations?
No limitations. 

4. Breaking changes (Example of before vs. after)
The endpoints don't need model_id anylonger :

> /models/query
> /models/doc-qa
> 

5. Link the issue that this relates to
Issue related #649 