### PR TITLE
Add models to demo docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ COPY haystack /home/user/haystack
 COPY setup.py requirements.txt README.md /home/user/
 RUN pip install -r requirements.txt
 RUN pip install -e .
-
-# download punkt tokenizer to be included in image
-RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data')"
+RUN python3 -c "from haystack.utils.docker import cache_models;cache_models()"
 
 # create folder for /file-upload API endpoint with write permissions, this might be adjusted depending on FILE_UPLOAD_PATH
 RUN mkdir -p /home/user/file-upload

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY haystack /home/user/haystack
 
 # install as a package
 COPY setup.py requirements.txt README.md /home/user/
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 RUN pip install -e .
 RUN python3 -c "from haystack.utils.docker import cache_models;cache_models()"

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -43,9 +43,6 @@ RUN echo "Install required packages" && \
     # Install from requirements.txt		
     pip3 install -r requirements.txt
 
-# download punkt tokenizer to be included in image
-RUN python3 -c "import nltk;nltk.download('punkt', download_dir='/usr/nltk_data')"
-
 # copy saved models
 COPY README.md models* /home/user/models/
 
@@ -57,6 +54,9 @@ COPY haystack /home/user/haystack
 
 # Install package
 RUN pip3 install -e .
+
+# Cache Roberta and NLTK data
+RUN python3 -c "from haystack.utils.docker import cache_models;cache_models()"
 
 # optional : copy sqlite db if needed for testing
 #COPY qa.db /home/user/

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -37,6 +37,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 
 # Copy package setup files
 COPY setup.py requirements.txt README.md /home/user/
 
+RUN pip install --upgrade pip
 RUN echo "Install required packages" && \
     # Install PyTorch for CUDA 11
     pip3 install torch==1.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html && \

--- a/haystack/utils/docker.py
+++ b/haystack/utils/docker.py
@@ -1,0 +1,15 @@
+
+def cache_models():
+    """
+    Small function that caches models and other data.
+    Used only in the Dockerfile to include these caches in the images.
+    """
+    # download punkt tokenizer
+    import nltk
+    nltk.download('punkt', download_dir='/usr/nltk_data')
+    
+    # Cache roberta-base-squad2 model
+    import transformers
+    model_to_cache='deepset/roberta-base-squad2'
+    transformers.AutoTokenizer.from_pretrained(model_to_cache)
+    transformers.AutoModel.from_pretrained(model_to_cache)

--- a/haystack/utils/docker.py
+++ b/haystack/utils/docker.py
@@ -1,3 +1,4 @@
+import logging
 
 def cache_models():
     """
@@ -5,10 +6,12 @@ def cache_models():
     Used only in the Dockerfile to include these caches in the images.
     """
     # download punkt tokenizer
+    logging.info("Caching punkt data")
     import nltk
-    nltk.download('punkt', download_dir='/usr/nltk_data')
+    nltk.download('punkt', download_dir='/root/nltk_data')
     
     # Cache roberta-base-squad2 model
+    logging.info("Caching deepset/roberta-base-squad2")
     import transformers
     model_to_cache='deepset/roberta-base-squad2'
     transformers.AutoTokenizer.from_pretrained(model_to_cache)


### PR DESCRIPTION
Introduces a small utility to download and cache the demo's model and NLTK data, then modifies Dockerimage and Dockerimage-GPU to call this function at build time.

This will provide users with a demo that does not need to download any model at its first run, making the demo installation process easier and a bit faster too.

Closes #1652 
