### PR TITLE
ignore empty filters parameter

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -160,7 +160,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore)
 #### \_\_init\_\_
 
 ```python
- | __init__(host: Union[str, List[str]] = "localhost", port: Union[int, List[int]] = 9200, username: str = "", password: str = "", api_key_id: Optional[str] = None, api_key: Optional[str] = None, aws4auth=None, index: str = "document", label_index: str = "label", search_fields: Union[str, list] = "content", content_field: str = "content", name_field: str = "name", embedding_field: str = "embedding", embedding_dim: int = 768, custom_mapping: Optional[dict] = None, excluded_meta_data: Optional[list] = None, analyzer: str = "standard", scheme: str = "http", ca_certs: Optional[str] = None, verify_certs: bool = True, create_index: bool = True, refresh_type: str = "wait_for", similarity="dot_product", timeout=30, return_embedding: bool = False, duplicate_documents: str = 'overwrite', index_type: str = "flat", scroll: str = "1d")
+ | __init__(host: Union[str, List[str]] = "localhost", port: Union[int, List[int]] = 9200, username: str = "", password: str = "", api_key_id: Optional[str] = None, api_key: Optional[str] = None, aws4auth=None, index: str = "document", label_index: str = "label", search_fields: Union[str, list] = "content", content_field: str = "content", name_field: str = "name", embedding_field: str = "embedding", embedding_dim: int = 768, custom_mapping: Optional[dict] = None, excluded_meta_data: Optional[list] = None, analyzer: str = "standard", scheme: str = "http", ca_certs: Optional[str] = None, verify_certs: bool = True, create_index: bool = True, refresh_type: str = "wait_for", similarity="dot_product", timeout=30, return_embedding: bool = False, duplicate_documents: str = 'overwrite', index_type: str = "flat", scroll: str = "1d", skip_missing_embeddings: bool = True)
 ```
 
 A DocumentStore using Elasticsearch to store and query the documents for our search.
@@ -215,6 +215,10 @@ A DocumentStore using Elasticsearch to store and query the documents for our sea
 - `scroll`: Determines how long the current index is fixed, e.g. during updating all documents with embeddings.
                Defaults to "1d" and should not be larger than this. Can also be in minutes "5m" or hours "15h"
                For details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html
+- `skip_missing_embeddings`: Parameter to control queries based on vector similarity when indexed documents miss embeddings.
+                                Parameter options: (True, False)
+                                False: Raises exception if one or more documents do not have embeddings at query time
+                                True: Query will ignore all documents without embeddings (recommended if you concurrently index and query)
 
 <a name="elasticsearch.ElasticsearchDocumentStore.get_document_by_id"></a>
 #### get\_document\_by\_id

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -82,15 +82,19 @@ def _format_filters(filters):
     Put filter values into a list and remove filters with null value.
     """
     new_filters = {}
-    for key, values in filters.items():
-        if values is None:
-            logger.warning(f"Request with deprecated filter format ('{key}: null'). "
-                           f"Remove null values from filters to be compliant with future versions")
-            continue
-        elif not isinstance(values, list):
-            logger.warning(f"Request with deprecated filter format ('{key}': {values}). "
-                           f"Change to '{key}':[{values}]' to be compliant with future versions")
-            values = [values]
+    if filters is None:
+        logger.warning(f"Request with deprecated filter format ('\"filters\": null'). "
+                       f"Remove empty filters from params to be compliant with future versions")
+    else:
+        for key, values in filters.items():
+            if values is None:
+                logger.warning(f"Request with deprecated filter format ('{key}: null'). "
+                               f"Remove null values from filters to be compliant with future versions")
+                continue
+            elif not isinstance(values, list):
+                logger.warning(f"Request with deprecated filter format ('{key}': {values}). "
+                               f"Change to '{key}':[{values}]' to be compliant with future versions")
+                values = [values]
 
-        new_filters[key] = values
+            new_filters[key] = values
     return new_filters


### PR DESCRIPTION
Our web app sets filters to None (deprecated format): https://github.com/deepset-ai/haystack/blob/8aa4ca29c2b32a6188742a6555240da516a17e07/ui/utils.py#L30

The REST API did not handle this deprecated format until now but failed at calling `filters.items` with `filters` being `None` here:
https://github.com/deepset-ai/haystack/blob/8aa4ca29c2b32a6188742a6555240da516a17e07/rest_api/controller/search.py#L85

This pull request introduces a check for `filters` being `None` and in that case skips filter formatting.

Fixes a bug introduced in https://github.com/deepset-ai/haystack/pull/1774