### PR TITLE
cosine similarity for  Milvus and Weaviate DocStores 

### DIFF
--- a/haystack/document_store/base.py
+++ b/haystack/document_store/base.py
@@ -199,7 +199,21 @@ class BaseDocumentStore(BaseComponent):
     @abstractmethod
     def get_document_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
         pass
-
+    
+    @abstractmethod
+    def normalize_embedding(self, emb: np.ndarray, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings vector inplace.
+        """
+        pass
+    
+    @abstractmethod
+    def normalize_documents_embeddings(self, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings of already existing documents.
+        """
+        pass
+        
     @abstractmethod
     def query_by_embedding(self,
                            query_emb: np.ndarray,

--- a/haystack/document_store/elasticsearch.py
+++ b/haystack/document_store/elasticsearch.py
@@ -745,7 +745,19 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
         documents = [self._convert_es_hit_to_document(hit, return_embedding=self.return_embedding) for hit in result]
         return documents
-
+    
+    def normalize_embedding(self, emb: np.ndarray, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings vector inplace.
+        """
+        pass
+    
+    def normalize_documents_embeddings(self, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings of already existing documents.
+        """
+        pass
+        
     def query_by_embedding(self,
                            query_emb: np.ndarray,
                            filters: Optional[Dict[str, List[str]]] = None,

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -197,8 +197,7 @@ class FAISSDocumentStore(SQLDocumentStore):
                 embeddings = [doc.embedding for doc in document_objects[i: i + batch_size]]
                 embeddings_to_index = np.array(embeddings, dtype="float32")
 
-                if self.similarity == 'cosine':
-                    faiss.normalize_L2(embeddings_to_index)
+                if self.similarity == 'cosine': self.normalize_embedding(embeddings_to_index)
 
                 self.faiss_indexes[index].add(embeddings_to_index)
 
@@ -278,8 +277,7 @@ class FAISSDocumentStore(SQLDocumentStore):
 
                 embeddings_to_index = np.array(embeddings, dtype="float32")
 
-                if self.similarity == 'cosine':
-                    faiss.normalize_L2(embeddings_to_index)
+                if self.similarity == 'cosine': self.normalize_embedding(embeddings_to_index)
 
                 self.faiss_indexes[index].add(embeddings_to_index)
 
@@ -415,7 +413,13 @@ class FAISSDocumentStore(SQLDocumentStore):
             else:
                 self.faiss_indexes[index].reset()
         super().delete_documents(index=index, filters=filters)
-
+    
+    def normalize_embedding(self, emb: np.ndarray, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings vector inplace.
+        """
+        faiss.normalize_L2(query_emb)
+        
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
@@ -447,8 +451,7 @@ class FAISSDocumentStore(SQLDocumentStore):
 
         query_emb = query_emb.reshape(1, -1).astype(np.float32)
 
-        if self.similarity == 'cosine':
-            faiss.normalize_L2(query_emb)
+        if self.similarity == 'cosine': self.normalize_embedding(query_emb)
 
         score_matrix, vector_id_matrix = self.faiss_indexes[index].search(query_emb, top_k)
         vector_ids_for_query = [str(vector_id) for vector_id in vector_id_matrix[0] if vector_id != -1]

--- a/haystack/document_store/faiss.py
+++ b/haystack/document_store/faiss.py
@@ -418,7 +418,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         """
             Performs L2 normalization of embeddings vector inplace.
         """
-        faiss.normalize_L2(query_emb)
+        faiss.normalize_L2(emb)
         
     def query_by_embedding(
         self,

--- a/haystack/document_store/memory.py
+++ b/haystack/document_store/memory.py
@@ -151,7 +151,19 @@ class InMemoryDocumentStore(BaseDocumentStore):
         index = index or self.index
         documents = [self.indexes[index][id] for id in ids]
         return documents
-
+    
+    def normalize_embedding(self, emb: np.ndarray, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings vector inplace.
+        """
+        pass
+    
+    def normalize_documents_embeddings(self, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings of already existing documents.
+        """
+        pass
+        
     def query_by_embedding(self,
                            query_emb: np.ndarray,
                            filters: Optional[Dict[str, List[str]]] = None,

--- a/haystack/document_store/sql.py
+++ b/haystack/document_store/sql.py
@@ -447,7 +447,19 @@ class SQLDocumentStore(BaseDocumentStore):
             id=row.id
         )
         return label
-
+    
+    def normalize_embedding(self, emb: np.ndarray, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings vector inplace.
+        """
+        pass
+    
+    def normalize_documents_embeddings(self, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings of already existing documents.
+        """
+        pass
+        
     def query_by_embedding(self,
                            query_emb: np.ndarray,
                            filters: Optional[dict] = None,

--- a/haystack/document_store/weaviate.py
+++ b/haystack/document_store/weaviate.py
@@ -379,6 +379,8 @@ class WeaviateDocumentStore(BaseDocumentStore):
 
                     doc_id = str(_doc.pop("id"))
                     vector = _doc.pop(self.embedding_field)
+                    if self.similarity == 'cosine': self.normalize_embedding(vector)
+                    
                     if _doc.get(self.faq_question_field) is None:
                         _doc.pop(self.faq_question_field)
 
@@ -570,7 +572,22 @@ class WeaviateDocumentStore(BaseDocumentStore):
             documents.append(doc)
 
         return documents
-
+    
+    @njit(fastmath=True)
+    def normalize_embedding(self, emb: np.ndarray, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings vector inplace.
+        """
+        norm = np.sqrt(emb.dot(emb))
+        if norm != 0.0:
+            emb /= norm
+        
+    def normalize_documents_embeddings(self, kind:str="L2")->None:
+        """
+            Performs L2 normalization of embeddings of already existing documents.
+        """
+        pass
+        
     def query_by_embedding(self,
                            query_emb: np.ndarray,
                            filters: Optional[dict] = None,
@@ -597,6 +614,9 @@ class WeaviateDocumentStore(BaseDocumentStore):
         properties.append("_additional {id, certainty, vector}")
 
         query_emb = query_emb.reshape(1, -1).astype(np.float32)
+        
+        if self.similarity == 'cosine': self.normalize_embedding(query_emb)
+        
         query_string = {
             "vector" : query_emb
         }
@@ -676,6 +696,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
                                    "Specify the arg `embedding_dim` when initializing WeaviateDocumentStore()")
             for doc, emb in zip(document_batch, embeddings):
                 # Using update method to only update the embeddings, other properties will be in tact
+                if self.similarity == 'cosine': self.normalize_embedding(emb)
                 self.weaviate_client.data_object.update({}, class_name=index, uuid=doc.id, vector=emb)
 
     def delete_all_documents(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,4 @@ SPARQLWrapper
 mmh3
 weaviate-client==2.5.0
 ray==1.5.0
+numba


### PR DESCRIPTION
**Proposed changes**:
Added uniform normalization method to each of the DocStores (implemented), so that now Milvus and Weaviate doc stores can use cosine similarity, plus future method for making existing embeddings normalized (empty for now).

**Status (please check what you already did)**:
- [V ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
