### PR TITLE
Fix loading a saved `FAISSDocumentStore`

### DIFF
--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -106,7 +106,6 @@ class FAISSDocumentStore(SQLDocumentStore):
             sql_url=sql_url, 
             vector_dim=vector_dim, 
             faiss_index_factory_str=faiss_index_factory_str,
-            faiss_index=faiss_index, 
             return_embedding=return_embedding,
             duplicate_documents=duplicate_documents, 
             index=index, 

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -53,7 +53,14 @@ def test_faiss_index_save_and_load(tmp_path):
 
     # test saving and loading the loaded faiss index
     new_document_store.save(tmp_path / "haystack_test_faiss")
-    new_document_store.load(tmp_path / "haystack_test_faiss")
+    reloaded_document_store = FAISSDocumentStore.load(tmp_path / "haystack_test_faiss")
+
+    # check faiss index is restored
+    assert reloaded_document_store.faiss_indexes[document_store.index].ntotal == len(DOCUMENTS)
+    # check if documents are restored
+    assert len(reloaded_document_store.get_all_documents()) == len(DOCUMENTS)
+    # Check if the init parameters are kept
+    assert not reloaded_document_store.progress_bar
 
     # test loading the index via init
     new_document_store = FAISSDocumentStore(faiss_index_path=tmp_path / "haystack_test_faiss")
@@ -96,7 +103,14 @@ def test_faiss_index_save_and_load_custom_path(tmp_path):
 
     # test saving and loading the loaded faiss index
     new_document_store.save(tmp_path / "haystack_test_faiss", config_path=tmp_path / "custom_path.json")
-    new_document_store.load(tmp_path / "haystack_test_faiss", config_path=tmp_path / "custom_path.json")
+    reloaded_document_store = FAISSDocumentStore.load(tmp_path / "haystack_test_faiss", config_path=tmp_path / "custom_path.json")
+
+    # check faiss index is restored
+    assert reloaded_document_store.faiss_indexes[document_store.index].ntotal == len(DOCUMENTS)
+    # check if documents are restored
+    assert len(reloaded_document_store.get_all_documents()) == len(DOCUMENTS)
+    # Check if the init parameters are kept
+    assert not reloaded_document_store.progress_bar
 
     # test loading the index via init
     new_document_store = FAISSDocumentStore(faiss_index_path=tmp_path / "haystack_test_faiss", faiss_config_path=tmp_path / "custom_path.json")

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -51,6 +51,10 @@ def test_faiss_index_save_and_load(tmp_path):
     # Check if the init parameters are kept
     assert not new_document_store.progress_bar
 
+    # test saving and loading the loaded faiss index
+    new_document_store.save(tmp_path / "haystack_test_faiss")
+    new_document_store.load(tmp_path / "haystack_test_faiss")
+
     # test loading the index via init
     new_document_store = FAISSDocumentStore(faiss_index_path=tmp_path / "haystack_test_faiss")
 
@@ -89,6 +93,10 @@ def test_faiss_index_save_and_load_custom_path(tmp_path):
     assert len(new_document_store.get_all_documents()) == len(DOCUMENTS)
     # Check if the init parameters are kept
     assert not new_document_store.progress_bar
+
+    # test saving and loading the loaded faiss index
+    new_document_store.save(tmp_path / "haystack_test_faiss", config_path=tmp_path / "custom_path.json")
+    new_document_store.load(tmp_path / "haystack_test_faiss", config_path=tmp_path / "custom_path.json")
 
     # test loading the index via init
     new_document_store = FAISSDocumentStore(faiss_index_path=tmp_path / "haystack_test_faiss", faiss_config_path=tmp_path / "custom_path.json")


### PR DESCRIPTION
Loading a saved `FAISSDocumentStore` resulted in the following error: 
`TypeError: Object of type IndexFlat is not JSON serializable`

To fix this, I removed the `faiss_index` parameter from the config, as this cannot be serialized. 

Closes #1932