### PR TITLE
Correct bug with encoding when generating Markdown documentation issue #1880

### DIFF
--- a/docs/_src/tutorials/tutorials/convert_ipynb.py
+++ b/docs/_src/tutorials/tutorials/convert_ipynb.py
@@ -26,7 +26,7 @@ e = MarkdownExporter(exclude_output=True)
 for i, nb in enumerate(notebooks):
     body, resources = e.from_filename(dir / nb)
     print(f"Processing {dir}/{nb}")
-    with open(str(i + 1) + ".md", "w") as f:
+    with open(str(i + 1) + ".md", "w", encoding='utf-8') as f:
         f.write(headers[i + 1] + "\n\n")
         f.write(body)
 


### PR DESCRIPTION
**Proposed changes**:
- Adding UTF-8 encoding when reading the notebooks.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests - *no need; tested just by executing the command to generate the documentation*
- [x] Updated documentation - *no need*
