### PR TITLE
Fixed the grammatical issue in optimization guides #1940

### DIFF
--- a/docs/_src/usage/usage/optimization.md
+++ b/docs/_src/usage/usage/optimization.md
@@ -42,7 +42,7 @@ which is why we recommend using the `PreProcessor` class to clean and split your
 
 For **sparse retrievers**, very long documents pose a challenge since the signal of the relevant section of text
 can get washed out by the rest of the document.
-To get a good balance between Reader speed and Retriever performance, we splitting documents to a maximum of 500 words. 
+To get a good balance between Reader speed and Retriever performance, we split documents to a maximum of 500 words. 
 If there is no Reader in the pipeline following the Retriever, we recommend that **documents be no longer than 10,000 words**.
 
 **Dense retrievers** are limited in the length of text that they can read in one pass.

--- a/docs/v0.10.0/_src/usage/usage/optimization.md
+++ b/docs/v0.10.0/_src/usage/usage/optimization.md
@@ -42,7 +42,7 @@ which is why we recommend using the `PreProcessor` class to clean and split your
 
 For **sparse retrievers**, very long documents pose a challenge since the signal of the relevant section of text
 can get washed out by the rest of the document.
-To get a good balance between Reader speed and Retriever performance, we splitting documents to a maximum of 500 words. 
+To get a good balance between Reader speed and Retriever performance, we split documents to a maximum of 500 words. 
 If there is no Reader in the pipeline following the Retriever, we recommend that **documents be no longer than 10,000 words**.
 
 **Dense retrievers** are limited in the length of text that they can read in one pass.

--- a/docs/v0.9.0/_src/usage/usage/optimization.md
+++ b/docs/v0.9.0/_src/usage/usage/optimization.md
@@ -42,7 +42,7 @@ which is why we recommend using the `PreProcessor` class to clean and split your
 
 For **sparse retrievers**, very long documents pose a challenge since the signal of the relevant section of text
 can get washed out by the rest of the document.
-To get a good balance between Reader speed and Retriever performance, we splitting documents to a maximum of 500 words. 
+To get a good balance between Reader speed and Retriever performance, we split documents to a maximum of 500 words. 
 If there is no Reader in the pipeline following the Retriever, we recommend that **documents be no longer than 10,000 words**.
 
 **Dense retrievers** are limited in the length of text that they can read in one pass.

--- a/docs/v1.0.0/_src/usage/usage/optimization.md
+++ b/docs/v1.0.0/_src/usage/usage/optimization.md
@@ -42,7 +42,7 @@ which is why we recommend using the `PreProcessor` class to clean and split your
 
 For **sparse retrievers**, very long documents pose a challenge since the signal of the relevant section of text
 can get washed out by the rest of the document.
-To get a good balance between Reader speed and Retriever performance, we splitting documents to a maximum of 500 words. 
+To get a good balance between Reader speed and Retriever performance, we split documents to a maximum of 500 words. 
 If there is no Reader in the pipeline following the Retriever, we recommend that **documents be no longer than 10,000 words**.
 
 **Dense retrievers** are limited in the length of text that they can read in one pass.


### PR DESCRIPTION
There was a small grammatical mistake on the page [https://haystack.deepset.ai/guides/optimization](url). The error was under "Document Length" in the second paragraph. The error was "we splitting documents to a maximum of 500 words " it should have been "we split documents to a maximum of 500 words."


**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [x] Updated documentation
