### PR TITLE
Skip upgrading pip in tutorials because of regression bug

### DIFF
--- a/tutorials/Tutorial10_Knowledge_Graph.ipynb
+++ b/tutorials/Tutorial10_Knowledge_Graph.ipynb
@@ -33,7 +33,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,graphdb]"
    ]
   },

--- a/tutorials/Tutorial11_Pipelines.ipynb
+++ b/tutorials/Tutorial11_Pipelines.ipynb
@@ -82,7 +82,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]\n",
     "\n",
     "# Install pygraphviz\n",

--- a/tutorials/Tutorial12_LFQA.ipynb
+++ b/tutorials/Tutorial12_LFQA.ipynb
@@ -50,7 +50,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial13_Question_generation.ipynb
+++ b/tutorials/Tutorial13_Question_generation.ipynb
@@ -50,7 +50,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial14_Query_Classifier.ipynb
+++ b/tutorials/Tutorial14_Query_Classifier.ipynb
@@ -532,7 +532,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]\n",
     "\n",
     "# Install  pygraphviz\n",

--- a/tutorials/Tutorial15_TableQA.ipynb
+++ b/tutorials/Tutorial15_TableQA.ipynb
@@ -51,7 +51,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]\n",
     "\n",
     "# The TaPAs-based TableReader requires the torch-scatter library\n",

--- a/tutorials/Tutorial16_Document_Classifier_at_Index_Time.ipynb
+++ b/tutorials/Tutorial16_Document_Classifier_at_Index_Time.ipynb
@@ -45,7 +45,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]\n",
     "\n",
     "!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz\n",

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -59,7 +59,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -55,7 +55,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -55,7 +55,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -63,7 +63,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -73,7 +73,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -285,7 +285,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss,milvus]"
    ]
   },

--- a/tutorials/Tutorial7_RAG_Generator.ipynb
+++ b/tutorials/Tutorial7_RAG_Generator.ipynb
@@ -71,7 +71,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]"
    ]
   },

--- a/tutorials/Tutorial8_Preprocessing.ipynb
+++ b/tutorials/Tutorial8_Preprocessing.ipynb
@@ -62,7 +62,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]\n",
     "\n",
     "!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz\n",

--- a/tutorials/Tutorial9_DPR_training.ipynb
+++ b/tutorials/Tutorial9_DPR_training.ipynb
@@ -32,7 +32,7 @@
     "#! pip install farm-haystack\n",
     "\n",
     "# Install the latest master of Haystack\n",
-    "!pip install --upgrade pip\n",
+    "# !pip install --upgrade pip # we don't upgrade the default pip version because of a bug in 22.0.2\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },


### PR DESCRIPTION
**Proposed changes**:
- skip upgrading ip version to 22.0.2 because of a regression bug and keep the current default 21.1.3.

Tutorials 5,7,13 do not use our new way of installing dependencies and still include the grpcio dependency fix. I still need to look into these three tutorials and update them.
