### PR TITLE
Add QuestionGenerator

### DIFF
--- a/docs/_src/usage/usage/question_generator.md
+++ b/docs/_src/usage/usage/question_generator.md
@@ -1,0 +1,45 @@
+<!---
+title: "Question Generator"
+metaTitle: "Question Generator"
+metaDescription: ""
+slug: "/docs/question_generator"
+date: "2020-11-05"
+id: "questiongeneratormd"
+--->
+
+# Question Generator
+
+<div class="recommendation">
+
+**Running examples**
+
+Have a look at our [tutorial notebook](/docs/latest/tutorial13md))) if you'd like to start trying out Question Generation straight away!
+
+</div>
+
+The Question Generation module is used to generate SQuAD style questions on a given document.
+
+This module is useful when it comes to labelling in a new domain. It can be used to generate questions quickly for an
+annotator to answer. If used in conjunction with a trained Reader model, you can automatically generate question answer
+pairs. High impact annotations can then be created if a human annotator looks over these pairs and corrects the incorrect predictions.
+
+Question generation is also a good way to make large documents more navigable. Generated questions can 
+quickly give the user a sense of what information is contained within the document, thus acting as a kind of summarization.
+
+To initialize a question generator, simply call:
+
+```python
+from haystack.question_generator import QuestionGenerator
+
+question_generator = QuestionGenerator()
+```
+
+This loads the [`valhalla/t5-base-e2e-qg`](https://huggingface.co/valhalla/t5-base-e2e-qg) model by default which is a T5 model trained on SQuAD for question generation.
+
+To run the node in isolation, simply use the `generate()` method:
+
+```python
+result = question_generator.generate(text="Nirvana was an American rock band formed in Aberdeen, Washington in 1987.")
+```
+
+Otherwise, the node can be used in a pipeline where its `run()` method will called.

--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -21,6 +21,7 @@ class BaseDocumentStore(BaseComponent):
     label_index: Optional[str]
     similarity: Optional[str]
     duplicate_documents_options: tuple = ('skip', 'overwrite', 'fail')
+    ids_iterator = None
 
     @abstractmethod
     def write_documents(self, documents: Union[List[dict], List[Document]], index: Optional[str] = None,
@@ -64,6 +65,20 @@ class BaseDocumentStore(BaseComponent):
         :param return_embedding: Whether to return the document embeddings.
         """
         pass
+
+    def __iter__(self):
+        if not self.ids_iterator:
+            self.ids_iterator = [x.id for x in self.get_all_documents()]
+        return self
+
+    def __next__(self):
+        if len(self.ids_iterator) == 0:
+            raise StopIteration
+        else:
+            curr_id = self.ids_iterator[0]
+            ret = self.get_document_by_id(curr_id)
+            self.ids_iterator = self.ids_iterator[1:]
+            return ret
 
     @abstractmethod
     def get_all_labels(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> List[Label]:

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List, Optional, Dict, Union, Any
 import pickle
 import urllib
+from functools import wraps
 
 from transformers import AutoTokenizer, AutoModelForSequenceClassification, TextClassificationPipeline
 
@@ -587,6 +588,73 @@ class TranslationWrapperPipeline(BaseStandardPipeline):
         self.pipeline.add_node(component=output_translator, name="OutputTranslator", inputs=previous_node_name)
 
     def run(self, **kwargs):
+        output = self.pipeline.run(**kwargs)
+        return output
+
+
+class QuestionGenerationPipeline(BaseStandardPipeline):
+    """
+    A simple pipeline that takes documents as input and generates
+    questions that it thinks can be answered by the documents.
+    """
+    def __init__(self, question_generator):
+        self.pipeline = Pipeline()
+        self.pipeline.add_node(component=question_generator, name="QuestionGenerator", inputs=["Query"])
+
+    def run(self, documents, **kwargs):
+        output = self.pipeline.run(documents, **kwargs)
+        return output
+
+
+class RetrieverQuestionGenerationPipeline(BaseStandardPipeline):
+    """
+    A simple pipeline that takes a query as input, performs retrieval, and then generates
+    questions that it thinks can be answered by the retrieved documents.
+    """
+    def __init__(self, retriever, question_generator):
+        self.pipeline = Pipeline()
+        self.pipeline.add_node(component=retriever, name="Retriever", inputs=["Query"])
+        self.pipeline.add_node(component=question_generator, name="Question Generator", inputs=["Retriever"])
+
+    def run(self, query, **kwargs):
+        kwargs["query"] = query
+        output = self.pipeline.run(**kwargs)
+        return output
+
+class dotdict(dict):
+    """dot.notation access to dictionary attributes"""
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+class QuestionAnswerGenerationPipeline(BaseStandardPipeline):
+    """
+    This is a pipeline which takes a document as input, generates questions that the model thinks can be answered by
+    this document, and then performs question answering of this questions using that single document.
+    """
+    def __init__(self, question_generator, reader):
+        question_generator.run = self.formatting_wrapper(question_generator.run)
+        reader.run = reader.run_batch
+        self.pipeline = Pipeline()
+        self.pipeline.add_node(component=question_generator, name="QuestionGenerator", inputs=["Query"])
+        self.pipeline.add_node(component=reader, name="Reader", inputs=["QuestionGenerator"])
+
+    def formatting_wrapper(self, fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            output, output_stream = fn(*args, **kwargs)
+            questions = output["generated_questions"][0]["questions"]
+            documents = output["documents"]
+            query_doc_list = []
+            for q in questions:
+                query_dot_dict = dotdict({"question": q})
+                query_doc_list.append({"question": query_dot_dict, "docs": documents})
+            kwargs["query_doc_list"] = query_doc_list
+            return kwargs, output_stream
+        return wrapper
+
+    def run(self, document, **kwargs):
+        kwargs["documents"] = [document]
         output = self.pipeline.run(**kwargs)
         return output
 

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -602,7 +602,8 @@ class QuestionGenerationPipeline(BaseStandardPipeline):
         self.pipeline.add_node(component=question_generator, name="QuestionGenerator", inputs=["Query"])
 
     def run(self, documents, **kwargs):
-        output = self.pipeline.run(documents, **kwargs)
+        kwargs["documents"] = documents
+        output = self.pipeline.run(**kwargs)
         return output
 
 
@@ -621,11 +622,6 @@ class RetrieverQuestionGenerationPipeline(BaseStandardPipeline):
         output = self.pipeline.run(**kwargs)
         return output
 
-class dotdict(dict):
-    """dot.notation access to dictionary attributes"""
-    __getattr__ = dict.get
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
 
 class QuestionAnswerGenerationPipeline(BaseStandardPipeline):
     """
@@ -647,8 +643,7 @@ class QuestionAnswerGenerationPipeline(BaseStandardPipeline):
             documents = output["documents"]
             query_doc_list = []
             for q in questions:
-                query_dot_dict = dotdict({"question": q})
-                query_doc_list.append({"question": query_dot_dict, "docs": documents})
+                query_doc_list.append({"queries": q, "docs": documents})
             kwargs["query_doc_list"] = query_doc_list
             return kwargs, output_stream
         return wrapper

--- a/haystack/pipeline.py
+++ b/haystack/pipeline.py
@@ -630,11 +630,13 @@ class QuestionAnswerGenerationPipeline(BaseStandardPipeline):
     """
     def __init__(self, question_generator, reader):
         question_generator.run = self.formatting_wrapper(question_generator.run)
+        # Overwrite reader.run function so it can handle a batch of questions being passed on by the QuestionGenerator
         reader.run = reader.run_batch
         self.pipeline = Pipeline()
         self.pipeline.add_node(component=question_generator, name="QuestionGenerator", inputs=["Query"])
         self.pipeline.add_node(component=reader, name="Reader", inputs=["QuestionGenerator"])
 
+    # This is used to format the output of the QuestionGenerator so that its questions are ready to be answered by the reader
     def formatting_wrapper(self, fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):

--- a/haystack/question_generator/__init__.py
+++ b/haystack/question_generator/__init__.py
@@ -1,0 +1,1 @@
+from haystack.question_generator.question_generator import QuestionGenerator

--- a/haystack/question_generator/question_generator.py
+++ b/haystack/question_generator/question_generator.py
@@ -1,6 +1,7 @@
 from transformers import AutoModelForSeq2SeqLM
 from transformers import AutoTokenizer
 from haystack import BaseComponent
+from haystack.preprocessor import PreProcessor
 
 text = "generate questions: Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum \
 and first released in 1991, Python's design philosophy emphasizes code \
@@ -11,9 +12,13 @@ readability with its notable use of significant whitespace."
 TODO
 top_k instead of length
 device and use gpu
-Why does __init__ not work?
 split to base class?
 Not totally sure about args
+text limits?
+run method
+Does it clip long texts??
+https://discuss.huggingface.co/t/t5-finetuning-tips/684
+Inefficient because we feed it 50 words
 """
 
 class QuestionGenerator(BaseComponent):
@@ -24,34 +29,64 @@ class QuestionGenerator(BaseComponent):
                  max_length=256,
                  no_repeat_ngram_size=3,
                  length_penalty=1.5,
-                 early_stopping=True):
+                 early_stopping=True,
+                 split_length=50,
+                 split_overlap=10):
         self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         self.set_config(
             model_name_or_path=model_name_or_path, model_version=model_version,
             max_length=max_length, num_beams=num_beams, no_repeat_ngram_size=no_repeat_ngram_size,
-            length_penalty=length_penalty, early_stopping=early_stopping
+            length_penalty=length_penalty, early_stopping=early_stopping, split_length=split_length,
+            split_overlap=split_overlap
         )
         self.num_beams = num_beams
         self.max_length = max_length
         self.no_repeat_ngram_size = no_repeat_ngram_size
         self.length_penalty = length_penalty
         self.early_stopping = early_stopping
