### PR TITLE
Fix WIndows CI

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.8
       - name: Test with mypy
         run: |
-          pip install mypy types-Markdown types-requests types-PyYAML pydantic
+          pip install mypy==0.910 types-Markdown types-requests types-PyYAML pydantic
           mypy haystack
 
   build-cache:


### PR DESCRIPTION
In my previous PR, I only set the version for mypy in the Linux CI. This PR also sets the version for mpy to 0.910 in the Windows CI, as  the newly released mypy version 0.920 seems to be incompatible with pydantic. We should review at a later point of time if future versions are compatible again.
