### PR TITLE
Fix tesseract installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.
 RUN apt-get install libpoppler-cpp-dev pkg-config -y --fix-missing
 
 # Install Tesseract
-RUN apt-get install tesseract-ocr libtesseract-dev poppler-utils
+RUN apt-get install tesseract-ocr libtesseract-dev poppler-utils -y
 
 # copy code
 COPY haystack /home/user/haystack

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -17,6 +17,7 @@ RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.
 tar -xvf xpdf-tools-linux-4.03.tar.gz && cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
 
 RUN apt-get install libpoppler-cpp-dev pkg-config -y --fix-missing
+RUN apt-get install tesseract-ocr libtesseract-dev poppler-utils -y
 
 # copy code
 COPY haystack /home/user/haystack


### PR DESCRIPTION
**Proposed changes**:
- Automatic builds of Docker images were not running due to missing `-y` flag of tesseract installation