### PR TITLE
Run Pinecone tests only if files related to Pinecone changed

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -385,6 +385,7 @@ jobs:
             **/document_stores/pinecone.py
             **/document_stores/sql.py
             **/document_stores/base.py
+            **/document_stores/filter_utils.py
 
       - name: Run tests
         env:

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -377,7 +377,18 @@ jobs:
         run: |
           pip install .[test]
 
+      - name: Files related to Pinecone
+        id: pinecone-files
+        uses: tj-actions/changed-files@v18.4
+        with:
+          files: |
+            **/document_stores/pinecone.py
+            **/document_stores/sql.py
+            **/document_stores/base.py
+
       - name: Run tests
         env:
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-        run: pytest -s test/test_document_store.py test/test_pipeline.py test/test_standard_pipelines.py test/test_pipeline_extractive_qa.py --document_store_type="pinecone"
+        if: steps.pinecone-files.outputs.any_changed == 'true'
+        run: |
+          pytest -s test/test_document_store.py test/test_pipeline.py test/test_standard_pipelines.py test/test_pipeline_extractive_qa.py --document_store_type="pinecone"

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -18,7 +18,6 @@ from haystack.errors import DocumentStoreError
 
 
 logger = logging.getLogger(__name__)
-#
 
 
 class PineconeDocumentStore(SQLDocumentStore):

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -18,6 +18,7 @@ from haystack.errors import DocumentStoreError
 
 
 logger = logging.getLogger(__name__)
+#
 
 
 class PineconeDocumentStore(SQLDocumentStore):


### PR DESCRIPTION
Previously, the Pinecone tests in our CI were failing as a result of multiple concurrent requests in the Pinecone API due to multiple open PRs. This PR makes sure that the Pinecone tests are only run in our CI, if any of the Pinecone related files (`document_stores/pinecone.py`, `document_stores/base.py`, `document_stores/sql.py`, `document_stores/filter_utils.py`) changes.
