### PR TITLE
Changed document_store to ElasticsearchDocumentStore

### DIFF
--- a/tutorials/Tutorial1_Basic_QA_Pipeline.py
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.py
@@ -10,7 +10,7 @@
 # marvellous seven kingdoms.
 
 import logging
-from haystack.document_stores import ElasticsearchDocumentStore, FAISSDocumentStore
+from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.utils import clean_wiki_text, convert_files_to_dicts, fetch_archive_from_http, print_answers, launch_es
 from haystack.nodes import FARMReader, TransformersReader, ElasticsearchRetriever
 
@@ -38,9 +38,7 @@ def tutorial1_basic_qa_pipeline():
     launch_es()
 
     # Connect to Elasticsearch
-    document_store = FAISSDocumentStore(
-        sql_url="sqlite://"
-    )  # ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
+    document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
 
     # ## Preprocessing of documents
     #


### PR DESCRIPTION
because FAISSDocumentStore errored with ElasticSearchRetriever

**Proposed changes**:
- change DocumentStore as the FAISSDocumentstore is not compatible with the ElasticSearchRetriever used later on
- in the Notebook version of this tutorial there is no FAISSDocumentstore being used either

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
