### PR TITLE
Simplify tests & allow running on individual doc stores

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ Do not parameterize it yourself.
 Example:
 ```
 def test_write_with_duplicate_doc_ids(document_store):
+        ...
+        document_store.write(docs)
         ....
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,96 @@ Please give a concise description in the first comment in the PR that includes:
 - What are limitations?
 - Breaking changes (Example of before vs. after)
 - Link the issue that this relates to
+
+## Running tests
+
+### CI
+Tests will automatically run in our CI for every commit you push to your PR. This is the most convenient way for you and we encourage you to create early "WIP Pull requests".
+
+### Local
+However, you can also run the tests locally by executing pytest in your terminal from the `/test` folder.
+
+#### Running all tests
+**Important**: If you want to run **all** tests locally, you'll need **all** document stores running in the background before you run the tests.
+Many of the tests will then be executed multiple times with different document stores.
+
+You can launch them like this:
+```
+docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
+docker run -d -p 19530:19530 -p 19121:19121 milvusdb/milvus:1.1.0-cpu-d050721-5e559c
+docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' semitechnologies/weaviate:1.7.0
+docker run -d -p 7200:7200 --name haystack_test_graphdb deepset/graphdb-free:9.4.1-adoptopenjdk11
+docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
+```
+Then run all tests:
+```
+cd test
+pytest
+```
+
+#### Recommendation: Running a subset of tests
+In most cases you rather want to run a **subset of tests** locally that are related to your dev:
+
+Run tests that are possible for a **selected document store**. The InMemoryDocument store is a very good starting point as it doesn't require any of the external docker containers from above: 
+```
+pytest . --doc_store_type="memory"
+```
+Run tests using a **combination of document stores**:
+```
+pytest . --doc_store_type="memory,elasticsearch"
+```
+*Note: You will need to launch the elasticsearch container here as described above'*
+
+Just run **one individual test**:
+```
+pytest -v test_retriever.py::test_dpr_embedding
+```
+Select a **logical subset of tests** via markers and the optional "not" keyword:
+```
+pytest -m not elasticsearch
+pytest -m elasticsearch
+pytest -m generator
+pytest -m tika
+pytest -m not slow
+...
+```
+
+
+## Writing tests
+
+If you are writing a test that depend on a document store, there are a few conventions to define on which document store type this test should/can run:
+
+### Option 1: The test should run on all document stores / those supplied in the CLI arg `--doc_store_type`: 
+Use one of the fixtures `document_store` or `document_store_with_docs` or `document_store_type`.
+Do not parameterize it yourself. 
+
+Example:
+```
+def test_write_with_duplicate_doc_ids(document_store):
+        ....
+
+```
+
+### Option 2: The test is only compatible with certain document stores: 
+Some tests you don't want to run on all possible document stores. Either because the test is specific to one/few doc store(s) or the test is not really document store related and it's enough to test it on one document store and speed up the execution time.
+
+Example:
+```
+# Currently update_document_meta() is not implemented for InMemoryDocStore so it's not listed here as an option
+
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss"], indirect=True)
+def test_update_meta(document_store):
+    ....
+``` 
+
+### Option 3: The test is not using a `document_store`/ fixture, but still has a hard requirement for a certain document store:
+
+Example:
+```
+@pytest.mark.elasticsearch
+def test_elasticsearch_custom_fields(elasticsearch_fixture):
+    client = Elasticsearch()
+    client.indices.delete(index='haystack_test_custom', ignore=[404])
+    document_store = ElasticsearchDocumentStore(index="haystack_test_custom", text_field="custom_text_field",
+                                                embedding_field="custom_embedding_field")
+``` 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,13 @@ pytest
 #### Recommendation: Running a subset of tests
 In most cases you rather want to run a **subset of tests** locally that are related to your dev:
 
+The most important option to reduce the number of tests in a meaningful way, is to shrink the "test grid" of document stores.
+This is possible by adding the `--doc_store_type` arg to your pytest command. Possible values are: `"elasticsearch, faiss, memory, milvus, weaviate"`.
+For example, calling `pytest . --doc_store_type="memory"` will run all tests that can be run with the InMemoryDocumentStore, i.e.: 
+- all the tests that we typically run on the whole "document store grid" will only be run for InMemoryDocumentStore
+- any test that is specific to other document stores (e.g. elasticsearch) and is not supported by the chosen document store will be skipped (and marked in the logs accordingly)
+
+
 Run tests that are possible for a **selected document store**. The InMemoryDocument store is a very good starting point as it doesn't require any of the external docker containers from above: 
 ```
 pytest . --doc_store_type="memory"

