### PR TITLE
Unpin ray version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ pymilvus
 SPARQLWrapper
 mmh3
 weaviate-client==2.5.0
-ray==1.5.0
+ray>=1.5.0,<=1.8.0
 dataclasses-json
 quantulum3
 azure-ai-formrecognizer==3.2.0b2


### PR DESCRIPTION
Related to #1310 
Motivated by compatibility problems between `ray==1.5.0` and M1 processors.

**Proposed changes**:
- Include later ray versions`ray>=1.5.0,<=1.8.0`

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Update the docs ([PR](https://github.com/deepset-ai/haystack-website/pull/223))