### PR TITLE
Add missing dependency to the Streamlit container

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,3 @@
 streamlit>=1.2.0
 st-annotated-text==2.0.0
+markdown>=3.3.4


### PR DESCRIPTION
The Streamlit UI Docker image seems to miss a dependency on `markdown`. I though it would get pulled as a dep of Streamlit, but somehow it is not. This fixes the deps list to include `markdown`.
