### PR TITLE
Allow multiple files to upload for Haystack UI

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,2 @@
-streamlit>=0.76.0
+streamlit>=0.84.0
 st-annotated-text==1.1.0

--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,2 @@
-streamlit==0.84.0
+streamlit>=0.76.0
 st-annotated-text==1.1.0

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -65,14 +65,15 @@ eval_mode = st.sidebar.checkbox("Evaluation mode")
 debug = st.sidebar.checkbox("Show debug info")
 
 st.sidebar.write("## File Upload:")
-data_file = st.sidebar.file_uploader("", type=["pdf", "txt", "docx"])
-# Upload file
-if data_file:
-    raw_json = upload_doc(data_file)
-    st.sidebar.write(raw_json)
-    if debug:
-        st.subheader("REST API JSON response")
+data_files = st.sidebar.file_uploader("", type=["pdf", "txt", "docx"], accept_multiple_files=True)
+for data_file in data_files:
+    # Upload file
+    if data_file:
+        raw_json = upload_doc(data_file)
         st.sidebar.write(raw_json)
+        if debug:
+            st.subheader("REST API JSON response")
+            st.sidebar.write(raw_json)
 
 # load csv into pandas dataframe
 if eval_mode:


### PR DESCRIPTION
When using Haystack UI and streamlit, the default behavior is to upload one file at at time. Trying to upload a new file will override any file one has already uploaded. Streamlit now supports uploading multiple files and may be more intuitive for users of Haystack to use it as the default behavior.   
   
Return type for `st.sidebar.file_uploader` when `accept_multiple_files=True` is a list of the files and empty if no files are provided   
   
**Proposed changes**:
- Change `st.sidebar.file_uploader` to default to `accept_multiple_files=True` to allow for multiple files to be uploaded.   

**Status (please check what you already did)**:   
- [X] First draft (up for discussions & feedback)   
- [X] Final code   
   