### PR TITLE
Upgrade torch to v1.10.0

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt -e .
           pip install --upgrade --upgrade-strategy eager -r requirements.txt -e .
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.9.0+cpu.html
+          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
     needs: build-cache

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt -e .
           pip install --upgrade --upgrade-strategy eager -f https://download.pytorch.org/whl/torch_stable.html -r requirements.txt -e .
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.9.0+cpu.html
+          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
     needs: build-cache

--- a/docs/_src/tutorials/tutorials/15.md
+++ b/docs/_src/tutorials/tutorials/15.md
@@ -36,7 +36,7 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git
 
 # The TaPAs-based TableReader requires the torch-scatter library
-!pip install torch-scatter -f https://data.pyg.org/whl/torch-1.9.0+cu111.html
+!pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cu113.html
 
 # If you run this notebook on Google Colab, you might need to
 # restart the runtime after installing haystack.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ wheel
 # PyTorch
 # Temp. disabled the next line as it gets currently resolved to https://download.pytorch.org/whl/rocm3.8/torch-1.7.1%2Brocm3.8-cp38-cp38-linux_x86_64.whl
 # --find-links=https://download.pytorch.org/whl/torch_stable.html
-torch>1.5,<1.10
+torch==1.10.0
 # progress bars in model download and training scripts
 tqdm
 # Used for downloading models over HTTP

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ wheel
 # PyTorch
 # Temp. disabled the next line as it gets currently resolved to https://download.pytorch.org/whl/rocm3.8/torch-1.7.1%2Brocm3.8-cp38-cp38-linux_x86_64.whl
 # --find-links=https://download.pytorch.org/whl/torch_stable.html
-torch==1.10.0
+torch>1.5,<1.11
 # progress bars in model download and training scripts
 tqdm
 # Used for downloading models over HTTP

--- a/tutorials/Tutorial15_TableQA.ipynb
+++ b/tutorials/Tutorial15_TableQA.ipynb
@@ -13,16 +13,7 @@
   "language_info": {
    "name": "python"
   },
-  "accelerator": "GPU",
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
-  }
+  "accelerator": "GPU"
  },
  "cells": [
   {
@@ -76,7 +67,7 @@
     "!pip install git+https://github.com/deepset-ai/haystack.git\n",
     "\n",
     "# The TaPAs-based TableReader requires the torch-scatter library\n",
-    "!pip install torch-scatter -f https://data.pyg.org/whl/torch-1.9.0+cu111.html\n",
+    "!pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cu113.html\n",
     "\n",
     "# If you run this notebook on Google Colab, you might need to\n",
     "# restart the runtime after installing haystack."


### PR DESCRIPTION
This PR upgrades Pytorch to version 1.10.0. This should allow to use Haystack again inside Google Colab notebooks and, therefore, fix #1786, #1787 and #1788. The reason for the RestAPI tests to fail doesn't seem to be caused by the upgrade of the torch version, given that they fail on the current master branch as well.