### PR TITLE
remove queries param from pipeline.eval()

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -162,7 +162,7 @@ Runs the pipeline, one node at a time.
 #### eval
 
 ```python
- | eval(queries: List[str], labels: List[MultiLabel], params: Optional[dict] = None, sas_model_name_or_path: str = None) -> EvaluationResult
+ | eval(labels: List[MultiLabel], params: Optional[dict] = None, sas_model_name_or_path: str = None) -> EvaluationResult
 ```
 
 Evaluates the pipeline by running the pipeline once per query in debug mode
@@ -170,7 +170,6 @@ and putting together all data that is needed for evaluation, e.g. calculating me
 
 **Arguments**:
 
-- `queries`: The queries to evaluate
 - `labels`: The labels to evaluate on
 - `params`: Dictionary of parameters to be dispatched to the nodes.
             If you want to pass a param to all nodes, you can just use: {"top_k":10}
@@ -628,7 +627,7 @@ Instance of DocumentStore or None
 #### eval
 
 ```python
- | eval(queries: List[str], labels: List[MultiLabel], params: Optional[dict], sas_model_name_or_path: str = None) -> EvaluationResult
+ | eval(labels: List[MultiLabel], params: Optional[dict], sas_model_name_or_path: str = None) -> EvaluationResult
 ```
 
 Evaluates the pipeline by running the pipeline once per query in debug mode
@@ -636,7 +635,6 @@ and putting together all data that is needed for evaluation, e.g. calculating me
 
 **Arguments**:
 
