### PR TITLE
Make FAISS import conditional

### DIFF
--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -2,7 +2,10 @@ import logging
 from pathlib import Path
 from typing import Union, List, Optional, Dict, Generator
 from tqdm import tqdm
-import faiss
+try:
+    import faiss
+except ImportError:
+    faiss = None
 import numpy as np
 
 from haystack import Document


### PR DESCRIPTION
The FAISS library installation does not work out-of-the-box on some architectures like ppc64le. This PR enables Haystack to work without FAISS. 