### PR TITLE
Adding TfidfRetriever to __init__.py of the retriever package

### DIFF
--- a/haystack/retriever/__init__.py
+++ b/haystack/retriever/__init__.py
@@ -1,2 +1,2 @@
 from haystack.retriever.dense import DensePassageRetriever, EmbeddingRetriever
-from haystack.retriever.sparse import ElasticsearchRetriever
+from haystack.retriever.sparse import ElasticsearchRetriever, TfidfRetriever


### PR DESCRIPTION
Adding TfidfRetriever to  __init__.py of the retriever package, so people can import it like from haystack.retriever import TfidfRetriever.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [ ] Updated documentation
