### PR TITLE
Add white space normalization warning

### DIFF
--- a/haystack/preprocessor/preprocessor.py
+++ b/haystack/preprocessor/preprocessor.py
@@ -164,6 +164,14 @@ class PreProcessor(BasePreProcessor):
 
         text = document["text"]
 
+        if split_by == "word":
+            # Check if splitting by word causes cleaning of multiple whitespaces as a side effect
+            if len(document["text"]) != len(" ".join(document["text"].split())):
+                logger.warning(f"During PreProcessor.split(), white space normalization has occurred. This can cause "
+                               f"issues during evaluation if an answer span contains multiple whitespaces. "
+                               f"This problem may be solved by initializing the PreProcessor with split_by=\'passage\'"
+                               f"(Problematic doc_id: {document['id']}, beginning of doc: {document['text'][:100]})")
+
         if split_respect_sentence_boundary and split_by == "word":
             # split by words ensuring no sub sentence splits
             sentences = nltk.tokenize.sent_tokenize(text)

--- a/haystack/preprocessor/preprocessor.py
+++ b/haystack/preprocessor/preprocessor.py
@@ -170,7 +170,7 @@ class PreProcessor(BasePreProcessor):
                 logger.warning(f"During PreProcessor.split(), white space normalization has occurred. This can cause "
                                f"issues during evaluation if an answer span contains multiple whitespaces. "
                                f"This problem may be solved by initializing the PreProcessor with split_by=\'passage\'"
-                               f"(Problematic doc_id: {document['id']}, beginning of doc: {document['text'][:100]})")
+                               f"(Problematic doc_id: {document.get('id', None)}, beginning of doc: {document['text'][:100]})")
 
         if split_respect_sentence_boundary and split_by == "word":
             # split by words ensuring no sub sentence splits


### PR DESCRIPTION
Logs a warning message if `PreProcessor.split()` causes whitespace normalization as a side effect. The need for this was raised by #983 