### PR TITLE
Remove double mentions from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ seqeval
 mlflow<=1.13.1
 # huggingface repository
 transformers==4.7.0
-sentence-transformers
 # pickle extension for (de-)serialization
 dill
 # Inference with ONNX models. Install onnxruntime-gpu for Inference on GPUs

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ fastapi
 uvicorn
 gunicorn
 pandas
-sklearn
 psycopg2-binary; sys_platform != 'win32' and sys_platform != 'cygwin'
 elasticsearch>=7.7,<=7.10
 elastic-apm


### PR DESCRIPTION
**Proposed changes**:
This PR removes one mention of `sentence-transformers` from the requirements. Before, there was `sentence-transformers` in line 20 and `sentence-transformers>=0.4.0` in line 44. This resulted in the following error when trying to install the requirements:
```
Double requirement given: sentence-transformers>=0.4.0 (from -r requirements.txt (line 44)) (already in sentence-transformers (from -r requirements.txt (line 20)), name=‘sentence-transformers’)
```
