### PR TITLE
Sas gpu additions

### DIFF
--- a/haystack/nodes/evaluator/evaluator.py
+++ b/haystack/nodes/evaluator/evaluator.py
@@ -403,8 +403,9 @@ def semantic_answer_similarity(
     :param gold_labels: Labels as list of multiple possible answers per question
     :param sas_model_name_or_path: SentenceTransformers semantic textual similarity model, should be path or string
                                      pointing to downloadable models.
-    :param batch_size: Batch size for encoding
-    :param use_gpu: Bool that indicates whether GPU is used for calculating SAS. If False CPU is used, if True GPU is used if available.
+    :param batch_size: Number of prediction label pairs to encode at once.
+    :param use_gpu: Whether to use a GPU or the CPU for calculating semantic answer similarity.
+                    Falls back to CPU if no GPU is available.
     :return: top_1_sas, top_k_sas
     """
     assert len(predictions) == len(gold_labels)

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -754,7 +754,7 @@ class Pipeline(BasePipeline):
                     predictions = [[a] for a in df["answer"].values]
                     sas, _ = semantic_answer_similarity(
                         predictions=predictions, gold_labels=gold_labels, sas_model_name_or_path=sas_model_name_or_path,
-                        sas_batch_size=sas_batch_size, sas_use_gpu=sas_use_gpu
+                        batch_size=sas_batch_size, use_gpu=sas_use_gpu
                     )
                     df["sas"] = sas
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -684,6 +684,8 @@ class Pipeline(BasePipeline):
         documents: Optional[List[List[Document]]] = None,
         params: Optional[dict] = None,
         sas_model_name_or_path: str = None,
+        sas_batch_size: int = 32,
+        sas_use_gpu: bool = True,
         add_isolated_node_eval: bool = False,
     ) -> EvaluationResult:
         """
@@ -749,7 +751,8 @@ class Pipeline(BasePipeline):
                     gold_labels = df["gold_answers"].values
                     predictions = [[a] for a in df["answer"].values]
                     sas, _ = semantic_answer_similarity(
-                        predictions=predictions, gold_labels=gold_labels, sas_model_name_or_path=sas_model_name_or_path
+                        predictions=predictions, gold_labels=gold_labels, sas_model_name_or_path=sas_model_name_or_path,
+                        sas_batch_size=sas_batch_size, sas_use_gpu=sas_use_gpu
                     )
                     df["sas"] = sas
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -709,8 +709,9 @@ class Pipeline(BasePipeline):
                     - Good default for multiple languages: "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
                     - Large, powerful, but slow model for English only: "cross-encoder/stsb-roberta-large"
                     - Large model for German only: "deepset/gbert-large-sts"
-        :param batch_size: Batch size for encoding that is used by CrossEncoder or SentenceTransformer to calculate SAS.
-        :param use_gpu: Bool that indicates whether GPU is used for calculating SAS. If False CPU is used, if True GPU is used if available.
+        :param sas_batch_size: Number of prediction label pairs to encode at once by CrossEncoder or SentenceTransformer while calculating SAS.
+        :param sas_use_gpu: Whether to use a GPU or the CPU for calculating semantic answer similarity.
+                            Falls back to CPU if no GPU is available.
         :param add_isolated_node_eval: If set to True, in addition to the integrated evaluation of the pipeline, each node is evaluated in isolated evaluation mode.
                     This mode helps to understand the bottlenecks of a pipeline in terms of output quality of each individual node.
                     If a node performs much better in the isolated evaluation than in the integrated evaluation, the previous node needs to be optimized to improve the pipeline's performance.

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -709,6 +709,8 @@ class Pipeline(BasePipeline):
                     - Good default for multiple languages: "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
                     - Large, powerful, but slow model for English only: "cross-encoder/stsb-roberta-large"
                     - Large model for German only: "deepset/gbert-large-sts"
+        :param batch_size: Batch size for encoding that is used by CrossEncoder or SentenceTransformer to calculate SAS.
+        :param use_gpu: Bool that indicates whether GPU is used for calculating SAS. If False CPU is used, if True GPU is used if available.
         :param add_isolated_node_eval: If set to True, in addition to the integrated evaluation of the pipeline, each node is evaluated in isolated evaluation mode.
                     This mode helps to understand the bottlenecks of a pipeline in terms of output quality of each individual node.
                     If a node performs much better in the isolated evaluation than in the integrated evaluation, the previous node needs to be optimized to improve the pipeline's performance.


### PR DESCRIPTION
**Proposed changes**:
- Added sas_batch_size and sas_use_gpu to pipeline.eval and semantic_answer_similarity
- sas_batch_size defaults to 32 as in CrossEncoder and SentenceTransformer
- sas_use_gpu defaults to True which is used to set device in semantic_answer_similarity to None which is the default behavior in CrossEncoder and SentenceTransformer and checks if GPU is available. If False, device is set to 'cpu'

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
