### PR TITLE
Fix `normalize_embedding` using numba

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -212,8 +212,6 @@ TODO drop params
 #### normalize\_embedding
 
 ```python
-@staticmethod
-@njit
 def normalize_embedding(emb: np.ndarray) -> None
 ```
 

--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -341,9 +341,7 @@ class BaseDocumentStore(BaseComponent):
     ) -> int:
         pass
 
-    @staticmethod
-    @njit  # (fastmath=True)
-    def normalize_embedding(emb: np.ndarray) -> None:
+    def normalize_embedding(self, emb: np.ndarray) -> None:
         """
         Performs L2 normalization of embeddings vector inplace. Input can be a single vector (1D array) or a matrix
         (2D array).
@@ -352,16 +350,26 @@ class BaseDocumentStore(BaseComponent):
 
         # Single vec
         if len(emb.shape) == 1:
-            norm = np.sqrt(emb.dot(emb))  # faster than np.linalg.norm()
-            if norm != 0.0:
-                emb /= norm
+            self.normalize_embedding_1D(emb)
         # 2D matrix
         else:
-            for vec in emb:
-                vec = np.ascontiguousarray(vec)
-                norm = np.sqrt(vec.dot(vec))
-                if norm != 0.0:
-                    vec /= norm
+            self.normalize_embedding_2D(emb)
+
+    @staticmethod
+    @njit  # (fastmath=True)
+    def normalize_embedding_1D(emb: np.ndarray) -> None:
+        norm = np.sqrt(emb.dot(emb))  # faster than np.linalg.norm()
+        if norm != 0.0:
+            emb /= norm
+
+    @staticmethod
+    @njit  # (fastmath=True)
+    def normalize_embedding_2D(emb: np.ndarray) -> None:
+        for vec in emb:
+            vec = np.ascontiguousarray(vec)
+            norm = np.sqrt(vec.dot(vec))
+            if norm != 0.0:
+                vec /= norm
 
     def finalize_raw_score(self, raw_score: float, similarity: Optional[str]) -> float:
         if similarity == "cosine":

--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -350,21 +350,21 @@ class BaseDocumentStore(BaseComponent):
 
         # Single vec
         if len(emb.shape) == 1:
-            self.normalize_embedding_1D(emb)
+            self._normalize_embedding_1D(emb)
         # 2D matrix
         else:
-            self.normalize_embedding_2D(emb)
+            self._normalize_embedding_2D(emb)
 
     @staticmethod
     @njit  # (fastmath=True)
-    def normalize_embedding_1D(emb: np.ndarray) -> None:
+    def _normalize_embedding_1D(emb: np.ndarray) -> None:
         norm = np.sqrt(emb.dot(emb))  # faster than np.linalg.norm()
         if norm != 0.0:
             emb /= norm
 
     @staticmethod
     @njit  # (fastmath=True)
-    def normalize_embedding_2D(emb: np.ndarray) -> None:
+    def _normalize_embedding_2D(emb: np.ndarray) -> None:
         for vec in emb:
             vec = np.ascontiguousarray(vec)
             norm = np.sqrt(vec.dot(vec))


### PR DESCRIPTION
Currently when passing a single vector to `DocumentStore.normalize_embedding` an error is thrown if numba is installed. `normalize_embedding` expects 1-dimensional or 2-dimentional vectors, selecting an appropriate code path for each. However numba needs to compile the whole function. Thus the 2-dim path is also being compiled with 1-dim args resulting in a `TypingError` as `ascontigousarray()` only exists for ndarrays and not for floats:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tstad/git/haystack/haystack/document_stores/weaviate.py", line 477, in write_documents
    self.normalize_embedding(vector)
  File "/home/tstad/miniconda3/envs/haystack-dev/lib/python3.7/site-packages/numba/core/dispatcher.py", line 468, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/home/tstad/miniconda3/envs/haystack-dev/lib/python3.7/site-packages/numba/core/dispatcher.py", line 409, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function ascontiguousarray>) found for signature:
 
 >>> ascontiguousarray(float32)
 
```

**Impact**:
`normalized_embedding` is used by `FAISSDocumentStore`, `Milvus1DocumentStore`, `PineconeDocumentStore` and `WeaviateDocumentStore` when using `cosine` similarity.

**Proposed changes**:
- split "dynamic-typed" `normalize_embedding` into "static-typed" `normalize_embedding_1D` and `normalize_embedding_2D`, so numba can deal with it.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code

Fixes the bad one in https://github.com/deepset-ai/haystack/issues/2346