### PR TITLE
Pin Milvus to <2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ more_itertools
 networkx
 # Refer milvus version support matrix at https://github.com/milvus-io/pymilvus#install-pymilvus
 # For milvus 2.x version use this library `pymilvus===2.0.0rc6`
-pymilvus
+pymilvus<2.0.0
 # Optional: For crawling
 #selenium
 #webdriver-manager


### PR DESCRIPTION
Due to the new 2.0.0 release, we should pin `pymilvus<2.0.0` for now
