### PR TITLE
Fix document_store_type flag for tests with multiple fixtures

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -109,8 +109,14 @@ def pytest_collection_modifyitems(config,items):
         # if the cli argument "--document_store_type" is used, we want to skip all tests that have markers of other docstores
         # Example: pytest -v test_document_store.py --document_store_type="memory" => skip all tests marked with "elasticsearch"
         document_store_types_to_run = config.getoption("--document_store_type")
+        keywords = []
+        for i in item.keywords:
+            if "-" in i:
+                keywords.extend(i.split("-"))
+            else:
+                keywords.append(i)
         for cur_doc_store in ["elasticsearch", "faiss", "sql", "memory", "milvus", "weaviate"]:
-            if cur_doc_store in item.keywords and cur_doc_store not in document_store_types_to_run:
+            if cur_doc_store in keywords and cur_doc_store not in document_store_types_to_run:
                 skip_docstore = pytest.mark.skip(
                     reason=f'{cur_doc_store} is disabled. Enable via pytest --document_store_type="{cur_doc_store}"')
                 item.add_marker(skip_docstore)


### PR DESCRIPTION
The selection of a certain `--document_store_type` introduced in #1487 did not work for tests that had multiple fixtures with parametrization as their signature rather looks like [faiss-farm] and the plain "faiss" keyword is therefore contained in item.keywords .

**Proposed changes**:
Extended the keyword check

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation

FYI @lalitpagaria 