### PR TITLE
Fix missing embeddings not skipped if filters are used

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1212,9 +1212,13 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         # +1 in similarity to avoid negative numbers (for cosine sim)
         body = {"size": top_k, "query": self._get_vector_similarity_query(query_emb, top_k)}
         if filters:
-            body["query"]["script_score"]["query"] = {
+            filter_ = {
                 "bool": {"filter": LogicalFilterClause.parse(filters).convert_to_elasticsearch()}
             }
+            if body["query"]["script_score"]["query"] ==  {"match_all": {}}:
+                body["query"]["script_score"]["query"] = filter_
+            else:
+                body["query"]["script_score"]["query"]["bool"]["filter"]["bool"]["must"].append(filter_)
 
         excluded_meta_data: Optional[list] = None
 

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1269,10 +1269,13 @@ def test_elasticsearch_delete_index():
     index_exists = client.indices.exists(index=index_name)
     assert not index_exists
 
+
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store):
     document_store.write_documents(DOCUMENTS)
-    document_without_embedding = Document(content="Doc without embedding", meta={"name": "name_7", "year": "2021", "month": "04"})
+    document_without_embedding = Document(
+        content="Doc without embedding", meta={"name": "name_7", "year": "2021", "month": "04"}
+    )
     document_store.write_documents([document_without_embedding])
     filters = {"year": "2021"}
     document_store.skip_missing_embeddings = False
@@ -1282,6 +1285,7 @@ def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store)
     document_store.skip_missing_embeddings = True
     documents = document_store.query_by_embedding(np.random.rand(768), filters=filters)
     assert len(documents) == 3
+
 
 @pytest.mark.elasticsearch
 def test_get_document_count_only_documents_without_embedding_arg():

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1269,6 +1269,19 @@ def test_elasticsearch_delete_index():
     index_exists = client.indices.exists(index=index_name)
     assert not index_exists
 
+@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
+def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store):
+    document_store.write_documents(DOCUMENTS)
+    document_without_embedding = Document(content="Doc without embedding", meta={"name": "name_7", "year": "2021", "month": "04"})
+    document_store.write_documents([document_without_embedding])
+    filters = {"year": "2021"}
+    document_store.skip_missing_embeddings = False
+    with pytest.raises(RequestError):
+        document_store.query_by_embedding(np.random.rand(768), filters=filters)
+
+    document_store.skip_missing_embeddings = True
+    documents = document_store.query_by_embedding(np.random.rand(768), filters=filters)
+    assert len(documents) == 3
 
 @pytest.mark.elasticsearch
 def test_get_document_count_only_documents_without_embedding_arg():


### PR DESCRIPTION
**Proposed changes**:
This PR fixes the bug that the `skip_missing_embeddings` parameter is ignored when filters are specified. Closes #2113.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [x] Added tests
- [ ] Updated documentation
