### PR TITLE
Fix Elasticsearch connection for non-admin users

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -180,11 +180,17 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                                         scheme=scheme, ca_certs=ca_certs, verify_certs=verify_certs,
                                         timeout=timeout)
 
-            # Test connection
+        # Test connection
         try:
-            status = client.ping()
-            if not status:
-                raise ConnectionError(f"Initial connection to Elasticsearch failed. Make sure you run an Elasticsearch instance at `{hosts}` and that it has finished the initial ramp up (can take > 30s).")
+            # ping uses a HEAD request on the root URI. In some cases, the user might not have permissions for that,
+            # resulting in a HTTP Forbidden 403 response.
+            if username in ["", "elastic"]:
+                status = client.ping()
+                if not status:
+                    raise ConnectionError(
+                        f"Initial connection to Elasticsearch failed. Make sure you run an Elasticsearch instance "
+                        f"at `{hosts}` and that it has finished the initial ramp up (can take > 30s)."
+                    )
         except Exception:
             raise ConnectionError(
                 f"Initial connection to Elasticsearch failed. Make sure you run an Elasticsearch instance at `{hosts}` and that it has finished the initial ramp up (can take > 30s).")


### PR DESCRIPTION
`ElasticsearchDocumentStore` uses `ping()` to test the connection. This triggers an HTTP HEAD request to the Elasticsearch root URI. In case the user does not have sufficient privileges, it raises a Forbidden 403 response.

This PR adjusts the `ping()` to trigger only for the default Elasticsearch user as it might be helpful in debugging for new users. 