### PR TITLE
Change document attribute from text to content

### DIFF
--- a/docs/_src/tutorials/tutorials/1.md
+++ b/docs/_src/tutorials/tutorials/1.md
@@ -126,7 +126,7 @@ dicts = convert_files_to_dicts(dir_path=doc_dir, clean_func=clean_wiki_text, spl
 # If your texts come from a different source (e.g. a DB), you can of course skip convert_files_to_dicts() and create the dictionaries yourself.
 # The default format here is:
 # {
-#    'text': "<DOCUMENT_TEXT_HERE>",
+#    'content': "<DOCUMENT_TEXT_HERE>",
 #    'meta': {'name': "<DOCUMENT_NAME_HERE>", ...}
 # }
 # (Optionally: you can also add more key-value-pairs here, that will be indexed as fields in Elasticsearch and

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -185,7 +185,7 @@
     "# If your texts come from a different source (e.g. a DB), you can of course skip convert_files_to_dicts() and create the dictionaries yourself.\n",
     "# The default format here is:\n",
     "# {\n",
-    "#    'text': \"<DOCUMENT_TEXT_HERE>\",\n",
+    "#    'content': \"<DOCUMENT_TEXT_HERE>\",\n",
     "#    'meta': {'name': \"<DOCUMENT_NAME_HERE>\", ...}\n",
     "# }\n",
     "# (Optionally: you can also add more key-value-pairs here, that will be indexed as fields in Elasticsearch and\n",


### PR DESCRIPTION
**Proposed changes**:
- A comment in the tutorial described `Document` as having a `text` attribute. This has been renamed to `content`.
