### PR TITLE
Prevent merge of same questions on different documents during evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+          key: ${{ env.pythonLocation }}-${{ env.GITHUB_ENV }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install dependencies
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
@@ -69,12 +69,12 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+        key: ${{ env.pythonLocation }}-${{ env.GITHUB_ENV }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 
     - name: Run Milvus
-      run: docker run -d -p 19530:19530 -p 19121:19121 milvusdb/milvus:1.0.0-cpu-d030521-1ea92e
+      run: docker run -d -p 19530:19530 -p 19121:19121 milvusdb/milvus:1.1.0-cpu-d050721-5e559c
 
     - name: Run GraphDB
       run: docker run -d -p 7200:7200 --name haystack_test_graphdb deepset/graphdb-free:9.4.1-adoptopenjdk11

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -399,6 +399,24 @@ Delete documents in an index. All documents are deleted if no filters are passed
 
 None
 
+<a name="elasticsearch.ElasticsearchDocumentStore.delete_documents"></a>
+#### delete\_documents
+
+```python
+ | delete_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
+```
+
+Delete documents in an index. All documents are deleted if no filters are passed.
+
+**Arguments**:
+
+- `index`: Index name to delete the document from.
+- `filters`: Optional filters to narrow down the documents to be deleted.
+
+**Returns**:
+
+None
+
 <a name="elasticsearch.OpenDistroElasticsearchDocumentStore"></a>
 ## OpenDistroElasticsearchDocumentStore Objects
 
@@ -614,6 +632,24 @@ Delete documents in an index. All documents are deleted if no filters are passed
 
 None
 
+<a name="memory.InMemoryDocumentStore.delete_documents"></a>
+#### delete\_documents
+
+```python
+ | delete_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
+```
+
+Delete documents in an index. All documents are deleted if no filters are passed.
+
+**Arguments**:
+
+- `index`: Index name to delete the document from.
+- `filters`: Optional filters to narrow down the documents to be deleted.
+
+**Returns**:
+
+None
+
 <a name="sql"></a>
 # Module sql
 
@@ -803,6 +839,24 @@ Delete documents in an index. All documents are deleted if no filters are passed
 
 None
 
+<a name="sql.SQLDocumentStore.delete_documents"></a>
+#### delete\_documents
+
+```python
+ | delete_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
+```
+
+Delete documents in an index. All documents are deleted if no filters are passed.
+
+**Arguments**:
+
+- `index`: Index name to delete the document from.
+- `filters`: Optional filters to narrow down the documents to be deleted.
+
+**Returns**:
+
+None
+
 <a name="faiss"></a>
 # Module faiss
 
@@ -963,6 +1017,15 @@ None
 
 ```python
  | delete_all_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
+```
+
+Delete all documents from the document store.
+
+<a name="faiss.FAISSDocumentStore.delete_documents"></a>
+#### delete\_documents
+
+```python
+ | delete_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
 ```
 
 Delete all documents from the document store.
@@ -1177,6 +1240,25 @@ Find the document that is most similar to the provided `query_emb` by using a ve
 
 ```python
  | delete_all_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
+```
+
+Delete all documents (from SQL AND Milvus).
+
+**Arguments**:
+
+- `index`: (SQL) index name for storing the docs and metadata
+- `filters`: Optional filters to narrow down the search space.
+                Example: {"name": ["some", "more"], "category": ["only_one"]}
+
+**Returns**:
+
+None
+
+<a name="milvus.MilvusDocumentStore.delete_documents"></a>
+#### delete\_documents
+
+```python
+ | delete_documents(index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None)
 ```
 
 Delete all documents (from SQL AND Milvus).

--- a/docs/_src/api/api/file_converter.md
+++ b/docs/_src/api/api/file_converter.md
@@ -87,26 +87,6 @@ Route files in an Indexing Pipeline to corresponding file converters.
 class TextConverter(BaseConverter)
 ```
 
-<a name="txt.TextConverter.__init__"></a>
-#### \_\_init\_\_
-
-```python
- | __init__(remove_numeric_tables: bool = False, valid_languages: Optional[List[str]] = None)
-```
-
-**Arguments**:
-
-- `remove_numeric_tables`: This option uses heuristics to remove numeric rows from the tables.
-                              The tabular structures in documents might be noise for the reader model if it
-                              does not have table parsing capability for finding answers. However, tables
-                              may also have long strings that could possible candidate for searching answers.
-                              The rows containing strings are thus retained in this option.
-- `valid_languages`: validate languages from a list of languages specified in the ISO 639-1
-                        (https://en.wikipedia.org/wiki/ISO_639-1) format.
-                        This option can be used to add test for encoding errors. If the extracted text is
-                        not one of the valid languages, then it might likely be encoding error resulting
-                        in garbled text.
-
 <a name="txt.TextConverter.convert"></a>
 #### convert
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -91,7 +91,7 @@ be passed.
 Here's a sample configuration:
 
     ```yaml
-    |   version: '0.7'
+    |   version: '0.8'
     |
     |    components:    # define all the building-blocks for Pipeline
     |    - name: MyReader       # custom-name for the component; helpful for visualization & debugging
@@ -126,6 +126,20 @@ Here's a sample configuration:
                                      to change index name param for an ElasticsearchDocumentStore, an env
                                      variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
                                      `_` sign must be used to specify nested hierarchical properties.
+
+<a name="pipeline.Pipeline.save_to_yaml"></a>
+#### save\_to\_yaml
+
+```python
+ | save_to_yaml(path: Path, return_defaults: bool = False)
+```
+
+Save a YAML configuration for the Pipeline that can be used with `Pipeline.load_from_yaml()`.
+
+**Arguments**:
+
+- `path`: path of the output YAML file.
+- `return_defaults`: whether to output parameters that have the default values.
 
 <a name="pipeline.BaseStandardPipeline"></a>
 ## BaseStandardPipeline Objects

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -39,7 +39,7 @@ While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interf
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: Union[str, Path], model_version: Optional[str] = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k: int = 10, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128, progress_bar: bool = True)
+ | __init__(model_name_or_path: Union[str, Path], model_version: Optional[str] = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k: int = 10, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128, progress_bar: bool = True, duplicate_filtering: int = 0)
 ```
 
 **Arguments**:
@@ -78,6 +78,8 @@ and that FARM includes no_answer in the sorted list of predictions.
 - `doc_stride`: Length of striding window for splitting long texts (used if ``len(text) > max_seq_len``)
 - `progress_bar`: Whether to show a tqdm progress bar or not.
                      Can be helpful to disable in production deployments to keep the logs clean.
+- `duplicate_filtering`: Answers are filtered based on their position. Both start and end position of the answers are considered.
+                            The higher the value, answers that are more apart are filtered out. 0 corresponds to exact duplicates. -1 turns off duplicate removal.
 
 <a name="farm.FARMReader.train"></a>
 #### train

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -344,7 +344,7 @@ Embeddings of documents / passages shape (batch_size, embedding_dim)
 #### train
 
 ```python
- | train(data_dir: str, train_filename: str, dev_filename: str = None, test_filename: str = None, max_sample: int = None, max_processes: int = 128, dev_split: float = 0, batch_size: int = 2, embed_title: bool = True, num_hard_negatives: int = 1, num_positives: int = 1, n_epochs: int = 3, evaluate_every: int = 1000, n_gpu: int = 1, learning_rate: float = 1e-5, epsilon: float = 1e-08, weight_decay: float = 0.0, num_warmup_steps: int = 100, grad_acc_steps: int = 1, optimizer_name: str = "TransformersAdamW", optimizer_correct_bias: bool = True, save_dir: str = "../saved_models/dpr", query_encoder_save_dir: str = "query_encoder", passage_encoder_save_dir: str = "passage_encoder")
+ | train(data_dir: str, train_filename: str, dev_filename: str = None, test_filename: str = None, max_sample: int = None, max_processes: int = 128, dev_split: float = 0, batch_size: int = 2, embed_title: bool = True, num_hard_negatives: int = 1, num_positives: int = 1, n_epochs: int = 3, evaluate_every: int = 1000, n_gpu: int = 1, learning_rate: float = 1e-5, epsilon: float = 1e-08, weight_decay: float = 0.0, num_warmup_steps: int = 100, grad_acc_steps: int = 1, use_amp: str = None, optimizer_name: str = "TransformersAdamW", optimizer_correct_bias: bool = True, save_dir: str = "../saved_models/dpr", query_encoder_save_dir: str = "query_encoder", passage_encoder_save_dir: str = "passage_encoder")
 ```
 
 train a DensePassageRetrieval model
@@ -370,6 +370,12 @@ train a DensePassageRetrieval model
 - `epsilon`: epsilon parameter of optimizer
 - `weight_decay`: weight decay parameter of optimizer
 - `grad_acc_steps`: number of steps to accumulate gradient over before back-propagation is done
+- `use_amp`: Whether to use automatic mixed precision (AMP) or not. The options are:
+            "O0" (FP32)
+            "O1" (Mixed Precision)
+            "O2" (Almost FP16)
+            "O3" (Pure FP16).
+            For more information, refer to: https://nvidia.github.io/apex/amp.html
 - `optimizer_name`: what optimizer to use (default: TransformersAdamW)
 - `num_warmup_steps`: number of warmup steps
 - `optimizer_correct_bias`: Whether to correct bias in optimizer

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -5,7 +5,7 @@
 ## BaseTranslator Objects
 
 ```python
-class BaseTranslator(ABC)
+class BaseTranslator(BaseComponent)
 ```
 
 Abstract class for a Translator component that translates either a query or a doc from language A to language B.

--- a/docs/_src/usage/usage/preprocessing.md
+++ b/docs/_src/usage/usage/preprocessing.md
@@ -131,7 +131,7 @@ processor = PreProcessor(
     split_respect_sentence_boundary=True,
     split_overlap=0
 )
-docs = processor.process(d)
+docs = processor.process(doc)
 ```
 
 * `clean_empty_lines` will normalize 3 or more consecutive empty lines to be just a two empty lines

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -78,15 +78,15 @@ class BaseDocumentStore(BaseComponent):
         # Collect all answers to a question in a dict
         question_ans_dict: dict = {}
         for l in all_labels:
-            key_tuple = (l.id, l.question)
+            id_question_tuple = (l.id, l.question)
             # only aggregate labels with correct answers, as only those can be currently used in evaluation
             if not l.is_correct_answer:
                 continue
 
-            if key_tuple in question_ans_dict:
-                question_ans_dict[key_tuple].append(l)
+            if id_question_tuple in question_ans_dict:
+                question_ans_dict[id_question_tuple].append(l)
             else:
-                question_ans_dict[key_tuple] = [l]
+                question_ans_dict[id_question_tuple] = [l]
 
         # Aggregate labels
         for q, ls in question_ans_dict.items():

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -83,19 +83,19 @@ class BaseDocumentStore(BaseComponent):
             # This group_by_id determines the key by which we aggregate labels. Its contents depend on
             # whether we are in an open / closed domain setting,
             # or if there are fields in the meta data that we should group by (set using group_by_meta)
-            group_by_id = None
+            group_by_id_list: list = []
             if open_domain:
-                group_by_id = [l.question]
+                group_by_id_list = [l.question]
             else:
-                group_by_id = [l.document_id, l.question]
+                group_by_id_list = [l.document_id, l.question]
             if aggregate_by_meta:
                 if type(aggregate_by_meta) == str:
                     aggregate_by_meta = [aggregate_by_meta]
                 for meta_key in aggregate_by_meta:
                     curr_meta = l.meta.get(meta_key, None)
                     if curr_meta:
-                        group_by_id.append(curr_meta)
-            group_by_id = tuple(group_by_id)
+                        group_by_id_list.append(curr_meta)
+            group_by_id = tuple(group_by_id_list)
 
             # only aggregate labels with correct answers, as only those can be currently used in evaluation
             if not l.is_correct_answer:

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -71,22 +71,40 @@ class BaseDocumentStore(BaseComponent):
 
     def get_all_labels_aggregated(self,
                                   index: Optional[str] = None,
-                                  filters: Optional[Dict[str, List[str]]] = None) -> List[MultiLabel]:
+                                  filters: Optional[Dict[str, List[str]]] = None,
+                                  open_domain=False,
+                                  group_by_meta=None) -> List[MultiLabel]:
         aggregated_labels = []
         all_labels = self.get_all_labels(index=index, filters=filters)
 
         # Collect all answers to a question in a dict
         question_ans_dict: dict = {}
         for l in all_labels:
