### PR TITLE
Improve open api spec

### DIFF
--- a/rest_api/application.py
+++ b/rest_api/application.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import uvicorn
 from fastapi import FastAPI, HTTPException
+from fastapi.routing import APIRoute
 from starlette.middleware.cors import CORSMiddleware
 
 from rest_api.controller.errors.http_error import http_error_handler
@@ -19,7 +20,7 @@ from rest_api.controller.router import router as api_router
 
 
 def get_application() -> FastAPI:
-    application = FastAPI(title="Haystack-API", debug=True, version="0.1", root_path=ROOT_PATH)
+    application = FastAPI(title="Haystack-API", debug=True, version="0.10", root_path=ROOT_PATH)
 
     # This middleware enables allow all cross-domain requests to the API from a browser. For production
     # deployments, it could be made more restrictive.
@@ -28,14 +29,23 @@ def get_application() -> FastAPI:
     )
 
     application.add_exception_handler(HTTPException, http_error_handler)
-
     application.include_router(api_router)
 
     return application
 
+def use_route_names_as_operation_ids(app: FastAPI) -> None:
+    """
+    Simplify operation IDs so that generated API clients have simpler function
+    names (see https://fastapi.tiangolo.com/advanced/path-operation-advanced-configuration/#using-the-path-operation-function-name-as-the-operationid).
+    The operation IDs will be the same as the route names (i.e. the python method names of the endpoints)
+    Should be called only after all routes have been added.
+    """
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route.operation_id = route.name
 
 app = get_application()
