### PR TITLE
Fix evaluation mode in UI

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,2 @@
-streamlit==0.72.0
+streamlit==0.81.0
 st-annotated-text==1.0.1


### PR DESCRIPTION
Resolves #1017

The `help` argument for `button()` is not available in streamlit v0.72.0. This PR upgrades it to the latest version.