### PR TITLE
Fix dependency management in Tutorial 6

### DIFF
--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -79,7 +79,7 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 
 # Install the latest master of Haystack
 !pip install --upgrade pip
-!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]
 ```
 
 
@@ -102,8 +102,6 @@ For more info on which suits your use case: https://github.com/facebookresearch/
 
 
 ```python
-!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[faiss]
-
 from haystack.document_stores import FAISSDocumentStore
 
 document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")

--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -79,7 +79,7 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 
 # Install the latest master of Haystack
 !pip install --upgrade pip
-!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss,milvus]
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
 
@@ -102,6 +102,8 @@ For more info on which suits your use case: https://github.com/facebookresearch/
 
 
 ```python
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[faiss]
+
 from haystack.document_stores import FAISSDocumentStore
 
 document_store = FAISSDocumentStore(faiss_index_factory_str="Flat")
@@ -116,6 +118,8 @@ See [their docs](https://milvus.io/docs/v1.0.0/milvus_docker-cpu.md) for more de
 
 
 ```python
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[milvus]
+
 from haystack.utils import launch_milvus
 from haystack.document_stores import MilvusDocumentStore
 

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -286,7 +286,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install --upgrade pip\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
+    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]"
    ]
   },
   {
@@ -349,8 +349,6 @@
     }
    ],
    "source": [
-    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[faiss]\n",
-    "\n",
     "from haystack.document_stores import FAISSDocumentStore\n",
     "\n",
     "document_store = FAISSDocumentStore(faiss_index_factory_str=\"Flat\")"

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -382,13 +382,13 @@
    },
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[milvus]\n",
+    "# !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[milvus]\n",
     "\n",
-    "from haystack.utils import launch_milvus\n",
-    "from haystack.document_stores import MilvusDocumentStore\n",
+    "#from haystack.utils import launch_milvus\n",
+    "#from haystack.document_stores import MilvusDocumentStore\n",
     "\n",
-    "launch_milvus()\n",
-    "document_store = MilvusDocumentStore()"
+    "#launch_milvus()\n",
+    "#document_store = MilvusDocumentStore()"
    ]
   },
   {

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -286,7 +286,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install --upgrade pip\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss,milvus]"
+    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]"
    ]
   },
   {
@@ -349,6 +349,7 @@
     }
    ],
    "source": [
+    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[faiss]\n",
     "from haystack.document_stores import FAISSDocumentStore\n",
     "\n",
     "document_store = FAISSDocumentStore(faiss_index_factory_str=\"Flat\")"
@@ -382,6 +383,8 @@
    },
    "outputs": [],
    "source": [
+    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[milvus]\n",
+    "\n",
     "from haystack.utils import launch_milvus\n",
     "from haystack.document_stores import MilvusDocumentStore\n",
     "\n",

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -286,7 +286,7 @@
     "\n",
     "# Install the latest master of Haystack\n",
     "!pip install --upgrade pip\n",
-    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]"
+    "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]"
    ]
   },
   {
@@ -350,6 +350,7 @@
    ],
    "source": [
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[faiss]\n",
+    "\n",
     "from haystack.document_stores import FAISSDocumentStore\n",
     "\n",
     "document_store = FAISSDocumentStore(faiss_index_factory_str=\"Flat\")"


### PR DESCRIPTION
Removes the installation of `milvus` extra on the Colab notebook of Tutorial 6. It's needless (Milvus can't run on Colab anyway) and was probably causing the dependency resolution & backtracking issue we spotted occasionally.
