### PR TITLE
Added explicit refresh call during refresh_type is false in update em…

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -904,6 +904,9 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         if index is None:
             index = self.index
 
+        if self.refresh_type == 'false':
+            self.client.indices.refresh(index=index)
+
         if not self.embedding_field:
             raise RuntimeError("Specify the arg `embedding_field` when initializing ElasticsearchDocumentStore()")
 


### PR DESCRIPTION
I have created PR for the #1246 issue 


**Why?**
The `query_by_embedding` throws error. The root cause is for some data the embedding are not created. This issue is because when we call the `update_embedding` after the `write_document` some data loss happens. Though Elastic search takes some time to refresh the index after writing to document_store. At that point, when the update embedding calls the index it takes the un-refreshed index which doesn't have full data.

 **What is changing?**
 We are calling the refresh API externally before update embedding to make sure the index is refreshed and searchable. 

