### PR TITLE
Add ElasticDocStore as 3rd option to DPR tutorial

### DIFF
--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -127,7 +127,7 @@ launch_milvus()
 document_store = MilvusDocumentStore()
 ```
 
-#### OPTION3: Elasticsearch
+#### Option 3: Elasticsearch
 Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.
 Section "Retriever Speed" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR:
 It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.

--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -127,7 +127,7 @@ launch_milvus()
 document_store = MilvusDocumentStore()
 ```
 
-#### Option 3: Elasticsearch
+#### OPTION3: Elasticsearch
 Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.
 Section "Retriever Speed" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR:
 It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.

--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -130,8 +130,8 @@ document_store = MilvusDocumentStore()
 #### OPTION3: Elasticsearch 
 Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.
 Section "Retriever Speed" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR: 
-# It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.
-# Like Milvus, Elasticsearch runs through Docker.
+It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.
+Like Milvus, Elasticsearch runs through Docker.
 
 
 ```python

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -395,11 +395,11 @@
   {
    "cell_type": "markdown",
    "source": [
-    "#### OPTION3: Elasticsearch \n",
+    "#### OPTION3: Elasticsearch\n",
     "Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.\n",
-    "Section \"Retriever Speed\" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR: \n",
-    "# It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.\n",
-    "# Like Milvus, Elasticsearch runs through Docker."
+    "Section \"Retriever Speed\" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR:\n",
+    "It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.\n",
+    "Like Milvus, Elasticsearch runs through Docker."
    ],
    "metadata": {
     "collapsed": false,

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -395,6 +395,80 @@
   {
    "cell_type": "markdown",
    "source": [
+    "#### OPTION3: Elasticsearch \n",
+    "Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.\n",
+    "Section \"Retriever Speed\" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR: \n",
+    "# It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.\n",
+    "# Like Milvus, Elasticsearch runs through Docker."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# In environments where Docker can be used: Start Elasticsearch using Docker via the Haystack utility function\n",
+    "from haystack.utils import launch_es\n",
+    "launch_es()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# In Colab / No Docker environments: Start Elasticsearch from source\n",
+    "! wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.2-linux-x86_64.tar.gz -q\n",
+    "! tar -xzf elasticsearch-7.9.2-linux-x86_64.tar.gz\n",
+    "! chown -R daemon:daemon elasticsearch-7.9.2\n",
+    "\n",
+    "import os\n",
+    "from subprocess import Popen, PIPE, STDOUT\n",
+    "es_server = Popen(['elasticsearch-7.9.2/bin/elasticsearch'],\n",
+    "                   stdout=PIPE, stderr=STDOUT,\n",
+    "                   preexec_fn=lambda: os.setuid(1)  # as daemon\n",
+    "                  )\n",
+    "# wait until ES has started\n",
+    "! sleep 30"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Connect to Elasticsearch\n",
+    "from haystack.document_stores import ElasticsearchDocumentStore\n",
+    "document_store = ElasticsearchDocumentStore()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "### Cleaning & indexing documents\n",
     "\n",
     "Similarly to the previous tutorials, we download, convert and index some Game of Thrones articles to our DocumentStore"

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -395,7 +395,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "#### OPTION3: Elasticsearch\n",
+    "#### Option 3: Elasticsearch\n",
     "Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.\n",
     "Section \"Retriever Speed\" in our [benchmarks](https://haystack.deepset.ai/benchmarks/latest) compares different document stores in combination with DPR:\n",
     "It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.\n",

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -3,7 +3,7 @@ from haystack.utils import clean_wiki_text, print_answers, launch_milvus, launch
 from haystack.nodes import FARMReader, DensePassageRetriever
 
 def tutorial6_better_retrieval_via_dpr():
-    # OPTION 1: FAISS is a library for efficient similarity search on a cluster of dense vectors.
+    # Option 1: FAISS is a library for efficient similarity search on a cluster of dense vectors.
     # The FAISSDocumentStore uses a SQL(SQLite in-memory be default) document store under-the-hood
     # to store the document text and other meta data. The vector embeddings of the text are
     # indexed on a FAISS Index that later is queried for searching answers.
@@ -12,14 +12,14 @@ def tutorial6_better_retrieval_via_dpr():
     # For more info on which suits your use case: https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
     document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
 
-    # OPTION2: Milvus is an open source database library that is also optimized for vector similarity searches like FAISS.
+    # Option 2: Milvus is an open source database library that is also optimized for vector similarity searches like FAISS.
     # Like FAISS it has both a "Flat" and "HNSW" mode but it outperforms FAISS when it comes to dynamic data management.
     # It does require a little more setup, however, as it is run through Docker and requires the setup of some config files.
     # See https://milvus.io/docs/v1.0.0/milvus_docker-cpu.md
     # launch_milvus()
     # document_store = MilvusDocumentStore()
 
-    # OPTION3: Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.
+    # Option 3: Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.
     # Section "Retriever Speed" in our benchmarks compares different document stores in combination with DPR: https://haystack.deepset.ai/benchmarks/latest
     # It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.
     # Like Milvus, Elasticsearch runs through Docker.
@@ -58,7 +58,7 @@ def tutorial6_better_retrieval_via_dpr():
     document_store.update_embeddings(retriever)
 
     ### Reader
-    # Load a  local model or any of the QA models on
+    # Load a local model or any of the QA models on
     # Hugging Face's model hub (https://huggingface.co/models)
     reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2", use_gpu=True)
 

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -1,5 +1,5 @@
-from haystack.document_stores import FAISSDocumentStore, MilvusDocumentStore
-from haystack.utils import clean_wiki_text, print_answers, launch_milvus, convert_files_to_dicts, fetch_archive_from_http
+from haystack.document_stores import FAISSDocumentStore, MilvusDocumentStore, ElasticsearchDocumentStore
+from haystack.utils import clean_wiki_text, print_answers, launch_milvus, launch_es, convert_files_to_dicts, fetch_archive_from_http
 from haystack.nodes import FARMReader, DensePassageRetriever
 
 def tutorial6_better_retrieval_via_dpr():
@@ -18,6 +18,13 @@ def tutorial6_better_retrieval_via_dpr():
     # See https://milvus.io/docs/v1.0.0/milvus_docker-cpu.md
     # launch_milvus()
     # document_store = MilvusDocumentStore()
+
+    # OPTION3: Elasticsearch is not optimized for vector similarity searches but it can still store embedding vectors and thus supports DPR.
+    # Section "Retriever Speed" in our benchmarks compares different document stores in combination with DPR: https://haystack.deepset.ai/benchmarks/latest
+    # It shows that queries to Elasticsearch are significantly slower than to FAISS and Milvus if more than a few thousand documents are stored.
+    # Like Milvus, Elasticsearch runs through Docker.
+    # launch_es()
+    # document_store = ElasticsearchDocumentStore()
 
     # ## Preprocessing of documents
     # Let's first get some documents that we want to query


### PR DESCRIPTION
**Proposed changes**:
- @aantti suggested to include ElasticsearchDocumentStore as a 3rd option in the DPR tutorial. This PR adds ElasticsearchDocumentStore as a 3rd option in the DPR tutorial (script and notebook). Before this PR, the tutorial mentioned only FAISS and Milvus. 

- [x] Tried it on colab https://colab.research.google.com/github/deepset-ai/haystack/blob/add_elastic_to_tutorial_6/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