-            id_question_tuple = (l.id, l.question)
+            # This group_by_id determines the key by which we aggregate labels. Its contents depend on
+            # whether we are in an open / closed domain setting,
+            # or if there are fields in the meta data that we should group by (set using group_by_meta)
+            group_by_id = None
+            if open_domain:
+                group_by_id = [l.question]
+            else:
+                group_by_id = [l.document_id, l.question]
+            if group_by_meta:
+                if type(group_by_meta) == str:
+                    group_by_meta = [group_by_meta]
+                for meta_key in group_by_meta:
+                    curr_meta = l.meta.get(meta_key, None)
+                    if curr_meta:
+                        group_by_id.append(curr_meta)
+            group_by_id = tuple(group_by_id)
+
             # only aggregate labels with correct answers, as only those can be currently used in evaluation
             if not l.is_correct_answer:
                 continue
 
-            if id_question_tuple in question_ans_dict:
-                question_ans_dict[id_question_tuple].append(l)
+            if group_by_id in question_ans_dict:
+                question_ans_dict[group_by_id].append(l)
             else:
-                question_ans_dict[id_question_tuple] = [l]
+                question_ans_dict[group_by_id] = [l]
 
         # Aggregate labels
         for q, ls in question_ans_dict.items():

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -152,7 +152,10 @@ class BaseDocumentStore(BaseComponent):
             for i, l in enumerate(ls):
                 if i == 0:
                     # Keep only the label metadata that we are aggregating by