-- `queries`: The queries to evaluate
 - `labels`: The labels to evaluate on
 - `params`: Params for the `retriever` and `reader`. For instance,
                params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -366,7 +366,6 @@ class Pipeline(BasePipeline):
 
     def eval(
         self,
-        queries: List[str],
         labels: List[MultiLabel],
         params: Optional[dict] = None,
         sas_model_name_or_path: str = None
@@ -375,7 +374,6 @@ class Pipeline(BasePipeline):
             Evaluates the pipeline by running the pipeline once per query in debug mode 
             and putting together all data that is needed for evaluation, e.g. calculating metrics.
 
-            :param queries: The queries to evaluate
             :param labels: The labels to evaluate on
             :param params: Dictionary of parameters to be dispatched to the nodes. 
                         If you want to pass a param to all nodes, you can just use: {"top_k":10}
@@ -392,11 +390,9 @@ class Pipeline(BasePipeline):
                         - Good default for multiple languages: "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
                         - Large, powerful, but slow model for English only: "cross-encoder/stsb-roberta-large"
                         - Large model for German only: "deepset/gbert-large-sts"
-        """
-        if len(queries) != len(labels):
-            raise ValueError("length of queries must match length of labels")
-        
+        """    
         eval_result = EvaluationResult()
+        queries = [label.query for label in labels]
         for query, label in zip(queries, labels):
             predictions = self.run(query=query, labels=label, params=params, debug=True)
             

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -151,7 +151,6 @@ class BaseStandardPipeline(ABC):
         return self.pipeline.get_document_store()
 
     def eval(self,
-            queries: List[str],
             labels: List[MultiLabel],
             params: Optional[dict],
             sas_model_name_or_path: str = None) -> EvaluationResult:
@@ -160,14 +159,13 @@ class BaseStandardPipeline(ABC):
         Evaluates the pipeline by running the pipeline once per query in debug mode 
         and putting together all data that is needed for evaluation, e.g. calculating metrics.
 
-        :param queries: The queries to evaluate
         :param labels: The labels to evaluate on
         :param params: Params for the `retriever` and `reader`. For instance,
                        params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}
         :param sas_model_name_or_path: SentenceTransformers semantic textual similarity model to be used for sas value calculation, 
                                     should be path or string pointing to downloadable models.
         """
-        output = self.pipeline.eval(queries=queries, labels=labels, params=params, 
+        output = self.pipeline.eval(labels=labels, params=params, 
             sas_model_name_or_path=sas_model_name_or_path)
         return output
 

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -197,7 +197,6 @@ def test_eval_data_split_passage(document_store):
     assert len(docs[1].content) == 56
 
 
-EVAL_QUERIES = ["Who lives in Berlin?", "Who lives in Munich?"]
 EVAL_LABELS = [
         MultiLabel(labels=[Label(query="Who lives in Berlin?", answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]), 
             document=Document(id='a0747b83aea0b60c4b114b15476dd32d', content_type="text", content='My name is Carla and I live in Berlin'), 
@@ -210,12 +209,10 @@ EVAL_LABELS = [
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval(reader, retriever_with_docs, tmp_path):
-    queries = EVAL_QUERIES[:1]
     labels = EVAL_LABELS[:1]
 
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result = pipeline.eval(
-        queries=queries, 
         labels=labels,
         params={"Retriever": {"top_k": 5}}, 
     )
@@ -255,7 +252,6 @@ def test_extractive_qa_eval(reader, retriever_with_docs, tmp_path):
 def test_extractive_qa_eval_multiple_queries(reader, retriever_with_docs, tmp_path):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -305,7 +301,6 @@ def test_extractive_qa_eval_multiple_queries(reader, retriever_with_docs, tmp_pa
 def test_extractive_qa_eval_sas(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}, 
         sas_model_name_or_path="sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
@@ -329,7 +324,6 @@ def test_extractive_qa_eval_sas(reader, retriever_with_docs):
 def test_extractive_qa_eval_doc_relevance_col(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}, 
     )
@@ -348,7 +342,6 @@ def test_extractive_qa_eval_doc_relevance_col(reader, retriever_with_docs):
 def test_extractive_qa_eval_simulated_top_k_reader(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}},
         sas_model_name_or_path="sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
@@ -393,7 +386,6 @@ def test_extractive_qa_eval_simulated_top_k_reader(reader, retriever_with_docs):
 def test_extractive_qa_eval_simulated_top_k_retriever(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -444,7 +436,6 @@ def test_extractive_qa_eval_simulated_top_k_retriever(reader, retriever_with_doc
 def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriever_with_docs):
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 10}}
     )
@@ -494,7 +485,6 @@ def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriev
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval_wrong_examples(reader, retriever_with_docs):
 
-    queries = ["Who lives in Berlin?", "Who lives in Munich?"]
     labels = [
         MultiLabel(labels=[Label(query="Who lives in Berlin?", answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]), 
             document=Document(id='a0747b83aea0b60c4b114b15476dd32d', content_type="text", content='My name is Carla and I live in Berlin'), 
@@ -506,7 +496,6 @@ def test_extractive_qa_eval_wrong_examples(reader, retriever_with_docs):
 
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=queries, 
         labels=labels,
         params={"Retriever": {"top_k": 5}}, 
     )
@@ -522,7 +511,6 @@ def test_extractive_qa_eval_wrong_examples(reader, retriever_with_docs):
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
 
-    queries = ["Who lives in Berlin?", "Who lives in Munich?"]
     labels = [
         MultiLabel(labels=[Label(query="Who lives in Berlin?", answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]), 
             document=Document(id='a0747b83aea0b60c4b114b15476dd32d', content_type="text", content='My name is Carla and I live in Berlin'), 
@@ -534,7 +522,6 @@ def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
 
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=queries, 
         labels=labels,
         params={"Retriever": {"top_k": 5}}, 
     )
@@ -547,7 +534,6 @@ def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
 def test_document_search_calculate_metrics(retriever_with_docs):
     pipeline = DocumentSearchPipeline(retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -579,7 +565,6 @@ def test_generativeqa_calculate_metrics(document_store_with_docs: InMemoryDocume
     document_store_with_docs.update_embeddings(retriever=retriever)
     pipeline = GenerativeQAPipeline(generator=rag_generator, retriever=retriever)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -609,7 +594,6 @@ def test_summarizer_calculate_metrics(document_store_with_docs: ElasticsearchDoc
     document_store_with_docs.update_embeddings(retriever=retriever)
     pipeline = SearchSummarizationPipeline(retriever=retriever, summarizer=summarizer, return_in_answer_format=True)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -637,7 +621,6 @@ def test_summarizer_calculate_metrics(document_store_with_docs: ElasticsearchDoc
 def test_faq_calculate_metrics(retriever_with_docs):
     pipeline = FAQPipeline(retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -663,7 +646,6 @@ def test_extractive_qa_eval_translation(reader, retriever_with_docs, de_to_en_tr
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     pipeline = TranslationWrapperPipeline(input_translator=de_to_en_translator, output_translator=de_to_en_translator, pipeline=pipeline)
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -698,7 +680,6 @@ def test_question_generation_eval(retriever_with_docs, question_generator):
     pipeline = RetrieverQuestionGenerationPipeline(retriever=retriever_with_docs, question_generator=question_generator)
 
     eval_result: EvaluationResult = pipeline.eval(
-        queries=EVAL_QUERIES, 
         labels=EVAL_LABELS,
         params={"Retriever": {"top_k": 5}}
     )
@@ -738,15 +719,13 @@ def test_qa_multi_retriever_pipeline_eval(document_store_with_docs, reader):
 
     # EVAL_QUERIES: 2 go dpr way
     # in Berlin goes es way
-    queries = EVAL_QUERIES + ["in Berlin"]
     labels = EVAL_LABELS + [
-        MultiLabel(labels=[Label(query="Berlin", answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]), 
+        MultiLabel(labels=[Label(query="in Berlin", answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]), 
             document=Document(id='a0747b83aea0b60c4b114b15476dd32d', content_type="text", content='My name is Carla and I live in Berlin'), 
             is_correct_answer=True, is_correct_document=True, origin="gold-label")])
             ]
 
     eval_result: EvaluationResult = pipeline.eval(
-        queries=queries, 
         labels=labels,
         params={"ESRetriever": {"top_k": 5}, "DPRRetriever": {"top_k": 5}}
     )
@@ -789,15 +768,13 @@ def test_multi_retriever_pipeline_eval(document_store_with_docs, reader):
 
     # EVAL_QUERIES: 2 go dpr way
     # in Berlin goes es way
-    queries = EVAL_QUERIES + ["in Berlin"]
     labels = EVAL_LABELS + [
-        MultiLabel(labels=[Label(query="Berlin", answer=None, 
+        MultiLabel(labels=[Label(query="in Berlin", answer=None, 
             document=Document(id='a0747b83aea0b60c4b114b15476dd32d', content_type="text", content='My name is Carla and I live in Berlin'), 
             is_correct_answer=True, is_correct_document=True, origin="gold-label")])
             ]
 
     eval_result: EvaluationResult = pipeline.eval(
-        queries=queries, 
         labels=labels,
         params={"ESRetriever": {"top_k": 5}, "DPRRetriever": {"top_k": 5}}
     )
@@ -837,15 +814,13 @@ def test_multi_retriever_pipeline_with_asymmetric_qa_eval(document_store_with_do
 
     # EVAL_QUERIES: 2 go dpr way
     # in Berlin goes es way
-    queries = EVAL_QUERIES + ["in Berlin"]
     labels = EVAL_LABELS + [
-        MultiLabel(labels=[Label(query="Berlin", answer=None, 
+        MultiLabel(labels=[Label(query="in Berlin", answer=None, 
             document=Document(id='a0747b83aea0b60c4b114b15476dd32d', content_type="text", content='My name is Carla and I live in Berlin'), 
             is_correct_answer=True, is_correct_document=True, origin="gold-label")])
             ]
 
     eval_result: EvaluationResult = pipeline.eval(
-        queries=queries, 
         labels=labels,
         params={"ESRetriever": {"top_k": 5}, "DPRRetriever": {"top_k": 5}}
     )


### PR DESCRIPTION
**Proposed changes**:
- get rid of redundant queries param in pipeline.eval()

Each label already contains the query.
