### PR TITLE
Add tests for missing `__init__` and `super().__init__()` in custom nodes

### DIFF
--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -39,7 +39,10 @@ def exportable_to_yaml(init_func):
             self._component_config = {"params": {}, "type": type(self).__name__}
 
         # Make sure it runs only on the __init__of the implementations, not in superclasses
-        if init_func.__qualname__ == f"{self.__class__.__name__}.{init_func.__name__}":
+        # NOTE: we use 'in' because inner classes's __qualname__ will include the parent class'
+        #   name, like: ParentClass.InnerClass.__init__. 
+        #   Inner classes are heavily used in tests. 
+        if f"{self.__class__.__name__}.{init_func.__name__}" in init_func.__qualname__:
 
             # Store all the named input parameters in self._component_config
             for k, v in kwargs.items():


### PR DESCRIPTION
Following a potential bug report from @brandenchan I realized no tests were covering the cases for:
- nodes not having any explicit `__init__`
- nodes forgetting to call `super().__init__()`
- saving pipelines with custom nodes initialized with kwargs only
- saving pipelines with custom nodes initialized with args

The last two entries lead to the discovery of a small bug related to inner classes. The bug is now fixed.