### PR TITLE
Fixed the Search Field mapping in ElasticSearch DocumentStore

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -302,8 +302,13 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                 }
             }
             if self.search_fields:
+                if self.synonyms:
+                    search_fields_mapping = {"type": "text", "analyzer": "synonym"}
+                else:
+                    search_fields_mapping = {"type": "text"}
+
                 for field in self.search_fields:
-                    mapping["mappings"]["properties"].update({field: {"type": "text"}})
+                    mapping["mappings"]["properties"].update({field: search_fields_mapping})
 
             if self.synonyms:
                 mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -280,8 +280,7 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
             mapping = {
                 "mappings": {
                     "properties": {
-                        self.name_field: {"type": "keyword"},
-                        self.content_field: {"type": "text"},
+                        self.name_field: {"type": "keyword"}
                     },
                     "dynamic_templates": [
                         {
@@ -301,21 +300,25 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                     }
                 }
             }
-            if self.search_fields:
-                if self.synonyms:
-                    search_fields_mapping = {"type": "text", "analyzer": "synonym"}
-                else:
-                    search_fields_mapping = {"type": "text"}
-
-                for field in self.search_fields:
-                    mapping["mappings"]["properties"].update({field: search_fields_mapping})
 
             if self.synonyms:
-                mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}
+                for field in self.search_fields:
+                    mapping["mappings"]["properties"].update({field: {"type": "text", "analyzer": "synonym"}})
+
+                if self.content_field not in self.search_fields:
+                    mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}
+
                 mapping["settings"]["analysis"]["analyzer"]["synonym"] = {"tokenizer": "whitespace",
                                                                           "filter": ["lowercase",
                                                                                      "synonym"]}
                 mapping["settings"]["analysis"]["filter"] = {"synonym": {"type": self.synonym_type, "synonyms": self.synonyms}}
+
+            else:
+                for field in self.search_fields:
+                    mapping["mappings"]["properties"].update({field: {"type": "text"}})
+
+                if self.content_field not in self.search_fields:
+                    mapping["mappings"]["properties"][self.content_field] = {"type": "text"}
 
             if self.embedding_field:
                 mapping["mappings"]["properties"][self.embedding_field] = {"type": "dense_vector", "dims": self.embedding_dim}
@@ -1361,8 +1364,7 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
             mapping = {
                 "mappings": {
                     "properties": {
-                        self.name_field: {"type": "keyword"},
-                        self.content_field: {"type": "text"},
+                        self.name_field: {"type": "keyword"}
                     },
                     "dynamic_templates": [
                         {

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -301,6 +301,10 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                     }
                 }
             }
+            if self.search_fields:
+                for field in self.search_fields:
+                    mapping["mappings"]["properties"].update({field: {"type": "text"}})
+
             if self.synonyms:
                 mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}
                 mapping["settings"]["analysis"]["analyzer"]["synonym"] = {"tokenizer": "whitespace",

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -280,7 +280,8 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
             mapping = {
                 "mappings": {
                     "properties": {
-                        self.name_field: {"type": "keyword"}
+                        self.name_field: {"type": "keyword"},
+                        self.content_field: {"type": "text"}
                     },
                     "dynamic_templates": [
                         {
@@ -304,9 +305,7 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
             if self.synonyms:
                 for field in self.search_fields:
                     mapping["mappings"]["properties"].update({field: {"type": "text", "analyzer": "synonym"}})
-
-                if self.content_field not in self.search_fields:
-                    mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}
+                mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}
 
                 mapping["settings"]["analysis"]["analyzer"]["synonym"] = {"tokenizer": "whitespace",
                                                                           "filter": ["lowercase",
@@ -316,9 +315,6 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
             else:
                 for field in self.search_fields:
                     mapping["mappings"]["properties"].update({field: {"type": "text"}})
-
-                if self.content_field not in self.search_fields:
-                    mapping["mappings"]["properties"][self.content_field] = {"type": "text"}
 
             if self.embedding_field:
                 mapping["mappings"]["properties"][self.embedding_field] = {"type": "dense_vector", "dims": self.embedding_dim}
@@ -1364,7 +1360,8 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
             mapping = {
                 "mappings": {
                     "properties": {
-                        self.name_field: {"type": "keyword"}
+                        self.name_field: {"type": "keyword"},
+                        self.content_field: {"type": "text"}
                     },
                     "dynamic_templates": [
                         {
@@ -1384,6 +1381,21 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
                     }
                 }
             }
+
+            if self.synonyms:
+                for field in self.search_fields:
+                    mapping["mappings"]["properties"].update({field: {"type": "text", "analyzer": "synonym"}})
+                mapping["mappings"]["properties"][self.content_field] = {"type": "text", "analyzer": "synonym"}
+
+                mapping["settings"]["analysis"]["analyzer"]["synonym"] = {"tokenizer": "whitespace",
+                                                                          "filter": ["lowercase",
+                                                                                     "synonym"]}
+                mapping["settings"]["analysis"]["filter"] = {"synonym": {"type": self.synonym_type, "synonyms": self.synonyms}}
+
+            else:
+                for field in self.search_fields:
+                    mapping["mappings"]["properties"].update({field: {"type": "text"}})
+
             if self.embedding_field:
 
                 if self.similarity == "cosine":

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1191,3 +1191,29 @@ def test_DeepsetCloudDocumentStore_query_by_embedding(deepset_cloud_document_sto
 
     emb_docs = deepset_cloud_document_store.query_by_embedding(query_emb)
     assert len(emb_docs) == 0
+
+
+@pytest.mark.elasticsearch
+def test_elasticsearch_search_field_mapping():
+
+    client = Elasticsearch()
+    client.indices.delete(index='haystack_search_field_mapping', ignore=[404])
+
+    index_data = [
+            {"title": "Green tea components",
+             "meta": {"content": "The green tea plant contains a range of healthy compounds that make it into the final drink","sub_content":"Drink tip"},"id": "1"},
+            {"title": "Green tea catechin",
+             "meta": {"content": "Green tea contains a catechin called epigallocatechin-3-gallate (EGCG).","sub_content":"Ingredients tip"}, "id": "2"},
+            {"title": "Minerals in Green tea",
+             "meta": {"content": "Green tea also has small amounts of minerals that can benefit your health.","sub_content":"Minerals tip"}, "id": "3"},
+            {"title": "Green tea Benefits",
+             "meta": {"content": "Green tea does more than just keep you alert, it may also help boost brain function.","sub_content":"Health tip"},"id": "4"}
+        ]
+
+    document_store = ElasticsearchDocumentStore(index="haystack_search_field_mapping",search_fields=["content", "sub_content"],content_field= "title")
+    document_store.write_documents(index_data)
+
+    indexed_settings = client.indices.get_mapping(index="haystack_search_field_mapping")
+
+    assert indexed_settings["haystack_search_field_mapping"]["mappings"]["properties"]["content"]["type"] == 'text'
+    assert indexed_settings["haystack_search_field_mapping"]["mappings"]["properties"]["sub_content"]["type"] == 'text'


### PR DESCRIPTION
Added the fix for the #2055 issue.

**Proposed changes:**
Once the search fields are set in the Elasticsearchdocument store initializing, those fields should be mapped as "text" fields while indexing. 
Added the code which will take the search fields and add the type as "text". This matches the checks added in "_create_document_index" and makes the search fields full-text searchable.


**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
