### PR TITLE
Add OpenDistro init

### DIFF
--- a/haystack/document_store/__init__.py
+++ b/haystack/document_store/__init__.py
@@ -1,4 +1,4 @@
-from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
+from haystack.document_store.elasticsearch import ElasticsearchDocumentStore, OpenDistroElasticsearchDocumentStore
 from haystack.document_store.faiss import FAISSDocumentStore
 from haystack.document_store.memory import InMemoryDocumentStore
 from haystack.document_store.milvus import MilvusDocumentStore


### PR DESCRIPTION
Add `OpenDistroElasticsearchDocumentStore` to `haystack/document_store/__init__.py` so that it can be loaded simply with
`from haystack.document_store import OpenDistroElasticsearchDocumentStore`