### PR TITLE
WIP: bump FARM to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-farm==0.7.1
+farm==0.8.1
 --find-links=https://download.pytorch.org/whl/torch_stable.html
 fastapi
 uvicorn


### PR DESCRIPTION
Before the next release of Haystack, we need to upgrade to the newest FARM version 0.8.0.