### PR TITLE
Ensure num_hard_negatives is 0 when embedding passages

### DIFF
--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -269,6 +269,12 @@ class DensePassageRetriever(BaseRetriever):
         :param docs: List of Document objects used to represent documents / passages in a standardized way within Haystack.
         :return: Embeddings of documents / passages shape (batch_size, embedding_dim)
         """
+
+        if self.processor.num_hard_negatives != 0:
+            logger.warning(f"'num_hard_negatives' is set to {self.processor.num_hard_negatives}, but inference does "
+                           f"not require any hard negatives. Setting num_hard_negatives to 0.")
+            self.processor.num_hard_negatives = 0
+
         passages = [{'passages': [{
             "title": d.meta["name"] if d.meta and "name" in d.meta else "",
             "text": d.text,


### PR DESCRIPTION
Fixes #1305 

**Proposed changes**:
If `num_hard_negatives` is not 0, the retriever will create embeddings for empty hard negative passages when updating embeddings. This PR makes sure that `num_hard_negatives` is 0 when embedding passages.