### PR TITLE
Prevent Preprocessor from changing existing documents

### DIFF
--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -224,7 +224,10 @@ class PreProcessor(BasePreProcessor):
         for substring in remove_substrings:
             text = text.replace(substring, "")
 
-        document["content"] = text
+        if text != document["content"]:
+            document = deepcopy(document)
+            document["content"] = text
+
         return document
 
     def split(

--- a/test/test_preprocessor.py
+++ b/test/test_preprocessor.py
@@ -92,7 +92,7 @@ def test_clean_header_footer():
 
 
 def test_remove_substrings():
-    document = Document("This is a header. Some additional text. wiki. Some emoji ✨ 🪲 Weird whitespace\b\b\b.")
+    document = {"content": "This is a header. Some additional text. wiki. Some emoji ✨ 🪲 Weird whitespace\b\b\b."}
 
     # check that the file contains the substrings we are about to remove
     assert "This is a header." in document["content"]
@@ -104,8 +104,8 @@ def test_remove_substrings():
     preprocessor = PreProcessor(remove_substrings=["This is a header.", "wiki", "🪲"])
     documents = preprocessor.process(document)
 
-    assert "This is a header." not in document["content"]
-    assert "wiki" not in document["content"]
-    assert "🪲" not in document["content"]
-    assert "whitespace" in document["content"]
-    assert "✨" in document["content"]
+    assert "This is a header." not in documents[0]["content"]
+    assert "wiki" not in documents[0]["content"]
+    assert "🪲" not in documents[0]["content"]
+    assert "whitespace" in documents[0]["content"]
+    assert "✨" in documents[0]["content"]


### PR DESCRIPTION
I actually just wanted to fix the bug in test `test_remove_substrings` as it uses a Document and not a dict. But I found it counterintuitive that preprocessor changes the input inplace if it's not splitting texts. This PR fixes this too.

**Proposed changes**:
- fix bug in `test_remove_substrings`
- deepcopy document if text is changed during cleaning

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
