### PR TITLE
Evaluating a pipeline consisting only of a reader node

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1150,6 +1150,36 @@ def get_documents_by_id(ids: List[str], index: Optional[str] = None) -> List[Doc
 
 Fetch documents by specifying a list of text id strings.
 
+<a id="memory.InMemoryDocumentStore.get_scores_torch"></a>
+
+#### get\_scores\_torch
+
+```python
+def get_scores_torch(query_emb: np.ndarray, document_to_search: List[Document]) -> List[float]
+```
+
+Calculate similarity scores between query embedding and a list of documents using torch.
+
+**Arguments**:
+
+- `query_emb`: Embedding of the query (e.g. gathered from DPR)
+- `document_to_search`: List of documents to compare `query_emb` against.
+
+<a id="memory.InMemoryDocumentStore.get_scores_numpy"></a>
+
+#### get\_scores\_numpy
+
+```python
+def get_scores_numpy(query_emb: np.ndarray, document_to_search: List[Document]) -> List[float]
+```
+
+Calculate similarity scores between query embedding and a list of documents using numpy.
+
+**Arguments**:
+
+- `query_emb`: Embedding of the query (e.g. gathered from DPR)
+- `document_to_search`: List of documents to compare `query_emb` against.
+
 <a id="memory.InMemoryDocumentStore.query_by_embedding"></a>
 
 #### query\_by\_embedding

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -202,7 +202,7 @@ then be found in the dict returned by this method under the key "_debug"
 #### eval
 
 ```python
-def eval(labels: List[MultiLabel], params: Optional[dict] = None, sas_model_name_or_path: str = None, add_isolated_node_eval: bool = False) -> EvaluationResult
+def eval(labels: List[MultiLabel], params: Optional[dict] = None, sas_model_name_or_path: str = None, add_isolated_node_eval: bool = False, pass_documents_as_input: bool = False) -> EvaluationResult
 ```
 
 Evaluates the pipeline by running the pipeline once per query in debug mode
@@ -235,6 +235,7 @@ The isolated evaluation calculates the upper bound of each node's evaluation met
 To this end, labels are used as input to the node instead of the output of the previous node in the pipeline.
 The generated dataframes in the EvaluationResult then contain additional rows, which can be distinguished from the integrated evaluation results based on the
 values "integrated" or "isolated" in the column "eval_mode" and the evaluation report then additionally lists the upper bound of each node's evaluation metrics.
+- `pass_documents_as_input`: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
 
 <a id="base.Pipeline.get_nodes_by_class"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -202,7 +202,7 @@ then be found in the dict returned by this method under the key "_debug"
 #### eval
 
 ```python
-def eval(labels: List[MultiLabel], params: Optional[dict] = None, sas_model_name_or_path: str = None, add_isolated_node_eval: bool = False, pass_documents_as_input: bool = False) -> EvaluationResult
+def eval(labels: List[MultiLabel], documents: Optional[List[List[Document]]] = None, params: Optional[dict] = None, sas_model_name_or_path: str = None, add_isolated_node_eval: bool = False) -> EvaluationResult
 ```
 
 Evaluates the pipeline by running the pipeline once per query in debug mode
@@ -212,6 +212,7 @@ and putting together all data that is needed for evaluation, e.g. calculating me
 **Arguments**:
 
 - `labels`: The labels to evaluate on
+- `documents`: List of List of Document that the first node in the pipeline should get as input per multilabel. Can be used to evaluate a pipeline that consists of a reader without a retriever.
 - `params`: Dictionary of parameters to be dispatched to the nodes.
 If you want to pass a param to all nodes, you can just use: {"top_k":10}
 If you want to pass it to targeted nodes, you can do:
@@ -235,7 +236,6 @@ The isolated evaluation calculates the upper bound of each node's evaluation met
 To this end, labels are used as input to the node instead of the output of the previous node in the pipeline.
 The generated dataframes in the EvaluationResult then contain additional rows, which can be distinguished from the integrated evaluation results based on the
 values "integrated" or "isolated" in the column "eval_mode" and the evaluation report then additionally lists the upper bound of each node's evaluation metrics.
-- `pass_documents_as_input`: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
 
 <a id="base.Pipeline.get_nodes_by_class"></a>
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -472,7 +472,7 @@ class Pipeline(BasePipeline):
                     To this end, labels are used as input to the node instead of the output of the previous node in the pipeline.
                     The generated dataframes in the EvaluationResult then contain additional rows, which can be distinguished from the integrated evaluation results based on the
                     values "integrated" or "isolated" in the column "eval_mode" and the evaluation report then additionally lists the upper bound of each node's evaluation metrics.
-        :param pass_documents_as_input: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
+        :param documents: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
         """
         eval_result = EvaluationResult()
         if add_isolated_node_eval:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -472,7 +472,7 @@ class Pipeline(BasePipeline):
                     To this end, labels are used as input to the node instead of the output of the previous node in the pipeline.
                     The generated dataframes in the EvaluationResult then contain additional rows, which can be distinguished from the integrated evaluation results based on the
                     values "integrated" or "isolated" in the column "eval_mode" and the evaluation report then additionally lists the upper bound of each node's evaluation metrics.
-        :param documents: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
+        :param pass_documents_as_input: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
         """
         eval_result = EvaluationResult()
         if add_isolated_node_eval:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -479,7 +479,9 @@ class Pipeline(BasePipeline):
             if params is None:
                 params = {}
             params["add_isolated_node_eval"] = True
-        for i,label in enumerate(labels):
+
+        # if documents is None, set docs_per_label to None for each label
+        for docs_per_label,label in zip(documents or [None]*len(labels),labels):
             params_per_label = copy.deepcopy(params)
             if label.filters is not None:
                 if params_per_label is None:
@@ -487,11 +489,7 @@ class Pipeline(BasePipeline):
                 else:
                     # join both filters and overwrite filters in params with filters in labels
                     params_per_label["filters"] = {**params_per_label.get("filters", {}), **label.filters}
-            if documents is not None:
-                # documents are passed as input to the first node in the pipeline
-                predictions = self.run(query=label.query, labels=label, documents=documents[i], params=params_per_label, debug=True)
-            else:
-                predictions = self.run(query=label.query, labels=label, params=params_per_label, debug=True)
+            predictions = self.run(query=label.query, labels=label, documents=docs_per_label, params=params_per_label, debug=True)
 
             for node_name in predictions["_debug"].keys():
                 node_output = predictions["_debug"][node_name]["output"]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -481,7 +481,7 @@ class Pipeline(BasePipeline):
             params["add_isolated_node_eval"] = True
 
         # if documents is None, set docs_per_label to None for each label
-        for docs_per_label,label in zip(documents or [None]*len(labels),labels):
+        for docs_per_label, label in zip(documents or [None] * len(labels), labels):
             params_per_label = copy.deepcopy(params)
             if label.filters is not None:
                 if params_per_label is None:
@@ -489,7 +489,9 @@ class Pipeline(BasePipeline):
                 else:
                     # join both filters and overwrite filters in params with filters in labels
                     params_per_label["filters"] = {**params_per_label.get("filters", {}), **label.filters}
-            predictions = self.run(query=label.query, labels=label, documents=docs_per_label, params=params_per_label, debug=True)
+            predictions = self.run(
+                query=label.query, labels=label, documents=docs_per_label, params=params_per_label, debug=True
+            )
 
             for node_name in predictions["_debug"].keys():
                 node_output = predictions["_debug"][node_name]["output"]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -439,17 +439,16 @@ class Pipeline(BasePipeline):
     def eval(
         self,
         labels: List[MultiLabel],
-        documents: Optional[List[List[Document]]] = None,
         params: Optional[dict] = None,
         sas_model_name_or_path: str = None,
         add_isolated_node_eval: bool = False,
+        pass_documents_as_input: bool = False
     ) -> EvaluationResult:
         """
         Evaluates the pipeline by running the pipeline once per query in debug mode
         and putting together all data that is needed for evaluation, e.g. calculating metrics.
 
         :param labels: The labels to evaluate on
-        :param documents: List of List of Document that the first node in the pipeline should get as input per multilabel. Can be used to evaluate a pipeline that consists of a reader without a retriever.
         :param params: Dictionary of parameters to be dispatched to the nodes.
                     If you want to pass a param to all nodes, you can just use: {"top_k":10}
                     If you want to pass it to targeted nodes, you can do:
@@ -473,13 +472,14 @@ class Pipeline(BasePipeline):
                     To this end, labels are used as input to the node instead of the output of the previous node in the pipeline.
                     The generated dataframes in the EvaluationResult then contain additional rows, which can be distinguished from the integrated evaluation results based on the
                     values "integrated" or "isolated" in the column "eval_mode" and the evaluation report then additionally lists the upper bound of each node's evaluation metrics.
+        :param documents: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
         """
         eval_result = EvaluationResult()
         if add_isolated_node_eval:
             if params is None:
                 params = {}
             params["add_isolated_node_eval"] = True
-        for i,label in enumerate(labels):
+        for label in labels:
             params_per_label = copy.deepcopy(params)
             if label.filters is not None:
                 if params_per_label is None:
@@ -487,11 +487,8 @@ class Pipeline(BasePipeline):
                 else:
                     # join both filters and overwrite filters in params with filters in labels
                     params_per_label["filters"] = {**params_per_label.get("filters", {}), **label.filters}
-            if documents is not None:
-                # documents are passed as input to the first node in the pipeline
-                predictions = self.run(query=label.query, labels=label, documents=documents[i], params=params_per_label, debug=True)
-            else:
-                predictions = self.run(query=label.query, labels=label, params=params_per_label, debug=True)
+            documents = [l.document for l in label.labels] if pass_documents_as_input else None
+            predictions = self.run(query=label.query, labels=label, documents=documents, params=params_per_label, debug=True)
 
             for node_name in predictions["_debug"].keys():
                 node_output = predictions["_debug"][node_name]["output"]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -439,16 +439,17 @@ class Pipeline(BasePipeline):
     def eval(
         self,
         labels: List[MultiLabel],
+        documents: Optional[List[List[Document]]] = None,
         params: Optional[dict] = None,
         sas_model_name_or_path: str = None,
         add_isolated_node_eval: bool = False,
-        pass_documents_as_input: bool = False
     ) -> EvaluationResult:
         """
         Evaluates the pipeline by running the pipeline once per query in debug mode
         and putting together all data that is needed for evaluation, e.g. calculating metrics.
 
         :param labels: The labels to evaluate on
+        :param documents: List of List of Document that the first node in the pipeline should get as input per multilabel. Can be used to evaluate a pipeline that consists of a reader without a retriever.
         :param params: Dictionary of parameters to be dispatched to the nodes.
                     If you want to pass a param to all nodes, you can just use: {"top_k":10}
                     If you want to pass it to targeted nodes, you can do:
@@ -472,14 +473,13 @@ class Pipeline(BasePipeline):
                     To this end, labels are used as input to the node instead of the output of the previous node in the pipeline.
                     The generated dataframes in the EvaluationResult then contain additional rows, which can be distinguished from the integrated evaluation results based on the
                     values "integrated" or "isolated" in the column "eval_mode" and the evaluation report then additionally lists the upper bound of each node's evaluation metrics.
-        :param documents: If set to True, the documents specified in the labels are passed as input to the first node in the pipeline. Can be used to evaluate a pipeline that consists of a reader without a retriever.
         """
         eval_result = EvaluationResult()
         if add_isolated_node_eval:
             if params is None:
                 params = {}
             params["add_isolated_node_eval"] = True
-        for label in labels:
+        for i,label in enumerate(labels):
             params_per_label = copy.deepcopy(params)
             if label.filters is not None:
                 if params_per_label is None:
@@ -487,8 +487,11 @@ class Pipeline(BasePipeline):
                 else:
                     # join both filters and overwrite filters in params with filters in labels
                     params_per_label["filters"] = {**params_per_label.get("filters", {}), **label.filters}
-            documents = [l.document for l in label.labels] if pass_documents_as_input else None
-            predictions = self.run(query=label.query, labels=label, documents=documents, params=params_per_label, debug=True)
+            if documents is not None:
+                # documents are passed as input to the first node in the pipeline
+                predictions = self.run(query=label.query, labels=label, documents=documents[i], params=params_per_label, debug=True)
+            else:
+                predictions = self.run(query=label.query, labels=label, params=params_per_label, debug=True)
 
             for node_name in predictions["_debug"].keys():
                 node_output = predictions["_debug"][node_name]["output"]

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -524,8 +524,8 @@ def test_reader_eval_in_pipeline(reader):
     pipeline.add_node(component=reader, name="Reader", inputs=["Query"])
     eval_result: EvaluationResult = pipeline.eval(
         labels=EVAL_LABELS,
-        params={},
-        pass_documents_as_input=True
+        documents=[[label.document for label in multilabel.labels] for multilabel in EVAL_LABELS],
+        params={}
     )
 
     metrics = eval_result.calculate_metrics()

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -519,6 +519,21 @@ def test_extractive_qa_eval_sas(reader, retriever_with_docs):
     assert metrics["Reader"]["sas"] == pytest.approx(1.0)
 
 
+def test_reader_eval_in_pipeline(reader):
+    pipeline = Pipeline()
+    pipeline.add_node(component=reader, name="Reader", inputs=["Query"])
+    eval_result: EvaluationResult = pipeline.eval(
+        labels=EVAL_LABELS,
+        documents=[[label.document for label in multilabel.labels] for multilabel in EVAL_LABELS],
+        params={}
+    )
+
+    metrics = eval_result.calculate_metrics()
+
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+
+
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval_doc_relevance_col(reader, retriever_with_docs):

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -524,8 +524,8 @@ def test_reader_eval_in_pipeline(reader):
     pipeline.add_node(component=reader, name="Reader", inputs=["Query"])
     eval_result: EvaluationResult = pipeline.eval(
         labels=EVAL_LABELS,
-        documents=[[label.document for label in multilabel.labels] for multilabel in EVAL_LABELS],
-        params={}
+        params={},
+        pass_documents_as_input=True
     )
 
     metrics = eval_result.calculate_metrics()

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -525,7 +525,7 @@ def test_reader_eval_in_pipeline(reader):
     eval_result: EvaluationResult = pipeline.eval(
         labels=EVAL_LABELS,
         documents=[[label.document for label in multilabel.labels] for multilabel in EVAL_LABELS],
-        params={}
+        params={},
     )
 
     metrics = eval_result.calculate_metrics()


### PR DESCRIPTION
**Proposed changes**:
- `pipeline.eval()` gets an additional parameter `pass_documents_as_input` that enables passing the gold documents specified in the labels to the first node in the pipeline as input. It's an alternative way to evaluate the reader node only, with the advantage that no retriever needs to be specified in the pipeline.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [x] Added tests
- [x] Updated documentation
