### PR TITLE
rename label: ignore-for-release-notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,7 @@
 changelog:
   exclude:
     labels:
-      - ignore-for-release
+      - ignore-for-release-notes
   categories:
     - title: Breaking Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,6 +17,9 @@ changelog:
         - topic:document_store
         - topic:elasticsearch
         - topic:faiss
+        - topic:milvus
+        - topic:weaviate
+        - topic:pinecone
         - topic:sql
     - title: REST API
       labels:
@@ -24,7 +27,6 @@ changelog:
     - title: UI / Demo
       labels:
         - topic:ui
-        - topic:demo
     - title: Documentation
       labels:
         - type:documentation


### PR DESCRIPTION
**Proposed changes**:
- Currently, the label to exclude a PR from the release notes is called `ignore-for-release`. That might be misleading. Let's rename it to `ignore-for-release-notes`. I have already renamed the label within GitHub.