### PR TITLE
ElasticsearchDocumentStore get_label_count() bug fixed.

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -517,6 +517,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         """
         Return the number of labels in the document store
         """
+        index = index or self.label_index
         return self.get_document_count(index=index)
 
     def get_embedding_count(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> int:


### PR DESCRIPTION
**Proposed changes**:
- Missing label_index var added.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [X] Final code
- [ ] Added tests
- [ ] Updated documentation