-                    meta_new = {k: v for k, v in l.meta.items() if k in aggregate_by_meta}
+                    if aggregate_by_meta:
+                        meta_new = {k: v for k, v in l.meta.items() if k in aggregate_by_meta}
+                    else:
+                        meta_new = {}
 
                     agg_label = MultiLabel(question=l.question,
                                            multiple_answers=[l.answer],

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -78,14 +78,15 @@ class BaseDocumentStore(BaseComponent):
         # Collect all answers to a question in a dict
         question_ans_dict: dict = {}
         for l in all_labels:
+            key_tuple = (l.id, l.question)
             # only aggregate labels with correct answers, as only those can be currently used in evaluation
             if not l.is_correct_answer:
                 continue
 
-            if l.question in question_ans_dict:
-                question_ans_dict[l.question].append(l)
+            if key_tuple in question_ans_dict:
+                question_ans_dict[key_tuple].append(l)
             else:
-                question_ans_dict[l.question] = [l]
+                question_ans_dict[key_tuple] = [l]
 
         # Aggregate labels
         for q, ls in question_ans_dict.items():

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -72,8 +72,30 @@ class BaseDocumentStore(BaseComponent):
     def get_all_labels_aggregated(self,
                                   index: Optional[str] = None,
                                   filters: Optional[Dict[str, List[str]]] = None,
-                                  open_domain=False,
-                                  aggregate_by_meta=None) -> List[MultiLabel]:
+                                  open_domain: bool=False,
+                                  aggregate_by_meta: Optional[Union[str, list]]=None) -> List[MultiLabel]:
+        """
+        Return all labels in the DocumentStore, aggregated into MultiLabel objects.
+        How they are aggregated is defined by the open_domain and aggregate_by_meta parameters.
+        If the questions are being asked to a single document (i.e. SQuAD style), you should set open_domain=False.
+        If the questions are being asked to your full collection of documents, you should set open_domain=True.
+        If the questions are being asked to a subslice of your document set (e.g. product review use cases),
+        you should set open_domain=True and populate aggregate_by_meta with the names of Label meta fields.
+        For example, in a product review use case, you might set aggregate_by_meta=["product_id"] so that Labels
+        with the same question but different answers from different documents are aggregated into the one MultiLabel
+        object, provided that they have the same product_id (to be found in Label.meta["product_id"])
+
+        :param index: Name of the index to get the labels from. If None, the
+                      DocumentStore's default index (self.index) will be used.
+        :param filters: Optional filters to narrow down the labels to return.
+                        Example: {"name": ["some", "more"], "category": ["only_one"]}
+        :param open_domain: When True, labels are aggregated purely based on the question text alone.
+                            When False, labels are aggregated in a closed domain fashion based on the question text
+                            and also the id of the document that the label is tied to. In this setting, this function
+                            might return multiple MultiLabel objects with the same question string.
+        :param aggregate_by_meta: The names of the Label meta fields by which to aggregate.
+
+        """
         aggregated_labels = []
         all_labels = self.get_all_labels(index=index, filters=filters)
 

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy.special import expit
 from tqdm.auto import tqdm
 
-from haystack.document_store.base import BaseDocumentStore
+from haystack.document_store.base import BaseDocumentStore, DuplicateDocumentError
 from haystack import Document, Label
 from haystack.utils import get_batches_from_generator
 
@@ -43,11 +43,11 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         ca_certs: Optional[str] = None,
         verify_certs: bool = True,
         create_index: bool = True,
-        update_existing_documents: bool = False,
         refresh_type: str = "wait_for",
         similarity="dot_product",
         timeout=30,
         return_embedding: bool = False,
+        duplicate_documents: str = 'overwrite',
     ):
         """
         A DocumentStore using Elasticsearch to store and query the documents for our search.
@@ -80,11 +80,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         :param scheme: 'https' or 'http', protocol used to connect to your elasticsearch instance
         :param ca_certs: Root certificates for SSL: it is a path to certificate authority (CA) certs on disk. You can use certifi package with certifi.where() to find where the CA certs file is located in your machine.
         :param verify_certs: Whether to be strict about ca certificates
-        :param create_index: Whether to try creating a new index (If the index of that name is already existing, we will just continue in any case)
-        :param update_existing_documents: Whether to update any existing documents with the same ID when adding
-                                          documents. When set as True, any document with an existing ID gets updated.
-                                          If set to False, an error is raised if the document ID of the document being
-                                          added already exists.
+        :param create_index: Whether to try creating a new index (If the index of that name is already existing, we will just continue in any case
         :param refresh_type: Type of ES refresh used to control when changes made by a request (e.g. bulk) are made visible to search.
                              If set to 'wait_for', continue only after changes are visible (slow, but safe).
                              If set to 'false', continue directly (fast, but sometimes unintuitive behaviour when docs are not immediately available after ingestion).
@@ -93,6 +89,12 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                            more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
         :param timeout: Number of seconds after which an ElasticSearch request times out.
         :param return_embedding: To return document embedding
+        :param duplicate_documents: Handle duplicates document based on parameter options.
+                                    Parameter options : ( 'skip','overwrite','fail')
+                                    skip: Ignore the duplicates documents
+                                    overwrite: Update any existing documents with the same ID when adding documents.
+                                    fail: an error is raised if the document ID of the document being added already
+                                    exists.
 
         """
         # save init parameters to enable export of component config as YAML
@@ -102,7 +104,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             name_field=name_field, embedding_field=embedding_field, embedding_dim=embedding_dim,
             custom_mapping=custom_mapping, excluded_meta_data=excluded_meta_data, analyzer=analyzer, scheme=scheme,
             ca_certs=ca_certs, verify_certs=verify_certs, create_index=create_index,
-            update_existing_documents=update_existing_documents, refresh_type=refresh_type, similarity=similarity,
+            duplicate_documents=duplicate_documents, refresh_type=refresh_type, similarity=similarity,
             timeout=timeout, return_embedding=return_embedding,
         )
 
@@ -137,7 +139,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             self._create_document_index(index)
             self._create_label_index(label_index)
 
-        self.update_existing_documents = update_existing_documents
+        self.duplicate_documents = duplicate_documents
         self.refresh_type = refresh_type
 
     def _init_elastic_client(self,
@@ -303,7 +305,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         else:
             return None
 
-    def get_documents_by_id(self, ids: List[str], index: Optional[str] = None) -> List[Document]:
+    def get_documents_by_id(self, ids: List[str], index: Optional[str] = None) -> List[Document]:  # type: ignore
         """Fetch documents by specifying a list of text id strings"""
         index = index or self.index
         query = {"query": {"ids": {"values": ids}}}
@@ -349,9 +351,8 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             bucket["value"] = bucket.pop("key")
         return buckets
 
-    def write_documents(
-        self, documents: Union[List[dict], List[Document]], index: Optional[str] = None,  batch_size: int = 10_000
-    ):
+    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None,
+                        batch_size: int = 10_000,duplicate_documents: Optional[str] = None):
         """
         Indexes documents for later queries in Elasticsearch.
 
@@ -371,6 +372,13 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                           should be changed to what you have set for self.text_field and self.name_field.
         :param index: Elasticsearch index where the documents should be indexed. If not supplied, self.index will be used.
         :param batch_size: Number of documents that are passed to Elasticsearch's bulk function at a time.
+        :param duplicate_documents: Handle duplicates document based on parameter options.
+                                    Parameter options : ( 'skip','overwrite','fail')
+                                    skip: Ignore the duplicates documents
+                                    overwrite: Update any existing documents with the same ID when adding documents.
+                                    fail: an error is raised if the document ID of the document being added already
+                                    exists.
+        :raises DuplicateDocumentError: Exception trigger on duplicate document
         :return: None
         """
 
@@ -379,17 +387,17 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
         if index is None:
             index = self.index
+        duplicate_documents = duplicate_documents or self.duplicate_documents
+        assert duplicate_documents in self.duplicate_documents_options, \
+            f"duplicate_documents parameter must be {', '.join(self.duplicate_documents_options)}"
 
+        field_map = self._create_document_field_map()
+        document_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
+        document_objects = self._handle_duplicate_documents(document_objects, duplicate_documents)
         documents_to_index = []
-        for document in documents:
-            # Make sure we comply to Document class format
-            if isinstance(document, dict):
-                doc = Document.from_dict(document, field_map=self._create_document_field_map())
-            else:
-                doc = document
-
+        for doc in document_objects:
             _doc = {
-                "_op_type": "index" if self.update_existing_documents else "create",
+                "_op_type": "index" if duplicate_documents == 'overwrite' else "create",
                 "_index": index,
                 **doc.to_dict(field_map=self._create_document_field_map())
             }  # type: Dict[str, Any]
@@ -450,7 +458,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                 label.updated_at = label.created_at
 
             _label = {
-                "_op_type": "index" if self.update_existing_documents else "create",
+                "_op_type": "index" if self.duplicate_documents == "overwrite" else "create",
                 "_index": index,
                 **label.to_dict()
             }  # type: Dict[str, Any]

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -235,7 +235,8 @@ class FAISSDocumentStore(SQLDocumentStore):
             only_documents_without_embedding=not update_existing_embeddings
         )
         batched_documents = get_batches_from_generator(result, batch_size)
