### PR TITLE
Adding indentation to markup files

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -23,12 +23,12 @@ Indexes documents for later queries.
 **Arguments**:
 
 - `documents`: a list of Python dictionaries or a list of Haystack Document objects.
-For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
-Optionally: Include meta data via {"text": "<the-actual-text>",
-"meta":{"name": "<some-document-name>, "author": "somebody", ...}}
-It can be used for filtering and is accessible in the responses of the Finder.
+                  For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
+                  Optionally: Include meta data via {"text": "<the-actual-text>",
+                  "meta":{"name": "<some-document-name>, "author": "somebody", ...}}
+                  It can be used for filtering and is accessible in the responses of the Finder.
 - `index`: Optional name of index where the documents shall be written to.
-If None, the DocumentStore's default index (self.index) will be used.
+              If None, the DocumentStore's default index (self.index) will be used.
 
 **Returns**:
 
@@ -47,9 +47,9 @@ Get documents from the document store.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 
 <a name="base.BaseDocumentStore.add_eval_data"></a>
@@ -69,15 +69,15 @@ from disk and also indexed batchwise to the DocumentStore in order to prevent ou
 - `doc_index`: Elasticsearch index where evaluation documents should be stored
 - `label_index`: Elasticsearch index where labeled questions should be stored
 - `batch_size`: Optional number of documents that are loaded and processed at a time.
-When set to None (default) all documents are processed at once.
+                   When set to None (default) all documents are processed at once.
 - `preprocessor`: Optional PreProcessor to preprocess evaluation documents.
-It can be used for splitting documents into passages (and assigning labels to corresponding passages).
-Currently the PreProcessor does not support split_by sentence, cleaning nor split_overlap != 0.
-When set to None (default) preprocessing is disabled.
+                     It can be used for splitting documents into passages (and assigning labels to corresponding passages).
+                     Currently the PreProcessor does not support split_by sentence, cleaning nor split_overlap != 0.
+                     When set to None (default) preprocessing is disabled.
 - `max_docs`: Optional number of documents that will be loaded.
-When set to None (default) all available eval documents are used.
+                 When set to None (default) all available eval documents are used.
 - `open_domain`: Set this to True if your file is an open domain dataset where two different answers to the
-same question might be found in different contexts.
+                    same question might be found in different contexts.
 
 <a name="elasticsearch"></a>
 # Module elasticsearch
@@ -98,9 +98,9 @@ class ElasticsearchDocumentStore(BaseDocumentStore)
 
 A DocumentStore using Elasticsearch to store and query the documents for our search.
 
-* Keeps all the logic to store and query documents from Elastic, incl. mapping of fields, adding filters or boosts to your queries, and storing embeddings
-* You can either use an existing Elasticsearch index or create a new one via haystack
-* Retrievers operate on top of this DocumentStore to find the relevant documents for a query
+    * Keeps all the logic to store and query documents from Elastic, incl. mapping of fields, adding filters or boosts to your queries, and storing embeddings
+    * You can either use an existing Elasticsearch index or create a new one via haystack
+    * Retrievers operate on top of this DocumentStore to find the relevant documents for a query
 
 **Arguments**:
 
@@ -114,30 +114,30 @@ A DocumentStore using Elasticsearch to store and query the documents for our sea
 - `label_index`: Name of index in elasticsearch to use for storing labels. If not existing yet, we will create one.
 - `search_fields`: Name of fields used by ElasticsearchRetriever to find matches in the docs to our incoming query (using elastic's multi_match query), e.g. ["title", "full_text"]
 - `text_field`: Name of field that might contain the answer and will therefore be passed to the Reader Model (e.g. "full_text").
-If no Reader is used (e.g. in FAQ-Style QA) the plain content of this field will just be returned.
+                   If no Reader is used (e.g. in FAQ-Style QA) the plain content of this field will just be returned.
 - `name_field`: Name of field that contains the title of the the doc
 - `embedding_field`: Name of field containing an embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
 - `embedding_dim`: Dimensionality of embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
 - `custom_mapping`: If you want to use your own custom mapping for creating a new index in Elasticsearch, you can supply it here as a dictionary.
 - `analyzer`: Specify the default analyzer from one of the built-ins when creating a new Elasticsearch Index.
-Elasticsearch also has built-in analyzers for different languages (e.g. impacting tokenization). More info at:
-https://www.elastic.co/guide/en/elasticsearch/reference/7.9/analysis-analyzers.html
+                 Elasticsearch also has built-in analyzers for different languages (e.g. impacting tokenization). More info at:
+                 https://www.elastic.co/guide/en/elasticsearch/reference/7.9/analysis-analyzers.html
 - `excluded_meta_data`: Name of fields in Elasticsearch that should not be returned (e.g. [field_one, field_two]).
-Helpful if you have fields with long, irrelevant content that you don't want to display in results (e.g. embedding vectors).
+                           Helpful if you have fields with long, irrelevant content that you don't want to display in results (e.g. embedding vectors).
 - `scheme`: 'https' or 'http', protocol used to connect to your elasticsearch instance
 - `ca_certs`: Root certificates for SSL: it is a path to certificate authority (CA) certs on disk. You can use certifi package with certifi.where() to find where the CA certs file is located in your machine.
 - `verify_certs`: Whether to be strict about ca certificates
 - `create_index`: Whether to try creating a new index (If the index of that name is already existing, we will just continue in any case)
 - `update_existing_documents`: Whether to update any existing documents with the same ID when adding
-documents. When set as True, any document with an existing ID gets updated.
-If set to False, an error is raised if the document ID of the document being
-added already exists.
+                                  documents. When set as True, any document with an existing ID gets updated.
+                                  If set to False, an error is raised if the document ID of the document being
+                                  added already exists.
 - `refresh_type`: Type of ES refresh used to control when changes made by a request (e.g. bulk) are made visible to search.
-If set to 'wait_for', continue only after changes are visible (slow, but safe).
-If set to 'false', continue directly (fast, but sometimes unintuitive behaviour when docs are not immediately available after ingestion).
-More info at https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-refresh.html
+                     If set to 'wait_for', continue only after changes are visible (slow, but safe).
+                     If set to 'false', continue directly (fast, but sometimes unintuitive behaviour when docs are not immediately available after ingestion).
+                     More info at https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-refresh.html
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default sine it is
-more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
+                   more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
 - `timeout`: Number of seconds after which an ElasticSearch request times out.
 - `return_embedding`: To return document embedding
 
@@ -167,7 +167,7 @@ Fetch documents by specifying a list of text id strings
 ```
 
 Get values associated with a metadata key. The output is in the format:
-[{"value": "my-value-1", "count": 23}, {"value": "my-value-2", "count": 12}, ... ]
+    [{"value": "my-value-1", "count": 23}, {"value": "my-value-2", "count": 12}, ... ]
 
 **Arguments**:
 
@@ -175,7 +175,7 @@ Get values associated with a metadata key. The output is in the format:
 - `query`: narrow down the scope to documents matching the query string.
 - `filters`: narrow down the scope to documents that match the given filters.
 - `index`: Elasticsearch index where the meta values should be searched. If not supplied,
-self.index will be used.
+              self.index will be used.
 
 <a name="elasticsearch.ElasticsearchDocumentStore.write_documents"></a>
 #### write\_documents
@@ -196,12 +196,12 @@ they will automatically get UUIDs assigned. See the `Document` class for details
 **Arguments**:
 
 - `documents`: a list of Python dictionaries or a list of Haystack Document objects.
-For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
-Optionally: Include meta data via {"text": "<the-actual-text>",
-"meta":{"name": "<some-document-name>, "author": "somebody", ...}}
-It can be used for filtering and is accessible in the responses of the Finder.
-Advanced: If you are using your own Elasticsearch mapping, the key names in the dictionary
-should be changed to what you have set for self.text_field and self.name_field.
+                  For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
+                  Optionally: Include meta data via {"text": "<the-actual-text>",
+                  "meta":{"name": "<some-document-name>, "author": "somebody", ...}}
+                  It can be used for filtering and is accessible in the responses of the Finder.
+                  Advanced: If you are using your own Elasticsearch mapping, the key names in the dictionary
+                  should be changed to what you have set for self.text_field and self.name_field.
 - `index`: Elasticsearch index where the documents should be indexed. If not supplied, self.index will be used.
 - `batch_size`: Number of documents that are passed to Elasticsearch's bulk function at a time.
 
@@ -262,9 +262,9 @@ Get documents from the document store.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -282,9 +282,9 @@ a large number of documents without having to load all documents in memory.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -327,7 +327,7 @@ Find the document that is most similar to the provided `query_emb` by using a ve
 
 - `query_emb`: Embedding of the query (e.g. gathered from DPR)
 - `filters`: Optional filters to narrow down the search space.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `top_k`: How many documents to return
 - `index`: Index name for storing the docs and metadata
 - `return_embedding`: To return document embedding
@@ -360,11 +360,11 @@ This can be useful if want to add or change the embeddings for your documents (e
 - `retriever`: Retriever to use to update the embeddings.
 - `index`: Index name to update
 - `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
-only documents without embeddings are processed. This mode can be used for
-incremental updating of embeddings, wherein, only newly indexed documents
-get processed.
+                                   only documents without embeddings are processed. This mode can be used for
+                                   incremental updating of embeddings, wherein, only newly indexed documents
+                                   get processed.
 - `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
@@ -423,15 +423,15 @@ In-memory document store
 **Arguments**:
 
 - `index`: The documents are scoped to an index attribute that can be used when writing, querying,
-or deleting documents. This parameter sets the default value for document index.
+              or deleting documents. This parameter sets the default value for document index.
 - `label_index`: The default value of index attribute for the labels.
 - `embedding_field`: Name of field containing an embedding vector (Only needed when using a dense retriever (e.g. DensePassageRetriever, EmbeddingRetriever) on top)
 - `embedding_dim`: The size of the embedding vector.
 - `return_embedding`: To return document embedding
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default sine it is
-more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
+           more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
 - `progress_bar`: Whether to show a tqdm progress bar or not.
-Can be helpful to disable in production deployments to keep the logs clean.
+                     Can be helpful to disable in production deployments to keep the logs clean.
 
 <a name="memory.InMemoryDocumentStore.write_documents"></a>
 #### write\_documents
@@ -446,12 +446,12 @@ Indexes documents for later queries.
 **Arguments**:
 
 - `documents`: a list of Python dictionaries or a list of Haystack Document objects.
-For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
-Optionally: Include meta data via {"text": "<the-actual-text>",
-"meta": {"name": "<some-document-name>, "author": "somebody", ...}}
-It can be used for filtering and is accessible in the responses of the Finder.
+                   For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
+                   Optionally: Include meta data via {"text": "<the-actual-text>",
+                   "meta": {"name": "<some-document-name>, "author": "somebody", ...}}
+                   It can be used for filtering and is accessible in the responses of the Finder.
 - `index`: write documents to a custom namespace. For instance, documents for evaluation can be indexed in a
-separate index than the documents for search.
+               separate index than the documents for search.
 
 **Returns**:
 
@@ -497,7 +497,7 @@ Find the document that is most similar to the provided `query_emb` by using a ve
 
 - `query_emb`: Embedding of the query (e.g. gathered from DPR)
 - `filters`: Optional filters to narrow down the search space.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `top_k`: How many documents to return
 - `index`: Index name for storing the docs and metadata
 - `return_embedding`: To return document embedding
@@ -521,11 +521,11 @@ This can be useful if want to add or change the embeddings for your documents (e
 - `retriever`: Retriever to use to get embeddings for text
 - `index`: Index name for which embeddings are to be updated. If set to None, the default self.index is used.
 - `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
-only documents without embeddings are processed. This mode can be used for
-incremental updating of embeddings, wherein, only newly indexed documents
-get processed.
+                                   only documents without embeddings are processed. This mode can be used for
+                                   incremental updating of embeddings, wherein, only newly indexed documents
+                                   get processed.
 - `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
@@ -563,9 +563,9 @@ documents.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 
 <a name="memory.InMemoryDocumentStore.get_all_labels"></a>
@@ -618,13 +618,13 @@ An SQL backed DocumentStore. Currently supports SQLite, PostgreSQL and MySQL bac
 
 - `url`: URL for SQL database as expected by SQLAlchemy. More info here: https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls
 - `index`: The documents are scoped to an index attribute that can be used when writing, querying, or deleting documents.
-This parameter sets the default value for document index.
+              This parameter sets the default value for document index.
 - `label_index`: The default value of index attribute for the labels.
 - `update_existing_documents`: Whether to update any existing documents with the same ID when adding
-documents. When set as True, any document with an existing ID gets updated.
-If set to False, an error is raised if the document ID of the document being
-added already exists. Using this parameter could cause performance degradation
-for document insertion.
+                                  documents. When set as True, any document with an existing ID gets updated.
+                                  If set to False, an error is raised if the document ID of the document being
+                                  added already exists. Using this parameter could cause performance degradation
+                                  for document insertion.
 
 <a name="sql.SQLDocumentStore.get_document_by_id"></a>
 #### get\_document\_by\_id
@@ -657,7 +657,7 @@ Fetch documents by specifying a list of text vector id strings
 
 - `vector_ids`: List of vector_id strings.
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 <a name="sql.SQLDocumentStore.get_all_documents_generator"></a>
@@ -674,9 +674,9 @@ a large number of documents without having to load all documents in memory.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -701,12 +701,12 @@ Indexes documents for later queries.
 **Arguments**:
 
 - `documents`: a list of Python dictionaries or a list of Haystack Document objects.
-For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
-Optionally: Include meta data via {"text": "<the-actual-text>",
-"meta":{"name": "<some-document-name>, "author": "somebody", ...}}
-It can be used for filtering and is accessible in the responses of the Finder.
+                  For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
+                  Optionally: Include meta data via {"text": "<the-actual-text>",
+                  "meta":{"name": "<some-document-name>, "author": "somebody", ...}}
+                  It can be used for filtering and is accessible in the responses of the Finder.
 - `index`: add an optional index attribute to documents. It can be later used for filtering. For instance,
-documents for evaluation can be indexed in a separate index than the documents for search.
+              documents for evaluation can be indexed in a separate index than the documents for search.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
@@ -819,36 +819,36 @@ the vector embeddings are indexed in a FAISS Index.
 **Arguments**:
 
 - `sql_url`: SQL connection URL for database. It defaults to local file based SQLite DB. For large scale
-deployment, Postgres is recommended.
+                deployment, Postgres is recommended.
 - `vector_dim`: the embedding vector size.
 - `faiss_index_factory_str`: Create a new FAISS index of the specified type.
-The type is determined from the given string following the conventions
-of the original FAISS index factory.
-Recommended options:
-- "Flat" (default): Best accuracy (= exact). Becomes slow and RAM intense for > 1 Mio docs.
-- "HNSW": Graph-based heuristic. If not further specified,
-we use a RAM intense, but more accurate config:
-HNSW256, efConstruction=256 and efSearch=256
-- "IVFx,Flat": Inverted Index. Replace x with the number of centroids aka nlist.
-Rule of thumb: nlist = 10 * sqrt (num_docs) is a good starting point.
-For more details see:
-- Overview of indices https://github.com/facebookresearch/faiss/wiki/Faiss-indexes
-- Guideline for choosing an index https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
-- FAISS Index factory https://github.com/facebookresearch/faiss/wiki/The-index-factory
-Benchmarks: XXX
+                                The type is determined from the given string following the conventions
+                                of the original FAISS index factory.
+                                Recommended options:
+                                - "Flat" (default): Best accuracy (= exact). Becomes slow and RAM intense for > 1 Mio docs.
+                                - "HNSW": Graph-based heuristic. If not further specified,
+                                          we use a RAM intense, but more accurate config:
+                                          HNSW256, efConstruction=256 and efSearch=256
+                                - "IVFx,Flat": Inverted Index. Replace x with the number of centroids aka nlist.
+                                                  Rule of thumb: nlist = 10 * sqrt (num_docs) is a good starting point.
+                                For more details see:
+                                - Overview of indices https://github.com/facebookresearch/faiss/wiki/Faiss-indexes
+                                - Guideline for choosing an index https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
+                                - FAISS Index factory https://github.com/facebookresearch/faiss/wiki/The-index-factory
+                                Benchmarks: XXX
 - `faiss_index`: Pass an existing FAISS Index, i.e. an empty one that you configured manually
-or one with docs that you used in Haystack before and want to load again.
+                    or one with docs that you used in Haystack before and want to load again.
 - `return_embedding`: To return document embedding
 - `update_existing_documents`: Whether to update any existing documents with the same ID when adding
-documents. When set as True, any document with an existing ID gets updated.
-If set to False, an error is raised if the document ID of the document being
-added already exists.
+                                  documents. When set as True, any document with an existing ID gets updated.
+                                  If set to False, an error is raised if the document ID of the document being
+                                  added already exists.
 - `index`: Name of index in document store to use.
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default sine it is
-more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
+           more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
 - `embedding_field`: Name of field containing an embedding vector.
 - `progress_bar`: Whether to show a tqdm progress bar or not.
-Can be helpful to disable in production deployments to keep the logs clean.
+                     Can be helpful to disable in production deployments to keep the logs clean.
 
 <a name="faiss.FAISSDocumentStore.write_documents"></a>
 #### write\_documents
@@ -862,7 +862,7 @@ Add new documents to the DocumentStore.
 **Arguments**:
 
 - `documents`: List of `Dicts` or List of `Documents`. If they already contain the embeddings, we'll index
-them right away in FAISS. If not, you can later call update_embeddings() to create & index them.
+                  them right away in FAISS. If not, you can later call update_embeddings() to create & index them.
 - `index`: (SQL) index name for storing the docs and metadata
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -885,11 +885,11 @@ This can be useful if want to add or change the embeddings for your documents (e
 - `retriever`: Retriever to use to get embeddings for text
 - `index`: Index name for which embeddings are to be updated. If set to None, the default self.index is used.
 - `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
-only documents without embeddings are processed. This mode can be used for
-incremental updating of embeddings, wherein, only newly indexed documents
-get processed.
+                                   only documents without embeddings are processed. This mode can be used for
+                                   incremental updating of embeddings, wherein, only newly indexed documents
+                                   get processed.
 - `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 **Returns**:
@@ -910,9 +910,9 @@ a large number of documents without having to load all documents in memory.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -959,7 +959,7 @@ Find the document that is most similar to the provided `query_emb` by using a ve
 
 - `query_emb`: Embedding of the query (e.g. gathered from DPR)
 - `filters`: Optional filters to narrow down the search space.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `top_k`: How many documents to return
 - `index`: Index name to query the document from.
 - `return_embedding`: To return document embedding
@@ -995,14 +995,14 @@ None
 
 Load a saved FAISS index from a file and connect to the SQL database.
 Note: In order to have a correct mapping from FAISS to SQL,
-make sure to use the same SQL DB that you used when calling `save()`.
+      make sure to use the same SQL DB that you used when calling `save()`.
 
 **Arguments**:
 
 - `faiss_file_path`: Stored FAISS index file. Can be created via calling `save()`
 - `sql_url`: Connection string to the SQL database that contains your docs and metadata.
 - `index`: Index name to load the FAISS index as. It must match the index name used for
-when creating the FAISS index.
+              when creating the FAISS index.
 
 **Returns**:
 
@@ -1043,11 +1043,11 @@ Usage:
 **Arguments**:
 
 - `sql_url`: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
-deployment, Postgres is recommended. If using MySQL then same server can also be used for
-Milvus metadata. For more details see https://milvus.io/docs/v0.10.5/data_manage.md.
+                deployment, Postgres is recommended. If using MySQL then same server can also be used for
+                Milvus metadata. For more details see https://milvus.io/docs/v0.10.5/data_manage.md.
 - `milvus_url`: Milvus server connection URL for storing and processing vectors.
-Protocol, host and port will automatically be inferred from the URL.
-See https://milvus.io/docs/v0.10.5/install_milvus.md for instructions to start a Milvus instance.
+                   Protocol, host and port will automatically be inferred from the URL.
+                   See https://milvus.io/docs/v0.10.5/install_milvus.md for instructions to start a Milvus instance.
 - `connection_pool`: Connection pool type to connect with Milvus server. Default: "SingletonThread".
 - `index`: Index name for text, embedding and metadata (in Milvus terms, this is the "collection name").
 - `vector_dim`: The embedding vector size. Default: 768.
@@ -1058,30 +1058,30 @@ As a rule of thumb, we would see a 30% ~ 50% increase in the search performance 
 Note that an overly large index_file_size value may cause failure to load a segment into the memory or graphics memory.
 (From https://milvus.io/docs/v0.10.5/performance_faq.md#How-can-I-get-the-best-performance-from-Milvus-through-setting-index_file_size)
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default and recommended for DPR embeddings.
-'cosine' is recommended for Sentence Transformers, but is not directly supported by Milvus.
-However, you can normalize your embeddings and use `dot_product` to get the same results.
-See https://milvus.io/docs/v0.10.5/metric.md?Inner-product-(IP)`floating`.
+                   'cosine' is recommended for Sentence Transformers, but is not directly supported by Milvus.
+                   However, you can normalize your embeddings and use `dot_product` to get the same results.
+                   See https://milvus.io/docs/v0.10.5/metric.md?Inner-product-(IP)`floating`.
 - `index_type`: Type of approximate nearest neighbour (ANN) index used. The choice here determines your tradeoff between speed and accuracy.
-Some popular options:
-- FLAT (default): Exact method, slow
-- IVF_FLAT, inverted file based heuristic, fast
-- HSNW: Graph based, fast
-- ANNOY: Tree based, fast
-See: https://milvus.io/docs/v0.10.5/index.md
+                   Some popular options:
+                   - FLAT (default): Exact method, slow
+                   - IVF_FLAT, inverted file based heuristic, fast
+                   - HSNW: Graph based, fast
+                   - ANNOY: Tree based, fast
+                   See: https://milvus.io/docs/v0.10.5/index.md
 - `index_param`: Configuration parameters for the chose index_type needed at indexing time.
-For example: {"nlist": 16384} as the number of cluster units to create for index_type IVF_FLAT.
-See https://milvus.io/docs/v0.10.5/index.md
+                    For example: {"nlist": 16384} as the number of cluster units to create for index_type IVF_FLAT.
+                    See https://milvus.io/docs/v0.10.5/index.md
 - `search_param`: Configuration parameters for the chose index_type needed at query time
-For example: {"nprobe": 10} as the number of cluster units to query for index_type IVF_FLAT.
-See https://milvus.io/docs/v0.10.5/index.md
+                     For example: {"nprobe": 10} as the number of cluster units to query for index_type IVF_FLAT.
+                     See https://milvus.io/docs/v0.10.5/index.md
 - `update_existing_documents`: Whether to update any existing documents with the same ID when adding
-documents. When set as True, any document with an existing ID gets updated.
-If set to False, an error is raised if the document ID of the document being
-added already exists.
+                                  documents. When set as True, any document with an existing ID gets updated.
+                                  If set to False, an error is raised if the document ID of the document being
+                                  added already exists.
 - `return_embedding`: To return document embedding.
 - `embedding_field`: Name of field containing an embedding vector.
 - `progress_bar`: Whether to show a tqdm progress bar or not.
-Can be helpful to disable in production deployments to keep the logs clean.
+                     Can be helpful to disable in production deployments to keep the logs clean.
 
 <a name="milvus.MilvusDocumentStore.write_documents"></a>
 #### write\_documents
@@ -1095,7 +1095,7 @@ Add new documents to the DocumentStore.
 **Arguments**:
 
 - `documents`: List of `Dicts` or List of `Documents`. If they already contain the embeddings, we'll index
-them right away in Milvus. If not, you can later call update_embeddings() to create & index them.
+                          them right away in Milvus. If not, you can later call update_embeddings() to create & index them.
 - `index`: (SQL) index name for storing the docs and metadata
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -1119,11 +1119,11 @@ This can be useful if want to add or change the embeddings for your documents (e
 - `index`: (SQL) index name for storing the docs and metadata
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 - `update_existing_embeddings`: Whether to update existing embeddings of the documents. If set to False,
-only documents without embeddings are processed. This mode can be used for
-incremental updating of embeddings, wherein, only newly indexed documents
-get processed.
+                                   only documents without embeddings are processed. This mode can be used for
+                                   incremental updating of embeddings, wherein, only newly indexed documents
+                                   get processed.
 - `filters`: Optional filters to narrow down the documents for which embeddings are to be updated.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 
 **Returns**:
 
@@ -1142,7 +1142,7 @@ Find the document that is most similar to the provided `query_emb` by using a ve
 
 - `query_emb`: Embedding of the query (e.g. gathered from DPR)
 - `filters`: Optional filters to narrow down the search space.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `top_k`: How many documents to return
 - `index`: (SQL) index name for storing the docs and metadata
 - `return_embedding`: To return document embedding
@@ -1164,7 +1164,7 @@ Delete all documents (from SQL AND Milvus).
 
 - `index`: (SQL) index name for storing the docs and metadata
 - `filters`: Optional filters to narrow down the search space.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 
 **Returns**:
 
@@ -1184,9 +1184,9 @@ a large number of documents without having to load all documents in memory.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -1202,9 +1202,9 @@ Get documents from the document store (optionally using filter criteria).
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `filters`: Optional filters to narrow down the documents to return.
-Example: {"name": ["some", "more"], "category": ["only_one"]}
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
 - `return_embedding`: Whether to return the document embeddings.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
@@ -1221,7 +1221,7 @@ Fetch a document by specifying its text id string
 
 - `id`: ID of the document
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 
 <a name="milvus.MilvusDocumentStore.get_documents_by_id"></a>
 #### get\_documents\_by\_id
@@ -1236,7 +1236,7 @@ Fetch multiple documents by specifying their IDs (strings)
 
 - `ids`: List of IDs of the documents
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 - `batch_size`: When working with large number of documents, batching can help reduce memory footprint.
 
 <a name="milvus.MilvusDocumentStore.get_all_vectors"></a>
@@ -1251,7 +1251,7 @@ Helper function to dump all vectors stored in Milvus server.
 **Arguments**:
 
 - `index`: Name of the index to get the documents from. If None, the
-DocumentStore's default index (self.index) will be used.
+              DocumentStore's default index (self.index) will be used.
 
 **Returns**:
 

--- a/docs/_src/api/api/file_converter.md
+++ b/docs/_src/api/api/file_converter.md
@@ -20,15 +20,15 @@ Base class for implementing file converts to transform input documents to text f
 **Arguments**:
 
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 
 <a name="base.BaseConverter.convert"></a>
 #### convert
@@ -48,15 +48,15 @@ supplied meta data like author, url, external IDs can be supplied as a dictionar
 - `file_path`: path of the file to convert
 - `meta`: dictionary of meta data key-value pairs to append in the returned document.
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 - `encoding`: Select the file encoding (default is `utf-8`)
 
 <a name="base.BaseConverter.validate_language"></a>
@@ -88,15 +88,15 @@ class TextConverter(BaseConverter)
 **Arguments**:
 
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 
 <a name="txt.TextConverter.convert"></a>
 #### convert
@@ -112,15 +112,15 @@ Reads text from a txt file and executes optional preprocessing steps.
 - `file_path`: path of the file to convert
 - `meta`: dictionary of meta data key-value pairs to append in the returned document.
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 - `encoding`: Select the file encoding (default is `utf-8`)
 
 **Returns**:
@@ -153,15 +153,15 @@ For compliance with other converters we nevertheless opted for keeping the metho
 - `file_path`: Path to the .docx file you want to convert
 - `meta`: dictionary of meta data key-value pairs to append in the returned document.
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 - `encoding`: Not applicable
 
 <a name="tika"></a>
@@ -185,15 +185,15 @@ class TikaConverter(BaseConverter)
 
 - `tika_url`: URL of the Tika server
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 
 <a name="tika.TikaConverter.convert"></a>
 #### convert
@@ -207,15 +207,15 @@ in garbled text.
 - `file_path`: path of the file to convert
 - `meta`: dictionary of meta data key-value pairs to append in the returned document.
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 - `encoding`: Not applicable
 
 **Returns**:
@@ -242,15 +242,15 @@ class PDFToTextConverter(BaseConverter)
 **Arguments**:
 
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 
 <a name="pdf.PDFToTextConverter.convert"></a>
 #### convert
@@ -265,21 +265,21 @@ Extract text from a .pdf file using the pdftotext library (https://www.xpdfreade
 
 - `file_path`: Path to the .pdf file you want to convert
 - `meta`: Optional dictionary with metadata that shall be attached to all resulting documents.
-Can be any custom keys and values.
+             Can be any custom keys and values.
 - `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-The tabular structures in documents might be noise for the reader model if it
-does not have table parsing capability for finding answers. However, tables
-may also have long strings that could possible candidate for searching answers.
-The rows containing strings are thus retained in this option.
+                              The tabular structures in documents might be noise for the reader model if it
+                              does not have table parsing capability for finding answers. However, tables
+                              may also have long strings that could possible candidate for searching answers.
+                              The rows containing strings are thus retained in this option.
 - `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-(https://en.wikipedia.org/wiki/ISO_639-1) format.
-This option can be used to add test for encoding errors. If the extracted text is
-not one of the valid languages, then it might likely be encoding error resulting
-in garbled text.
+                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
+                        This option can be used to add test for encoding errors. If the extracted text is
+                        not one of the valid languages, then it might likely be encoding error resulting
+                        in garbled text.
 - `encoding`: Encoding that will be passed as -enc parameter to pdftotext. "Latin 1" is the default encoding
-of pdftotext. While this works well on many PDFs, it might be needed to switch to "UTF-8" or
-others if your doc contains special characters (e.g. German Umlauts, Cyrillic characters ...).
-Note: With "UTF-8" we experienced cases, where a simple "fi" gets wrongly parsed as
-"xef\xac\x81c" (see test cases). That's why we keep "Latin 1" as default here.
-(See list of available encodings by running `pdftotext -listencodings` in the terminal)
+                 of pdftotext. While this works well on many PDFs, it might be needed to switch to "UTF-8" or
+                 others if your doc contains special characters (e.g. German Umlauts, Cyrillic characters ...).
+                 Note: With "UTF-8" we experienced cases, where a simple "fi" gets wrongly parsed as
+                 "xef\xac\x81c" (see test cases). That's why we keep "Latin 1" as default here.
+                 (See list of available encodings by running `pdftotext -listencodings` in the terminal)
 

--- a/docs/_src/api/api/generator.md
+++ b/docs/_src/api/api/generator.md
@@ -93,8 +93,8 @@ See https://huggingface.co/transformers/model_doc/rag.html for more details
 **Arguments**:
 
 - `model_name_or_path`: Directory of a saved model or the name of a public model e.g.
-'facebook/rag-token-nq', 'facebook/rag-sequence-nq'.
-See https://huggingface.co/models for full list of available models.
+                           'facebook/rag-token-nq', 'facebook/rag-sequence-nq'.
+                           See https://huggingface.co/models for full list of available models.
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `retriever`: `DensePassageRetriever` used to embedded passage
 - `generator_type`: Which RAG generator implementation to use? RAG-TOKEN or RAG-SEQUENCE

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -26,15 +26,15 @@ Add a new node to the pipeline.
 **Arguments**:
 
 - `component`: The object to be called when the data is passed to the node. It can be a Haystack component
-(like Retriever, Reader, or Generator) or a user-defined object that implements a run()
-method to process incoming data from predecessor node.
+                  (like Retriever, Reader, or Generator) or a user-defined object that implements a run()
+                  method to process incoming data from predecessor node.
 - `name`: The name for the node. It must not contain any dots.
 - `inputs`: A list of inputs to the node. If the predecessor node has a single outgoing edge, just the name
-of node is sufficient. For instance, a 'ElasticsearchRetriever' node would always output a single
-edge with a list of documents. It can be represented as ["ElasticsearchRetriever"].
+               of node is sufficient. For instance, a 'ElasticsearchRetriever' node would always output a single
+               edge with a list of documents. It can be represented as ["ElasticsearchRetriever"].
 
-In cases when the predecessor node has multiple outputs, e.g., a "QueryClassifier", the output
-must be specified explicitly as "QueryClassifier.output_2".
+               In cases when the predecessor node has multiple outputs, e.g., a "QueryClassifier", the output
+               must be specified explicitly as "QueryClassifier.output_2".
 
 <a name="pipeline.Pipeline.get_node"></a>
 #### get\_node
@@ -90,42 +90,42 @@ be passed.
 
 Here's a sample configuration:
 
-```yaml
-|   version: '0.7'
-|
-|    components:    # define all the building-blocks for Pipeline
-|    - name: MyReader       # custom-name for the component; helpful for visualization & debugging
-|      type: FARMReader    # Haystack Class name for the component
-|      params:
-|        no_ans_boost: -10
-|        model_name_or_path: deepset/roberta-base-squad2
-|    - name: MyESRetriever
-|      type: ElasticsearchRetriever
-|      params:
-|        document_store: MyDocumentStore    # params can reference other components defined in the YAML
-|        custom_query: null
-|    - name: MyDocumentStore
-|      type: ElasticsearchDocumentStore
-|      params:
-|        index: haystack_test
-|
-|    pipelines:    # multiple Pipelines can be defined using the components from above
-|    - name: my_query_pipeline    # a simple extractive-qa Pipeline
-|      nodes:
-|      - name: MyESRetriever
-|        inputs: [Query]
-|      - name: MyReader
-|        inputs: [MyESRetriever]
-```
+    ```yaml
+    |   version: '0.7'
+    |
+    |    components:    # define all the building-blocks for Pipeline
+    |    - name: MyReader       # custom-name for the component; helpful for visualization & debugging
+    |      type: FARMReader    # Haystack Class name for the component
+    |      params:
+    |        no_ans_boost: -10
+    |        model_name_or_path: deepset/roberta-base-squad2
+    |    - name: MyESRetriever
+    |      type: ElasticsearchRetriever
+    |      params:
+    |        document_store: MyDocumentStore    # params can reference other components defined in the YAML
+    |        custom_query: null
+    |    - name: MyDocumentStore
+    |      type: ElasticsearchDocumentStore
+    |      params:
+    |        index: haystack_test
+    |
+    |    pipelines:    # multiple Pipelines can be defined using the components from above
+    |    - name: my_query_pipeline    # a simple extractive-qa Pipeline
+    |      nodes:
+    |      - name: MyESRetriever
+    |        inputs: [Query]
+    |      - name: MyReader
+    |        inputs: [MyESRetriever]
+    ```
 
 **Arguments**:
 
 - `path`: path of the YAML file.
 - `pipeline_name`: if the YAML contains multiple pipelines, the pipeline_name to load must be set.
 - `overwrite_with_env_variables`: Overwrite the YAML configuration with environment variables. For example,
-to change index name param for an ElasticsearchDocumentStore, an env
-variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
-`_` sign must be used to specify nested hierarchical properties.
+                                     to change index name param for an ElasticsearchDocumentStore, an env
+                                     variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
+                                     `_` sign must be used to specify nested hierarchical properties.
 
 <a name="pipeline.BaseStandardPipeline"></a>
 ## BaseStandardPipeline Objects
@@ -146,15 +146,15 @@ Add a new node to the pipeline.
 **Arguments**:
 
 - `component`: The object to be called when the data is passed to the node. It can be a Haystack component
-(like Retriever, Reader, or Generator) or a user-defined object that implements a run()
-method to process incoming data from predecessor node.
+                  (like Retriever, Reader, or Generator) or a user-defined object that implements a run()
+                  method to process incoming data from predecessor node.
 - `name`: The name for the node. It must not contain any dots.
 - `inputs`: A list of inputs to the node. If the predecessor node has a single outgoing edge, just the name
-of node is sufficient. For instance, a 'ElasticsearchRetriever' node would always output a single
-edge with a list of documents. It can be represented as ["ElasticsearchRetriever"].
+               of node is sufficient. For instance, a 'ElasticsearchRetriever' node would always output a single
+               edge with a list of documents. It can be represented as ["ElasticsearchRetriever"].
 
-In cases when the predecessor node has multiple outputs, e.g., a "QueryClassifier", the output
-must be specified explicitly as "QueryClassifier.output_2".
+               In cases when the predecessor node has multiple outputs, e.g., a "QueryClassifier", the output
+               must be specified explicitly as "QueryClassifier.output_2".
 
 <a name="pipeline.BaseStandardPipeline.get_node"></a>
 #### get\_node
@@ -291,10 +291,10 @@ Initialize a Pipeline that retrieves documents for a query and then summarizes t
 - `query`: Your search query
 - `filters`: 
 - `top_k_retriever`: Number of top docs the retriever should pass to the summarizer.
-The higher this value, the slower your pipeline.
+                        The higher this value, the slower your pipeline.
 - `generate_single_summary`: Whether to generate single summary from all retrieved docs (True) or one per doc (False).
 - `return_in_answer_format`: Whether the results should be returned as documents (False) or in the answer format used in other QA pipelines (True).
-With the latter, you can use this pipeline as a "drop-in replacement" for other QA pipelines.
+                                With the latter, you can use this pipeline as a "drop-in replacement" for other QA pipelines.
 
 <a name="pipeline.FAQPipeline"></a>
 ## FAQPipeline Objects
@@ -340,7 +340,7 @@ Wrap a given `pipeline` with the `input_translator` and `output_translator`.
 - `input_translator`: A Translator node that shall translate the input query from language A to B
 - `output_translator`: A Translator node that shall translate the pipeline results from language B to A
 - `pipeline`: The pipeline object (e.g. ExtractiveQAPipeline) you want to "wrap".
-Note that pipelines with split or merge nodes are currently not supported.
+                 Note that pipelines with split or merge nodes are currently not supported.
 
 <a name="pipeline.JoinDocuments"></a>
 ## JoinDocuments Objects
@@ -366,9 +366,9 @@ The node allows multiple join modes:
 **Arguments**:
 
 - `join_mode`: `concatenate` to combine documents from multiple retrievers or `merge` to aggregate scores of
-individual documents.
+                  individual documents.
 - `weights`: A node-wise list(length of list must be equal to the number of input nodes) of weights for
-adjusting document scores when using the `merge` join_mode. By default, equal weight is given
-to each retriever score. This param is not compatible with the `concatenate` join_mode.
+                adjusting document scores when using the `merge` join_mode. By default, equal weight is given
+                to each retriever score. This param is not compatible with the `concatenate` join_mode.
 - `top_k_join`: Limit documents to top_k based on the resulting scores of the join.
 

--- a/docs/_src/api/api/preprocessor.md
+++ b/docs/_src/api/api/preprocessor.md
@@ -37,23 +37,23 @@ class PreProcessor(BasePreProcessor)
 **Arguments**:
 
 - `clean_header_footer`: Use heuristic to remove footers and headers across different pages by searching
-for the longest common string. This heuristic uses exact matches and therefore
-works well for footers like "Copyright 2019 by XXX", but won't detect "Page 3 of 4"
-or similar.
+                             for the longest common string. This heuristic uses exact matches and therefore
+                             works well for footers like "Copyright 2019 by XXX", but won't detect "Page 3 of 4"
+                             or similar.
 - `clean_whitespace`: Strip whitespaces before or after each line in the text.
 - `clean_empty_lines`: Remove more than two empty lines in the text.
 - `split_by`: Unit for splitting the document. Can be "word", "sentence", or "passage". Set to None to disable splitting.
 - `split_length`: Max. number of the above split unit (e.g. words) that are allowed in one document. For instance, if n -> 10 & split_by ->
-"sentence", then each output document will have 10 sentences.
+                   "sentence", then each output document will have 10 sentences.
 - `split_overlap`: Word overlap between two adjacent documents after a split.
-Setting this to a positive number essentially enables the sliding window approach.
-For example, if split_by -> `word`,
-split_length -> 5 & split_overlap -> 2, then the splits would be like:
-[w1 w2 w3 w4 w5, w4 w5 w6 w7 w8, w7 w8 w10 w11 w12].
-Set the value to 0 to ensure there is no overlap among the documents after splitting.
+                      Setting this to a positive number essentially enables the sliding window approach.
+                      For example, if split_by -> `word`,
+                      split_length -> 5 & split_overlap -> 2, then the splits would be like:
+                      [w1 w2 w3 w4 w5, w4 w5 w6 w7 w8, w7 w8 w10 w11 w12].
+                      Set the value to 0 to ensure there is no overlap among the documents after splitting.
 - `split_respect_sentence_boundary`: Whether to split in partial sentences if split_by -> `word`. If set
-to True, the individual split will always have complete sentences &
-the number of words will be <= split_length.
+                                        to True, the individual split will always have complete sentences &
+                                        the number of words will be <= split_length.
 
 <a name="preprocessor.PreProcessor.process"></a>
 #### process

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -49,10 +49,10 @@ While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interf
 See https://huggingface.co/models for full list of available models.
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `context_window_size`: The size, in characters, of the window around the answer span that is used when
-displaying the context around the answer.
+                            displaying the context around the answer.
 - `batch_size`: Number of samples the model receives in one batch for inference.
-Memory consumption is much lower in inference mode. Recommendation: Increase the batch size
-to a value so only a single batch is used.
+                   Memory consumption is much lower in inference mode. Recommendation: Increase the batch size
+                   to a value so only a single batch is used.
 - `use_gpu`: Whether to use GPU (if available)
 - `no_ans_boost`: How much the no_answer logit is boosted/increased.
 If set to 0 (default), the no_answer logit is not changed.
@@ -72,12 +72,12 @@ Note that this is not the number of "final answers" you will receive
 (see `top_k` in FARMReader.predict() or Finder.get_answers() for that)
 and that FARM includes no_answer in the sorted list of predictions.
 - `num_processes`: The number of processes for `multiprocessing.Pool`. Set to value of 0 to disable
-multiprocessing. Set to None to let Inferencer determine optimum number. If you
-want to debug the Language Model, you might need to disable multiprocessing!
+                      multiprocessing. Set to None to let Inferencer determine optimum number. If you
+                      want to debug the Language Model, you might need to disable multiprocessing!
 - `max_seq_len`: Max sequence length of one input text for the model
 - `doc_stride`: Length of striding window for splitting long texts (used if ``len(text) > max_seq_len``)
 - `progress_bar`: Whether to show a tqdm progress bar or not.
-Can be helpful to disable in production deployments to keep the logs clean.
+                     Can be helpful to disable in production deployments to keep the logs clean.
 
 <a name="farm.FARMReader.train"></a>
 #### train
@@ -98,28 +98,28 @@ Fine-tune a model on a QA dataset. Options:
 - `dev_filename`: Filename of dev / eval data
 - `test_filename`: Filename of test data
 - `dev_split`: Instead of specifying a dev_filename, you can also specify a ratio (e.g. 0.1) here
-that gets split off from training data for eval.
+                  that gets split off from training data for eval.
 - `use_gpu`: Whether to use GPU (if available)
 - `batch_size`: Number of samples the model receives in one batch for training
 - `n_epochs`: Number of iterations on the whole training data set
 - `learning_rate`: Learning rate of the optimizer
 - `max_seq_len`: Maximum text length (in tokens). Everything longer gets cut down.
 - `warmup_proportion`: Proportion of training steps until maximum learning rate is reached.
-Until that point LR is increasing linearly. After that it's decreasing again linearly.
-Options for different schedules are available in FARM.
+                          Until that point LR is increasing linearly. After that it's decreasing again linearly.
+                          Options for different schedules are available in FARM.
 - `evaluate_every`: Evaluate the model every X steps on the hold-out eval dataset
 - `save_dir`: Path to store the final model
 - `num_processes`: The number of processes for `multiprocessing.Pool` during preprocessing.
-Set to value of 1 to disable multiprocessing. When set to 1, you cannot split away a dev set from train set.
-Set to None to use all CPU cores minus one.
+                      Set to value of 1 to disable multiprocessing. When set to 1, you cannot split away a dev set from train set.
+                      Set to None to use all CPU cores minus one.
 - `use_amp`: Optimization level of NVIDIA's automatic mixed precision (AMP). The higher the level, the faster the model.
-Available options:
-None (Don't use AMP)
-"O0" (Normal FP32 training)
-"O1" (Mixed Precision => Recommended)
-"O2" (Almost FP16)
-"O3" (Pure FP16).
-See details on: https://nvidia.github.io/apex/amp.html
+                Available options:
+                None (Don't use AMP)
+                "O0" (Normal FP32 training)
+                "O1" (Mixed Precision => Recommended)
+                "O2" (Almost FP16)
+                "O3" (Pure FP16).
+                See details on: https://nvidia.github.io/apex/amp.html
 
 **Returns**:
 
@@ -179,20 +179,20 @@ Use loaded QA model to find answers for a query in the supplied list of Document
 
 Returns dictionaries containing answers sorted by (desc.) probability.
 Example:
-```python
-|{
-|    'query': 'Who is the father of Arya Stark?',
-|    'answers':[
-|                 {'answer': 'Eddard,',
-|                 'context': " She travels with her father, Eddard, to King's Landing when he is ",
-|                 'offset_answer_start': 147,
-|                 'offset_answer_end': 154,
-|                 'probability': 0.9787139466668613,
-|                 'score': None,
-|                 'document_id': '1337'
-|                 },...
-|              ]
-|}
+ ```python
+    |{
+    |    'query': 'Who is the father of Arya Stark?',
+    |    'answers':[
+    |                 {'answer': 'Eddard,',
+    |                 'context': " She travels with her father, Eddard, to King's Landing when he is ",
+    |                 'offset_answer_start': 147,
+    |                 'offset_answer_end': 154,
+    |                 'probability': 0.9787139466668613,
+    |                 'score': None,
+    |                 'document_id': '1337'
+    |                 },...
+    |              ]
+    |}
 ```
 
 **Arguments**:
@@ -214,9 +214,9 @@ Dict containing query and answers
 
 Performs evaluation on a SQuAD-formatted file.
 Returns a dict containing the following metrics:
-- "EM": exact match score
-- "f1": F1-Score
-- "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
+    - "EM": exact match score
+    - "f1": F1-Score
+    - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
 **Arguments**:
 
@@ -236,9 +236,9 @@ Returns a dict containing the following metrics:
 
 Performs evaluation on evaluation documents in the DocumentStore.
 Returns a dict containing the following metrics:
-- "EM": Proportion of exact matches of predicted answers with their corresponding correct answers
-- "f1": Average overlap between predicted answers and their corresponding correct answers
-- "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
+      - "EM": Proportion of exact matches of predicted answers with their corresponding correct answers
+      - "f1": Average overlap between predicted answers and their corresponding correct answers
+      - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
 **Arguments**:
 
@@ -257,20 +257,20 @@ Returns a dict containing the following metrics:
 Use loaded QA model to find answers for a question in the supplied list of Document.
 Returns dictionaries containing answers sorted by (desc.) probability.
 Example:
-```python
-|{
-|    'question': 'Who is the father of Arya Stark?',
-|    'answers':[
-|                 {'answer': 'Eddard,',
-|                 'context': " She travels with her father, Eddard, to King's Landing when he is ",
-|                 'offset_answer_start': 147,
-|                 'offset_answer_end': 154,
-|                 'probability': 0.9787139466668613,
-|                 'score': None,
-|                 'document_id': '1337'
-|                 },...
-|              ]
-|}
+ ```python
+    |{
+    |    'question': 'Who is the father of Arya Stark?',
+    |    'answers':[
+    |                 {'answer': 'Eddard,',
+    |                 'context': " She travels with her father, Eddard, to King's Landing when he is ",
+    |                 'offset_answer_start': 147,
+    |                 'offset_answer_end': 154,
+    |                 'probability': 0.9787139466668613,
+    |                 'score': None,
+    |                 'document_id': '1337'
+    |                 },...
+    |              ]
+    |}
 ```
 
 **Arguments**:
@@ -296,19 +296,19 @@ can be loaded with in the `FARMReader` using the export path as `model_name_or_p
 
 Usage:
 
-`from haystack.reader.farm import FARMReader
-from pathlib import Path
-onnx_model_path = Path("roberta-onnx-model")
-FARMReader.convert_to_onnx(model_name="deepset/bert-base-cased-squad2", output_path=onnx_model_path)
-reader = FARMReader(onnx_model_path)`
+    `from haystack.reader.farm import FARMReader
+    from pathlib import Path
+    onnx_model_path = Path("roberta-onnx-model")
+    FARMReader.convert_to_onnx(model_name="deepset/bert-base-cased-squad2", output_path=onnx_model_path)
+    reader = FARMReader(onnx_model_path)`
 
 **Arguments**:
 
 - `model_name`: transformers model name
 - `output_path`: Path to output the converted model
 - `convert_to_float16`: Many models use float32 precision by default. With the half precision of float16,
-inference is faster on Nvidia GPUs with Tensor core like T4 or V100. On older GPUs,
-float32 could still be be more performant.
+                           inference is faster on Nvidia GPUs with Tensor core like T4 or V100. On older GPUs,
+                           float32 could still be be more performant.
 - `quantize`: convert floating point number to integers
 - `task_type`: Type of task for the model. Available options: "question_answering" or "embeddings".
 - `opset_version`: ONNX opset version
@@ -352,7 +352,7 @@ See https://huggingface.co/models for full list of available models.
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `tokenizer`: Name of the tokenizer (usually the same as model)
 - `context_window_size`: Num of chars (before and after the answer) to return as "context" for each answer.
-The context usually helps users to understand if the answer really makes sense.
+                            The context usually helps users to understand if the answer really makes sense.
 - `use_gpu`: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
 - `top_k`: The maximum number of answers to return
 - `top_k_per_candidate`: How many answers to extract for each candidate doc that is coming from the retriever (might be a long text).
@@ -377,20 +377,20 @@ Use loaded QA model to find answers for a query in the supplied list of Document
 Returns dictionaries containing answers sorted by (desc.) probability.
 Example:
 
-```python
-|{
-|    'query': 'Who is the father of Arya Stark?',
-|    'answers':[
-|                 {'answer': 'Eddard,',
-|                 'context': " She travels with her father, Eddard, to King's Landing when he is ",
-|                 'offset_answer_start': 147,
-|                 'offset_answer_end': 154,
-|                 'probability': 0.9787139466668613,
-|                 'score': None,
-|                 'document_id': '1337'
-|                 },...
-|              ]
-|}
+ ```python
+    |{
+    |    'query': 'Who is the father of Arya Stark?',
+    |    'answers':[
+    |                 {'answer': 'Eddard,',
+    |                 'context': " She travels with her father, Eddard, to King's Landing when he is ",
+    |                 'offset_answer_start': 147,
+    |                 'offset_answer_end': 154,
+    |                 'probability': 0.9787139466668613,
+    |                 'score': None,
+    |                 'document_id': '1337'
+    |                 },...
+    |              ]
+    |}
 ```
 
 **Arguments**:

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -48,14 +48,14 @@ position in the ranking of documents the correct document is.
 
 |  Returns a dict containing the following metrics:
 
-- "recall": Proportion of questions for which correct document is among retrieved documents
-- "mrr": Mean of reciprocal rank. Rewards retrievers that give relevant documents a higher rank.
-Only considers the highest ranked relevant document.
-- "map": Mean of average precision for each question. Rewards retrievers that give relevant
-documents a higher rank. Considers all retrieved relevant documents. If ``open_domain=True``,
-average precision is normalized by the number of retrieved relevant documents per query.
-If ``open_domain=False``, average precision is normalized by the number of all relevant documents
-per query.
+    - "recall": Proportion of questions for which correct document is among retrieved documents
+    - "mrr": Mean of reciprocal rank. Rewards retrievers that give relevant documents a higher rank.
+      Only considers the highest ranked relevant document.
+    - "map": Mean of average precision for each question. Rewards retrievers that give relevant
+      documents a higher rank. Considers all retrieved relevant documents. If ``open_domain=True``,
+      average precision is normalized by the number of retrieved relevant documents per query.
+      If ``open_domain=False``, average precision is normalized by the number of all relevant documents
+      per query.
 
 **Arguments**:
 
@@ -63,11 +63,11 @@ per query.
 - `doc_index`: Index/Table in DocumentStore where documents that are used for evaluation are stored
 - `top_k`: How many documents to return per query
 - `open_domain`: If ``True``, retrieval will be evaluated by checking if the answer string to a question is
-contained in the retrieved docs (common approach in open-domain QA).
-If ``False``, retrieval uses a stricter evaluation that checks if the retrieved document ids
-are within ids explicitly stated in the labels.
+                    contained in the retrieved docs (common approach in open-domain QA).
+                    If ``False``, retrieval uses a stricter evaluation that checks if the retrieved document ids
+                    are within ids explicitly stated in the labels.
 - `return_preds`: Whether to add predictions in the returned dictionary. If True, the returned dictionary
-contains the keys "predictions" and "metrics".
+                     contains the keys "predictions" and "metrics".
 
 <a name="sparse"></a>
 # Module sparse
@@ -91,36 +91,36 @@ class ElasticsearchRetriever(BaseRetriever)
 - `document_store`: an instance of a DocumentStore to retrieve documents from.
 - `custom_query`: query string as per Elasticsearch DSL with a mandatory query placeholder(query).
 
-Optionally, ES `filter` clause can be added where the values of `terms` are placeholders
-that get substituted during runtime. The placeholder(${filter_name_1}, ${filter_name_2}..)
-names must match with the filters dict supplied in self.retrieve().
-::
+                     Optionally, ES `filter` clause can be added where the values of `terms` are placeholders
+                     that get substituted during runtime. The placeholder(${filter_name_1}, ${filter_name_2}..)
+                     names must match with the filters dict supplied in self.retrieve().
+                     ::
 
-**An example custom_query:**
-```python
-|    {
-|        "size": 10,
-|        "query": {
-|            "bool": {
-|                "should": [{"multi_match": {
-|                    "query": ${query},                 // mandatory query placeholder
-|                    "type": "most_fields",
-|                    "fields": ["text", "title"]}}],
-|                "filter": [                                 // optional custom filters
-|                    {"terms": {"year": ${years}}},
-|                    {"terms": {"quarter": ${quarters}}},
-|                    {"range": {"date": {"gte": ${date}}}}
-|                    ],
-|            }
-|        },
-|    }
-```
+                         **An example custom_query:**
+                         ```python
+                        |    {
+                        |        "size": 10,
+                        |        "query": {
+                        |            "bool": {
+                        |                "should": [{"multi_match": {
+                        |                    "query": ${query},                 // mandatory query placeholder
+                        |                    "type": "most_fields",
+                        |                    "fields": ["text", "title"]}}],
+                        |                "filter": [                                 // optional custom filters
+                        |                    {"terms": {"year": ${years}}},
+                        |                    {"terms": {"quarter": ${quarters}}},
+                        |                    {"range": {"date": {"gte": ${date}}}}
+                        |                    ],
+                        |            }
+                        |        },
+                        |    }
+                         ```
 
-**For this custom_query, a sample retrieve() could be:**
-```python
-|    self.retrieve(query="Why did the revenue increase?",
-|                  filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
-```
+                     **For this custom_query, a sample retrieve() could be:**
+                     ```python
+                    |    self.retrieve(query="Why did the revenue increase?",
+                    |                  filters={"years": ["2019"], "quarters": ["Q1", "Q2"]})
+                    ```
 - `top_k`: How many documents to return per query.
 
 <a name="sparse.ElasticsearchRetriever.retrieve"></a>
@@ -246,29 +246,29 @@ The checkpoint format matches huggingface transformers' model format
 
 **Example:**
 
-```python
-|    # remote model from FAIR
-|    DensePassageRetriever(document_store=your_doc_store,
-|                          query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
-|                          passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base")
-|    # or from local path
-|    DensePassageRetriever(document_store=your_doc_store,
-|                          query_embedding_model="model_directory/question-encoder",
-|                          passage_embedding_model="model_directory/context-encoder")
-```
+        ```python
+        |    # remote model from FAIR
+        |    DensePassageRetriever(document_store=your_doc_store,
+        |                          query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
+        |                          passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base")
+        |    # or from local path
+        |    DensePassageRetriever(document_store=your_doc_store,
+        |                          query_embedding_model="model_directory/question-encoder",
+        |                          passage_embedding_model="model_directory/context-encoder")
+        ```
 
 **Arguments**:
 
 - `document_store`: An instance of DocumentStore from which to retrieve documents.
 - `query_embedding_model`: Local path or remote name of question encoder checkpoint. The format equals the
-one used by hugging-face transformers' modelhub models
-Currently available remote names: ``"facebook/dpr-question_encoder-single-nq-base"``
+                              one used by hugging-face transformers' modelhub models
+                              Currently available remote names: ``"facebook/dpr-question_encoder-single-nq-base"``
 - `passage_embedding_model`: Local path or remote name of passage encoder checkpoint. The format equals the
-one used by hugging-face transformers' modelhub models
-Currently available remote names: ``"facebook/dpr-ctx_encoder-single-nq-base"``
+                                one used by hugging-face transformers' modelhub models
+                                Currently available remote names: ``"facebook/dpr-ctx_encoder-single-nq-base"``
 - `single_model_path`: Local path or remote name of a query and passage embedder in one single model. Those
-models are typically trained within FARM.
-Currently available remote names: TODO add FARM DPR model to HF modelhub
+                          models are typically trained within FARM.
+                          Currently available remote names: TODO add FARM DPR model to HF modelhub
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `max_seq_len_query`: Longest length of each query sequence. Maximum number of tokens for the query text. Longer ones will be cut down."
 - `max_seq_len_passage`: Longest length of each passage/context sequence. Maximum number of tokens for the passage text. Longer ones will be cut down."
@@ -276,18 +276,18 @@ Currently available remote names: TODO add FARM DPR model to HF modelhub
 - `use_gpu`: Whether to use gpu or not
 - `batch_size`: Number of questions or passages to encode at once
 - `embed_title`: Whether to concatenate title and passage to a text pair that is then used to create the embedding.
-This is the approach used in the original paper and is likely to improve performance if your
-titles contain meaningful information for retrieval (topic, entities etc.) .
-The title is expected to be present in doc.meta["name"] and can be supplied in the documents
-before writing them to the DocumentStore like this:
-{"text": "my text", "meta": {"name": "my title"}}.
+                    This is the approach used in the original paper and is likely to improve performance if your
+                    titles contain meaningful information for retrieval (topic, entities etc.) .
+                    The title is expected to be present in doc.meta["name"] and can be supplied in the documents
+                    before writing them to the DocumentStore like this:
+                    {"text": "my text", "meta": {"name": "my title"}}.
 - `use_fast_tokenizers`: Whether to use fast Rust tokenizers
 - `infer_tokenizer_classes`: Whether to infer tokenizer class from the model config / name.
-If `False`, the class always loads `DPRQuestionEncoderTokenizer` and `DPRContextEncoderTokenizer`.
+                                If `False`, the class always loads `DPRQuestionEncoderTokenizer` and `DPRContextEncoderTokenizer`. 
 - `similarity_function`: Which function to apply for calculating the similarity of query and passage embeddings during training.
-Options: `dot_product` (Default) or `cosine`
+                            Options: `dot_product` (Default) or `cosine`
 - `progress_bar`: Whether to show a tqdm progress bar or not.
-Can be helpful to disable in production deployments to keep the logs clean.
+                     Can be helpful to disable in production deployments to keep the logs clean.
 
 <a name="dense.DensePassageRetriever.retrieve"></a>
 #### retrieve
@@ -356,7 +356,7 @@ train a DensePassageRetrieval model
 - `dev_filename`: development set filename, file to be used by model in eval step of training
 - `test_filename`: test set filename, file to be used by model in test step after training
 - `max_processes`: the maximum number of processes to spawn in the multiprocessing.Pool used in DataSilo.
-It can be set to 1 to disable the use of multiprocessing or make debugging easier.
+                      It can be set to 1 to disable the use of multiprocessing or make debugging easier.
 - `dev_split`: The proportion of the train set that will sliced. Only works if dev_filename is set to None
 - `batch_size`: total number of samples in 1 batch of data
 - `embed_title`: whether to concatenate passage title with each passage. The default setting in official DPR embeds passage title with the corresponding passage
@@ -427,18 +427,18 @@ class EmbeddingRetriever(BaseRetriever)
 - `use_gpu`: Whether to use gpu or not
 - `model_format`: Name of framework that was used for saving the model. Options:
 
-- ``'farm'``
-- ``'transformers'``
-- ``'sentence_transformers'``
+                     - ``'farm'``
+                     - ``'transformers'``
+                     - ``'sentence_transformers'``
 - `pooling_strategy`: Strategy for combining the embeddings from the model (for farm / transformers models only).
-Options:
+                         Options:
 
-- ``'cls_token'`` (sentence vector)
-- ``'reduce_mean'`` (sentence vector)
-- ``'reduce_max'`` (sentence vector)
-- ``'per_token'`` (individual token vectors)
+                         - ``'cls_token'`` (sentence vector)
+                         - ``'reduce_mean'`` (sentence vector)
+                         - ``'reduce_max'`` (sentence vector)
+                         - ``'per_token'`` (individual token vectors)
 - `emb_extraction_layer`: Number of layer from which the embeddings shall be extracted (for farm / transformers models only).
-Default: -1 (very last layer).
+                             Default: -1 (very last layer).
 - `top_k`: How many documents to return per query.
 
 <a name="dense.EmbeddingRetriever.retrieve"></a>


### PR DESCRIPTION
pydoc-markdown changed handling of indentation as described here: https://github.com/NiklasRosenstein/pydoc-markdown/commit/f8ec013786698bce6ee0f88760ca210b89e0516b 
Previously, indentation was removed for all lines in docstring, including the code blocks. Now, indentation is preserved.

This PR adjusts the indentation according to the latest version of pydoc-markdown

Thanks @brandenchan for your support!