### PR TITLE
WIP: Add BatchEncoding flatten

### DIFF
--- a/haystack/modeling/data_handler/dataset.py
+++ b/haystack/modeling/data_handler/dataset.py
@@ -1,14 +1,31 @@
 import logging
 import numbers
-from typing import Iterable
+from typing import Iterable, List
 
 import numpy as np
 import torch
 from torch.utils.data import Dataset, ConcatDataset, TensorDataset
+from transformers import BatchEncoding
 
 from haystack.modeling.utils import flatten_list
 
 logger = logging.getLogger(__name__)
+
+
+def flatten(encoded_batch: BatchEncoding, keys: List[str], renamed_keys: List[str] = None):
+    if encoded_batch is None:
+        return []
+    if not keys:
+        keys = list(encoded_batch.keys())
+    if not renamed_keys:
+        renamed_keys = keys
+    assert len(keys) == len(renamed_keys), f"keys and renamed_keys have different size {len(keys)} != {len(renamed_keys)}"
+    assert any([key in encoded_batch for key in keys]), f"one of the keys {keys} is not in batch {encoded_batch.keys()}"
+    features_flat = []
+    for item in range(len(encoded_batch[keys[0]])):
+        feat_dict = {k: v for k, v in zip(renamed_keys, [encoded_batch[k][item] for k in keys])}
+        features_flat.append(feat_dict)
+    return features_flat
 
 
 def convert_features_to_dataset(features):

--- a/haystack/retriever/dense.py
+++ b/haystack/retriever/dense.py
@@ -6,7 +6,7 @@ from torch.nn import DataParallel
 import numpy as np
 from pathlib import Path
 
-from haystack.modeling.data_handler.dataset import convert_features_to_dataset
+from haystack.modeling.data_handler.dataset import convert_features_to_dataset, flatten
 from haystack.modeling.utils import initialize_device_settings
 from tqdm.auto import tqdm
 from transformers import AutoTokenizer, AutoModel
@@ -748,14 +748,8 @@ class _RetribertEmbeddingEncoder(_EmbeddingEncoder):
             padding=True
         )
 
-        features_flat = []
-        for input_ids, segment_ids, padding_mask in zip(
-                tokenized_batch["input_ids"], tokenized_batch["token_type_ids"], tokenized_batch["attention_mask"]
-        ):
-            feat_dict = {"input_ids": input_ids,
-                         "padding_mask": padding_mask,
-                         "segment_ids": segment_ids}
-            features_flat.append(feat_dict)
-
+        features_flat = flatten(tokenized_batch,
+                                ["input_ids", "token_type_ids", "attention_mask"],
+                                ["input_ids", "segment_ids", "padding_mask"])
         dataset, tensornames = convert_features_to_dataset(features=features_flat)
         return dataset, tensornames


### PR DESCRIPTION
Yesterday I completed #1559. However,  "by hand" and explicit BatchEncoding flattening has left me with a bit of an unsatisfied feeling as it could be generalized and included as a utility function. This PR adds flatten for BatchEncoding so that any HF BatchEncoding could be converted to a list of feature dicts. For example,

```
from haystack.modeling.data_handler.dataset import flatten

batch_sentences = ["Hello I'm a single sentence", "And another sentence", "And the very very last one"]
encoded_inputs = tokenizer(batch_sentences, padding=True, truncation=True)

features_flat = flatten(tokenized_batch,
                       ["input_ids", "token_type_ids", "attention_mask"],
                       ["input_ids", "segment_ids", "padding_mask"])

# or just flatten if you are not changing names of keys
features_flat = flatten(tokenized_batch)

```

I lumped it with `dataset.py` as I was unsure where to put this utility function. This PR is WIP and just a proposal, but if you like it we can expand from here with unit tests, finding a proper home for it etc. Perhaps flatten already exists somewhere in the codebase but likely not as I have seen variations of explicit conversion throughout the codebase. LMK.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
