### PR TITLE
Remove feedback from no-answers

### DIFF
--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -24,7 +24,7 @@ services:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
       - PIPELINE_YAML_PATH=/home/user/rest_api/pipeline/pipelines_dpr.yaml
-      - CONCURRENT_REQUEST_PER_WORKER=12
+      - CONCURRENT_REQUEST_PER_WORKER
     depends_on:
       - elasticsearch
     command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -24,6 +24,7 @@ services:
       # See rest_api/pipelines.yaml for configurations of Search & Indexing Pipeline.
       - DOCUMENTSTORE_PARAMS_HOST=elasticsearch
       - PIPELINE_YAML_PATH=/home/user/rest_api/pipeline/pipelines_dpr.yaml
+      - CONCURRENT_REQUEST_PER_WORKER=12
     depends_on:
       - elasticsearch
     command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 1 --timeout 180'"

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -46,12 +46,12 @@ def query(query, filters={}, top_k_reader=5, top_k_retriever=5) -> Tuple[List[Di
     url = f"{API_ENDPOINT}/{DOC_REQUEST}"
     params = {"filters": filters, "Retriever": {"top_k": top_k_retriever}, "Reader": {"top_k": top_k_reader}}
     req = {"query": query, "params": params}
-    response_raw = requests.post(url, json=req).json()
+    response_raw = requests.post(url, json=req)
 
     if response_raw.status_code >= 400:
         raise Exception(f"{response_raw}")
 
-    response = requests.post(url, json=req).json()
+    response = response_raw.json()
     if "errors" in response:
         raise Exception(", ".join(response["errors"]))
 

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -66,7 +66,7 @@ def query(query, filters={}, top_k_reader=5, top_k_retriever=5) -> Tuple[List[Di
                     "answer": answer.get("answer", None),
                     "source": answer["meta"]["name"],
                     "relevance": round(answer["score"] * 100, 2),
-                    "document": [doc for doc in response_raw["documents"] if doc["id"] == answer["document_id"]][0],
+                    "document": [doc for doc in response["documents"] if doc["id"] == answer["document_id"]][0],
                     "offset_start_in_doc": answer["offsets_in_document"][0]["start"],
                     "_raw": answer
                 }

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -186,7 +186,7 @@ Ask any question on this topic and see if Haystack can find the correct answer t
                 st.info("🤔 &nbsp;&nbsp; Haystack is unsure whether any of the documents contain an answer to your question. Try to reformulate it!")
                 st.write("**Relevance:** ", result["relevance"])
                 
-            if eval_mode:
+            if eval_mode and result["answer"]:
                 # Define columns for buttons
                 is_correct_answer = None
                 is_correct_document = None


### PR DESCRIPTION
Removes the feedback buttons from no-answers: seems like Labels can't be created for them (which makes some sense). Also raises the number of concurrent requests per worker, given that I haven't found an easy way to raise the number of workers, to do some manual load tests tomorrow.

Also, in the last demo PR I added a line that didn't make sense :facepalm:. Here is how it should look like instead.