### PR TITLE
adding create checkpoint feature for reader.train function in farm reader

### DIFF
--- a/haystack/reader/farm.py
+++ b/haystack/reader/farm.py
@@ -14,6 +14,7 @@ from haystack.modeling.model.optimization import initialize_optimizer
 from haystack.modeling.model.predictions import QAPred, QACandidate
 from haystack.modeling.model.adaptive_model import AdaptiveModel
 from haystack.modeling.training.base import Trainer
+from haystack.modeling.training.base import create_or_load_checkpoint
 from haystack.modeling.evaluation.eval import Evaluator
 from haystack.modeling.utils import set_all_seeds, initialize_device_settings
 
@@ -233,19 +234,7 @@ class FARMReader(BaseReader):
             use_amp=use_amp,
         )
         # 4. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
-        trainer = Trainer(
-            model=model,
-            optimizer=optimizer,
-            data_silo=data_silo,
-            epochs=n_epochs,
-            n_gpu=n_gpu,
-            lr_schedule=lr_schedule,
-            evaluate_every=evaluate_every,
-            device=device,
-            use_amp=use_amp,
-            disable_tqdm=not self.progress_bar
-        )
-
+        trainer = create_or_load_checkpoint()
 
         # 5. Let it grow!
         self.inferencer.model = trainer.train()


### PR DESCRIPTION
**Proposed changes**:
- Current reader.train function in the farm reader lacks the features like saving the model after each epoch and resuming training from a checkpoint. As a result, people who train the model on colab will face runtime limitations issues and will not have the model for inference or can train only for a certain number of epochs.
- `Trainer(...)` in `reader.train()` has been replaced by `create_or_load_checkpoint()` function. This facilitates the saving of the model after certain steps and resuming training from the saved checkpoint.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
