### PR TITLE
Fix `TableReader` for tables without rows

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -140,7 +140,9 @@ class TableReader(BaseReader):
                 logger.warning(f"Skipping document with id {document.id} in TableReader, as it is not of type table.")
                 continue
             if document.content.shape[0] == 0:
-                logger.warning(f"Skipping document with id {document.id} in TableReader as it does not contain any rows.")
+                logger.warning(
+                    f"Skipping document with id {document.id} in TableReader as it does not contain any rows."
+                )
                 continue
 
             table: pd.DataFrame = document.content

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -139,6 +139,9 @@ class TableReader(BaseReader):
             if document.content_type != "table":
                 logger.warning(f"Skipping document with id {document.id} in TableReader, as it is not of type table.")
                 continue
+            if document.content.shape[0] == 0:
+                logger.warning(f"Skipping document with id {document.id} in TableReader as it does not contain any rows.")
+                continue
 
             table: pd.DataFrame = document.content
             # Tokenize query and current table

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -137,15 +137,15 @@ class TableReader(BaseReader):
         no_answer_score = 1.0
         for document in documents:
             if document.content_type != "table":
-                logger.warning(f"Skipping document with id {document.id} in TableReader, as it is not of type table.")
-                continue
-            if document.content.shape[0] == 0:
-                logger.warning(
-                    f"Skipping document with id {document.id} in TableReader as it does not contain any rows."
-                )
+                logger.warning(f"Skipping document with id '{document.id}' in TableReader as it is not of type table.")
                 continue
 
             table: pd.DataFrame = document.content
+            if table.shape[0] == 0:
+                logger.warning(
+                    f"Skipping document with id '{document.id}' in TableReader as it does not contain any rows."
+                )
+                continue
             # Tokenize query and current table
             inputs = self.tokenizer(
                 table=table, queries=query, max_length=self.max_seq_len, return_tensors="pt", truncation=True
@@ -530,10 +530,15 @@ class RCIReader(BaseReader):
         answers = []
         for document in documents:
             if document.content_type != "table":
-                logger.warning(f"Skipping document with id {document.id} in RCIReader, as it is not of type table.")
+                logger.warning(f"Skipping document with id '{document.id}' in RCIReader as it is not of type table.")
                 continue
 
             table: pd.DataFrame = document.content
+            if table.shape[0] == 0:
+                logger.warning(
+                    f"Skipping document with id '{document.id}' in RCIReader as it does not contain any rows."
+                )
+                continue
             table = table.astype(str)
             # Create row and column representations
             row_reps, column_reps = self._create_row_column_representations(table)

--- a/test/test_table_reader.py
+++ b/test/test_table_reader.py
@@ -1,3 +1,5 @@
+import logging
+
 import pandas as pd
 import pytest
 
@@ -60,3 +62,21 @@ def test_table_reader_aggregation(table_reader):
     assert prediction["answers"][0].answer == "43046.0 m"
     assert prediction["answers"][0].meta["aggregation_operator"] == "SUM"
     assert prediction["answers"][0].meta["answer_cells"] == ["8848m", "8,611 m", "8 586m", "8 516 m", "8,485m"]
+
+
+def test_table_without_rows(caplog, table_reader):
+    # empty DataFrame
+    table = pd.DataFrame()
+    document = Document(content=table, content_type="table", id="no_rows")
+    with caplog.at_level(logging.WARNING):
+        predictions = table_reader.predict(query="test", documents=[document])
+        assert "Skipping document with id 'no_rows'" in caplog.text
+        assert len(predictions["answers"]) == 0
+
+
+def test_text_document(caplog, table_reader):
+    document = Document(content="text", id="text_doc")
+    with caplog.at_level(logging.WARNING):
+        predictions = table_reader.predict(query="test", documents=[document])
+        assert "Skipping document with id 'text_doc'" in caplog.text
+        assert len(predictions["answers"]) == 0


### PR DESCRIPTION
Previously, when passing tables to the `TableReader` that do not contain any rows, the `TableReader` was running into `IndexError: index -1 is out of bounds for axis 0 with size 0`. This PR fixes this bug by skipping tables that do not contain any rows.

CC @Timoeller 