### PR TITLE
Remove NER and text classification from model conversion

### DIFF
--- a/haystack/modeling/conversion/transformers.py
+++ b/haystack/modeling/conversion/transformers.py
@@ -72,7 +72,7 @@ class Converter:
                 task_type = "question_answering"
             else:
                 logger.error("Could not infer task type from model config. Please provide task type manually. "
-                             "('lm', 'question_answering', 'regression', 'text_classification', 'ner' or 'embeddings')")
+                             "('question_answering' or 'embeddings')")
 
 
         if task_type == "question_answering":


### PR DESCRIPTION
**Proposed changes**:
This PR removes mentions of NER and text classification as possible task types from an error log message. Since FARM migration these task types are not supported anymore.
