### PR TITLE
Add newline between paragraphs in DocxToTextConverter

### DIFF
--- a/haystack/file_converter/docx.py
+++ b/haystack/file_converter/docx.py
@@ -48,6 +48,6 @@ class DocxToTextConverter(BaseConverter):
 
         file = docx.Document(file_path)  # Creating word reader object.
         paragraphs = [para.text for para in file.paragraphs]
-        text = "".join(paragraphs)
+        text = "\n".join(paragraphs)
         document = {"text": text, "meta": meta}
         return document


### PR DESCRIPTION
**Proposed changes**:
This PR introduces a small change that introduces a newline character between paragraphs in the `DocxToTextConverter`. Before, separate paragraphs were concatenated without any space.

If the docx looked like this:
```
Introduction
This is the introduction...
```

The output string was:
```
IntroductionThis is the introduction...
```

With the changes made in this PR, the output string is:
```
Introduction
This is the introduction...
```