### PR TITLE
Distinguish labels for calculating similarity scores

### DIFF
--- a/docs/_src/usage/usage/ranker.md
+++ b/docs/_src/usage/usage/ranker.md
@@ -30,6 +30,7 @@ Alternatively, [this example](https://github.com/deepset-ai/FARM/blob/master/exa
 ### Description
 
 The FARMRanker consists of a Transformer-based model for document re-ranking using the TextPairClassifier of [FARM](https://github.com/deepset-ai/FARM).
+Given a text pair of query and passage, the TextPairClassifier either predicts label "1" if the pair is similar or label "0" if they are dissimilar (accompanied with a probability).
 While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interface remains the same.
 With a FARMRanker, you can:
 * Directly get predictions (re-ranked version of the supplied list of Document) via predict() if supplying a pre-trained model

--- a/haystack/ranker/farm.py
+++ b/haystack/ranker/farm.py
@@ -258,7 +258,7 @@ class FARMRanker(BaseRanker):
         # calculate similarity of query and each document
         query_and_docs = [{"text": (query, doc.text)} for doc in documents]
         result = self.inferencer.inference_from_dicts(dicts=query_and_docs)
-        similarity_scores = [pred["probability"] for preds in result for pred in preds["predictions"]]
+        similarity_scores = [pred["probability"] if pred["label"] == "1" else 1-pred["probability"] for preds in result for pred in preds["predictions"]]
 
         # rank documents according to scores
         sorted_scores_and_documents = sorted(zip(similarity_scores, documents),


### PR DESCRIPTION
**Proposed changes**:
The ranker now distinguishes predictions with label "0" (dissimilar) and label "1" (similar) when extracting the probability of the prediction (similarity score).
Before this change, the re-ranking gave wrong results when documents to be re-ranked had a probability larger than 0.5 of being dissimilar. This probability was wrongly assumed to be the similarity score. 