### PR TITLE
fix typo in docstring of crawler 

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -24,7 +24,7 @@ class Crawler(BaseComponent):
     |    crawler = Crawler(output_dir="crawled_files")
     |    # crawl Haystack docs, i.e. all pages that include haystack.deepset.ai/overview/
     |    docs = crawler.crawl(urls=["https://haystack.deepset.ai/overview/get-started"],
-    |                         filter_urls= ["haystack\.deepset\.ai\/docs\/"])
+    |                         filter_urls= ["haystack\.deepset\.ai\/overview\/"])
     ```
     """
     outgoing_edges = 1


### PR DESCRIPTION
the old reference of /docs from the old website no longer exists
