### PR TITLE
WIP: add query baseline query classifier and boilerplate in pipeline

### DIFF
--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -6,6 +6,8 @@ from abc import ABC
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional, Dict
+import urllib.request
+import pickle
 
 import networkx as nx
 import yaml
@@ -592,6 +594,29 @@ class RootNode:
     def run(self, **kwargs):
         return kwargs, "output_1"
 
+
+class QueryClassifier:
+        outgoing_edges = 2
+        query_vectorizer = pickle.load(
+            urllib.request.urlopen(
+                "https://raw.githubusercontent.com/shahrukhx01/ocr-test/main/query_vectorizer.pickle"
+            )
+        ) 
+        model = pickle.load(
+            urllib.request.urlopen(
+                "https://raw.githubusercontent.com/shahrukhx01/ocr-test/main/query_classifier.pickle"
+            )
+        ) 
+        
+        
+        def run(self, **kwargs):
+            query_vector = self.query_vectorizer.transform([kwargs["query"]])
+            is_question: bool = self.model.predict(query_vector)[0]
+            if is_question:
+                return (kwargs, "output_1")
+
+            else:
+                return (kwargs, "output_2")
 
 class JoinDocuments(BaseComponent):
     """


### PR DESCRIPTION
**Proposed changes**:
- Query classifier baseline and its boilerplate in the pipeline

**Status (please check what you already did)**:
- [*] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation

Discussion Points:
I have added the baseline model, however, 

- Currently, I'm reading models from temporarily hosted raw files on Github, I'd need some direction in replacing GitHub placeholder files with S3 hosted models for classification. 
- Could you please comment on how we are going to extend the QueryClassifier class since I intend to add a transformer finetuned model for the same purpose. Should we then completely replace sklearn based classifier or keep both?
- Any other major pointer that I missed.

Issue: [Linked Issue](https://github.com/deepset-ai/haystack/issues/611)

PS: 
This is my first PR on here, please let me know any contribution guideline that I might have missed. Also, any instructions manuals for contributors, which would help me get started with the codebase quickly since I'd like to actively contribute to the haystack in general. Thanks!
