### PR TITLE
Standardize initialisation of device settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data'
 
 # create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
 RUN mkdir -p /home/user/file-upload
-RUN chmod 666 /home/user/file-upload
+RUN chmod 777 /home/user/file-upload
 
 # copy saved models
 COPY README.md models* /home/user/models/

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -39,7 +39,7 @@ RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data'
 
 # create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
 RUN mkdir -p /home/user/file-upload
-RUN chmod 666 /home/user/file-upload
+RUN chmod 777 /home/user/file-upload
 
 # copy saved models
 COPY README.md models* /home/user/models/

--- a/docs/_src/api/api/document_classifier.md
+++ b/docs/_src/api/api/document_classifier.md
@@ -59,7 +59,7 @@ With this document_classifier, you can directly get predictions via predict()
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str = "bhadresh-savani/distilbert-base-uncased-emotion", model_version: Optional[str] = None, tokenizer: Optional[str] = None, use_gpu: int = 0, return_all_scores: bool = False, task: str = 'text-classification', labels: Optional[List[str]] = None)
+ | __init__(model_name_or_path: str = "bhadresh-savani/distilbert-base-uncased-emotion", model_version: Optional[str] = None, tokenizer: Optional[str] = None, use_gpu: bool = True, return_all_scores: bool = False, task: str = 'text-classification', labels: Optional[List[str]] = None)
 ```
 
 Load a text classification model from Transformers.
@@ -81,7 +81,7 @@ Filter for zero-shot classification models (NLI): https://huggingface.co/models?
 See https://huggingface.co/models for full list of available models.
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `tokenizer`: Name of the tokenizer (usually the same as model)
-- `use_gpu`: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
+- `use_gpu`: Whether to use GPU (if available).
 - `return_all_scores`: Whether to return all prediction scores or just the one of the predicted class. Only used for task 'text-classification'.
 - `task`: 'text-classification' or 'zero-shot-classification'
 - `labels`: Only used for task 'zero-shot-classification'. List of string defining class labels, e.g.,

--- a/docs/_src/api/api/ranker.md
+++ b/docs/_src/api/api/ranker.md
@@ -82,7 +82,7 @@ p.add_node(component=ranker, name="Ranker", inputs=["ESRetriever"])
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: Union[str, Path], model_version: Optional[str] = None, top_k: int = 10)
+ | __init__(model_name_or_path: Union[str, Path], model_version: Optional[str] = None, top_k: int = 10, use_gpu: bool = True)
 ```
 
 **Arguments**:
@@ -92,6 +92,7 @@ p.add_node(component=ranker, name="Ranker", inputs=["ESRetriever"])
 See https://huggingface.co/cross-encoder for full list of available models
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `top_k`: The maximum number of documents to return
+- `use_gpu`: Whether to use GPU (if available).
 
 <a name="sentence_transformers.SentenceTransformersRanker.predict_batch"></a>
 #### predict\_batch

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -376,7 +376,7 @@ With this reader, you can directly get predictions via predict()
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: Optional[str] = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: int = 0, top_k: int = 10, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
+ | __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: Optional[str] = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: bool = True, top_k: int = 10, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
 ```
 
 Load a QA model from Transformers.
@@ -397,7 +397,7 @@ See https://huggingface.co/models for full list of available models.
 - `tokenizer`: Name of the tokenizer (usually the same as model)
 - `context_window_size`: Num of chars (before and after the answer) to return as "context" for each answer.
                             The context usually helps users to understand if the answer really makes sense.
-- `use_gpu`: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
+- `use_gpu`: Whether to use GPU (if available).
 - `top_k`: The maximum number of answers to return
 - `top_k_per_candidate`: How many answers to extract for each candidate doc that is coming from the retriever (might be a long text).
 Note that this is not the number of "final answers" you will receive

--- a/docs/_src/api/api/summarizer.md
+++ b/docs/_src/api/api/summarizer.md
@@ -81,7 +81,7 @@ See the up-to-date list of available models on
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str = "google/pegasus-xsum", model_version: Optional[str] = None, tokenizer: Optional[str] = None, max_length: int = 200, min_length: int = 5, use_gpu: int = 0, clean_up_tokenization_spaces: bool = True, separator_for_single_summary: str = " ", generate_single_summary: bool = False)
+ | __init__(model_name_or_path: str = "google/pegasus-xsum", model_version: Optional[str] = None, tokenizer: Optional[str] = None, max_length: int = 200, min_length: int = 5, use_gpu: bool = True, clean_up_tokenization_spaces: bool = True, separator_for_single_summary: str = " ", generate_single_summary: bool = False)
 ```
 
 Load a Summarization model from Transformers.
@@ -97,7 +97,7 @@ https://huggingface.co/models?filter=summarization
 - `tokenizer`: Name of the tokenizer (usually the same as model)
 - `max_length`: Maximum length of summarized text
 - `min_length`: Minimum length of summarized text
-- `use_gpu`: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
+- `use_gpu`: Whether to use GPU (if available).
 - `clean_up_tokenization_spaces`: Whether or not to clean up the potential extra spaces in the text output
 - `separator_for_single_summary`: If `generate_single_summary=True` in `predict()`, we need to join all docs
                                      into a single text. This separator appears between those subsequent docs.

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -61,7 +61,7 @@ We currently recommend using OPUS models (see __init__() for details)
 #### \_\_init\_\_
 
 ```python
- | __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True)
+ | __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True)
 ```
 
 Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
@@ -84,6 +84,7 @@ They also have a few multilingual models that support multiple languages at once
                        tokenizer.
 - `max_seq_len`: The maximum sentence length the model accepts. (Optional)
 - `clean_up_tokenization_spaces`: Whether or not to clean up the tokenization spaces. (default True)
