### PR TITLE
Rename openapi-1.2.0rc0.json into openapi-1.2.0.json

### DIFF
--- a/docs/_src/api/openapi/openapi-1.2.0.json
+++ b/docs/_src/api/openapi/openapi-1.2.0.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Haystack REST API",
-        "version": "1.2.0rc0"
+        "version": "1.2.0"
     },
     "paths": {
         "/initialized": {


### PR DESCRIPTION
Rename openapi specs for release
