### PR TITLE
Add TableTextRetriever to nodes' __init__.py

### DIFF
--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -30,6 +30,7 @@ from haystack.nodes.retriever import (
     ElasticsearchFilterOnlyRetriever,
     TfidfRetriever,
     Text2SparqlRetriever,
+    TableTextRetriever,
 )
 from haystack.nodes.summarizer import BaseSummarizer, TransformersSummarizer
 from haystack.nodes.translator import BaseTranslator, TransformersTranslator


### PR DESCRIPTION
This PR adds the `TableTextRetriever` to nodes `__init__.py`. This allows to import the retriever like this:
`from haystack.nodes import TableTextRetriever`.