### PR TITLE
Disable cache in linux ci

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -29,13 +29,13 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          # The cache will be rebuild every day and at every change of the dependency files
-          key: haystack-ci-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+#       - name: Cache
+#         id: cache-python-env
+#         uses: actions/cache@v2
+#         with:
+#           path: ${{ env.pythonLocation }}
+#           # The cache will be rebuild every day and at every change of the dependency files
+#           key: haystack-ci-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -37,16 +37,16 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          # The cache will be rebuild every day and at every change of the dependency files
-          key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+#       - name: Cache
+#         id: cache-python-env
+#         uses: actions/cache@v2
+#         with:
+#           path: ${{ env.pythonLocation }}
+#           # The cache will be rebuild every day and at every change of the dependency files
+#           key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
+#         if: steps.cache-python-env.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade pip
           pip install .[test]
@@ -103,16 +103,16 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Cache Python
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+#       - name: Cache Python
+#         uses: actions/cache@v2
+#         with:
+#           path: ${{ env.pythonLocation }}
+#           key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install Dependencies (on cache miss only)
         # The cache might miss during the execution of an action: there should always be a fallback step to
         # rebuild it in case it goes missing
-        if: steps.cache.outputs.cache-hit != 'true'
+#         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade pip
           pip install .[all]
@@ -148,16 +148,16 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Cache Python
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+#       - name: Cache Python
+#         uses: actions/cache@v2
+#         with:
+#           path: ${{ env.pythonLocation }}
+#           key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install Dependencies (on cache miss only)
         # The cache might miss during the execution of an action: there should always be a fallback step to
         # rebuild it in case it goes missing
-        if: steps.cache.outputs.cache-hit != 'true'
+#         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install --upgrade pip
           pip install .[all]
@@ -247,11 +247,11 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Cache Python
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+#     - name: Cache Python
+#       uses: actions/cache@v2
+#       with:
+#         path: ${{ env.pythonLocation }}
+#         key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
@@ -283,7 +283,7 @@ jobs:
     - name: Install Dependencies (on cache miss only)
       # The cache might miss during the execution of an action: there should always be a fallback step to
       # rebuild it in case it goes missing
-      if: steps.cache.outputs.cache-hit != 'true'
+#       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install --upgrade pip
         pip install .[test]
@@ -316,11 +316,11 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Cache Python
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+#     - name: Cache Python
+#       uses: actions/cache@v2
+#       with:
+#         path: ${{ env.pythonLocation }}
+#         key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
     - name: Run Milvus 1
       run: docker run -d -p 19530:19530 -p 19121:19121 milvusdb/milvus:1.1.0-cpu-d050721-5e559c
@@ -331,7 +331,7 @@ jobs:
     - name: Install Dependencies (on cache miss only)
       # The cache might miss during the execution of an action: there should always be a fallback step to
       # rebuild it in case it goes missing
-      if: steps.cache.outputs.cache-hit != 'true'
+#       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install --upgrade pip
         pip install .[test]

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -27,15 +27,15 @@ on:
 
 jobs:
 
-  build-cache:
-    runs-on: ubuntu-20.04
-    steps:
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+#   build-cache:
+#     runs-on: ubuntu-20.04
+#     steps:
+#       - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
+#       - uses: actions/checkout@v2
+#       - uses: actions/setup-python@v2
+#         with:
+#           python-version: 3.7
 
 #       - name: Cache
 #         id: cache-python-env
@@ -45,16 +45,16 @@ jobs:
 #           # The cache will be rebuild every day and at every change of the dependency files
 #           key: linux-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
-      - name: Install dependencies
+#       - name: Install dependencies
 #         if: steps.cache-python-env.outputs.cache-hit != 'true'
-        run: |
-          pip install --upgrade pip
-          pip install .[test]
-          pip install rest_api/
-          pip install ui/
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-          echo "=== pip freeze ==="
-          pip freeze
+#         run: |
+#           pip install --upgrade pip
+#           pip install .[test]
+#           pip install rest_api/
+#           pip install ui/
+#           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+#           echo "=== pip freeze ==="
+#           pip freeze
 
 
   type-check:
@@ -130,7 +130,7 @@ jobs:
 
   
   code-and-docs-check:
-    needs: build-cache
+#     needs: build-cache
     runs-on: ubuntu-latest
     if: ${{ github.event_name }} != "push"
 
@@ -218,7 +218,7 @@ jobs:
 
 
   prepare-matrix:
-    needs: build-cache
+#     needs: build-cache
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -304,7 +304,7 @@ jobs:
 
 
   test-milvus1:
-    needs: build-cache
+#     needs: build-cache
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [ master ]
-#  pull_request:
-#    branches: [ master ]
 
 jobs:
   type-check:
@@ -20,42 +18,42 @@ jobs:
           pip install mypy==0.910 types-Markdown types-requests types-PyYAML pydantic
           mypy haystack
 
-  build-cache:
-    needs: type-check
-    runs-on: windows-latest
+#   build-cache:
+#     needs: type-check
+#     runs-on: windows-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions/setup-python@v2
+#         with:
+#           python-version: 3.7
 
-      - name: Cache
-        id: cache-python-env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          # The cache currently misses at every change in the Python files to ensure
-          # that the code changes to Haystack are not being cached along with the dependencies.
-          # TODO for the tests refactoring: We could speed up the process by caching only 
-          # the dependencies and installing Haystack again separately for each test runner.
-          key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
+#       - name: Cache
+#         id: cache-python-env
+#         uses: actions/cache@v2
+#         with:
+#           path: ${{ env.pythonLocation }}
+#           # The cache currently misses at every change in the Python files to ensure
+#           # that the code changes to Haystack are not being cached along with the dependencies.
+#           # TODO for the tests refactoring: We could speed up the process by caching only 
+#           # the dependencies and installing Haystack again separately for each test runner.
+#           key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
       
-      - name: Install Pytorch on windows
-        run: |
-          pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+#       - name: Install Pytorch on windows
+#         run: |
+#           pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
       
-      - name: Install dependencies
-        if: steps.cache-python-env.outputs.cache-hit != 'true'
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager .[test]
-          pip install --upgrade --upgrade-strategy eager rest_api/
-          pip install --upgrade --upgrade-strategy eager ui/
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
+#       - name: Install dependencies
+#         if: steps.cache-python-env.outputs.cache-hit != 'true'
+#         run: |
+#           python -m pip install --upgrade pip
+#           pip install --upgrade --upgrade-strategy eager .[test]
+#           pip install --upgrade --upgrade-strategy eager rest_api/
+#           pip install --upgrade --upgrade-strategy eager ui/
+#           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
 
   prepare-build:
-    needs: build-cache
+#     needs: build-cache
     # With Windows it gives error, also this step only listing test files only
     runs-on: ubuntu-20.04
     steps:
@@ -80,11 +78,11 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
+#     - name: Cache
+#       uses: actions/cache@v2
+#       with:
+#         path: ${{ env.pythonLocation }}
+#         key: windows-${{ hashFiles('**/*.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('.github') }}
 
     # Windows runner can't run Linux containers. Refer https://github.com/actions/virtual-environments/issues/1143
     - name: Set up Windows test env


### PR DESCRIPTION
**Problem**
Due to a bug in `hashFiles`, CI fails constantly on the Post Cache task.

**Solution**
This PR comments out all uses of the cache in CI

**NOTE**: Do not forget to re-enable the cache in one or two weeks, when the bug will be solved.