### PR TITLE
save_to_deepset_cloud: automatically convert document stores

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -393,8 +393,8 @@ class BasePipeline:
         document_stores = [c for c in distinct_components if c["type"].endswith("DocumentStore")]
         for document_store in document_stores:
             if document_store["type"] != "DeepsetCloudDocumentStore":
-                logger.info(f"In order to be used in Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
-                            f"has been automatically converted to DeepsetCloudDocumentStore. "
+                logger.info(f"In order to be used on Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
+                            f"has been automatically converted to type DeepsetCloudDocumentStore. "
                             f"Usually the replacement will result in equivalent pipeline quality. "
                             f"However depending on chosen settings of '{document_store['name']}' differences might occur.")
                 document_store["type"] = "DeepsetCloudDocumentStore"

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -396,7 +396,7 @@ class BasePipeline:
                 logger.info(f"In order to be used in Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
                             f"has been automatically converted to DeepsetCloudDocumentStore. "
                             f"Usually the replacement will result in equivalent pipeline quality. "
-                            f"Depending on your chosen settings of '{document_store['name']}' differences with respect to retrieval quality might occur.")
+                            f"However depending on chosen settings of '{document_store['name']}' differences might occur.")
                 document_store["type"] = "DeepsetCloudDocumentStore"
                 document_store["params"] = {}
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -389,7 +389,16 @@ class BasePipeline:
         pipelines = query_config["pipelines"] + index_config["pipelines"]
         all_components = query_config["components"] + index_config["components"]
         distinct_components = [c for c in {component["name"]: component for component in all_components}.values()]
-        config = {"components": distinct_components, "pipelines": pipelines, "version": "0.9"}
+        config = {"components": distinct_components, "pipelines": pipelines, "version": __version__}
+        document_stores = [c for c in distinct_components if c["type"].endswith("DocumentStore")]
+        for document_store in document_stores:
+            if document_store["type"] != "DeepsetCloudDocumentStore":
+                logger.info(f"In order to be used in Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
+                            f"has been automatically converted to DeepsetCloudDocumentStore. "
+                            f"Usually the replacement will result in equivalent pipeline quality. "
+                            f"Depending on your chosen settings of '{document_store['name']}' differences with respect to retrieval quality might occur.")
+                document_store["type"] = "DeepsetCloudDocumentStore"
+                document_store["params"] = {}
 
         client = DeepsetCloud.get_pipeline_client(api_key=api_key, api_endpoint=api_endpoint, workspace=workspace)
         pipeline_config_info = client.get_pipeline_config_info(pipeline_config_name=pipeline_config_name)

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -389,16 +389,18 @@ class BasePipeline:
         pipelines = query_config["pipelines"] + index_config["pipelines"]
         all_components = query_config["components"] + index_config["components"]
         distinct_components = [c for c in {component["name"]: component for component in all_components}.values()]
-        config = {"components": distinct_components, "pipelines": pipelines, "version": __version__}
         document_stores = [c for c in distinct_components if c["type"].endswith("DocumentStore")]
         for document_store in document_stores:
             if document_store["type"] != "DeepsetCloudDocumentStore":
-                logger.info(f"In order to be used on Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
-                            f"has been automatically converted to type DeepsetCloudDocumentStore. "
-                            f"Usually this replacement will result in equivalent pipeline quality. "
-                            f"However depending on chosen settings of '{document_store['name']}' differences might occur.")
+                logger.info(
+                    f"In order to be used on Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
+                    f"has been automatically converted to type DeepsetCloudDocumentStore. "
+                    f"Usually this replacement will result in equivalent pipeline quality. "
+                    f"However depending on chosen settings of '{document_store['name']}' differences might occur."
+                )
                 document_store["type"] = "DeepsetCloudDocumentStore"
                 document_store["params"] = {}
