### PR TITLE
Add faiss dependency to tutorial 12

### DIFF
--- a/tutorials/Tutorial12_LFQA.ipynb
+++ b/tutorials/Tutorial12_LFQA.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install --upgrade pip\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
+    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]"
    ]
   },
   {


### PR DESCRIPTION
**Proposed changes**:
- Install faiss dependency in tutorial 12 as it uses a FAISSDocumentStore later on.
