### PR TITLE
Add more flexible options for model downloads (Proxies, resume_download, local_files_only...)

### DIFF
--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -51,7 +51,11 @@ class FARMReader(BaseReader):
         max_seq_len: int = 256,
         doc_stride: int = 128,
         progress_bar: bool = True,
-        duplicate_filtering: int = 0
+        duplicate_filtering: int = 0,
+        proxies=None,
+        local_files_only=False,
+        force_download=False,
+        **kwargs
     ):
 
         """
@@ -99,7 +103,8 @@ class FARMReader(BaseReader):
             batch_size=batch_size, use_gpu=use_gpu, no_ans_boost=no_ans_boost, return_no_answer=return_no_answer,
             top_k=top_k, top_k_per_candidate=top_k_per_candidate, top_k_per_sample=top_k_per_sample,
             num_processes=num_processes, max_seq_len=max_seq_len, doc_stride=doc_stride, progress_bar=progress_bar,
-            duplicate_filtering=duplicate_filtering
+            duplicate_filtering=duplicate_filtering,proxies=proxies,local_files_only=local_files_only,
+            force_download=force_download,**kwargs
         )
 
         self.return_no_answers = return_no_answer
@@ -109,7 +114,11 @@ class FARMReader(BaseReader):
                                             task_type="question_answering", max_seq_len=max_seq_len,
                                             doc_stride=doc_stride, num_processes=num_processes, revision=model_version,
                                             disable_tqdm=not progress_bar,
-                                            strict=False)
+                                            strict=False,
+                                            proxies=proxies,
+                                            local_files_only=local_files_only,
+                                            force_download=force_download,
+                                            **kwargs)
         self.inferencer.model.prediction_heads[0].context_window_size = context_window_size
         self.inferencer.model.prediction_heads[0].no_ans_boost = no_ans_boost
         self.inferencer.model.prediction_heads[0].n_best = top_k_per_candidate + 1 # including possible no_answer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-farm==0.8.0
+git+git://github.com/deepset-ai/FARM@master#egg=farm
 --find-links=https://download.pytorch.org/whl/torch_stable.html
 fastapi
 uvicorn

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -52,6 +52,11 @@ def test_prediction_attributes(prediction):
     for ag in attributes_gold:
         assert ag in prediction
 
+@pytest.mark.slow
+def test_model_download_options():
+    # download disabled and model is not cached locally
+    with pytest.raises(OSError):
+        impossible_reader = FARMReader("mfeb/albert-xxlarge-v2-squad2", local_files_only=True)
 
 def test_answer_attributes(prediction):
     # TODO Transformers answer also has meta key


### PR DESCRIPTION
**Proposed changes**:
Fix for #997. 
Builts on the changes in FARM (https://github.com/deepset-ai/FARM/pull/809/files)

This PR introduces more configuration options to control the download behaviour of the model and tokenizer needed for the FARMReader. We add three new args (`proxies`, `local_files_only` and `force_download`). Those are passed all the way down from the FARMReader to the inferencer and over some intermediate steps to Huggingface's modeling_utils. In addition to the three args, all other params listed here could be passed to the FARMReader via `**kwargs`. I think this is more user-friendly at this point in time than polluting the signature of FARMReader with many, not frequently used args. We can easily extend this later if we see other args becoming important for users.

@cregouby Could you please test if this works in your env? (you will need to use this haystack branch + install FARM from the latest master as pinned in the requirements.txt here)

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [x] Added tests
- [ ] Updated documentation
