### PR TITLE
Make FAISSDocumentStore work with yaml

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1098,20 +1098,6 @@ None
 <a name="faiss"></a>
 # Module faiss
 
-<a name="faiss.preload_index"></a>
-#### preload\_index
-
-```python
-preload_index(init)
-```
-
-This decorator overrides the __init__ method to enable loading a saved index from disk.
-In this case all required __init__ params are stored in a config file next to the index.
-Saved index and config are specified by faiss_index_path and faiss_config_path params. 
-If present they get converted into the corresponding __init__ params deduced from the saved index.
-Don't worry that faiss_index_path and faiss_config_path aren't actually used in __init__.
-They are in the method signature to signal that they can be used as usual params.
-
 <a name="faiss.FAISSDocumentStore"></a>
 ## FAISSDocumentStore Objects
 
@@ -1131,7 +1117,6 @@ the vector embeddings are indexed in a FAISS Index.
 #### \_\_init\_\_
 
 ```python
- | @preload_index
  | __init__(sql_url: str = "sqlite:///faiss_document_store.db", vector_dim: int = 768, faiss_index_factory_str: str = "Flat", faiss_index: Optional["faiss.swigfaiss.Index"] = None, return_embedding: bool = False, index: str = "document", similarity: str = "dot_product", embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = 'overwrite', faiss_index_path: Union[str, Path] = None, faiss_config_path: Union[str, Path] = None, **kwargs, ,)
 ```
 

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1117,7 +1117,8 @@ the vector embeddings are indexed in a FAISS Index.
 #### \_\_init\_\_
 
 ```python
- | __init__(sql_url: str = "sqlite:///faiss_document_store.db", vector_dim: int = 768, faiss_index_factory_str: str = "Flat", faiss_index: Optional["faiss.swigfaiss.Index"] = None, return_embedding: bool = False, index: str = "document", similarity: str = "dot_product", embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = 'overwrite', **kwargs, ,)
+ | @preload_index
+ | __init__(sql_url: str = "sqlite:///faiss_document_store.db", vector_dim: int = 768, faiss_index_factory_str: str = "Flat", faiss_index: Optional["faiss.swigfaiss.Index"] = None, return_embedding: bool = False, index: str = "document", similarity: str = "dot_product", embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = 'overwrite', faiss_index_path: str = None, faiss_config_path: str = None, **kwargs, ,)
 ```
 
 **Arguments**:
@@ -1158,6 +1159,10 @@ the vector embeddings are indexed in a FAISS Index.
                             overwrite: Update any existing documents with the same ID when adding documents.
                             fail: an error is raised if the document ID of the document being added already
                             exists.
+- `faiss_index_path`: Stored FAISS index file. Can be created via calling `save()`.
+    If specified no other params besides faiss_config_path must be specified.
+- `faiss_config_path`: Stored FAISS initial configuration parameters.
+    Can be created via calling `save()`
 
 <a name="faiss.FAISSDocumentStore.write_documents"></a>
 #### write\_documents
@@ -1359,15 +1364,6 @@ Note: In order to have a correct mapping from FAISS to SQL,
 - `index_path`: Stored FAISS index file. Can be created via calling `save()`
 - `config_path`: Stored FAISS initial configuration parameters.
     Can be created via calling `save()`
-- `sql_url`: Connection string to the SQL database that contains your docs and metadata.
-    Overrides the value defined in the `faiss_init_params_path` file, if present
-- `index`: Index name to load the FAISS index as. It must match the index name used for
-              when creating the FAISS index. Overrides the value defined in the 
-              `faiss_init_params_path` file, if present
-
-**Returns**:
-
-the DocumentStore
 
 <a name="milvus"></a>
 # Module milvus

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1098,6 +1098,20 @@ None
 <a name="faiss"></a>
 # Module faiss
 
