### PR TITLE
Add docu of confidence scores and calibration method

### DIFF
--- a/docs/_src/usage/usage/ranker.md
+++ b/docs/_src/usage/usage/ranker.md
@@ -30,6 +30,7 @@ Alternatively, [this example](https://github.com/deepset-ai/FARM/blob/master/exa
 ### Description
 
 The FARMRanker consists of a Transformer-based model for document re-ranking using the TextPairClassifier of [FARM](https://github.com/deepset-ai/FARM).
+Given a text pair of query and passage, the TextPairClassifier either predicts label "1" if the pair is similar or label "0" if they are dissimilar (accompanied with a probability).
 While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interface remains the same.
 With a FARMRanker, you can:
 * Directly get predictions (re-ranked version of the supplied list of Document) via predict() if supplying a pre-trained model

--- a/docs/_src/usage/usage/ranker.md
+++ b/docs/_src/usage/usage/ranker.md
@@ -30,7 +30,6 @@ Alternatively, [this example](https://github.com/deepset-ai/FARM/blob/master/exa
 ### Description
 
 The FARMRanker consists of a Transformer-based model for document re-ranking using the TextPairClassifier of [FARM](https://github.com/deepset-ai/FARM).
-Given a text pair of query and passage, the TextPairClassifier either predicts label "1" if the pair is similar or label "0" if they are dissimilar (accompanied with a probability).
 While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interface remains the same.
 With a FARMRanker, you can:
 * Directly get predictions (re-ranked version of the supplied list of Document) via predict() if supplying a pre-trained model

--- a/docs/_src/usage/usage/reader.md
+++ b/docs/_src/usage/usage/reader.md
@@ -272,9 +272,9 @@ print_answers(prediction, details="all")
 
 In order to align this probability score with the model's accuracy, finetuning needs to be performed
 on a specific dataset. 
-To this end, the reader has a `calibrate_confidence_scores()` method. 
-This method needs the has the same input parameters as the `eval()` method because the calibration of confidence scores is performed on a dataset that comes with gold labels.
-The calibration therefore needs a DocumentStore containing labeled questions and evaluation documents.
+To this end, the reader has a method `calibrate_confidence_scores(document_store, device, label_index, doc_index, label_origin)`.
+The parameters of this method are the same as for the `eval()` method because the calibration of confidence scores is performed on a dataset that comes with gold labels.
+The calibration calls the `eval()` method internally and therefore needs a DocumentStore containing labeled questions and evaluation documents.
 
 Have a look at this [FARM tutorial](https://github.com/deepset-ai/FARM/blob/master/examples/question_answering_confidence.py)
 to see how to compare calibrated confidence scores with uncalibrated confidence scores within FARM. 

--- a/docs/_src/usage/usage/reader.md
+++ b/docs/_src/usage/usage/reader.md
@@ -247,7 +247,7 @@ When printing the full results of a Reader,
 you will see that each prediction is accompanied 
 by a value in the range of 0 to 1 reflecting the model's confidence in that prediction
 
-In the output of `print_answers()`, you will find the model confidence in dictionary key called `probability`.
+In the output of `print_answers()`, you will find the model confidence in dictionary key called `confidence`.
 
 ```python
 from haystack.utils import print_answers
@@ -263,7 +263,7 @@ print_answers(prediction, details="all")
                        'She travels with her father, Eddard, to '
                        "King's Landing when he is made Hand of the "
                        'King. Before she leaves,',
-            'probability': 0.9899835586547852,
+            'confidence': 0.9899835586547852,
             ...
         },
     ]
@@ -271,9 +271,14 @@ print_answers(prediction, details="all")
 ```
 
 In order to align this probability score with the model's accuracy, finetuning needs to be performed
-on a specific dataset. Have a look at this [FARM tutorial](https://github.com/deepset-ai/FARM/blob/master/examples/question_answering_confidence.py)
-to see how this is done. 
-Note that a finetuned confidence score is specific to the domain that its finetuned on. 
+on a specific dataset. 
+To this end, the reader has a `calibrate_confidence_scores()` method. 
+This method needs the has the same input parameters as the `eval()` method because the calibration of confidence scores is performed on a dataset that comes with gold labels.
+The calibration therefore needs a DocumentStore containing labeled questions and evaluation documents.
+
+Have a look at this [FARM tutorial](https://github.com/deepset-ai/FARM/blob/master/examples/question_answering_confidence.py)
+to see how to compare calibrated confidence scores with uncalibrated confidence scores within FARM. 
+Note that a finetuned confidence score is specific to the domain that it is finetuned on. 
 There is no guarantee that this performance can transfer to a new domain.
 
 Having a confidence score is particularly useful in cases where you need Haystack to work with a certain accuracy threshold.

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -449,6 +449,7 @@ class FARMReader(BaseReader):
             label_index: str = "label",
             doc_index: str = "eval_document",
             label_origin: str = "gold_label",
+            calibrate_confidence_scores: bool = False
     ):
         """
         Performs evaluation on evaluation documents in the DocumentStore.
@@ -461,6 +462,8 @@ class FARMReader(BaseReader):
         :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
         :param label_index: Index/Table name where labeled questions are stored
         :param doc_index: Index/Table name where documents that are used for evaluation are stored
+        :param label_origin: Field name where the gold labels are stored
+        :param calibrate_confidence_scores: Whether to calibrate the temperature for temperature scaling of the confidence scores
         """
 
         if self.top_k_per_candidate != 4:
@@ -543,7 +546,7 @@ class FARMReader(BaseReader):
 
         evaluator = Evaluator(data_loader=data_loader, tasks=self.inferencer.processor.tasks, device=device)
 
-        eval_results = evaluator.eval(self.inferencer.model)
+        eval_results = evaluator.eval(self.inferencer.model, calibrate_confidence_scores=calibrate_confidence_scores)
         toc = perf_counter()
         reader_time = toc - tic
         results = {
@@ -602,6 +605,30 @@ class FARMReader(BaseReader):
         answers = answers[:top_k]
 
         return answers, max_no_ans_gap
+
+    def calibrate_confidence_scores(
+            self,
+            document_store: BaseDocumentStore,
+            device: str,
+            label_index: str = "label",
+            doc_index: str = "eval_document",
+            label_origin: str = "gold_label"
+    ):
+        """
+        Calibrates confidence scores on evaluation documents in the DocumentStore.
+
+        :param document_store: DocumentStore containing the evaluation documents
+        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
+        :param label_index: Index/Table name where labeled questions are stored
+        :param doc_index: Index/Table name where documents that are used for evaluation are stored
+        :param label_origin: Field name where the gold labels are stored
+        """
+        self.eval(document_store=document_store,
+                  device=device,
+                  label_index=label_index,
+                  doc_index=doc_index,
+                  label_origin=label_origin,
+                  calibrate_confidence_scores=True)
 
     @staticmethod
     def _get_pseudo_prob(score: float):

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -449,7 +449,7 @@ class FARMReader(BaseReader):
             label_index: str = "label",
             doc_index: str = "eval_document",
             label_origin: str = "gold_label",
-            calibrate_confidence_scores: bool = False
+            calibrate_conf_scores: bool = False
     ):
         """
         Performs evaluation on evaluation documents in the DocumentStore.
@@ -463,7 +463,7 @@ class FARMReader(BaseReader):
         :param label_index: Index/Table name where labeled questions are stored
         :param doc_index: Index/Table name where documents that are used for evaluation are stored
         :param label_origin: Field name where the gold labels are stored
-        :param calibrate_confidence_scores: Whether to calibrate the temperature for temperature scaling of the confidence scores
+        :param calibrate_conf_scores: Whether to calibrate the temperature for temperature scaling of the confidence scores
         """
 
         if self.top_k_per_candidate != 4:
@@ -546,7 +546,7 @@ class FARMReader(BaseReader):
 
         evaluator = Evaluator(data_loader=data_loader, tasks=self.inferencer.processor.tasks, device=device)
 
-        eval_results = evaluator.eval(self.inferencer.model, calibrate_confidence_scores=calibrate_confidence_scores)
+        eval_results = evaluator.eval(self.inferencer.model, calibrate_conf_scores=calibrate_conf_scores)
         toc = perf_counter()
         reader_time = toc - tic
         results = {
@@ -628,7 +628,7 @@ class FARMReader(BaseReader):
                   label_index=label_index,
                   doc_index=doc_index,
                   label_origin=label_origin,
-                  calibrate_confidence_scores=True)
+                  calibrate_conf_scores=True)
 
     @staticmethod
     def _get_pseudo_prob(score: float):


### PR DESCRIPTION
**Proposed changes**:
- Add more detailed documentation of confidence calibration to the reader's usage page.
- Add `calibrate_confidence_scores()` method to reader, which internally calls `eval()` method

closes #1032 