+- `use_gpu`: Whether to use GPU (if available).
 
 <a name="transformers.TransformersTranslator.translate"></a>
 #### translate

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -7,7 +7,7 @@ root_logger.setLevel(logging.DEBUG)
 
 # Then reconfigure the StreamHandler not to display anything below WARNING as default
 stream_handler = logging.StreamHandler()
-stream_handler.setLevel(logging.WARNING)
+stream_handler.setLevel(logging.INFO)
 root_logger.addHandler(stream_handler)
 
 # Change log-levels before modules are loaded to avoid verbose log messages.

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -70,13 +70,12 @@ class Inferencer:
         MLFlowLogger.disable()
 
         # Init device and distributed settings
-        device, n_gpu = initialize_device_settings(use_cuda=gpu, local_rank=-1, use_amp=None)
+        self.devices, n_gpu = initialize_device_settings(use_cuda=gpu, multi_gpu=False)
 
         self.processor = processor
         self.model = model
         self.model.eval()
         self.batch_size = batch_size
-        self.device = device
         self.language = self.model.get_language()
         self.task_type = task_type
         self.disable_tqdm = disable_tqdm
@@ -164,12 +163,12 @@ class Inferencer:
         if tokenizer_args is None:
             tokenizer_args = {}
 
-        device, n_gpu = initialize_device_settings(use_cuda=gpu, local_rank=-1, use_amp=None)
+        devices, n_gpu = initialize_device_settings(use_cuda=gpu, multi_gpu=False)
         name = os.path.basename(model_name_or_path)
 
         # a) either from local dir
         if os.path.exists(model_name_or_path):
-            model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=device, strict=strict)
+            model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=devices[0], strict=strict)
             if task_type == "embeddings":
                 processor = InferenceProcessor.load_from_dir(model_name_or_path)
             else:
@@ -184,7 +183,7 @@ class Inferencer:
 
             model = AdaptiveModel.convert_from_transformers(model_name_or_path,
                                                             revision=revision,
-                                                            device=device,
+                                                            device=devices[0],
                                                             task_type=task_type,
                                                             **kwargs)
             processor = Processor.convert_from_transformers(model_name_or_path,
@@ -439,7 +438,7 @@ class Inferencer:
         )  # type ignore
         preds_all = []
         for i, batch in enumerate(tqdm(data_loader, desc=f"Inferencing Samples", unit=" Batches", disable=self.disable_tqdm)):
-            batch = {key: batch[key].to(self.device) for key in batch}
+            batch = {key: batch[key].to(self.devices[0]) for key in batch}
             batch_samples = samples[i * self.batch_size : (i + 1) * self.batch_size]
 
             # get logits
@@ -478,7 +477,7 @@ class Inferencer:
 
         for i, batch in enumerate(tqdm(data_loader, desc=f"Inferencing Samples", unit=" Batches", disable=self.disable_tqdm)):
 
-            batch = {key: batch[key].to(self.device) for key in batch}
+            batch = {key: batch[key].to(self.devices[0]) for key in batch}
 
             # get logits
             with torch.no_grad():

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -32,14 +32,14 @@ class Inferencer:
         model: AdaptiveModel,
         processor: Processor,
         task_type: Optional[str],
-        batch_size: int =4,
-        gpu: bool =False,
-        name: Optional[str] =None,
-        return_class_probs: bool=False,
+        batch_size: int = 4,
+        gpu: bool = False,
+        name: Optional[str] = None,
+        return_class_probs: bool = False,
         extraction_strategy: Optional[str] = None,
         extraction_layer: Optional[int] = None,
-        num_processes: Optional[int] =None,
-        disable_tqdm: bool =False
+        num_processes: Optional[int] = None,
+        disable_tqdm: bool = False
     ):
         """
         Initializes Inferencer from an AdaptiveModel and a Processor instance.

--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -48,25 +48,33 @@ def set_all_seeds(seed: int, deterministic_cudnn: bool=False) -> None:
         torch.backends.cudnn.benchmark = False
 
 
-def initialize_device_settings(use_cuda, local_rank=-1, use_amp=None):
+def initialize_device_settings(use_cuda: bool, local_rank: int = -1, multi_gpu: bool = True):
+    """
+    Returns a list of available devices.
+
+    :param use_cuda: Whether to make use of CUDA GPUs (if available).
+    :param local_rank: Ordinal of device to be used. If -1 and multi_gpu is True, all devices will be used.
+    :param multi_gpu: Whether to make use of all GPUs (if available).
+    """
     if not use_cuda:
-        device = torch.device("cpu")
+        devices = [torch.device("cpu")]
         n_gpu = 0
     elif local_rank == -1:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        if not torch.cuda.is_available():
-            n_gpu = 0
-        else:
+        if torch.cuda.is_available():
+            devices = [torch.device(device) for device in range(torch.cuda.device_count())]
             n_gpu = torch.cuda.device_count()
+        else:
+            devices = [torch.device("cpu")]
+            n_gpu = 0
     else:
-        device = torch.device("cuda", local_rank)
+        devices = [torch.device("cuda", local_rank)]
         torch.cuda.set_device(device)
         n_gpu = 1
         # Initializes the distributed backend which will take care of sychronizing nodes/GPUs
         torch.distributed.init_process_group(backend="nccl")
-    logger.info(f"Using device: {str(device).upper()} ")
+    logger.info(f"Using devices: {' ,'.join(devices).upper()}")
     logger.info(f"Number of GPUs: {n_gpu}")
-    return device, n_gpu
+    return devices, n_gpu
 
 
 def flatten_list(nested_list):

--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -66,8 +66,6 @@ def initialize_device_settings(use_cuda, local_rank=-1, use_amp=None):
         torch.distributed.init_process_group(backend="nccl")
     logger.info(f"Using device: {str(device).upper()} ")
     logger.info(f"Number of GPUs: {n_gpu}")
-    logger.info(f"Distributed Training: {bool(local_rank != -1)}")
-    logger.info(f"Automatic Mixed Precision: {use_amp}")
     return device, n_gpu
 
 

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional
 
 import numpy
 import torch
-from torch.nn import DataParallel
 from haystack.modeling.utils import initialize_device_settings
 from transformers import RagTokenizer, RagTokenForGeneration, AutoTokenizer, \
     AutoModelForSeq2SeqLM, PreTrainedTokenizer, BatchEncoding
@@ -79,7 +78,6 @@ class RAGenerator(BaseGenerator):
             embed_title: bool = True,
             prefix: Optional[str] = None,
             use_gpu: bool = True,
-            devices: Optional[List[Union[int, str, torch.device]]] = None
     ):
         """
         Load a RAG model from Transformers along with passage_embedding_model.
