### PR TITLE
Support conjunctive queries in sparse retrieval

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -305,7 +305,7 @@ Base class for implementing Document Stores that support keyword searches.
 
 ```python
 @abstractmethod
-def query(query: Optional[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: int = 10, custom_query: Optional[str] = None, index: Optional[str] = None, headers: Optional[Dict[str, str]] = None) -> List[Document]
+def query(query: Optional[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: int = 10, custom_query: Optional[str] = None, index: Optional[str] = None, headers: Optional[Dict[str, str]] = None, all_terms_must_match: bool = False) -> List[Document]
 ```
 
 Scan through documents in DocumentStore and return a small number documents
@@ -382,6 +382,10 @@ operation.
 - `custom_query`: Custom query to be executed.
 - `index`: The name of the index in the DocumentStore from which to retrieve documents
 - `headers`: Custom HTTP headers to pass to document store client if supported (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='} for basic authentication)
+- `all_terms_must_match`: Whether all terms of the query must match the document.
+If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+Defaults to False.
 
 <a id="base.get_batches_from_generator"></a>
 
@@ -762,7 +766,7 @@ Return all labels in the document store
 #### query
 
 ```python
-def query(query: Optional[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: int = 10, custom_query: Optional[str] = None, index: Optional[str] = None, headers: Optional[Dict[str, str]] = None) -> List[Document]
+def query(query: Optional[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: int = 10, custom_query: Optional[str] = None, index: Optional[str] = None, headers: Optional[Dict[str, str]] = None, all_terms_must_match: bool = False) -> List[Document]
 ```
 
 Scan through documents in DocumentStore and return a small number documents
@@ -903,6 +907,10 @@ You will find the highlighted output in the returned Document's meta field by ke
 - `index`: The name of the index in the DocumentStore from which to retrieve documents
 - `headers`: Custom HTTP headers to pass to elasticsearch client (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='})
 Check out https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html for more information.
+- `all_terms_must_match`: Whether all terms of the query must match the document.
+If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+Defaults to false.
 
 <a id="elasticsearch.ElasticsearchDocumentStore.query_by_embedding"></a>
 
@@ -4135,7 +4143,7 @@ operation.
 #### query
 
 ```python
-def query(query: Optional[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: int = 10, custom_query: Optional[str] = None, index: Optional[str] = None, headers: Optional[Dict[str, str]] = None) -> List[Document]
+def query(query: Optional[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: int = 10, custom_query: Optional[str] = None, index: Optional[str] = None, headers: Optional[Dict[str, str]] = None, all_terms_must_match: bool = False) -> List[Document]
 ```
 
 Scan through documents in DocumentStore and return a small number documents
@@ -4212,6 +4220,10 @@ operation.
 - `custom_query`: Custom query to be executed.
 - `index`: The name of the index in the DocumentStore from which to retrieve documents
 - `headers`: Custom HTTP headers to pass to requests
+- `all_terms_must_match`: Whether all terms of the query must match the document.
+If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+Defaults to False.
 
 <a id="deepsetcloud.DeepsetCloudDocumentStore.write_documents"></a>
 

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -107,12 +107,16 @@ class ElasticsearchRetriever(BaseRetriever)
 #### \_\_init\_\_
 
 ```python
-def __init__(document_store: KeywordDocumentStore, top_k: int = 10, custom_query: Optional[str] = None)
+def __init__(document_store: KeywordDocumentStore, top_k: int = 10, all_terms_must_match: bool = False, custom_query: Optional[str] = None)
 ```
 
 **Arguments**:
 
 - `document_store`: an instance of an ElasticsearchDocumentStore to retrieve documents from.
+- `all_terms_must_match`: Whether all terms of the query must match the document.
+If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+Defaults to False.
 - `custom_query`: query string as per Elasticsearch DSL with a mandatory query placeholder(query).
  Optionally, ES `filter` clause can be added where the values of `terms` are placeholders
  that get substituted during runtime. The placeholder(${filter_name_1}, ${filter_name_2}..)

--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -740,7 +740,7 @@ class KeywordDocumentStore(BaseDocumentStore):
         :param all_terms_must_match: Whether all terms of the query must match the document.
                                      If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
                                      Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
-                                     Defaults to false.
+                                     Defaults to False.
         """
 
 

--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -662,6 +662,7 @@ class KeywordDocumentStore(BaseDocumentStore):
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        all_terms_must_match: bool = False,
     ) -> List[Document]:
         """
         Scan through documents in DocumentStore and return a small number documents
@@ -736,6 +737,10 @@ class KeywordDocumentStore(BaseDocumentStore):
         :param custom_query: Custom query to be executed.
         :param index: The name of the index in the DocumentStore from which to retrieve documents
         :param headers: Custom HTTP headers to pass to document store client if supported (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='} for basic authentication)
+        :param all_terms_must_match: Whether all terms of the query must match the document.
+                                     If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+                                     Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+                                     Defaults to false.
         """
 
 

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -407,7 +407,13 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
                                      Defaults to False.
         """
         doc_dicts = self.client.query(
-            query=query, filters=filters, top_k=top_k, custom_query=custom_query, index=index, all_terms_must_match=all_terms_must_match, headers=headers
+            query=query,
+            filters=filters,
+            top_k=top_k,
+            custom_query=custom_query,
+            index=index,
+            all_terms_must_match=all_terms_must_match,
+            headers=headers,
         )
         docs = [Document.from_dict(doc) for doc in doc_dicts]
         return docs

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -404,7 +404,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param all_terms_must_match: Whether all terms of the query must match the document.
                                      If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
                                      Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
-                                     Defaults to false.
+                                     Defaults to False.
         """
         doc_dicts = self.client.query(
             query=query, filters=filters, top_k=top_k, custom_query=custom_query, index=index, all_terms_must_match=all_terms_must_match, headers=headers

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -327,6 +327,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        all_terms_must_match: bool = False,
     ) -> List[Document]:
         """
         Scan through documents in DocumentStore and return a small number documents
@@ -400,9 +401,13 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param custom_query: Custom query to be executed.
         :param index: The name of the index in the DocumentStore from which to retrieve documents
         :param headers: Custom HTTP headers to pass to requests
+        :param all_terms_must_match: Whether all terms of the query must match the document.
+                                     If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+                                     Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+                                     Defaults to false.
         """
         doc_dicts = self.client.query(
-            query=query, filters=filters, top_k=top_k, custom_query=custom_query, index=index, headers=headers
+            query=query, filters=filters, top_k=top_k, custom_query=custom_query, index=index, all_terms_must_match=all_terms_must_match, headers=headers
         )
         docs = [Document.from_dict(doc) for doc in doc_dicts]
         return docs

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -872,6 +872,7 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        all_terms_must_match: bool = False,
     ) -> List[Document]:
         """
         Scan through documents in DocumentStore and return a small number documents
@@ -1011,6 +1012,10 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         :param index: The name of the index in the DocumentStore from which to retrieve documents
         :param headers: Custom HTTP headers to pass to elasticsearch client (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='})
                 Check out https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html for more information.
+        :param all_terms_must_match: Whether all terms of the query must match the document.
+                                     If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+                                     Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+                                     Defaults to false.
         """
 
         if index is None:
@@ -1045,11 +1050,21 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                     "The query provided seems to be not a string, but an object "
                     f"of type {type(query)}. This can cause Elasticsearch to fail."
                 )
+            operator = "AND" if all_terms_must_match else "OR"
             body = {
                 "size": str(top_k),
                 "query": {
                     "bool": {
-                        "must": [{"multi_match": {"query": query, "type": "most_fields", "fields": self.search_fields}}]
+                        "must": [
+                            {
+                                "multi_match": {
+                                    "query": query,
+                                    "type": "most_fields",
+                                    "fields": self.search_fields,
+                                    "operator": operator,
+                                }
+                            }
+                        ]
                     }
                 },
             }

--- a/haystack/json-schemas/haystack-pipeline-1.2.1rc0.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-1.2.1rc0.schema.json
@@ -1630,6 +1630,11 @@
               "default": 10,
               "type": "integer"
             },
+            "all_terms_must_match": {
+              "title": "All Terms Must Match",
+              "default": false,
+              "type": "boolean"
+            },
             "custom_query": {
               "title": "Custom Query",
               "type": "string"
@@ -1674,6 +1679,11 @@
               "title": "Top K",
               "default": 10,
               "type": "integer"
+            },
+            "all_terms_must_match": {
+              "title": "All Terms Must Match",
+              "default": false,
+              "type": "boolean"
             },
             "custom_query": {
               "title": "Custom Query",

--- a/haystack/json-schemas/haystack-pipeline-unstable.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-unstable.schema.json
@@ -1633,6 +1633,11 @@
               "default": 10,
               "type": "integer"
             },
+            "all_terms_must_match": {
+              "title": "All Terms Must Match",
+              "default": false,
+              "type": "boolean"
+            },
             "custom_query": {
               "title": "Custom Query",
               "type": "string"
@@ -1677,6 +1682,11 @@
               "title": "Top K",
               "default": 10,
               "type": "integer"
+            },
+            "all_terms_must_match": {
+              "title": "All Terms Must Match",
+              "default": false,
+              "type": "boolean"
             },
             "custom_query": {
               "title": "Custom Query",

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -28,7 +28,7 @@ class ElasticsearchRetriever(BaseRetriever):
         :param all_terms_must_match: Whether all terms of the query must match the document.
                                      If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
                                      Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
-                                     Defaults to false.
+                                     Defaults to False.
         :param custom_query: query string as per Elasticsearch DSL with a mandatory query placeholder(query).
 
                              Optionally, ES `filter` clause can be added where the values of `terms` are placeholders

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -16,9 +16,19 @@ logger = logging.getLogger(__name__)
 
 
 class ElasticsearchRetriever(BaseRetriever):
-    def __init__(self, document_store: KeywordDocumentStore, top_k: int = 10, custom_query: Optional[str] = None):
+    def __init__(
+        self,
+        document_store: KeywordDocumentStore,
+        top_k: int = 10,
+        all_terms_must_match: bool = False,
+        custom_query: Optional[str] = None,
+    ):
         """
         :param document_store: an instance of an ElasticsearchDocumentStore to retrieve documents from.
+        :param all_terms_must_match: Whether all terms of the query must match the document.
+                                     If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
+                                     Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").
+                                     Defaults to false.
         :param custom_query: query string as per Elasticsearch DSL with a mandatory query placeholder(query).
 
                              Optionally, ES `filter` clause can be added where the values of `terms` are placeholders
@@ -91,6 +101,7 @@ class ElasticsearchRetriever(BaseRetriever):
         self.document_store: KeywordDocumentStore = document_store
         self.top_k = top_k
         self.custom_query = custom_query
+        self.all_terms_must_match = all_terms_must_match
 
     def retrieve(
         self,
@@ -116,7 +127,15 @@ class ElasticsearchRetriever(BaseRetriever):
         if index is None:
             index = self.document_store.index
 
-        documents = self.document_store.query(query, filters, top_k, self.custom_query, index, headers=headers)
+        documents = self.document_store.query(
+            query=query,
+            filters=filters,
+            top_k=top_k,
+            all_terms_must_match=self.all_terms_must_match,
+            custom_query=self.custom_query,
+            index=index,
+            headers=headers,
+        )
         return documents
 
 

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -312,6 +312,7 @@ class IndexClient:
         similarity: Optional[str] = None,
         workspace: Optional[str] = None,
         index: Optional[str] = None,
+        all_terms_must_match: Optional[bool] = None,
         headers: dict = None,
     ) -> List[dict]:
         index_url = self._build_index_url(workspace=workspace, index=index)
@@ -324,6 +325,7 @@ class IndexClient:
             "query_emb": query_emb,
             "similarity": similarity,
             "return_embedding": return_embedding,
+            "all_terms_must_match": all_terms_must_match
         }
         response = self.client.post(url=query_url, json=request, headers=headers)
         return response.json()

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -325,7 +325,7 @@ class IndexClient:
             "query_emb": query_emb,
             "similarity": similarity,
             "return_embedding": return_embedding,
-            "all_terms_must_match": all_terms_must_match
+            "all_terms_must_match": all_terms_must_match,
         }
         response = self.client.post(url=query_url, json=request, headers=headers)
         return response.json()

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1598,7 +1598,7 @@ def test_DeepsetCloudDocumentStore_query(deepset_cloud_document_store):
         responses.add(
             method=responses.POST,
             url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}/documents-query",
-            match=[matchers.json_params_matcher({"query": "winterfell", "top_k": 50})],
+            match=[matchers.json_params_matcher({"query": "winterfell", "top_k": 50, "all_terms_must_match": False})],
             status=200,
             body=query_winterfell_response,
         )
@@ -1612,6 +1612,7 @@ def test_DeepsetCloudDocumentStore_query(deepset_cloud_document_store):
                         "query": "winterfell",
                         "top_k": 50,
                         "filters": {"file_id": [query_winterfell_docs[0]["meta"]["file_id"]]},
+                        "all_terms_must_match": False,
                     }
                 )
             ],

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -514,3 +514,38 @@ def test_elasticsearch_filter_must_not_increase_results():
     results_w_filter = doc_store.query(query="drink", filters={"content_type": "text"})
     assert len(results_w_filter) == 1
     doc_store.delete_index(index)
