### PR TITLE
WIP: Fix issues with writing documents to Weaviate

### DIFF
--- a/haystack/document_store/__init__.py
+++ b/haystack/document_store/__init__.py
@@ -3,3 +3,4 @@ from haystack.document_store.faiss import FAISSDocumentStore
 from haystack.document_store.memory import InMemoryDocumentStore
 from haystack.document_store.milvus import MilvusDocumentStore
 from haystack.document_store.sql import SQLDocumentStore
+from haystack.document_store.weaviate import WeaviateDocumentStore

--- a/haystack/document_store/weaviate.py
+++ b/haystack/document_store/weaviate.py
@@ -378,7 +378,6 @@ class WeaviateDocumentStore(BaseDocumentStore):
                             _doc[k] = v
                         _doc.pop("meta")
 
-                    doc_id = str(_doc.pop("id"))
                     vector = _doc.pop(self.embedding_field)
                     if _doc.get(self.faq_question_field) is None:
                         _doc.pop(self.faq_question_field)
@@ -391,7 +390,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
                             self._update_schema(property, index)
                             current_properties.append(property)
 
-                    docs_batch.add(_doc, class_name=index, uuid=doc_id, vector=vector)
+                    docs_batch.add(_doc, class_name=index, uuid=None, vector=vector)
 
                 # Ingest a batch of documents
                 results = self.weaviate_client.batch.create(docs_batch)

--- a/haystack/utils.py
+++ b/haystack/utils.py
@@ -58,6 +58,20 @@ def launch_milvus():
         time.sleep(15)
 
 
+def launch_weaviate():
+    # Start a Weaviate server via Docker
+
+    logger.info("Starting Weaviate ...")
+    status = subprocess.run(
+        ["docker run -d -p 8080:8080 --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' semitechnologies/weaviate:1.4.0"], shell=True
+    )
+    if status.returncode:
+        logger.warning("Tried to start Weaviate through Docker but this failed. "
+                       "It is likely that there is already an existing Weaviate instance running. ")
+    else:
+        time.sleep(15)
+
+
 def print_answers(results: dict, details: str = "all"):
     # TODO: unify the output format of Generator and Reader so that this function doesn't have the try/except
     #  Or implement a class method like PredReader.print() and PredGenerator.print() that handles all this functionality.

--- a/tutorials/weaviate_debug.py
+++ b/tutorials/weaviate_debug.py
@@ -1,0 +1,49 @@
+
+
+import logging
+import subprocess
+import time
+
+from haystack.document_store import WeaviateDocumentStore
+from haystack.preprocessor.cleaning import clean_wiki_text
+from haystack.preprocessor.utils import convert_files_to_dicts, fetch_archive_from_http
+from haystack.reader.farm import FARMReader
+from haystack.reader.transformers import TransformersReader
+from haystack.utils import print_answers, launch_weaviate
+from haystack.retriever.dense import DensePassageRetriever
+
+index="Document"
+
+def weaviate_debug():
+    logger = logging.getLogger(__name__)
+    launch_weaviate()
+
+    document_store = WeaviateDocumentStore(index=index)
+    document_store.delete_all_documents(index=index)
+
+    doc_dir = "data/article_txt_got"
+    s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt.zip"
+    fetch_archive_from_http(url=s3_url, output_dir=doc_dir)
+
+    dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, split_paragraphs=True)
+
+    document_store.write_documents(dicts, index=index)
+
+    retriever = DensePassageRetriever(document_store=document_store)
+
+    document_store.update_embeddings(retriever)
+
+    reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
+
+    from haystack.pipeline import ExtractiveQAPipeline
+    pipe = ExtractiveQAPipeline(reader, retriever)
+
+    ## Voilà! Ask a question!
+    prediction = pipe.run(query="Who is the father of Arya Stark?", top_k_retriever=10, top_k_reader=5)
+
+
+    print_answers(prediction, details="minimal")
+
+
+if __name__ == "__main__":
+    weaviate_debug()

--- a/tutorials/weaviate_debug.py
+++ b/tutorials/weaviate_debug.py
@@ -31,6 +31,9 @@ def weaviate_debug():
 
     retriever = DensePassageRetriever(document_store=document_store)
 
+    all_docs = document_store.get_all_documents()
+    _ = document_store.get_document_by_id(all_docs[0].id)
+
     document_store.update_embeddings(retriever)
 
     reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)


### PR DESCRIPTION
In the past, the document id was passed in to Weaviate as the uid. However, this would raise the following error if the id is not in a Weaviate compatible format: `ValueError: Not valid 'uuid' or 'uuid' can not be extracted from value`.

This PR stops the program from passing the document id into weaviate. Weaviate uids are now generated for each document as it is being indexed.