### PR TITLE
Use scikit-learn, not sklearn, in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ tqdm
 requests
 # Scipy & sklearn for stats in run_classifier
 scipy>=1.3.2
-sklearn
+scikit-learn>=1.0.0
 # Metrics or logging related
 seqeval
 mlflow<=1.13.1


### PR DESCRIPTION
**Proposed changes**:

Solves #1963

As discussed in the issue, the correct dependency should be `scikit-learn`, not `sklearn`. This change should have no impact on actual behavior because `scikit-learn` was still installed correctly as a 3rd party dependency.

I took the freedom to add `>=1.0.0` as version (which is already met currently).

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