--- a/README.md
+++ b/README.md
@@ -558,41 +558,11 @@ You will find the Swagger API documentation at
 
 ## :heart: Contributing
 
-We are very open to the community's contributions - be it a quick fix of a typo, or a completely new feature! You don't need to be a Haystack expert to provide meaningful improvements. To avoid any extra work on either side, please check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) first.
+We are very open to the community's contributions - be it a quick fix of a typo, or a completely new feature! You don't need to be a Haystack expert to provide meaningful improvements. 
+To avoid any extra work on either side, please check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) first.
+You can also find instructions to run the tests locally there.
+
 
 We'd also like to invite you to our Slack community channels. Please join [here](https://haystack.deepset.ai/community/join)!
 
-#### Tests
-Tests will automatically run in our CI for every commit you push to your PR. You can also run them locally by executing pytest in your terminal from the root folder of this repository.
-If you want to run **all** tests locally, you'll need **all** document stores running in the background.
-You can launch them like this:
-```
-docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
-docker run -d -p 19530:19530 -p 19121:19121 milvusdb/milvus:1.1.0-cpu-d050721-5e559c
-docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' semitechnologies/weaviate:1.7.0
-docker run -d -p 7200:7200 --name haystack_test_graphdb deepset/graphdb-free:9.4.1-adoptopenjdk11
-docker run -d -p 9998:9998 -e "TIKA_CHILD_JAVA_OPTS=-JXms128m" -e "TIKA_CHILD_JAVA_OPTS=-JXmx128m" apache/tika:1.24.1
-```
-Then run all tests:
-```
-cd test
-pytest
-```
-To just run individual tests:
-```
-pytest -v test_retriever.py::test_dpr_embedding
-```
-To just select a logical subset of tests via markers and the optional "not" keyword:
-```
-pytest -m not elasticsearch
-pytest -m elasticsearch
-pytest -m generator
-pytest -m tika
-pytest -m not slow
-...
-```
-If you want to run all test cases but not with all document store variants, you can make use of the arg `--document_store_type`:
-```
-pytest -v test_retriever.py::test_dpr_embedding --document_store_type="faiss"
-pytest -v test_retriever.py::test_dpr_embedding --document_store_type="faiss, memory"
-```
+

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1536,6 +1536,9 @@ Usage:
 1. Start a Weaviate server (see https://www.semi.technology/developers/weaviate/current/getting-started/installation.html)
 2. Init a WeaviateDocumentStore in Haystack
 
+Limitations:
+The current implementation is not supporting the storage of labels, so you cannot run any evaluation workflows.
+
 <a name="weaviate.WeaviateDocumentStore.__init__"></a>
 #### \_\_init\_\_
 

--- a/haystack/document_store/weaviate.py
+++ b/haystack/document_store/weaviate.py
@@ -29,6 +29,9 @@ class WeaviateDocumentStore(BaseDocumentStore):
     Usage:
     1. Start a Weaviate server (see https://www.semi.technology/developers/weaviate/current/getting-started/installation.html)
     2. Init a WeaviateDocumentStore in Haystack
+
+    Limitations:
+    The current implementation is not supporting the storage of labels, so you cannot run any evaluation workflows.
     """
 
     def __init__(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -419,11 +419,13 @@ def get_retriever(retriever_type, document_store):
 
     return retriever
 
-@pytest.fixture
-def document_store_with_docs(document_store, test_docs_xs):
-    # document_store = get_document_store(request.param)
+
+@pytest.fixture(params=["elasticsearch", "faiss", "memory", "sql", "milvus"])
+def document_store_with_docs(request, test_docs_xs):
+    document_store = get_document_store(request.param)
     document_store.write_documents(test_docs_xs)
     yield document_store
+    document_store.delete_documents()
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -420,7 +420,7 @@ def get_retriever(retriever_type, document_store):
     return retriever
 
 
-@pytest.fixture(params=["elasticsearch", "faiss", "memory", "sql", "milvus"])
+@pytest.fixture(params=["elasticsearch", "faiss", "memory", "milvus"])
 def document_store_with_docs(request, test_docs_xs):
     document_store = get_document_store(request.param)
     document_store.write_documents(test_docs_xs)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -54,6 +54,13 @@ def pytest_generate_tests(metafunc):
             break
     # for all others that don't have explicit parametrization, we add the ones from the CLI arg
     if 'document_store' in metafunc.fixturenames and not found_mark_parametrize_document_store:
+        # TODO: Remove the following if-condition once weaviate is fully compliant
+        # Background: Currently, weaviate is not fully compliant (e.g. "_" in "meta_field", problems with uuids ...)
+        # Therefore, we have separate tests in test_weaviate.py and we don't want to parametrize our generic
+        # tests (e.g. in test_document_store.py) with the weaviate fixture. However, we still need the weaviate option
+        # in the CLI arg as we want to skip test_weaviate.py if weaviate is not selected from CLI
+        if "weaviate" in selected_doc_stores:
+            selected_doc_stores.remove("weaviate")
         metafunc.parametrize("document_store", selected_doc_stores, indirect=True)
 
 
@@ -282,7 +289,7 @@ def test_docs_xs():
     return [
         # current "dict" format for a document
         {"text": "My name is Carla and I live in Berlin", "meta": {"meta_field": "test1", "name": "filename1"}},
-        # meta_field at the top level for backward compatibility
+        # metafield at the top level for backward compatibility
         {"text": "My name is Paul and I live in New York", "meta_field": "test2", "name": "filename2"},
         # Document object for a doc
         Document(text="My name is Christelle and I live in Paris", meta={"meta_field": "test3", "name": "filename3"})

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -301,6 +301,7 @@ def reader_without_normalized_scores():
         use_confidence_scores=False
     )
 
+
 @pytest.fixture(params=["farm", "transformers"], scope="module")
 def reader(request):
     if request.param == "farm":

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -49,11 +49,7 @@ def pytest_generate_tests(metafunc):
     # @pytest.mark.parametrize("document_store", ["memory"], indirect=False)
     found_mark_parametrize_document_store = False
     for marker in metafunc.definition.iter_markers('parametrize'):
-        if 'document_store' in marker.args[0] or 'document_store_with_docs' in marker.args[0]:
-            # TODO if there's a parametrization marker already, remove those docstores that are not selected by user
-            default_doc_stores = marker.args[1]
-            updated_doc_stores = [d for d in default_doc_stores if d in selected_doc_stores]
-            marker.args[1] = updated_doc_stores
+        if 'document_store' in marker.args[0] or 'document_store_with_docs' in marker.args[0] or 'document_store_type' in marker.args[0]:
             found_mark_parametrize_document_store = True
             break
     # for all others that don't have explicit parametrization, we add the ones from the CLI arg
@@ -80,10 +76,6 @@ SQLDocumentStore.__getattribute__ = _sql_session_rollback
 
 
 def pytest_collection_modifyitems(config,items):
-    # for item in items:
-    #     if "elasticsearch" in item.keywords:
-    #         item.add_marker(skip_docstore)
-
     for item in items:
 
         # add pytest markers for tests that are not explicitly marked but include some keywords
@@ -108,7 +100,7 @@ def pytest_collection_modifyitems(config,items):
         # if the cli argument "--document_store_type" is used, we want to skip all tests that have markers of other docstores
         # Example: pytest -v test_document_store.py --document_store_type="memory" => skip all tests marked with "elasticsearch"
         document_store_types_to_run = config.getoption("--document_store_type")
-        for cur_doc_store in ["elasticsearch", "faiss", "memory", "milvus", "weaviate"]:
+        for cur_doc_store in ["elasticsearch", "faiss", "sql", "memory", "milvus", "weaviate"]:
             if cur_doc_store in item.keywords and cur_doc_store not in document_store_types_to_run:
                 skip_docstore = pytest.mark.skip(
                     reason=f'{cur_doc_store} is disabled. Enable via pytest --document_store_type="{cur_doc_store}"')

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -10,4 +10,3 @@ markers =
     summarizer: marks summarizer tests
     weaviate: marks tests that require weaviate container
     vector_dim: marks usage of document store with non-default embedding dimension (e.g @pytest.mark.vector_dim(128))
-    sql: marks tests where a SQLDocumentStore is mandatory

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -10,3 +10,4 @@ markers =
     summarizer: marks summarizer tests
     weaviate: marks tests that require weaviate container
     vector_dim: marks usage of document store with non-default embedding dimension (e.g @pytest.mark.vector_dim(128))
+    sql: marks tests where a SQLDocumentStore is mandatory

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -91,9 +91,10 @@ def test_get_all_documents_with_correct_filters(document_store_with_docs):
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
 
 
-@pytest.mark.sql
-@pytest.mark.parametrize("document_store_with_docs", ["sql"], indirect=True)
-def test_get_all_documents_with_correct_filters_legacy_sqlite(document_store_with_docs):
+def test_get_all_documents_with_correct_filters_legacy_sqlite(test_docs_xs):
+    document_store_with_docs = get_document_store("sql")
+    document_store_with_docs.write_documents(test_docs_xs)
+
     document_store_with_docs.use_windowed_query = False
     documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
     assert len(documents) == 1
@@ -492,7 +493,7 @@ def test_multilabel_no_answer(document_store):
     document_store.delete_documents(index="haystack_test_multilabel_no_answer")
 
 
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "sql"], indirect=True)
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss"], indirect=True)
 # Currently update_document_meta() is not implemented for Memory doc store
 def test_update_meta(document_store):
     documents = [

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -31,7 +31,6 @@ def test_init_elastic_client():
     _ = ElasticsearchDocumentStore(host=["localhost"], port=[9200], api_key="test", api_key_id="test")
 
 
-@pytest.mark.elasticsearch
 def test_write_with_duplicate_doc_ids(document_store):
     documents = [
         Document(
@@ -48,7 +47,6 @@ def test_write_with_duplicate_doc_ids(document_store):
         document_store.write_documents(documents, duplicate_documents="fail")
 
 
-@pytest.mark.elasticsearch
 def test_get_all_documents_without_filters(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents()
     assert all(isinstance(d, Document) for d in documents)
@@ -57,7 +55,6 @@ def test_get_all_documents_without_filters(document_store_with_docs):
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test2", "test3"}
 
 
-@pytest.mark.elasticsearch
 def test_get_all_document_filter_duplicate_text_value(document_store):
     documents = [
         Document(
@@ -83,7 +80,6 @@ def test_get_all_document_filter_duplicate_text_value(document_store):
     assert {d.meta["meta_id"] for d in documents} == {"0"}
 
 
-@pytest.mark.elasticsearch
 def test_get_all_documents_with_correct_filters(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
     assert len(documents) == 1
@@ -95,6 +91,7 @@ def test_get_all_documents_with_correct_filters(document_store_with_docs):
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
 
 
+@pytest.mark.sql
 @pytest.mark.parametrize("document_store_with_docs", ["sql"], indirect=True)
 def test_get_all_documents_with_correct_filters_legacy_sqlite(document_store_with_docs):
     document_store_with_docs.use_windowed_query = False
@@ -108,19 +105,16 @@ def test_get_all_documents_with_correct_filters_legacy_sqlite(document_store_wit
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
 
 
-@pytest.mark.elasticsearch
 def test_get_all_documents_with_incorrect_filter_name(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents(filters={"incorrect_meta_field": ["test2"]})
     assert len(documents) == 0
 
 
-@pytest.mark.elasticsearch
 def test_get_all_documents_with_incorrect_filter_value(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["incorrect_value"]})
     assert len(documents) == 0
 
 
-@pytest.mark.elasticsearch
 def test_get_documents_by_id(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents()
     doc = document_store_with_docs.get_document_by_id(documents[0].id)
@@ -128,7 +122,6 @@ def test_get_documents_by_id(document_store_with_docs):
     assert doc.text == documents[0].text
 
 
-@pytest.mark.elasticsearch
 def test_get_document_count(document_store):
     documents = [
         {"text": "text1", "id": "1", "meta_field_for_count": "a"},
@@ -142,7 +135,6 @@ def test_get_document_count(document_store):
     assert document_store.get_document_count(filters={"meta_field_for_count": ["b"]}) == 3
 
 
-@pytest.mark.elasticsearch
 def test_get_all_documents_generator(document_store):
     documents = [
         {"text": "text1", "id": "1", "meta_field_for_count": "a"},
@@ -156,7 +148,6 @@ def test_get_all_documents_generator(document_store):
     assert len(list(document_store.get_all_documents_generator(batch_size=2))) == 5
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("update_existing_documents", [True, False])
 def test_update_existing_documents(document_store, update_existing_documents):
     original_docs = [
@@ -184,7 +175,6 @@ def test_update_existing_documents(document_store, update_existing_documents):
         assert stored_docs[0].text == original_docs[0]["text"]
 
 
-@pytest.mark.elasticsearch
 def test_write_document_meta(document_store):
     documents = [
         {"text": "dict_without_meta", "id": "1"},
@@ -202,7 +192,6 @@ def test_write_document_meta(document_store):
     assert document_store.get_document_by_id("4").meta["meta_field"] == "test4"
 
 
-@pytest.mark.elasticsearch
 def test_write_document_index(document_store):
     documents = [
         {"text": "text1", "id": "1"},
@@ -218,7 +207,6 @@ def test_write_document_index(document_store):
     assert len(document_store.get_all_documents()) == 0
 
 
-@pytest.mark.elasticsearch
 def test_document_with_embeddings(document_store):
     documents = [
         {"text": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
@@ -320,7 +308,6 @@ def test_update_embeddings(document_store, retriever):
     assert document_store.get_embedding_count(index="haystack_test_1") == 14
 
 
-@pytest.mark.elasticsearch
 def test_delete_all_documents(document_store_with_docs):
     assert len(document_store_with_docs.get_all_documents()) == 3
 
@@ -329,7 +316,6 @@ def test_delete_all_documents(document_store_with_docs):
     assert len(documents) == 0
 
 
-@pytest.mark.elasticsearch
 def test_delete_documents(document_store_with_docs):
     assert len(document_store_with_docs.get_all_documents()) == 3
 
@@ -347,7 +333,6 @@ def test_delete_documents_with_filters(document_store_with_docs):
     assert documents[0].meta["meta_field"] == "test3"
 
 
-@pytest.mark.elasticsearch
 def test_labels(document_store):
     label = Label(
         question="question",
@@ -367,7 +352,6 @@ def test_labels(document_store):
     assert len(labels) == 0
 
 
-@pytest.mark.elasticsearch
 def test_multilabel(document_store):
     labels =[
         Label(
@@ -446,7 +430,6 @@ def test_multilabel(document_store):
     document_store.delete_documents(index="haystack_test_multilabel")
 
 
-@pytest.mark.elasticsearch
 def test_multilabel_no_answer(document_store):
     labels = [
         Label(
@@ -512,18 +495,19 @@ def test_multilabel_no_answer(document_store):
 
 @pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "sql"], indirect=True)
+# Currently update_document_meta() is not implemented for Memory doc store
 def test_update_meta(document_store):
     documents = [
         Document(
-            text="Doc1",
+            content="Doc1",
             meta={"meta_key_1": "1", "meta_key_2": "1"}
         ),
         Document(
-            text="Doc2",
+            content="Doc2",
             meta={"meta_key_1": "2", "meta_key_2": "2"}
         ),
         Document(
-            text="Doc3",
+            content="Doc3",
             meta={"meta_key_1": "3", "meta_key_2": "3"}
         )
     ]

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -493,7 +493,6 @@ def test_multilabel_no_answer(document_store):
     document_store.delete_documents(index="haystack_test_multilabel_no_answer")
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "sql"], indirect=True)
 # Currently update_document_meta() is not implemented for Memory doc store
 def test_update_meta(document_store):

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -520,7 +520,6 @@ def test_update_meta(document_store):
     assert updated_document.meta["meta_key_2"] == "2"
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store_type", ["elasticsearch", "memory"])
 def test_custom_embedding_field(document_store_type):
     document_store = get_document_store(
@@ -534,7 +533,6 @@ def test_custom_embedding_field(document_store_type):
     np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 def test_get_meta_values_by_key(document_store):
     documents = [

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -324,7 +324,6 @@ def test_delete_documents(document_store_with_docs):
     assert len(documents) == 0
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 def test_delete_documents_with_filters(document_store_with_docs):
     document_store_with_docs.delete_documents(filters={"meta_field": ["test1", "test2"]})
@@ -498,15 +497,15 @@ def test_multilabel_no_answer(document_store):
 def test_update_meta(document_store):
     documents = [
         Document(
-            content="Doc1",
+            text="Doc1",
             meta={"meta_key_1": "1", "meta_key_2": "1"}
         ),
         Document(
-            content="Doc2",
+            text="Doc2",
             meta={"meta_key_1": "2", "meta_key_2": "2"}
         ),
         Document(
-            content="Doc3",
+            text="Doc3",
             meta={"meta_key_1": "3", "meta_key_2": "3"}
         )
     ]

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -5,7 +5,6 @@ from haystack.eval import EvalAnswers, EvalDocuments
 from haystack import Pipeline
 
 @pytest.mark.parametrize("batch_size", [None, 20])
-@pytest.mark.elasticsearch
 def test_add_eval_data(document_store, batch_size):
     # add eval data (SQUAD format)
     document_store.add_eval_data(
@@ -45,7 +44,6 @@ def test_add_eval_data(document_store, batch_size):
     assert doc.text[start:end] == "France"
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_eval_reader(reader, document_store: BaseDocumentStore):
     # add eval data (SQUAD format)
@@ -91,6 +89,7 @@ def test_eval_elastic_retriever(document_store: BaseDocumentStore, open_domain, 
         assert results["map"] == 1.0
 
 
+# TODO simplify with a mock retriever and make it independent of elasticsearch documentstore
 @pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
@@ -131,7 +130,7 @@ def test_eval_pipeline(document_store: BaseDocumentStore, reader, retriever):
     assert round(eval_reader_cross.top_k_sas, 3) == 0.671
     assert eval_reader.top_k_em == eval_reader_vanila.top_k_em
 
-@pytest.mark.elasticsearch
+
 def test_eval_data_split_word(document_store):
     # splitting by word
     preprocessor = PreProcessor(
@@ -156,7 +155,6 @@ def test_eval_data_split_word(document_store):
     assert len(set(labels[0].multiple_document_ids)) == 2
 
 
-@pytest.mark.elasticsearch
 def test_eval_data_split_passage(document_store):
     # splitting by passage
     preprocessor = PreProcessor(

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -448,7 +448,6 @@ def test_lfqa_pipeline(document_store, retriever, eli5_generator):
 
 @pytest.mark.slow
 @pytest.mark.generator
-@pytest.mark.inmemory
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
@@ -470,7 +469,6 @@ def test_lfqa_pipeline_unknown_converter(document_store, retriever):
 
 @pytest.mark.slow
 @pytest.mark.generator
-@pytest.mark.inmemory
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -499,7 +499,6 @@ def test_lfqa_pipeline_invalid_converter(document_store, retriever):
 # Keeping few (retriever,document_store) combination to reduce test time
 @pytest.mark.slow
 @pytest.mark.generator
-@pytest.mark.inmemory
 @pytest.mark.parametrize(
     "retriever,document_store",
     [("embedding", "memory")],

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -416,12 +416,7 @@ def test_rag_token_generator(rag_generator):
 
 @pytest.mark.slow
 @pytest.mark.generator
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize(
-    "retriever,document_store",
-    [("embedding", "memory"), ("embedding", "faiss"), ("embedding", "milvus"), ("elasticsearch", "elasticsearch")],
-    indirect=True,
-)
+@pytest.mark.parametrize("retriever", ["embedding"], indirect=True)
 def test_generator_pipeline(document_store, retriever, rag_generator):
     document_store.write_documents(DOCS_WITH_EMBEDDINGS)
     query = "What is capital of the Germany?"
@@ -434,7 +429,6 @@ def test_generator_pipeline(document_store, retriever, rag_generator):
 
 @pytest.mark.slow
 @pytest.mark.generator
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
 def test_lfqa_pipeline(document_store, retriever, eli5_generator):
@@ -454,6 +448,7 @@ def test_lfqa_pipeline(document_store, retriever, eli5_generator):
 
 @pytest.mark.slow
 @pytest.mark.generator
+@pytest.mark.inmemory
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
@@ -475,6 +470,7 @@ def test_lfqa_pipeline_unknown_converter(document_store, retriever):
 
 @pytest.mark.slow
 @pytest.mark.generator
+@pytest.mark.inmemory
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
@@ -503,10 +499,10 @@ def test_lfqa_pipeline_invalid_converter(document_store, retriever):
 # Keeping few (retriever,document_store) combination to reduce test time
 @pytest.mark.slow
 @pytest.mark.generator
-@pytest.mark.elasticsearch
+@pytest.mark.inmemory
 @pytest.mark.parametrize(
     "retriever,document_store",
-    [("embedding", "memory"), ("elasticsearch", "elasticsearch")],
+    [("embedding", "memory")],
     indirect=True,
 )
 def test_generator_pipeline_with_translator(

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -21,6 +21,7 @@ from haystack.retriever.sparse import ElasticsearchRetriever
 from haystack.schema import Document
 
 
+@pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 def test_load_and_save_yaml(document_store, tmp_path):
     # test correct load of indexing pipeline from yaml
@@ -135,10 +136,15 @@ def test_invalid_run_args():
     assert "Invalid parameter 'invalid' for the node 'ESRetriever'" in str(exc.value)
 
 
+#TODO verify that docstore selection works here indirectly
 @pytest.mark.slow
-@pytest.mark.elasticsearch
+@pytest.mark.parametrize(
+    "retriever_with_docs, document_store_with_docs",
+    [("elasticsearch", "elasticsearch")],
+    indirect=True,
+)
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
-def test_extractive_qa_answers(reader, retriever_with_docs):
+def test_extractive_qa_answers(reader, retriever_with_docs, document_store_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     prediction = pipeline.run(
         query="Who lives in Berlin?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}},

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -594,7 +594,6 @@ def test_query_keyword_statement_classifier():
     assert output["output"] == "question"
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize(
         "retriever,document_store",
         [

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -86,14 +86,31 @@ def test_load_and_save_yaml(document_store, tmp_path):
     ).replace("\n", "")
 
 
-@pytest.mark.slow
-@pytest.mark.elasticsearch
+# @pytest.mark.slow
+# @pytest.mark.elasticsearch
+# @pytest.mark.parametrize(
+#     "retriever_with_docs, document_store_with_docs",
+#     [("elasticsearch", "elasticsearch")],
+#     indirect=True,
+# )
 @pytest.mark.parametrize(
-    "retriever_with_docs, document_store_with_docs",
-    [("elasticsearch", "elasticsearch")],
+    "retriever_with_docs,document_store_with_docs",
+    [
+        ("dpr", "elasticsearch"),
+        ("dpr", "faiss"),
+        ("dpr", "memory"),
+        ("dpr", "milvus"),
+        ("embedding", "elasticsearch"),
+        ("embedding", "faiss"),
+        ("embedding", "memory"),
+        ("embedding", "milvus"),
+        ("elasticsearch", "elasticsearch"),
+        ("es_filter_only", "elasticsearch"),
+        ("tfidf", "memory"),
+    ],
     indirect=True,
 )
-def test_graph_creation(reader, retriever_with_docs, document_store_with_docs):
+def test_graph_creation(retriever_with_docs, document_store_with_docs):
     pipeline = Pipeline()
     pipeline.add_node(name="ES", component=retriever_with_docs, inputs=["Query"])
 
@@ -136,13 +153,7 @@ def test_invalid_run_args():
     assert "Invalid parameter 'invalid' for the node 'ESRetriever'" in str(exc.value)
 
 
-#TODO verify that docstore selection works here indirectly
 @pytest.mark.slow
-@pytest.mark.parametrize(
-    "retriever_with_docs, document_store_with_docs",
-    [("elasticsearch", "elasticsearch")],
-    indirect=True,
-)
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 def test_extractive_qa_answers(reader, retriever_with_docs, document_store_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
@@ -163,7 +174,6 @@ def test_extractive_qa_answers(reader, retriever_with_docs, document_store_with_
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 def test_extractive_qa_answers_without_normalized_scores(reader_without_normalized_scores, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader_without_normalized_scores, retriever=retriever_with_docs)
@@ -183,7 +193,6 @@ def test_extractive_qa_answers_without_normalized_scores(reader_without_normaliz
     assert len(prediction["answers"]) == 3
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 def test_extractive_qa_offsets(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
@@ -200,7 +209,6 @@ def test_extractive_qa_offsets(reader, retriever_with_docs):
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 def test_extractive_qa_answers_single_result(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
@@ -210,7 +218,6 @@ def test_extractive_qa_answers_single_result(reader, retriever_with_docs):
     assert len(prediction["answers"]) == 1
 
 
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize(
     "retriever,document_store",
     [
@@ -260,17 +267,7 @@ def test_faq_pipeline(retriever, document_store):
         assert len(output["answers"]) == 1
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize(
-    "retriever,document_store",
-    [
-        ("embedding", "memory"),
-        ("embedding", "faiss"),
-        ("embedding", "milvus"),
-        ("embedding", "elasticsearch"),
-    ],
-    indirect=True,
-)
+@pytest.mark.parametrize("retriever_with_docs", ["embedding"], indirect=True)
 def test_document_search_pipeline(retriever, document_store):
     documents = [
         {"text": "Sample text for document-1", "meta": {"source": "wiki1"}},
@@ -293,7 +290,6 @@ def test_document_search_pipeline(retriever, document_store):
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 def test_extractive_qa_answers_with_translator(
     reader, retriever_with_docs, en_to_de_translator, de_to_en_translator
@@ -317,6 +313,7 @@ def test_extractive_qa_answers_with_translator(
     )
 
 
+@pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_join_document_pipeline(document_store_with_docs, reader):

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -38,7 +38,7 @@ DOCS = [
     ),
 ]
 
-@pytest.mark.elasticsearch
+#TODO check if we this works with only "memory" arg
 @pytest.mark.parametrize(
     "retriever_with_docs,document_store_with_docs",
     [

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -139,7 +139,6 @@ def test_elasticsearch_custom_query(elasticsearch_fixture):
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever", ["dpr"], indirect=True)
 def test_dpr_embedding(document_store, retriever):
 
@@ -162,7 +161,6 @@ def test_dpr_embedding(document_store, retriever):
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.parametrize("retriever", ["retribert"], indirect=True)
 @pytest.mark.vector_dim(128)
 def test_retribert_embedding(document_store, retriever):

--- a/test/test_summarizer.py
+++ b/test/test_summarizer.py
@@ -53,11 +53,10 @@ def test_summarization_one_summary(summarizer):
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.summarizer
 @pytest.mark.parametrize(
     "retriever,document_store",
-    [("embedding", "memory"), ("embedding", "faiss"), ("embedding", "milvus"), ("elasticsearch", "elasticsearch")],
+    [("embedding", "memory"), ("elasticsearch", "elasticsearch")],
     indirect=True,
 )
 def test_summarization_pipeline(document_store, retriever, summarizer):
@@ -75,11 +74,10 @@ def test_summarization_pipeline(document_store, retriever, summarizer):
 
 
 @pytest.mark.slow
-@pytest.mark.elasticsearch
 @pytest.mark.summarizer
 @pytest.mark.parametrize(
     "retriever,document_store",
-    [("embedding", "memory"), ("embedding", "faiss"), ("embedding", "milvus"), ("elasticsearch", "elasticsearch")],
+    [("embedding", "memory"), ("elasticsearch", "elasticsearch")],
     indirect=True,
 )
 def test_summarization_pipeline_one_summary(document_store, retriever, summarizer):


### PR DESCRIPTION
**Proposed changes**:
Running the tests locally is currently quite cumbersome as you need to start various external docker containers for elasticsearch, milvus etc. 

Let's simplify this and extend the option that was introduced in #1202, to run tests only on a subset or single documentstore. 
This means, when calling `pytest . --doc_store_type="memory"` we will run all tests that can be run just with the InMemoryDocumentStore, i.e.: 
- all the tests that we typically run on the whole "document store grid" will only be run for InMemoryDocumentStore
- any test that is specific to other document stores (e.g. elasticsearch) and is not supported by the chosen document store will be skipped (and marked in the logs accordingly)


## New conventions for creating new tests:

### Test should run on all document stores / those supplied in the CLI arg `--doc_store_type`: 
Use one of the fixtures `document_store` or `document_store_with_docs` or `document_store_type`.
Do not parameterize it yourself. 

Example:
```
def test_write_with_duplicate_doc_ids(document_store):
        ....

```

### Test is only compatible with certain document stores: 
Some tests you don't want to run on all possible document stores. Either because the test is specific to one/few doc store(s) or the test is not really document store related and it's enough to test it on one document store and speed up the execution time.

Example:
```
# Currently update_document_meta() is not implemented for InMemoryDocStore so it's not listed here as an option

@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss"], indirect=True)
def test_update_meta(document_store):
    ....
``` 

### Test is not using a `document_store`/ fixture, but still has a hard requirement for a certain document store:

Example:
```
@pytest.mark.elasticsearch
def test_elasticsearch_custom_fields(elasticsearch_fixture):
    client = Elasticsearch()
    client.indices.delete(index='haystack_test_custom', ignore=[404])
    document_store = ElasticsearchDocumentStore(index="haystack_test_custom", text_field="custom_text_field",
                                                embedding_field="custom_embedding_field")
``` 



## Limitations / future work: 
- As of now, you will still need to launch the external document stores yourself, in a separate PR we could also automate this. We can probably get rid of the document stores fixtures in conftest.py and move the launch logic there into `get_document_store()`
- We should make weaviate fully compliant so that we can get rid of the "special tests" in test_weaviate.py and rather add it as another parametrization value in test_document_store.py (see [comment](https://github.com/deepset-ai/haystack/blob/535d7b8d0baa107995b3553de320457427294c25/test/conftest.py#L57))
- Revisit which tests really need the option to run on the whole document store grid, and where we can maybe just reduce it to InMemoryDocumentStore to speed up the CI
- We currently have quite many integration tests, more unit tests would be helpful and could speed things up
- There was recently a `MockRetriever` introduced in `test_faiss_cosine_similarity`. We can check if we can use this one in more places and in general mock more of the expensive components.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [x] Updated documentation
