### PR TITLE
Bump to FARM 0.8.0, torch 1.8.1 and transformers 4.6.1

### DIFF
--- a/haystack/graph_retriever/text_to_sparql.py
+++ b/haystack/graph_retriever/text_to_sparql.py
@@ -28,7 +28,7 @@ class Text2SparqlRetriever(BaseGraphRetriever):
 
         self.knowledge_graph = knowledge_graph
         # TODO We should extend this to any seq2seq models and use the AutoModel class
-        self.model = BartForConditionalGeneration.from_pretrained(model_name_or_path, force_bos_token_to_be_generated=True)
+        self.model = BartForConditionalGeneration.from_pretrained(model_name_or_path, forced_bos_token_id=0)
         self.tok = BartTokenizer.from_pretrained(model_name_or_path)
         self.top_k = top_k
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-farm==0.7.1
+farm==0.8.1
 --find-links=https://download.pytorch.org/whl/torch_stable.html
 fastapi
 uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-farm==0.8.1
+farm==0.8.0
 --find-links=https://download.pytorch.org/whl/torch_stable.html
 fastapi
 uvicorn


### PR DESCRIPTION
Before the next Haystack release, we need to upgrade FARM from 0.7.1 to 0.8.0

I see only one problem that needs to be fixed. It's about the Text2SPARQL Retriever. The parameter `force_bos_token_to_be_generated` of the method `BartForConditionalGeneration.from_pretrained() `is deprecated now. as also discussed here https://github.com/huggingface/transformers/issues/11952 

All other tests pass and except for the transformers and torch upgrades there were no major changes in FARM. For DPR, I tested FARM and Haystack and we also got confirmation from https://github.com/deepset-ai/haystack/issues/1046#issuecomment-858559193 