### PR TITLE
Disable pip cache for Dockerfiles

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - docker-reduce-size
 
 jobs:
   build:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - docker-build
+      - docker-reduce-size
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,20 @@ FROM python:3.7.4-stretch
 
 WORKDIR /home/user
 
-RUN apt-get update && apt-get install -y curl git pkg-config cmake
+RUN apt-get update && apt-get install -y \
+    curl  \
+    git  \
+    pkg-config  \
+    cmake \
+    libpoppler-cpp-dev  \
+    tesseract-ocr  \
+    libtesseract-dev  \
+    poppler-utils && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install PDF converter
 RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && \
     tar -xvf xpdf-tools-linux-4.03.tar.gz && cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
-
-RUN apt-get install libpoppler-cpp-dev pkg-config -y --fix-missing
-
-# Install Tesseract
-RUN apt-get install tesseract-ocr libtesseract-dev poppler-utils -y
 
 # copy code
 COPY haystack /home/user/haystack
@@ -19,7 +23,7 @@ COPY haystack /home/user/haystack
 # install as a package
 COPY setup.py requirements.txt README.md /home/user/
 RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install -e .
 RUN python3 -c "from haystack.utils.docker import cache_models;cache_models()"
 

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -1,4 +1,4 @@
-FROM  nvidia/cuda:11.1-runtime-ubuntu20.04
+FROM nvidia/cuda:11.1-runtime-ubuntu20.04
 
 WORKDIR /home/user
 
@@ -11,7 +11,7 @@ RUN mkdir -p /home/user/file-upload && chmod 777 /home/user/file-upload
 # Install software dependencies
 RUN apt-get update && apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
-    apt-get update && apt-get install -y \
+    apt-get install -y \
         cmake \
         curl \
         git \
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y software-properties-common && \
         python3.7-distutils \
         swig \
         tesseract-ocr \
-        wget
+        wget && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install PDF converter
 RUN curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.03/bin64/pdftotext
@@ -40,9 +41,9 @@ COPY setup.py requirements.txt README.md /home/user/
 RUN pip install --upgrade pip
 RUN echo "Install required packages" && \
     # Install PyTorch for CUDA 11
-    pip3 install torch==1.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html && \
-    # Install from requirements.txt		
-    pip3 install -r requirements.txt
+    pip3 install --no-cache-dir torch==1.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html && \
+    # Install from requirements.txt
+    pip3 install --no-cache-dir -r requirements.txt
 
 # copy saved models
 COPY README.md models* /home/user/models/


### PR DESCRIPTION
With this PR, 

- `haystack-cpu` Docker Image compressed size is reduced to 2.01 GB from 3.11 GB.
- `haystack-gpu` Docker Image compressed size is reduced to 4.4 GB from 6.66 GB.