### PR TITLE
WIP Add rest api endpoint to delete documents by filter

### DIFF
--- a/rest_api/application.py
+++ b/rest_api/application.py
@@ -1,17 +1,30 @@
 import logging
 
+from pathlib import Path
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from starlette.middleware.cors import CORSMiddleware
 
+from haystack import Pipeline
+from rest_api.config import PIPELINE_YAML_PATH, QUERY_PIPELINE_NAME
 from rest_api.controller.errors.http_error import http_error_handler
-from rest_api.controller.router import router as api_router
 from rest_api.config import ROOT_PATH
+
 
 logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p")
 logger = logging.getLogger(__name__)
 logging.getLogger("elasticsearch").setLevel(logging.WARNING)
 logging.getLogger("haystack").setLevel(logging.INFO)
+
+
+PIPELINE = Pipeline.load_from_yaml(Path(PIPELINE_YAML_PATH), pipeline_name=QUERY_PIPELINE_NAME)
+# TODO make this generic for other pipelines with different naming
+RETRIEVER = PIPELINE.get_node(name="Retriever")
+DOCUMENT_STORE = RETRIEVER.document_store if RETRIEVER else None
+logging.info(f"Loaded pipeline nodes: {PIPELINE.graph.nodes.keys()}")
+
+
+from rest_api.controller.router import router as api_router
 
 
 def get_application() -> FastAPI:
@@ -31,6 +44,7 @@ def get_application() -> FastAPI:
 
 
 app = get_application()
