### PR TITLE
Use Reader's device by default

### DIFF
--- a/haystack/generator/transformers.py
+++ b/haystack/generator/transformers.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy
 import torch
+from farm.utils import initialize_device_settings
 from transformers import RagTokenizer, RagTokenForGeneration, AutoTokenizer, \
     AutoModelForSeq2SeqLM, PreTrainedTokenizer, BatchEncoding
 

--- a/haystack/generator/transformers.py
+++ b/haystack/generator/transformers.py
@@ -11,7 +11,6 @@ from transformers import RagTokenizer, RagTokenForGeneration, AutoTokenizer, \
 from haystack import Document
 from haystack.generator.base import BaseGenerator
 from haystack.retriever.dense import DensePassageRetriever
-from haystack.utils import get_device
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +118,7 @@ class RAGenerator(BaseGenerator):
 
         self.top_k = top_k
 
-        self.device = get_device(use_gpu)
+        self.device, _ = initialize_device_settings(use_cuda=use_gpu)
 
         self.tokenizer = RagTokenizer.from_pretrained(model_name_or_path)
 
@@ -377,7 +376,7 @@ class Seq2SeqGenerator(BaseGenerator):
 
         self.top_k = top_k
 
-        self.device = get_device(use_gpu)
+        self.device, _ = initialize_device_settings(use_cuda=use_gpu)
 
         Seq2SeqGenerator._register_converters(model_name_or_path, input_converter)
 

--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -124,6 +124,7 @@ class FARMReader(BaseReader):
         self.max_seq_len = max_seq_len
         self.use_gpu = use_gpu
         self.progress_bar = progress_bar
+        self.device, _ = initialize_device_settings(use_cuda=self.use_gpu)
 
     def train(
         self,
@@ -392,7 +393,7 @@ class FARMReader(BaseReader):
 
         return result
 
-    def eval_on_file(self, data_dir: str, test_filename: str, device: str):
+    def eval_on_file(self, data_dir: str, test_filename: str, device: Optional[str] = None):
         """
         Performs evaluation on a SQuAD-formatted file.
         Returns a dict containing the following metrics:
@@ -404,9 +405,11 @@ class FARMReader(BaseReader):
         :type data_dir: Path or str
         :param test_filename: The name of the file containing the test data in SQuAD format.
         :type test_filename: str
-        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
+        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda" or use the Reader's device by default.
         :type device: str
         """
+        if device is None:
+            device = self.device
         eval_processor = SquadProcessor(
             tokenizer=self.inferencer.processor.tokenizer,
             max_seq_len=self.inferencer.processor.max_seq_len,
@@ -435,7 +438,7 @@ class FARMReader(BaseReader):
     def eval(
             self,
             document_store: BaseDocumentStore,
-            device: str,
+            device: Optional[str] = None,
             label_index: str = "label",
             doc_index: str = "eval_document",
             label_origin: str = "gold_label",
@@ -449,13 +452,14 @@ class FARMReader(BaseReader):
               - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
         :param document_store: DocumentStore containing the evaluation documents
-        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
+        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda" or use the Reader's device by default.
         :param label_index: Index/Table name where labeled questions are stored
         :param doc_index: Index/Table name where documents that are used for evaluation are stored
         :param label_origin: Field name where the gold labels are stored
         :param calibrate_conf_scores: Whether to calibrate the temperature for temperature scaling of the confidence scores
         """
-
+        if device is None:
+            device = self.device
         if self.top_k_per_candidate != 4:
             logger.info(f"Performing Evaluation using top_k_per_candidate = {self.top_k_per_candidate} \n"
                         f"and consequently, QuestionAnsweringPredictionHead.n_best = {self.top_k_per_candidate + 1}. \n"
@@ -601,7 +605,7 @@ class FARMReader(BaseReader):
     def calibrate_confidence_scores(
             self,
             document_store: BaseDocumentStore,
-            device: str,
+            device: Optional[str] = None,
             label_index: str = "label",
             doc_index: str = "eval_document",
             label_origin: str = "gold_label"
@@ -610,11 +614,13 @@ class FARMReader(BaseReader):
         Calibrates confidence scores on evaluation documents in the DocumentStore.
 
         :param document_store: DocumentStore containing the evaluation documents
-        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
+        :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda" or use the Reader's device by default.
         :param label_index: Index/Table name where labeled questions are stored
         :param doc_index: Index/Table name where documents that are used for evaluation are stored
         :param label_origin: Field name where the gold labels are stored
         """
+        if device is None:
+            device = self.device
         self.eval(document_store=document_store,
                   device=device,
                   label_index=label_index,

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -4,6 +4,8 @@ from typing import List, Union, Optional
 import torch
 import numpy as np
 from pathlib import Path
+
+from farm.utils import initialize_device_settings
 from tqdm.auto import tqdm
 from transformers import AutoTokenizer, AutoModel
 

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -10,7 +10,6 @@ from transformers import AutoTokenizer, AutoModel
 from haystack.document_store.base import BaseDocumentStore
 from haystack import Document
 from haystack.retriever.base import BaseRetriever
-from haystack.utils import get_device
 
 from farm.infer import Inferencer
 from farm.modeling.tokenization import Tokenizer
@@ -121,7 +120,7 @@ class DensePassageRetriever(BaseRetriever):
                            "We recommend you use dot_product instead. "
                            "This can be set when initializing the DocumentStore")
 
-        self.device = get_device(use_gpu)
+        self.device, _ = initialize_device_settings(use_cuda=use_gpu)
 
         self.infer_tokenizer_classes = infer_tokenizer_classes
         tokenizers_default_classes = {
@@ -628,7 +627,7 @@ class _SentenceTransformersEmbeddingEncoder(_EmbeddingEncoder):
                               "For details see https://github.com/UKPLab/sentence-transformers ")
         # pretrained embedding models coming from: https://github.com/UKPLab/sentence-transformers#pretrained-models
         # e.g. 'roberta-base-nli-stsb-mean-tokens'
-        device = get_device(retriever.use_gpu)
+        device, _ = initialize_device_settings(use_cuda=retriever.use_gpu)
         self.embedding_model = SentenceTransformer(retriever.embedding_model, device=device)
         self.show_progress_bar = retriever.progress_bar
         document_store = retriever.document_store

--- a/haystack/utils.py
+++ b/haystack/utils.py
@@ -200,9 +200,3 @@ def get_batches_from_generator(iterable, n):
     while x:
         yield x
         x = tuple(islice(it, n))
-
-
-def get_device(use_gpu: bool = True) -> str:
-    if use_gpu and torch.cuda.is_available():
-        return "cuda"
-    return "cpu"


### PR DESCRIPTION
**Proposed changes**:
- `init()` method now runs `initialize_device_settings(use_cuda=self.use_gpu)` to get Reader's device
- Reader's device is now used as default device of `eval()`, `eval_from_file()`, and `calibrate_confidence_scores()` but can be overwritten when calling these methods
- doc strings are updated accordingly

Note that `train()` also calls `initialize_device_settings(use_cuda=use_gpu,use_amp=use_amp)` as before because `train()` can be initialized with other a different value for `use_gpu` than the Reader itself.

closes #1137 