### PR TITLE
Disable `autoformat.yml` on master

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -10,9 +10,13 @@ on:
   # cannot push changes back to the source fork.
   # TODO make sure this is still necessary later on.
   push:
+    branches-ignore:    
+      - 'master'
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
+      - '**/*.png'
+      - '**/*.gif'
 
 
 jobs:


### PR DESCRIPTION
`autoformat.yml` can't succeed on `master`, therefore it should be disabled.

Note: this means that contributors pushing to their fork's `master` won't see `autoformat.yml` trigger unless they manually start it. A comment in the docs will be added on this regard.