+
 
 logger.info("Open http://127.0.0.1:8000/docs to see Swagger API Documentation.")
 logger.info(

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 
-PIPELINE_YAML_PATH = os.getenv("PIPELINE_YAML_PATH", str((Path(__file__).parent / "rest_api"/"pipeline"/"pipelines.yaml").absolute()))
+PIPELINE_YAML_PATH = os.getenv("PIPELINE_YAML_PATH", str((Path(__file__).parent / "pipeline" / "pipelines.yaml").absolute()))
 QUERY_PIPELINE_NAME = os.getenv("QUERY_PIPELINE_NAME", "query")
 INDEXING_PIPELINE_NAME = os.getenv("INDEXING_PIPELINE_NAME", "indexing")
 

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -1,10 +1,12 @@
 import os
+from pathlib import Path
 
-PIPELINE_YAML_PATH = os.getenv("PIPELINE_YAML_PATH", "rest_api/pipeline/pipelines.yaml")
+
+PIPELINE_YAML_PATH = os.getenv("PIPELINE_YAML_PATH", str((Path(__file__).parent / "rest_api"/"pipeline"/"pipelines.yaml").absolute()))
 QUERY_PIPELINE_NAME = os.getenv("QUERY_PIPELINE_NAME", "query")
 INDEXING_PIPELINE_NAME = os.getenv("INDEXING_PIPELINE_NAME", "indexing")
 
-FILE_UPLOAD_PATH = os.getenv("FILE_UPLOAD_PATH", "./file-upload")
+FILE_UPLOAD_PATH = os.getenv("FILE_UPLOAD_PATH", str((Path(__file__).parent / "file-upload").absolute()))
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 ROOT_PATH = os.getenv("ROOT_PATH", "/")

--- a/rest_api/controller/document.py
+++ b/rest_api/controller/document.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("haystack")
 router = APIRouter()
 
 
-@router.delete("/documents", response_model=bool)
+@router.post("/documents/delete_by_filters", response_model=bool)
 def delete_documents(filters: FilterRequest):
     """
     Can be used to delete documents from a document store.

--- a/rest_api/controller/document.py
+++ b/rest_api/controller/document.py
@@ -1,0 +1,26 @@
+import logging
+
+from fastapi import APIRouter
+
+from rest_api.application import DOCUMENT_STORE
+from rest_api.config import LOG_LEVEL
+from rest_api.schema import FilterRequest
+
+
+logging.getLogger("haystack").setLevel(LOG_LEVEL)
+logger = logging.getLogger("haystack")
+
+
+router = APIRouter()
+
+
+@router.delete("/documents", response_model=bool)
+def delete_documents(filters: FilterRequest):
+    """
+    Can be used to delete documents from a document store.
+
+    :param filters: Filters to narrow down the documents to delete.
+                    Example: {"name": ["some", "more"], "category": ["only_one"]}
+    """
+    DOCUMENT_STORE.delete_documents(filters=filters.filters)
+    return True

--- a/rest_api/controller/router.py
+++ b/rest_api/controller/router.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from rest_api.controller import file_upload, search, feedback
+from rest_api.controller import file_upload, search, feedback, document
 
 router = APIRouter()
 
 router.include_router(search.router, tags=["search"])
 router.include_router(feedback.router, tags=["feedback"])
 router.include_router(file_upload.router, tags=["file-upload"])
+router.include_router(document.router, tags=["document"])

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -1,48 +1,19 @@
-import json
 import logging
 import time
-from pathlib import Path
-from typing import Dict, List, Optional, Union, Any
 
 from fastapi import APIRouter
-from pydantic import BaseModel
 
-from haystack import Pipeline
-from rest_api.config import PIPELINE_YAML_PATH, LOG_LEVEL, QUERY_PIPELINE_NAME, CONCURRENT_REQUEST_PER_WORKER
+from rest_api.application import PIPELINE
+from rest_api.config import LOG_LEVEL, CONCURRENT_REQUEST_PER_WORKER
+from rest_api.schema import QueryRequest, QueryResponse
 from rest_api.controller.utils import RequestLimiter
+
 
 logging.getLogger("haystack").setLevel(LOG_LEVEL)
 logger = logging.getLogger("haystack")
 
+
 router = APIRouter()
-
-
-class Request(BaseModel):
-    query: str
-    params: Optional[dict] = None
-
-
-class Answer(BaseModel):
-    answer: Optional[str]
-    question: Optional[str]
-    score: Optional[float] = None
-    probability: Optional[float] = None
-    context: Optional[str]
-    offset_start: Optional[int]
-    offset_end: Optional[int]
-    offset_start_in_doc: Optional[int]
-    offset_end_in_doc: Optional[int]
-    document_id: Optional[str] = None
-    meta: Optional[Dict[str, Any]]
-
-
-class Response(BaseModel):
-    query: str
-    answers: List[Answer]
-
-
-PIPELINE = Pipeline.load_from_yaml(Path(PIPELINE_YAML_PATH), pipeline_name=QUERY_PIPELINE_NAME)
-logger.info(f"Loaded pipeline nodes: {PIPELINE.graph.nodes.keys()}")
 concurrency_limiter = RequestLimiter(CONCURRENT_REQUEST_PER_WORKER)
 
 
@@ -58,14 +29,14 @@ def initialized():
     return True
 
 
-@router.post("/query", response_model=Response)
-def query(request: Request):
+@router.post("/query", response_model=QueryResponse)
+def query(request: QueryRequest):
     with concurrency_limiter.run():
         result = _process_request(PIPELINE, request)
         return result
 
 
-def _process_request(pipeline, request) -> Response:
+def _process_request(pipeline, request) -> QueryResponse:
     start_time = time.time()
 
     params = request.params or {}

--- a/rest_api/schema.py
+++ b/rest_api/schema.py
@@ -1,0 +1,46 @@
+from typing import Dict, List, Optional, Union, Any
+from pydantic import BaseModel, Field
+
+
+class QueryRequest(BaseModel):
+    query: str
+    params: Optional[dict] = None
+
+
+class FilterRequest(BaseModel):
+    filters: Optional[Dict[str, Optional[Union[str, List[str]]]]] = None
+
+
+class QueryAnswer(BaseModel):
+    answer: Optional[str]
+    question: Optional[str]
+    score: Optional[float] = None
+    probability: Optional[float] = None
+    context: Optional[str]
+    offset_start: Optional[int]
+    offset_end: Optional[int]
+    offset_start_in_doc: Optional[int]
+    offset_end_in_doc: Optional[int]
+    document_id: Optional[str] = None
+    meta: Optional[Dict[str, Any]]
+
+
+class QueryResponse(BaseModel):
+    query: str
+    answers: List[QueryAnswer]
+
+
+class ExtractiveQAFeedback(BaseModel):
+    question: str = Field(..., description="The question input by the user, i.e., the query.")
+    is_correct_answer: bool = Field(..., description="Whether the answer is correct or not.")
+    document_id: str = Field(..., description="The document in the query result for which feedback is given.")
+    model_id: Optional[int] = Field(None, description="The model used for the query.")
+    is_correct_document: bool = Field(
+        ...,
+        description="In case of negative feedback, there could be two cases; incorrect answer but correct "
+        "document & incorrect document. This flag denotes if the returned document was correct.",
+    )
+    answer: str = Field(..., description="The answer string.")
+    offset_start_in_doc: int = Field(
+        ..., description="The answer start offset in the original doc. Only required for doc-qa feedback."
+    )

--- a/test/test_rest_api.py
+++ b/test/test_rest_api.py
@@ -20,7 +20,7 @@ def populated_client(client: TestClient) -> TestClient:
     file_to_upload = {'files': (Path(__file__).parent / "samples"/"pdf"/"sample_pdf_1.pdf").open('rb')}
     client.post(url="/file-upload", files=file_to_upload, data={"meta": '{"meta_key": "meta_value"}'})
     yield client
-    client.delete(url="/documents", data={"meta_key": ["meta_value"]})
+    client.post(url="/documents/delete_by_filters", data={"meta_key": ["meta_value"]})
 
 
 
@@ -33,8 +33,7 @@ def test_delete_documents(client: TestClient):
     file_to_upload = {'files': (Path(__file__).parent / "samples"/"pdf"/"sample_pdf_1.pdf").open('rb')}
     response = client.post(url="/file-upload", files=file_to_upload, data={"meta": '{"meta_key": "meta_value"}'})
 
-    filters = {"filters": {"meta_key": ["meta_value"]}}
-    response = client.delete(url="/documents", json=filters)
+    client.post(url="/documents/delete_by_filters", data={"meta_key": ["meta_value"]})
     assert 200 == response.status_code
 
 def test_query_with_no_filter(populated_client: TestClient):

--- a/test/test_rest_api.py
+++ b/test/test_rest_api.py
@@ -1,65 +1,80 @@
+import os
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
+from rest_api.application import app
 from rest_api.application import DOCUMENT_STORE
 
 
-def get_test_client_and_override_dependencies():
-    import os
+@pytest.fixture(scope="session")
+def client() -> TestClient:
     os.environ["PIPELINE_YAML_PATH"] = str((Path(__file__).parent / "samples"/"pipeline"/"test_pipeline.yaml").absolute())
     os.environ["QUERY_PIPELINE_NAME"] = "query_pipeline"
     os.environ["INDEXING_PIPELINE_NAME"] = "indexing_pipeline"
-
-    from rest_api.application import app
     return TestClient(app)
 
+@pytest.fixture(scope="session")
+def populated_client(client: TestClient) -> TestClient:
+    file_to_upload = {'files': (Path(__file__).parent / "samples"/"pdf"/"sample_pdf_1.pdf").open('rb')}
+    client.post(url="/file-upload", files=file_to_upload, data={"meta": '{"meta_key": "meta_value"}'})
+    yield client
+    client.delete(url="/documents", data={"meta_key": ["meta_value"]})
 
-@pytest.mark.slow
-@pytest.mark.elasticsearch
-#@pytest.mark.parametrize("reader", ["farm"], indirect=True)
-#@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
-def test_api():#reader, document_store):
-    client = get_test_client_and_override_dependencies()
 
-    # test file upload API
+
+def test_file_upload(client: TestClient):
     file_to_upload = {'files': (Path(__file__).parent / "samples"/"pdf"/"sample_pdf_1.pdf").open('rb')}
     response = client.post(url="/file-upload", files=file_to_upload, data={"meta": '{"meta_key": "meta_value"}'})
     assert 200 == response.status_code
 
-    # test query API
+def test_delete_documents(client: TestClient):
+    file_to_upload = {'files': (Path(__file__).parent / "samples"/"pdf"/"sample_pdf_1.pdf").open('rb')}
+    response = client.post(url="/file-upload", files=file_to_upload, data={"meta": '{"meta_key": "meta_value"}'})
+
+    filters = {"filters": {"meta_key": ["meta_value"]}}
+    response = client.delete(url="/documents", json=filters)
+    assert 200 == response.status_code
+
+def test_query_with_no_filter(populated_client: TestClient):
     query_with_no_filter_value = {"query": "Who made the PDF specification?"}
-    response = client.post(url="/query", json=query_with_no_filter_value)
+    response = populated_client.post(url="/query", json=query_with_no_filter_value)
     assert 200 == response.status_code
     response_json = response.json()
     assert response_json["answers"][0]["answer"] == "Adobe Systems"
-    document_id = response_json["answers"][0]["document_id"]
 
+def test_query_with_one_filter(populated_client: TestClient):
     query_with_filter = {"query": "Who made the PDF specification?", "params": {"filters": {"meta_key": "meta_value"}}}
-    response = client.post(url="/query", json=query_with_filter)
+    response = populated_client.post(url="/query", json=query_with_filter)
     assert 200 == response.status_code
     response_json = response.json()
     assert response_json["answers"][0]["answer"] == "Adobe Systems"
 
+def test_query_with_filter_list(populated_client: TestClient):
     query_with_filter_list = {
         "query": "Who made the PDF specification?",
         "params": {"filters": {"meta_key": ["meta_value", "another_value"]}}
     }
-    response = client.post(url="/query", json=query_with_filter_list)
+    response = populated_client.post(url="/query", json=query_with_filter_list)
     assert 200 == response.status_code
     response_json = response.json()
     assert response_json["answers"][0]["answer"] == "Adobe Systems"
 
+def test_query_with_invalid_filter(populated_client: TestClient):
     query_with_invalid_filter = {
         "query": "Who made the PDF specification?", "params": {"filters": {"meta_key": "invalid_value"}}
     }
-    response = client.post(url="/query", json=query_with_invalid_filter)
+    response = populated_client.post(url="/query", json=query_with_invalid_filter)
     assert 200 == response.status_code
     response_json = response.json()
     assert len(response_json["answers"]) == 0
 
-    # test write feedback
+def test_write_feedback(populated_client: TestClient):
+    response = populated_client.post(url="/query", json={"query": "Who made the PDF specification?"})
+    response_json = response.json()
+    document_id = response_json["answers"][0]["document_id"]
+
     feedback = {
         "question": "Who made the PDF specification?",
         "is_correct_answer": True,
@@ -68,20 +83,31 @@ def test_api():#reader, document_store):
         "answer": "Adobe Systems",
         "offset_start_in_doc": 60
     }
-    response = client.post(url="/feedback", json=feedback)
+    response = populated_client.post(url="/feedback", json=feedback)
     assert 200 == response.status_code
 
-    # test export feedback
+def test_export_feedback(populated_client: TestClient):
+    response = populated_client.post(url="/query", json={"query": "Who made the PDF specification?"})
+    response_json = response.json()
+    document_id = response_json["answers"][0]["document_id"]
+
+    feedback = {
+        "question": "Who made the PDF specification?",
+        "is_correct_answer": True,
+        "document_id": document_id,
+        "is_correct_document": True,
+        "answer": "Adobe Systems",
+        "offset_start_in_doc": 60
+    }
     feedback_urls = [
         "/export-feedback?full_document_context=true",
         "/export-feedback?full_document_context=false&context_size=50",
         "/export-feedback?full_document_context=false&context_size=50000",
     ]
     for url in feedback_urls:
-        response = client.get(url=url, json=feedback)
+        response = populated_client.get(url=url, json=feedback)
         response_json = response.json()
         context = response_json["data"][0]["paragraphs"][0]["context"]
         answer_start = response_json["data"][0]["paragraphs"][0]["qas"][0]["answers"][0]["answer_start"]
         answer = response_json["data"][0]["paragraphs"][0]["qas"][0]["answers"][0]["text"]
         assert context[answer_start:answer_start+len(answer)] == answer
-

--- a/test/test_rest_api.py
+++ b/test/test_rest_api.py
@@ -3,10 +3,12 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from rest_api.application import DOCUMENT_STORE
+
 
 def get_test_client_and_override_dependencies():
     import os
-    os.environ["PIPELINE_YAML_PATH"] = "samples/pipeline/test_pipeline.yaml"
+    os.environ["PIPELINE_YAML_PATH"] = str((Path(__file__).parent / "samples"/"pipeline"/"test_pipeline.yaml").absolute())
     os.environ["QUERY_PIPELINE_NAME"] = "query_pipeline"
     os.environ["INDEXING_PIPELINE_NAME"] = "indexing_pipeline"
 
@@ -16,13 +18,13 @@ def get_test_client_and_override_dependencies():
 
 @pytest.mark.slow
 @pytest.mark.elasticsearch
-@pytest.mark.parametrize("reader", ["farm"], indirect=True)
-@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
-def test_api(reader, document_store):
+#@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+#@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
+def test_api():#reader, document_store):
     client = get_test_client_and_override_dependencies()
 
     # test file upload API
-    file_to_upload = {'files': Path("samples/pdf/sample_pdf_1.pdf").open('rb')}
+    file_to_upload = {'files': (Path(__file__).parent / "samples"/"pdf"/"sample_pdf_1.pdf").open('rb')}
     response = client.post(url="/file-upload", files=file_to_upload, data={"meta": '{"meta_key": "meta_value"}'})
     assert 200 == response.status_code
 


### PR DESCRIPTION
Related to #797 
-----------------------

Adds a new `document` router and a new `DELETE /documents` endpoint, accepting filters, that allow deleting documents in the document store. Uses the underlying `BaseDocumentStore.delete_documents()` method.

**Status (please check what you already did)**:
- [X] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [x] Updated documentation
