### PR TITLE
Support OpenDistro init

### DIFF
--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -1134,10 +1134,10 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
 
 
 class OpenDistroElasticsearchDocumentStore(OpenSearchDocumentStore):
+    """
+    A DocumentStore which has an Open Distro for Elasticsearch service behind it.
+    """
     def __init__(self, host="https://admin:admin@localhost:9200/", similarity="cosine", **kwargs):
-        """
-        The init of the
-        """
         logger.warning("Open Distro for Elasticsearch has been replaced by OpenSearch! "
                        "See https://opensearch.org/faq/ for details. "
                        "We recommend using the OpenSearchDocumentStore instead.")

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -165,16 +165,8 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                              ca_certs: Optional[str],
                              verify_certs: bool,
                              timeout: int) -> Elasticsearch:
-        # Create list of host(s) + port(s) to allow direct client connections to multiple elasticsearch nodes
-        if isinstance(host, list):
-            if isinstance(port, list):
-                if not len(port) == len(host):
-                    raise ValueError("Length of list `host` must match length of list `port`")
-                hosts = [{"host":h, "port":p} for h, p in zip(host,port)]
-            else:
-                hosts = [{"host": h, "port": port} for h in host]
-        else:
-            hosts = [{"host": host, "port": port}]
+
+        hosts = self._prepare_hosts(host, port)
 
         if (api_key or api_key_id) and not(api_key and api_key_id):
             raise ValueError("You must provide either both or none of `api_key_id` and `api_key`")
@@ -213,6 +205,19 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             raise ConnectionError(
                 f"Initial connection to Elasticsearch failed. Make sure you run an Elasticsearch instance at `{hosts}` and that it has finished the initial ramp up (can take > 30s).")
         return client
+
+    def _prepare_hosts(self, host, port):
+        # Create list of host(s) + port(s) to allow direct client connections to multiple elasticsearch nodes
+        if isinstance(host, list):
+            if isinstance(port, list):
+                if not len(port) == len(host):
+                    raise ValueError("Length of list `host` must match length of list `port`")
+                hosts = [{"host":h, "port":p} for h, p in zip(host,port)]
+            else:
+                hosts = [{"host": h, "port": port} for h in host]
+        else:
+            hosts = [{"host": host, "port": port}]
+        return hosts
 
     def _create_document_index(self, index_name: str):
         """
@@ -1129,7 +1134,15 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
 
 
 class OpenDistroElasticsearchDocumentStore(OpenSearchDocumentStore):
-    def __init__(self):
+    def __init__(self, host="https://admin:admin@localhost:9200/", similarity="cosine", **kwargs):
+        """
+        The init of the
+        """
         logger.warning("Open Distro for Elasticsearch has been replaced by OpenSearch! "
                        "See https://opensearch.org/faq/ for details. "
                        "We recommend using the OpenSearchDocumentStore instead.")
+        super(OpenDistroElasticsearchDocumentStore, self).__init__(host=host,
+                                                                   similarity=similarity,
+                                                                   **kwargs)
+    def _prepare_hosts(self, host, port):
+        return host


### PR DESCRIPTION
Fixes #1316 . 

In Haystack 0.9, the client is initialized [here](https://github.com/deepset-ai/haystack/blob/9e4d7bf9be8ac98de72338d8ba9db339d2af5d21/haystack/document_store/elasticsearch.py#L182). In this case, `hosts` is a dictionary that looks something like this:
```
hosts = [{'host': 'localhost', 'port': 9200}]
```

However, this doesn't work for an OpenDistro service. In [this thread](https://github.com/opendistro-for-elasticsearch/sample-code/issues/242) about OpenDistro, they present `hosts` as a list of strings. i.e.

```
hosts = ["https://admin:admin@localhost:9200/"]
```

This PR allows for this latter format of `hosts` to work.  