### PR TITLE
Improve docker images: Add nltk download, add folder for file upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ COPY setup.py requirements.txt README.md /home/user/
 RUN pip install -r requirements.txt
 RUN pip install -e .
 
+# download punkt tokenizer to be included in image
+RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data')"
+
+# create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
+RUN mkdir -p /home/user/file-upload
+RUN chmod 666 /home/user/file-upload
+
 # copy saved models
 COPY README.md models* /home/user/models/
 

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -34,6 +34,13 @@ RUN pip3 install faiss-cpu==1.6.3
 RUN pip3 install -r requirements.txt
 RUN pip3 install -e .
 
+# download punkt tokenizer to be included in image
+RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data')"
+
+# create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
+RUN mkdir -p /home/user/file-upload
+RUN chmod 666 /home/user/file-upload
+
 # copy saved models
 COPY README.md models* /home/user/models/
 


### PR DESCRIPTION
Add punkt tokenizer into image, so it does not have to be downloaded when container is started. Internet access might not be available or behind proxies.

Add a folder for /file-upload endpoint with read and write permissions. By default the user does not have permissions to this folder and when an image is run as non root this produced "permission denied" errors.
