### PR TITLE
Improve document stores unit test parametrization

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,6 +32,24 @@ from haystack.summarizer.transformers import TransformersSummarizer
 from haystack.translator import TransformersTranslator
 
 
+def pytest_addoption(parser):
+    parser.addoption("--document_store_type", action="store", default="all")
+
+
+def pytest_generate_tests(metafunc):
+    mark = metafunc.definition.get_closest_marker('parametrize')
+    # parametrize document_store fixture if it's in the test function argument list
+    # but does not have an explicit parametrize annotation e.g
+    # @pytest.mark.parametrize("document_store", ["memory"], indirect=False)
+    if (not mark or 'document_store' not in mark.args[0]) and 'document_store' in metafunc.fixturenames:
+        document_store_type = metafunc.config.option.document_store_type
+        if "all" in document_store_type:
+            document_store_type = "elasticsearch, faiss, memory, milvus, weaviate"
+
+        document_store_types = [item.strip() for item in document_store_type.split(",")]
+        metafunc.parametrize("document_store", document_store_types, indirect=True)
+
+
 def _sql_session_rollback(self, attr):
     """
     Inject SQLDocumentStore at runtime to do a session rollback each time it is called. This allows to catch
@@ -348,7 +366,8 @@ def document_store_with_docs(request, test_docs_xs):
     yield document_store
     document_store.delete_all_documents()
 
-@pytest.fixture(params=["elasticsearch", "faiss", "memory", "sql", "milvus"])
+
+@pytest.fixture
 def document_store(request, test_docs_xs):
     vector_dim = request.node.get_closest_marker("vector_dim", pytest.mark.vector_dim(768))
     document_store = get_document_store(request.param, vector_dim.args[0])

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -49,7 +49,7 @@ def pytest_generate_tests(metafunc):
     if 'document_store' in metafunc.fixturenames and not found_mark_parametrize_document_store:
         document_store_type = metafunc.config.option.document_store_type
         if "all" in document_store_type:
-            document_store_type = "elasticsearch, faiss, memory, milvus, weaviate"
+            document_store_type = "elasticsearch, faiss, memory, milvus, sql"
 
         document_store_types = [item.strip() for item in document_store_type.split(",")]
         metafunc.parametrize("document_store", document_store_types, indirect=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,11 +37,16 @@ def pytest_addoption(parser):
 
 
 def pytest_generate_tests(metafunc):
-    mark = metafunc.definition.get_closest_marker('parametrize')
     # parametrize document_store fixture if it's in the test function argument list
     # but does not have an explicit parametrize annotation e.g
     # @pytest.mark.parametrize("document_store", ["memory"], indirect=False)
-    if (not mark or 'document_store' not in mark.args[0]) and 'document_store' in metafunc.fixturenames:
+    found_mark_parametrize_document_store = False
+    for marker in metafunc.definition.iter_markers('parametrize'):
+        if 'document_store' in marker.args[0]:
+            found_mark_parametrize_document_store = True
+            break
+
+    if 'document_store' in metafunc.fixturenames and not found_mark_parametrize_document_store:
         document_store_type = metafunc.config.option.document_store_type
         if "all" in document_store_type:
             document_store_type = "elasticsearch, faiss, memory, milvus, weaviate"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -49,7 +49,7 @@ def pytest_generate_tests(metafunc):
     if 'document_store' in metafunc.fixturenames and not found_mark_parametrize_document_store:
         document_store_type = metafunc.config.option.document_store_type
         if "all" in document_store_type:
-            document_store_type = "elasticsearch, faiss, memory, milvus, sql"
+            document_store_type = "elasticsearch, faiss, memory, milvus"
 
         document_store_types = [item.strip() for item in document_store_type.split(",")]
         metafunc.parametrize("document_store", document_store_types, indirect=True)

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -32,7 +32,6 @@ def test_init_elastic_client():
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "sql", "milvus"], indirect=True)
 def test_write_with_duplicate_doc_ids(document_store):
     documents = [
         Document(
@@ -158,7 +157,6 @@ def test_get_all_documents_generator(document_store):
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "sql", "faiss", "milvus"], indirect=True)
 @pytest.mark.parametrize("update_existing_documents", [True, False])
 def test_update_existing_documents(document_store, update_existing_documents):
     original_docs = [
@@ -221,7 +219,6 @@ def test_write_document_index(document_store):
 
 
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus"], indirect=True)
 def test_document_with_embeddings(document_store):
     documents = [
         {"text": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
@@ -240,7 +237,6 @@ def test_document_with_embeddings(document_store):
 
 
 @pytest.mark.parametrize("retriever", ["dpr", "embedding"], indirect=True)
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus"], indirect=True)
 def test_update_embeddings(document_store, retriever):
     documents = []
     for i in range(6):

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -435,7 +435,6 @@ def test_generator_pipeline(document_store, retriever, rag_generator):
 @pytest.mark.slow
 @pytest.mark.generator
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus"], indirect=True)
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
 def test_lfqa_pipeline(document_store, retriever, eli5_generator):

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -140,7 +140,6 @@ def test_elasticsearch_custom_query(elasticsearch_fixture):
 
 @pytest.mark.slow
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus"], indirect=True)
 @pytest.mark.parametrize("retriever", ["dpr"], indirect=True)
 def test_dpr_embedding(document_store, retriever):
 
@@ -164,7 +163,6 @@ def test_dpr_embedding(document_store, retriever):
 
 @pytest.mark.slow
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus"], indirect=True)
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
 def test_retribert_embedding(document_store, retriever):


### PR DESCRIPTION
**Proposed changes**:

Parametrizes document store tests allowing developers to select a subset of document stores in the generic document store related tests. 

~~This is just a preview and request for feedback. Only test/test_retriever.py tests have been updated for this preview. Updating other tests is trivial given this approach is approved.~~ All relevant generic document store tests have been updated.

To run tests for all document stores, an explicit parametrize annotation marker with a list of all document stores needs to be removed from a unit test function (see diff). However, we want to leave a particular explicit parametrize annotation in some test cases as the test might test a particular functionality for a specific document store. 


To try out an updated test approach, we'll focus on test_dpr_embedding test in test_retriever.py

To run tests for all document stores, no changes in pytest command invocation are needed. That remains a default option.
To run a particular test or a subset of tests with a desired document store type a developer needs to add a command-line parameter. For example, to run test for faiss only one should invoke this command: 

```
pytest -v test_retriever.py::test_dpr_embedding --document_store_type="faiss" 
```

One can also run a test on a subset of document stores:

```
pytest -v test_retriever.py::test_dpr_embedding --document_store_type="faiss, memory" 
```

Resolves https://github.com/deepset-ai/haystack/issues/1108 
Looking forward to your feedback.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
