### PR TITLE
Pipelines now tolerate custom _debug content

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -550,7 +550,7 @@ Pipeline for semantic document search.
 **Arguments**:
 
 - `query`: the query string.
-- `params`: params for the `retriever` and `reader`. For instance, params={"retriever": {"top_k": 10}}
+- `params`: params for the `retriever` and `reader`. For instance, params={"Retriever": {"top_k": 10}}
 - `debug`: Whether the pipeline should instruct nodes to collect debug information
       about their execution. By default these include the input parameters
       they received and the output they generated.
@@ -631,7 +631,7 @@ Pipeline that retrieves documents for a query and then summarizes those document
 
 - `query`: the query string.
 - `params`: params for the `retriever` and `summarizer`. For instance,
-               params={"retriever": {"top_k": 10}, "summarizer": {"generate_single_summary": True}}
+               params={"Retriever": {"top_k": 10}, "Summarizer": {"generate_single_summary": True}}
 - `debug`: Whether the pipeline should instruct nodes to collect debug information
       about their execution. By default these include the input parameters
       they received and the output they generated.
@@ -668,7 +668,7 @@ Pipeline for finding similar FAQs using semantic document search.
 **Arguments**:
 
 - `query`: the query string.
-- `params`: params for the `retriever`. For instance, params={"retriever": {"top_k": 10}}
+- `params`: params for the `retriever`. For instance, params={"Retriever": {"top_k": 10}}
 - `debug`: Whether the pipeline should instruct nodes to collect debug information
       about their execution. By default these include the input parameters
       they received and the output they generated.

--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -135,17 +135,23 @@ class BaseComponent:
         output, stream = self.run(**run_inputs, **run_params)
 
         # Collect debug information
-        current_debug = output.get("_debug", {})
+        debug_info = {}
         if getattr(self, "debug", None):
-            current_debug["input"] = {**run_inputs, **run_params}
-            current_debug["input"]["debug"] = self.debug
+            # Include input
+            debug_info["input"] = {**run_inputs, **run_params}
+            debug_info["input"]["debug"] = self.debug
+            # Include output
             filtered_output = {key: value for key, value in output.items() if key != "_debug"}  # Exclude _debug to avoid recursion
-            current_debug["output"] = filtered_output
+            debug_info["output"] = filtered_output
+        # Include custom debug info
+        custom_debug = output.get("_debug", {})
+        if custom_debug:
+            debug_info["runtime"] = custom_debug
 
         # append _debug information from nodes
         all_debug = arguments.get("_debug", {})
-        if current_debug:
-            all_debug[self.name] = current_debug
+        if debug_info:
+            all_debug[self.name] = debug_info
         if all_debug:
             output["_debug"] = all_debug
 

--- a/test/test_pipeline_debug_and_validation.py
+++ b/test/test_pipeline_debug_and_validation.py
@@ -174,7 +174,7 @@ def test_debug_info_propagation():
     class B(RootNode):
         def run(self, test):
             test += "B"
-            return {"test": test, "_debug": {"debug_key_b": "debug_value_b"}}, "output_1"
+            return {"test": test, "_debug": "debug_value_b"}, "output_1"
 
     class C(RootNode):
         def run(self, test):
@@ -184,7 +184,7 @@ def test_debug_info_propagation():
     class D(RootNode):
         def run(self, test, _debug):
             test += "C"
-            assert _debug["B"]["debug_key_b"] == "debug_value_b"
+            assert _debug["B"]["runtime"] == "debug_value_b"
             return {"test": test}, "output_1"
 
     pipeline = Pipeline()
@@ -193,5 +193,5 @@ def test_debug_info_propagation():
     pipeline.add_node(name="C", component=C(), inputs=["B"])
     pipeline.add_node(name="D", component=D(), inputs=["C"])
     output = pipeline.run(query="test")
-    assert output["_debug"]["A"]["debug_key_a"] == "debug_value_a"
-    assert output["_debug"]["B"]["debug_key_b"] == "debug_value_b"
+    assert output["_debug"]["A"]["runtime"]["debug_key_a"] == "debug_value_a"
+    assert output["_debug"]["B"]["runtime"] == "debug_value_b"


### PR DESCRIPTION
Makes pipeline resistant to nodes that set strings or other non-dict values to their `_debug` output key. Related to https://github.com/deepset-ai/haystack-website/pull/191 

Right now whatever gets assigned to a node to their output `_debug` key will arrive in the pipeline's output as:
```
{
    ....
    _debug: {
        custom_node: {
            input: { ... }
            output: { ... }
            runtime: { <content of the _debug key of the node> }
        }
        < other node's debug output >
    },
    ....
}
```