@@ -97,9 +95,7 @@ class RAGenerator(BaseGenerator):
         :param num_beams: Number of beams for beam search. 1 means no beam search.
         :param embed_title: Embedded the title of passage while generating embedding
         :param prefix: The prefix used by the generator's tokenizer.
-        :param use_gpu: Whether to use all available GPUs or the CPU. Falls back on CPU if no GPU is available.
-        :param devices: List of GPU devices to limit inference to certain GPUs and not use all available ones (e.g. ["cuda:0"]).
-                        As multi-GPU training is currently not implemented for DPR, training will only use the first device provided in this list.
+        :param use_gpu: Whether to use GPU. Falls back on CPU if no GPU is available.
         """
 
         # save init parameters to enable export of component config as YAML
@@ -124,10 +120,7 @@ class RAGenerator(BaseGenerator):
 
         self.top_k = top_k
 
-        if devices is not None:
-            self.devices = devices
-        else:
-            self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=True)
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
 
         self.tokenizer = RagTokenizer.from_pretrained(model_name_or_path)
 
@@ -139,9 +132,6 @@ class RAGenerator(BaseGenerator):
         else:
             self.model = RagTokenForGeneration.from_pretrained(model_name_or_path, revision=model_version)
             self.model.to(str(self.devices[0]))
-
-            if len(self.devices) > 1:
-                self.model = DataParallel(self.model, device_ids=self.devices)
 
     # Copied cat_input_and_doc method from transformers.RagRetriever
     # Refer section 2.3 of https://arxiv.org/abs/2005.11401
@@ -182,8 +172,8 @@ class RAGenerator(BaseGenerator):
             truncation=True,
         )
 
-        return contextualized_inputs["input_ids"].to(self.device), \
-               contextualized_inputs["attention_mask"].to(self.device)
+        return contextualized_inputs["input_ids"].to(self.devices[0]), \
+               contextualized_inputs["attention_mask"].to(self.devices[0])
 
     def _prepare_passage_embeddings(self, docs: List[Document], embeddings: List[numpy.ndarray]) -> torch.Tensor:
 
@@ -201,7 +191,7 @@ class RAGenerator(BaseGenerator):
             dim=0
         )
 
-        return embeddings_in_tensor.to(self.device)
+        return embeddings_in_tensor.to(self.devices[0])
 
     def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None) -> Dict:
         """
@@ -255,7 +245,7 @@ class RAGenerator(BaseGenerator):
             src_texts=[query],
             return_tensors="pt"
         )
-        input_ids = input_dict['input_ids'].to(self.device)
+        input_ids = input_dict['input_ids'].to(self.devices[0])
         # Query embedding
         query_embedding = self.model.question_encoder(input_ids)[0]
 
@@ -362,7 +352,6 @@ class Seq2SeqGenerator(BaseGenerator):
             min_length: int = 2,
             num_beams: int = 8,
             use_gpu: bool = True,
-            devices: Optional[List[Union[int, str, torch.device]]] = None
     ):
         """
         :param model_name_or_path: a HF model name for auto-regressive language model like GPT2, XLNet, XLM, Bart, T5 etc
@@ -375,9 +364,7 @@ class Seq2SeqGenerator(BaseGenerator):
         :param max_length: Maximum length of generated text
         :param min_length: Minimum length of generated text
         :param num_beams: Number of beams for beam search. 1 means no beam search.
-        :param use_gpu: Whether to use all available GPUs or the CPU. Falls back on CPU if no GPU is available.
-        :param devices: List of GPU devices to limit inference to certain GPUs and not use all available ones (e.g. ["cuda:0"]).
-                        As multi-GPU training is currently not implemented for DPR, training will only use the first device provided in this list.
+        :param use_gpu: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
         """
 
         self.model_name_or_path = model_name_or_path
@@ -391,10 +378,7 @@ class Seq2SeqGenerator(BaseGenerator):
 
         self.top_k = top_k
 
-        if devices is not None:
-            self.devices = devices
-        else:
-            self.devices, _ = initialize_device_settings(use_cuda=use_gpu)
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
 
         Seq2SeqGenerator._register_converters(model_name_or_path, input_converter)
 
@@ -402,10 +386,6 @@ class Seq2SeqGenerator(BaseGenerator):
         self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
         self.model.to(str(self.devices[0]))
         self.model.eval()
-
-        if len(self.devices) > 1:
-            self.model = DataParallel(self.model, device_ids=self.devices)
-
 
     @classmethod
     def _register_converters(cls, model_name_or_path: str, custom_converter: Optional[Callable]):