-        with tqdm(total=document_count, disable=not self.progress_bar) as progress_bar:
+        with tqdm(total=document_count, disable=not self.progress_bar, position=0, unit=" docs",
+                  desc="Updating Embedding") as progress_bar:
             for document_batch in batched_documents:
                 embeddings = retriever.embed_passages(document_batch)  # type: ignore
                 assert len(document_batch) == len(embeddings)
@@ -248,8 +249,8 @@ class FAISSDocumentStore(SQLDocumentStore):
                     vector_id_map[doc.id] = vector_id
                     vector_id += 1
                 self.update_vector_ids(vector_id_map, index=index)
+                progress_bar.set_description_str("Documents Processed")
                 progress_bar.update(batch_size)
-        progress_bar.close()
 
     def get_all_documents(
         self,

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -81,6 +81,9 @@ class InMemoryDocumentStore(BaseDocumentStore):
         documents_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
 
         for document in documents_objects:
+            if document.id in self.indexes[index]:
+                # TODO Make error type consistent across document stores and add user options to deal with duplicate documents (ignore, overwrite, fail)
+                raise ValueError(f"Duplicate Documents: write_documents() failed - Document with id '{document.id} already exists in index '{index}'")
             self.indexes[index][document.id] = document
 
     def _create_document_field_map(self):

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -10,7 +10,7 @@ from scipy.spatial.distance import cosine
 from tqdm import tqdm
 
 from haystack import Document, Label
-from haystack.document_store.base import BaseDocumentStore
+from haystack.document_store.base import BaseDocumentStore, DuplicateDocumentError
 from haystack.retriever.base import BaseRetriever
 from haystack.utils import get_batches_from_generator
 
@@ -31,6 +31,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         return_embedding: bool = False,
         similarity: str = "dot_product",
         progress_bar: bool = True,
+        duplicate_documents: str = 'overwrite',
     ):
         """
         :param index: The documents are scoped to an index attribute that can be used when writing, querying,
@@ -43,12 +44,19 @@ class InMemoryDocumentStore(BaseDocumentStore):
                    more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
         :param progress_bar: Whether to show a tqdm progress bar or not.
                              Can be helpful to disable in production deployments to keep the logs clean.
+        :param duplicate_documents: Handle duplicates document based on parameter options.
+                                    Parameter options : ( 'skip','overwrite','fail')
+                                    skip: Ignore the duplicates documents
+                                    overwrite: Update any existing documents with the same ID when adding documents.
+                                    fail: an error is raised if the document ID of the document being added already
+                                    exists.
         """
 
         # save init parameters to enable export of component config as YAML
         self.set_config(
-            index=index, label_index=label_index, embedding_field=embedding_field, embedding_dim=embedding_dim,
-            return_embedding=return_embedding, similarity=similarity, progress_bar=progress_bar,
+                index=index, label_index=label_index, embedding_field=embedding_field, embedding_dim=embedding_dim,
+                return_embedding=return_embedding, similarity=similarity, progress_bar=progress_bar,
+                duplicate_documents=duplicate_documents,
         )
 
         self.indexes: Dict[str, Dict] = defaultdict(dict)
@@ -59,8 +67,10 @@ class InMemoryDocumentStore(BaseDocumentStore):
         self.return_embedding = return_embedding
         self.similarity = similarity
         self.progress_bar = progress_bar
+        self.duplicate_documents = duplicate_documents
 
-    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None):
+    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None,  # type: ignore
+                        duplicate_documents: Optional[str] = None):
         """
         Indexes documents for later queries.
 
@@ -72,18 +82,34 @@ class InMemoryDocumentStore(BaseDocumentStore):
                           It can be used for filtering and is accessible in the responses of the Finder.
         :param index: write documents to a custom namespace. For instance, documents for evaluation can be indexed in a
                       separate index than the documents for search.
+        :param duplicate_documents: Handle duplicates document based on parameter options.
+                                    Parameter options : ( 'skip','overwrite','fail')
+                                    skip: Ignore the duplicates documents
+                                    overwrite: Update any existing documents with the same ID when adding documents.
+                                    fail: an error is raised if the document ID of the document being added already
+                                    exists.
+        :raises DuplicateDocumentError: Exception trigger on duplicate document
         :return: None
         """
         index = index or self.index
+        duplicate_documents = duplicate_documents or self.duplicate_documents
+        assert duplicate_documents in self.duplicate_documents_options, \
+            f"duplicate_documents parameter must be {', '.join(self.duplicate_documents_options)}"
 
         field_map = self._create_document_field_map()
         documents = deepcopy(documents)
-        documents_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
+        documents_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in
+                             documents]
 
         for document in documents_objects:
             if document.id in self.indexes[index]:
-                # TODO Make error type consistent across document stores and add user options to deal with duplicate documents (ignore, overwrite, fail)
-                raise ValueError(f"Duplicate Documents: write_documents() failed - Document with id '{document.id} already exists in index '{index}'")
+                if duplicate_documents == "fail":
+                    raise DuplicateDocumentError(f"Document with id '{document.id} already "
+                                                 f"exists in index '{index}'")
+                elif duplicate_documents == "skip":
+                    logger.warning(f"Duplicate Documents: Document with id '{document.id} already exists in index "
+                                   f"'{index}'")
+                    continue
             self.indexes[index][document.id] = document
 
     def _create_document_field_map(self):
@@ -114,7 +140,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         else:
             return None
 
-    def get_documents_by_id(self, ids: List[str], index: Optional[str] = None) -> List[Document]:
+    def get_documents_by_id(self, ids: List[str], index: Optional[str] = None) -> List[Document]:  # type: ignore
         """Fetch documents by specifying a list of text id strings"""
         index = index or self.index
         documents = [self.indexes[index][id] for id in ids]

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -210,7 +210,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
         document_count = len(result)
         logger.info(f"Updating embeddings for {document_count} docs ...")
         batched_documents = get_batches_from_generator(result, batch_size)
-        with tqdm(total=document_count, disable=not self.progress_bar) as progress_bar:
+        with tqdm(total=document_count, disable=not self.progress_bar, position=0, unit=" docs",
+                  desc="Updating Embedding") as progress_bar:
             for document_batch in batched_documents:
                 embeddings = retriever.embed_passages(document_batch)  # type: ignore
                 assert len(document_batch) == len(embeddings)
@@ -222,6 +223,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
                 for doc, emb in zip(document_batch, embeddings):
                     self.indexes[index][doc.id].embedding = emb
+                progress_bar.set_description_str("Documents Processed")
+                progress_bar.update(batch_size)
 
     def get_document_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
         """

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -267,7 +267,8 @@ class MilvusDocumentStore(SQLDocumentStore):
             only_documents_without_embedding=not update_existing_embeddings
         )
         batched_documents = get_batches_from_generator(result, batch_size)
-        with tqdm(total=document_count, disable=not self.progress_bar) as progress_bar:
+        with tqdm(total=document_count, disable=not self.progress_bar, position=0, unit=" docs",
+                  desc="Updating Embedding") as progress_bar:
             for document_batch in batched_documents:
                 self._delete_vector_ids_from_milvus(documents=document_batch, index=index)
 
@@ -284,8 +285,8 @@ class MilvusDocumentStore(SQLDocumentStore):
                     vector_id_map[doc.id] = vector_id
 
                 self.update_vector_ids(vector_id_map, index=index)
+                progress_bar.set_description_str("Documents Processed")
                 progress_bar.update(batch_size)
-        progress_bar.close()
 
         self.milvus_server.flush([index])
         self.milvus_server.compact(collection_name=index)

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -12,6 +12,7 @@ from haystack import Document
 from haystack.document_store.sql import SQLDocumentStore
 from haystack.retriever.base import BaseRetriever
 from haystack.utils import get_batches_from_generator
+from haystack.document_store.base import DuplicateDocumentError
 
 logger = logging.getLogger(__name__)
 
@@ -46,10 +47,10 @@ class MilvusDocumentStore(SQLDocumentStore):
             index_type: IndexType = IndexType.FLAT,
             index_param: Optional[Dict[str, Any]] = None,
             search_param: Optional[Dict[str, Any]] = None,
-            update_existing_documents: bool = False,
             return_embedding: bool = False,
             embedding_field: str = "embedding",
             progress_bar: bool = True,
+            duplicate_documents: str = 'overwrite',
             **kwargs,
     ):
         """
