### PR TITLE
Enable docker-compose for GPUs & Add public UI image

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The quickest way to see what Haystack offers is to start a [Docker Compose](http
     cd haystack
     docker-compose pull
     docker-compose up
+    
+    # Or on a GPU machine: docker-compose -f docker-compose-gpu.yml up
 ```
 
 You should be able to see the following in your terminal window as part of the log output:

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -13,7 +13,6 @@ services:
           - driver: nvidia
             count: 1
             capabilities: [gpu]
-    pull_policy: always
     # Mount custom Pipeline YAML and custom Components.
     # volumes:
     #   - ./rest_api/pipeline:/home/user/rest_api/pipeline

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -1,0 +1,46 @@
+version: "3"
+services:
+  haystack-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: "deepset/haystack-gpu:latest"
+    # in recent docker-compose version you can enable GPU resources. Make sure to fulfill the prerequisites listed here: https://docs.docker.com/compose/gpu-support/
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu]
+    pull_policy: always
+    # Mount custom Pipeline YAML and custom Components.
+    # volumes:
+    #   - ./rest_api/pipeline:/home/user/rest_api/pipeline
+    ports:
+      - 8000:8000
+    environment:
+      # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
+      - ELASTICSEARCHDOCUMENTSTORE_PARAMS_HOST=elasticsearch
+    restart: always
+    depends_on:
+      - elasticsearch
+    command: "/bin/bash -c 'sleep 15 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"
+  elasticsearch:
+    # This will start an empty elasticsearch instance (so you have to add your documents yourself)
+    #image: "elasticsearch:7.9.2"
+    # If you want a demo image instead that is "ready-to-query" with some indexed Game of Thrones articles:
+    image: "deepset/elasticsearch-game-of-thrones"
+    ports:
+      - 9200:9200
+    environment:
+      - discovery.type=single-node
+  ui:
+    build:
+      context: ui
+      dockerfile: Dockerfile
+    ports:
+      - 8501:8501
+    environment:
+      - API_ENDPOINT=http://haystack-api:8000
+      - EVAL_FILE=eval_labels_example.csv

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -39,6 +39,7 @@ services:
     build:
       context: ui
       dockerfile: Dockerfile
+    image: "deepset/haystack-streamlit-ui:latest"
     ports:
       - 8501:8501
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     build:
       context: ui
       dockerfile: Dockerfile
+    image: "deepset/haystack-streamlit-ui:latest"
     ports:
       - 8501:8501
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       context: .
       dockerfile: Dockerfile
     image: "deepset/haystack-cpu:latest"
-    pull_policy: always
     # Mount custom Pipeline YAML and custom Components.
     # volumes:
     #   - ./rest_api/pipeline:/home/user/rest_api/pipeline


### PR DESCRIPTION
**Proposed changes**:
- docker-compose finally allows a way to directly enable GPU resources: https://docs.docker.com/compose/gpu-support/
Prerequisite: You still need to have the nvidia-container-runtime installed on your host https://docs.docker.com/config/containers/resource_constraints/#gpu  

So you can now run the "demo-stack" via: 
```
docker-compose -f docker-compose-gpu.yml up -d
``` 
- Adding the public UI image to ensure that we have compatible versions and do not always need to build locally
- Removing `pull_policy` as this caused trouble with earlier docker-compose versions and even with most recent version did not work on all machines as intended