### PR TITLE
Format doc classifier usage example

### DIFF
--- a/docs/_src/api/api/document_classifier.md
+++ b/docs/_src/api/api/document_classifier.md
@@ -32,28 +32,28 @@ Transformer based model for document classification using the HuggingFace's tran
 While the underlying model can vary (BERT, Roberta, DistilBERT ...), the interface remains the same.
 This node classifies documents and adds the output from the classification step to the document's meta data.
 The meta field of the document is a dictionary with the following format:
-'meta': {'name': '450_Baelor.txt', 'classification': {'label': 'neutral', 'probability' = 0.9997646, ...} }
+``'meta': {'name': '450_Baelor.txt', 'classification': {'label': 'neutral', 'probability' = 0.9997646, ...} }``
 
 With this document_classifier, you can directly get predictions via predict()
 
-Usage example:
-...
-retriever = ElasticsearchRetriever(document_store=document_store)
-document_classifier = TransformersDocumentClassifier(model_name_or_path="bhadresh-savani/distilbert-base-uncased-emotion")
-p = Pipeline()
-p.add_node(component=retriever, name="Retriever", inputs=["Query"])
-p.add_node(component=document_classifier, name="Classifier", inputs=["Retriever"])
-res = p.run(
-    query="Who is the father of Arya Stark?",
-    params={"Retriever": {"top_k": 10}}
-)
-
-__print the classification results__
-
-print_documents(res, max_text_len=100, print_meta=True)
-__or access the predicted class label directly__
-
-res["documents"][0].to_dict()["meta"]["classification"]["label"]
+ **Usage example:**
+ ```python
+|    ...
+|    retriever = ElasticsearchRetriever(document_store=document_store)
+|    document_classifier = TransformersDocumentClassifier(model_name_or_path="bhadresh-savani/distilbert-base-uncased-emotion")
+|    p = Pipeline()
+|    p.add_node(component=retriever, name="Retriever", inputs=["Query"])
+|    p.add_node(component=document_classifier, name="Classifier", inputs=["Retriever"])
+|    res = p.run(
+|        query="Who is the father of Arya Stark?",
+|        params={"Retriever": {"top_k": 10}}
+|    )
+|    
+|    # print the classification results
+|    print_documents(res, max_text_len=100, print_meta=True)
+|    # or access the predicted class label directly
+|    res["documents"][0].to_dict()["meta"]["classification"]["label"]
+ ```
 
 <a name="transformers.TransformersDocumentClassifier.__init__"></a>
 #### \_\_init\_\_

--- a/haystack/document_classifier/transformers.py
+++ b/haystack/document_classifier/transformers.py
@@ -16,26 +16,28 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
     While the underlying model can vary (BERT, Roberta, DistilBERT ...), the interface remains the same.
     This node classifies documents and adds the output from the classification step to the document's meta data.
     The meta field of the document is a dictionary with the following format:
-    'meta': {'name': '450_Baelor.txt', 'classification': {'label': 'neutral', 'probability' = 0.9997646, ...} }
+    ``'meta': {'name': '450_Baelor.txt', 'classification': {'label': 'neutral', 'probability' = 0.9997646, ...} }``
 
     With this document_classifier, you can directly get predictions via predict()
-
-    Usage example:
-    ...
-    retriever = ElasticsearchRetriever(document_store=document_store)
-    document_classifier = TransformersDocumentClassifier(model_name_or_path="bhadresh-savani/distilbert-base-uncased-emotion")
-    p = Pipeline()
-    p.add_node(component=retriever, name="Retriever", inputs=["Query"])
-    p.add_node(component=document_classifier, name="Classifier", inputs=["Retriever"])
-    res = p.run(
-        query="Who is the father of Arya Stark?",
-        params={"Retriever": {"top_k": 10}}
-    )
-
-    # print the classification results
-    print_documents(res, max_text_len=100, print_meta=True)
-    # or access the predicted class label directly
-    res["documents"][0].to_dict()["meta"]["classification"]["label"]
+    
+     **Usage example:**
+     ```python
+    |    ...
+    |    retriever = ElasticsearchRetriever(document_store=document_store)
+    |    document_classifier = TransformersDocumentClassifier(model_name_or_path="bhadresh-savani/distilbert-base-uncased-emotion")
+    |    p = Pipeline()
+    |    p.add_node(component=retriever, name="Retriever", inputs=["Query"])
+    |    p.add_node(component=document_classifier, name="Classifier", inputs=["Retriever"])
+    |    res = p.run(
+    |        query="Who is the father of Arya Stark?",
+    |        params={"Retriever": {"top_k": 10}}
+    |    )
+    |    
+    |    # print the classification results
+    |    print_documents(res, max_text_len=100, print_meta=True)
+    |    # or access the predicted class label directly
+    |    res["documents"][0].to_dict()["meta"]["classification"]["label"]
+     ```
     """
 
     def __init__(


### PR DESCRIPTION
**Proposed changes**:
- Format usage example of doc classifier so that formatting on docs website is correct. It's broken at the moment: https://haystack-website-git-transformers-docum-1662f6-deepset-overnice.vercel.app/reference/document-classifier
- Should instead look like other code snippets, e.g., https://haystack-website-git-transformers-docum-1662f6-deepset-overnice.vercel.app/reference/retriever
![image](https://user-images.githubusercontent.com/4181769/135620875-e1addf8a-84ac-4fa5-b9a3-d35498292d4e.png)

