### PR TITLE
Fix dependency graph for indexing pipelines during codegen

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -361,7 +361,7 @@ Reader from multiple Retrievers, or re-ranking of candidate documents.
 #### add\_node
 
 ```python
-def add_node(component, name: str, inputs: List[str])
+def add_node(component: BaseComponent, name: str, inputs: List[str])
 ```
 
 Add a new node to the pipeline.

--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -94,7 +94,7 @@ class BaseComponent(ABC):
         component_signature = self._get_signature()
         params: Dict[str, Any] = {}
         for key, value in self._component_config["params"].items():
-            if value == component_signature[key].default or return_defaults:
+            if value != component_signature[key].default or return_defaults:
                 params[key] = value
         if return_defaults:
             for key, param in component_signature.items():

--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -41,10 +41,7 @@ def exportable_to_yaml(init_func):
 
             # Store all the named input parameters in self._component_config
             for k, v in kwargs.items():
-                if isinstance(v, BaseComponent):
-                    self._component_config["params"][k] = v._component_config
-                elif v is not None:
-                    self._component_config["params"][k] = v
+                self._component_config["params"][k] = v
 
     return wrapper_exportable_to_yaml
 
@@ -55,7 +52,6 @@ class BaseComponent(ABC):
     """
 
     outgoing_edges: int
-    name: Optional[str] = None
     _subclasses: dict = {}
     _component_config: dict = {}
 
@@ -73,6 +69,38 @@ class BaseComponent(ABC):
         # Keeps track of all available subclasses by name.
         # Enables generic load() for all specific component implementations.
         cls._subclasses[cls.__name__] = cls
+
+    @property
+    def name(self) -> Optional[str]:
+        if "name" not in self._component_config:
+            return None
+        return self._component_config["name"]
+
+    @name.setter
+    def name(self, value: str):
+        self._component_config["name"] = value
+
+    @property
+    def sub_components(self) -> List[BaseComponent]:
+        if "params" not in self._component_config:
+            return list()
+        return [param for param in self._component_config["params"].values() if isinstance(param, BaseComponent)]
+
+    @property
+    def type(self) -> str:
+        return self._component_config["type"]
+
+    def get_params(self, return_defaults: bool = False) -> Dict[str, Any]:
+        component_signature = self._get_signature()
+        params: Dict[str, Any] = {}
+        for key, value in self._component_config["params"].items():
+            if value == component_signature[key].default or return_defaults:
+                params[key] = value
+        if return_defaults:
+            for key, param in component_signature.items():
+                if key not in params:
+                    params[key] = param.default
+        return params
 
     @classmethod
     def get_subclass(cls, component_type: str):
@@ -207,3 +235,13 @@ class BaseComponent(ABC):
 
         output["params"] = params
         return output, stream
+
+    @classmethod
+    def _get_signature(cls) -> Dict[str, inspect.Parameter]:
+        component_classes = inspect.getmro(cls)
+        component_signature: Dict[str, inspect.Parameter] = {
+            param_key: parameter
+            for class_ in component_classes
+            for param_key, parameter in inspect.signature(class_).parameters.items()
+        }
+        return component_signature

--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -79,7 +79,7 @@ class BaseComponent(ABC):
         self._component_config["name"] = value
 
     @property
-    def dependencies(self) -> List[BaseComponent]:
+    def utilized_components(self) -> List[BaseComponent]:
         if "params" not in self._component_config:
             return list()
         return [param for param in self._component_config["params"].values() if isinstance(param, BaseComponent)]

--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -72,16 +72,14 @@ class BaseComponent(ABC):
 
     @property
     def name(self) -> Optional[str]:
-        if "name" not in self._component_config:
-            return None
-        return self._component_config["name"]
+        return self._component_config.get("name", None)
 
     @name.setter
     def name(self, value: str):
         self._component_config["name"] = value
 
     @property
-    def sub_components(self) -> List[BaseComponent]:
+    def dependencies(self) -> List[BaseComponent]:
         if "params" not in self._component_config:
             return list()
         return [param for param in self._component_config["params"].values() if isinstance(param, BaseComponent)]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1224,7 +1224,7 @@ class Pipeline(BasePipeline):
                 component_names.update(sub_component_names)
         return component_names
 
-    def _set_sub_component_names(self, component: BaseComponent, component_names: Optional[Set[str]] = None):
+    def _set_sub_component_names(self, component: BaseComponent, component_names: Set[str]):
         for sub_component in component.dependencies:
             if sub_component.name is None:
                 sub_component.name = self._generate_component_name(

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1196,7 +1196,7 @@ class Pipeline(BasePipeline):
                     }
 
                     # search for existing components that match the subcomponent
-                    sub_component_name: str = None
+                    sub_component_name: Optional[str] = None
                     for existing_node in self.graph.nodes:
                         node_component = self.graph.nodes.get(existing_node)["component"]._component_config
                         if (

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1220,12 +1220,12 @@ class Pipeline(BasePipeline):
         for component in components_to_search:
             if component.name is not None:
                 component_names.add(component.name)
-                sub_component_names = self._get_all_component_names(component.dependencies)
+                sub_component_names = self._get_all_component_names(component.utilized_components)
                 component_names.update(sub_component_names)
         return component_names
 
     def _set_sub_component_names(self, component: BaseComponent, component_names: Set[str]):
-        for sub_component in component.dependencies:
+        for sub_component in component.utilized_components:
             if sub_component.name is None:
                 sub_component.name = self._generate_component_name(
                     type_name=sub_component.type, existing_component_names=component_names

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1171,7 +1171,7 @@ class Pipeline(BasePipeline):
             if node_name != component.name:
                 raise PipelineError(f"Component name '{component.name}' does not match node name '{node_name}'.")
 
-            self._add_component_to_component_definitions(
+            self._add_component_to_definitions(
                 component=component, component_definitions=component_definitions, return_defaults=return_defaults
             )
 
@@ -1187,7 +1187,7 @@ class Pipeline(BasePipeline):
         }
         return config
 
-    def _add_component_to_component_definitions(
+    def _add_component_to_definitions(
         self, component: BaseComponent, component_definitions: Dict[str, Dict], return_defaults: bool = False
     ):
         if component.name is None:
@@ -1198,7 +1198,7 @@ class Pipeline(BasePipeline):
         for param_key, param_value in component_params.items():
             if isinstance(param_value, BaseComponent):
                 sub_component = param_value
-                self._add_component_to_component_definitions(sub_component, component_definitions, return_defaults)
+                self._add_component_to_definitions(sub_component, component_definitions, return_defaults)
                 component_params[param_key] = sub_component.name
 
         component_definitions[component.name] = {

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1199,21 +1199,26 @@ class Pipeline(BasePipeline):
                     sub_component_name: str = None
                     for existing_node in self.graph.nodes:
                         node_component = self.graph.nodes.get(existing_node)["component"]._component_config
-                        if node_component["type"] == sub_component_type_name and node_component["params"] == sub_component_params:
+                        if (
+                            node_component["type"] == sub_component_type_name
+                            and node_component["params"] == sub_component_params
+                        ):
                             sub_component_name = existing_node
                             break
-                    
+
                     # if there is no matching existing component we create one
                     if sub_component_name is None:
                         sub_component_name = self._generate_component_name(
-                            type_name=sub_component_type_name, params=sub_component_params, existing_components=components
+                            type_name=sub_component_type_name,
+                            params=sub_component_params,
+                            existing_components=components,
                         )
                         components[sub_component_name] = {
                             "name": sub_component_name,
                             "type": sub_component_type_name,
                             "params": sub_component_params,
                         }
-                
+
                     components[node]["params"][param_key] = sub_component_name
                 else:
                     if component_signature[param_key].default != param_value or return_defaults is True:
@@ -1221,7 +1226,6 @@ class Pipeline(BasePipeline):
 
             # create the Pipeline definition with how the Component are connected
             pipelines[pipeline_name]["nodes"].append({"name": node, "inputs": list(self.graph.predecessors(node))})
-
 
         config = {
             "components": list(components.values()),

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from os import pipe
-from typing import Dict, List, Optional, Any, Sequence, Set
+from typing import Dict, List, Optional, Any, Set
 
 import copy
 import json
@@ -1214,14 +1214,14 @@ class Pipeline(BasePipeline):
         for component in components_to_search:
             if component.name is not None:
                 component_names.add(component.name)
-                sub_component_names = self._get_all_component_names(component.sub_components)
+                sub_component_names = self._get_all_component_names(component.dependencies)
                 component_names.update(sub_component_names)
         return component_names
 
     def _set_sub_component_names(self, component: BaseComponent, component_names: Optional[Set[str]] = None):
         if component_names is None:
             component_names = self._get_all_component_names()
-        for sub_component in component.sub_components:
+        for sub_component in component.dependencies:
             if sub_component.name is None:
                 sub_component.name = self._generate_component_name(
                     type_name=sub_component.type, existing_component_names=component_names

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1178,7 +1178,7 @@ class Pipeline(BasePipeline):
                 # other parameters like "custom_mapping" that are dicts.
                 # This currently only checks for the case single-level nesting case, wherein, "a Component has another
                 # Component as a parameter". For deeper nesting cases, this function should be made recursive.
-                if isinstance(param_value, dict) and "type" in param_value.keys():  
+                if isinstance(param_value, dict) and "type" in param_value.keys():
                     # the parameter is a Component
                     sub_component = param_value
                     sub_component_type_name = sub_component["type"]
@@ -1206,7 +1206,7 @@ class Pipeline(BasePipeline):
                         }
 
                     component_definitions[node_name]["params"][param_key] = sub_component_name
-                else:  
+                else:
                     # normal parameter (not a Component)
                     if component_signature[param_key].default != param_value or return_defaults is True:
                         component_definitions[node_name]["params"][param_key] = param_value
@@ -1242,7 +1242,9 @@ class Pipeline(BasePipeline):
 
         return component_signature
 
-    def _generate_component_name(self, type_name: str, params: Dict[str, Any], existing_components: Dict[str, Any]) -> str:
+    def _generate_component_name(
+        self, type_name: str, params: Dict[str, Any], existing_components: Dict[str, Any]
+    ) -> str:
         component_name: str = type_name
         # add number if there are multiple distinct ones of the same type
         while component_name in existing_components and params != existing_components[component_name]["params"]:

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -113,12 +113,6 @@ def build_component_dependency_graph(
     :param component_definitions: the definition of the pipeline components (e.g. use get_component_definitions() to obtain it)
     """
     graph = DiGraph()
