### PR TITLE
changing top_k to top_k_answers 

### DIFF
--- a/tutorials/Tutorial7_RAG_Generator.ipynb
+++ b/tutorials/Tutorial7_RAG_Generator.ipynb
@@ -194,7 +194,7 @@
     "generator = RAGenerator(\n",
     "    model_name_or_path=\"facebook/rag-token-nq\",\n",
     "    use_gpu=True,\n",
-    "    top_k=1,\n",
+    "    top_k_answers=2,\n",
     "    max_length=200,\n",
     "    min_length=2,\n",
     "    embed_title=True,\n",

--- a/tutorials/Tutorial7_RAG_Generator.py
+++ b/tutorials/Tutorial7_RAG_Generator.py
@@ -57,7 +57,7 @@ def tutorial7_rag_generator():
     generator = RAGenerator(
         model_name_or_path="facebook/rag-token-nq",
         use_gpu=True,
-        top_k=1,
+        top_k_answers=2,
         max_length=200,
         min_length=2,
         embed_title=True,


### PR DESCRIPTION
**Proposed changes**:
- Since RAGenerator has the parameter top_k_answers instead of top_k in the newer version, the old top_k param doesnt work. Thus, it should be replaced.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
