### PR TITLE
Add Ray integration for Pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
     - name: Run Apache Tika
       run: docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
 
+    - name: Run Ray
+      run: ray start --head
+
     - name: Install pdftotext
       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
     - name: Run Apache Tika
       run: docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
 
-#    - name: Run Ray
-#      run: ray start --head
+    - name: Run Ray
+      run: ray start --head
 
     - name: Install pdftotext
       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
 
     - name: Run tests
-      run: cd test && pytest ${{ matrix.test-path }}
+      run: cd test && pytest -s ${{ matrix.test-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
     - name: Run Apache Tika
       run: docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
 
-    - name: Run Ray
-      run: RAY_DISABLE_MEMORY_MONITOR=1 ray start --head
+#    - name: Run Ray
+#      run: RAY_DISABLE_MEMORY_MONITOR=1 ray start --head
 
     - name: Install pdftotext
       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       run: docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
 
     - name: Run Ray
-      run: ray start --head
+      run: RAY_DISABLE_MEMORY_MONITOR=1 ray start --head
 
     - name: Install pdftotext
       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
     - name: Run Apache Tika
       run: docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
 
-    - name: Run Ray
-      run: ray start --head
+#    - name: Run Ray
+#      run: ray start --head
 
     - name: Install pdftotext
       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -955,12 +955,11 @@ class JoinDocuments(BaseComponent):
 
 
 class RayPipeline(Pipeline):
-    def __init__(self, address: str = None):
+    def __init__(self, address: str = None, **kwargs):
         """
         :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
         """
-        if address:
-            ray.init(address=address)
+        ray.init(address=address, **kwargs)
         serve.start()
         super().__init__()
 
@@ -970,6 +969,7 @@ class RayPipeline(Pipeline):
             path: Path, pipeline_name: Optional[str] = None,
             overwrite_with_env_variables: bool = True,
             address: Optional[str] = None,
+            **kwargs,
     ):
         """
         Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -1017,7 +1017,7 @@ class RayPipeline(Pipeline):
         data, pipeline_config, definitions = cls._read_yaml(
             path=path, pipeline_name=pipeline_name, overwrite_with_env_variables=overwrite_with_env_variables
         )
-        pipeline = cls(address=address)
+        pipeline = cls(address=address, **kwargs)
 
         for node_config in pipeline_config["nodes"]:
             if pipeline.root_node is None:

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -10,8 +10,14 @@ from typing import List, Optional, Dict, Union, Any
 import pickle
 import urllib
 from functools import wraps
-import ray
-from ray import serve
+
+try:
+    from ray import serve
+    import ray
+except:
+    ray = None
+    serve = None
+
 
 from transformers import AutoTokenizer, AutoModelForSequenceClassification, TextClassificationPipeline
 

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -1091,7 +1091,8 @@ class RayPipeline(Pipeline):
         """
         Add the Ray deployment handle in the Pipeline Graph.
 
-        :param handle: Ray deployment `handle` to add in the Pipeline Graph.
+        :param handle: Ray deployment `handle` to add in the Pipeline Graph. The handle allow calling a Ray deployment
+                       from Python: https://docs.ray.io/en/master/serve/package-ref.html#servehandle-api.
         :param name: The name for the node. It must not contain any dots.
         :param inputs: A list of inputs to the node. If the predecessor node has a single outgoing edge, just the name
                        of node is sufficient. For instance, a 'ElasticsearchRetriever' node would always output a single

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -1204,13 +1204,31 @@ class RayPipeline(Pipeline):
 
 
 class _RayDeploymentWrapper:
+    """
+    Ray Serve supports calling of __init__ methods on the Classes to create "deployment" instances.
+
+    In case of Haystack, some Components like Retrievers have complex init methods that needs objects
+    like Document Stores.
+
+    This wrapper class encapsulates the initialization of Components. Given a Component Class
+    name, it creates an instance using the YAML Pipeline config.
+    """
     node: BaseComponent
 
-    def __init__(self, pipeline_config, component_name):
+    def __init__(self, pipeline_config: dict, component_name: str):
+        """
+        Create an instance of Component.
+
+        :param pipeline_config: Pipeline YAML parsed as a dict.
+        :param component_name: Component Class name.
+        """
         if component_name in ["Query", "File"]:
             self.node = RootNode()
         else:
             self.node = BaseComponent.load_from_pipeline_config(pipeline_config, component_name)
 
     def __call__(self, *args, **kwargs):
+        """
+        Ray calls this method which is then re-directed to the corresponding component's run().
+        """
         return self.node.run(*args, **kwargs)

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -78,7 +78,7 @@ class BasePipeline:
         return pipeline_config
 
     @classmethod
-    def _read_yaml(cls, path: Path, pipeline_name: str, overwrite_with_env_variables: bool):
+    def _read_yaml(cls, path: Path, pipeline_name: Optional[str], overwrite_with_env_variables: bool):
         """
         Parse the YAML and return the full YAML config, pipeline_config, and definitions of all components.
 

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -934,12 +934,20 @@ class RayPipeline(Pipeline):
         """
         :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
         """
-        ray.init(address=address)
+        if address:
+            ray.init(address=address)
+        else:
+            serve.start()
         serve.start()
         super().__init__()
 
     @classmethod
-    def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True):
+    def load_from_yaml(
+            cls,
+            path: Path, pipeline_name: Optional[str] = None,
+            overwrite_with_env_variables: bool = True,
+            address: Optional[str] = None,
+    ):
         """
         Load Pipeline from a YAML file defining the individual components and how they're tied together to form
         a Pipeline. A single YAML can declare multiple Pipelines, in which case an explicit `pipeline_name` must
@@ -981,6 +989,7 @@ class RayPipeline(Pipeline):
                                              to change index name param for an ElasticsearchDocumentStore, an env
                                              variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
                                              `_` sign must be used to specify nested hierarchical properties.
+        :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
         """
         with open(path, "r", encoding="utf-8") as stream:
             data = yaml.safe_load(stream)
@@ -995,7 +1004,7 @@ class RayPipeline(Pipeline):
             name = definition.pop("name")
             definitions[name] = definition
 
-        pipeline = cls()
+        pipeline = cls(address=address)
 
         for node_config in pipeline_config["nodes"]:
             if pipeline.root_node is None:

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -961,8 +961,6 @@ class RayPipeline(Pipeline):
         """
         if address:
             ray.init(address=address)
-        else:
-            serve.start()
         serve.start()
         super().__init__()
 

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -179,7 +179,7 @@ class BaseRetriever(BaseComponent):
             self.query_count += 1
             run_query_timed = self.timing(self.run_query, "query_time")
             output, stream = run_query_timed(**kwargs)
-        elif root_node == "Indexing":
+        elif root_node == "File":
             self.index_count += len(kwargs["documents"])
             run_indexing = self.timing(self.run_indexing, "index_time")
             output, stream = run_indexing(**kwargs)

--- a/haystack/retriever/base.py
+++ b/haystack/retriever/base.py
@@ -174,17 +174,17 @@ class BaseRetriever(BaseComponent):
         else:
             return metrics
 
-    def run(self, pipeline_type: str, **kwargs): # type: ignore
-        if pipeline_type == "Query":
+    def run(self, root_node: str, **kwargs):  # type: ignore
+        if root_node == "Query":
             self.query_count += 1
             run_query_timed = self.timing(self.run_query, "query_time")
             output, stream = run_query_timed(**kwargs)
-        elif pipeline_type == "Indexing":
+        elif root_node == "Indexing":
             self.index_count += len(kwargs["documents"])
             run_indexing = self.timing(self.run_indexing, "index_time")
             output, stream = run_indexing(**kwargs)
         else:
-            raise Exception(f"Invalid pipeline_type '{pipeline_type}'.")
+            raise Exception(f"Invalid root_node '{root_node}'.")
         return output, stream
 
     def run_query(

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -269,6 +269,13 @@ class BaseComponent:
         cls.subclasses[cls.__name__] = cls
 
     @classmethod
+    def get_subclass(cls, component_type: str):
+        if component_type not in cls.subclasses.keys():
+            raise Exception(f"Haystack component with the name '{component_type}' does not exist.")
+        subclass = cls.subclasses[component_type]
+        return subclass
+
+    @classmethod
     def load_from_args(cls, component_type: str, **kwargs):
         """
         Load a component instance of the given type using the kwargs.
@@ -276,10 +283,26 @@ class BaseComponent:
         :param component_type: name of the component class to load.
         :param kwargs: parameters to pass to the __init__() for the component. 
         """
-        if component_type not in cls.subclasses.keys():
-            raise Exception(f"Haystack component with the name '{component_type}' does not exist.")
-        instance = cls.subclasses[component_type](**kwargs)
+        subclass = cls.get_subclass(component_type)
+        instance = subclass(**kwargs)
         return instance
+
+    @classmethod
+    def load_from_pipeline_config(cls, pipeline_config, component_name):
+        if pipeline_config:
+            all_component_configs = pipeline_config["components"]
+            all_component_names = [comp["name"] for comp in all_component_configs]
+            component_config = next(comp for comp in all_component_configs if comp["name"] == component_name)
+            component_params = component_config["params"]
+
+            for key, value in component_params.items():
+                if value in all_component_names:  # check if the param value is a reference to another component
+                    component_params[key] = cls.load_from_pipeline_config(pipeline_config, value)
+
+            component_instance = cls.load_from_args(component_config["type"], **component_params)
+        else:
+            component_instance = cls.load_from_args(component_name)
+        return component_instance
 
     @abstractmethod
     def run(self, *args: Any, **kwargs: Any):

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -288,7 +288,13 @@ class BaseComponent:
         return instance
 
     @classmethod
-    def load_from_pipeline_config(cls, pipeline_config, component_name):
+    def load_from_pipeline_config(cls, pipeline_config: dict, component_name: str):
+        """
+        Load an individual component from a YAML config for Pipelines.
+
+        :param pipeline_config: the Pipelines YAML config parsed as a dict.
+        :param component_name: the name of the component to load.
+        """
         if pipeline_config:
             all_component_configs = pipeline_config["components"]
             all_component_names = [comp["name"] for comp in all_component_configs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ pymilvus
 SPARQLWrapper
 mmh3
 weaviate-client==2.5.0
-ray==1.4.0
+ray==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ pymilvus
 SPARQLWrapper
 mmh3
 weaviate-client==2.5.0
+ray==1.4.0

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -35,6 +35,12 @@ pipelines:
       - name: Reader
         inputs: [ESRetriever]
 
+  - name: ray_test_pipeline
+    type: Query
+    nodes:
+      - name: ESRetriever
+        inputs: [ Query ]
+
   - name: indexing_pipeline
     type: Indexing
     nodes:

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -24,10 +24,10 @@ components:
     type: PreProcessor
     params:
       clean_whitespace: true
-  - name: BERTReader
+  - name: MiniReader
     type: FARMReader
     params:
-      model_name_or_path: deepset/bert-base-cased-squad2
+      model_name_or_path: deepset/minilm-uncased-squad2
       num_processes: 0
 
 pipelines:
@@ -43,7 +43,7 @@ pipelines:
     nodes:
       - name: ESRetriever
         inputs: [ Query ]
-      - name: BERTReader
+      - name: MiniReader
         inputs: [ ESRetriever ]
 
   - name: indexing_pipeline

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -6,6 +6,7 @@ components:
     params:
       no_ans_boost: -10
       model_name_or_path: deepset/roberta-base-squad2
+      num_processes: 0
   - name: ESRetriever
     type: ElasticsearchRetriever
     params:
@@ -34,12 +35,6 @@ pipelines:
         inputs: [Query]
       - name: Reader
         inputs: [ESRetriever]
-
-  - name: ray_test_pipeline
-    type: Query
-    nodes:
-      - name: ESRetriever
-        inputs: [ Query ]
 
   - name: indexing_pipeline
     type: Indexing

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -24,11 +24,7 @@ components:
     type: PreProcessor
     params:
       clean_whitespace: true
-  - name: MiniReader
-    type: FARMReader
-    params:
-      model_name_or_path: mrm8488/bert-tiny-5-finetuned-squadv2
-      num_processes: 0
+
 
 pipelines:
   - name: query_pipeline
@@ -38,13 +34,6 @@ pipelines:
         inputs: [Query]
       - name: Reader
         inputs: [ESRetriever]
-  - name: ray_test_pipeline
-    type: RayPipeline
-    nodes:
-      - name: ESRetriever
-        inputs: [ Query ]
-      - name: MiniReader
-        inputs: [ ESRetriever ]
 
   - name: indexing_pipeline
     type: Indexing

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -6,7 +6,6 @@ components:
     params:
       no_ans_boost: -10
       model_name_or_path: deepset/roberta-base-squad2
-      num_processes: 0
   - name: ESRetriever
     type: ElasticsearchRetriever
     params:
@@ -25,7 +24,11 @@ components:
     type: PreProcessor
     params:
       clean_whitespace: true
-
+  - name: BERTReader
+    type: FARMReader
+    params:
+      model_name_or_path: deepset/bert-base-cased-squad2
+      num_processes: 0
 
 pipelines:
   - name: query_pipeline
@@ -35,6 +38,13 @@ pipelines:
         inputs: [Query]
       - name: Reader
         inputs: [ESRetriever]
+  - name: ray_test_pipeline
+    type: RayPipeline
+    nodes:
+      - name: ESRetriever
+        inputs: [ Query ]
+      - name: BERTReader
+        inputs: [ ESRetriever ]
 
   - name: indexing_pipeline
     type: Indexing

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -14,7 +14,7 @@ components:
   - name: DocumentStore
     type: ElasticsearchDocumentStore
     params:
-      index: haystack_test_document
+      index: haystack_test
       label_index: haystack_test_label
   - name: PDFConverter
     type: PDFToTextConverter

--- a/test/samples/pipeline/test_pipeline.yaml
+++ b/test/samples/pipeline/test_pipeline.yaml
@@ -27,7 +27,7 @@ components:
   - name: MiniReader
     type: FARMReader
     params:
-      model_name_or_path: deepset/minilm-uncased-squad2
+      model_name_or_path: mrm8488/bert-tiny-5-finetuned-squadv2
       num_processes: 0
 
 pipelines:

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -18,8 +18,8 @@ from haystack.retriever.dense import DensePassageRetriever
 from haystack.retriever.sparse import ElasticsearchRetriever
 
 
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_load_and_save_yaml(document_store_with_docs, tmp_path):
+@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
+def test_load_and_save_yaml(document_store, tmp_path):
     # test correct load of indexing pipeline from yaml
     pipeline = Pipeline.load_from_yaml(
         Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="indexing_pipeline"
@@ -58,7 +58,7 @@ def test_load_and_save_yaml(document_store_with_docs, tmp_path):
           type: ElasticsearchRetriever
         - name: ElasticsearchDocumentStore
           params:
-            index: haystack_test_document
+            index: haystack_test
             label_index: haystack_test_label
           type: ElasticsearchDocumentStore
         - name: Reader

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -75,7 +75,7 @@ def test_load_and_save_yaml(document_store, tmp_path):
           - inputs:
             - ESRetriever
             name: Reader
-          type: Query
+          type: Pipeline
         version: '0.8'
     """
     assert saved_yaml.replace(" ", "").replace("\n", "") == expected_yaml.replace(

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -7,7 +7,7 @@ from haystack.pipeline import RayPipeline
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline", address="auto"
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", address="auto"
     )
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -4,11 +4,11 @@ import pytest
 from haystack.pipeline import RayPipeline
 
 
-# @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-# def test_load_pipeline(document_store_with_docs):
-#     pipeline = RayPipeline.load_from_yaml(
-#         Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", #address="auto"
-#     )
-#     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
-#     assert prediction["query"] == "Who lives in Berlin?"
-#     assert prediction["answers"][0]["answer"] == "Carla"
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+def test_load_pipeline(document_store_with_docs):
+    pipeline = RayPipeline.load_from_yaml(
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline"
+    )
+    prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
+    assert prediction["query"] == "Who lives in Berlin?"
+    assert prediction["answers"][0]["answer"] == "Carla"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -7,7 +7,7 @@ from haystack.pipeline import RayPipeline
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline", address="auto"
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", address="auto"
     )
     # prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     # assert prediction["query"] == "Who lives in Berlin?"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from ray import serve
 from haystack.pipeline import RayPipeline
 
 
@@ -10,8 +9,6 @@ def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
         Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline", address="auto"
     )
-    prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
-    assert prediction["query"] == "Who lives in Berlin?"
-    assert prediction["answers"][0]["answer"] == "Carla"
-    serve.shutdown()
-
+    # prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
+    # assert prediction["query"] == "Who lives in Berlin?"
+    # assert prediction["answers"][0]["answer"] == "Carla"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -7,7 +7,7 @@ from haystack.pipeline import RayPipeline
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", num_cpus=8,
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline", num_cpus=8,
     )
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -4,11 +4,11 @@ import pytest
 from haystack.pipeline import RayPipeline
 
 
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_load_pipeline(document_store_with_docs):
-    pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", address="auto"
-    )
-    prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
-    assert prediction["query"] == "Who lives in Berlin?"
-    assert prediction["answers"][0]["answer"] == "Carla"
+# @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+# def test_load_pipeline(document_store_with_docs):
+#     pipeline = RayPipeline.load_from_yaml(
+#         Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", #address="auto"
+#     )
+#     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
+#     assert prediction["query"] == "Who lives in Berlin?"
+#     assert prediction["answers"][0]["answer"] == "Carla"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -7,8 +7,8 @@ from haystack.pipeline import RayPipeline
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", address="auto"
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline", address="auto"
     )
-    # prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
-    # assert prediction["query"] == "Who lives in Berlin?"
-    # assert prediction["answers"][0]["answer"] == "Carla"
+    prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
+    assert prediction["query"] == "Who lives in Berlin?"
+    assert prediction["answers"][0]["answer"] == "Carla"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -13,3 +13,5 @@ def test_load_pipeline(document_store_with_docs):
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"
     assert prediction["answers"][0]["answer"] == "Carla"
+    serve.shutdown()
+

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -8,9 +8,8 @@ from haystack.pipeline import RayPipeline
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline"
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline", address="auto"
     )
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"
     assert prediction["answers"][0]["answer"] == "Carla"
-    serve.shutdown()

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-import ray
+from ray import serve
 from haystack.pipeline import RayPipeline
 
 
@@ -13,4 +13,4 @@ def test_load_pipeline(document_store_with_docs):
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"
     assert prediction["answers"][0]["answer"] == "Carla"
-    ray.shutdown()
+    serve.shutdown()

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+from haystack.pipeline import RayPipeline
+
+
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+def test_load_pipeline(document_store_with_docs):
+    pipeline = RayPipeline.load_from_yaml(
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="query_pipeline"
+    )
+    prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
+    assert prediction["query"] == "Who lives in Berlin?"
+    assert prediction["answers"][0]["answer"] == "Carla"

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import ray
 from haystack.pipeline import RayPipeline
 
 
@@ -12,3 +13,4 @@ def test_load_pipeline(document_store_with_docs):
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"
     assert prediction["answers"][0]["answer"] == "Carla"
+    ray.shutdown()

--- a/test/test_ray.py
+++ b/test/test_ray.py
@@ -7,7 +7,7 @@ from haystack.pipeline import RayPipeline
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_load_pipeline(document_store_with_docs):
     pipeline = RayPipeline.load_from_yaml(
-        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline"
+        Path("samples/pipeline/test_pipeline.yaml"), pipeline_name="ray_test_pipeline", num_cpus=8,
     )
     prediction = pipeline.run(query="Who lives in Berlin?", top_k_retriever=10, top_k_reader=3)
     assert prediction["query"] == "Who lives in Berlin?"


### PR DESCRIPTION
# Ray Integration

This PR is an initial prototype of how Haystack Pipelines can be scaled horizontally and distributed across a cluster of machines using the Ray framework. 

## Design
The design goal is to provide a standardized interface for Pipelines similar to the Haystack Components. A new `BasePipeline` class is added that is extended by `Pipeline` and `RayPipeline`. This allows users to switch between "execution engines" for the Pipelines while retaining the configuration for the Components.

The new `RayPipeline` has methods similar to the `Pipeline` class. With the current implementation, a `RayPipeline` can be instantiated locally or on a remote cluster using a Pipeline YAML configuration. Ray provides a `handle`, that allows easy integration of deployed Pipelines with Python code or REST APIs. 

Ray allows independently scaling the components by adding more replicas. For instance, in a typical extractive QA Pipeline, multiple readers can be added in front of a single Elasticsearch instance. The number of replicas can be configured by the new `replicas` parameter for each component in the Pipeline. 

## Implementation
The nodes in a Pipeline are wrapped in individual Ray Deployments. The `Pipeline.run()` calls the "graph" of deployments to get the results for an input `query`(or indexes an uploaded `file` for indexing Pipelines). 

To create a deployment, the component `type` is passed to Ray together with the YAML configuration. The deployment then creates an instance of the component using parameters from the pipeline config.

## Breaking Changes
The current YAML configuration has a `type` attribute for `pipelines` that is being used to specify `Query` or `Indexing` pipelines. This conflicts with the `type` parameter for `components`, where it is used for component class.

With this PR, the `type` now determines the class to use – `Pipeline` or `RayPipeline`. 

The `pipeline_type` parameter is now replaced by `root_node`.