### PR TITLE
Add L2 support for FAISS HNSW

### DIFF
--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -88,6 +88,16 @@ class FAISSDocumentStore(SQLDocumentStore):
             embedding_field=embedding_field, progress_bar=progress_bar
         )
 
+        if similarity == "dot_product":
+            self.similarity = similarity
+            self.metric_type = faiss.METRIC_INNER_PRODUCT
+        elif similarity == "l2":
+            self.similarity = similarity
+            self.metric_type = faiss.METRIC_L2
+        else:
+            raise ValueError("The FAISS document store can currently only support dot_product similarity. "
+                             "Please set similarity=\"dot_product\"")
+
         self.vector_dim = vector_dim
         self.faiss_index_factory_str = faiss_index_factory_str
         self.faiss_indexes: Dict[str, faiss.swigfaiss.Index] = {}
@@ -97,17 +107,13 @@ class FAISSDocumentStore(SQLDocumentStore):
             self.faiss_indexes[index] = self._create_new_index(
                 vector_dim=self.vector_dim,
                 index_factory=faiss_index_factory_str,
-                metric_type=faiss.METRIC_INNER_PRODUCT,
+                metric_type=self.metric_type,
                 **kwargs
             )
 
         self.return_embedding = return_embedding
         self.embedding_field = embedding_field
-        if similarity == "dot_product":
-            self.similarity = similarity
-        else:
-            raise ValueError("The FAISS document store can currently only support dot_product similarity. "
-                             "Please set similarity=\"dot_product\"")
+
         self.progress_bar = progress_bar
         self.duplicate_documents = duplicate_documents
 
@@ -117,7 +123,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         )
 
     def _create_new_index(self, vector_dim: int, metric_type, index_factory: str = "Flat", **kwargs):
-        if index_factory == "HNSW" and metric_type == faiss.METRIC_INNER_PRODUCT:
+        if index_factory == "HNSW":
             # faiss index factory doesn't give the same results for HNSW IP, therefore direct init.
             # defaults here are similar to DPR codebase (good accuracy, but very high RAM consumption)
             n_links = kwargs.get("n_links", 64)

--- a/test/benchmarks/retriever_simplified.py
+++ b/test/benchmarks/retriever_simplified.py
@@ -1,11 +1,18 @@
-from haystack.document_store import MilvusDocumentStore
+"""
+This script performs the same query benchmarking as `retriever.py` but with less of the loops that iterate
+over all the parameters so that it is easier to inspect what is happening
+"""
+
+
+from haystack.document_store import MilvusDocumentStore, FAISSDocumentStore
 from haystack.retriever import DensePassageRetriever
 from retriever import prepare_data
 import datetime
 from pprint import pprint
 from milvus import IndexType
+from utils import get_document_store
 
-def main(index_type, n_docs=100_000, similarity="dot_product"):
+def benchmark_querying(index_type, n_docs=100_000, similarity="dot_product"):
 
     doc_index = "document"
     label_index = "label"
@@ -21,18 +28,23 @@ def main(index_type, n_docs=100_000, similarity="dot_product"):
         add_precomputed=True
     )
 
-    if index_type == "flat":
-        doc_store = MilvusDocumentStore(index=doc_index, similarity=similarity)
-    elif index_type == "hnsw":
-        index_param = {"M": 64, "efConstruction": 80}
-        search_param = {"ef": 20}
-        doc_store = MilvusDocumentStore(
-            index=doc_index,
-            index_type=IndexType.HNSW,
-            index_param=index_param,
-            search_param=search_param,
-            similarity=similarity
-        )
+    doc_store = get_document_store(
+        document_store_type=index_type,
+        similarity=similarity
+    )
+
+    # if index_type == "milvus_flat":
+    #     doc_store = MilvusDocumentStore(index=doc_index, similarity=similarity)
+    # elif index_type == "milvus_hnsw":
+    #     index_param = {"M": 64, "efConstruction": 80}
+    #     search_param = {"ef": 20}
+    #     doc_store = MilvusDocumentStore(
+    #         index=doc_index,
+    #         index_type=IndexType.HNSW,
+    #         index_param=index_param,
+    #         search_param=search_param,
+    #         similarity=similarity
+    #     )
 
     doc_store.write_documents(documents=docs, index=doc_index)
     doc_store.write_labels(labels=labels, index=label_index)
@@ -65,7 +77,9 @@ def main(index_type, n_docs=100_000, similarity="dot_product"):
 
 if __name__ == "__main__":
     similarity = "l2"
-    n_docs = 100_000
+    n_docs = 1000
 
-    main(index_type="flat", similarity=similarity, n_docs=n_docs)
-    main(index_type="hnsw", similarity=similarity, n_docs=n_docs)
+    benchmark_querying(index_type="milvus_flat", similarity=similarity, n_docs=n_docs)
+    benchmark_querying(index_type="milvus_hnsw", similarity=similarity, n_docs=n_docs)
+    benchmark_querying(index_type="faiss_flat", similarity=similarity, n_docs=n_docs)
+    benchmark_querying(index_type="faiss_hnsw", similarity=similarity, n_docs=n_docs)

--- a/test/benchmarks/utils.py
+++ b/test/benchmarks/utils.py
@@ -25,7 +25,7 @@ reader_types = ["farm"]
 doc_index = "eval_document"
 label_index = "label"
 
-def get_document_store(document_store_type, similarity='dot_product'):
+def get_document_store(document_store_type, similarity='dot_product', index="document"):
     """ TODO This method is taken from test/conftest.py but maybe should be within Haystack.
     Perhaps a class method of DocStore that just takes string for type of DocStore"""
     if document_store_type == "sql":
@@ -49,7 +49,13 @@ def get_document_store(document_store_type, similarity='dot_product'):
             index_type = IndexType.HNSW
             index_param = {"M": 64, "efConstruction": 80}
             search_param = {"ef": 20}
-        document_store = MilvusDocumentStore(similarity=similarity, index_type=index_type, index_param=index_param, search_param=search_param)
+        document_store = MilvusDocumentStore(
+            similarity=similarity,
+            index_type=index_type,
+            index_param=index_param,
+            search_param=search_param,
+            index=index
+        )
         assert document_store.get_document_count(index="eval_document") == 0
     elif document_store_type in("faiss_flat", "faiss_hnsw"):
         if document_store_type == "faiss_flat":
@@ -67,9 +73,12 @@ def get_document_store(document_store_type, similarity='dot_product'):
         status = subprocess.run(
             ['docker exec haystack-postgres psql -U postgres -c "CREATE DATABASE haystack;"'], shell=True)
         time.sleep(1)
-        document_store = FAISSDocumentStore(sql_url="postgresql://postgres:password@localhost:5432/haystack",
-                                            faiss_index_factory_str=index_type,
-                                            similarity=similarity)
+        document_store = FAISSDocumentStore(
+            sql_url="postgresql://postgres:password@localhost:5432/haystack",
+            faiss_index_factory_str=index_type,
+            similarity=similarity,
+            index=index
+        )
         assert document_store.get_document_count() == 0
 
     else:


### PR DESCRIPTION
Allows FAISS HNSW to be initialized with L2 similarity. Also allows for more DocumentStore options in  `test/benchmarks/retriever_simplified.py`