### PR TITLE
Fix elasticsearch scores if they are 0.0

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -957,7 +957,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         if name:
             meta_data["name"] = name
 
-        score = hit["_score"] if hit["_score"] is not None else None
+        score = hit["_score"]
         if score:
             if adapt_score_for_embedding:
                 score = self._scale_embedding_score(score)

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -957,7 +957,7 @@ class ElasticsearchDocumentStore(BaseDocumentStore):
         if name:
             meta_data["name"] = name
 
-        score = hit["_score"] if hit["_score"] else None
+        score = hit["_score"] if hit["_score"] is not None else None
         if score:
             if adapt_score_for_embedding:
                 score = self._scale_embedding_score(score)


### PR DESCRIPTION
**Proposed changes**:
- do not set scores to None if the returned score from elasticsearch is 0.0

**impact**:
Downstream nodes like `JoinDocument`cannot deal with `None` scores.

fixes https://github.com/deepset-ai/haystack/issues/1911