### PR TITLE
Make `ui` and `rest` proper packages

### DIFF
--- a/.github/workflows/generate_openapi_specs.yml
+++ b/.github/workflows/generate_openapi_specs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[rest]
+          python -m pip install rest_api/
 
       # Generates the docstrings and tutorials so that we have the latest for the deployment
       - name: Generate Docstrings and Tutorials

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager .[test]
+          pip install --upgrade --upgrade-strategy eager rest_api/
+          pip install --upgrade --upgrade-strategy eager ui/
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -79,7 +79,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+        key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
 
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -38,7 +38,7 @@ jobs:
           # that the code changes to Haystack are not being cached along with the dependencies.
           # TODO for the tests refactoring: We could speed up the process by caching only 
           # the dependencies and installing Haystack again separately for each test runner.
-          key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+          key: linux-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
 
       - name: Install dependencies
         if: steps.cache-python-env.outputs.cache-hit != 'true'

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -39,7 +39,7 @@ jobs:
           # that the code changes to Haystack are not being cached along with the dependencies.
           # TODO for the tests refactoring: We could speed up the process by caching only 
           # the dependencies and installing Haystack again separately for each test runner.
-          key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+          key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
       
       - name: Install Pytorch on windows
         run: |

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -50,6 +50,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager .[test]
+          pip install --upgrade --upgrade-strategy eager rest_api/
+          pip install --upgrade --upgrade-strategy eager ui/
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -84,7 +84,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('pyproject.toml') }}
+        key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ COPY rest_api /home/user/rest_api
 
 # Install package
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir .[docstores,crawler,preprocessing,ocr,ray,rest]
+RUN pip install --no-cache-dir .[docstores,crawler,preprocessing,ocr,ray]
+RUN pip install --no-cache-dir rest_api/
 RUN ls /home/user
 RUN pip freeze
 RUN python3 -c "from haystack.utils.docker import cache_models;cache_models()"

