### PR TITLE
Fix Numba TypingError in `normalize_embedding` for cosine similarity

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -104,11 +104,13 @@ object, provided that they have the same product_id (to be found in Label.meta["
 #### normalize\_embedding
 
 ```python
+ | @staticmethod
  | @njit
  | normalize_embedding(emb: np.ndarray) -> None
 ```
 
-Performs L2 normalization of embeddings vector inplace. Input can be a single vector (1D array) or a matrix (2D array).
+Performs L2 normalization of embeddings vector inplace. Input can be a single vector (1D array) or a matrix
+(2D array).
 
 <a name="base.BaseDocumentStore.add_eval_data"></a>
 #### add\_eval\_data

--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -191,22 +191,27 @@ class BaseDocumentStore(BaseComponent):
     def get_document_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
         pass
 
+    @staticmethod
     @njit#(fastmath=True)
-    def normalize_embedding(self, emb: np.ndarray) -> None:
+    def normalize_embedding(emb: np.ndarray) -> None:
         """
-        Performs L2 normalization of embeddings vector inplace. Input can be a single vector (1D array) or a matrix (2D array).
+        Performs L2 normalization of embeddings vector inplace. Input can be a single vector (1D array) or a matrix
+        (2D array).
         """
         # Might be extended to other normalizations in future
 
         # Single vec
         if len(emb.shape) == 1:
-            norm = np.sqrt(emb.dot(emb)) #faster than np.linalg.norm()
+            norm = np.sqrt(emb.dot(emb))  # faster than np.linalg.norm()
             if norm != 0.0:
                 emb /= norm
         # 2D matrix
         else:
-            norm = np.linalg.norm(emb, axis=1)
-            emb /= norm[:, None]
+            for vec in emb:
+                vec = np.ascontiguousarray(vec)
+                norm = np.sqrt(vec.dot(vec))
+                if norm != 0.0:
+                    vec /= norm
 
     def finalize_raw_score(self, raw_score: float, similarity: Optional[str]) -> float:
         if similarity == "cosine":


### PR DESCRIPTION
This PR fixes a Numba `TypingError` that occured when using a `DocumentStore` with `cosine` as similarity metric. There were two problems in `BaseDocumentStore`'s `normalize_embedding` method:
- Numba cannot handle the type `BaseDocumentStore`. Therefore, `normalize_embedding` needs to be a static method.
- Numba cannot handle the `axis` parameter of the `np.linalg.norm` method (see [here](https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#linear-algebra))

Closes #1924
