### PR TITLE
Add aiorwlock to 'ray' extra & fix maximum version for some dependencies

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1150,6 +1150,36 @@ def get_documents_by_id(ids: List[str], index: Optional[str] = None) -> List[Doc
 
 Fetch documents by specifying a list of text id strings.
 
+<a id="memory.InMemoryDocumentStore.get_scores_torch"></a>
+
+#### get\_scores\_torch
+
+```python
+def get_scores_torch(query_emb: np.ndarray, document_to_search: List[Document]) -> List[float]
+```
+
+Calculate similarity scores between query embedding and a list of documents using torch.
+
+**Arguments**:
+
+- `query_emb`: Embedding of the query (e.g. gathered from DPR)
+- `document_to_search`: List of documents to compare `query_emb` against.
+
+<a id="memory.InMemoryDocumentStore.get_scores_numpy"></a>
+
+#### get\_scores\_numpy
+
+```python
+def get_scores_numpy(query_emb: np.ndarray, document_to_search: List[Document]) -> List[float]
+```
+
+Calculate similarity scores between query embedding and a list of documents using numpy.
+
+**Arguments**:
+
+- `query_emb`: Embedding of the query (e.g. gathered from DPR)
+- `document_to_search`: List of documents to compare `query_emb` against.
+
 <a id="memory.InMemoryDocumentStore.query_by_embedding"></a>
 
 #### query\_by\_embedding

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,15 +103,15 @@ exclude =
 
 [options.extras_require]
 sql = 
-    sqlalchemy>=1.4.2
+    sqlalchemy>=1.4.2,<2
     sqlalchemy_utils
     psycopg2-binary; sys_platform != 'win32' and sys_platform != 'cygwin'
 only-faiss = 
-    faiss-cpu>=1.6.3
+    faiss-cpu>=1.6.3,<2
 faiss = 
     farm-haystack[sql,only-faiss]
 only-faiss-gpu = 
-    faiss-gpu>=1.6.3
+    faiss-gpu>=1.6.3,<2
 faiss-gpu = 
     farm-haystack[sql,only-faiss-gpu]
 only-milvus1 = 
@@ -119,7 +119,7 @@ only-milvus1 =
 milvus1 = 
     farm-haystack[sql,only-milvus1]
 only-milvus = 
-    pymilvus>=2.0.0  # Refer milvus version support matrix at https://github.com/milvus-io/pymilvus#install-pymilvus
+    pymilvus>=2.0.0,<3  # Refer milvus version support matrix at https://github.com/milvus-io/pymilvus#install-pymilvus
 milvus = 
     farm-haystack[sql,only-milvus]
 weaviate =
@@ -147,7 +147,8 @@ onnx-gpu =
     onnxruntime-gpu
     onnxruntime_tools
 ray = 
-    ray>=1.9.1
+    ray>=1.9.1,<2
+    aiorwlock>=1.3.0,<2
 colab = 
     grpcio==1.43.0
 dev = 


### PR DESCRIPTION
The latest Ray release made `aiorwlock` a required package. This PR adds `aiorwlock` to the `ray` extra dependency group.

It also fixes the range some dependencies which had no upper limit yet.