### PR TITLE
Remove Duplicate Benchmark Run

### DIFF
--- a/docs/_src/benchmarks/retriever_map.json
+++ b/docs/_src/benchmarks/retriever_map.json
@@ -36,16 +36,6 @@
             "map": 66.26543444531747
         },
         {
-            "model": "BM25 / Elasticsearch",
-            "n_docs": 100000,
-            "map": 56.200268351678716
-        },
-        {
-            "model": "BM25 / Elasticsearch",
-            "n_docs": 100000,
-            "map": 56.25299537353825
-        },
-        {
             "model": "Sentence Transformers / Elasticsearch",
             "n_docs": 1000,
             "map": 90.06638620360428
@@ -104,6 +94,11 @@
             "model": "DPR / Elasticsearch",
             "n_docs": 500000,
             "map": 80.86137228234091
+        },
+        {
+            "model": "BM25 / Elasticsearch",
+            "n_docs": 100000,
+            "map": 56.25299537353825
         },
         {
             "model": "BM25 / Elasticsearch",

--- a/docs/_src/benchmarks/retriever_performance.json
+++ b/docs/_src/benchmarks/retriever_performance.json
@@ -22,11 +22,11 @@
     },
     "data": [
         {
-            "model": "BM25 / Elasticsearch",
+            "model": "DPR / Elasticsearch",
             "n_docs": 100000,
-            "index_speed": 485.5602670200369,
-            "query_speed": 164.213361442627,
-            "map": 56.200268351678716
+            "index_speed": 71.36964873196698,
+            "query_speed": 5.192368815242574,
+            "map": 86.54606328368976
         },
         {
             "model": "BM25 / Elasticsearch",
@@ -34,13 +34,6 @@
             "index_speed": 485.5602670200369,
             "query_speed": 103.0884393334727,
             "map": 56.25299537353825
-        },
-        {
-            "model": "DPR / Elasticsearch",
-            "n_docs": 100000,
-            "index_speed": 71.36964873196698,
-            "query_speed": 5.192368815242574,
-            "map": 86.54606328368976
         },
         {
             "model": "Sentence Transformers / Elasticsearch",

--- a/docs/_src/benchmarks/retriever_speed.json
+++ b/docs/_src/benchmarks/retriever_speed.json
@@ -36,16 +36,6 @@
             "query_speed": 127.11481826852273
         },
         {
-            "model": "BM25 / Elasticsearch",
-            "n_docs": 100000,
-            "query_speed": 164.213361442627
-        },
-        {
-            "model": "BM25 / Elasticsearch",
-            "n_docs": 100000,
-            "query_speed": 103.0884393334727
-        },
-        {
             "model": "Sentence Transformers / Elasticsearch",
             "n_docs": 1000,
             "query_speed": 47.51341215808855
@@ -104,6 +94,11 @@
             "model": "DPR / Elasticsearch",
             "n_docs": 500000,
             "query_speed": 1.0337466563959614
+        },
+        {
+            "model": "BM25 / Elasticsearch",
+            "n_docs": 100000,
+            "query_speed": 103.0884393334727
         },
         {
             "model": "BM25 / Elasticsearch",


### PR DESCRIPTION
There is a duplicate benchmark run for BM25 / Elasticsearch at 100K docs.

The run is already removed from the csv. This PR removes it also from the json so that the website does not show it twice.