### PR TITLE
Adapt docker-compose-gpu.yml to use DPR by default

### DIFF
--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -33,7 +33,7 @@ services:
     #image: "elasticsearch:7.9.2"
     # If you want a demo image instead that is "ready-to-query" with some indexed articles 
     # about countries and capital cities from Wikipedia:
-    image: "julianrisch/elasticsearch-countries-and-capitals"
+    image: "deepset/elasticsearch-countries-and-capitals"
     ports:
       - 9200:9200
     restart: on-failure

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -51,5 +51,4 @@ services:
     environment:
       - API_ENDPOINT=http://haystack-api:8000
       - EVAL_FILE=eval_labels_example.csv
-      - HAYSTACK_UI_DISABLE_FILE_UPLOAD=1
     command: "/bin/bash -c 'sleep 15 && streamlit run webapp.py'"

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -1,5 +1,6 @@
 version: "3"
 services:
+
   haystack-api:
     build:
       context: .
@@ -22,19 +23,22 @@ services:
     environment:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
+      - PIPELINE_YAML_PATH=/home/user/rest_api/pipeline/pipeline_dpr.yaml
     depends_on:
       - elasticsearch
     command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"
+
   elasticsearch:
     # This will start an empty elasticsearch instance (so you have to add your documents yourself)
     #image: "elasticsearch:7.9.2"
     # If you want a demo image instead that is "ready-to-query" with some indexed Game of Thrones articles:
-    image: "deepset/elasticsearch-game-of-thrones"
+    image: "julianrisch/elasticsearch-countries-and-capitals"
     ports:
       - 9200:9200
     restart: on-failure
     environment:
       - discovery.type=single-node
+
   ui:
     build:
       context: ui
@@ -46,4 +50,5 @@ services:
     environment:
       - API_ENDPOINT=http://haystack-api:8000
       - EVAL_FILE=eval_labels_example.csv
+      - HAYSTACK_UI_DISABLE_FILE_UPLOAD=1
     command: "/bin/bash -c 'sleep 15 && streamlit run webapp.py'"

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -51,4 +51,5 @@ services:
     environment:
       - API_ENDPOINT=http://haystack-api:8000
       - EVAL_FILE=eval_labels_example.csv
+      - HAYSTACK_UI_DISABLE_FILE_UPLOAD   # docker-compose run -e HAYSTACK_UI_DISABLE_FILE_UPLOAD=1 ...
     command: "/bin/bash -c 'sleep 15 && streamlit run webapp.py'"

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -23,7 +23,7 @@ services:
     environment:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
-      - PIPELINE_YAML_PATH=/home/user/rest_api/pipeline/pipeline_dpr.yaml
+      - PIPELINE_YAML_PATH=/home/user/rest_api/pipeline/pipelines_dpr.yaml
     depends_on:
       - elasticsearch
     command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -31,7 +31,8 @@ services:
   elasticsearch:
     # This will start an empty elasticsearch instance (so you have to add your documents yourself)
     #image: "elasticsearch:7.9.2"
-    # If you want a demo image instead that is "ready-to-query" with some indexed Game of Thrones articles:
+    # If you want a demo image instead that is "ready-to-query" with some indexed articles 
+    # about countries and capital cities from Wikipedia:
     image: "julianrisch/elasticsearch-countries-and-capitals"
     ports:
       - 9200:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     # This will start an empty elasticsearch instance (so you have to add your documents yourself)
     #image: "elasticsearch:7.9.2"
     # If you want a demo image instead that is "ready-to-query" with some indexed Game of Thrones articles:
-    image: "deepset/elasticsearch-game-of-thrones"
+    image: "julianrisch/elasticsearch-countries-and-capitals"
     ports:
       - 9200:9200
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
   elasticsearch:
     # This will start an empty elasticsearch instance (so you have to add your documents yourself)
     #image: "elasticsearch:7.9.2"
-    # If you want a demo image instead that is "ready-to-query" with some indexed Game of Thrones articles:
+    # If you want a demo image instead that is "ready-to-query" with some indexed articles 
+    # about countries and capital cities from Wikipedia:
     image: "julianrisch/elasticsearch-countries-and-capitals"
     ports:
       - 9200:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     #image: "elasticsearch:7.9.2"
     # If you want a demo image instead that is "ready-to-query" with some indexed articles 
     # about countries and capital cities from Wikipedia:
-    image: "julianrisch/elasticsearch-countries-and-capitals"
+    image: "deepset/elasticsearch-countries-and-capitals"
     ports:
       - 9200:9200
     restart: on-failure

--- a/rest_api/pipeline/pipelines_dpr.yaml
+++ b/rest_api/pipeline/pipelines_dpr.yaml
@@ -14,6 +14,8 @@ components:    # define all the building-blocks for Pipeline
     type: FARMReader    # Haystack Class name for the component
     params:
       model_name_or_path: deepset/roberta-base-squad2
+      context_window_size: 1000
+      return_no_answer: true
   - name: TextFileConverter
     type: TextConverter
   - name: PDFFileConverter


### PR DESCRIPTION
Changes:

- Now both docker-compose files use Julian's countries dataset
- The GPU version uses DPR as the default pipeline in the REST API
- The GPU version has the file upload disabled to be ready to deploy as the hosted version (is this OK?)

Note: This assumes that the dataset used already has embeddings for the documents it contains. So do not merge before Julian confirms that the ES image has the embeddings too.