### PR TITLE
Add links to tutorial 12 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ If you'd like to learn more about Haystack, feel free to go through the tutorial
     [Colab](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial11_Pipelines.ipynb)
     |
     [Python](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial11_Pipelines.py)
+-   Tutorial 12 - Long-Form Question Answering:
+    [Jupyter noteboook](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial12_LFQA.ipynb)
+    |
+    [Colab](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial12_LFQA.ipynb)
+    |
+    [Python](https://github.com/deepset-ai/haystack/blob/master/tutorials/Tutorial12_LFQA.py)
 
 
 ## How to use Haystack


### PR DESCRIPTION
In the readme file, links to tutorial 12 (LFQA) were missing. Adding these links with this PR.
