### PR TITLE
create milvus2 containers outside of haystack

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -258,6 +258,7 @@ jobs:
 
     - name: Run Milvus
       run: |
+        cd ../../   # Avoid causing permission issues on hashFiles later by creating unreadable folders like "volumes"
         wget https://github.com/milvus-io/milvus/releases/download/v2.0.0/milvus-standalone-docker-compose.yml -O docker-compose.yml
         sudo docker-compose up -d
         sudo docker-compose ps


### PR DESCRIPTION
**Problem**
CI is breaking on `hashFiles` after tests are run due to permission problem in the "volume" folders created by docker-compose into the haystack folder. https://github.com/deepset-ai/haystack/runs/5495633130?check_suite_focus=true 

Related to https://github.com/actions/cache/issues/753

**Solution**:
Start docker-compose outside of the haystack folder.
