### PR TITLE
Remove 'restart=always' from 'haystack-api' in both docker-compose files

### DIFF
--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -21,7 +21,6 @@ services:
     environment:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
-    restart: always
     depends_on:
       - elasticsearch
     command: "/bin/bash -c 'sleep 15 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     environment:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
-    restart: always
     depends_on:
       - elasticsearch
     command: "/bin/bash -c 'sleep 15 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"


### PR DESCRIPTION
Related to #1497

**Proposed changes**:
Remove `restart=always` from `haystack-api` in both docker-compose files

**Status**:
- Ready to merge
