### PR TITLE
Lower minimum PIL version to avoid Colab restarts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ coverage
 langdetect # for PDF conversions
 # for PDF conversions using OCR
 pytesseract==0.3.7 
-pillow==8.3.2
+pillow>=7.0.0
 pdf2image==1.14.0
 sentence-transformers>=0.4.0
 python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,4 +63,3 @@ weaviate-client==2.5.0
 ray==1.5.0
 dataclasses-json
 quantulum3
-grpcio<1.38.0,>=1.22.0 # from pymilvus, somehow not enforced properly

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,4 +63,3 @@ weaviate-client==2.5.0
 ray==1.5.0
 dataclasses-json
 quantulum3
-grpcio>=1.42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ weaviate-client==2.5.0
 ray==1.5.0
 dataclasses-json
 quantulum3
+grpcio>=1.42.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ weaviate-client==2.5.0
 ray==1.5.0
 dataclasses-json
 quantulum3
+grpcio<1.38.0,>=1.22.0 # from pymilvus, somehow not enforced properly


### PR DESCRIPTION
Colab seems to have `PIL==7.1.3`, while we fixed our version at `PIL==8.3.2`. It's probably unnecessary to be this specific, and lowering PIL will prevent unnecessary Colab runtime restarts.

https://colab.research.google.com/drive/1X67Y8WJcfnj9SNHOBAHYabhAEKXWV72_?usp=sharing