### PR TITLE
[document_store] SQLDocumentStore get_label_count() index bug fixed.

### DIFF
--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -406,7 +406,7 @@ class SQLDocumentStore(BaseDocumentStore):
         """
         Return the number of labels in the document store
         """
-        index = index or self.index
+        index = index or self.label_index
         return self.session.query(LabelORM).filter_by(index=index).count()
 
     def _convert_sql_row_to_document(self, row) -> Document:


### PR DESCRIPTION
**Proposed changes**:
-In SQLDocumentStore write_labels using `self.label_index` and when calling get_label_count() we are using a different `self.index.` To solve this bug both indexes should be the same for labels.


**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [X] Final code
- [ ] Added tests
