### PR TITLE
Bugfix - save_to_yaml for OpenSearchDocumentStore

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -723,7 +723,7 @@ class Pipeline(BasePipeline):
                 # the 'ElasticsearchDocumentStore'. There are no parameters added within the constructor. 
                 # However, since 'inspect.signature' only returns the parameters defined in the respective 
                 # constructor, only explicitly overwritten arguments are returned. Therefore we need to use the parent class
-                # to fetch the parameters. 
+                # to fetch the parameters. See https://github.com/deepset-ai/haystack/issues/2012 for additional information.
                 component_signature = inspect.signature(ElasticsearchDocumentStore).parameters 
             else:
                 component_signature = inspect.signature(type(component_instance)).parameters

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -720,7 +720,7 @@ class Pipeline(BasePipeline):
             components[node] = {"name": node, "type": component_type, "params": {}}
             
             component_parent_classes = inspect.getmro(type(component_instance))
-            component_signature = {}
+            component_signature: dict = {}
             for component_parent in component_parent_classes:
                 component_signature = {**component_signature, **inspect.signature(component_parent).parameters}
                 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -25,7 +25,6 @@ except:
 from haystack.schema import EvaluationResult, MultiLabel, Document
 from haystack.nodes.base import BaseComponent
 from haystack.document_stores.base import BaseDocumentStore
-from haystack.document_stores.elasticsearch import OpenSearchDocumentStore, OpenDistroElasticsearchDocumentStore, ElasticsearchDocumentStore
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
**Proposed changes**:
Use parameters from `ElasticSearchDocumentStore` to fetch the signature, since `OpenSearchDocumentStore `and `OpenDistroElasticsearchDocumentStore` will return an incomplete list of availiable parameters.

linked issue #2012 

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
