### PR TITLE
Add simple docs2answer node to allow FAQ style QA / Doc search in API

### DIFF
--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -31,8 +31,8 @@ class Answer(BaseModel):
     score: Optional[float] = None
     probability: Optional[float] = None
     context: Optional[str]
-    offset_start: int
-    offset_end: int
+    offset_start: Optional[int]
+    offset_end: Optional[int]
     offset_start_in_doc: Optional[int]
     offset_end_in_doc: Optional[int]
     document_id: Optional[str] = None
@@ -75,6 +75,6 @@ def _process_request(pipeline, request) -> Response:
                           top_k_reader=request.top_k_reader)
 
     end_time = time.time()
-    logger.info(json.dumps({"request": request.dict(), "response": result, "time": f"{(end_time - start_time):.2f}"}))
+    # logger.info(json.dumps({"request": request.dict(), "response": result, "time": f"{(end_time - start_time):.2f}"}))
 
     return result

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -75,6 +75,6 @@ def _process_request(pipeline, request) -> Response:
                           top_k_reader=request.top_k_reader)
 
     end_time = time.time()
-    # logger.info(json.dumps({"request": request.dict(), "response": result, "time": f"{(end_time - start_time):.2f}"}))
+    logger.info(json.dumps({"request": request.dict(), "response": result, "time": f"{(end_time - start_time):.2f}"}))
 
     return result


### PR DESCRIPTION
**Proposed changes**:
Currently we enforce our `/search` endpoint in the REST API to return `Answers`. 
This doesn't work for pipelines that just have a retriever and return documents (like FAQ-Style).
 
For now we can mitigate it like this: 
- Add a `Docs2Answers` Node that can do the conversion in a pipeline
- Add a switch in there to distinguish between FAQ docs and regular ones

Long-term: We should rethink the API response format and also allow documents there

Usage Example:

```
version: '0.7'

components:    # define all the building-blocks for Pipelines
  - name: ElasticsearchDocumentStore
    type: ElasticsearchDocumentStore
    params:
      host: localhost
      index: document
      embedding_field: question_emb
      embedding_dim: 768
      excluded_meta_data:
      - question_emb
  - name: EBRetriever
    type: EmbeddingRetriever
    params:
      document_store: ElasticsearchDocumentStore    # params can reference other components defined in the YAML
      embedding_model: deepset/sentence_bert
      use_gpu: false
  - name: Reader       # custom-name for the component; helpful for visualization & debugging
    type: FARMReader    # Haystack Class name for the component
    params:
      model_name_or_path: deepset/roberta-base-squad2
  - name: TextFileConverter
    type: TextConverter
  - name: PDFFileConverter
    type: PDFToTextConverter
  - name: Preprocessor
    type: PreProcessor
    params:
      split_by: word
      split_length: 1000
  - name: FileTypeClassifier
    type: FileTypeClassifier
  - name: Docs2Answers
    params: {}
    type: Docs2Answers

pipelines:
  - name: query    # a sample extractive-qa Pipeline
    type: Query
    nodes:
      - name: EBRetriever
        inputs: [Query]
      - name: Docs2Answers
        inputs: [EBRetriever]

  - name: indexing
    type: Indexing
    nodes:
      - name: FileTypeClassifier
        inputs: [File]
      - name: TextFileConverter
        inputs: [FileTypeClassifier.output_1]
      - name: PDFFileConverter
        inputs: [FileTypeClassifier.output_2]
      - name: Preprocessor
        inputs: [PDFFileConverter, TextFileConverter]
      - name: ElasticsearchDocumentStore
        inputs: [Preprocessor]
```

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
