### PR TITLE
knowledge graph documentation

### DIFF
--- a/docs/_src/usage/usage/knowledge_graph.md
+++ b/docs/_src/usage/usage/knowledge_graph.md
@@ -1,0 +1,108 @@
+<!---
+title: "Knowledge Graph"
+metaTitle: "Knowledge Graph"
+metaDescription: ""
+slug: "/docs/knowledgegraph"
+date: "2021-04-19"
+id: "knowledgegraphmd"
+--->
+
+# Question Answering on a Knowledge Graph
+
+Haystack allows loading and querying knowledge graphs. In particular, Haystack can:
+ 
+* Load an existing knowledge graph given as a .ttl file
+* Execute SPARQL queries on a knowledge graph
+* Execute text queries on the knowledge graph by translating them to SPARQL queries with the help of a pre-trained seq2seq model
+
+Haystack's knowledge graph functionalities are still in a very early stage. Thus, don't expect our [exemplary tutorial](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial10_Knowledge_Graph.py) to work on your custom dataset out-of-the-box.
+Two classes implement the functionalities: GraphDBKnowledgeGraph and Text2SparqlRetriever.
+
+## GraphDBKnowledgeGraph
+
+GraphDBKnowledgeGraph is a triple store similar to Haystack's document stores. Currently, it is the only implementation of the BaseKnowledgeGraph class.
+GraphDBKnowledgeGraph runs on GraphDB. The licensing of GraphDB is rather complicated and it's more than unfortunate that GraphDB cannot be used right away in colab notebooks.
+On your local machine, you can start a GraphDB instance by running:
+
+```docker run -d -p 7200:7200 --name graphdb-instance-tutorial docker-registry.ontotext.com/graphdb-free:9.4.1-adoptopenjdk11```
+
+By default, GraphDBKnowledgeGraph connects to a GraphDB instance running on localhost at port 7200. 
+Similar to Haystack's ElasticsearchDocumentStore, the only additional setting needed is an index name.
+(Note that GraphDB internally calls these indices repositories.)
+
+```kg = GraphDBKnowledgeGraph(index="tutorial_10_index")```
+
+Indices can be deleted and created with ```delete_index()``` and ```create_index(config_path)```.
+```config_path``` needs to point to a .ttl file that contains configuration settings (see [GraphDB documentation](https://graphdb.ontotext.com/documentation/free/configuring-a-repository.html#configure-a-repository-programmatically) for details or use the file from our [tutorial](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial10_Knowledge_Graph.py)). It starts with something like:
+
+```
+#
+# Sesame configuration template for a GraphDB Free repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix owlim: <http://www.ontotext.com/trree/owlim#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "tutorial_10_index" ;
+    rdfs:label "tutorial 10 index" ;
+...
+```
+
+GraphDBKnowledgeGraph can load an existing knowledge graph represented in the form of a .ttl file with the method ```import_from_ttl_file(index, path)```, where path points to a ttl file starting with something like:
+
+```
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix hp: <https://deepset.ai/harry_potter/> .
+
+hp:Gryffindor hp:source_url "https://harrypotter.fandom.com/wiki/Gryffindor"^^xsd:string .
+hp:Gryffindor rdf:type hp:House_ .
+hp:Gryffindor hp:name hp:Gryffindor .
+hp:Gryffindor hp:founder hp:Godric_gryffindor .
+...
+```
+
+```get_all_triples()``` returns all loaded triples in the form of subject, predicate, and object. It is helpful to check whether the loading of a .ttl file was successful.
+
+```query(sparql_query)``` executes SPARQL queries on the knowledge graph. However, we usually do not want to use this method directly but use it through a retriever.
+
+## Text2SparqlRetriever
+Text2SparqlRetriever can execute SPARQL queries translated from text but also any other custom SPARQL queries. Currently, it is the only implementation of the BaseGraphRetriever class.
+Internally, Text2SparqlRetriever uses a pre-trained BART model to translate text questions to queries in SPARQL format.
+
+```retrieve(query)``` can be called with a text query, which is then automatically translated to a SPARQL query.
+
+```_query_kg(sparql_query)``` can be called with a SPARQL query.
+
+## Trying Question Answering on Knowledge Graphs with Custom Data
+If you want to use your custom data you would first need to have your custom knowledge graph in the format of a .ttl file.
+You can load your custom graph and execute SPARQL queries with ```_query_kg(sparql_query)```. To allow the use of abbreviations of namespaces, GraphDBKnowledgeGraph needs to know about them:
+
+```
+prefixes = """PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX hp: <https://deepset.ai/harry_potter/>
+    """
+kg.prefixes = prefixes
+```
+
+If you suspect you are having issues because of abbreviations of namespaces not mapped correctly, you can always try to execute a SPARQL query with the full namespace:
+
+```_query_kg(sparql_query="select distinct ?obj where { <https://deepset.ai/harry_potter/Hermione_granger> <https://deepset.ai/harry_potter/patronus> ?obj . }")```
+
+instead of using the abbreviated form:
+
+```_query_kg(sparql_query="select distinct ?obj where { hp:Hermione_granger hp:patronus ?obj . }")```
+
+If you would like to translate text queries to SPARQL queries for your custom data and use ```retrieve(query)```, there is significantly more effort necessary.
+We provide an exemplary pre-trained model in our [tutorial](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial10_Knowledge_Graph.py).
+One limitation is that this pre-trained model can only generate questions about resources it has seen during training.
+Otherwise, it cannot translate the name of the resource to the identifier used in the knowledge graph.
+For example, it can translate "Harry" to "hp:Harry_potter" only because we trained it to do so.
+
+Unfortunately, our pre-trained model for translating text queries does not work with your custom data.
+Instead, you need to train your own model. It needs to be trained according to the [seq2seq example for summarization with BART in transformers](https://github.com/huggingface/transformers/tree/master/examples/seq2seq).
+Haystack currently does not support the training of text2sparql models. We dont have concrete plans to extend the funtionality, but we are more than open to contributions. Don't hesitate to reach out! 

--- a/docs/_src/usage/usage/knowledge_graph.md
+++ b/docs/_src/usage/usage/knowledge_graph.md
@@ -32,7 +32,7 @@ Similar to Haystack's ElasticsearchDocumentStore, the only additional setting ne
 
 ```kg = GraphDBKnowledgeGraph(index="tutorial_10_index")```
 
-Indices can be deleted and created with ```delete_index()``` and ```create_index(config_path)```.
+Indices can be deleted and created with ```GraphDBKnowledgeGraph.delete_index()``` and ```GraphDBKnowledgeGraph.create_index(config_path)```.
 ```config_path``` needs to point to a .ttl file that contains configuration settings (see [GraphDB documentation](https://graphdb.ontotext.com/documentation/free/configuring-a-repository.html#configure-a-repository-programmatically) for details or use the file from our [tutorial](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial10_Knowledge_Graph.py)). It starts with something like:
 
 ```
@@ -51,7 +51,7 @@ Indices can be deleted and created with ```delete_index()``` and ```create_index
 ...
 ```
 
-GraphDBKnowledgeGraph can load an existing knowledge graph represented in the form of a .ttl file with the method ```import_from_ttl_file(index, path)```, where path points to a ttl file starting with something like:
+GraphDBKnowledgeGraph can load an existing knowledge graph represented in the form of a .ttl file with the method ```GraphDBKnowledgeGraph.import_from_ttl_file(index, path)```, where path points to a ttl file starting with something like:
 
 ```
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -65,21 +65,21 @@ hp:Gryffindor hp:founder hp:Godric_gryffindor .
 ...
 ```
 
-```get_all_triples()``` returns all loaded triples in the form of subject, predicate, and object. It is helpful to check whether the loading of a .ttl file was successful.
+```GraphDBKnowledgeGraph.get_all_triples()``` returns all loaded triples in the form of subject, predicate, and object. It is helpful to check whether the loading of a .ttl file was successful.
 
-```query(sparql_query)``` executes SPARQL queries on the knowledge graph. However, we usually do not want to use this method directly but use it through a retriever.
+```GraphDBKnowledgeGraph.query(sparql_query)``` executes SPARQL queries on the knowledge graph. However, we usually do not want to use this method directly but use it through a retriever.
 
 ## Text2SparqlRetriever
 Text2SparqlRetriever can execute SPARQL queries translated from text but also any other custom SPARQL queries. Currently, it is the only implementation of the BaseGraphRetriever class.
 Internally, Text2SparqlRetriever uses a pre-trained BART model to translate text questions to queries in SPARQL format.
 
-```retrieve(query)``` can be called with a text query, which is then automatically translated to a SPARQL query.
+```Text2SparqlRetriever.retrieve(query)``` can be called with a text query, which is then automatically translated to a SPARQL query.
 
-```_query_kg(sparql_query)``` can be called with a SPARQL query.
+```Text2SparqlRetriever._query_kg(sparql_query)``` can be called with a SPARQL query.
 
 ## Trying Question Answering on Knowledge Graphs with Custom Data
 If you want to use your custom data you would first need to have your custom knowledge graph in the format of a .ttl file.
-You can load your custom graph and execute SPARQL queries with ```_query_kg(sparql_query)```. To allow the use of abbreviations of namespaces, GraphDBKnowledgeGraph needs to know about them:
+You can load your custom graph and execute SPARQL queries with ```Text2SparqlRetriever._query_kg(sparql_query)```. To allow the use of abbreviations of namespaces, GraphDBKnowledgeGraph needs to know about them:
 
 ```
 prefixes = """PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -91,13 +91,13 @@ kg.prefixes = prefixes
 
 If you suspect you are having issues because of abbreviations of namespaces not mapped correctly, you can always try to execute a SPARQL query with the full namespace:
 
-```_query_kg(sparql_query="select distinct ?obj where { <https://deepset.ai/harry_potter/Hermione_granger> <https://deepset.ai/harry_potter/patronus> ?obj . }")```
+```Text2SparqlRetriever._query_kg(sparql_query="select distinct ?obj where { <https://deepset.ai/harry_potter/Hermione_granger> <https://deepset.ai/harry_potter/patronus> ?obj . }")```
 
 instead of using the abbreviated form:
 
-```_query_kg(sparql_query="select distinct ?obj where { hp:Hermione_granger hp:patronus ?obj . }")```
+```Text2SparqlRetriever._query_kg(sparql_query="select distinct ?obj where { hp:Hermione_granger hp:patronus ?obj . }")```
 
-If you would like to translate text queries to SPARQL queries for your custom data and use ```retrieve(query)```, there is significantly more effort necessary.
+If you would like to translate text queries to SPARQL queries for your custom data and use ```Text2SparqlRetriever.retrieve(query)```, there is significantly more effort necessary.
 We provide an exemplary pre-trained model in our [tutorial](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial10_Knowledge_Graph.py).
 One limitation is that this pre-trained model can only generate questions about resources it has seen during training.
 Otherwise, it cannot translate the name of the resource to the identifier used in the knowledge graph.

--- a/haystack/graph_retriever/text_to_sparql.py
+++ b/haystack/graph_retriever/text_to_sparql.py
@@ -15,6 +15,14 @@ class Text2SparqlRetriever(BaseGraphRetriever):
     """
 
     def __init__(self, knowledge_graph, model_name_or_path, top_k: int = 1):
+        """
+        Init the Retriever by providing a knowledge graph and a pre-trained BART model
+
+        :param knowledge_graph: An instance of BaseKnowledgeGraph on which to execute SPARQL queries.
+        :param model_name_or_path: Name of or path to a pre-trained BartForConditionalGeneration model.
+        :param top_k: How many SPARQL queries to generate per text query.
+        """
+        
         self.knowledge_graph = knowledge_graph
         # TODO We should extend this to any seq2seq models and use the AutoModel class
         self.model = BartForConditionalGeneration.from_pretrained(model_name_or_path, force_bos_token_to_be_generated=True)
@@ -22,6 +30,13 @@ class Text2SparqlRetriever(BaseGraphRetriever):
         self.top_k = top_k
 
     def retrieve(self, query: str, top_k: Optional[int] = None):
+        """
+        Translate a text query to SPARQL and execute it on the knowledge graph to retrieve a list of answers
+        
+        :param query: Text query that shall be translated to SPARQL and then executed on the knowledge graph
+        :param top_k: How many SPARQL queries to generate per text query.
+        """
+        
         if top_k is None:
             top_k = self.top_k
         inputs = self.tok([query], max_length=100, truncation=True, return_tensors='pt')
@@ -46,6 +61,12 @@ class Text2SparqlRetriever(BaseGraphRetriever):
         return results
 
     def _query_kg(self, sparql_query):
+        """
+        Execute a single SPARQL query on the knowledge graph to retrieve an answer and unpack different answer styles for boolean queries, count queries, and list queries
+        
+        :param sparql_query: SPARQL query that shall be executed on the knowledge graph
+        """
+        
         try:
             response = self.knowledge_graph.query(sparql_query=sparql_query)
 
@@ -73,7 +94,10 @@ class Text2SparqlRetriever(BaseGraphRetriever):
     def format_result(self, result):
         """
         Generate formatted dictionary output with text answer and additional info
+        
+        :param result: The result of a SPARQL query as retrieved from the knowledge graph
         """
+        
         query = result[1]
         prediction = result[0]
         prediction_meta = {"model": self.__class__.__name__, "sparql_query": query}

--- a/haystack/knowledge_graph/graphdb.py
+++ b/haystack/knowledge_graph/graphdb.py
@@ -22,6 +22,18 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
         index: Optional[str] = None,
         prefixes: str = ""
     ):
+        """
+        Init the knowledge graph by defining the settings to connect with a GraphDB instance
+        
+        :param host: address of server where the GraphDB instance is running
+        :param port: port where the GraphDB instance is running
+        :param username: username to login to the GraphDB instance (if any)
+        :param password: password to login to the GraphDB instance (if any)
+        :param index: name of the index (also called repository) stored in the GraphDB instance
+        :param prefixes: definitions of namespaces with a new line after each namespace, e.g., PREFIX hp: <https://deepset.ai/harry_potter/>
+        
+        """
+        
         self.url = f"http://{host}:{port}"
         self.index = index
         self.username = username
@@ -29,6 +41,12 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
         self.prefixes = prefixes
 
     def create_index(self, config_path: Path):
+        """
+        Create a new index (also called repository) stored in the GraphDB instance
+        
+        :param config_path: path to a .ttl file with configuration settings, details: https://graphdb.ontotext.com/documentation/free/configuring-a-repository.html#configure-a-repository-programmatically
+        """
+        
         url = f"{self.url}/rest/repositories"
         files = {'config': open(config_path, "r", encoding="utf-8")}
         response = requests.post(
@@ -39,12 +57,23 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
             raise Exception(response.text)
 
     def delete_index(self):
+        """
+        Delete the index that GraphDBKnowledgeGraph is connected to. This method deletes all data stored in the index.
+        """
+        
         url = f"{self.url}/rest/repositories/{self.index}"
         response = requests.delete(url)
         if response.status_code > 299:
             raise Exception(response.text)
 
     def import_from_ttl_file(self, index: str, path: Path):
+        """
+        Load an existing knowledge graph represented in the form of triples of subject, predicate, and object from a .ttl file into an index of GraphDB
+        
+        :param index: name of the index (also called repository) in the GraphDB instance where the imported triples shall be stored
+        :param path: path to a .ttl containing a knowledge graph
+        """
+        
         url = f"{self.url}/repositories/{index}/statements"
         headers = {"Content-type": "application/x-turtle"}
         response = requests.post(
@@ -57,26 +86,62 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
             raise Exception(response.text)
 
     def get_all_triples(self, index: Optional[str] = None):
+        """
+        Query the given index in the GraphDB instance for all its stored triples. Duplicates are not filtered.
+        
+        :param index: name of the index (also called repository) in the GraphDB instance
+        :return: all triples stored in the index
+        """
+        
         sparql_query = "SELECT * WHERE { ?s ?p ?o. }"
         results = self.query(sparql_query=sparql_query, index=index)
         return results
 
     def get_all_subjects(self, index: Optional[str] = None):
+        """
+        Query the given index in the GraphDB instance for all its stored subjects. Duplicates are not filtered.
+        
+        :param index: name of the index (also called repository) in the GraphDB instance
+        :return: all subjects stored in the index
+        """
+            
         sparql_query = "SELECT ?s WHERE { ?s ?p ?o. }"
         results = self.query(sparql_query=sparql_query, index=index)
         return results
 
     def get_all_predicates(self, index: Optional[str] = None):
+        """
+        Query the given index in the GraphDB instance for all its stored predicates. Duplicates are not filtered.
+        
+        :param index: name of the index (also called repository) in the GraphDB instance
+        :return: all predicates stored in the index
+        """
+        
         sparql_query = "SELECT ?p WHERE { ?s ?p ?o. }"
         results = self.query(sparql_query=sparql_query, index=index)
         return results
 
     def get_all_objects(self, index: Optional[str] = None):
+        """
+        Query the given index in the GraphDB instance for all its stored objects. Duplicates are not filtered.
+        
+        :param index: name of the index (also called repository) in the GraphDB instance
+        :return: all objects stored in the index
+        """
+        
         sparql_query = "SELECT ?o WHERE { ?s ?p ?o. }"
         results = self.query(sparql_query=sparql_query, index=index)
         return results
 
     def query(self, sparql_query: str, index: Optional[str] = None):
+        """
+        Execute a SPARQL query on the given index in the GraphDB instance
+        
+        :param sparql_query: SPARQL query that shall be executed
+        :param index: name of the index (also called repository) in the GraphDB instance
+        :return: query result
+        """
+            
         if self.index is None and index is None:
             raise Exception("Index name is required")
         index = index or self.index


### PR DESCRIPTION
While we already have a [tutorial](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial10_Knowledge_Graph.py) about question answering on knowledge graphs, there is no documentation page yet.
This PR adds such a documentation page and covers the two classes GraphDBKnowledgeGraph and Text2SparqlRetriever.

As part of this PR, I added doc strings, which also list the parameters of the methods of the two classes.