### PR TITLE
Relax typing for meta data

### DIFF
--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 
 from fastapi import APIRouter
 from pydantic import BaseModel
@@ -33,7 +33,7 @@ class Answer(BaseModel):
     offset_start_in_doc: Optional[int]
     offset_end_in_doc: Optional[int]
     document_id: Optional[str] = None
-    meta: Optional[Dict[str, str]]
+    meta: Optional[Dict[str, Any]]
 
 
 class Response(BaseModel):


### PR DESCRIPTION
Fix for #1122 

Let's not be so strict in what type of meta data we return. Even though we can't filter for other types yes, we could at least allow returning docs with these properties 