### PR TITLE
Update Ray to version 1.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ pymilvus
 SPARQLWrapper
 mmh3
 weaviate-client==2.5.0
-ray>=1.5.0,<=1.8.0
+ray>=1.9.1
 dataclasses-json
 quantulum3
 azure-ai-formrecognizer==3.2.0b2


### PR DESCRIPTION
This PR updates Ray to version 1.9.1 and higher. Earlier versions of Ray expose security vulnerabilities due to log4j.

Closes #1921