### PR TITLE
Fix link to squad_to_dpr.py in DPR train tutorial

### DIFF
--- a/docs/_src/tutorials/tutorials/9.md
+++ b/docs/_src/tutorials/tutorials/9.md
@@ -71,7 +71,7 @@ In the original DPR paper, these are fetched using a retriever to find the most 
 Passages which contain the answer text are filtered out.
 
 If you'd like to convert your SQuAD format data into something that can train a DPR model,
-check out the utility script at [`haystack/retriever/squad_to_dpr.py`](https://github.com/deepset-ai/haystack/blob/master/haystack/retriever/squad_to_dpr.py)
+check out the utility script at [`haystack/utils/squad_to_dpr.py`](https://github.com/deepset-ai/haystack/blob/master/haystack/utils/squad_to_dpr.py)
 
 ## Using Question Answering Data
 

--- a/tutorials/Tutorial9_DPR_training.ipynb
+++ b/tutorials/Tutorial9_DPR_training.ipynb
@@ -101,7 +101,7 @@
     "Passages which contain the answer text are filtered out.\n",
     "\n",
     "If you'd like to convert your SQuAD format data into something that can train a DPR model,\n",
-    "check out the utility script at [`haystack/retriever/squad_to_dpr.py`](https://github.com/deepset-ai/haystack/blob/master/haystack/retriever/squad_to_dpr.py)"
+    "check out the utility script at [`haystack/utils/squad_to_dpr.py`](https://github.com/deepset-ai/haystack/blob/master/haystack/utils/squad_to_dpr.py)"
    ]
   },
   {


### PR DESCRIPTION
**Proposed changes**:
Fix a broken link in the docs: `squad_to_dpr.py` was moved under the `utils` module.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [x] Updated documentation
