### PR TITLE
Suppress FAISS logs & apex warnings

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,5 +1,14 @@
 import logging
 
+# Change log-levels before modules are loaded to avoid verbose log messages.
+logging.getLogger('farm').setLevel(logging.WARNING)
+logging.getLogger('farm.utils').setLevel(logging.INFO)
+logging.getLogger('farm.infer').setLevel(logging.INFO)
+logging.getLogger('transformers').setLevel(logging.WARNING)
+logging.getLogger('farm.eval').setLevel(logging.INFO)
+logging.getLogger('farm.modeling.optimization').setLevel(logging.INFO)
+logging.getLogger('faiss.loader').setLevel(logging.WARNING)
+
 import pandas as pd
 from haystack.schema import Document, Label, MultiLabel, BaseComponent
 from haystack.finder import Finder
@@ -9,12 +18,3 @@ from haystack._version import __version__
 pd.options.display.max_colwidth = 80
 
 logger = logging.getLogger(__name__)
-
-logging.getLogger('farm').setLevel(logging.WARNING)
-logging.getLogger('farm.utils').setLevel(logging.INFO)
-logging.getLogger('farm.infer').setLevel(logging.INFO)
-logging.getLogger('transformers').setLevel(logging.WARNING)
-logging.getLogger('farm.eval').setLevel(logging.INFO)
-logging.getLogger('farm.modeling.optimization').setLevel(logging.INFO)
-
-


### PR DESCRIPTION
There's verbose logging from FAISS when Haystack is initialized. This PR sets the log-level of `faiss.loader` to WARN level. 

Currently, haystack import looks like:

```python
>>> import haystack
07/29/2021 14:07:35 - INFO - faiss.loader -   Loading faiss with AVX2 support.
07/29/2021 14:07:35 - INFO - faiss.loader -   Could not load library with AVX2 support due to:
ModuleNotFoundError("No module named 'faiss.swigfaiss_avx2'")
07/29/2021 14:07:35 - INFO - faiss.loader -   Loading faiss.
07/29/2021 14:07:35 - INFO - faiss.loader -   Successfully loaded faiss.
07/29/2021 14:07:35 - INFO - farm.modeling.prediction_head -   Better speed can be achieved with apex installed from https://www.github.com/nvidia/apex .
>>> 
```

With this PR:
```python
>>> import haystack
>>> 
```