@@ -449,7 +429,7 @@ class Seq2SeqGenerator(BaseGenerator):
 
         try:
             query_and_docs_encoded: BatchEncoding = converter(tokenizer=self.tokenizer, query=query,
-                                                              documents=documents, top_k=top_k).to(self.device)
+                                                              documents=documents, top_k=top_k).to(self.devices[0])
         except TypeError as e:
             raise TypeError(f"Language model input converter {converter} provided in Seq2SeqGenerator.__init__() does "
                             f"not have a valid __call__ method signature. The required Callable __call__ signature is: "

--- a/haystack/nodes/document_classifier/transformers.py
+++ b/haystack/nodes/document_classifier/transformers.py
@@ -86,8 +86,8 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
             logger.warning(f'Provided labels {labels} will be ignored for task text-classification. Set task to '
                            f'zero-shot-classification to use labels.')
 
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
-        device = 0 if device.type == "cuda" else -1
+        devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
+        device = 0 if devices[0].type == "cuda" else -1
 
         if tokenizer is None:
             tokenizer = model_name_or_path

--- a/haystack/nodes/document_classifier/transformers.py
+++ b/haystack/nodes/document_classifier/transformers.py
@@ -1,10 +1,11 @@
 from typing import List, Optional
-
 import logging
+
 from transformers import pipeline
 
 from haystack.schema import Document
 from haystack.nodes.document_classifier.base import BaseDocumentClassifier
+from haystack.modeling.utils import initialize_device_settings
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
         model_name_or_path: str = "bhadresh-savani/distilbert-base-uncased-emotion",
         model_version: Optional[str] = None,
         tokenizer: Optional[str] = None,
-        use_gpu: int = 0,
+        use_gpu: bool = True,
         return_all_scores: bool = False,
         task: str = 'text-classification',
         labels: Optional[List[str]] = None
@@ -68,7 +69,7 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
         See https://huggingface.co/models for full list of available models.
         :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param tokenizer: Name of the tokenizer (usually the same as model)
-        :param use_gpu: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
+        :param use_gpu: Whether to use GPU (if available).
         :param return_all_scores:  Whether to return all prediction scores or just the one of the predicted class. Only used for task 'text-classification'.
         :param task: 'text-classification' or 'zero-shot-classification'
         :param labels: Only used for task 'zero-shot-classification'. List of string defining class labels, e.g.,
@@ -85,12 +86,15 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
             logger.warning(f'Provided labels {labels} will be ignored for task text-classification. Set task to '
                            f'zero-shot-classification to use labels.')
 
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        device = 0 if device.type == "cuda" else -1
+
         if tokenizer is None:
             tokenizer = model_name_or_path
         if task == 'zero-shot-classification':
-            self.model = pipeline(task=task, model=model_name_or_path, tokenizer=tokenizer, device=use_gpu, revision=model_version)
+            self.model = pipeline(task=task, model=model_name_or_path, tokenizer=tokenizer, device=device, revision=model_version)
         elif task == 'text-classification':
-            self.model = pipeline(task=task, model=model_name_or_path, tokenizer=tokenizer, device=use_gpu, revision=model_version, return_all_scores=return_all_scores)
+            self.model = pipeline(task=task, model=model_name_or_path, tokenizer=tokenizer, device=device, revision=model_version, return_all_scores=return_all_scores)
         self.return_all_scores = return_all_scores
         self.labels = labels
         self.task = task

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -21,8 +21,7 @@ class EntityExtractor(BaseComponent):
 
     def __init__(self,
                  model_name_or_path: str = "dslim/bert-base-NER",
-                 use_gpu: bool = True,
-                 devices: Optional[List[Union[int, str, torch.device]]] = None):
+                 use_gpu: bool = True):
 
         self.set_config(model_name_or_path=model_name_or_path)
         self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
@@ -30,7 +29,8 @@ class EntityExtractor(BaseComponent):
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         token_classifier = AutoModelForTokenClassification.from_pretrained(model_name_or_path)
         token_classifier.to(str(self.devices[0]))
-        self.model = pipeline("ner", model=token_classifier, tokenizer=tokenizer, aggregation_strategy="simple")
+        self.model = pipeline("ner", model=token_classifier, tokenizer=tokenizer, aggregation_strategy="simple",
+                              device=0 if self.devices[0].type == "cuda" else -1)
 
     def run(self, documents: Optional[Union[List[Document], List[dict]]] = None) -> Tuple[Dict, str]:  # type: ignore
         """

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -21,13 +21,15 @@ class EntityExtractor(BaseComponent):
 
     def __init__(self,
                  model_name_or_path: str = "dslim/bert-base-NER",
-                 use_gpu: bool = True,):
+                 use_gpu: bool = True,
+                 devices: Optional[List[Union[int, str, torch.device]]] = None):
 
         self.set_config(model_name_or_path=model_name_or_path)
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
+
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         token_classifier = AutoModelForTokenClassification.from_pretrained(model_name_or_path)
-        token_classifier.to(device)
+        token_classifier.to(str(self.devices[0]))
         self.model = pipeline("ner", model=token_classifier, tokenizer=tokenizer, aggregation_strategy="simple")
 
     def run(self, documents: Optional[Union[List[Document], List[dict]]] = None) -> Tuple[Dict, str]:  # type: ignore

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -5,6 +5,7 @@ from transformers import pipeline
 
 from haystack.schema import Document
 from haystack.nodes.base import BaseComponent
+from haystack.modeling.utils import initialize_device_settings
 
 
 class EntityExtractor(BaseComponent):
@@ -19,11 +20,14 @@ class EntityExtractor(BaseComponent):
     outgoing_edges = 1
 
     def __init__(self,
-                 model_name_or_path="dslim/bert-base-NER"):
+                 model_name_or_path: str = "dslim/bert-base-NER",
+                 use_gpu: bool = True,):
 
         self.set_config(model_name_or_path=model_name_or_path)
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
         token_classifier = AutoModelForTokenClassification.from_pretrained(model_name_or_path)
+        token_classifier.to(device)
         self.model = pipeline("ner", model=token_classifier, tokenizer=tokenizer, aggregation_strategy="simple")
 
     def run(self, documents: Optional[Union[List[Document], List[dict]]] = None) -> Tuple[Dict, str]:  # type: ignore

--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -64,8 +64,8 @@ class TransformersQueryClassifier(BaseQueryClassifier):
         """
         # save init parameters to enable export of component config as YAML
         self.set_config(model_name_or_path=model_name_or_path)
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
-        device = 0 if device.type == "cuda" else -1
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu)
+        device = 0 if self.devices[0].type == "cuda" else -1
 
         model = AutoModelForSequenceClassification.from_pretrained(model_name_or_path)
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
@@ -73,7 +73,6 @@ class TransformersQueryClassifier(BaseQueryClassifier):
         self.query_classification_pipeline = TextClassificationPipeline(
             model=model, tokenizer=tokenizer, device=device
         )