+        config = {"components": distinct_components, "pipelines": pipelines, "version": __version__}
 
         client = DeepsetCloud.get_pipeline_client(api_key=api_key, api_endpoint=api_endpoint, workspace=workspace)
         pipeline_config_info = client.get_pipeline_config_info(pipeline_config_name=pipeline_config_name)

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -395,7 +395,7 @@ class BasePipeline:
             if document_store["type"] != "DeepsetCloudDocumentStore":
                 logger.info(f"In order to be used on Deepset Cloud, component '{document_store['name']}' of type '{document_store['type']}' "
                             f"has been automatically converted to type DeepsetCloudDocumentStore. "
-                            f"Usually the replacement will result in equivalent pipeline quality. "
+                            f"Usually this replacement will result in equivalent pipeline quality. "
                             f"However depending on chosen settings of '{document_store['name']}' differences might occur.")
                 document_store["type"] = "DeepsetCloudDocumentStore"
                 document_store["params"] = {}

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -749,6 +749,7 @@ def test_save_to_deepset_cloud():
         )
 
 
+@pytest.mark.elasticsearch
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
 @responses.activate
 def test_save_nonexisting_pipeline_to_deepset_cloud():

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -19,7 +19,7 @@ from haystack.nodes.retriever.sparse import ElasticsearchRetriever
 from haystack.pipelines import Pipeline, DocumentSearchPipeline, RootNode, ExtractiveQAPipeline
 from haystack.pipelines.config import _validate_user_input, validate_config
 from haystack.pipelines.utils import generate_code
-from haystack.nodes import DensePassageRetriever, EmbeddingRetriever, RouteDocuments
+from haystack.nodes import DensePassageRetriever, EmbeddingRetriever, RouteDocuments, PreProcessor, TextConverter
 
 from conftest import MOCK_DC, DC_API_ENDPOINT, DC_API_KEY, DC_TEST_INDEX, SAMPLES_PATH, deepset_cloud_fixture
 
@@ -787,6 +787,45 @@ def test_save_to_deepset_cloud():
             api_key=DC_API_KEY,
             overwrite=True,
         )
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_save_nonexisting_pipeline_to_deepset_cloud():
+    if MOCK_DC:
+        responses.add(
+            method=responses.GET,
+            url=f"{DC_API_ENDPOINT}/workspaces/default/pipelines/test_new_non_existing_pipeline",
+            json={"errors": ["Pipeline with the name test_pipeline_config_copy does not exists."]},
+            status=404,
+        )
+
+        responses.add(
+            method=responses.POST,
+            url=f"{DC_API_ENDPOINT}/workspaces/default/pipelines",
+            json={"name": "test_new_non_existing_pipeline"},
+            status=201,
+        )
+
+    es_document_store = ElasticsearchDocumentStore()
+    es_retriever = ElasticsearchRetriever(document_store=es_document_store)
+    file_converter = TextConverter()
+    preprocessor = PreProcessor()
+
+    query_pipeline = Pipeline()
+    query_pipeline.add_node(component=es_retriever, name="Retriever", inputs=["Query"])
+    index_pipeline = Pipeline()
+    index_pipeline.add_node(component=file_converter, name="FileConverter", inputs=["File"])
+    index_pipeline.add_node(component=preprocessor, name="Preprocessor", inputs=["FileConverter"])
+    index_pipeline.add_node(component=es_document_store, name="DocumentStore", inputs=["Preprocessor"])
+
+    Pipeline.save_to_deepset_cloud(
+        query_pipeline=query_pipeline,
+        index_pipeline=index_pipeline,
+        pipeline_config_name="test_new_non_existing_pipeline",
+        api_endpoint=DC_API_ENDPOINT,
+        api_key=DC_API_KEY,
+    )
 
 
 # @pytest.mark.slow


### PR DESCRIPTION
**Proposed changes**:
- convert document stores to type `DeepsetCloudDocumentStore`
- show info 
 
INFO:
```
In order to be used on Deepset Cloud, component 'MyDocumentStore' of type 'ElasticsearchDocumentStore' has been automatically converted to type DeepsetCloudDocumentStore. 
Usually this replacement will result in equivalent pipeline quality.  
However depending on chosen settings of 'MyDocumentStore' differences might occur.
```

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests

closes https://github.com/deepset-ai/haystack/issues/2235