@@ -85,21 +86,23 @@ class MilvusDocumentStore(SQLDocumentStore):
         :param search_param: Configuration parameters for the chose index_type needed at query time
                              For example: {"nprobe": 10} as the number of cluster units to query for index_type IVF_FLAT.
                              See https://milvus.io/docs/v1.0.0/index.md
-        :param update_existing_documents: Whether to update any existing documents with the same ID when adding
-                                          documents. When set as True, any document with an existing ID gets updated.
-                                          If set to False, an error is raised if the document ID of the document being
-                                          added already exists.
         :param return_embedding: To return document embedding.
         :param embedding_field: Name of field containing an embedding vector.
         :param progress_bar: Whether to show a tqdm progress bar or not.
                              Can be helpful to disable in production deployments to keep the logs clean.
+        :param duplicate_documents: Handle duplicates document based on parameter options.
+                                    Parameter options : ( 'skip','overwrite','fail')
+                                    skip: Ignore the duplicates documents
+                                    overwrite: Update any existing documents with the same ID when adding documents.
+                                    fail: an error is raised if the document ID of the document being added already
+                                    exists.
         """
 
         # save init parameters to enable export of component config as YAML
         self.set_config(
             sql_url=sql_url, milvus_url=milvus_url, connection_pool=connection_pool, index=index, vector_dim=vector_dim,
             index_file_size=index_file_size, similarity=similarity, index_type=index_type, index_param=index_param,
-            search_param=search_param, update_existing_documents=update_existing_documents,
+            search_param=search_param, duplicate_documents=duplicate_documents,
             return_embedding=return_embedding, embedding_field=embedding_field, progress_bar=progress_bar,
         )
 
@@ -122,10 +125,10 @@ class MilvusDocumentStore(SQLDocumentStore):
         self.return_embedding = return_embedding
         self.embedding_field = embedding_field
         self.progress_bar = progress_bar
+        self.duplicate_documents = duplicate_documents
 
         super().__init__(
             url=sql_url,
-            update_existing_documents=update_existing_documents,
             index=index
         )
 
@@ -162,9 +165,8 @@ class MilvusDocumentStore(SQLDocumentStore):
             self.index: self.embedding_field,
         }
 
-    def write_documents(
-            self, documents: Union[List[dict], List[Document]], index: Optional[str] = None, batch_size: int = 10_000
-    ):
+    def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None,
+                        batch_size: int = 10_000, duplicate_documents: Optional[str] = None):
         """
         Add new documents to the DocumentStore.
 
