### PR TITLE
Passing DPR retriever instance while generator instantiation

### DIFF
--- a/tutorials/Tutorial7_RAG_Generator.ipynb
+++ b/tutorials/Tutorial7_RAG_Generator.ipynb
@@ -193,6 +193,7 @@
     "# Initialize RAG Generator\n",
     "generator = RAGenerator(\n",
     "    model_name_or_path=\"facebook/rag-token-nq\",\n",
+    "    retriever = retriever
     "    use_gpu=True,\n",
     "    top_k=1,\n",
     "    max_length=200,\n",


### PR DESCRIPTION
I have tried this tutorial,  

The following exception has occurred. 
File "/home/ec2-user/SB360-MLServer/venv/lib/python3.7/site-packages/haystack/generator/transformers.py", line 232, in predict
    passage_embeddings = self._prepare_passage_embeddings(docs=documents, embeddings=flat_docs_dict["embedding"])
  File "/home/ec2-user/SB360-MLServer/venv/lib/python3.7/site-packages/haystack/generator/transformers.py", line 176, in _prepare_passage_embeddings
    raise AttributeError("_prepare_passage_embeddings need a DPR instance as self.retriever to embed document") 

Apparently generator requires dpr retriever while instantiation

**Proposed changes**:
- Passing the dpr instance while generator instantiation solved the issue

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
