### PR TITLE
Upgrade pillow version to 9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ coverage
 langdetect # for PDF conversions
 # for PDF conversions using OCR
 pytesseract==0.3.7 
-pillow==8.3.2
+pillow==9.0.0
 pdf2image==1.14.0
 sentence-transformers>=0.4.0
 python-multipart


### PR DESCRIPTION
Pillow:8.3.2 for python pil/pdfparser.py pdf parsing improper regular expression dos

Pillow package for python contains a flaw in pil/pdfparser.py that is triggered as carriage return characters are not properly handled in a regular expression. this may allow a context-dependent attacker to hang or slow down a python process using the library.

Security source: CVSS V3 from RBS

Fix version: 9.0.0

closes #1988 