### PR TITLE
rename text variable of document to content

### DIFF
--- a/docs/_src/usage/usage/preprocessing.md
+++ b/docs/_src/usage/usage/preprocessing.md
@@ -30,7 +30,7 @@ The sections below will show you all the tools you'll need to ready your data fo
 ```python
 docs = [
     {
-        'text': DOCUMENT_TEXT_HERE,
+        'content': DOCUMENT_TEXT_HERE,
         'meta': {'name': DOCUMENT_NAME, ...}
     }, ...
 ]


### PR DESCRIPTION
**Proposed changes**:
- Documentation used the old `text` field name in document, which is now renamed to `content`.

**Status (please check what you already did)**:
- [x] Updated documentation
