### PR TITLE
Add who uses Haystack section

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,4 +290,6 @@ Thanks so much to all those who have contributed to our project!
 
 Here's a list of organizations who use Haystack. Don't hessitate to send a PR to let the world know that you use Haystack. Join our growing community!
 
-- 
+- [Airbus](https://www.airbus.com/en)
+- [Alcatel-Lucent](https://www.al-enterprise.com/)
+- [Etalab](https://www.etalab.gouv.fr/)

--- a/README.md
+++ b/README.md
@@ -292,4 +292,5 @@ Here's a list of organizations who use Haystack. Don't hessitate to send a PR to
 
 - [Airbus](https://www.airbus.com/en)
 - [Alcatel-Lucent](https://www.al-enterprise.com/)
+- [Deepset](https://deepset.ai/)
 - [Etalab](https://www.etalab.gouv.fr/)

--- a/README.md
+++ b/README.md
@@ -294,3 +294,6 @@ Here's a list of organizations who use Haystack. Don't hesitate to send a PR to 
 - [Alcatel-Lucent](https://www.al-enterprise.com/)
 - [Deepset](https://deepset.ai/)
 - [Etalab](https://www.etalab.gouv.fr/)
+- [BetterUp](https://www.betterup.com/)
+- [Sooth.ai](https://sooth.ai/)
+- [Infineon](https://www.infineon.com/)

--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ Here's a list of organizations who use Haystack. Don't hesitate to send a PR to 
 
 - [Airbus](https://www.airbus.com/en)
 - [Alcatel-Lucent](https://www.al-enterprise.com/)
+- [BetterUp](https://www.betterup.com/)
 - [Deepset](https://deepset.ai/)
 - [Etalab](https://www.etalab.gouv.fr/)
-- [BetterUp](https://www.betterup.com/)
-- [Sooth.ai](https://sooth.ai/)
 - [Infineon](https://www.infineon.com/)
+- [Sooth.ai](https://sooth.ai/)

--- a/README.md
+++ b/README.md
@@ -284,3 +284,10 @@ Thanks so much to all those who have contributed to our project!
 <a href="https://github.com/deepset-ai/haystack/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=deepset-ai/haystack" />
 </a>
+
+
+## Who uses Haystack
+
+Here's a list of organizations who use Haystack. Don't hessitate to send a PR to let the world know that you use Haystack. Join our growing community!
+
+- 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Thanks so much to all those who have contributed to our project!
 
 ## Who uses Haystack
 
-Here's a list of organizations who use Haystack. Don't hessitate to send a PR to let the world know that you use Haystack. Join our growing community!
+Here's a list of organizations who use Haystack. Don't hesitate to send a PR to let the world know that you use Haystack. Join our growing community!
 
 - [Airbus](https://www.airbus.com/en)
 - [Alcatel-Lucent](https://www.al-enterprise.com/)


### PR DESCRIPTION
**Proposed changes**:
- Section that tells the reader about what companies already use Haystack, this helps strengthen the horizontal relationships in the community

The inspiration is taken from the [Apache Superset repository](https://github.com/apache/superset/blob/master/RESOURCES/INTHEWILD.md)

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
