### PR TITLE
disable file upload for InMemoryDocStore

### DIFF
--- a/rest_api/controller/file_upload.py
+++ b/rest_api/controller/file_upload.py
@@ -21,14 +21,15 @@ try:
         path=Path(PIPELINE_YAML_PATH), pipeline_name=INDEXING_PIPELINE_NAME, overwrite_with_env_variables=True
     )
     # Since each instance of FAISSDocumentStore creates an in-memory FAISS index, the Indexing & Query Pipelines would
-    # end up with different indices. The check below prevents creation of Indexing Pipelines with FAISSDocumentStore.   
-    is_faiss_present = False
+    # end up with different indices. The same applies for InMemoryDocumentStore. The check below prevents creation of 
+    # Indexing Pipelines with FAISSDocumentStore or InMemoryDocumentStore.   
+    is_faiss_or_inmemory_present = False
     for node in pipeline_config["nodes"]:
-        if definitions[node["name"]]["type"] == "FAISSDocumentStore":
-            is_faiss_present = True
+        if definitions[node["name"]]["type"] == "FAISSDocumentStore" or definitions[node["name"]]["type"] == "InMemoryDocumentStore":
+            is_faiss_or_inmemory_present = True
             break
-    if is_faiss_present:
-        logger.warning("Indexing Pipeline with FAISSDocumentStore is not supported with the REST APIs.")
+    if is_faiss_or_inmemory_present:
+        logger.warning("Indexing Pipeline with FAISSDocumentStore or InMemoryDocumentStore is not supported with the REST APIs.")
         INDEXING_PIPELINE = None
     else:
         INDEXING_PIPELINE = Pipeline.load_from_yaml(Path(PIPELINE_YAML_PATH), pipeline_name=INDEXING_PIPELINE_NAME)


### PR DESCRIPTION
**Proposed changes**:
- Disable file upload REST API for InMemoryDocStore. Indexing and query pipelines would create two different instances each with FAISS and InMemory document stores. While file upload with FAISS was already disabled, file upload with InMemoryDocStore was still enabled and this PR disables it.

A problem resulting from two separate instances of InMemoryDocStore in indexing and query pipelines where reported in #1637
