### PR TITLE
Feat: Download archive from url without temp file along with adding CI for win & mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,12 @@ jobs:
 
   build-cache:
     needs: type-check
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+        fail-fast: false
+        matrix:
+          os: [ ubuntu-latest, macos-latest, windows-latest ]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -33,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+          key: ${{ matrix.os }}-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
       - name: Install dependencies
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
@@ -43,17 +48,18 @@ jobs:
 
   prepare-build:
     needs: build-cache
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           echo "::set-output name=matrix::$(cd test && ls -d test_*.py | jq -R . | jq -cs .)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   build:
     needs: prepare-build
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         test-path: ${{fromJson(needs.prepare-build.outputs.matrix)}}
@@ -69,7 +75,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+        key: ${{ matrix.os }}-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 
@@ -89,9 +95,11 @@ jobs:
 #      run: RAY_DISABLE_MEMORY_MONITOR=1 ray start --head
 
     - name: Install pdftotext
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
 
     - name: Install tesseract
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
 
     - name: Run tests


### PR DESCRIPTION
Download archive from url without temp file along with adding CI for win & mac
To resolve https://github.com/deepset-ai/haystack/issues/1445

**Proposed changes**:
- Sometime on windows python process doesn't have permission to create temp file hence extracting archive directly via in memory stream remove the need of temp file. 
- Adding CI for Windows and Mac, but adding it in ci.yml is bit complex so will resolve issue step by step.

**Status (please check what you already did)**:
- [ X ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
