### PR TITLE
Improve `Label` and `MultiLabel` `__str__` and `__repr__`

### DIFF
--- a/docs/_src/api/openapi/openapi.json
+++ b/docs/_src/api/openapi/openapi.json
@@ -278,7 +278,7 @@
                     "file-upload"
                 ],
                 "summary": "Upload File",
-                "description": "You can use this endpoint to upload a file for indexing\n(see [http://localhost:3000/guides/rest-api#indexing-documents-in-the-haystack-rest-api-document-store]).",
+                "description": "You can use this endpoint to upload a file for indexing\n(see https://haystack.deepset.ai/guides/rest-api#indexing-documents-in-the-haystack-rest-api-document-store).",
                 "operationId": "upload_file_file_upload_post",
                 "requestBody": {
                     "content": {

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -481,11 +481,20 @@ class Label:
         return str(self.to_dict())
 
     def __str__(self):
-        return str(self.to_dict())
+        return f"<Label: {self.to_dict()}>"
 
 
 @dataclass
 class MultiLabel:
+    labels: List[Label]
+    query: str
+    answers: List[str]
+    no_answer: bool
+    document_ids: List[str]
+    document_contents: List[str]
+    gold_offsets_in_contexts: List[Dict]
+    gold_offsets_in_documents: List[Dict]
+
     def __init__(self, labels: List[Label], drop_negative_labels=False, drop_no_answers=False):
         """
         There are often multiple `Labels` associated with a single query. For example, there can be multiple annotated
@@ -499,7 +508,6 @@ class MultiLabel:
         :param drop_negative_labels: Whether to drop negative labels from that group (e.g. thumbs down feedback from UI)
         :param drop_no_answers: Whether to drop labels that specify the answer is impossible
         """
-
         # drop duplicate labels and remove negative labels if needed.
         labels = list(set(labels))
         if drop_negative_labels:
@@ -588,7 +596,7 @@ class MultiLabel:
         return str(self.to_dict())
 
     def __str__(self):
-        return str(self.to_dict())
+        return f"<MultiLabel: {self.to_dict()}>"
 
 
 def _pydantic_dataclass_from_dict(dict: dict, pydantic_dataclass_type) -> Any:


### PR DESCRIPTION
Due to the `@dataclass` decorator and the use of `asdict()` in `MultiLabel`, its `__repr__` and `__str__` were often looking like empty dictionaries. 

This PR fixes the empty representation of `MultiLabel` and also adds a small prefix to the `__str__` of both `MultiLabel` and `Label`, in such a way that the two outputs are distinguishable.

Closes #1972
