### PR TITLE
Disable cache on the CI

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -87,6 +87,9 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
+    
+    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
@@ -103,7 +106,7 @@ jobs:
       with:
           path: /var/lib/docker/
           key: linux-${{ env.date }}
-          
+
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -65,7 +65,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -28,15 +28,14 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      # - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      # - name: Cache
-      #   id: cache-python-env
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+      - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
+      - name: Cache
+        id: cache-python-env
+        uses: actions/cache@v2
+        with:
+          key: linux-${{ env.date }}
       - name: Install dependencies
-      #   if: steps.cache-python-env.outputs.cache-hit != 'true'
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[test]
@@ -65,12 +64,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
-        path: ${{ env.pythonLocation }}
-        key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+        key: linux-${{ env.date }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -20,29 +20,29 @@ jobs:
           pip install mypy==0.910 types-Markdown types-requests types-PyYAML pydantic
           mypy haystack
 
-  build-cache:
-    needs: type-check
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
-      - name: Install dependencies
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager -e .[test]
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+  # build-cache:
+  #   needs: type-check
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.7
+  #     - name: Cache
+  #       id: cache-python-env
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ env.pythonLocation }}
+  #         key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+  #     - name: Install dependencies
+  #       if: steps.cache-python-env.outputs.cache-hit != 'true'
+  #       run: |
+  #         pip install --upgrade pip
+  #         pip install --upgrade --upgrade-strategy eager -e .[test]
+  #         pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
-    needs: build-cache
+    needs: type-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -51,6 +51,7 @@ jobs:
           echo "::set-output name=matrix::$(find $(find . -type d -name test -not -path "./*env*/*") -type f -name test_*.py | jq -SR . | jq -cs .)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+
   build:
     needs: prepare-build
     runs-on: ubuntu-20.04
@@ -64,11 +65,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+    # - name: Cache
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 
@@ -95,6 +96,12 @@ jobs:
 
     - name: Install tesseract
       run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install --upgrade --upgrade-strategy eager -e .[test]
+        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
     - name: Run tests
       run: pytest -s ${{ matrix.test-path }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -43,32 +43,8 @@ jobs:
           pip install --upgrade --upgrade-strategy eager .[test]
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
-  docker-cache:
-    runs-on: ubuntu-20.04
-    steps:
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-
-      - name: Cache
-        id: cache-docker-images
-        uses: actions/cache@v2
-        with:
-          path: /var/lib/docker/
-          key: linux-${{ env.date }}
-
-      - name: Pull Docker images
-        if: steps.cache-docker-images.outputs.cache-hit != 'true'
-        run: |
-          docker pull elasticsearch:7.9.2
-          docker pull milvusdb/milvus:1.1.0-cpu-d050721-5e559c
-          docker pull semitechnologies/weaviate:1.7.2
-          docker pull deepset/graphdb-free:9.4.1-adoptopenjdk11
-          docker pull apache/tika:1.24.1
-          docker pull axarev/parsr:v1.2.2
-
   prepare-build:
-    needs: 
-     - build-cache
-     - docker-cache
+    needs: build-cache
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -87,8 +63,6 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    
-    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
@@ -100,12 +74,6 @@ jobs:
       with:
         path: ${{ env.pythonLocation }}
         key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
-
-    - name: Cache Docker
-      uses: actions/cache@v2
-      with:
-          path: /var/lib/docker/
-          key: linux-${{ env.date }}
 
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
@@ -133,14 +101,6 @@ jobs:
 
     - name: Install tesseract
       run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
-
-    # - name: Install Haystack
-    #   # run: |
-    #   #   pip install --upgrade pip
-    #   #   pip install --upgrade --upgrade-strategy eager -e .[test]
-    #   #   pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-    #   run: |
-    #     pip install -e .
 
     - name: Run tests
       run: pytest -s ${{ matrix.test-path }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -92,12 +92,18 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Cache
+    - name: Cache Python
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
         key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
 
+    - name: Cache Docker
+      uses: actions/cache@v2
+      with:
+          path: /var/lib/docker/
+          key: linux-${{ env.date }}
+          
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -43,8 +43,20 @@ jobs:
           pip install --upgrade --upgrade-strategy eager .[test]
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
+  docker-cache:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Cache
+        id: cache-docker-images
+        uses: actions/cache@v2
+        with:
+          path: /var/lib/docker/
+          key: linux-${{ env.date }}
+
       - name: Pull Docker images
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        if: steps.cache-docker-images.outputs.cache-hit != 'true'
         run: |
           docker pull elasticsearch:7.9.2
           docker pull milvusdb/milvus:1.1.0-cpu-d050721-5e559c
@@ -52,14 +64,6 @@ jobs:
           docker pull deepset/graphdb-free:9.4.1-adoptopenjdk11
           docker pull apache/tika:1.24.1
           docker pull axarev/parsr:v1.2.2
-
-      - name: Install pdftotext
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
-        run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
-
-      - name: Install tesseract
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
-        run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
 
   prepare-build:
     needs: build-cache
@@ -113,11 +117,11 @@ jobs:
 #    - name: Run Ray
 #      run: RAY_DISABLE_MEMORY_MONITOR=1 ray start --head
 
-#     - name: Install pdftotext
-#       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+    - name: Install pdftotext
+      run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
 
-#     - name: Install tesseract
-#       run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
+    - name: Install tesseract
+      run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
 
     # - name: Install Haystack
     #   # run: |

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -66,7 +66,9 @@ jobs:
           docker pull axarev/parsr:v1.2.2
 
   prepare-build:
-    needs: build-cache
+    needs: 
+     - build-cache
+     - docker-cache
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -28,15 +28,15 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+      # - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      # - name: Cache
+      #   id: cache-python-env
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
+      #   if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[test]

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -20,26 +20,26 @@ jobs:
           pip install mypy==0.910 types-Markdown types-requests types-PyYAML pydantic
           mypy haystack
 
-  # build-cache:
-  #   needs: type-check
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.7
-  #     - name: Cache
-  #       id: cache-python-env
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ env.pythonLocation }}
-  #         key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
-  #     - name: Install dependencies
-  #       if: steps.cache-python-env.outputs.cache-hit != 'true'
-  #       run: |
-  #         pip install --upgrade pip
-  #         pip install --upgrade --upgrade-strategy eager -e .[test]
-  #         pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+  build-cache:
+    needs: type-check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Cache
+        id: cache-python-env
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+      - name: Install dependencies
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade --upgrade-strategy eager -e .[test]
+          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
     needs: type-check
