### PR TITLE
Deprecate old pipeline eval nodes: EvalDocuments and EvalAnswers

### DIFF
--- a/docs/_src/api/api/evaluation.md
+++ b/docs/_src/api/api/evaluation.md
@@ -15,6 +15,9 @@ from this Node may differ from that when calling Retriever.eval() since that is 
 a look at our evaluation tutorial for more info about open vs closed domain eval (
 https://haystack.deepset.ai/tutorials/evaluation).
 
+EvalDocuments node is deprecated and will be removed in a future version.
+Please use pipeline.eval() instead.
+
 <a name="evaluator.EvalDocuments.__init__"></a>
 #### \_\_init\_\_
 
@@ -60,6 +63,9 @@ this class and updated as each sample passes through it. To view the results of 
 Note that results from this Node may differ from that when calling Reader.eval()
 since that is a closed domain evaluation. Have a look at our evaluation tutorial for more info about
 open vs closed domain eval (https://haystack.deepset.ai/tutorials/evaluation).
+
+EvalAnswers node is deprecated and will be removed in a future version.
+Please use pipeline.eval() instead.
 
 <a name="evaluator.EvalAnswers.__init__"></a>
 #### \_\_init\_\_

--- a/haystack/nodes/evaluator/evaluator.py
+++ b/haystack/nodes/evaluator/evaluator.py
@@ -33,6 +33,8 @@ class EvalDocuments(BaseComponent):
         :param debug: When True, a record of each sample and its evaluation will be stored in EvalDocuments.log
         :param top_k: calculate eval metrics for top k results, e.g., recall@k
         """
+        logger.warning("EvalDocuments node is deprecated and will be removed in a future version. "
+                       "Please use pipeline.eval() instead.")
         self.init_counts()
         self.no_answer_warning = False
         self.debug = debug
@@ -178,6 +180,8 @@ class EvalAnswers(BaseComponent):
                           - Large model for German only: "deepset/gbert-large-sts"
         :param debug: When True, a record of each sample and its evaluation will be stored in EvalAnswers.log
         """
+        logger.warning("EvalAnswers node is deprecated and will be removed in a future version. "
+                       "Please use pipeline.eval() instead.")
         self.log: List = []
         self.debug = debug
         self.skip_incorrect_retrieval = skip_incorrect_retrieval

--- a/haystack/nodes/evaluator/evaluator.py
+++ b/haystack/nodes/evaluator/evaluator.py
@@ -23,6 +23,9 @@ class EvalDocuments(BaseComponent):
     from this Node may differ from that when calling Retriever.eval() since that is a closed domain evaluation. Have
     a look at our evaluation tutorial for more info about open vs closed domain eval (
     https://haystack.deepset.ai/tutorials/evaluation).
+
+    EvalDocuments node is deprecated and will be removed in a future version.
+    Please use pipeline.eval() instead.
     """
     outgoing_edges = 1
 
@@ -154,6 +157,9 @@ class EvalAnswers(BaseComponent):
     Note that results from this Node may differ from that when calling Reader.eval()
     since that is a closed domain evaluation. Have a look at our evaluation tutorial for more info about
     open vs closed domain eval (https://haystack.deepset.ai/tutorials/evaluation).
+
+    EvalAnswers node is deprecated and will be removed in a future version.
+    Please use pipeline.eval() instead.
     """
 
     outgoing_edges = 1


### PR DESCRIPTION
**Proposed changes**:
- log warning in EvalDocuments and EvalAnswers constructors
- add warning to docstrings

Warning will be like:
```
WARNING - haystack.nodes.evaluator.evaluator -  EvalDocuments node is deprecated and will be removed in a future version. Please use pipeline.eval() instead.
WARNING - haystack.nodes.evaluator.evaluator -  EvalAnswers node is deprecated and will be removed in a future version. Please use pipeline.eval() instead.
```

**Status**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation

closes #1717

must not be merged before #1760