### PR TITLE
Allow Linux CI to push changes to forks

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -92,6 +92,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           ref: ${{github.event.pull_request.head.ref}}
       
       - name: Set up Python 3.7


### PR DESCRIPTION
Right now, the documentation and code style bot will fail on forks as the checkout@v2 action fails. This leads to the situation in which no code style or documentation will be updated on the PR and neither on merge to master (the bot can't push to master right now), but they will trigger on the first PR opened from the updated master.

This PR tries to make checkout@v2 push changes back to the source fork, if possible.