@@ -65,11 +65,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    # - name: Cache
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ${{ env.pythonLocation }}
-    #     key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 
@@ -97,11 +99,13 @@ jobs:
     - name: Install tesseract
       run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
 
-    - name: Install dependencies
+    - name: Install Haystack
+      # run: |
+      #   pip install --upgrade pip
+      #   pip install --upgrade --upgrade-strategy eager -e .[test]
+      #   pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
       run: |
-        pip install --upgrade pip
-        pip install --upgrade --upgrade-strategy eager -e .[test]
-        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+        pip install -e .
 
     - name: Run tests
       run: pytest -s ${{ matrix.test-path }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -28,21 +28,41 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
           key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+
       - name: Install dependencies
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager -e .[test]
+          pip install --upgrade --upgrade-strategy eager .[test]
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
+      - name: Pull Docker images
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        run: |
+          docker pull elasticsearch:7.9.2
+          docker pull milvusdb/milvus:1.1.0-cpu-d050721-5e559c
+          docker pull semitechnologies/weaviate:1.7.2
+          docker pull deepset/graphdb-free:9.4.1-adoptopenjdk11
+          docker pull apache/tika:1.24.1
+          docker pull axarev/parsr:v1.2.2
+
+      - name: Install pdftotext
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+
+      - name: Install tesseract
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
+
   prepare-build:
-    needs: type-check
+    needs: build-cache
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -93,19 +113,19 @@ jobs:
 #    - name: Run Ray
 #      run: RAY_DISABLE_MEMORY_MONITOR=1 ray start --head
 
-    - name: Install pdftotext
-      run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+#     - name: Install pdftotext
+#       run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
 
-    - name: Install tesseract
-      run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
+#     - name: Install tesseract
+#       run: sudo apt-get install tesseract-ocr libtesseract-dev poppler-utils
 
-    - name: Install Haystack
-      # run: |
-      #   pip install --upgrade pip
-      #   pip install --upgrade --upgrade-strategy eager -e .[test]
-      #   pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-      run: |
-        pip install -e .
+    # - name: Install Haystack
+    #   # run: |
+    #   #   pip install --upgrade pip
+    #   #   pip install --upgrade --upgrade-strategy eager -e .[test]
+    #   #   pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+    #   run: |
+    #     pip install -e .
 
     - name: Run tests
       run: pytest -s ${{ matrix.test-path }}

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -28,17 +28,17 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
+      - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: linux-${{ env.pythonLocation }}-${{ env.date }}
+          key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies
-      #   if: steps.cache-python-env.outputs.cache-hit != 'true'
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[test]
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
@@ -65,12 +65,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
+    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: linux-${{ env.pythonLocation }}-${{ env.date }}
+        key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
-        with:
-          key: linux-${{ env.date }}
-      - name: Install dependencies
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
@@ -68,6 +65,7 @@ jobs:
     - name: Cache
       uses: actions/cache@v2
       with:
+        path: ${{ env.pythonLocation }}
         key: linux-${{ env.date }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -34,6 +34,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
+          # The cache currently misses at every change in the Python files to ensure
+          # that the code changes to Haystack are not being cached along with the dependencies.
+          # TODO for the tests refactoring: We could speed up the process by caching only 
+          # the dependencies and installing Haystack again separately for each test runner.
           key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -28,13 +28,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+          key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       - name: Install dependencies
         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
@@ -65,12 +64,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: linux-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+        key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        with:
+          path: ${{ env.pythonLocation }}
+          key: linux-${{ env.pythonLocation }}-${{ env.date }}
+      - name: Install dependencies
+      #   if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[test]
@@ -61,12 +65,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
+    - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: linux-${{ env.date }}
+        key: linux-${{ env.pythonLocation }}-${{ env.date }}
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
+          # The cache currently misses at every change in the Python files to ensure
+          # that the code changes to Haystack are not being cached along with the dependencies.
+          # TODO for the tests refactoring: We could speed up the process by caching only 
+          # the dependencies and installing Haystack again separately for each test runner.
           key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       
       - name: Install Pytorch on windows

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -20,30 +20,30 @@ jobs:
           pip install mypy==0.910 types-Markdown types-requests types-PyYAML pydantic
           mypy haystack
 
-  build-cache:
-    needs: type-check
-    runs-on: windows-latest
+  # build-cache:
+  #   needs: type-check
+  #   runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
-      - name: Install Pytorch on windows
-        run: |
-          pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
-      - name: Install dependencies
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager -e .[test]
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.7
+  #     - name: Cache
+  #       id: cache-python-env
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: ${{ env.pythonLocation }}
+  #         key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+  #     - name: Install Pytorch on windows
+  #       run: |
+  #         pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+  #     - name: Install dependencies
+  #       if: steps.cache-python-env.outputs.cache-hit != 'true'
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install --upgrade --upgrade-strategy eager -e .[test]
+  #         pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
     needs: build-cache
@@ -70,11 +70,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+    # - name: Cache
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env
@@ -86,6 +86,16 @@ jobs:
         choco install elasticsearch --version=7.9.2
         refreshenv
         Get-Service elasticsearch-service-x64 | Start-Service
+
+    - name: Install Pytorch on windows
+      run: |
+        pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade --upgrade-strategy eager -e .[test]
+        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
     # We have to remove files if not test going to run from it
     # As on windows we are going to disable quite a few tests these, hence these files will throw error refer https://github.com/pytest-dev/pytest/issues/812

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -74,6 +74,7 @@ jobs:
     - name: Cache
       uses: actions/cache@v2
       with:
+        path: ${{ env.pythonLocation }}
         key: windows-${{ env.date }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -34,7 +34,8 @@ jobs:
         id: cache-python-env
         uses: actions/cache@v2
         with:
-          key: windows-${{ env.date }}
+          path: ${{ env.pythonLocation }}
+          key: windows-${{ env.pythonLocation }}-${{ env.date }}
       - name: Install Pytorch on windows
         run: |
           pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
@@ -75,7 +76,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: windows-${{ env.date }}
+        key: windows-${{ env.pythonLocation }}-${{ env.date }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -20,30 +20,33 @@ jobs:
           pip install mypy==0.910 types-Markdown types-requests types-PyYAML pydantic
           mypy haystack
 
-  # build-cache:
-  #   needs: type-check
-  #   runs-on: windows-latest
+  build-cache:
+    needs: type-check
+    runs-on: windows-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.7
-  #     - name: Cache
-  #       id: cache-python-env
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: ${{ env.pythonLocation }}
-  #         key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
-  #     - name: Install Pytorch on windows
-  #       run: |
-  #         pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
-  #     - name: Install dependencies
-  #       if: steps.cache-python-env.outputs.cache-hit != 'true'
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install --upgrade --upgrade-strategy eager -e .[test]
-  #         pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Cache
+        id: cache-python-env
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+      
+      - name: Install Pytorch on windows
+        run: |
+          pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+      
+      - name: Install dependencies
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade --upgrade-strategy eager .[test]
+          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
     needs: build-cache
@@ -70,11 +73,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    # - name: Cache
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ${{ env.pythonLocation }}
-    #     key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env
@@ -86,16 +90,6 @@ jobs:
         choco install elasticsearch --version=7.9.2
         refreshenv
         Get-Service elasticsearch-service-x64 | Start-Service
-
-    - name: Install Pytorch on windows
-      run: |
-        pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
-        
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade --upgrade-strategy eager -e .[test]
-        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
     # We have to remove files if not test going to run from it
     # As on windows we are going to disable quite a few tests these, hence these files will throw error refer https://github.com/pytest-dev/pytest/issues/812

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -29,13 +29,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+          key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Pytorch on windows
         run: |
           pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
@@ -71,12 +70,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+        key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -30,17 +30,17 @@ jobs:
         with:
           python-version: 3.7
       - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+      # - name: Cache
+      #   id: cache-python-env
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Pytorch on windows
         run: |
           pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
       - name: Install dependencies
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
+      #   if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[test]

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -29,18 +29,17 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
-      # - name: Cache
-      #   id: cache-python-env
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+      - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
+      - name: Cache
+        id: cache-python-env
+        uses: actions/cache@v2
+        with:
+          key: windows-${{ env.date }}
       - name: Install Pytorch on windows
         run: |
           pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
       - name: Install dependencies
-      #   if: steps.cache-python-env.outputs.cache-hit != 'true'
+        if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e .[test]
@@ -71,12 +70,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
+    - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
-        path: ${{ env.pythonLocation }}
-        key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('setup.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+        key: windows-${{ env.date }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -29,13 +29,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
+      - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
       - name: Cache
         id: cache-python-env
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: windows-${{ env.pythonLocation }}-${{ env.date }}
+          key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Pytorch on windows
         run: |
           pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
@@ -71,12 +71,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-    - run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $env:GITHUB_ENV
+    - run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
     - name: Cache
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: windows-${{ env.pythonLocation }}-${{ env.date }}
+        key: windows-${{ env.pythonLocation }}-${{ env.date }}-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -9,6 +9,7 @@ except ModuleNotFoundError:
 
 __version__ = metadata.version('farm-haystack')
 
+
 # This configuration must be done before any import to apply to all submodules
 import logging
 logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.WARNING)

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,14 +1,13 @@
 from typing import Union
 from types import ModuleType
 
-__version__ = None
 try:
     import importlib.metadata as metadata
-    __version__ = metadata.version('farm-haystack')
 except ModuleNotFoundError:
     # Python <= 3.7
     import importlib_metadata as metadata  # type: ignore
-    __version__ = metadata.version('haystack')
+
+__version__ = metadata.version('farm-haystack')
 
 # This configuration must be done before any import to apply to all submodules
 import logging

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -1,13 +1,14 @@
 from typing import Union
 from types import ModuleType
 
+__version__ = None
 try:
     import importlib.metadata as metadata
+    __version__ = metadata.version('farm-haystack')
 except ModuleNotFoundError:
     # Python <= 3.7
     import importlib_metadata as metadata  # type: ignore
-
-__version__ = metadata.version('farm-haystack')
+    __version__ = metadata.version('haystack')
 
 # This configuration must be done before any import to apply to all submodules
 import logging

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -9,7 +9,6 @@ except ModuleNotFoundError:
 
 __version__ = metadata.version('farm-haystack')
 
-
 # This configuration must be done before any import to apply to all submodules
 import logging
 logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.WARNING)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,9 @@ classifiers =
 use_scm_version = True
 python_requires = >=3.7
 packages = find:
+setup_requires =
+    setuptools
+    wheel
 install_requires =
     importlib-metadata; python_version < '3.8'
     torch>1.9,<1.11


### PR DESCRIPTION
It makes impossible to run tests reliably, as the cache will prevent the runner from picking up the latest code changes somehow.

While debugging this issue, let's disable the cache to not disrupt other PRs.