@@ -172,9 +174,19 @@ class MilvusDocumentStore(SQLDocumentStore):
                                   them right away in Milvus. If not, you can later call update_embeddings() to create & index them.
         :param index: (SQL) index name for storing the docs and metadata
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
+        :param duplicate_documents: Handle duplicates document based on parameter options.
+                                    Parameter options : ( 'skip','overwrite','fail')
+                                    skip: Ignore the duplicates documents
+                                    overwrite: Update any existing documents with the same ID when adding documents.
+                                    fail: an error is raised if the document ID of the document being added already
+                                    exists.
+        :raises DuplicateDocumentError: Exception trigger on duplicate document
         :return:
         """
         index = index or self.index
+        duplicate_documents = duplicate_documents or self.duplicate_documents
+        assert duplicate_documents in self.duplicate_documents_options, \
+            f"duplicate_documents parameter must be {', '.join(self.duplicate_documents_options)}"
         self._create_collection_and_index_if_not_exist(index)
         field_map = self._create_document_field_map()
 
@@ -183,7 +195,7 @@ class MilvusDocumentStore(SQLDocumentStore):
             return
 
         document_objects = [Document.from_dict(d, field_map=field_map) if isinstance(d, dict) else d for d in documents]
-
+        document_objects = self._handle_duplicate_documents(document_objects, duplicate_documents)
         add_vectors = False if document_objects[0].embedding is None else True
 
         batched_documents = get_batches_from_generator(document_objects, batch_size)
@@ -203,7 +215,7 @@ class MilvusDocumentStore(SQLDocumentStore):
                             raise AttributeError(f'Format of supplied document embedding {type(doc.embedding)} is not '
                                                  f'supported. Please use list or numpy.ndarray')
 
-                    if self.update_existing_documents:
+                    if duplicate_documents == 'overwrite':
                         existing_docs = super().get_documents_by_id(ids=doc_ids, index=index)
                         self._delete_vector_ids_from_milvus(documents=existing_docs, index=index)
 
@@ -218,12 +230,12 @@ class MilvusDocumentStore(SQLDocumentStore):
                         meta["vector_id"] = vector_ids[idx]
                     docs_to_write_in_sql.append(doc)
 
-                super().write_documents(docs_to_write_in_sql, index=index)
+                super().write_documents(docs_to_write_in_sql, index=index, duplicate_documents=duplicate_documents)
                 progress_bar.update(batch_size)
         progress_bar.close()
 
         self.milvus_server.flush([index])
-        if self.update_existing_documents:
+        if duplicate_documents == 'overwrite':
             self.milvus_server.compact(collection_name=index)
 
     def update_embeddings(

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -1,0 +1,7 @@
+# coding: utf8
+"""Custom Errors for Haystack stacks"""
+
+
+class DuplicateDocumentError(ValueError):
+    """Exception for Duplicate document"""
+    pass

--- a/haystack/eval.py
+++ b/haystack/eval.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple, Dict, Any
 import logging
 
-from haystack import MultiLabel
+from haystack import MultiLabel, Label
 
 from farm.evaluation.squad_evaluation import compute_f1 as calculate_f1_str
 from farm.evaluation.squad_evaluation import compute_exact as calculate_em_str
@@ -42,7 +42,8 @@ class EvalRetriever:
     def run(self, documents, labels: dict, **kwargs):
         """Run this node on one sample and its labels"""
         self.query_count += 1
-        retriever_labels = labels["retriever"]
+        retriever_labels = get_label(labels, kwargs["node_id"])
+
         # TODO retriever_labels is currently a Multilabel object but should eventually be a RetrieverLabel object
         # If this sample is impossible to answer and expects a no_answer response
         if retriever_labels.no_answer:
@@ -139,7 +140,7 @@ class EvalReader:
         skip = self.skip_incorrect_retrieval and not kwargs.get("correct_retrieval")
         if predictions and not skip:
             self.correct_retrieval_count += 1
-            multi_labels = labels["reader"]
+            multi_labels = get_label(labels, kwargs["node_id"])
             # If this sample is impossible to answer and expects a no_answer response
             if multi_labels.no_answer:
                 self.no_answer_count += 1
@@ -226,6 +227,13 @@ class EvalReader:
                     "(top k results are likely inflated since the Reader always returns a no_answer prediction in its top k)"
                 )
 
+def get_label(labels, node_id):
+    if type(labels) in [Label, MultiLabel]:
+        ret = labels
+    # If labels is a dict, then fetch the value using node_id (e.g. "EvalRetriever") as the key
+    else:
+        ret = labels[node_id]
+    return ret
 
 def calculate_em_str_multi(gold_labels, prediction):
     for gold_label in gold_labels:

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -119,6 +119,7 @@ class Pipeline:
         while queue:
             node_id = list(queue.keys())[i]
             node_input = queue[node_id]
+            node_input["node_id"] = node_id
             predecessors = set(nx.ancestors(self.graph, node_id))
             if predecessors.isdisjoint(set(queue.keys())):  # only execute if predecessor nodes are executed
                 try:

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -494,33 +494,33 @@ class FARMReader(BaseReader):
             }
             # get all questions / answers
             aggregated_per_question: Dict[tuple, Any] = defaultdict(list)
-            key_tuple = (label.id, label.question)
+            id_question_tuple = (label.id, label.question)
             if doc_id in aggregated_per_doc:
                 for label in aggregated_per_doc[doc_id]:
                     # add to existing answers
-                    if key_tuple in aggregated_per_question.keys():
+                    if id_question_tuple in aggregated_per_question.keys():
                         if label.offset_start_in_doc == 0 and label.answer == "":
                             continue
                         else:
                             # Hack to fix problem where duplicate questions are merged by doc_store processing creating a QA example with 8 annotations > 6 annotation max
-                            if len(aggregated_per_question[key_tuple]["answers"]) >= 6:
+                            if len(aggregated_per_question[id_question_tuple]["answers"]) >= 6:
                                 continue
-                            aggregated_per_question[key_tuple]["answers"].append({
+                            aggregated_per_question[id_question_tuple]["answers"].append({
                                         "text": label.answer,
                                         "answer_start": label.offset_start_in_doc})
-                            aggregated_per_question[key_tuple]["is_impossible"] = False
+                            aggregated_per_question[id_question_tuple]["is_impossible"] = False
                     # create new one
                     else:
                         # We don't need to create an answer dict if is_impossible / no_answer
                         if label.offset_start_in_doc == 0 and label.answer == "":
-                            aggregated_per_question[key_tuple] = {
+                            aggregated_per_question[id_question_tuple] = {
                                 "id": str(hash(str(doc_id) + label.question)),
                                 "question": label.question,
                                 "answers": [],
                                 "is_impossible": True
                             }
                         else:
-                            aggregated_per_question[key_tuple] = {
+                            aggregated_per_question[id_question_tuple] = {
                                 "id": str(hash(str(doc_id)+label.question)),
                                 "question": label.question,
                                 "answers": [{

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -504,6 +504,7 @@ class FARMReader(BaseReader):
                         else:
                             # Hack to fix problem where duplicate questions are merged by doc_store processing creating a QA example with 8 annotations > 6 annotation max
                             if len(aggregated_per_question[id_question_tuple]["answers"]) >= 6:
+                                logger.warning(f"Answers in this sample are being dropped because it has more than 6 answers. (doc_id: {doc_id}, question: {label.question}, label_id: {label.id})")
                                 continue
                             aggregated_per_question[id_question_tuple]["answers"].append({
                                         "text": label.answer,

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -493,33 +493,34 @@ class FARMReader(BaseReader):
                 "context": doc.text
             }
             # get all questions / answers
-            aggregated_per_question: Dict[str, Any] = defaultdict(list)
+            aggregated_per_question: Dict[tuple, Any] = defaultdict(list)
+            key_tuple = (label.id, label.question)
             if doc_id in aggregated_per_doc:
                 for label in aggregated_per_doc[doc_id]:
                     # add to existing answers
-                    if label.question in aggregated_per_question.keys():
+                    if key_tuple in aggregated_per_question.keys():
                         if label.offset_start_in_doc == 0 and label.answer == "":
                             continue
                         else:
                             # Hack to fix problem where duplicate questions are merged by doc_store processing creating a QA example with 8 annotations > 6 annotation max
-                            if len(aggregated_per_question[label.question]["answers"]) >= 6:
+                            if len(aggregated_per_question[key_tuple]["answers"]) >= 6:
                                 continue
-                            aggregated_per_question[label.question]["answers"].append({
+                            aggregated_per_question[key_tuple]["answers"].append({
                                         "text": label.answer,
                                         "answer_start": label.offset_start_in_doc})
-                            aggregated_per_question[label.question]["is_impossible"] = False
+                            aggregated_per_question[key_tuple]["is_impossible"] = False
                     # create new one
                     else:
                         # We don't need to create an answer dict if is_impossible / no_answer
                         if label.offset_start_in_doc == 0 and label.answer == "":
-                            aggregated_per_question[label.question] = {
+                            aggregated_per_question[key_tuple] = {
                                 "id": str(hash(str(doc_id) + label.question)),
                                 "question": label.question,
                                 "answers": [],
                                 "is_impossible": True
                             }
                         else:
-                            aggregated_per_question[label.question] = {
+                            aggregated_per_question[key_tuple] = {
                                 "id": str(hash(str(doc_id)+label.question)),
                                 "question": label.question,
                                 "answers": [{

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -96,12 +96,12 @@ class BaseRetriever(BaseComponent):
         # Collect questions and corresponding answers/document_ids in a dict
         question_label_dict = {}
         for label in labels:
-            key_tuple = (label.multiple_document_ids[0], label.question)
+            id_question_tuple = (label.multiple_document_ids[0], label.question)
             if open_domain:
-                question_label_dict[key_tuple] = label.multiple_answers
+                question_label_dict[id_question_tuple] = label.multiple_answers
             else:
                 deduplicated_doc_ids = list(set([str(x) for x in label.multiple_document_ids]))
-                question_label_dict[key_tuple] = deduplicated_doc_ids
+                question_label_dict[id_question_tuple] = deduplicated_doc_ids
 
         predictions = []
 

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -96,11 +96,12 @@ class BaseRetriever(BaseComponent):
         # Collect questions and corresponding answers/document_ids in a dict
         question_label_dict = {}
         for label in labels:
+            key_tuple = (label.multiple_document_ids[0], label.question)
             if open_domain:
-                question_label_dict[label.question] = label.multiple_answers
+                question_label_dict[key_tuple] = label.multiple_answers
             else:
                 deduplicated_doc_ids = list(set([str(x) for x in label.multiple_document_ids]))
-                question_label_dict[label.question] = deduplicated_doc_ids
+                question_label_dict[key_tuple] = deduplicated_doc_ids
 
         predictions = []
 
@@ -129,7 +130,7 @@ class BaseRetriever(BaseComponent):
                     summed_avg_precision += current_avg_precision / relevant_docs_found
         # Option 2: Strict evaluation by document ids that are listed in the labels
         else:
-            for question, gold_ids in tqdm(question_label_dict.items()):
+            for (_, question), gold_ids in tqdm(question_label_dict.items()):
                 retrieved_docs = timed_retrieve(question, top_k=top_k, index=doc_index)
                 if return_preds:
                     predictions.append({"question": question, "retrieved_docs": retrieved_docs})

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -87,7 +87,7 @@ class BaseRetriever(BaseComponent):
 
         timed_retrieve = self.timing(self.retrieve, "retrieve_time")
 
-        labels = self.document_store.get_all_labels_aggregated(index=label_index, filters=filters)
+        labels = self.document_store.get_all_labels_aggregated(index=label_index, filters=filters, open_domain=open_domain)
 
         correct_retrievals = 0
         summed_avg_precision = 0.0

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -305,6 +305,7 @@ class DensePassageRetriever(BaseRetriever):
               weight_decay: float = 0.0,
               num_warmup_steps: int = 100,
               grad_acc_steps: int = 1,
+              use_amp: str = None,
               optimizer_name: str = "TransformersAdamW",
               optimizer_correct_bias: bool = True,
               save_dir: str = "../saved_models/dpr",
@@ -332,6 +333,12 @@ class DensePassageRetriever(BaseRetriever):
         :param epsilon: epsilon parameter of optimizer
         :param weight_decay: weight decay parameter of optimizer
         :param grad_acc_steps: number of steps to accumulate gradient over before back-propagation is done
+        :param use_amp: Whether to use automatic mixed precision (AMP) or not. The options are:
+                    "O0" (FP32)
+                    "O1" (Mixed Precision)
+                    "O2" (Almost FP16)
+                    "O3" (Pure FP16).
+                    For more information, refer to: https://nvidia.github.io/apex/amp.html
         :param optimizer_name: what optimizer to use (default: TransformersAdamW)
         :param num_warmup_steps: number of warmup steps
         :param optimizer_correct_bias: Whether to correct bias in optimizer
@@ -364,7 +371,8 @@ class DensePassageRetriever(BaseRetriever):
             n_batches=len(data_silo.loaders["train"]),
             n_epochs=n_epochs,
             grad_acc_steps=grad_acc_steps,
-            device=self.device
+            device=self.device,
+            use_amp=use_amp
         )
 
         # 6. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
@@ -377,6 +385,7 @@ class DensePassageRetriever(BaseRetriever):
             lr_schedule=lr_schedule,
             evaluate_every=evaluate_every,
             device=self.device,
+            use_amp=use_amp
         )
 
         # 7. Let it grow! Watch the tracked metrics live on the public mlflow server: https://public-mlflow.deepset.ai

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -109,7 +109,9 @@ class Label:
                  no_answer: Optional[bool] = None,
                  model_id: Optional[int] = None,
                  created_at: Optional[str] = None,
-                 updated_at: Optional[str] = None):
+                 updated_at: Optional[str] = None,
+                 meta: Optional[dict] = None
+                 ):
         """
         Object used to represent label/feedback in a standardized way within Haystack.
         This includes labels from dataset like SQuAD, annotations from labeling tools,