+<a name="faiss.preload_index"></a>
+#### preload\_index
+
+```python
+preload_index(init)
+```
+
+This decorator overrides the __init__ method to enable loading a saved index from disk.
+In this case all required __init__ params are stored in a config file next to the index.
+Saved index and config are specified by faiss_index_path and faiss_config_path params. 
+If present they get converted into the corresponding __init__ params deduced from the saved index.
+Don't worry that faiss_index_path and faiss_config_path aren't actually used in __init__.
+They are in the method signature to signal that they can be used as usual params.
+
 <a name="faiss.FAISSDocumentStore"></a>
 ## FAISSDocumentStore Objects
 

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1118,7 +1118,7 @@ the vector embeddings are indexed in a FAISS Index.
 
 ```python
  | @preload_index
- | __init__(sql_url: str = "sqlite:///faiss_document_store.db", vector_dim: int = 768, faiss_index_factory_str: str = "Flat", faiss_index: Optional["faiss.swigfaiss.Index"] = None, return_embedding: bool = False, index: str = "document", similarity: str = "dot_product", embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = 'overwrite', faiss_index_path: str = None, faiss_config_path: str = None, **kwargs, ,)
+ | __init__(sql_url: str = "sqlite:///faiss_document_store.db", vector_dim: int = 768, faiss_index_factory_str: str = "Flat", faiss_index: Optional["faiss.swigfaiss.Index"] = None, return_embedding: bool = False, index: str = "document", similarity: str = "dot_product", embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = 'overwrite', faiss_index_path: Union[str, Path] = None, faiss_config_path: Union[str, Path] = None, **kwargs, ,)
 ```
 
 **Arguments**:

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -25,7 +25,14 @@ logger = logging.getLogger(__name__)
 
 
 def preload_index(init):
-
+    """
+    This decorator overrides the __init__ method to enable loading a saved index from disk.
+    In this case all required __init__ params are stored in a config file next to the index.
+    Saved index and config are specified by faiss_index_path and faiss_config_path params. 
+    If present they get converted into the corresponding __init__ params deduced from the saved index.
+    Don't worry that faiss_index_path and faiss_config_path aren't actually used in __init__.
+    They are in the method signature to signal that they can be used as usual params.
+    """
     @wraps(init)
     def new_init(self, *args, 
         faiss_index_path: Union[str, Path] = None, 

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -149,7 +149,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             index=index
         )
 
-        self._check_index_sync()
+        self._validate_index_sync()
 
     def _validate_params_load_from_disk(self, sig: Signature, locals: dict, kwargs: dict):
         allowed_params = ["faiss_index_path", "faiss_config_path", "self", "kwargs"]
@@ -164,7 +164,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         if invalid_param_set or len(kwargs) > 0:
             raise ValueError("if faiss_index_path is passed no other params besides faiss_config_path are allowed.")
 
-    def _check_index_sync(self):        
+    def _validate_index_sync(self):        
         # This check ensures the correct document database was loaded.
         # If it fails, make sure you provided the path to the database
         # used when creating the original FAISS index

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -28,8 +28,8 @@ def preload_index(init):
 
     @wraps(init)
     def new_init(self, *args, 
-        faiss_index_path: str = None, 
-        faiss_config_path: str = None,
+        faiss_index_path: Union[str, Path] = None, 
+        faiss_config_path: Union[str, Path] = None,
         **kwargs
     ):
         if faiss_index_path:
@@ -66,8 +66,8 @@ class FAISSDocumentStore(SQLDocumentStore):
         embedding_field: str = "embedding",
         progress_bar: bool = True,
         duplicate_documents: str = 'overwrite',
