### PR TITLE
Remove `rest` extra from Dockerfile-GPU

### DIFF
--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -48,7 +48,8 @@ RUN echo "Install required packages" && \
     pip3 install --no-cache-dir torch==1.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
 
 # Install package
-RUN pip install --no-cache .[docstores_gpu,crawler,preprocessing,ocr,ray,rest]
+RUN pip install --no-cache .[docstores_gpu,crawler,preprocessing,ocr,ray]
+RUN pip install --no-cache rest_api/
 
 # Cache Roberta and NLTK data
 RUN python3 -c "from haystack.utils.docker import cache_models;cache_models()"


### PR DESCRIPTION
Remove leftover `rest` extra from Dockerfile-GPU (removed in #2098)
