### PR TITLE
Make the docstring bot work only on master

### DIFF
--- a/.github/workflows/update_docsstrings_tutorials.yml
+++ b/.github/workflows/update_docsstrings_tutorials.yml
@@ -3,10 +3,10 @@ name: Update Docstrings and Tutorials
 # Controls when the action will run. Triggers the workflow on push 
 # events but only for the master branch
 on:
+  workflow_dispatch:
   push:
-    branches-ignore:
+    branches:
       - master
-      - benchmarks
 
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Right now it commits the updates on every branch, which is a bit distracting, especially for external contributors. This change makes the bot work only on pushes to `master`, removing the disturbance for open PRs.

Adds a `workflow_dispatch` trigger to allow manual triggers of this action if needed.