### PR TITLE
change file-upload response to sidebar

### DIFF
--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -52,10 +52,10 @@ data_file = st.sidebar.file_uploader("", type=["pdf", "txt", "docx"])
 # Upload file
 if data_file:
     raw_json = upload_doc(data_file)
-    st.write(raw_json)
+    st.sidebar.write(raw_json)
     if debug:
         st.subheader("REST API JSON response")
-        st.write(raw_json)
+        st.sidebar.write(raw_json)
 
 # load csv into pandas dataframe
 if eval_mode:


### PR DESCRIPTION
**Proposed changes**:
Earlier when we upload the file the response was shown in the query body which is inappropriate
I think it should be displayed in the sidebar like the below image
![image](https://user-images.githubusercontent.com/26653468/116805712-d89a0e00-ab45-11eb-9edf-83b523d69383.png)

Earlier it was coming after Haystack Demo Title

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation

**Review**
@oryx1729 @tholor 