### PR TITLE
Fix update_embeddings() for FAISSDocumentStore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       run: docker run -d -p 19530:19530 -p 19121:19121 milvusdb/milvus:1.0.0-cpu-d030521-1ea92e
 
     - name: Run GraphDB
-      run: docker run -d -p 7200:7200 --name haystack_test_graphdb docker-registry.ontotext.com/graphdb-free:9.4.1-adoptopenjdk11
+      run: docker run -d -p 7200:7200 --name haystack_test_graphdb deepset/graphdb-free:9.4.1-adoptopenjdk11
 
     - name: Run Apache Tika
       run: docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -490,7 +490,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         """
         return self.get_document_count(index=index)
 
-    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+    def get_embedding_count(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> int:
         """
         Return the count of embeddings in the document store.
         """

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -304,6 +304,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         """
         if filters:
             raise Exception("filters are not supported for get_embedding_count in FAISSDocumentStore")
+        index = index or self.index
         return self.faiss_indexes[index].ntotal
 
     def train_index(

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -199,6 +199,14 @@ class FAISSDocumentStore(SQLDocumentStore):
         """
 
         index = index or self.index
+
+        if update_existing_embeddings is True:
+            if filters is None:
+                self.faiss_indexes[index].reset()
+                self.reset_vector_ids(index)
+            else:
+                raise Exception("update_existing_embeddings is not supported with filters.")
+
         if not self.faiss_indexes.get(index):
             raise ValueError("Couldn't find a FAISS index. Try to init the FAISSDocumentStore() again ...")
 
@@ -289,6 +297,14 @@ class FAISSDocumentStore(SQLDocumentStore):
                 if doc.meta and doc.meta.get("vector_id") is not None:
                     doc.embedding = self.faiss_indexes[index].reconstruct(int(doc.meta["vector_id"]))
         return documents
+
+    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+        """
+        Return the count of embeddings in the document store.
+        """
+        if filters:
+            raise Exception("filters are not supported for get_embedding_count in FAISSDocumentStore")
+        return self.faiss_indexes[index].ntotal
 
     def train_index(
         self,

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -205,7 +205,7 @@ class FAISSDocumentStore(SQLDocumentStore):
                 self.faiss_indexes[index].reset()
                 self.reset_vector_ids(index)
             else:
-                raise Exception("update_existing_embeddings is not supported with filters.")
+                raise Exception("update_existing_embeddings=True is not supported with filters.")
 
         if not self.faiss_indexes.get(index):
             raise ValueError("Couldn't find a FAISS index. Try to init the FAISSDocumentStore() again ...")

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -298,7 +298,7 @@ class FAISSDocumentStore(SQLDocumentStore):
                     doc.embedding = self.faiss_indexes[index].reconstruct(int(doc.meta["vector_id"]))
         return documents
 
-    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+    def get_embedding_count(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> int:
         """
         Return the count of embeddings in the document store.
         """

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -220,6 +220,14 @@ class InMemoryDocumentStore(BaseDocumentStore):
         documents = self.get_all_documents(index=index, filters=filters)
         return len(documents)
 
+    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+        """
+        Return the count of embeddings in the document store.
+        """
+        documents = self.get_all_documents(filters=filters, index=index)
+        embedding_count = sum(doc.embedding is not None for doc in documents)
+        return embedding_count
+
     def get_label_count(self, index: Optional[str] = None) -> int:
         """
         Return the number of labels in the document store

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -520,3 +520,13 @@ class MilvusDocumentStore(SQLDocumentStore):
             return list()
 
         return vectors
+
+    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+        """
+        Return the count of embeddings in the document store.
+        """
+        if filters:
+            raise Exception("filters are not supported for get_embedding_count in MilvusDocumentStore.")
+        index = index or self.index
+        _, embedding_count = self.milvus_server.count_entities(index)
+        return embedding_count

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -521,7 +521,7 @@ class MilvusDocumentStore(SQLDocumentStore):
 
         return vectors
 
-    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+    def get_embedding_count(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> int:
         """
         Return the count of embeddings in the document store.
         """
@@ -529,4 +529,6 @@ class MilvusDocumentStore(SQLDocumentStore):
             raise Exception("filters are not supported for get_embedding_count in MilvusDocumentStore.")
         index = index or self.index
         _, embedding_count = self.milvus_server.count_entities(index)
+        if embedding_count is None:
+            embedding_count = 0
         return embedding_count

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -347,6 +347,10 @@ def get_document_store(document_store_type, embedding_field="embedding"):
             embedding_field=embedding_field,
             index="haystack_test",
         )
+        _, collections = document_store.milvus_server.list_collections()
+        for collection in collections:
+            if collection.startswith("haystack_test"):
+                document_store.milvus_server.drop_collection(collection)
         return document_store
     else:
         raise Exception(f"No document store fixture for '{document_store_type}'")


### PR DESCRIPTION
There are three main use cases for `update_embeddings()`:

1. Creating embeddings in a new document store after writing the documents. In this case, embeddings are created for all the documents in the document store. The default parameters for update_embeddings() are sufficient for this case.

2. Incremental update after adding more documents in an existing index. In this case, update_embeddings() can be called with `update_existing_embeddings` set to False to prevent recomputation of existing embeddings. 

3. Create/Update embeddings for a subset of documents in a document store using the `filters` parameter. For `FAISSDocumentStore`, `filters` cannot be used in conjunction with the `update_existing_embeddings` set to `True`.


This PR resolves #885 where `update_embeddings()` could result in more embeddings than the number of documents and adds a new method `get_embedding_count()` for all document stores.