### PR TITLE
Update url in POST /file-upload

### DIFF
--- a/rest_api/controller/file_upload.py
+++ b/rest_api/controller/file_upload.py
@@ -84,7 +84,7 @@ def upload_file(
 ):
     """
     You can use this endpoint to upload a file for indexing
-    (see [http://localhost:3000/guides/rest-api#indexing-documents-in-the-haystack-rest-api-document-store]).
+    (see https://haystack.deepset.ai/guides/rest-api#indexing-documents-in-the-haystack-rest-api-document-store).
     """
     if not INDEXING_PIPELINE:
         raise HTTPException(status_code=501, detail="Indexing Pipeline is not configured.")


### PR DESCRIPTION
Related to https://github.com/deepset-ai/haystack-website/pull/235.

A URL in `POST /file-upload` was referring to localhost: this PR fixes the URL so that points to the Haystack website.