-        x = 1
 
     def run(self, query):
         is_question: bool = (

--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from transformers import AutoTokenizer, AutoModelForSequenceClassification, TextClassificationPipeline
 from haystack.nodes.query_classifier import BaseQueryClassifier
+from haystack.modeling.utils import initialize_device_settings
 
 
 logger = logging.getLogger(__name__)
@@ -54,22 +55,25 @@ class TransformersQueryClassifier(BaseQueryClassifier):
     """
     def __init__(
         self,
-        model_name_or_path: Union[
-            Path, str
-        ] = "shahrukhx01/bert-mini-finetune-question-detection"
+        model_name_or_path: Union[Path, str] = "shahrukhx01/bert-mini-finetune-question-detection",
+        use_gpu: bool = True,
     ):
         """
         :param model_name_or_path: Transformer based fine tuned mini bert model for query classification
+        :param use_gpu: Whether to use GPU (if available).
         """
         # save init parameters to enable export of component config as YAML
         self.set_config(model_name_or_path=model_name_or_path)
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        device = 0 if device.type == "cuda" else -1
 
         model = AutoModelForSequenceClassification.from_pretrained(model_name_or_path)
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
 
         self.query_classification_pipeline = TextClassificationPipeline(
-            model=model, tokenizer=tokenizer
+            model=model, tokenizer=tokenizer, device=device
         )
+        x = 1
 
     def run(self, query):
         is_question: bool = (

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -1,8 +1,9 @@
 from typing import List, Optional, Union
-
 import logging
-import torch
 from pathlib import Path
+
+import torch
+from torch.nn import DataParallel
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 from haystack.schema import Document
@@ -38,6 +39,7 @@ class SentenceTransformersRanker(BaseRanker):
             model_version: Optional[str] = None,
             top_k: int = 10,
             use_gpu: bool = True,
+            devices: Optional[List[Union[int, str, torch.device]]] = None
     ):
         """
         :param model_name_or_path: Directory of a saved model or the name of a public model e.g.
@@ -45,7 +47,9 @@ class SentenceTransformersRanker(BaseRanker):
         See https://huggingface.co/cross-encoder for full list of available models
         :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param top_k: The maximum number of documents to return
-        :param use_gpu: Whether to use GPU (if available).
+        :param use_gpu: Whether to use all available GPUs or the CPU. Falls back on CPU if no GPU is available.
+        :param devices: List of GPU devices to limit inference to certain GPUs and not use all available ones (e.g. ["cuda:0"]).
+                        As multi-GPU training is currently not implemented for DPR, training will only use the first device provided in this list.
         """
 
         # save init parameters to enable export of component config as YAML
@@ -56,11 +60,17 @@ class SentenceTransformersRanker(BaseRanker):
 
         self.top_k = top_k
 
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        if devices is not None:
+            self.devices = devices
+        else:
+            self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=True)
         self.transformer_model = AutoModelForSequenceClassification.from_pretrained(pretrained_model_name_or_path=model_name_or_path, revision=model_version)
-        self.transformer_model.to(device)
+        self.transformer_model.to(str(self.devices[0]))
         self.transformer_tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model_name_or_path, revision=model_version)
         self.transformer_model.eval()
+
+        if len(self.devices) > 1:
+            self.model = DataParallel(self.model, device_ids=self.devices)
 
     def predict_batch(self, query_doc_list: List[dict], top_k: int = None, batch_size: int = None):
         """

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -118,6 +118,7 @@ class FARMReader(BaseReader):
             duplicate_filtering=duplicate_filtering, proxies=proxies, local_files_only=local_files_only,
             force_download=force_download, use_confidence_scores=use_confidence_scores, **kwargs
         )
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
 
         self.return_no_answers = return_no_answer
         self.top_k = top_k
@@ -145,7 +146,6 @@ class FARMReader(BaseReader):
         self.max_seq_len = max_seq_len
         self.use_gpu = use_gpu
         self.progress_bar = progress_bar
-        self.device, _ = initialize_device_settings(use_cuda=self.use_gpu)
         self.use_confidence_scores = use_confidence_scores
 
     def train(

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -227,7 +227,7 @@ class FARMReader(BaseReader):
         if max_seq_len is None:
             max_seq_len = self.max_seq_len
 
-        device, n_gpu = initialize_device_settings(use_cuda=use_gpu,use_amp=use_amp)
+        devices, n_gpu = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
 
         if not save_dir:
             save_dir = f"../../saved_models/{self.inferencer.model.language_model.name}"
@@ -259,7 +259,7 @@ class FARMReader(BaseReader):
             schedule_opts={"name": "LinearWarmup", "warmup_proportion": warmup_proportion},
             n_batches=len(data_silo.loaders["train"]),
             n_epochs=n_epochs,
-            device=device,
+            device=devices[0],
             use_amp=use_amp,
         )
         # 4. Feed everything to the Trainer, which keeps care of growing our model and evaluates it from time to time
@@ -271,7 +271,7 @@ class FARMReader(BaseReader):
             n_gpu=n_gpu,
             lr_schedule=lr_schedule,
             evaluate_every=evaluate_every,
-            device=device,
+            device=devices[0],
             use_amp=use_amp,
             disable_tqdm=not self.progress_bar,
             checkpoint_root_dir=Path(checkpoint_root_dir),

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -10,6 +10,7 @@ from transformers import pipeline, TapasTokenizer, TapasForQuestionAnswering, Ba
 
 from haystack.schema import Document, Answer, Span
 from haystack.nodes.reader.base import BaseReader
