### PR TITLE
Make `openapi.json` multiline so the diff is parsable

### DIFF
--- a/docs/_src/api/openapi/generate_openapi_specs.py
+++ b/docs/_src/api/openapi/generate_openapi_specs.py
@@ -19,4 +19,4 @@ specs = get_openapi_specs()
 
 # Dump the specs into a JSON file
 with open(f"openapi.json", "w") as f:
-    json.dump(specs, f)
+    json.dump(specs, f, indent=4)


### PR DESCRIPTION
Currently `openapi.json` is generated as a single line, making its diff nearly impossible to parse.

This PR makes `generate_openapi_specs` output a multiline `openapi.json` file.