### PR TITLE
initialize doc store with doc and label index in tutorial 5

### DIFF
--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -49,8 +49,8 @@ def tutorial5_evaluation():
 
     # Connect to Elasticsearch
     document_store = ElasticsearchDocumentStore(
-        host="localhost", username="", password="", index="document",
-        create_index=False, embedding_field="emb",
+        host="localhost", username="", password="", index=doc_index,
+        label_index = label_index, embedding_field="emb",
         embedding_dim=768, excluded_meta_data=["emb"]
     )
 


### PR DESCRIPTION
**Proposed changes**:
- initialize the doc store with the doc index name and label index name that is also used later
- remove `create_index=False`