+from haystack.modeling.utils import initialize_device_settings
 
 
 logger = logging.getLogger(__name__)
@@ -71,9 +72,9 @@ class TableReader(BaseReader):
                             query + table exceed max_seq_len, the table will be truncated by removing rows until the
                             input size fits the model.
         """
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
         self.model = TapasForQuestionAnswering.from_pretrained(model_name_or_path, revision=model_version)
-        if use_gpu and torch.cuda.is_available():
-                self.model.to("cuda")
+        self.model.to(device)
         if tokenizer is None:
             self.tokenizer = TapasTokenizer.from_pretrained(model_name_or_path)
         else:

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -10,6 +10,7 @@ from transformers import pipeline, TapasTokenizer, TapasForQuestionAnswering, Ba
 
 from haystack.schema import Document, Answer, Span
 from haystack.nodes.reader.base import BaseReader
+from haystack.modeling.utils import initialize_device_settings
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ class TransformersReader(BaseReader):
         model_version: Optional[str] = None,
         tokenizer: Optional[str] = None,
         context_window_size: int = 70,
-        use_gpu: int = 0,
+        use_gpu: bool = True,
         top_k: int = 10,
         top_k_per_candidate: int = 4,
         return_no_answers: bool = True,
@@ -52,7 +53,7 @@ class TransformersReader(BaseReader):
         :param tokenizer: Name of the tokenizer (usually the same as model)
         :param context_window_size: Num of chars (before and after the answer) to return as "context" for each answer.
                                     The context usually helps users to understand if the answer really makes sense.
-        :param use_gpu: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
+        :param use_gpu: Whether to use GPU (if available).
         :param top_k: The maximum number of answers to return
         :param top_k_per_candidate: How many answers to extract for each candidate doc that is coming from the retriever (might be a long text).
         Note that this is not the number of "final answers" you will receive
@@ -71,7 +72,9 @@ class TransformersReader(BaseReader):
             top_k_per_candidate=top_k_per_candidate, return_no_answers=return_no_answers, max_seq_len=max_seq_len,
         )
 
-        self.model = pipeline('question-answering', model=model_name_or_path, tokenizer=tokenizer, device=use_gpu,
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        device = 0 if device.type == "cuda" else -1
+        self.model = pipeline('question-answering', model=model_name_or_path, tokenizer=tokenizer, device=device,
                               revision=model_version)
         self.context_window_size = context_window_size
         self.top_k = top_k

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -72,8 +72,8 @@ class TransformersReader(BaseReader):
             top_k_per_candidate=top_k_per_candidate, return_no_answers=return_no_answers, max_seq_len=max_seq_len,
         )
 
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
-        device = 0 if device.type == "cuda" else -1
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
+        device = 0 if self.devices[0].type == "cuda" else -1
         self.model = pipeline('question-answering', model=model_name_or_path, tokenizer=tokenizer, device=device,
                               revision=model_version)
         self.context_window_size = context_window_size

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -50,6 +50,7 @@ class _DefaultEmbeddingEncoder(_BaseEmbeddingEncoder):
             retriever: 'EmbeddingRetriever'
     ):
 
+        device, _ = initialize_device_settings(use_cuda=retriever.use_gpu)
         self.embedding_model = Inferencer.load(
             retriever.embedding_model, revision=retriever.model_version, task_type="embeddings",
             extraction_strategy=retriever.pooling_strategy,
@@ -129,10 +130,7 @@ class _RetribertEmbeddingEncoder(_BaseEmbeddingEncoder):
     ):
 
         self.progress_bar = retriever.progress_bar
-        if retriever.use_gpu and torch.cuda.is_available():
-            self.device = torch.device("cuda")
-        else:
-            self.device = torch.device("cpu")
+        self.device, _ = initialize_device_settings(use_cuda=retriever.use_gpu)
 
         self.embedding_tokenizer = AutoTokenizer.from_pretrained(retriever.embedding_model)
         self.embedding_model = AutoModel.from_pretrained(retriever.embedding_model).to(self.device)

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -115,10 +115,9 @@ class DensePassageRetriever(BaseRetriever):
 
         if devices is not None:
             self.devices = devices
-        elif use_gpu and torch.cuda.is_available():
-            self.devices = [torch.device(device) for device in range(torch.cuda.device_count())]
         else:
-            self.devices = [torch.device("cpu")]
+            device, _ = initialize_device_settings(use_cuda=use_gpu)
+            self.devices = [device]
 
         if batch_size < len(self.devices):
             logger.warning("Batch size is less than the number of devices. All gpus will not be utilized.")
@@ -537,7 +536,7 @@ class TableTextRetriever(BaseRetriever):
         if devices is not None:
             self.devices = devices
         else:
-            device, _ = initialize_device_settings(use_gpu)
+            device, _ = initialize_device_settings(use_cuda=use_gpu)
             self.devices = [device]
 
         if batch_size < len(self.devices):

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -24,7 +24,6 @@ from haystack.modeling.data_handler.dataloader import NamedDataLoader
 from haystack.modeling.model.optimization import initialize_optimizer
 from haystack.modeling.training.base import Trainer
 from haystack.modeling.utils import initialize_device_settings
-from torch.utils.data.sampler import SequentialSampler
 
 
 logger = logging.getLogger(__name__)
@@ -116,8 +115,7 @@ class DensePassageRetriever(BaseRetriever):
         if devices is not None:
             self.devices = devices
         else:
-            device, _ = initialize_device_settings(use_cuda=use_gpu)
-            self.devices = [device]
+            self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=True)
 
         if batch_size < len(self.devices):
             logger.warning("Batch size is less than the number of devices. All gpus will not be utilized.")
@@ -536,8 +534,7 @@ class TableTextRetriever(BaseRetriever):
         if devices is not None:
             self.devices = devices
         else:
-            device, _ = initialize_device_settings(use_cuda=use_gpu)
-            self.devices = [device]
+            self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=True)
 
         if batch_size < len(self.devices):
             logger.warning("Batch size is less than the number of devices. All gpus will not be utilized.")
@@ -945,13 +942,14 @@ class EmbeddingRetriever(BaseRetriever):
         pooling_strategy: str = "reduce_mean",
         emb_extraction_layer: int = -1,
         top_k: int = 10,
-        progress_bar: bool = True
+        progress_bar: bool = True,
+        devices: Optional[List[Union[int, str, torch.device]]] = None
     ):
         """
         :param document_store: An instance of DocumentStore from which to retrieve documents.
         :param embedding_model: Local path or name of model in Hugging Face's model hub such as ``'sentence-transformers/all-MiniLM-L6-v2'``
         :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
