### PR TITLE
Remove `rest_api` module from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include requirements.txt
 include README.rst
+exclude rest_api


### PR DESCRIPTION
This PR removes the `rest_api` module from the Haystack PyPI Package. 