### PR TITLE
Upgrade streamlit

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,2 @@
-streamlit==0.81.0
-st-annotated-text==1.0.1
+streamlit==0.84.0
+st-annotated-text==1.1.0

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -22,8 +22,9 @@ def annotate_answer(answer, context):
     from the API that we highlight in the given context"""
     start_idx = context.find(answer)
     end_idx = start_idx + len(answer)
-    annotated_text(context[:start_idx], (answer, "ANSWER", "#8ef"), context[end_idx:])
-
+    # calculate dynamic height depending on context length
+    height = int(len(context) * 0.50) + 5
+    annotated_text(context[:start_idx], (answer, "ANSWER", "#8ef"), context[end_idx:], height=height)
 
 def show_plain_documents(text):
     """ If we are using a plain document search pipeline, i.e. only retriever, we'll get plain documents


### PR DESCRIPTION
**Proposed changes**:
- update streamlit and st-annotated-text to latest version
- make use of latest st-annotated-test version to pass height argument for the iframe annotated text

Why?
stay up-to-date with streamlit features.
Context returned by haystack-api comes in various lenght and the annotated text library was using a fixed height, which sometime did not show entire context/answer and the layout was not optimal. With the latest st-annotated-text we can pass a dynamic height based on the result context lenght.

Breaking changes - None

Issue #1278
