### PR TITLE
Fix passing a list as parameter value in Pipeline YAML

### DIFF
--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -259,7 +259,7 @@ class Pipeline(ABC):
             for key, value in component_params.items():
                 # Component params can reference to other components. For instance, a Retriever can reference a
                 # DocumentStore defined in the YAML. All references should be recursively resolved.
-                if value in definitions.keys():  # check if the param value is a reference to another component.
+                if isinstance(value, str) and value in definitions.keys():  # check if the param value is a reference to another component.
                     if value not in components.keys():  # check if the referenced component is already loaded.
                         cls._load_or_get_component(name=value, definitions=definitions, components=components)
                     component_params[key] = components[value]  # substitute reference (string) with the component object.


### PR DESCRIPTION
When loading a Pipeline, we check if any of the params reference another component. For instance, a Retriever instance can refer to a DocumentStore instance defined within the YAML.

This reference check throws an error in the case of a list as it tries to create a hash of it. This PR adds a validation that the parameter should be a string before checking if it references a component.

Resolves #951