### PR TITLE
fix UserWarning from slow tensor conversion

### DIFF
--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -625,6 +625,12 @@ Each row and each column is given a score with regard to the query by two separa
 is then calculated as the sum of the corresponding row score and column score. Accordingly, the predicted answer is
 the cell with the highest score.
 
+Pros and Cons of RCIReader compared to TableReader:
++ Provides meaningful confidence scores
++ Allows larger tables as input
+- Does not support aggregation over table cells
+- Slower
+
 <a name="table.RCIReader.__init__"></a>
 #### \_\_init\_\_
 

--- a/haystack/modeling/data_handler/dataset.py
+++ b/haystack/modeling/data_handler/dataset.py
@@ -62,7 +62,7 @@ def convert_features_to_dataset(features):
                            "Converting now to a tensor of default type long.")
 
         # Convert all remaining python objects to torch long tensors
-        cur_tensor = torch.tensor([sample[t_name] for sample in features], dtype=torch.long)
+        cur_tensor = torch.as_tensor(np.array([sample[t_name] for sample in features]), dtype=torch.long)
 
         all_tensors.append(cur_tensor)
 


### PR DESCRIPTION
**Proposed changes**:
- this fixes https://github.com/deepset-ai/haystack/issues/1945 . According to torch, a list of numpy arrays should be converted to an array first for perfomance reasons.
- not sure if this needs tests as so far the function is not tested directly and it's probably tested at  a higher level.

**Status (please check what you already did)**:
- [ x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
