### PR TITLE
Add execute permissions to file upload folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data'
 
 # create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
 RUN mkdir -p /home/user/file-upload
-RUN chmod 666 /home/user/file-upload
+RUN chmod 777 /home/user/file-upload
 
 # copy saved models
 COPY README.md models* /home/user/models/

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -39,7 +39,7 @@ RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data'
 
 # create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
 RUN mkdir -p /home/user/file-upload
-RUN chmod 666 /home/user/file-upload
+RUN chmod 777 /home/user/file-upload
 
 # copy saved models
 COPY README.md models* /home/user/models/


### PR DESCRIPTION
Sorry, my bad, I thought the file upload folder does not require execute permissions on its content. Turns out it actually needs it.