-        faiss_index_path: str = None,
-        faiss_config_path: str = None,
+        faiss_index_path: Union[str, Path] = None,
+        faiss_config_path: Union[str, Path] = None,
         **kwargs,
     ):
         """

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -27,15 +27,15 @@ logger = logging.getLogger(__name__)
 def preload_index(init):
 
     @wraps(init)
-    def new_init(self, *args, **kwargs):
-        if "faiss_index_path" in kwargs:
-            allowed_kwargs = ["faiss_index_path", "faiss_config_path"]
-            invaid_kwargs = set(kwargs.keys()).difference(allowed_kwargs)
-            if len(args) > 0 or len(invaid_kwargs) > 0:
+    def new_init(self, *args, 
+        faiss_index_path: str = None, 
+        faiss_config_path: str = None,
+        **kwargs
+    ):
+        if faiss_index_path:
+            if len(args) > 0 or len(kwargs) > 0:
                 raise ValueError("if faiss_index_path is passed no other params besides faiss_config_path are allowed.")
-            index_path = kwargs["faiss_index_path"]
-            config_path = kwargs.get("faiss_config_path", None)
-            init_params = self._load_init_params_from_config(index_path, config_path)
+            init_params = self._load_init_params_from_config(faiss_index_path, faiss_config_path)
             init(self, **init_params)
         else:
             init(self, *args, **kwargs)

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -156,8 +156,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         invalid_param_set = False
 
         for param in sig.parameters.values():
-            if param.name not in allowed_params:
-                if param.default != locals[param.name]:
+            if param.name not in allowed_params and param.default != locals[param.name]:
                     invalid_param_set = True
                     break
         

--- a/test/samples/pipeline/test_pipeline_faiss_indexing.yaml
+++ b/test/samples/pipeline/test_pipeline_faiss_indexing.yaml
@@ -1,0 +1,31 @@
+version: '0.7'
+
+components:
+  - name: DPRRetriever
+    type: DensePassageRetriever
+    params:
+      document_store: NewFAISSDocumentStore
+  - name: PDFConverter
+    type: PDFToTextConverter
+    params:
+      remove_numeric_tables: false
+  - name: Preprocessor
+    type: PreProcessor
+    params:
+      clean_whitespace: true
+  - name: NewFAISSDocumentStore
+    type: FAISSDocumentStore
+
+
+pipelines:
+  - name: indexing_pipeline
+    type: Pipeline
+    nodes:
+      - name: PDFConverter
+        inputs: [File]
+      - name: Preprocessor
+        inputs: [PDFConverter]
+      - name: DPRRetriever
+        inputs: [Preprocessor]
+      - name: NewFAISSDocumentStore
+        inputs: [DPRRetriever]

--- a/test/samples/pipeline/test_pipeline_faiss_retrieval.yaml
+++ b/test/samples/pipeline/test_pipeline_faiss_retrieval.yaml
@@ -1,0 +1,19 @@
+version: '0.7'
+
+components:
+  - name: DPRRetriever
+    type: DensePassageRetriever
+    params:
+      document_store: ExistingFAISSDocumentStore
+  - name: ExistingFAISSDocumentStore
+    type: FAISSDocumentStore
+    params:
+      faiss_index_path: 'existing_faiss_document_store'
+
+
+pipelines:
+  - name: query_pipeline
+    type: Pipeline
+    nodes:
+      - name: DPRRetriever
+        inputs: [Query]

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -90,6 +90,31 @@ def test_faiss_index_save_and_load_custom_path(tmp_path):
     # Check if the init parameters are kept
     assert not new_document_store.progress_bar
 
+    # test loading the index via init
+    new_document_store = FAISSDocumentStore(faiss_index_path=tmp_path / "haystack_test_faiss", faiss_config_path=tmp_path / "custom_path.json")
+
+    # check faiss index is restored
+    assert new_document_store.faiss_indexes[document_store.index].ntotal == len(DOCUMENTS)
+    # check if documents are restored
+    assert len(new_document_store.get_all_documents()) == len(DOCUMENTS)
+    # Check if the init parameters are kept
+    assert not new_document_store.progress_bar
+
+
+@pytest.mark.skipif(sys.platform in ['win32', 'cygwin'], reason="Test with tmp_path not working on windows runner")
+def test_faiss_index_mutual_exclusive_args(tmp_path):
+    with pytest.raises(ValueError):
+        FAISSDocumentStore(
+            sql_url=f"sqlite:////{tmp_path/'haystack_test.db'}",
+            faiss_index_path=f"{tmp_path/'haystack_test'}"
+        )
+
+    with pytest.raises(ValueError):
+        FAISSDocumentStore(
+            f"sqlite:////{tmp_path/'haystack_test.db'}",
+            faiss_index_path=f"{tmp_path/'haystack_test'}"
+        )
+
 
 @pytest.mark.parametrize("document_store", ["faiss"], indirect=True)
 @pytest.mark.parametrize("index_buffer_size", [10_000, 2])

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -51,6 +51,16 @@ def test_faiss_index_save_and_load(tmp_path):
     # Check if the init parameters are kept
     assert not new_document_store.progress_bar
 
+    # test loading the index via init
+    new_document_store = FAISSDocumentStore(faiss_index_path=tmp_path / "haystack_test_faiss")
+
+    # check faiss index is restored
+    assert new_document_store.faiss_indexes[document_store.index].ntotal == len(DOCUMENTS)
+    # check if documents are restored
+    assert len(new_document_store.get_all_documents()) == len(DOCUMENTS)
+    # Check if the init parameters are kept
+    assert not new_document_store.progress_bar
+
 
 @pytest.mark.skipif(sys.platform in ['win32', 'cygwin'], reason="Test with tmp_path not working on windows runner")
 def test_faiss_index_save_and_load_custom_path(tmp_path):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -750,12 +750,7 @@ def test_query_pipeline_with_document_classifier(document_store):
 
 
 def test_existing_faiss_document_store():
-    if Path('existing_faiss_document_store').exists():
-        os.remove('existing_faiss_document_store')
-    if Path('existing_faiss_document_store.json').exists():
-        os.remove('existing_faiss_document_store.json')
-    if Path('faiss_document_store.db').exists():
-        os.remove('faiss_document_store.db')
+    clean_faiss_document_store()
 
     pipeline = Pipeline.load_from_yaml(
         Path(__file__).parent/"samples"/"pipeline"/"test_pipeline_faiss_indexing.yaml", pipeline_name="indexing_pipeline"
@@ -783,7 +778,10 @@ def test_existing_faiss_document_store():
 
     assert prediction["query"] == "Who made the PDF specification?"
     assert len(prediction["documents"]) == 2
+    clean_faiss_document_store()
 
+
+def clean_faiss_document_store():
     if Path('existing_faiss_document_store').exists():
         os.remove('existing_faiss_document_store')
     if Path('existing_faiss_document_store.json').exists():

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import os
 import json
 import math
 import pytest
@@ -747,3 +748,45 @@ def test_query_pipeline_with_document_classifier(document_store):
     assert prediction["answers"][0].meta["classification"]["label"] == "joy"
     assert "_debug" not in prediction.keys()
 
+
+def test_existing_faiss_document_store():
+    if Path('existing_faiss_document_store').exists():
+        os.remove('existing_faiss_document_store')
+    if Path('existing_faiss_document_store.json').exists():
+        os.remove('existing_faiss_document_store.json')
+    if Path('faiss_document_store.db').exists():
+        os.remove('faiss_document_store.db')
+
+    pipeline = Pipeline.load_from_yaml(
+        Path(__file__).parent/"samples"/"pipeline"/"test_pipeline_faiss_indexing.yaml", pipeline_name="indexing_pipeline"
+    )
+    pipeline.run(
+        file_paths=Path(__file__).parent/"samples"/"pdf"/"sample_pdf_1.pdf"
+    )
+
+    new_document_store = pipeline.get_document_store()
+    new_document_store.save('existing_faiss_document_store')
+
+    # test correct load of query pipeline from yaml
+    pipeline = Pipeline.load_from_yaml(
+        Path(__file__).parent/"samples"/"pipeline"/"test_pipeline_faiss_retrieval.yaml", pipeline_name="query_pipeline"
+    )
+
+    retriever = pipeline.get_node("DPRRetriever")
+    existing_document_store = retriever.document_store
+    faiss_index = existing_document_store.faiss_indexes['document']
+    assert faiss_index.ntotal == 2
+
+    prediction = pipeline.run(
+        query="Who made the PDF specification?", params={"DPRRetriever": {"top_k": 10}}
+    )
+
+    assert prediction["query"] == "Who made the PDF specification?"
+    assert len(prediction["documents"]) == 2
+
+    if Path('existing_faiss_document_store').exists():
+        os.remove('existing_faiss_document_store')
+    if Path('existing_faiss_document_store.json').exists():
+        os.remove('existing_faiss_document_store.json')
+    if Path('faiss_document_store.db').exists():
+        os.remove('faiss_document_store.db')


### PR DESCRIPTION
**Proposed changes**:
- support faiss_index_path and faiss_config_path as constructor params
- override init or call recursively
- keep save() and load() class methods
- implement tests that use fresh FAISSDocumentStore and an existing

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [x] Updated documentation

closes #1698