### PR TITLE
docker-compose always pull REST API Image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     image: "deepset/haystack-cpu:latest"
+    pull_policy: always
+    # Mount custom Pipeline YAML and custom Components.
+    # volumes:
+    #   - ./rest_api/pipeline:/home/user/rest_api/pipeline
     ports:
       - 8000:8000
     environment:


### PR DESCRIPTION
With this change, `docker-compose` will always check for new images for the API before running.