+        self.split_length = split_length
+        self.split_overlap = split_overlap
+        self.preprocessor = PreProcessor()
+        self.prompt = "generate questions:"
 
     def generate(self, text):
-        tokenized = self.tokenizer([text], return_tensors="pt")
-        input_ids = tokenized["input_ids"]
-        attention_mask = tokenized["attention_mask"]   # necessary if padding is enabled so the model won't attend pad tokens
-        tokens_output = self.model.generate(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            num_beams=self.num_beams,
-            max_length=self.max_length,
-            no_repeat_ngram_size=self.no_repeat_ngram_size,
-            length_penalty=self.length_penalty,
-            early_stopping=self.early_stopping,
+        # Performing splitting because T5 has a max input length
+        # Also currently, it seems that it only generates about 3 questions for the beginning section of text
+        split_texts_dict = self.preprocessor.split(
+            document={"text": text},
+            split_by="word",
+            split_respect_sentence_boundary=False,
+            split_overlap=self.split_overlap,
+            split_length=self.split_length
         )
+        split_texts = [x["text"] for x in split_texts_dict]
+        ret = []
+        for split_text in split_texts:
+            if self.prompt not in split_text:
+                split_text = self.prompt + " " + split_text
+            tokenized = self.tokenizer([split_text], return_tensors="pt")
+            input_ids = tokenized["input_ids"]
+            attention_mask = tokenized["attention_mask"]   # necessary if padding is enabled so the model won't attend pad tokens
+            tokens_output = self.model.generate(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                num_beams=self.num_beams,
+                max_length=self.max_length,
+                no_repeat_ngram_size=self.no_repeat_ngram_size,
+                length_penalty=self.length_penalty,
+                early_stopping=self.early_stopping,
+            )
 
-        ret = [self.tokenizer.decode(t) for t in tokens_output]
+            string_output = self.tokenizer.decode(tokens_output[0])
+            string_output = string_output.replace("<pad>", "").replace("</s>", "")
+            questions_string = string_output.split("<sep>")
+            questions = [x for x in questions_string if x]
+
+            # Doing this instead of set to maintain order since the generated questions seem to have answers
+            # that occur in order in the text
+            for q in questions:
+                if q not in ret:
+                    ret.append(q)
         return ret
 

--- a/haystack/question_generator/question_generator.py
+++ b/haystack/question_generator/question_generator.py
@@ -26,6 +26,12 @@ class QuestionGenerator(BaseComponent):
                  split_length=50,
                  split_overlap=10,
                  prompt="generate questions:"):
