### PR TITLE
Remove quickfix from reader and ranker

### DIFF
--- a/haystack/ranker/farm.py
+++ b/haystack/ranker/farm.py
@@ -172,7 +172,7 @@ class FARMRanker(BaseRanker):
 
         # 3. Create an optimizer and pass the already initialized model
         model, optimizer, lr_schedule = initialize_optimizer(
-            model=model,
+            model=self.inferencer.model,
             learning_rate=learning_rate,
             schedule_opts={"name": "LinearWarmup", "warmup_proportion": warmup_proportion},
             n_batches=len(data_silo.loaders["train"]),

--- a/haystack/ranker/farm.py
+++ b/haystack/ranker/farm.py
@@ -7,10 +7,8 @@ from farm.data_handler.data_silo import DataSilo
 from farm.data_handler.processor import TextPairClassificationProcessor
 from farm.infer import Inferencer
 from farm.modeling.optimization import initialize_optimizer
-from farm.modeling.adaptive_model import BaseAdaptiveModel
 from farm.train import Trainer
 from farm.utils import set_all_seeds, initialize_device_settings
-import shutil
 
 from haystack import Document
 from haystack.ranker.base import BaseRanker
@@ -171,13 +169,6 @@ class FARMRanker(BaseRanker):
         # 2. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them
         # and calculates a few descriptive statistics of our datasets
         data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False, max_processes=num_processes)
-
-        # Quick-fix until this is fixed upstream in FARM:
-        # We must avoid applying DataParallel twice (once when loading the inferencer,
-        # once when calling initalize_optimizer)
-        self.inferencer.model.save("tmp_model")
-        model = BaseAdaptiveModel.load(load_dir="tmp_model", device=device, strict=True)
-        shutil.rmtree('tmp_model')
 
         # 3. Create an optimizer and pass the already initialized model
         model, optimizer, lr_schedule = initialize_optimizer(

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -13,12 +13,11 @@ from farm.data_handler.inputs import QAInput, Question
 from farm.infer import QAInferencer
 from farm.modeling.optimization import initialize_optimizer
 from farm.modeling.predictions import QAPred, QACandidate
-from farm.modeling.adaptive_model import BaseAdaptiveModel, AdaptiveModel
+from farm.modeling.adaptive_model import AdaptiveModel
 from farm.train import Trainer
 from farm.eval import Evaluator
 from farm.utils import set_all_seeds, initialize_device_settings
 from scipy.special import expit
-import shutil
 
 from haystack import Document
 from haystack.document_store.base import BaseDocumentStore
@@ -220,13 +219,6 @@ class FARMReader(BaseReader):
         # 2. Create a DataSilo that loads several datasets (train/dev/test), provides DataLoaders for them
         # and calculates a few descriptive statistics of our datasets
         data_silo = DataSilo(processor=processor, batch_size=batch_size, distributed=False, max_processes=num_processes)
-
-        # Quick-fix until this is fixed upstream in FARM:
-        # We must avoid applying DataParallel twice (once when loading the inferencer,
-        # once when calling initalize_optimizer)
-        self.inferencer.model.save("tmp_model")
-        model = BaseAdaptiveModel.load(load_dir="tmp_model", device=device, strict=True)
-        shutil.rmtree('tmp_model')
 
         # 3. Create an optimizer and pass the already initialized model
         model, optimizer, lr_schedule = initialize_optimizer(

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -222,7 +222,7 @@ class FARMReader(BaseReader):
 
         # 3. Create an optimizer and pass the already initialized model
         model, optimizer, lr_schedule = initialize_optimizer(
-            model=model,
+            model=self.inferencer.model,
             # model=self.inferencer.model,
             learning_rate=learning_rate,
             schedule_opts={"name": "LinearWarmup", "warmup_proportion": warmup_proportion},


### PR DESCRIPTION
#234 introduced a quickfix that prevented Dataparallel from being applied twice. This quickfix is not needed anymore as the call of optimize_model in the Inferencer has been removed here deepset-ai/FARM@94c6b8d#diff-8a98ef73f1fa756ee7fdc0cd3a2f8bdc07f4e2eb490111356337ddc8c170066cR278

closes #1093 