### PR TITLE
Add type check for meta & add tests

### DIFF
--- a/rest_api/controller/file_upload.py
+++ b/rest_api/controller/file_upload.py
@@ -91,7 +91,7 @@ def upload_file(
 
     file_paths: list = []
     file_metas: list = []
-    
+
     meta_form = json.loads(meta) or {}  # type: ignore
     if not isinstance(meta_form, dict):
         raise HTTPException(status_code=500, detail=f"The meta field must be a dict or None, not {type(meta_form)}")

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -175,7 +175,7 @@ def test_file_upload_with_no_meta(client: TestClient):
     response = client.post(
         url="/file-upload",
         files=file_to_upload,
-        data={"meta": ''},
+        data={"meta": ""},
     )
     assert 200 == response.status_code
 
@@ -191,12 +191,13 @@ def test_file_upload_with_wrong_meta(client: TestClient):
     response = client.post(
         url="/file-upload",
         files=file_to_upload,
-        data={"meta": '1'},
+        data={"meta": "1"},
     )
     assert 500 == response.status_code
 
     response = client.post(url="/documents/get_by_filters", data='{"filters": {}}')
     assert len(response.json()) == 0
+
 
 def test_query_with_no_filter(populated_client: TestClient):
     query_with_no_filter_value = {"query": "Who made the PDF specification?"}


### PR DESCRIPTION
Adds an explicit type check on the `meta` field in the `POST /file-upload` endpoint, which must be a dictionary. Falls back to an empty dict if the `meta` field is `None`.

Closes #2183 


