### PR TITLE
Adjust WeaviateDocumentStore import

### DIFF
--- a/haystack/document_store/__init__.py
+++ b/haystack/document_store/__init__.py
@@ -3,3 +3,4 @@ from haystack.document_store.faiss import FAISSDocumentStore
 from haystack.document_store.memory import InMemoryDocumentStore
 from haystack.document_store.milvus import MilvusDocumentStore
 from haystack.document_store.sql import SQLDocumentStore
+from haystack.document_store.weaviate import WeaviateDocumentStore


### PR DESCRIPTION
Suggested by #1369. Add `WeaviateDocumentStore` to `document_store/__init__.py` so that it can be imported as follows:

`from haystack.document_store import WeaviateDocumentStore`