+
+
+def test_elasticsearch_all_terms_must_match():
+    index = "all_terms_must_match"
+    client = Elasticsearch()
+    client.indices.delete(index=index, ignore=[404])
+    documents = [
+        {
+            "content": "The green tea plant contains a range of healthy compounds that make it into the final drink",
+            "meta": {"content_type": "text"},
+            "id": "1",
+        },
+        {
+            "content": "Green tea contains a catechin called epigallocatechin-3-gallate (EGCG).",
+            "meta": {"content_type": "text"},
+            "id": "2",
+        },
+        {
+            "content": "Green tea also has small amounts of minerals that can benefit your health.",
+            "meta": {"content_type": "text"},
+            "id": "3",
+        },
+        {
+            "content": "Green tea does more than just keep you alert, it may also help boost brain function.",
+            "meta": {"content_type": "text"},
+            "id": "4",
+        },
+    ]
+    doc_store = ElasticsearchDocumentStore(index=index)
+    doc_store.write_documents(documents)
+    results_wo_all_terms_must_match = doc_store.query(query="drink green tea")
+    assert len(results_wo_all_terms_must_match) == 4
+    results_w_all_terms_must_match = doc_store.query(query="drink green tea", all_terms_must_match=True)
+    assert len(results_w_all_terms_must_match) == 1
+    doc_store.delete_index(index)


### PR DESCRIPTION
Currently we only support disjunctive queries in sparse retrieval. I.e. only one query term needs to be present in a document in order to be retrieved. This is a highly recall-favouring approach. In some use-cases (e.g. document retrieval) a more precision-focused approach might be better, however. Conjunctive queries ensure that all query terms must be present in a document in order to be retrieved. Within elasticsearch/OpenSearch this could easily be achieved by setting the `operator` param of the `match` clause to `AND`.

**Proposed changes**:
- add `all_terms_must_match` to `ElasticsearchRetriever`'s `query()` method
- set `operator` of match clause in elasticsearch and OpenSearch queries according to `all_terms_must_match`
- delegate `all_terms_must_match` to `DeepsetCloudDocumentStore`

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