-        :param use_gpu: Whether to use gpu or not
+        :param use_gpu: Whether to use all available GPUs or the CPU. Falls back on CPU if no GPU is available.
         :param model_format: Name of framework that was used for saving the model. Options:
 
                              - ``'farm'``
@@ -968,6 +966,8 @@ class EmbeddingRetriever(BaseRetriever):
                                      Default: -1 (very last layer).
         :param top_k: How many documents to return per query.
         :param progress_bar: If true displays progress bar during embedding.
+        :param devices: List of GPU devices to limit inference to certain GPUs and not use all available ones (e.g. ["cuda:0"]).
+                        As multi-GPU training is currently not implemented for DPR, training will only use the first device provided in this list.
         """
         # save init parameters to enable export of component config as YAML
         self.set_config(
@@ -975,6 +975,11 @@ class EmbeddingRetriever(BaseRetriever):
             use_gpu=use_gpu, model_format=model_format, pooling_strategy=pooling_strategy,
             emb_extraction_layer=emb_extraction_layer, top_k=top_k,
         )
+
+        if devices is not None:
+            self.devices = devices
+        else:
+            self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=True)
 
         self.document_store = document_store
         self.embedding_model = embedding_model

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -6,6 +6,7 @@ from transformers.models.auto.modeling_auto import AutoModelForSeq2SeqLM
 
 from haystack.schema import Document
 from haystack.nodes.summarizer import BaseSummarizer
+from haystack.modeling.utils import initialize_device_settings
 
 
 logger = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ class TransformersSummarizer(BaseSummarizer):
             tokenizer: Optional[str] = None,
             max_length: int = 200,
             min_length: int = 5,
-            use_gpu: int = 0,
+            use_gpu: bool = True,
             clean_up_tokenization_spaces: bool = True,
             separator_for_single_summary: str = " ",
             generate_single_summary: bool = False,
@@ -71,7 +72,7 @@ class TransformersSummarizer(BaseSummarizer):
         :param tokenizer: Name of the tokenizer (usually the same as model)
         :param max_length: Maximum length of summarized text
         :param min_length: Minimum length of summarized text
-        :param use_gpu: If < 0, then use cpu. If >= 0, this is the ordinal of the gpu to use
+        :param use_gpu: Whether to use GPU (if available).
         :param clean_up_tokenization_spaces: Whether or not to clean up the potential extra spaces in the text output
         :param separator_for_single_summary: If `generate_single_summary=True` in `predict()`, we need to join all docs
                                              into a single text. This separator appears between those subsequent docs.
@@ -88,11 +89,13 @@ class TransformersSummarizer(BaseSummarizer):
             separator_for_single_summary=separator_for_single_summary, generate_single_summary=generate_single_summary,
         )
 
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        device = 0 if device.type == "cuda" else -1
         # TODO AutoModelForSeq2SeqLM is only necessary with transformers==4.1.1, with newer versions use the pipeline directly
         if tokenizer is None:
             tokenizer = model_name_or_path
         model = AutoModelForSeq2SeqLM.from_pretrained(pretrained_model_name_or_path=model_name_or_path, revision=model_version)
-        self.summarizer = pipeline("summarization", model=model, tokenizer=tokenizer, device=use_gpu)
+        self.summarizer = pipeline("summarization", model=model, tokenizer=tokenizer, device=device)
         self.max_length = max_length
         self.min_length = min_length
         self.clean_up_tokenization_spaces = clean_up_tokenization_spaces

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -89,8 +89,8 @@ class TransformersSummarizer(BaseSummarizer):
             separator_for_single_summary=separator_for_single_summary, generate_single_summary=generate_single_summary,
         )
 
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
-        device = 0 if device.type == "cuda" else -1
+        self.devices, _ = initialize_device_settings(use_cuda=use_gpu)
+        device = 0 if self.devices[0].type == "cuda" else -1
         # TODO AutoModelForSeq2SeqLM is only necessary with transformers==4.1.1, with newer versions use the pipeline directly
         if tokenizer is None:
             tokenizer = model_name_or_path

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -2,6 +2,8 @@ import logging
 from typing import Any, Dict, List, Optional, Union
 
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+import torch
+from torch.nn import DataParallel
 
 from haystack.schema import Document, Answer
 from haystack.nodes.translator import BaseTranslator
@@ -38,6 +40,7 @@ class TransformersTranslator(BaseTranslator):
         max_seq_len: Optional[int] = None,
         clean_up_tokenization_spaces: Optional[bool] = True,
         use_gpu: bool = True,
+        devices: Optional[List[Union[int, str, torch.device]]] = None,
     ):
         """ Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
         models from Hugging Face's model hub, we recommend using the OPUS models from Helsiniki NLP. They provide plenty
@@ -57,7 +60,9 @@ class TransformersTranslator(BaseTranslator):
                                tokenizer.
         :param max_seq_len: The maximum sentence length the model accepts. (Optional)
         :param clean_up_tokenization_spaces: Whether or not to clean up the tokenization spaces. (default True)
