### PR TITLE
Fix typo

### DIFF
--- a/haystack/modeling/data_handler/dataset.py
+++ b/haystack/modeling/data_handler/dataset.py
@@ -43,7 +43,7 @@ def convert_features_to_dataset(features):
     all_tensors = []
     for t_name in tensor_names:
         try:
-            # Checking weather a non-integer will be silently converted to torch.long
+            # Checking whether a non-integer will be silently converted to torch.long
             check = features[0][t_name]
             if isinstance(check, numbers.Number):
                 base = check

--- a/haystack/modeling/data_handler/processor.py
+++ b/haystack/modeling/data_handler/processor.py
@@ -433,7 +433,7 @@ class SquadProcessor(Processor):
 
         :param dicts: dict, input dictionary with SQuAD style information present
         :param indices: list, indices used during multiprocessing so that IDs assigned to our baskets is unique
-        :param return_baskets: boolean, weather to return the baskets or not (baskets are needed during inference)
+        :param return_baskets: boolean, whether to return the baskets or not (baskets are needed during inference)
         """
         # Convert to standard format
         pre_baskets = [self.convert_qa_input_dict(x) for x in dicts] # TODO move to input object conversion
@@ -955,7 +955,7 @@ class TextSimilarityProcessor(Processor):
                                         ]
                          }
         :param indices: indices used during multiprocessing so that IDs assigned to our baskets is unique
-        :param return_baskets: weather to return the baskets or not (baskets are needed during inference)
+        :param return_baskets: whether to return the baskets or not (baskets are needed during inference)
         :return dataset, tensor_names, problematic_ids, [baskets]
         """
         # Take the dict and insert into our basket structure, this stages also adds an internal IDs
@@ -1433,7 +1433,7 @@ class TableTextSimilarityProcessor(Processor):
                                         ]
                          }
         :param indices: list, indices used during multiprocessing so that IDs assigned to our baskets is unique
-        :param return_baskets: boolean, weather to return the baskets or not (baskets are needed during inference)
+        :param return_baskets: boolean, whether to return the baskets or not (baskets are needed during inference)
         """
 
         # Take the dict and insert into our basket structure, this stages also adds an internal IDs

--- a/haystack/modeling/data_handler/samples.py
+++ b/haystack/modeling/data_handler/samples.py
@@ -174,7 +174,7 @@ def offset_to_token_idx_vecorized(token_offsets, ch_idx):
     # case ch_idx is at end of tokens
     if ch_idx >= np.max(token_offsets):
         # TODO check "+ 1" (it is needed for making end indices compliant with old offset_to_token_idx() function)
-        # check weather end token is incluse or exclusive
+        # check whether end token is incluse or exclusive
         idx = np.argmax(token_offsets) + 1
     # looking for the first occurence of token_offsets larger than ch_idx and taking one position to the left.
     # This is needed to overcome n special_tokens at start of sequence

--- a/haystack/modeling/model/optimization.py
+++ b/haystack/modeling/model/optimization.py
@@ -1,4 +1,4 @@
-#TODO analyse if this optimization is needed or weather we can use HF transformers code
+#TODO analyse if this optimization is needed or whether we can use HF transformers code
 from typing import Dict, Any
 
 import inspect


### PR DESCRIPTION
Hi there,

thanks a stack for conceiving this framework. While we haven't used it yet, we hope to be able to find some time soon. Our general interest is related to the topic of natural language question answering in the domain of weather forecasts, see also https://github.com/deepset-ai/haystack/issues/573#issuecomment-990305673 and https://github.com/earthobservations/weather-nlp/issues/4.

In this manner, this very little patch fixes some occurrences in the code base where the word "weather" was used, while "whether" would have been applicable.

With kind regards,
Andreas.
