### PR TITLE
adding quotes for zsh shell issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ The following command will install the latest version of Haystack from the maste
 git clone https://github.com/deepset-ai/haystack.git
 cd haystack
 pip install --upgrade pip
-pip install -e .[all] ## or 'all-gpu' for the GPU-enabled dependencies
+pip install -e '.[all]' ## or 'all-gpu' for the GPU-enabled dependencies
 ```
 
 If you cannot upgrade `pip` to version 21.3 or higher, you will need to replace:
-- `[all]` with `[sql,only-faiss,only-milvus1,weaviate,graphdb,crawler,preprocessing,ocr,onnx,ray,dev]`
-- `[all-gpu]` with `[sql,only-faiss-gpu,only-milvus1,weaviate,graphdb,crawler,preprocessing,ocr,onnx-gpu,ray,dev]`
+- `'.[all]'` with `'.[sql,only-faiss,only-milvus1,weaviate,graphdb,crawler,preprocessing,ocr,onnx,ray,dev]'`
+- `'.[all-gpu]'` with `'.[sql,only-faiss-gpu,only-milvus1,weaviate,graphdb,crawler,preprocessing,ocr,onnx-gpu,ray,dev]'`
 
 For an complete list of the dependency groups available, have a look at the `haystack/setup.cfg` file.
 

--- a/haystack/utils/import_utils.py
+++ b/haystack/utils/import_utils.py
@@ -50,7 +50,7 @@ def _optional_component_not_installed(component: str, dep_group: str, source_err
     raise ImportError(
         f"Failed to import '{component}', "
         "which is an optional component in Haystack.\n"
-        f"Run 'pip install farm-haystack[{dep_group}]' "
+        f"Run 'pip install 'farm-haystack[{dep_group}]'' "
         "to install the required dependencies and make this component available."
     ) from source_error
 


### PR DESCRIPTION
**Proposed changes**:
- Adding quotes around square brackets in install commands to go around the zsh shell issue. Works for others as well
@ZanSara, I'll also add quotes to the line in `import_utils.py` below: 

```
def _optional_component_not_installed(component: str, dep_group: str, source_error: Exception):
    raise ImportError(
        f"Failed to import '{component}', "
        "which is an optional component in Haystack.\n"
        f"Run 'pip install farm-haystack[{dep_group}]' "
        "to install the required dependencies and make this component available."
    ) from source_error
```

What this prompt suggests will also result in `zsh: no matches found: farm-haystack[crawler]`. 
But let me know if I should keep them out here.

**Status (please check what you already did)**:
- [ x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