-
+use_route_names_as_operation_ids(app)
 
 logger.info("Open http://127.0.0.1:8000/docs to see Swagger API Documentation.")
 logger.info(

--- a/rest_api/controller/document.py
+++ b/rest_api/controller/document.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("haystack")
 router = APIRouter()
 
 
-@router.post("/documents/get_by_filters", response_model=List[DocumentSerialized])
+@router.post("/documents/get_by_filters", response_model=List[DocumentSerialized], operation_id="get_documents", response_model_exclude_none=True)
 def get_documents_by_filter(filters: FilterRequest):
     """
     Can be used to get documents from a document store.
@@ -32,7 +32,7 @@ def get_documents_by_filter(filters: FilterRequest):
     return docs
 
 
-@router.post("/documents/delete_by_filters", response_model=bool)
+@router.post("/documents/delete_by_filters", response_model=bool, operation_id="delete_documents")
 def delete_documents_by_filter(filters: FilterRequest):
     """
     Can be used to delete documents from a document store.

--- a/rest_api/controller/document.py
+++ b/rest_api/controller/document.py
@@ -16,8 +16,8 @@ logger = logging.getLogger("haystack")
 router = APIRouter()
 
 
-@router.post("/documents/get_by_filters", response_model=List[DocumentSerialized], operation_id="get_documents", response_model_exclude_none=True)
-def get_documents_by_filter(filters: FilterRequest):
+@router.post("/documents/get_by_filters", response_model=List[DocumentSerialized], response_model_exclude_none=True)
+def get_documents(filters: FilterRequest):
     """
     Can be used to get documents from a document store.
 
@@ -32,8 +32,8 @@ def get_documents_by_filter(filters: FilterRequest):
     return docs
 
 
-@router.post("/documents/delete_by_filters", response_model=bool, operation_id="delete_documents")
-def delete_documents_by_filter(filters: FilterRequest):
+@router.post("/documents/delete_by_filters", response_model=bool)
+def delete_documents(filters: FilterRequest):
     """
     Can be used to delete documents from a document store.
 

--- a/rest_api/controller/feedback.py
+++ b/rest_api/controller/feedback.py
@@ -61,8 +61,8 @@ def eval_extractive_qa_feedback(filters: FilterRequest = None):
     return res
 
 
-@router.get("/export-feedback", operation_id="export_feedback")
-def export_extractive_qa_feedback(
+@router.get("/export-feedback")
+def export_feedback(
     context_size: int = 100_000, full_document_context: bool = True, only_positive_labels: bool = False
 ):
     """

--- a/rest_api/controller/feedback.py
+++ b/rest_api/controller/feedback.py
@@ -11,20 +11,20 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.post("/feedback")
+@router.post("/feedback", operation_id="post_feedback")
 def user_feedback(feedback: LabelSerialized):
     if feedback.origin is None:
         feedback.origin = "user-feedback"
     DOCUMENT_STORE.write_labels([feedback])
 
 
-@router.get("/feedback")
+@router.get("/feedback", operation_id="get_feedback")
 def user_feedback():
     labels = DOCUMENT_STORE.get_all_labels()
     return labels
 
 
-@router.post("/eval-feedback")
+@router.post("/eval-feedback", operation_id="get_feedback_metrics")
 def eval_extractive_qa_feedback(filters: FilterRequest = None):
     """
     Return basic accuracy metrics based on the user feedback.
@@ -61,7 +61,7 @@ def eval_extractive_qa_feedback(filters: FilterRequest = None):
     return res
 
 
-@router.get("/export-feedback")
+@router.get("/export-feedback", operation_id="export_feedback")
 def export_extractive_qa_feedback(
     context_size: int = 100_000, full_document_context: bool = True, only_positive_labels: bool = False
 ):

--- a/rest_api/controller/file_upload.py
+++ b/rest_api/controller/file_upload.py
@@ -62,7 +62,7 @@ class Response(BaseModel):
     file_id: str
 
 
-@router.post("/file-upload")
+@router.post("/file-upload", operation_id="upload_file")
 def file_upload(
     files: List[UploadFile] = File(...),
     meta: Optional[str] = Form("null"),  # JSON serialized string

--- a/rest_api/controller/file_upload.py
+++ b/rest_api/controller/file_upload.py
@@ -62,8 +62,8 @@ class Response(BaseModel):
     file_id: str
 
 
-@router.post("/file-upload", operation_id="upload_file")
-def file_upload(
+@router.post("/file-upload")
+def upload_file(
     files: List[UploadFile] = File(...),
     meta: Optional[str] = Form("null"),  # JSON serialized string
     fileconverter_params: FileConverterParams = Depends(FileConverterParams.as_form),

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -30,8 +30,8 @@ logging.info(f"Loaded pipeline nodes: {PIPELINE.graph.nodes.keys()}")
 concurrency_limiter = RequestLimiter(CONCURRENT_REQUEST_PER_WORKER)
 
 
-@router.get("/initialized", operation_id="check_status")
-def initialized():
+@router.get("/initialized")
+def check_status():
     """
     This endpoint can be used during startup to understand if the 
     server is ready to take any requests, or is still loading.
@@ -42,7 +42,7 @@ def initialized():
     return True
 
 
-@router.post("/query", response_model=QueryResponse, operation_id="query", response_model_exclude_none=True)
+@router.post("/query", response_model=QueryResponse, response_model_exclude_none=True)
 def query(request: QueryRequest):
     with concurrency_limiter.run():
         result = _process_request(PIPELINE, request)

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -30,7 +30,7 @@ logging.info(f"Loaded pipeline nodes: {PIPELINE.graph.nodes.keys()}")
 concurrency_limiter = RequestLimiter(CONCURRENT_REQUEST_PER_WORKER)
 
 
-@router.get("/initialized")
+@router.get("/initialized", operation_id="check_status")
 def initialized():
     """
     This endpoint can be used during startup to understand if the 
@@ -42,7 +42,7 @@ def initialized():
     return True
 
 
-@router.post("/query", response_model=QueryResponse)
+@router.post("/query", response_model=QueryResponse, operation_id="query", response_model_exclude_none=True)
 def query(request: QueryRequest):
     with concurrency_limiter.run():
         result = _process_request(PIPELINE, request)

--- a/rest_api/schema.py
+++ b/rest_api/schema.py
@@ -29,7 +29,7 @@ class AnswerSerialized(Answer):
 @pydantic_dataclass
 class DocumentSerialized(Document):
     content: str
-    embedding: List[float]
+    embedding: Optional[List[float]]
 
 @pydantic_dataclass
 class LabelSerialized(Label):


### PR DESCRIPTION
**Proposed changes**:
- Introduce `operation_id` per endpoints as those will become part of the open API definition and is helpful when creating clients from there 
- Adding `response_model_exclude_none=True` to the search endpoint to exclude all fields with null value from the response (e.g. embedding=null won't be part of the response anymore)

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
