### PR TITLE
change old "text" to "content" for translator examples

### DIFF
--- a/docs/v1.1.0/_src/api/api/translator.md
+++ b/docs/v1.1.0/_src/api/api/translator.md
@@ -50,7 +50,7 @@ We currently recommend using OPUS models (see __init__() for details)
 
 ```python
 |    DOCS = [
-|        Document(text="Heinz von Foerster was an Austrian American scientist combining physics and philosophy,
+|        Document(content="Heinz von Foerster was an Austrian American scientist combining physics and philosophy,
 |                       and widely attributed as the originator of Second-order cybernetics.")
 |    ]
 |    translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-en-de")


### PR DESCRIPTION
**Proposed changes**:
The example snippets of the translator include the argument "text", though it should be "content"