-    for node in pipeline_definition["nodes"]:
-        node_name = node["name"]
-        graph.add_node(node_name)
-        for input in node["inputs"]:
-            if input in component_definitions:
-                graph.add_edge(input, node_name)
     for component_name, component_definition in component_definitions.items():
         params = component_definition.get("params", {})
         referenced_components: List[str] = list()
@@ -129,6 +123,17 @@ def build_component_dependency_graph(
                 referenced_components.append(param_value)
         for referenced_component in referenced_components:
             graph.add_edge(referenced_component, component_name)
+    for node in pipeline_definition["nodes"]:
+        node_name = node["name"]
+        graph.add_node(node_name)
+        for input in node["inputs"]:
+            if input in component_definitions:
+                # Special case for (actually permitted) cyclic dependencies between two components:
+                # e.g. DensePassageRetriever depends on ElasticsearchDocumentStore.
+                # In indexing pipelines ElasticsearchDocumentStore depends on DensePassageRetriever's output.
+                # But this second dependency is looser, so we neglect it. 
+                if not graph.has_edge(node_name, input):
+                    graph.add_edge(input, node_name)
     return graph
 
 

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -131,7 +131,7 @@ def build_component_dependency_graph(
                 # Special case for (actually permitted) cyclic dependencies between two components:
                 # e.g. DensePassageRetriever depends on ElasticsearchDocumentStore.
                 # In indexing pipelines ElasticsearchDocumentStore depends on DensePassageRetriever's output.
-                # But this second dependency is looser, so we neglect it. 
+                # But this second dependency is looser, so we neglect it.
                 if not graph.has_edge(node_name, input):
                     graph.add_edge(input, node_name)
     return graph

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -112,12 +112,14 @@ def test_to_code_can_handle_weak_cyclic_pipelines():
     pipeline.add_node(component=parent, name="parent", inputs=["Query"])
     pipeline.add_node(component=child, name="child", inputs=["parent"])
     code = pipeline.to_code(generate_imports=False)
-    assert code == ("child = ChildComponent()\n"
-                    "parent = ParentComponent(dependent=child)\n"
-                    "\n"
-                    "pipeline = Pipeline()\n"
-                    "pipeline.add_node(component=parent, name=\"parent\", inputs=[\"Query\"])\n"
-                    "pipeline.add_node(component=child, name=\"child\", inputs=[\"parent\"])")
+    assert code == (
+        "child = ChildComponent()\n"
+        "parent = ParentComponent(dependent=child)\n"
+        "\n"
+        "pipeline = Pipeline()\n"
+        'pipeline.add_node(component=parent, name="parent", inputs=["Query"])\n'
+        'pipeline.add_node(component=child, name="child", inputs=["parent"])'
+    )
 
 
 def test_get_config_creates_dependent_component():

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -279,6 +279,30 @@ def test_get_config_reuses_same_unnamed_dependent_components():
         assert expected_component in config["components"]
 
 
+def test_get_config_multi_level_dependencies():
+    child = ChildComponent()
+    intermediate = ParentComponent(dependent=child)
+    parent = ParentComponent(dependent=intermediate)
+    p_ensemble = Pipeline()
+    p_ensemble.add_node(component=parent, name="Parent", inputs=["Query"])
+
+    expected_components = [
+        {"name": "Parent", "type": "ParentComponent", "params": {"dependent": "ParentComponent"}},
+        {"name": "ChildComponent", "type": "ChildComponent", "params": {}},
+        {"name": "ParentComponent", "type": "ParentComponent", "params": {"dependent": "ChildComponent"}},
+    ]
+
+    expected_pipelines = [
+        {"name": "query", "nodes": [{"name": "Parent", "inputs": ["Query"]}]}
+    ]
+
+    config = p_ensemble.get_config()
+    for expected_pipeline in expected_pipelines:
+        assert expected_pipeline in config["pipelines"]
+    for expected_component in expected_components:
+        assert expected_component in config["components"]
+
+
 def test_get_config_component_with_superclass_arguments():
     class CustomBaseDocumentStore(MockDocumentStore):
         def __init__(self, base_parameter: str):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -292,9 +292,7 @@ def test_get_config_multi_level_dependencies():
         {"name": "ParentComponent", "type": "ParentComponent", "params": {"dependent": "ChildComponent"}},
     ]
 
-    expected_pipelines = [
-        {"name": "query", "nodes": [{"name": "Parent", "inputs": ["Query"]}]}
-    ]
+    expected_pipelines = [{"name": "query", "nodes": [{"name": "Parent", "inputs": ["Query"]}]}]
 
     config = p_ensemble.get_config()
     for expected_pipeline in expected_pipelines:

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -105,6 +105,21 @@ def test_to_code_creates_same_pipelines():
     assert index_pipeline.get_config() == locals()["index_pipeline_from_code"].get_config()
 
 
+def test_to_code_can_handle_weak_cyclic_pipelines():
+    child = ChildComponent()
+    parent = ParentComponent(dependent=child)
+    pipeline = Pipeline()
+    pipeline.add_node(component=parent, name="parent", inputs=["Query"])
+    pipeline.add_node(component=child, name="child", inputs=["parent"])
+    code = pipeline.to_code(generate_imports=False)
+    assert code == ("child = ChildComponent()\n"
+                    "parent = ParentComponent(dependent=child)\n"
+                    "\n"
+                    "pipeline = Pipeline()\n"
+                    "pipeline.add_node(component=parent, name=\"parent\", inputs=[\"Query\"])\n"
+                    "pipeline.add_node(component=child, name=\"child\", inputs=[\"parent\"])")
+
+
 def test_get_config_creates_dependent_component():
     child = ChildComponent()
     parent = ParentComponent(dependent=child)


### PR DESCRIPTION
This fixes a NetworkUnfeasible Exception during topological_sort of component construction code lines in `generate_code()` if we need the retriever during indexing:
```Graph contains a cycle or graph changed during iteration```

Sample YAML to reproduce:
```yaml
version: 'unstable'
components:    # define all the building-blocks for Pipeline
- name: DocumentStore
  type: DeepsetCloudDocumentStore
- name: Retriever
  type: ElasticsearchRetriever
  params:
    document_store: DocumentStore    # params can reference other components defined in the YAML
- name: TextFileConverter
  type: TextConverter
- name: Preprocessor
  type: PreProcessor

pipelines:
- name: indexing
  nodes:
    - name: TextFileConverter
      inputs: [File]
    - name: Preprocessor
      inputs: [TextFileConverter]
    - name: Retriever
      inputs: [Preprocessor]
    - name: DocumentStore
      inputs: [Retriever]

```

Retriever depends on DocumentStore during initialization.
DocumentStore depends on Retriever's output during pipeline execution.

During fixing that some other bugs in `Pipeline.get_config()` surfaced: 
- it didn't reuse components if they are the same instance
- default values were not properly added if `return_defaults` was true (due to the new paradigm of `_component_config` which stores only given params)

This is also fixed in this PR. 
And I took the opportunity to refactor `Pipeline.get_config()` such as it is possible to have dependent components beyond one level of dependency (i.e. `Pipeline.get_config()` is fully recursive now).

**Proposed changes**:
- neglect weak node dependencies (they are only there to improve the order of component creation which makes it more understandable in complex pipelines) if there is already a hard component dependency
- fix bugs in get_config:
  - fix `return_defaults=True` option
  - reuse dependent components if they are the same instance
  - make get_config() fully recursive in terms of dependent components

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
