### PR TITLE
Fix PreProcessor test

### DIFF
--- a/docs/_src/api/api/preprocessor.md
+++ b/docs/_src/api/api/preprocessor.md
@@ -15,7 +15,7 @@ class BasePreProcessor(BaseComponent)
 #### process
 
 ```python
-def process(documents: Union[dict, List[dict]], clean_whitespace: Optional[bool] = True, clean_header_footer: Optional[bool] = False, clean_empty_lines: Optional[bool] = True, split_by: Optional[str] = "word", split_length: Optional[int] = 1000, split_overlap: Optional[int] = None, split_respect_sentence_boundary: Optional[bool] = True) -> List[dict]
+def process(documents: Union[dict, List[dict]], clean_whitespace: Optional[bool] = True, clean_header_footer: Optional[bool] = False, clean_empty_lines: Optional[bool] = True, remove_substrings: List[str] = [], split_by: Optional[str] = "word", split_length: Optional[int] = 1000, split_overlap: Optional[int] = None, split_respect_sentence_boundary: Optional[bool] = True) -> List[dict]
 ```
 
 Perform document cleaning and splitting. Takes a single document as input and returns a list of documents.

--- a/haystack/nodes/preprocessor/base.py
+++ b/haystack/nodes/preprocessor/base.py
@@ -9,14 +9,14 @@ class BasePreProcessor(BaseComponent):
     def process(
         self,
         documents: Union[dict, List[dict]],
-        clean_whitespace: Optional[bool] = None,
-        clean_header_footer: Optional[bool] = None,
-        clean_empty_lines: Optional[bool] = None,
+        clean_whitespace: Optional[bool] = True,
+        clean_header_footer: Optional[bool] = False,
+        clean_empty_lines: Optional[bool] = True,
         remove_substrings: List[str] = [],
-        split_by: Optional[str] = None,
-        split_length: Optional[int] = None,
+        split_by: Optional[str] = "word",
+        split_length: Optional[int] = 1000,
         split_overlap: Optional[int] = None,
-        split_respect_sentence_boundary: Optional[bool] = None,
+        split_respect_sentence_boundary: Optional[bool] = True,
     ) -> List[dict]:
         """
         Perform document cleaning and splitting. Takes a single document as input and returns a list of documents.

--- a/haystack/nodes/preprocessor/base.py
+++ b/haystack/nodes/preprocessor/base.py
@@ -9,13 +9,14 @@ class BasePreProcessor(BaseComponent):
     def process(
         self,
         documents: Union[dict, List[dict]],
-        clean_whitespace: Optional[bool] = True,
-        clean_header_footer: Optional[bool] = False,
-        clean_empty_lines: Optional[bool] = True,
-        split_by: Optional[str] = "word",
-        split_length: Optional[int] = 1000,
+        clean_whitespace: Optional[bool] = None,
+        clean_header_footer: Optional[bool] = None,
+        clean_empty_lines: Optional[bool] = None,
+        remove_substrings: List[str] = [],
+        split_by: Optional[str] = None,
+        split_length: Optional[int] = None,
         split_overlap: Optional[int] = None,
-        split_respect_sentence_boundary: Optional[bool] = True,
+        split_respect_sentence_boundary: Optional[bool] = None,
     ) -> List[dict]:
         """
         Perform document cleaning and splitting. Takes a single document as input and returns a list of documents.
@@ -23,7 +24,12 @@ class BasePreProcessor(BaseComponent):
         raise NotImplementedError
 
     def clean(
-        self, document: dict, clean_whitespace: bool, clean_header_footer: bool, clean_empty_lines: bool
+        self,
+        document: dict,
+        clean_whitespace: bool,
+        clean_header_footer: bool,
+        clean_empty_lines: bool,
+        remove_substrings: List[str],
     ) -> Dict[str, Any]:
         raise NotImplementedError
 

--- a/test/test_preprocessor.py
+++ b/test/test_preprocessor.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from haystack import Document
 from haystack.nodes.file_converter.pdf import PDFToTextConverter
 from haystack.nodes.preprocessor.preprocessor import PreProcessor
 


### PR DESCRIPTION
Due to an oversight from my side when merging a recent Preprocessor feature, the preprocessor tests now fail for a missing `Document` import.

This PR fixes the issue.
