### PR TITLE
Introduce Reader.eval_in_single_node_pipeline()

### DIFF
--- a/haystack/nodes/reader/base.py
+++ b/haystack/nodes/reader/base.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from functools import wraps
 from time import perf_counter
+from haystack.pipelines import Pipeline
 
 from haystack.schema import Document, Answer, Span, MultiLabel
 from haystack.nodes.base import BaseComponent
@@ -101,6 +102,13 @@ class BaseReader(BaseComponent):
             ]
 
         return results, "output_1"
+
+    def eval_in_single_node_pipeline(self, labels: List[MultiLabel], params: dict = {}, sas_model_name_or_path: Optional[str] = None):
+        pipeline = Pipeline()
+        pipeline.add_node(self, name="Reader", inputs=["query"])
+        documents = [[d for d in {l.document.id: l.document for l in label.labels}.values()] for label in labels]
+        eval_result = pipeline.eval(labels=labels, documents=documents, params=params, sas_model_name_or_path=sas_model_name_or_path)
+        return eval_result
 
     def run_batch(self, query_doc_list: List[Dict], top_k: Optional[int] = None):
         """A unoptimized implementation of running Reader queries in batch"""

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -597,7 +597,7 @@ class Pipeline(BasePipeline):
     def eval(
         self,
         labels: List[MultiLabel],
-        documents: Optional[List[Optional[List[Document]]]] = None,
+        documents: Optional[List[List[Document]]] = None,
         params: Optional[dict] = None,
         sas_model_name_or_path: str = None,
         add_isolated_node_eval: bool = False,
@@ -639,7 +639,8 @@ class Pipeline(BasePipeline):
             params["add_isolated_node_eval"] = True
 
         # if documents is None, set docs_per_label to None for each label
-        for docs_per_label, label in zip(documents or [None] * len(labels), labels):
+        label_documents = documents or [None] * len(labels) #type: ignore
+        for docs_per_label, label in zip(label_documents, labels):
             params_per_label = copy.deepcopy(params)
             if label.filters is not None:
                 if params_per_label is None:


### PR DESCRIPTION
I'm not sure if it's actually worth it: dependencies need to be checked (Reader using Pipeline). But that way you won't need to mess around with documents from labels.

**Proposed changes**:
- simple convenience function for readers to do single node eval

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
