### PR TITLE
Update tests for FAISSDocumentStore

### DIFF
--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -1,5 +1,3 @@
-import os
-
 import faiss
 import numpy as np
 import pytest
@@ -24,7 +22,6 @@ def test_faiss_index_save_and_load(tmp_path):
         sql_url=f"sqlite:////{tmp_path/'haystack_test.db'}",
         index="haystack_test",
     )
-    document_store.delete_all_documents()
     document_store.write_documents(DOCUMENTS)
 
     # test saving the index
@@ -133,10 +130,9 @@ def test_update_with_empty_store(document_store, retriever):
 
 
 @pytest.mark.parametrize("index_factory", ["Flat", "HNSW", "IVF1,Flat"])
-def test_faiss_retrieving(index_factory):
+def test_faiss_retrieving(index_factory, tmp_path):
     document_store = FAISSDocumentStore(
-        sql_url="sqlite:///test_faiss_retrieving.db",
-        faiss_index_factory_str=index_factory
+        sql_url=f"sqlite:////{tmp_path/'test_faiss_retrieving.db'}", faiss_index_factory_str=index_factory
     )
 
     document_store.delete_all_documents(index="document")
@@ -156,8 +152,6 @@ def test_faiss_retrieving(index_factory):
 
     # Cleanup
     document_store.faiss_indexes[document_store.index].reset()
-    if os.path.exists("test_faiss_retrieving.db"):
-        os.remove("test_faiss_retrieving.db")
 
 
 @pytest.mark.parametrize("retriever", ["embedding"], indirect=True)
@@ -187,7 +181,7 @@ def test_pipeline(document_store, retriever):
     assert len(output["documents"]) == 3
 
 
-def test_faiss_passing_index_from_outside():
+def test_faiss_passing_index_from_outside(tmp_path):
     d = 768
     nlist = 2
     quantizer = faiss.IndexFlatIP(d)
@@ -195,7 +189,9 @@ def test_faiss_passing_index_from_outside():
     faiss_index = faiss.IndexIVFFlat(quantizer, d, nlist, faiss.METRIC_INNER_PRODUCT)
     faiss_index.set_direct_map_type(faiss.DirectMap.Hashtable)
     faiss_index.nprobe = 2
-    document_store = FAISSDocumentStore(sql_url="sqlite:///haystack_test_faiss.db", faiss_index=faiss_index, index=index)
+    document_store = FAISSDocumentStore(
+        sql_url=f"sqlite:////{tmp_path/'haystack_test_faiss.db'}", faiss_index=faiss_index, index=index
+    )
 
     document_store.delete_all_documents()
     # as it is a IVF index we need to train it before adding docs


### PR DESCRIPTION
This PR adds a test case to verify if the documents are loaded correctly from a saved FAISS Document Store and introduces the [tmp_path](https://docs.pytest.org/en/stable/tmpdir.html) fixture. 