### PR TITLE
Fix Tutorial 11 on Google Colab

### DIFF
--- a/docs/_src/tutorials/tutorials/11.md
+++ b/docs/_src/tutorials/tutorials/11.md
@@ -33,9 +33,6 @@ These lines are to install Haystack through pip
 
 
 ```python
-# Install the latest release of Haystack in your own environment
-!pip install farm-haystack
-
 # Install the latest master of Haystack
 !pip install grpcio-tools==1.34.1
 !pip install --upgrade git+https://github.com/deepset-ai/haystack.git

--- a/tutorials/Tutorial11_Pipelines.ipynb
+++ b/tutorials/Tutorial11_Pipelines.ipynb
@@ -66,9 +66,6 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "# Install the latest release of Haystack in your own environment\n",
-    "!pip install farm-haystack\n",
-    "\n",
     "# Install the latest master of Haystack\n",
     "!pip install grpcio-tools==1.34.1\n",
     "!pip install --upgrade git+https://github.com/deepset-ai/haystack.git\n",


### PR DESCRIPTION
This PR removes the installation of the latest Haystack release from the Tutorial 11 notebook, as the latest release requires torch<1.10, which is causing problems on the current Google Colab environment.
