### PR TITLE
Removed comma from last item in json list

### DIFF
--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ]
   },
   {

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ]
   },
   {

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ]
   },
   {

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ]
   },
   {

--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -77,7 +77,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ]
   },
   {

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -286,7 +286,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ]
   },
   {

--- a/tutorials/Tutorial7_RAG_Generator.ipynb
+++ b/tutorials/Tutorial7_RAG_Generator.ipynb
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "!pip install grpcio-tools==1.34.1\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git\n"
    ],
    "metadata": {
     "collapsed": false,


### PR DESCRIPTION
**Proposed changes**
There were syntax errors in some of the notebooks that are now resolved. The last item in a json list was followed by a comma, which is incorrect syntax. This PR removes these commas.

I uploaded the updated notebooks to colab and each of them loads correctly now.

Thanks to @cvgoudar for informing me about the issue!