@@ -150,6 +152,10 @@ class Label:
         self.offset_start_in_doc = offset_start_in_doc
         self.no_answer = no_answer
         self.model_id = model_id
+        if not meta:
+            self.meta = dict()
+        else:
+            self.meta = meta
 
     @classmethod
     def from_dict(cls, dict):
@@ -200,7 +206,9 @@ class MultiLabel:
                  multiple_document_ids: List[Any],
                  multiple_offset_start_in_docs: List[Any],
                  no_answer: Optional[bool] = None,
-                 model_id: Optional[int] = None):
+                 model_id: Optional[int] = None,
+                 meta: dict = None
+                 ):
         """
         Object used to aggregate multiple possible answers for the same question
 
@@ -225,6 +233,10 @@ class MultiLabel:
         self.multiple_offset_start_in_docs = multiple_offset_start_in_docs
         self.no_answer = no_answer
         self.model_id = model_id
+        if not meta:
+            self.meta = dict()
+        else:
+            self.meta = meta
 
     @classmethod
     def from_dict(cls, dict):

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1,46 +1,65 @@
 from typing import Any, Optional, Dict, List
 from uuid import uuid4
+
+import mmh3
 import numpy as np
 from abc import abstractmethod
 
 
 class Document:
-    def __init__(self, text: str,
-                 id: Optional[str] = None,
-                 score: Optional[float] = None,
-                 probability: Optional[float] = None,
-                 question: Optional[str] = None,
-                 meta: Dict[str, Any] = None,
-                 embedding: Optional[np.ndarray] = None):
+    def __init__(
+        self,
+        text: str,
+        id: Optional[str] = None,
+        score: Optional[float] = None,
+        probability: Optional[float] = None,
+        question: Optional[str] = None,
+        meta: Dict[str, Any] = None,
+        embedding: Optional[np.ndarray] = None,
+        id_hash_keys: Optional[List[str]] = None
+    ):
         """
-        Object used to represent documents / passages in a standardized way within Haystack.
-        For example, this is what the retriever will return from the DocumentStore,
-        regardless if it's ElasticsearchDocumentStore or InMemoryDocumentStore.
+        One of the core data classes in Haystack. It's used to represent documents / passages in a standardized way within Haystack.
+        Documents are stored in DocumentStores, are returned by Retrievers, are the input for Readers and are used in
+        many other places that manipulate or interact with document-level data.
 
-        Note that there can be multiple Documents originating from one file (e.g. PDF),
-        if you split the text into smaller passages. We'll have one Document per passage in this case.
+        Note: There can be multiple Documents originating from one file (e.g. PDF), if you split the text
+        into smaller passages. We'll have one Document per passage in this case.
 
-        :param id: ID used within the DocumentStore
+        Each document has a unique ID. This can be supplied by the user or generated automatically.
+        It's particularly helpful for handling of duplicates and referencing documents in other objects (e.g. Labels)
+
+        There's an easy option to convert from/to dicts via `from_dict()` and `to_dict`.
+
         :param text: Text of the document
+        :param id: Unique ID for the document. If not supplied by the user, we'll generate one automatically by
+                   creating a hash from the supplied text. This behaviour can be further adjusted by `id_hash_keys`.
         :param score: Retriever's query score for a retrieved document
         :param probability: a pseudo probability by scaling score in the range 0 to 1
-        :param question: Question text for FAQs.
+        :param question: Question text (e.g. for FAQs where one document usually consists of one question and one answer text).
         :param meta: Meta fields for a document like name, url, or author.
         :param embedding: Vector encoding of the text