-        :param use_gpu: Whether to use GPU (if available).
+        :param use_gpu: Whether to use all available GPUs or the CPU. Falls back on CPU if no GPU is available.
+        :param devices: List of GPU devices to limit inference to certain GPUs and not use all available ones (e.g. ["cuda:0"]).
+                        As multi-GPU training is currently not implemented for DPR, training will only use the first device provided in this list.
         """
 
         # save init parameters to enable export of component config as YAML
@@ -66,7 +71,10 @@ class TransformersTranslator(BaseTranslator):
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
         )
 
-        device, _ = initialize_device_settings(use_cuda=use_gpu)
+        if devices is not None:
+            self.devices = devices
+        else:
+            self.devices, _ = initialize_device_settings(use_cuda=use_gpu)
         self.max_seq_len = max_seq_len
         self.clean_up_tokenization_spaces = clean_up_tokenization_spaces
         tokenizer_name = tokenizer_name or model_name_or_path
@@ -74,7 +82,10 @@ class TransformersTranslator(BaseTranslator):
             tokenizer_name
         )
         self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
-        self.model.to(device)
+        self.model.to(str(self.devices[0]))
+
+        if len(self.devices) > 1:
+            self.model = DataParallel(self.model, device_ids=self.devices)
 
     def translate(
         self,

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -5,6 +5,7 @@ from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
 from haystack.schema import Document, Answer
 from haystack.nodes.translator import BaseTranslator
+from haystack.modeling.utils import initialize_device_settings
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,8 @@ class TransformersTranslator(BaseTranslator):
         model_name_or_path: str,
         tokenizer_name: Optional[str] = None,
         max_seq_len: Optional[int] = None,
-        clean_up_tokenization_spaces: Optional[bool] = True
+        clean_up_tokenization_spaces: Optional[bool] = True,
+        use_gpu: bool = True,
     ):
         """ Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
         models from Hugging Face's model hub, we recommend using the OPUS models from Helsiniki NLP. They provide plenty
@@ -55,6 +57,7 @@ class TransformersTranslator(BaseTranslator):
                                tokenizer.
         :param max_seq_len: The maximum sentence length the model accepts. (Optional)
         :param clean_up_tokenization_spaces: Whether or not to clean up the tokenization spaces. (default True)
+        :param use_gpu: Whether to use GPU (if available).
         """
 
         # save init parameters to enable export of component config as YAML
@@ -63,6 +66,7 @@ class TransformersTranslator(BaseTranslator):
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,
         )
 
+        device, _ = initialize_device_settings(use_cuda=use_gpu)
         self.max_seq_len = max_seq_len
         self.clean_up_tokenization_spaces = clean_up_tokenization_spaces
         tokenizer_name = tokenizer_name or model_name_or_path
@@ -70,6 +74,7 @@ class TransformersTranslator(BaseTranslator):
             tokenizer_name
         )
         self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
+        self.model.to(device)
 
     def translate(
         self,

--- a/test/test_modeling_dpr.py
+++ b/test/test_modeling_dpr.py
@@ -21,7 +21,7 @@ def test_dpr_modules(caplog=None):
         caplog.set_level(logging.CRITICAL)
 
     set_all_seeds(seed=42)
-    device, n_gpu = initialize_device_settings(use_cuda=True)
+    devices, n_gpu = initialize_device_settings(use_cuda=True)
 
     # 1.Create question and passage tokenizers
     query_tokenizer = Tokenizer.load(pretrained_model_name_or_path="facebook/dpr-question_encoder-single-nq-base",
@@ -60,7 +60,7 @@ def test_dpr_modules(caplog=None):
         embeds_dropout_prob=0.0,
         lm1_output_types=["per_sequence"],
         lm2_output_types=["per_sequence"],
-        device=device,
+        device=devices[0],
     )
 
     model.connect_heads_with_processor(processor.tasks)
@@ -91,7 +91,7 @@ def test_dpr_modules(caplog=None):
          }
 
     dataset, tensor_names, _ = processor.dataset_from_dicts(dicts=[d], return_baskets=False)
-    features = {key: val.unsqueeze(0).to(device) for key, val in zip(tensor_names, dataset[0])}
+    features = {key: val.unsqueeze(0).to(devices[0]) for key, val in zip(tensor_names, dataset[0])}
 
     # test features
     assert torch.all(torch.eq(features["query_input_ids"][0][:10].cpu(),

--- a/test/test_modeling_prediction_head.py
+++ b/test/test_modeling_prediction_head.py
@@ -11,7 +11,7 @@ def test_prediction_head_load_save(tmp_path, caplog=None):
         caplog.set_level(logging.CRITICAL)
 
     set_all_seeds(seed=42)
-    device, n_gpu = initialize_device_settings(use_cuda=False)
+    devices, n_gpu = initialize_device_settings(use_cuda=False)
     lang_model = "bert-base-german-cased"
 
     language_model = LanguageModel.load(lang_model)
@@ -22,7 +22,7 @@ def test_prediction_head_load_save(tmp_path, caplog=None):
         prediction_heads=[prediction_head],
         embeds_dropout_prob=0.1,
         lm_output_types=["per_sequence"],
-        device=device)
+        device=devices[0])
 
     model.save(tmp_path)
     model_loaded = AdaptiveModel.load(tmp_path, device='cpu')


### PR DESCRIPTION
Related to #1538 

This PR makes all nodes use the `initialize_device_settings` method from `haystack.modeling.utils` in order to set the device in a standard way.
Furthermore it sets the level for the StreamHandler defined in `haystack/__init__.py` to `INFO` in order to print the device settings to the console. However, I am not sure if we really want to do this, as this would increase the console output substantially. Also, it seems that the StreamHandler level that is set [here](https://github.com/deepset-ai/haystack/blob/27793814cf85d306e300e6fb06488e7f5b9d03c4/haystack/__init__.py#L10) overwrites the following lines where we set the logging level for `haystack.modeling.utils` to `INFO`.