### PR TITLE
Add a restart policy `on-failure` to all containers

### DIFF
--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -18,6 +18,7 @@ services:
     #   - ./rest_api/pipeline:/home/user/rest_api/pipeline
     ports:
       - 8000:8000
+    restart: on-failure
     environment:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
@@ -31,6 +32,7 @@ services:
     image: "deepset/elasticsearch-game-of-thrones"
     ports:
       - 9200:9200
+    restart: on-failure
     environment:
       - discovery.type=single-node
   ui:
@@ -40,6 +42,7 @@ services:
     image: "deepset/haystack-streamlit-ui:latest"
     ports:
       - 8501:8501
+    restart: on-failure
     environment:
       - API_ENDPOINT=http://haystack-api:8000
       - EVAL_FILE=eval_labels_example.csv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     #   - ./rest_api/pipeline:/home/user/rest_api/pipeline
     ports:
       - 8000:8000
+    restart: on-failure
     environment:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
@@ -23,6 +24,7 @@ services:
     image: "deepset/elasticsearch-game-of-thrones"
     ports:
       - 9200:9200
+    restart: on-failure
     environment:
       - discovery.type=single-node
   ui:
@@ -32,6 +34,7 @@ services:
     image: "deepset/haystack-streamlit-ui:latest"
     ports:
       - 8501:8501
+    restart: on-failure
     environment:
       - API_ENDPOINT=http://haystack-api:8000
       - EVAL_FILE=eval_labels_example.csv


### PR DESCRIPTION
The timing of the startup of the various container in the demo is sometimes hard to predict, and causes issues in which the REST API server seems to boot too early and then crash when trying to connect to a still booting Elasticsearch container.

In the past we used `restart: always`, but that implied that the demo had to be manually stopped or it would restart at the next boot of the user's laptop, which keeps the relevant ports occupied on the system and can cause headaches.

With `restart: on-failure`, the containers are restarted only if they fail, which is a bit more conservative and does not make the containers restart every time they're stopped by a system shutdown.

This change should be able to solve issues like #1583 and #1416.