### PR TITLE
Fix behavior of delete_documents() with filters for Milvus

### DIFF
--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -403,9 +403,8 @@ class MilvusDocumentStore(SQLDocumentStore):
         if status.code != Status.SUCCESS:
             raise RuntimeError(f'Milvus has collection check failed: {status}')
         if ok:
-            status = self.milvus_server.drop_collection(collection_name=index)
-            if status.code != Status.SUCCESS:
-                raise RuntimeError(f'Milvus drop collection failed: {status}')
+            existing_docs = super().get_all_documents(filters=filters, index=index)
+            self._delete_vector_ids_from_milvus(documents=existing_docs, index=index)
 
             self.milvus_server.flush([index])
             self.milvus_server.compact(collection_name=index)

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -404,12 +404,12 @@ class MilvusDocumentStore(SQLDocumentStore):
             raise RuntimeError(f'Milvus has collection check failed: {status}')
         if ok:
             if filters:
+                existing_docs = super().get_all_documents(filters=filters, index=index)
+                self._delete_vector_ids_from_milvus(documents=existing_docs, index=index)
+            else:
                 status = self.milvus_server.drop_collection(collection_name=index)
                 if status.code != Status.SUCCESS:
                     raise RuntimeError(f'Milvus drop collection failed: {status}')
-            else:
-                existing_docs = super().get_all_documents(filters=filters, index=index)
-                self._delete_vector_ids_from_milvus(documents=existing_docs, index=index)
 
             self.milvus_server.flush([index])
             self.milvus_server.compact(collection_name=index)

--- a/haystack/document_store/milvus.py
+++ b/haystack/document_store/milvus.py
@@ -403,8 +403,13 @@ class MilvusDocumentStore(SQLDocumentStore):
         if status.code != Status.SUCCESS:
             raise RuntimeError(f'Milvus has collection check failed: {status}')
         if ok:
-            existing_docs = super().get_all_documents(filters=filters, index=index)
-            self._delete_vector_ids_from_milvus(documents=existing_docs, index=index)
+            if filters:
+                status = self.milvus_server.drop_collection(collection_name=index)
+                if status.code != Status.SUCCESS:
+                    raise RuntimeError(f'Milvus drop collection failed: {status}')
+            else:
+                existing_docs = super().get_all_documents(filters=filters, index=index)
+                self._delete_vector_ids_from_milvus(documents=existing_docs, index=index)
 
             self.milvus_server.flush([index])
             self.milvus_server.compact(collection_name=index)


### PR DESCRIPTION
Delete filtered set of vectors rather than the whole collection

**Proposed changes**:
- changed delete_documents() in MilvusDocumentStore to match expected behavior when deleting documents based on a filter
- Now deletes filtered set of vectors rather than the whole collection when deleting based on a filter

**Status (please check what you already did)**:
- [X] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [x] Updated documentation