--- a/rest_api/LICENSE
+++ b/rest_api/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 deepset GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rest_api/setup.py
+++ b/rest_api/setup.py
@@ -32,6 +32,9 @@ setup(
     packages=find_packages(),
     python_requires='>=3.7, <4',
     install_requires=[
+        # The link below cannot be translated properly into setup.cfg
+        # because it looks into the parent folder.
+        # TODO check if this is still a limitation later on
         f"farm-haystack @ file://localhost/{Path(__file__).parent.parent}#egg=farm-haystack",
         "fastapi<1",
         "uvicorn<1",

--- a/rest_api/setup.py
+++ b/rest_api/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(),
     python_requires='>=3.7, <4',
     install_requires=[
-        "farm-haystack>=1.1.0, <2",
+        f"farm-haystack @ file://localhost/{Path(__file__).parent.parent}#egg=farm-haystack",
         "fastapi<1",
         "uvicorn<1",
         "gunicorn<21",

--- a/rest_api/setup.py
+++ b/rest_api/setup.py
@@ -1,0 +1,41 @@
+from setuptools import setup, find_packages
+import logging
+from pathlib import Path
+
+
+VERSION = None
+try:
+    VERSION = open(Path(__file__).parent.parent/'VERSION.txt', "r").read()
+except Exception as e:
+    logging.exception("No VERSION.txt found!", e)
+
+
+setup(
+    name="farm-haystack-rest-api",
+    version=VERSION,
+    description='Demo REST API server for Haystack (https://github.com/deepset-ai/haystack)',
+    author='deepset.ai',
+    author_email='malte.pietsch@deepset.ai',
+    url=' https://github.com/deepset-ai/haystack/tree/master/rest_api',
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    packages=find_packages(),
+    python_requires='>=3.7, <4',
+    install_requires=[
+        "farm-haystack>=1.1.0, <2",
+        "fastapi<1",
+        "uvicorn<1",
+        "gunicorn<21",
+        "python-multipart<1"  # optional FastAPI dependency for form data
+    ],  
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ classifiers =
 
 [options]
 use_scm_version = True
-python_requires = >=3.7
+python_requires = >=3.7, <4
 packages = find:
 setup_requires =
     setuptools
@@ -150,15 +150,6 @@ ray =
     ray>=1.9.1
 colab = 
     grpcio==1.43.0
-rest =
-    fastapi
-    uvicorn
-    gunicorn
-    python-multipart  # optional FastAPI dependency for form data
-ui = 
-    streamlit>=1.2.0
-    st-annotated-text==2.0.0
-    markdown>=3.3.4
 dev = 
     mypy
     pytest
@@ -170,11 +161,11 @@ dev =
     pylint
     black
 test = 
-    farm-haystack[docstores,crawler,preprocessing,ocr,ray,rest,ui,dev]
+    farm-haystack[docstores,crawler,preprocessing,ocr,ray,dev]
 all =
-    farm-haystack[docstores,crawler,preprocessing,ocr,ray,rest,ui,dev,onnx]
+    farm-haystack[docstores,crawler,preprocessing,ocr,ray,dev,onnx]
 all-gpu =
-    farm-haystack[docstores-gpu,crawler,preprocessing,ocr,ray,rest,ui,dev,onnx-gpu]
+    farm-haystack[docstores-gpu,crawler,preprocessing,ocr,ray,dev,onnx-gpu]
 
 
 [tool:pytest]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,14 +4,16 @@ WORKDIR /home/user
 
 RUN apt-get update && apt-get install -y curl git pkg-config cmake
 
-# install as a package
-COPY requirements.txt /home/user/
-RUN pip install -r requirements.txt
-
 # copy code
+COPY setup.py /home/user/
+COPY README.md /home/user/
+COPY ../VERSION.txt /home/user/
 COPY utils.py /home/user/
 COPY webapp.py /home/user/
 COPY eval_labels_example.csv /home/user/
+
+# install as a package
+RUN pip install .
 
 EXPOSE 8501
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -6,8 +6,6 @@ RUN apt-get update && apt-get install -y curl git pkg-config cmake
 
 # copy code
 COPY setup.py /home/user/
-COPY README.md /home/user/
-COPY ../VERSION.txt /home/user/
 COPY utils.py /home/user/
 COPY webapp.py /home/user/
 COPY eval_labels_example.csv /home/user/

--- a/ui/LICENSE
+++ b/ui/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 deepset GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -1,0 +1,44 @@
+from setuptools import setup, find_packages
+import logging
+from pathlib import Path
+
+
+VERSION = None
+try:
+    # In the normal repo layout, it's in the root folder
+    VERSION = open(Path(__file__).parent.parent/'VERSION.txt', "r").read()
+except Exception:
+    try:
+        # In Docker, they're siblings
+        VERSION = open(Path(__file__).parent/'VERSION.txt', "r").read()
+    except Exception as e:
+        logging.exception("No VERSION.txt found!", e)
+
+
+setup(
+    name="farm-haystack-ui",
+    version=VERSION,
+    description='Demo UI for Haystack (https://github.com/deepset-ai/haystack)',
+    author='deepset.ai',
+    author_email='malte.pietsch@deepset.ai',
+    url=' https://github.com/deepset-ai/haystack/tree/master/ui',
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    packages=find_packages(),
+    python_requires='>=3.7, <4',
+    install_requires=[
+        'streamlit>=1.2.0, <2', 
+        'st-annotated-text>=2.0.0, <3', 
+        'markdown>=3.3.4, <4'
+    ]
+)

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -3,21 +3,8 @@ import logging
 from pathlib import Path
 
 
-VERSION = None
-try:
-    # In the normal repo layout, it's in the root folder
-    VERSION = open(Path(__file__).parent.parent/'VERSION.txt', "r").read()
-except Exception:
-    try:
-        # In Docker, they're siblings
-        VERSION = open(Path(__file__).parent/'VERSION.txt', "r").read()
-    except Exception as e:
-        logging.exception("No VERSION.txt found!", e)
-
-
 setup(
     name="farm-haystack-ui",
-    version=VERSION,
     description='Demo UI for Haystack (https://github.com/deepset-ai/haystack)',
     author='deepset.ai',
     author_email='malte.pietsch@deepset.ai',

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -3,8 +3,20 @@ import logging
 from pathlib import Path
 
 
+VERSION = None
+try:
+    # After git clone, VERSION.txt is in the root folder
+    VERSION = open(Path(__file__).parent.parent/'VERSION.txt', "r").read()
+except Exception:
+    try:
+        # In Docker, VERSION.txt is in the same folder
+        VERSION = open(Path(__file__).parent/'VERSION.txt', "r").read()
+    except Exception as e:
+        logging.exception("No VERSION.txt found!", e)
+
 setup(
     name="farm-haystack-ui",
+    version=VERSION,
     description='Demo UI for Haystack (https://github.com/deepset-ai/haystack)',
     author='deepset.ai',
     author_email='malte.pietsch@deepset.ai',


### PR DESCRIPTION
As noticed with #2086, the dependency management of the UI and REST_API was suboptimal, as it treated the dependencies of these two packages as dependencies of Haystack itself. However, the UI does not even depend on Haystack, while the REST API should install Haystack as their own dependency, rather than the contrary.

As a solution I propose:

- Make a `setup.py` file for the `ui/` folder. 
    - From now on, the UI will be installed (after a git clone) with `pip install ui/` (or `pip install .` from the `ui/` folder).
    - Installing the UI will not install Haystack.
    - There is no more `pip install farm-haystack[ui]`.
    - In this case I chose a `setup.py` file because apparently a package cannot be installed if it lacks both `setup.py` and `pyproject.toml`. Given that both would be basically empty, but `setup.py` is still required for editable installs, I chose to keep only `setup.py`.

- Make a `setup.py` for the `rest_api/` folder
    - From now on, the REST API will be installed (after a git clone) with `pip install rest_api/` (or `pip install .` from the `rest_api/` folder).
    - There is no more `pip install farm-haystack[rest]`.
    - Installing the REST API will install the local Haystack that was git cloned with the `rest_api` folder.
    - The above feature required me to use `setup.py` instead of `setup.cfg`, because it needed to look up into the parent directory for `farm-haystack` (something that seemingly `setup.cfg` can't do).

On top of the above changes, this PR also updates the Dockerfiles to make use of this new setup. Version information is also aligned with the version of Haystack itself.

Note that for the time being, I left both packages without license information, as they were lacking it before as well. However this might become a trouble for companies. @tholor shall I add an explicit Apache 2.0 to these two packages as well?

Closes #2086 