+        :param id_hash_keys: Generate the document id from a custom list of strings.
+                             If you want ensure you don't have duplicate documents in your DocumentStore but texts are
+                             not unique, you can provide custom strings here that will be used (e.g. ["filename_xy", "text_of_doc"].
         """
 
         self.text = text
-        # Create a unique ID (either new one, or one from user input)
-        if id:
-            self.id = str(id)
-        else:
-            self.id = str(uuid4())
-
         self.score = score
         self.probability = probability
         self.question = question
         self.meta = meta or {}
         self.embedding = embedding
+
+        # Create a unique ID (either new one, or one from user input)
+        if id:
+            self.id = str(id)
+        else:
+            self.id = self._get_id(id_hash_keys)
+
+    def _get_id(self, id_hash_keys):
+        final_hash_key = ":".join(id_hash_keys) if id_hash_keys else self.text
+        return '{:02x}'.format(mmh3.hash128(final_hash_key, signed=False))
 
     def to_dict(self, field_map={}):
         inv_field_map = {v:k for k, v in field_map.items()}

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ pymilvus
 #selenium
 #webdriver-manager
 SPARQLWrapper
+mmh3

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -32,6 +32,23 @@ def test_init_elastic_client():
 
 
 @pytest.mark.elasticsearch
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "sql", "milvus"], indirect=True)
+def test_write_with_duplicate_doc_ids(document_store):
+    documents = [
+        Document(
+            text="Doc1",
+            id_hash_keys=["key1"]
+        ),
+        Document(
+            text="Doc2",
+            id_hash_keys=["key1"]
+        )
+    ]
+    with pytest.raises(Exception):
+        document_store.write_documents(documents)
+
+
+@pytest.mark.elasticsearch
 def test_get_all_documents_without_filters(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents()
     assert all(isinstance(d, Document) for d in documents)
@@ -41,19 +58,22 @@ def test_get_all_documents_without_filters(document_store_with_docs):
 
 
 @pytest.mark.elasticsearch
-def test_get_all_document_filter_duplicate_value(document_store):
+def test_get_all_document_filter_duplicate_text_value(document_store):
     documents = [
         Document(
             text="Doc1",
-            meta={"f1": "0"}
+            meta={"f1": "0"},
+            id_hash_keys=["Doc1", "1"]
         ),
         Document(
             text="Doc1",
-            meta={"f1": "1", "meta_id": "0"}
+            meta={"f1": "1", "meta_id": "0"},
+            id_hash_keys=["Doc1", "2"]
         ),
         Document(
             text="Doc2",
-            meta={"f3": "0"}
+            meta={"f3": "0"},
+            id_hash_keys=["Doc2", "3"]
         )
     ]
     document_store.write_documents(documents)

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -44,8 +44,9 @@ def test_write_with_duplicate_doc_ids(document_store):
             id_hash_keys=["key1"]
         )
     ]
+    document_store.write_documents(documents, duplicate_documents="skip")
     with pytest.raises(Exception):
-        document_store.write_documents(documents)
+        document_store.write_documents(documents, duplicate_documents="fail")
 
 
 @pytest.mark.elasticsearch
@@ -168,15 +169,14 @@ def test_update_existing_documents(document_store, update_existing_documents):
         {"text": "text1_new", "id": "1", "meta_field_for_count": "a"},
     ]
 
-    document_store.update_existing_documents = update_existing_documents
     document_store.write_documents(original_docs)
     assert document_store.get_document_count() == 1
 
     if update_existing_documents:
-        document_store.write_documents(updated_docs)
+        document_store.write_documents(updated_docs, duplicate_documents="overwrite")
     else:
         with pytest.raises(Exception):
-            document_store.write_documents(updated_docs)
+            document_store.write_documents(updated_docs, duplicate_documents="fail")
 
     stored_docs = document_store.get_all_documents()
     assert len(stored_docs) == 1

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -92,8 +92,8 @@ def test_update_docs(document_store, retriever, batch_size):
 @pytest.mark.slow
 @pytest.mark.parametrize("retriever", ["dpr"], indirect=True)
 @pytest.mark.parametrize("document_store", ["milvus", "faiss"], indirect=True)
-def test_update_exiting_docs(document_store, retriever):
-    document_store.update_existing_documents = True
+def test_update_existing_docs(document_store, retriever):
+    document_store.duplicate_documents = "overwrite"
     old_document = Document(text="text_1")
     # initial write
     document_store.write_documents([old_document])

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,0 +1,24 @@
+from haystack import Document
+
+
+def test_generate_doc_id_using_text():
+    text1 = "text1"
+    text2 = "text2"
+    doc1_text1 = Document(text=text1, meta={"name": "doc1"})
+    doc2_text1 = Document(text=text1, meta={"name": "doc2"})
+    doc3_text2 = Document(text=text2, meta={"name": "doc3"})
+
+    assert doc1_text1.id == doc2_text1.id
+    assert doc1_text1.id != doc3_text2.id
+
+
+def test_generate_doc_id_using_custom_list():
+    text1 = "text1"
+    text2 = "text2"
+
+    doc1_text1 = Document(text=text1, meta={"name": "doc1"}, id_hash_keys=["key1", text1])
+    doc2_text1 = Document(text=text1, meta={"name": "doc2"}, id_hash_keys=["key1", text1])
+    doc3_text2 = Document(text=text2, meta={"name": "doc3"}, id_hash_keys=["key1", text2])
+
+    assert doc1_text1.id == doc2_text1.id
+    assert doc1_text1.id != doc3_text2.id

--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -228,13 +228,7 @@
     ")\n",
     "\n",
     "# Let's prepare the labels that we need for the retriever and the reader\n",
-    "labels = document_store.get_all_labels_aggregated(index=label_index)\n",
-    "q_to_l_dict = {\n",
-    "    l.question: {\n",
-    "        \"retriever\": l,\n",
-    "        \"reader\": l\n",
-    "    } for l in labels\n",
-    "}"
+    "labels = document_store.get_all_labels_aggregated(index=label_index)"
    ]
   },
   {
@@ -509,9 +503,9 @@
    "outputs": [],
    "source": [
     "# This is how to run the pipeline\n",
-    "for q, l in q_to_l_dict.items():\n",
+    "for l in labels:\n",
     "    res = p.run(\n",
-    "        query=q,\n",
+    "        query=l.question,\n",
     "        top_k_retriever=10,\n",
     "        labels=l,\n",
     "        top_k_reader=10,\n",

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -140,7 +140,7 @@ def tutorial5_evaluation():
             res = p.run(
                 query=l.question,
                 top_k_retriever=10,
-                labels={"reader": l, "retriever": l},
+                labels=l,
                 top_k_reader=10,
                 index=doc_index,
             )

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -57,6 +57,7 @@ def tutorial5_evaluation():
     # We first delete the custom tutorial indices to not have duplicate elements
     # and also split our documents into shorter passages using the PreProcessor
     preprocessor = PreProcessor(
+        split_by="word",
         split_length=500,
         split_overlap=0,
         split_respect_sentence_boundary=False,
@@ -75,7 +76,7 @@ def tutorial5_evaluation():
     # Let's prepare the labels that we need for the retriever and the reader
     labels = document_store.get_all_labels_aggregated(index=label_index)
     q_to_l_dict = {
-        l.question: {
+        (l.multiple_document_ids[0], l.question): {
             "retriever": l,
             "reader": l
         } for l in labels
@@ -89,7 +90,7 @@ def tutorial5_evaluation():
     # Here, for nq_dev_subset_v2.json we have avg. num of tokens = 5220(!).
     # DPR still outperforms Elastic's BM25 by a small margin here.
     # retriever = DensePassageRetriever(document_store=document_store,
-    #                                   query_embedding_model="facebook/dpr-qPreProuestion_encoder-single-nq-base",
+    #                                   query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
     #                                   passage_embedding_model="facebook/dpr-ctx_encoder-single-nq-base",
     #                                   use_gpu=True,
     #                                   embed_title=True,
@@ -142,7 +143,7 @@ def tutorial5_evaluation():
         p.add_node(component=eval_reader, name="EvalReader", inputs=["QAReader"])
         results = []
 
-        for q, l in q_to_l_dict.items():
+        for (_, q), l in q_to_l_dict.items():
             res = p.run(
                 query=q,
                 top_k_retriever=10,
@@ -162,6 +163,8 @@ def tutorial5_evaluation():
         reader.print_time()
         print()
         eval_reader.print(mode="pipeline")
+    else:
+        raise Exception()
 
 
 if __name__ == "__main__":

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -74,12 +74,6 @@ def tutorial5_evaluation():
 
     # Let's prepare the labels that we need for the retriever and the reader
     labels = document_store.get_all_labels_aggregated(index=label_index)
-    q_to_l_dict = {
-        (l.multiple_document_ids[0], l.question): {
-            "retriever": l,
-            "reader": l
-        } for l in labels
-    }
 
     # Initialize Retriever
     retriever = ElasticsearchRetriever(document_store=document_store)
@@ -142,17 +136,16 @@ def tutorial5_evaluation():
         p.add_node(component=eval_reader, name="EvalReader", inputs=["QAReader"])
         results = []
 
-        for (_, q), l in q_to_l_dict.items():
+        for l in labels:
             res = p.run(
-                query=q,
+                query=l.question,
                 top_k_retriever=10,
-                labels=l,
+                labels={"reader": l, "retriever": l},
                 top_k_reader=10,
                 index=doc_index,
             )
             results.append(res)
 
-        n_queries = len(labels)
         eval_retriever.print()
         print()
         retriever.print_time()

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -20,7 +20,6 @@ def tutorial5_evaluation():
     ##############################################
     # Settings
     ##############################################
-
     # Choose from Evaluation style from ['retriever_closed', 'reader_closed', 'retriever_reader_open']
     # 'retriever_closed' - evaluates only the retriever, based on whether the gold_label document is retrieved.
     # 'reader_closed' - evaluates only the reader in a closed domain fashion i.e. the reader is given one query
@@ -164,7 +163,7 @@ def tutorial5_evaluation():
         print()
         eval_reader.print(mode="pipeline")
     else:
-        raise Exception()
+        raise ValueError(f'style={style} is not a valid option. Choose from retriever_closed, reader_closed, retriever_reader_open')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The issue is raised here (#933). This PR solves this by using a tuple of id and question when aggregating labels. This is done in a few different functions where labels are loaded. 