### PR TITLE
Add support for no Docker envs in Tutorial 13

### DIFF
--- a/docs/_src/tutorials/tutorials/13.md
+++ b/docs/_src/tutorials/tutorials/13.md
@@ -16,6 +16,16 @@ generate questions which the question generation model thinks can be answered by
 
 
 ```python
+# Install needed libraries
+
+!pip install grpcio-tools==1.34.1
+!pip install git+https://github.com/deepset-ai/haystack.git
+```
+
+
+```python
+# Imports needed to run this notebook
+
 from haystack.question_generator import QuestionGenerator
 from haystack.utils import launch_es
 from haystack.document_store import ElasticsearchDocumentStore
@@ -26,11 +36,35 @@ from tqdm import tqdm
 from haystack.pipeline import QuestionGenerationPipeline, RetrieverQuestionGenerationPipeline, QuestionAnswerGenerationPipeline
 ```
 
+Let's start an Elasticsearch instance with one of the options below:
+
 
 ```python
-# Start Elasticsearch service via Docker
+# Option 1: Start Elasticsearch service via Docker
 launch_es()
+```
 
+
+```python
+# Option 2: In Colab / No Docker environments: Start Elasticsearch from source
+! wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.2-linux-x86_64.tar.gz -q
+! tar -xzf elasticsearch-7.9.2-linux-x86_64.tar.gz
+! chown -R daemon:daemon elasticsearch-7.9.2
+
+import os
+from subprocess import Popen, PIPE, STDOUT
+es_server = Popen(['elasticsearch-7.9.2/bin/elasticsearch'],
+                   stdout=PIPE, stderr=STDOUT,
+                   preexec_fn=lambda: os.setuid(1)  # as daemon
+                  )
+# wait until ES has started
+! sleep 30
+```
+
+Let's initialize some core components
+
+
+```python
 text1 = "Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace."
 text2 = "Princess Arya Stark is the third child and second daughter of Lord Eddard Stark and his wife, Lady Catelyn Stark. She is the sister of the incumbent Westerosi monarchs, Sansa, Queen in the North, and Brandon, King of the Andals and the First Men. After narrowly escaping the persecution of House Stark by House Lannister, Arya is trained as a Faceless Man at the House of Black and White in Braavos, using her abilities to avenge her family. Upon her return to Westeros, she exacts retribution for the Red Wedding by exterminating the Frey male line."
 text3 = "Dry Cleaning are an English post-punk band who formed in South London in 2018.[3] The band is composed of vocalist Florence Shaw, guitarist Tom Dowse, bassist Lewis Maynard and drummer Nick Buxton. They are noted for their use of spoken word primarily in lieu of sung vocals, as well as their unconventional lyrics. Their musical stylings have been compared to Wire, Magazine and Joy Division.[4] The band released their debut single, 'Magic of Meghan' in 2019. Shaw wrote the song after going through a break-up and moving out of her former partner's apartment the same day that Meghan Markle and Prince Harry announced they were engaged.[5] This was followed by the release of two EPs that year: Sweet Princess in August and Boundary Road Snacks and Drinks in October. The band were included as part of the NME 100 of 2020,[6] as well as DIY magazine's Class of 2020.[7] The band signed to 4AD in late 2020 and shared a new single, 'Scratchcard Lanyard'.[8] In February 2021, the band shared details of their debut studio album, New Long Leg. They also shared the single 'Strong Feelings'.[9] The album, which was produced by John Parish, was released on 2 April 2021.[10]"

--- a/tutorials/Tutorial13_Question_generation.ipynb
+++ b/tutorials/Tutorial13_Question_generation.ipynb
@@ -22,6 +22,25 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# Install needed libraries\n",
+    "\n",
+    "!pip install grpcio-tools==1.34.1\n",
+    "!pip install git+https://github.com/deepset-ai/haystack.git"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Imports needed to run this notebook\n",
+    "\n",
     "from haystack.question_generator import QuestionGenerator\n",
     "from haystack.utils import launch_es\n",
     "from haystack.document_store import ElasticsearchDocumentStore\n",
@@ -39,13 +58,75 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "Let's start an Elasticsearch instance with one of the options below:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],
    "source": [
-    "# Start Elasticsearch service via Docker\n",
-    "launch_es()\n",
+    "# Option 1: Start Elasticsearch service via Docker\n",
+    "launch_es()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Option 2: In Colab / No Docker environments: Start Elasticsearch from source\n",
+    "! wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.2-linux-x86_64.tar.gz -q\n",
+    "! tar -xzf elasticsearch-7.9.2-linux-x86_64.tar.gz\n",
+    "! chown -R daemon:daemon elasticsearch-7.9.2\n",
     "\n",
+    "import os\n",
+    "from subprocess import Popen, PIPE, STDOUT\n",
+    "es_server = Popen(['elasticsearch-7.9.2/bin/elasticsearch'],\n",
+    "                   stdout=PIPE, stderr=STDOUT,\n",
+    "                   preexec_fn=lambda: os.setuid(1)  # as daemon\n",
+    "                  )\n",
+    "# wait until ES has started\n",
+    "! sleep 30"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% \n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Let's initialize some core components"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "text1 = \"Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.\"\n",
     "text2 = \"Princess Arya Stark is the third child and second daughter of Lord Eddard Stark and his wife, Lady Catelyn Stark. She is the sister of the incumbent Westerosi monarchs, Sansa, Queen in the North, and Brandon, King of the Andals and the First Men. After narrowly escaping the persecution of House Stark by House Lannister, Arya is trained as a Faceless Man at the House of Black and White in Braavos, using her abilities to avenge her family. Upon her return to Westeros, she exacts retribution for the Red Wedding by exterminating the Frey male line.\"\n",
     "text3 = \"Dry Cleaning are an English post-punk band who formed in South London in 2018.[3] The band is composed of vocalist Florence Shaw, guitarist Tom Dowse, bassist Lewis Maynard and drummer Nick Buxton. They are noted for their use of spoken word primarily in lieu of sung vocals, as well as their unconventional lyrics. Their musical stylings have been compared to Wire, Magazine and Joy Division.[4] The band released their debut single, 'Magic of Meghan' in 2019. Shaw wrote the song after going through a break-up and moving out of her former partner's apartment the same day that Meghan Markle and Prince Harry announced they were engaged.[5] This was followed by the release of two EPs that year: Sweet Princess in August and Boundary Road Snacks and Drinks in October. The band were included as part of the NME 100 of 2020,[6] as well as DIY magazine's Class of 2020.[7] The band signed to 4AD in late 2020 and shared a new single, 'Scratchcard Lanyard'.[8] In February 2021, the band shared details of their debut studio album, New Long Leg. They also shared the single 'Strong Feelings'.[9] The album, which was produced by John Parish, was released on 2 April 2021.[10]\"\n",
@@ -206,6 +287,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.6"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As suggested [here](https://github.com/deepset-ai/haystack/pull/1267#issuecomment-899000223), we can make Tutorial 13 run end-to-end in colab by supplying a no docker option for Elasticsearch.

Thanks @cvgoudar for pointing this out!