### PR TITLE
Change answer aggregation key to (doc_id, query) instead of (label_id, query)

### DIFF
--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -526,9 +526,10 @@ class FARMReader(BaseReader):
             # get all questions / answers
             #TODO check if we can simplify this by using MultiLabel
             aggregated_per_question: Dict[tuple, Any] = defaultdict(list)
-            id_question_tuple = (label.id, label.query)
+
             if doc_id in aggregated_per_doc:
                 for label in aggregated_per_doc[doc_id]:
+                    aggregation_key = (doc_id, label.query)
                     if label.answer is None:
                         logger.error(f"Label.answer was None, but Answer object was expected: {label} ")
                         continue
@@ -538,30 +539,30 @@ class FARMReader(BaseReader):
                     else:
                         # add to existing answers
                         #TODO offsets (whole block)
-                        if id_question_tuple in aggregated_per_question.keys():
+                        if aggregation_key in aggregated_per_question.keys():
                             if label.no_answer:
                                 continue
                             else:
                                 # Hack to fix problem where duplicate questions are merged by doc_store processing creating a QA example with 8 annotations > 6 annotation max
-                                if len(aggregated_per_question[id_question_tuple]["answers"]) >= 6:
+                                if len(aggregated_per_question[aggregation_key]["answers"]) >= 6:
                                     logger.warning(f"Answers in this sample are being dropped because it has more than 6 answers. (doc_id: {doc_id}, question: {label.query}, label_id: {label.id})")
                                     continue
-                                aggregated_per_question[id_question_tuple]["answers"].append({
+                                aggregated_per_question[aggregation_key]["answers"].append({
                                             "text": label.answer.answer,
                                             "answer_start": label.answer.offsets_in_document[0].start})
-                                aggregated_per_question[id_question_tuple]["is_impossible"] = False
+                                aggregated_per_question[aggregation_key]["is_impossible"] = False
                         # create new one
                         else:
                             # We don't need to create an answer dict if is_impossible / no_answer
                             if label.no_answer == True:
-                                aggregated_per_question[id_question_tuple] = {
+                                aggregated_per_question[aggregation_key] = {
                                     "id": str(hash(str(doc_id) + label.query)),
                                     "question": label.query,
                                     "answers": [],
                                     "is_impossible": True
                                 }
                             else:
-                                aggregated_per_question[id_question_tuple] = {
+                                aggregated_per_question[aggregation_key] = {
                                     "id": str(hash(str(doc_id) + label.query)),
                                     "question": label.query,
                                     "answers": [{


### PR DESCRIPTION
@ju-gu and I found a bug in the `eval()` method of `FARMReader` eval when using GermanQuAD. It seems that answers are wrongly aggregated such that answers to different questions end up in the same MultiLabel because the aggregation key label.id, label.query wasn't updated.
The label id is different for every annotation, while the query can be the same in multi-way annotated files.

**Proposed changes**:
- Use the tuple (doc_id, query) as key. There can't be multiple queries with the same text in the same document anyways. Questions with the same text can only occur in different documents. I am not sure why the label.id was included in the key.

**Open questions**:
- I saw that a question is assumed to be impossible to answer in case `label.no_answer == True:`. However, I could imagine that one annotator thinks there is no answer to one question while another thinks that there is an answer. We should decide how to handle this edge case and document that.

- [x] confirmation from @ju-gu that the aggregation works as expected now