### PR TITLE
Small fixes to the public demo

### DIFF
--- a/rest_api/pipeline/pipelines.yaml
+++ b/rest_api/pipeline/pipelines.yaml
@@ -14,6 +14,7 @@ components:    # define all the building-blocks for Pipeline
     type: FARMReader    # Haystack Class name for the component
     params:
       model_name_or_path: deepset/roberta-base-squad2
+      context_window_size: 500
   - name: TextFileConverter
     type: TextConverter
   - name: PDFFileConverter

--- a/rest_api/pipeline/pipelines.yaml
+++ b/rest_api/pipeline/pipelines.yaml
@@ -15,6 +15,7 @@ components:    # define all the building-blocks for Pipeline
     params:
       model_name_or_path: deepset/roberta-base-squad2
       context_window_size: 500
+      return_no_answer: true
   - name: TextFileConverter
     type: TextConverter
   - name: PDFFileConverter

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -27,7 +27,7 @@ def haystack_version():
     return requests.get(url).json()["hs_version"]
 
 
-def retrieve_doc(query, filters=None, top_k_reader=5, top_k_retriever=5):
+def retrieve_doc(query, filters={}, top_k_reader=5, top_k_retriever=5):
     # Query Haystack API
     url = f"{API_ENDPOINT}/{DOC_REQUEST}"
     params = {"filters": filters, "Retriever": {"top_k": top_k_retriever}, "Reader": {"top_k": top_k_reader}}

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -24,8 +24,7 @@ def haystack_is_ready():
 @st.cache
 def haystack_version():
     url = f"{API_ENDPOINT}/{HS_VERSION}"
-    return requests.get(url).json()["hs_version"]
-
+    return requests.get(url, timeout=0.1).json()["hs_version"]
 
 def retrieve_doc(query, filters={}, top_k_reader=5, top_k_retriever=5):
     # Query Haystack API

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -159,6 +159,9 @@ def main():
             st.write("## Correct answers:")
             st.write(state.random_answer)
 
+        if state.results[0]["relevance"] < 50.00:
+            st.warning("🤔 &nbsp;&nbsp; Haystack is not very confident about these answers. Try to formulate your question differently!")
+
         st.write("## Results:")
         count = 0  # Make every button key unique
 

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -1,12 +1,15 @@
 import os
 import sys
 
+import html
 import logging
 import pandas as pd
 from json import JSONDecodeError
 from pathlib import Path
 import streamlit as st
-from annotated_text import annotated_text
+from annotated_text import annotation
+from markdown import markdown
+from htbuilder import H
 
 # streamlit does not support any states out of the box. On every button click, streamlit reload the whole page
 # and every value gets lost. To keep track of our feedback state we use the official streamlit gist mentioned
@@ -164,9 +167,10 @@ def main():
                 answer, context = result["answer"], result["context"]
                 start_idx = context.find(answer)
                 end_idx = start_idx + len(answer)
-                annotated_text(context[:start_idx], (answer, "ANSWER", "#8ef"), context[end_idx:])
+                # Hack due to this bug: https://github.com/streamlit/streamlit/issues/3190 
+                st.write(markdown(context[:start_idx] + str(annotation(answer, "ANSWER", "#8ef")) + context[end_idx:]), unsafe_allow_html=True)
             else:
-                st.markdown(result["context"])
+                st.markdown(result["context"], unsafe_allow_html=True)
 
             st.write("**Relevance:** ", result["relevance"], "**Source:** ", result["source"])
             if eval_mode:

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -159,9 +159,6 @@ def main():
             st.write("## Correct answers:")
             st.write(state.random_answer)
 
-        if state.results[0]["relevance"] < 50.00:
-            st.warning("🤔 &nbsp;&nbsp; Haystack is not very confident about these answers. Try to formulate your question differently!")
-
         st.write("## Results:")
         count = 0  # Make every button key unique
 
@@ -172,10 +169,12 @@ def main():
                 end_idx = start_idx + len(answer)
                 # Hack due to this bug: https://github.com/streamlit/streamlit/issues/3190 
                 st.write(markdown(context[:start_idx] + str(annotation(answer, "ANSWER", "#8ef")) + context[end_idx:]), unsafe_allow_html=True)
-            else:
-                st.markdown(result["context"], unsafe_allow_html=True)
+                st.write("**Relevance:** ", result["relevance"], "**Source:** ", result["source"])
 
-            st.write("**Relevance:** ", result["relevance"], "**Source:** ", result["source"])
+            else:
+                st.warning("🤔 &nbsp;&nbsp; Haystack found no good answer to your question. Try to formulate it differently!")
+                st.write("**Relevance:** ", result["relevance"])
+                
             if eval_mode:
                 # Define columns for buttons
                 button_col1, button_col2, button_col3, _ = st.columns([1, 1, 1, 6])
@@ -183,11 +182,11 @@ def main():
                     feedback_doc(
                         question=question, 
                         is_correct_answer="true", 
-                        document_id=result["document_id"], 
+                        document_id=result.get("document_id", None), 
                         model_id=1, 
                         is_correct_document="true",
-                        answer=result["answer"], 
-                        offset_start_in_doc=result["offset_start_in_doc"]
+                        answer=result["answer"],
+                        offset_start_in_doc=result.get("offset_start_in_doc", None)
                     )
                     st.success("✨ &nbsp;&nbsp; Thanks for your feedback! &nbsp;&nbsp; ✨")
 
@@ -195,11 +194,11 @@ def main():
                     feedback_doc(
                         question=question, 
                         is_correct_answer="false", 
-                        document_id=result["document_id"], 
+                        document_id=result.get("document_id", None), 
                         model_id=1, 
                         is_correct_document="false",
                         answer=result["answer"], 
-                        offset_start_in_doc=result["offset_start_in_doc"]
+                        offset_start_in_doc=result.get("offset_start_in_doc", None)
                     )
                     st.success("✨ &nbsp;&nbsp; Thanks for your feedback! &nbsp;&nbsp; ✨")
 
@@ -207,11 +206,11 @@ def main():
                     feedback_doc(
                         question=question, 
                         is_correct_answer="false", 
-                        document_id=result["document_id"], 
+                        document_id=result.get("document_id", None), 
                         model_id=1, 
                         is_correct_document="true",
                         answer=result["answer"], 
-                        offset_start_in_doc=result["offset_start_in_doc"]
+                        offset_start_in_doc=result.get("offset_start_in_doc", None)
                     )
                     st.success("✨ &nbsp;&nbsp; Thanks for your feedback! &nbsp;&nbsp; ✨")
                 count += 1


### PR DESCRIPTION
- Make the call that fetches the haystack version not critical (if it fails, ignore it) and quick (fail with a timeout of 100ms)
- Add a different error message if there is an error while decoding the API response (i.e. an error is returned instead of JSON)
- Fix parsing issue with nested MD/HTML (https://github.com/streamlit/streamlit/issues/3190)
- Make the default filters for the REST API /query endpoint an empty dict instead of None (https://github.com/deepset-ai/haystack/pull/1783)
- Return more context around each answer