### PR TITLE
Add Milvus to the retriever / document store table

### DIFF
--- a/docs/_src/usage/usage/retriever.md
+++ b/docs/_src/usage/usage/retriever.md
@@ -27,12 +27,12 @@ It is an tool for sifting out the obvious negative cases, saving the Reader from
 Note that not all Retrievers can be paired with every DocumentStore.
 Here are the combinations which are supported:
 
-| | Memory | Elasticsearch | SQL | FAISS |
-| --- | --- | --- | ---- | ---- |
-| BM25 | N | Y | N | N |
-| TF-IDF | Y | Y | Y | N |
-| Embedding | Y | Y | N | Y |
-| DPR | Y | Y | N | Y |
+| | Memory | Elasticsearch | SQL | FAISS | Milvus |
+| --- | --- | --- | ---- | ---- | ---- |
+| BM25 | N | Y | N | N | N |
+| TF-IDF | Y | Y | Y | N | N |
+| Embedding | Y | Y | N | Y | Y |
+| DPR | Y | Y | N | Y | Y |
 
 See [Optimization](/docs/latest/optimizationmd) for suggestions on how to choose top-k values.
 


### PR DESCRIPTION
Following the discussion on Slack ([link](https://haystack-community.slack.com/archives/C01J3TZM9HT/p1616749575046800)), the Y/N entries are simply copied over from the FAISS ones