### PR TITLE
Facilitate concurrent query / indexing in Elasticsearch with dense retrievers (new `skip_missing_embeddings` param)

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -826,24 +826,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             try:
                 result = self.client.search(index=index, body=body, request_timeout=300)["hits"]["hits"]
                 if len(result) == 0:
-                    body = {
-                        "query": {
-                            "bool": {
-                                "filter": {
-                                    "bool": {
-                                        "must": [
-                                            {
-                                                "exists": {
-                                                    "field": self.embedding_field
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    count_embeddings = self.client.count(index=index, body=body)["count"]
+                    count_embeddings = self.get_embedding_count(index=index)
                     if count_embeddings == 0:
                         raise RequestError(400, "search_phase_execution_exception",
                                            {"error": "No documents with embeddings"})

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -847,7 +847,21 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
 
         query = {
             "script_score": {
-                "query": {"match_all": {}},
+                "query": {
+                    "bool": {
+                        "filter": {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "exists": {
+                                            "field": self.embedding_field
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
                 "script": {
                     # offset score to ensure a positive range as required by Elasticsearch
                     "source": f"{similarity_fn_name}(params.query_vector,'{self.embedding_field}') + 1000",

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -825,6 +825,9 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             logger.debug(f"Retriever query: {body}")
             try:
                 result = self.client.search(index=index, body=body, request_timeout=300)["hits"]["hits"]
+                if len(result) <= 0:
+                    raise RequestError(400, "search_phase_execution_exception",
+                                       {"error": "No documents with embeddings"})
             except RequestError as e:
                 if e.error == "search_phase_execution_exception":
                     error_message: str = "search_phase_execution_exception: Likely some of your stored documents don't have embeddings." \

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -849,7 +849,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             raise Exception("Invalid value for similarity in ElasticSearchDocumentStore constructor. Choose between \'cosine\' and \'dot_product\'")
 
         # To handle scenarios where embeddings may be missing
-        script_score_query = {"match_all": {}}
+        script_score_query: dict = {"match_all": {}}
         if self.skip_missing_embeddings:
             script_score_query = {
                 "bool": {

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -105,11 +105,10 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         :param scroll: Determines how long the current index is fixed, e.g. during updating all documents with embeddings.
                        Defaults to "1d" and should not be larger than this. Can also be in minutes "5m" or hours "15h"
                        For details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html
-        :param skip_missing_embeddings: Parameter to control vector similarity when indexed documents miss embeddings.
+        :param skip_missing_embeddings: Parameter to control queries based on vector similarity when indexed documents miss embeddings.
                                         Parameter options: (True, False)
-                                        False: Raises exception if one or more documents do not have embeddings at the
-                                               time of vector similarity computation
-                                        True: Filters out documents not containing embeddings
+                                        False: Raises exception if one or more documents do not have embeddings at query time
+                                        True: Query will ignore all documents without embeddings (recommended if you concurrently index and query)
 
         """
         # save init parameters to enable export of component config as YAML
@@ -829,7 +828,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                     count_embeddings = self.get_embedding_count(index=index)
                     if count_embeddings == 0:
                         raise RequestError(400, "search_phase_execution_exception",
-                                           {"error": "No documents with embeddings"})
+                                           {"error": "No documents with embeddings. Make sure to add documents and compute their embeddings via the doc store's update_embeddings() method."})
             except RequestError as e:
                 if e.error == "search_phase_execution_exception":
                     error_message: str = "search_phase_execution_exception: Likely some of your stored documents don't have embeddings." \

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -825,9 +825,28 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
             logger.debug(f"Retriever query: {body}")
             try:
                 result = self.client.search(index=index, body=body, request_timeout=300)["hits"]["hits"]
-                if len(result) <= 0:
-                    raise RequestError(400, "search_phase_execution_exception",
-                                       {"error": "No documents with embeddings"})
+                if len(result) == 0:
+                    body = {
+                        "query": {
+                            "bool": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {
+                                                "exists": {
+                                                    "field": self.embedding_field
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    count_embeddings = self.client.count(index=index, body=body)["count"]
+                    if count_embeddings == 0:
+                        raise RequestError(400, "search_phase_execution_exception",
+                                           {"error": "No documents with embeddings"})
             except RequestError as e:
                 if e.error == "search_phase_execution_exception":
                     error_message: str = "search_phase_execution_exception: Likely some of your stored documents don't have embeddings." \

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -105,6 +105,11 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         :param scroll: Determines how long the current index is fixed, e.g. during updating all documents with embeddings.
                        Defaults to "1d" and should not be larger than this. Can also be in minutes "5m" or hours "15h"
                        For details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html
+        :param skip_missing_embeddings: Parameter to control vector similarity when indexed documents miss embeddings.
+                                        Parameter options: (True, False)
+                                        False: Raises exception if one or more documents do not have embeddings at the
+                                               time of vector similarity computation
+                                        True: Filters out documents not containing embeddings
 
         """
         # save init parameters to enable export of component config as YAML

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -52,7 +52,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         duplicate_documents: str = 'overwrite',
         index_type: str = "flat",
         scroll: str = "1d",
-        skip_missing_embeddings: bool = False
+        skip_missing_embeddings: bool = True
     ):
         """
         A DocumentStore using Elasticsearch to store and query the documents for our search.

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -828,7 +828,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
                     count_embeddings = self.get_embedding_count(index=index)
                     if count_embeddings == 0:
                         raise RequestError(400, "search_phase_execution_exception",
-                                           {"error": "No documents with embeddings. Make sure to add documents and compute their embeddings via the doc store's update_embeddings() method."})
+                                           {"error": "No documents with embeddings."})
             except RequestError as e:
                 if e.error == "search_phase_execution_exception":
                     error_message: str = "search_phase_execution_exception: Likely some of your stored documents don't have embeddings." \

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -888,13 +888,13 @@ def test_get_document_count_only_documents_without_embedding_arg():
                                              filters={"meta_field_for_count": ["b"]}) == 2
 
 
-@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
-def test_skip_missing_embedding():
+@pytest.mark.elasticsearch
+def test_skip_missing_embeddings():
     documents = [
         {"content": "text1", "id": "1"},  # a document without embeddings
         {"content": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
         {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
-        {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)}
     ]
     document_store = ElasticsearchDocumentStore(index="skip_missing_embedding_index")
     document_store.write_documents(documents)
@@ -909,10 +909,10 @@ def test_skip_missing_embedding():
 
     # Test scenario with no embeddings for the entire index
     documents = [
-            {"content": "text1", "id": "1"},  # a document without embeddings
+            {"content": "text1", "id": "1"},
             {"content": "text2", "id": "2"},
             {"content": "text3", "id": "3"},
-            {"content": "text4", "id": "4"},
+            {"content": "text4", "id": "4"}
         ]
 
     document_store.delete_documents()

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -894,7 +894,8 @@ def test_skip_missing_embedding(document_store):
         {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
         {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
-    document_store.write_documents(documents, index="skip_missing_embedding_index")
+    document_store = ElasticsearchDocumentStore(index="skip_missing_embedding_index")
+    document_store.write_documents(documents)
 
     document_store.skip_missing_embeddings = True
     retrieved_docs = document_store.query_by_embedding(np.random.rand(768).astype(np.float32))


### PR DESCRIPTION
**Proposed changes**:
Filter documents not containing embedding field
closes #1695

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [x] Updated documentation
