### PR TITLE
Added delete_document_by_id and delete_documents_by_id for InMemoryDocumentStore

### DIFF
--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -397,3 +397,33 @@ class InMemoryDocumentStore(BaseDocumentStore):
             raise NotImplementedError("Delete by filters is not implemented for InMemoryDocumentStore.")
         index = index or self.index
         self.indexes[index] = {}
+
+    def delete_documents_by_id(self, ids: List[str], index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
+        """
+        Delete a list of document by specifying their id list
+
+        :param ids: List of Ids of the documents to be deleted.
+        :param index: Index name to delete the documents from.
+        :param filters: Optional filters to narrow down the documents to be deleted.
+        :return: None
+        """
+        if filters:
+            raise NotImplementedError("Delete by filters is not implemented for InMemoryDocumentStore.")
+        index = index or self.index
+        for id in ids:
+            if id in self.indexes[index].keys():
+                self.indexes[index].pop(id)
+            else:
+                logger.warning(f"Document Key Error: Document with id '{id} not found in index "f"'{index}'")
+
+
+    def delete_document_by_id(self, id: str, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):
+        """
+        Delete a document by specifying its text id string
+
+        :param id: Id of the document to be deleted.
+        :param index: Index name to delete the document from.
+        :param filters: Optional filters to narrow down the document to be deleted.
+        :return: None
+        """
+        self.delete_documents_by_id([id], index, filters)

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -348,6 +348,21 @@ def test_delete_documents_with_filters(document_store_with_docs):
 
 
 @pytest.mark.elasticsearch
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+def test_delete_document_by_id(document_store_with_docs):
+    documents = document_store_with_docs.get_all_documents()
+    assert len(documents) == 3
+
+    doc_id_to_delete = documents[0].id
+    document_store_with_docs.delete_document_by_id(doc_id_to_delete)
+
+    documents = document_store_with_docs.get_all_documents()
+    doc_ids = [doc.id for doc in documents]
+    assert len(documents) == 2
+    assert doc_id_to_delete not in doc_ids
+
+
+@pytest.mark.elasticsearch
 def test_labels(document_store):
     label = Label(
         question="question",


### PR DESCRIPTION
What is changed?
- Added delete_document_by_id in InMemoryDocumentStore
- Added delete_documents_by_id in InMemoryDocumentStore
- Added tests (test_delete_document_by_id) for memory store 

Why?
We can not delete a single document from the InMemoryDocumentStore if required, currently, we can only delete the whole index and not a single document within that index.

Breaking changes - None

Link to Issue - https://github.com/deepset-ai/haystack/issues/1269

**Status**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [x] Added tests
- [ ] Updated documentation
