### PR TITLE
Add sentence-transformers as mandatory dependency and remove from dev…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 # Add extra dependencies only required for tests and local dev setup
 mypy
 pytest
-sentence-transformers
 selenium
 webdriver-manager
 beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ elastic-apm
 tox
 coverage
 langdetect # for PDF conversions
-# optional: sentence-transformers
+sentence-transformers
 python-multipart
 python-docx
 sqlalchemy>=1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ elastic-apm
 tox
 coverage
 langdetect # for PDF conversions
-sentence-transformers
+sentence-transformers>=0.4.0
 python-multipart
 python-docx
 sqlalchemy>=1.4.2


### PR DESCRIPTION
… dependency

fixes #1356 

**Proposed changes**:
- sentence-transformers is a mandatory dependency in requirements.txt now (not optional anymore)
- sentence-transformers is removed from requirements-dev.txt

Note that there is still a line of code in `_SentenceTransformersEmbeddingEncoder ` that checks whether sentence-transformers is installed:
https://github.com/deepset-ai/haystack/blob/4021eb838e40bb242c997d3a4a70be4ac7fb9968/haystack/retriever/dense.py#L630
For consistency with other dependencies, we could remove that check but I would argue to still keep it.