### PR TITLE
WIP: Minimal haystack docker image

### DIFF
--- a/Dockerfile-GPU-minimal
+++ b/Dockerfile-GPU-minimal
@@ -1,0 +1,45 @@
+FROM nvidia/cuda:11.1-runtime-ubuntu20.04
+
+WORKDIR /home/user
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# Install software dependencies
+RUN apt-get update && apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get install -y \
+    cmake \
+    curl \
+    git \
+    libpoppler-cpp-dev \
+    libtesseract-dev \
+    pkg-config \
+    poppler-utils \
+    python3-pip \
+    python3.7 \
+    python3.7-dev \
+    python3.7-distutils \
+    swig \
+    tesseract-ocr \
+    wget 
+
+# Set default Python version
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
+    update-alternatives --set python3 /usr/bin/python3.7
+
+# Copy Haystack code
+COPY haystack /home/user/haystack/
+# Copy package files & models
+COPY setup.py setup.cfg pyproject.toml VERSION.txt LICENSE README.md /home/user/
+
+
+# Install package
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir .
+
+# Install PyTorch for CUDA 11
+RUN pip3 install --no-cache-dir torch==1.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
+
+RUN rm -rf /var/lib/apt/lists/* && \ 
+    rm -rf /home/user/*


### PR DESCRIPTION
**Motivation**
It would be helpful to have a minimal docker gpu image that can be used as a base image to build containers on top of it. 
This could also be used as a base image for the current GPU image. We will just need to add the rest_api folder and install additional requirements. 

**Proposed changes**:
- [x] added a docker file that installs the minimal requirements for haystack 
- [ ] added this image to the ci, s.t. we publish a new `haystack-gpu:minimal-<hash>` image on each commit
- [ ] used this image as a base image for the current haystack-gpu image

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
