### PR TITLE
update link to annotation tool docu

### DIFF
--- a/docs/_src/tutorials/tutorials/2.md
+++ b/docs/_src/tutorials/tutorials/2.md
@@ -54,7 +54,7 @@ from haystack.nodes import FARMReader
 
 There are two ways to generate training data
 
-1. **Annotation**: You can use the [annotation tool](https://github.com/deepset-ai/haystack#labeling-tool) to label your data, i.e. highlighting answers to your questions in a document. The tool supports structuring your workflow with organizations, projects, and users. The labels can be exported in SQuAD format that is compatible for training with Haystack.
+1. **Annotation**: You can use the [annotation tool](https://haystack.deepset.ai/guides/annotation) to label your data, i.e. highlighting answers to your questions in a document. The tool supports structuring your workflow with organizations, projects, and users. The labels can be exported in SQuAD format that is compatible for training with Haystack.
 
 ![Snapshot of the annotation tool](https://raw.githubusercontent.com/deepset-ai/haystack/master/docs/_src/img/annotation_tool.png)
 

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "There are two ways to generate training data\n",
     "\n",
-    "1. **Annotation**: You can use the [annotation tool](https://github.com/deepset-ai/haystack#labeling-tool) to label your data, i.e. highlighting answers to your questions in a document. The tool supports structuring your workflow with organizations, projects, and users. The labels can be exported in SQuAD format that is compatible for training with Haystack.\n",
+    "1. **Annotation**: You can use the [annotation tool](https://haystack.deepset.ai/guides/annotation) to label your data, i.e. highlighting answers to your questions in a document. The tool supports structuring your workflow with organizations, projects, and users. The labels can be exported in SQuAD format that is compatible for training with Haystack.\n",
     "\n",
     "![Snapshot of the annotation tool](https://raw.githubusercontent.com/deepset-ai/haystack/master/docs/_src/img/annotation_tool.png)\n",
     "\n",


### PR DESCRIPTION
**Proposed changes**:
- Changed the link to the annotation tool to https://haystack.deepset.ai/guides/annotation (old link was pointing to a subsection of the readme that does not exist anymore)

Alternative link would have been https://annotate.deepset.ai/ but then users wouldn't be able to learn that they can host the tool themselves and what it does.