+        """
+        Uses the valhalla/t5-base-e2e-qg model by default. This class supports any question generation model that is
+        implemented as a Seq2SeqLM in HuggingFace Transformers. Note that this style of question generation (where the only input
+        is a document) is sometimes referred to as end-to-end question generation. Answer-supervised question
+        generation is not currently supported.
+        """
         self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         self.set_config(

--- a/haystack/question_generator/question_generator.py
+++ b/haystack/question_generator/question_generator.py
@@ -10,11 +10,10 @@ readability with its notable use of significant whitespace."
 
 """
 TODO
-top_k instead of length
+top_k instead of length?
 device and use gpu
 split to base class?
 Not totally sure about args
-text limits?
 run method
 Does it clip long texts??
 https://discuss.huggingface.co/t/t5-finetuning-tips/684
@@ -31,7 +30,8 @@ class QuestionGenerator(BaseComponent):
                  length_penalty=1.5,
                  early_stopping=True,
                  split_length=50,
-                 split_overlap=10):
+                 split_overlap=10,
+                 prompt="generate questions:"):
         self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         self.set_config(
@@ -48,7 +48,7 @@ class QuestionGenerator(BaseComponent):
         self.split_length = split_length
         self.split_overlap = split_overlap
         self.preprocessor = PreProcessor()
-        self.prompt = "generate questions:"
+        self.prompt = prompt
 
     def generate(self, text):
         # Performing splitting because T5 has a max input length

--- a/haystack/question_generator/question_generator.py
+++ b/haystack/question_generator/question_generator.py
@@ -1,0 +1,57 @@
+from transformers import AutoModelForSeq2SeqLM
+from transformers import AutoTokenizer
+from haystack import BaseComponent
+
+text = "generate questions: Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum \
+and first released in 1991, Python's design philosophy emphasizes code \
+readability with its notable use of significant whitespace."
+
+
+"""
+TODO
+top_k instead of length
+device and use gpu
+Why does __init__ not work?
+split to base class?
+Not totally sure about args
+"""
+
+class QuestionGenerator(BaseComponent):
+    def __init__(self,
+                 model_name_or_path="valhalla/t5-base-e2e-qg",
+                 model_version=None,
+                 num_beams=4,
+                 max_length=256,
+                 no_repeat_ngram_size=3,
+                 length_penalty=1.5,
+                 early_stopping=True):
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.set_config(
+            model_name_or_path=model_name_or_path, model_version=model_version,
+            max_length=max_length, num_beams=num_beams, no_repeat_ngram_size=no_repeat_ngram_size,
+            length_penalty=length_penalty, early_stopping=early_stopping
+        )
+        self.num_beams = num_beams
+        self.max_length = max_length
+        self.no_repeat_ngram_size = no_repeat_ngram_size
+        self.length_penalty = length_penalty
+        self.early_stopping = early_stopping
+
+    def generate(self, text):
+        tokenized = self.tokenizer([text], return_tensors="pt")
+        input_ids = tokenized["input_ids"]
+        attention_mask = tokenized["attention_mask"]   # necessary if padding is enabled so the model won't attend pad tokens
+        tokens_output = self.model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            num_beams=self.num_beams,
+            max_length=self.max_length,
+            no_repeat_ngram_size=self.no_repeat_ngram_size,
+            length_penalty=self.length_penalty,
+            early_stopping=self.early_stopping,
+        )
+
+        ret = [self.tokenizer.decode(t) for t in tokens_output]
+        return ret
+

--- a/haystack/reader/base.py
+++ b/haystack/reader/base.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.special import expit
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Dict
 from functools import wraps
 from time import perf_counter
 
@@ -67,6 +67,15 @@ class BaseReader(BaseComponent):
                     ans["meta"] = deepcopy(doc.meta)
 
         results.update(**kwargs)
+        return results, "output_1"
+
+    def run_batch(self, query_doc_list: List[Dict], top_k_reader: Optional[int] = None, **kwargs):
+        self.query_count += len(query_doc_list)
+        if query_doc_list:
+            predict_batch = self.timing(self.predict_batch, "query_time")
+            results = predict_batch(query_doc_list=query_doc_list, top_k=top_k_reader)
+        else:
+            results = [{"answers": [], "query": ""}]
         return results, "output_1"
 
     def timing(self, fn, attr_name):

--- a/haystack/reader/base.py
+++ b/haystack/reader/base.py
@@ -70,6 +70,7 @@ class BaseReader(BaseComponent):
         return results, "output_1"
 
     def run_batch(self, query_doc_list: List[Dict], top_k_reader: Optional[int] = None, **kwargs):
+        """ A unoptimized implementation of running Reader queries in batch """
         self.query_count += len(query_doc_list)
         results = []
         if query_doc_list:

--- a/haystack/reader/base.py
+++ b/haystack/reader/base.py
@@ -71,9 +71,14 @@ class BaseReader(BaseComponent):
 
     def run_batch(self, query_doc_list: List[Dict], top_k_reader: Optional[int] = None, **kwargs):
         self.query_count += len(query_doc_list)
+        results = []
         if query_doc_list:
-            predict_batch = self.timing(self.predict_batch, "query_time")
-            results = predict_batch(query_doc_list=query_doc_list, top_k=top_k_reader)
+            for qd in query_doc_list:
+                q = qd["queries"]
+                docs = qd["docs"]
+                predict = self.timing(self.predict, "query_time")
+                result = predict(query=q, documents=docs, top_k=top_k_reader)
+                results.append(result)
         else:
             results = [{"answers": [], "query": ""}]
         return results, "output_1"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,6 +31,7 @@ from haystack.reader.farm import FARMReader
 from haystack.reader.transformers import TransformersReader
 from haystack.summarizer.transformers import TransformersSummarizer
 from haystack.translator import TransformersTranslator
+from haystack.question_generator import QuestionGenerator
 
 
 def pytest_addoption(parser):
@@ -230,6 +231,11 @@ def rag_generator():
         model_name_or_path="facebook/rag-token-nq",
         generator_type=RAGeneratorType.TOKEN
     )
+
+
+@pytest.fixture(scope="module")
+def question_generator():
+    return QuestionGenerator(model_name_or_path="valhalla/t5-small-e2e-qg")
 
 
 @pytest.fixture(scope="module")

--- a/test/test_question_generator.py
+++ b/test/test_question_generator.py
@@ -1,0 +1,36 @@
+from haystack.pipeline import QuestionAnswerGenerationPipeline, QuestionGenerationPipeline, RetrieverQuestionGenerationPipeline
+from haystack import Document
+import pytest
+
+
+text = 'The Living End are an Australian punk rockabilly band from Melbourne, formed in 1994. Since 2002, the line-up consists of Chris Cheney (vocals, guitar), Scott Owen (double bass, vocals), and Andy Strachan (drums). The band rose to fame in 1997 after the release of their EP Second Solution / Prisoner of Society, which peaked at No. 4 on the Australian ARIA Singles Chart. They have released eight studio albums, two of which reached the No. 1 spot on the ARIA Albums Chart: The Living End (October 1998) and State of Emergency (February 2006). They have also achieved chart success in the U.S. and the United Kingdom. The Band was nominated 27 times and won five awards at the Australian ARIA Music Awards ceremonies: "Highest Selling Single" for Second Solution / Prisoner of Society (1998), "Breakthrough Artist – Album" and "Best Group" for The Living End (1999), as well as "Best Rock Album" for White Noise (2008) and The Ending Is Just the Beginning Repeating (2011). In October 2010, their debut album was listed in the book "100 Best Australian Albums". Australian musicologist Ian McFarlane described the group as "one of Australia’s premier rock acts. By blending a range of styles (punk, rockabilly and flat out rock) with great success, The Living End has managed to produce anthemic choruses and memorable songs in abundance".'
+document = Document(text=text)
+query = "Living End"
+
+
+def test_qg_pipeline(question_generator):
+    p = QuestionGenerationPipeline(question_generator)
+    result = p.run(documents=[document])
+    keys = list(result)
+    assert "generated_questions" in keys
+    assert len(result["generated_questions"][0]["questions"]) > 0
+
+
+@pytest.mark.parametrize("retriever,document_store", [("elasticsearch", "elasticsearch")], indirect=True)
+def test_rqg_pipeline(question_generator, retriever):
+    retriever.document_store.write_documents([{"text": text}])
+    p = RetrieverQuestionGenerationPipeline(retriever, question_generator)
+    result = p.run(query)
+    keys = list(result)
+    assert "generated_questions" in keys
+    assert len(result["generated_questions"][0]["questions"]) > 0
+
+
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_qag_pipeline(question_generator, reader):
+    p = QuestionAnswerGenerationPipeline(question_generator, reader)
+    result = p.run(document=document)
+    assert len(result) > 0
+    assert result[0]["query"]
+    assert len(result[0]["answers"]) > 0
+    assert result[0]["answers"][0]["answer"]

--- a/tutorials/Tutorial13_Question_generation.ipynb
+++ b/tutorials/Tutorial13_Question_generation.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Question Generation\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial13_Question_generation.ipynb)\n",
+    "\n",
+    "This is a bare bones tutorial showing what is possible with the QuestionGenerator Nodes and Pipelines which automatically\n",
+    "generate questions which the question generation model thinks can be answered by a given document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from haystack.question_generator import QuestionGenerator\n",
+    "from haystack.utils import launch_es\n",
+    "from haystack.document_store import ElasticsearchDocumentStore\n",
+    "from haystack.retriever import ElasticsearchRetriever\n",
+    "from pprint import pprint\n",
+    "from haystack.reader import FARMReader\n",
+    "from tqdm import tqdm\n",
+    "from haystack.pipeline import QuestionGenerationPipeline, RetrieverQuestionGenerationPipeline, QuestionAnswerGenerationPipeline"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Start Elasticsearch service via Docker\n",
+    "launch_es()\n",
+    "\n",
+    "text1 = \"Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.\"\n",
+    "text2 = \"Princess Arya Stark is the third child and second daughter of Lord Eddard Stark and his wife, Lady Catelyn Stark. She is the sister of the incumbent Westerosi monarchs, Sansa, Queen in the North, and Brandon, King of the Andals and the First Men. After narrowly escaping the persecution of House Stark by House Lannister, Arya is trained as a Faceless Man at the House of Black and White in Braavos, using her abilities to avenge her family. Upon her return to Westeros, she exacts retribution for the Red Wedding by exterminating the Frey male line.\"\n",
+    "text3 = \"Dry Cleaning are an English post-punk band who formed in South London in 2018.[3] The band is composed of vocalist Florence Shaw, guitarist Tom Dowse, bassist Lewis Maynard and drummer Nick Buxton. They are noted for their use of spoken word primarily in lieu of sung vocals, as well as their unconventional lyrics. Their musical stylings have been compared to Wire, Magazine and Joy Division.[4] The band released their debut single, 'Magic of Meghan' in 2019. Shaw wrote the song after going through a break-up and moving out of her former partner's apartment the same day that Meghan Markle and Prince Harry announced they were engaged.[5] This was followed by the release of two EPs that year: Sweet Princess in August and Boundary Road Snacks and Drinks in October. The band were included as part of the NME 100 of 2020,[6] as well as DIY magazine's Class of 2020.[7] The band signed to 4AD in late 2020 and shared a new single, 'Scratchcard Lanyard'.[8] In February 2021, the band shared details of their debut studio album, New Long Leg. They also shared the single 'Strong Feelings'.[9] The album, which was produced by John Parish, was released on 2 April 2021.[10]\"\n",
+    "\n",
+    "docs = [{\"text\": text1},\n",
+    "        {\"text\": text2},\n",
+    "        {\"text\": text3}]\n",
+    "\n",
+    "# Initialize document store and write in the documents\n",
+    "document_store = ElasticsearchDocumentStore()\n",
+    "document_store.write_documents(docs)\n",
+    "\n",
+    "# Initialize Question Generator\n",
+    "question_generator = QuestionGenerator()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Question Generation Pipeline\n",
+    "\n",
+    "The most basic version of a question generator pipeline takes a document as input and outputs generated questions\n",
+    "which the the document can answer."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "question_generation_pipeline = QuestionGenerationPipeline(question_generator)\n",
+    "for document in document_store:\n",
+    "        result = question_generation_pipeline.run(documents=[document])\n",
+    "        pprint(result)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Retriever Question Generation Pipeline\n",
+    "\n",
+    "This pipeline takes a query as input. It retrieves relevant documents and then generates questions based on these."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "retriever = ElasticsearchRetriever(document_store=document_store)\n",
+    "rqg_pipeline = RetrieverQuestionGenerationPipeline(retriever, question_generator)\n",
+    "result = rqg_pipeline.run(query=\"Arya Stark\")\n",
+    "pprint(result)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Question Answer Generation Pipeline\n",
+    "\n",
+    "This pipeline takes a document as input, generates questions on it, and attempts to answer these questions using\n",
+    "a Reader model"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "reader = FARMReader(\"deepset/roberta-base-squad2\")\n",
+    "qag_pipeline = QuestionAnswerGenerationPipeline(question_generator, reader)\n",
+    "for document in tqdm(document_store):\n",
+    "    result = qag_pipeline.run(document=document)\n",
+    "    pprint(result)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## About us\n",
+    "\n",
+    "This [Haystack](https://github.com/deepset-ai/haystack/) notebook was made with love by [deepset](https://deepset.ai/) in Berlin, Germany\n",
+    "\n",
+    "We bring NLP to the industry via open source!\n",
+    "Our focus: Industry specific language models & large scale QA systems.\n",
+    "\n",
+    "Some of our other work:\n",
+    "- [German BERT](https://deepset.ai/german-bert)\n",
+    "- [GermanQuAD and GermanDPR](https://deepset.ai/germanquad)\n",
+    "- [FARM](https://github.com/deepset-ai/FARM)\n",
+    "\n",
+    "Get in touch:\n",
+    "[Twitter](https://twitter.com/deepset_ai) | [LinkedIn](https://www.linkedin.com/company/deepset-ai/) | [Slack](https://haystack.deepset.ai/community/join) | [GitHub Discussions](https://github.com/deepset-ai/haystack/discussions) | [Website](https://deepset.ai)\n",
+    "\n",
+    "By the way: [we're hiring!](https://apply.workable.com/deepset/)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tutorials/question_generation.py
+++ b/tutorials/question_generation.py
@@ -1,0 +1,11 @@
+from transformers import pipeline
+from transformers import AutoModelForSeq2SeqLM
+from transformers import AutoTokenizer
+from haystack.question_generator import QuestionGenerator
+
+text = "generate questions: Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum \
+and first released in 1991, Python's design philosophy emphasizes code \
+readability with its notable use of significant whitespace."
+
+question_generator = QuestionGenerator(max_length=512, early_stopping=False)
+print(question_generator.generate(text))

--- a/tutorials/question_generation.py
+++ b/tutorials/question_generation.py
@@ -12,74 +12,42 @@ from tqdm import tqdm
 from haystack import Document
 from haystack.pipeline import QuestionGenerationPipeline, RetrieverQuestionGenerationPipeline, QuestionAnswerGenerationPipeline
 
+""" This script shows what is possible with the QuestionGenerator Node and how it can be used in conjunction
+with other Haystack nodes to automatically generate questions which the model thinks can be answered by a given document"""
+
+
 launch_es()
 
-text = "Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum \
-and first released in 1991, Python's design philosophy emphasizes code \
-readability with its notable use of significant whitespace."
-
+text1 = "Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace."
 text2 = "Princess Arya Stark is the third child and second daughter of Lord Eddard Stark and his wife, Lady Catelyn Stark. She is the sister of the incumbent Westerosi monarchs, Sansa, Queen in the North, and Brandon, King of the Andals and the First Men. After narrowly escaping the persecution of House Stark by House Lannister, Arya is trained as a Faceless Man at the House of Black and White in Braavos, using her abilities to avenge her family. Upon her return to Westeros, she exacts retribution for the Red Wedding by exterminating the Frey male line."
-
 text3 = "Dry Cleaning are an English post-punk band who formed in South London in 2018.[3] The band is composed of vocalist Florence Shaw, guitarist Tom Dowse, bassist Lewis Maynard and drummer Nick Buxton. They are noted for their use of spoken word primarily in lieu of sung vocals, as well as their unconventional lyrics. Their musical stylings have been compared to Wire, Magazine and Joy Division.[4] The band released their debut single, 'Magic of Meghan' in 2019. Shaw wrote the song after going through a break-up and moving out of her former partner's apartment the same day that Meghan Markle and Prince Harry announced they were engaged.[5] This was followed by the release of two EPs that year: Sweet Princess in August and Boundary Road Snacks and Drinks in October. The band were included as part of the NME 100 of 2020,[6] as well as DIY magazine's Class of 2020.[7] The band signed to 4AD in late 2020 and shared a new single, 'Scratchcard Lanyard'.[8] In February 2021, the band shared details of their debut studio album, New Long Leg. They also shared the single 'Strong Feelings'.[9] The album, which was produced by John Parish, was released on 2 April 2021.[10]"
 
-docs = [{"text": text},
+docs = [{"text": text1},
         {"text": text2},
         {"text": text3}]
+
 document_store = ElasticsearchDocumentStore()
 document_store.write_documents(docs)
 
 question_generator = QuestionGenerator()
 
-
-# # Pipeline 1
-# question_generation_pipeline = QuestionGenerationPipeline(question_generator)
-# for document in document_store:
-#         result = question_generation_pipeline.run(documents=[document])
-
-
-# # Pipeline 2
-# retriever = ElasticsearchRetriever(document_store=document_store)
-# rqg_pipeline = RetrieverQuestionGenerationPipeline(retriever, question_generator)
-# result = rqg_pipeline.run(query="Arya Stark")
-# pprint(result)
+# QuestionGenerationPipeline
+question_generation_pipeline = QuestionGenerationPipeline(question_generator)
+for document in document_store:
+        result = question_generation_pipeline.run(documents=[document])
+        pprint(result)
 
 
-# Pipeline 3
+# RetrieverQuestionGenerationPipeline
+retriever = ElasticsearchRetriever(document_store=document_store)
+rqg_pipeline = RetrieverQuestionGenerationPipeline(retriever, question_generator)
+result = rqg_pipeline.run(query="Arya Stark")
+pprint(result)
+
+
+# QuestionAnswerGenerationPipeline
 reader = FARMReader("deepset/roberta-base-squad2")
 qag_pipeline = QuestionAnswerGenerationPipeline(question_generator, reader)
 for document in tqdm(document_store):
     result = qag_pipeline.run(document=document)
-
-
-
-# Pipeline3
-reader = FARMReader("deepset/roberta-base-squad2")
-
-results = []
-for document in tqdm(document_store):
-        questions = question_generator.generate(text=document.text)
-        results.append({"generated_questions": questions,
-                        "document_text": document.text,
-                        "document_id": document.id})
-
-ret = []
-for result in tqdm(results):
-    generated_questions = result["generated_questions"]
-    document_text = result["document_text"]
-    document_id = result["document_id"]
-    for q in generated_questions:
-        answers = reader.predict(query=q, documents=[Document.from_dict({"text": document_text})])["answers"]
-        ret.append({"document_text": document_text,
-                        "document_id": document_id,
-                        "question": q,
-                        "answers": answers})
-
-curr_text = ""
-for r in ret:
-    if curr_text != r["document_text"]:
-        curr_text = r["document_text"]
-        print(f"Document: {curr_text}")
-    print(f"\t{r['question']}")
-    for a in r["answers"]:
-        print(f"\t\t{a['answer']}")
-        break
+    pprint(result)

--- a/tutorials/question_generation.py
+++ b/tutorials/question_generation.py
@@ -2,10 +2,84 @@ from transformers import pipeline
 from transformers import AutoModelForSeq2SeqLM
 from transformers import AutoTokenizer
 from haystack.question_generator import QuestionGenerator
+from haystack.utils import launch_es
+from haystack.document_store import ElasticsearchDocumentStore
+from haystack.retriever import ElasticsearchRetriever
+from pprint import pprint
+from haystack import Pipeline
+from haystack.reader import FARMReader
+from tqdm import tqdm
+from haystack import Document
+from haystack.pipeline import QuestionGenerationPipeline, RetrieverQuestionGenerationPipeline, QuestionAnswerGenerationPipeline
 
-text = "generate questions: Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum \
+launch_es()
+
+text = "Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum \
 and first released in 1991, Python's design philosophy emphasizes code \
 readability with its notable use of significant whitespace."
 
-question_generator = QuestionGenerator(max_length=512, early_stopping=False)
-print(question_generator.generate(text))
+text2 = "Princess Arya Stark is the third child and second daughter of Lord Eddard Stark and his wife, Lady Catelyn Stark. She is the sister of the incumbent Westerosi monarchs, Sansa, Queen in the North, and Brandon, King of the Andals and the First Men. After narrowly escaping the persecution of House Stark by House Lannister, Arya is trained as a Faceless Man at the House of Black and White in Braavos, using her abilities to avenge her family. Upon her return to Westeros, she exacts retribution for the Red Wedding by exterminating the Frey male line."
+
+text3 = "Dry Cleaning are an English post-punk band who formed in South London in 2018.[3] The band is composed of vocalist Florence Shaw, guitarist Tom Dowse, bassist Lewis Maynard and drummer Nick Buxton. They are noted for their use of spoken word primarily in lieu of sung vocals, as well as their unconventional lyrics. Their musical stylings have been compared to Wire, Magazine and Joy Division.[4] The band released their debut single, 'Magic of Meghan' in 2019. Shaw wrote the song after going through a break-up and moving out of her former partner's apartment the same day that Meghan Markle and Prince Harry announced they were engaged.[5] This was followed by the release of two EPs that year: Sweet Princess in August and Boundary Road Snacks and Drinks in October. The band were included as part of the NME 100 of 2020,[6] as well as DIY magazine's Class of 2020.[7] The band signed to 4AD in late 2020 and shared a new single, 'Scratchcard Lanyard'.[8] In February 2021, the band shared details of their debut studio album, New Long Leg. They also shared the single 'Strong Feelings'.[9] The album, which was produced by John Parish, was released on 2 April 2021.[10]"
+
+docs = [{"text": text},
+        {"text": text2},
+        {"text": text3}]
+document_store = ElasticsearchDocumentStore()
+document_store.write_documents(docs)
+
+question_generator = QuestionGenerator()
+
+
+# # Pipeline 1
+# question_generation_pipeline = QuestionGenerationPipeline(question_generator)
+# for document in document_store:
+#         result = question_generation_pipeline.run(documents=[document])
+
+
+# # Pipeline 2
+# retriever = ElasticsearchRetriever(document_store=document_store)
+# rqg_pipeline = RetrieverQuestionGenerationPipeline(retriever, question_generator)
+# result = rqg_pipeline.run(query="Arya Stark")
+# pprint(result)
+
+
+# Pipeline 3
+reader = FARMReader("deepset/roberta-base-squad2")
+qag_pipeline = QuestionAnswerGenerationPipeline(question_generator, reader)
+for document in tqdm(document_store):
+    result = qag_pipeline.run(document=document)
+
+
+
+# Pipeline3
+reader = FARMReader("deepset/roberta-base-squad2")
+
+results = []
+for document in tqdm(document_store):
+        questions = question_generator.generate(text=document.text)
+        results.append({"generated_questions": questions,
+                        "document_text": document.text,
+                        "document_id": document.id})
+
+ret = []
+for result in tqdm(results):
+    generated_questions = result["generated_questions"]
+    document_text = result["document_text"]
+    document_id = result["document_id"]
+    for q in generated_questions:
+        answers = reader.predict(query=q, documents=[Document.from_dict({"text": document_text})])["answers"]
+        ret.append({"document_text": document_text,
+                        "document_id": document_id,
+                        "question": q,
+                        "answers": answers})
+
+curr_text = ""
+for r in ret:
+    if curr_text != r["document_text"]:
+        curr_text = r["document_text"]
+        print(f"Document: {curr_text}")
+    print(f"\t{r['question']}")
+    for a in r["answers"]:
+        print(f"\t\t{a['answer']}")
+        break


### PR DESCRIPTION
This PR creates a QuestionGenerator class that takes a document as input and generates questions as output. Since the default models used only seem to generate about 3 questions per passage, input text is split into 50 word chunks with 10 word split overlap. This is somewhat inefficient since T5's max seq len is significantly longer. But this allows us to handle variable length documents.

As a bonus, this also allows the DocumentStore to be used as an iterator

TODO:
- [x] Documentation
- [x] Design implementation into pipelines

For future:
- [ ] Consider how to speed up QG
- [ ] Consider a QuestGen implementation