### PR TITLE
Fix CI build-cache issue causing code changes to take no effect

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager .[test]
+          pip install --upgrade --upgrade-strategy eager -e .[test]
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager .[test]
+          pip install --upgrade --upgrade-strategy eager -e .[test]
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:


### PR DESCRIPTION
Currently if the build-cache is hit, code changes take no effect:
- without editable mode, a wheel file for haystack is created and it is installed into the python env site-packages (farm_haystack-1.1.0.dist-info) linking to the haystack location. Although there is no code installed, changes of the next commit take no effect, probably due to the interplay of python caching and build chaching.
- with editable mode there is only a farm-haystack.egg-link created in the python env pointing to the haystack location

**Proposed changes**:
- install haystack in editable mode in CI scripts

