### PR TITLE
Upgrade torch version

### DIFF
--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -1,4 +1,4 @@
-FROM  nvidia/cuda:11.0-runtime-ubuntu20.04
+FROM  nvidia/cuda:11.1-runtime-ubuntu20.04
 
 WORKDIR /home/user
 
@@ -39,7 +39,7 @@ COPY setup.py requirements.txt README.md /home/user/
 
 RUN echo "Install required packages" && \
     # Install PyTorch for CUDA 11
-    pip3 install torch==1.10.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html && \
+    pip3 install torch==1.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html && \
     # Install faiss separately as building latest versions can cause trouble with swig
     pip3 install faiss-cpu==1.6.3 && \
     # Install extra packages

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -39,7 +39,7 @@ COPY setup.py requirements.txt README.md /home/user/
 
 RUN echo "Install required packages" && \
     # Install PyTorch for CUDA 11
-    pip3 install torch==1.7.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html && \
+    pip3 install torch==1.10.1+cu110 -f https://download.pytorch.org/whl/torch_stable.html && \
     # Install faiss separately as building latest versions can cause trouble with swig
     pip3 install faiss-cpu==1.6.3 && \
     # Install extra packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ wheel
 # PyTorch
 # Temp. disabled the next line as it gets currently resolved to https://download.pytorch.org/whl/rocm3.8/torch-1.7.1%2Brocm3.8-cp38-cp38-linux_x86_64.whl
 # --find-links=https://download.pytorch.org/whl/torch_stable.html
-torch>1.5,<1.11
+torch>1.9,<1.11
 # progress bars in model download and training scripts
 tqdm
 # Used for downloading models over HTTP


### PR DESCRIPTION
We use `torch.set_warn_always` [here](torch.set_warn_always) that was introduced in torch v1.9.0.

This PR upgrades the minimum required version for PyTorch. 