### PR TITLE
Apply filter in eval only if no gold docs are given as input

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -242,7 +242,7 @@ then be found in the dict returned by this method under the key "_debug"
 #### eval
 
 ```python
-def eval(labels: List[MultiLabel], documents: Optional[List[Optional[List[Document]]]] = None, params: Optional[dict] = None, sas_model_name_or_path: str = None, add_isolated_node_eval: bool = False) -> EvaluationResult
+def eval(labels: List[MultiLabel], documents: Optional[List[List[Document]]] = None, params: Optional[dict] = None, sas_model_name_or_path: str = None, add_isolated_node_eval: bool = False) -> EvaluationResult
 ```
 
 Evaluates the pipeline by running the pipeline once per query in debug mode

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -522,7 +522,7 @@ class Pipeline(BasePipeline):
             params["add_isolated_node_eval"] = True
 
         # if documents is None, set docs_per_label to None for each label
-        for docs_per_label, label in zip(documents or [None] * len(labels), labels):
+        for docs_per_label, label in zip(documents or [None] * len(labels), labels): # type: ignore
             params_per_label = copy.deepcopy(params)
             # If the label contains a filter, the filter is applied unless documents are already given
             if label.filters is not None and documents is None:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -522,7 +522,7 @@ class Pipeline(BasePipeline):
             params["add_isolated_node_eval"] = True
 
         # if documents is None, set docs_per_label to None for each label
-        for docs_per_label, label in zip(documents or [None] * len(labels), labels): # type: ignore
+        for docs_per_label, label in zip(documents or [None] * len(labels), labels):  # type: ignore
             params_per_label = copy.deepcopy(params)
             # If the label contains a filter, the filter is applied unless documents are already given
             if label.filters is not None and documents is None:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -524,7 +524,8 @@ class Pipeline(BasePipeline):
         # if documents is None, set docs_per_label to None for each label
         for docs_per_label, label in zip(documents or [None] * len(labels), labels):
             params_per_label = copy.deepcopy(params)
-            if label.filters is not None:
+            # If the label contains a filter, the filter is applied unless documents are already given
+            if label.filters is not None and documents is None:
                 if params_per_label is None:
                     params_per_label = {"filters": label.filters}
                 else:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -480,7 +480,7 @@ class Pipeline(BasePipeline):
     def eval(
         self,
         labels: List[MultiLabel],
-        documents: Optional[List[Optional[List[Document]]]] = None,
+        documents: Optional[List[List[Document]]] = None,
         params: Optional[dict] = None,
         sas_model_name_or_path: str = None,
         add_isolated_node_eval: bool = False,


### PR DESCRIPTION
**Issue**
I noticed that pipelines with only a reader node cannot process labels that contain a filter setting. That's because the pipeline receives the filters via the parameters of the pipeline and the pipeline finds that none of its nodes can process this parameter. The error raised is: https://github.com/deepset-ai/haystack/blob/795c7c8a475ce34ad8920cf9d30cc0f1c8113df5/haystack/pipelines/base.py#L410

**Proposed changes**:
As either documents are given as input to the evaluation or there is a retriever that can deal with filters, I suggest the following change:
-  In `pipeline.eval()`, if the label contains a filter, the filter is applied unless documents are already given