### PR TITLE
Convert doc embedding from ndarray to list of float for REST API

### DIFF
--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -75,8 +75,8 @@ def _process_request(pipeline, request) -> QueryResponse:
     result = pipeline.run(query=request.query, params=params,debug=request.debug)
     
     # if any of the documents contains an embedding as an ndarray the latter needs to be converted to list of float
-    if any(isinstance(document.embedding, ndarray) for document in result['documents']):
-        for document in result['documents']:
+    for document in result['documents']:
+        if isinstance(document.embedding, ndarray):
             document.embedding = document.embedding.tolist()
     
     end_time = time.time()

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -75,7 +75,7 @@ def _process_request(pipeline, request) -> QueryResponse:
     result = pipeline.run(query=request.query, params=params,debug=request.debug)
     
     # if any of the documents contains an embedding as an ndarray the latter needs to be converted to list of float
-    for document in result['documents']:
+    for document in result['documents'] or []:
         if isinstance(document.embedding, ndarray):
             document.embedding = document.embedding.tolist()
     

--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -2,6 +2,7 @@ import logging
 import time
 import json
 from pathlib import Path
+from numpy import ndarray
 
 from fastapi import APIRouter
 
@@ -72,6 +73,12 @@ def _process_request(pipeline, request) -> QueryResponse:
             params[key]["filters"] = _format_filters(params[key]["filters"])
 
     result = pipeline.run(query=request.query, params=params,debug=request.debug)
+    
+    # if any of the documents contains an embedding as an ndarray the latter needs to be converted to list of float
+    if any(isinstance(document.embedding, ndarray) for document in result['documents']):
+        for document in result['documents']:
+            document.embedding = document.embedding.tolist()
+    
     end_time = time.time()
     logger.info(json.dumps({"request": request, "response": result, "time": f"{(end_time - start_time):.2f}"}, default=str))
 


### PR DESCRIPTION
- QueryResponse needs to be a dictionary where the documents contain embeddings as list of float but currently they are of type ndarray

**Proposed changes**:
Before returning the result of search queries check if any document contains an embedding of the wrong type and if so convert all of them.

The existing `to_json()` method of Document is never called neither by pydantic nor fastAPI. We should discuss whether a nicer solution than this PR that leverages the NumpyEncoder instead is possible. An alternative is described below.

closes #1815

**Alternative:**
As an alternative, we could only make changes in `rest_api/schema.py`, which define how to encode **QueryResponse** as json and keep the type of `embedding` in `DocumentSerialized` a `np.ndarray` (as in `Document`). In that case, the encoding is triggered by fastAPI.

```
@pydantic_dataclass
class DocumentSerialized(Document):
    content: str

class QueryResponse(BaseModel):
    query: str
    answers: List[AnswerSerialized]
    documents: Optional[List[DocumentSerialized]]
    debug: Optional[Dict] = Field(None, alias="_debug")

    class Config:
        json_encoders = {np.ndarray: lambda s: s.tolist()}
```

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
