### PR TITLE
Use CommitID for Docker tags 

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -34,7 +34,7 @@ jobs:
             latest=true
           tags: |
             type=ref,event=tag
-            type=sha
+            type=sha,format=long
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Commit IDs might be easier to copy-paste than the SHA.