### PR TITLE
Fix retrieving documents in `WeaviateDocumentStore` with `content_type=None`

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -7,7 +7,6 @@ import logging
 import json
 import numpy as np
 from tqdm import tqdm
-import pandas as pd
 
 from haystack.schema import Document
 from haystack.document_stores import BaseDocumentStore
@@ -220,6 +219,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
             # Converting JSON-string to original datatype (string or nested list)
             content = json.loads(str(props.get(self.content_field)))
 
+        content_type = None
         if props.get("contenttype") is not None:
             content_type = str(props.pop("contenttype"))
 


### PR DESCRIPTION
If we add Documents to `WeaviateDocumentStore` with `content_type=None`, we are not able to retrieve these Documents as `_convert_weaviate_result_to_document` will run into an `UnboundLocalError`. This PR makes sure that if we add a Document with `content_type=None`, we are setting `content_type` to `None` also when retrieving these documents.

Related to #1929