### PR TITLE
Use smaller model for one generator test case

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -256,7 +256,8 @@ def xpdf_fixture(tika_fixture):
 def rag_generator():
     return RAGenerator(
         model_name_or_path="facebook/rag-token-nq",
-        generator_type=RAGeneratorType.TOKEN
+        generator_type=RAGeneratorType.TOKEN,
+        max_length=20
     )
 
 
@@ -267,7 +268,7 @@ def question_generator():
 
 @pytest.fixture(scope="module")
 def eli5_generator():
-    return Seq2SeqGenerator(model_name_or_path="yjernite/bart_eli5")
+    return Seq2SeqGenerator(model_name_or_path="yjernite/bart_eli5", max_length=20)
 
 
 @pytest.fixture(scope="module")

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -7,9 +7,6 @@ from haystack import Document
 from haystack.generator.transformers import Seq2SeqGenerator
 from haystack.pipeline import TranslationWrapperPipeline, GenerativeQAPipeline
 
-# Avoid Warning .huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
-import os
-os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 DOCS_WITH_EMBEDDINGS = [
     Document(


### PR DESCRIPTION
**Proposed changes**:
- Reduce memory consumption of one lfqa generator test case by using smaller model
- Reduce max_length of generated sequences

Memory consumption measured with pytest-monitor:
* with large model: test_lfqa_pipeline_invalid_converter | 6588.703125
* with smaller model: test_lfqa_pipeline_invalid_converter | 4402.6640625

test_lfqa_pipeline_invalid_converter was the test with the largest memory consumption:
* test_rag_token_generator|2944.28125
* test_generator_pipeline|3298.59375
* test_lfqa_pipeline|5750.875
* test_lfqa_pipeline_unknown_converter|4402.96875
* test_lfqa_pipeline_invalid_converter|6588.703125
* test_generator_pipeline_with_translator|6211.65234375

Reduced max_length of generated sequences further reduced memory consumption of the latter two tests:
* test_lfqa_pipeline_invalid_converter|4510.1640625
* test_generator_pipeline_with_translator|4744.95703125

As turning off TOKENIZERS_PARALLELISM did not solve the problem, I am turning it on again. However, I noticed that this slightly increases the memory consumption but does not reduce runtime.