### PR TITLE
Add confidence filtering to FARMReader

### DIFF
--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -55,7 +55,7 @@ While the underlying model can vary (BERT, Roberta, DistilBERT, ...), the interf
 #### \_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str, model_version: Optional[str] = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k: int = 10, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128, progress_bar: bool = True, duplicate_filtering: int = 0, use_confidence_scores: bool = True, proxies: Optional[Dict[str, str]] = None, local_files_only=False, force_download=False, use_auth_token: Optional[Union[str, bool]] = None, **kwargs, ,)
+def __init__(model_name_or_path: str, model_version: Optional[str] = None, context_window_size: int = 150, batch_size: int = 50, use_gpu: bool = True, no_ans_boost: float = 0.0, return_no_answer: bool = False, top_k: int = 10, top_k_per_candidate: int = 3, top_k_per_sample: int = 1, num_processes: Optional[int] = None, max_seq_len: int = 256, doc_stride: int = 128, progress_bar: bool = True, duplicate_filtering: int = 0, use_confidence_scores: bool = True, confidence_threshold: Optional[float] = None, proxies: Optional[Dict[str, str]] = None, local_files_only=False, force_download=False, use_auth_token: Optional[Union[str, bool]] = None, **kwargs, ,)
 ```
 
 **Arguments**:
@@ -102,6 +102,7 @@ This score can also be further calibrated on your dataset via self.eval()
 (see https://haystack.deepset.ai/components/reader#confidence-scores) .
 `False` => an unscaled, raw score [-inf, +inf] which is the sum of start and end logit
 from the model for the predicted span.
+- `confidence_threshold`: Filters out predictions below confidence_threshold. Value should be between 0 and 1. Disabled by default.
 - `proxies`: Dict of proxy servers to use for downloading external models. Example: {'http': 'some.proxy:1234', 'http://hostname': 'my.proxy:3111'}
 - `local_files_only`: Whether to force checking for local files only (and forbid downloads)
 - `force_download`: Whether fo force a (re-)download even if the model exists locally in the cache.

--- a/haystack/json-schemas/haystack-pipeline-1.2.1rc0.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-1.2.1rc0.schema.json
@@ -2060,6 +2060,10 @@
               "default": true,
               "type": "boolean"
             },
+            "confidence_threshold": {
+              "title": "Confidence Threshold",
+              "type": "number"
+            },
             "proxies": {
               "title": "Proxies",
               "type": "object",

--- a/haystack/json-schemas/haystack-pipeline-unstable.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-unstable.schema.json
@@ -2063,6 +2063,10 @@
               "default": true,
               "type": "boolean"
             },
+            "confidence_threshold": {
+              "title": "Confidence Threshold",
+              "type": "number"
+            },
             "proxies": {
               "title": "Proxies",
               "type": "object",

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -1021,7 +1021,7 @@ class FARMReader(BaseReader):
 
         # apply confidence based filtering if enabled
         if self.confidence_threshold is not None:
-            answers = [x for x in answers if x.score >= self.confidence_threshold] # type: ignore
+            answers = [ans for ans in answers if ans.score is not None and ans.score >= self.confidence_threshold]
 
         return answers, max_no_ans_gap
 

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -1021,7 +1021,7 @@ class FARMReader(BaseReader):
 
         # apply confidence based filtering if enabled
         if self.confidence_threshold is not None:
-            answers = [x for x in answers if x.score >= self.confidence_threshold]
+            answers = [x for x in answers if x.score >= self.confidence_threshold] # type: ignore
 
         return answers, max_no_ans_gap
 

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -56,6 +56,7 @@ class FARMReader(BaseReader):
         progress_bar: bool = True,
         duplicate_filtering: int = 0,
         use_confidence_scores: bool = True,
+        confidence_threshold: Optional[float] = None,
         proxies: Optional[Dict[str, str]] = None,
         local_files_only=False,
         force_download=False,
@@ -106,6 +107,7 @@ class FARMReader(BaseReader):
                                       (see https://haystack.deepset.ai/components/reader#confidence-scores) .
                                       `False` => an unscaled, raw score [-inf, +inf] which is the sum of start and end logit
                                       from the model for the predicted span.
+        :param confidence_threshold: Filters out predictions below confidence_threshold. Value should be between 0 and 1. Disabled by default.
         :param proxies: Dict of proxy servers to use for downloading external models. Example: {'http': 'some.proxy:1234', 'http://hostname': 'my.proxy:3111'}
         :param local_files_only: Whether to force checking for local files only (and forbid downloads)
         :param force_download: Whether fo force a (re-)download even if the model exists locally in the cache.
@@ -153,6 +155,7 @@ class FARMReader(BaseReader):
         self.use_gpu = use_gpu
         self.progress_bar = progress_bar
         self.use_confidence_scores = use_confidence_scores
+        self.confidence_threshold = confidence_threshold
         self.model_name_or_path = model_name_or_path  # Used in distillation, see DistillationDataSilo._get_checksum()
 
     def _training_procedure(
@@ -1015,6 +1018,10 @@ class FARMReader(BaseReader):
         # sort answers by score (descending) and select top-k
         answers = sorted(answers, reverse=True)
         answers = answers[:top_k]
+
+        # apply confidence based filtering if enabled
+        if self.confidence_threshold is not None:
+            answers = [x for x in answers if x.score >= self.confidence_threshold]
 
         return answers, max_no_ans_gap
 


### PR DESCRIPTION
**Proposed changes**:
This PR adds a parameter to filter out predictions below a certain confidence threshold.
This enables a simple way to not return answers next to our no_ans_boost because the no_ans_boost also changes the confidence score of valid answers (undesirable).
Also we can configure the FARMReader for downstream apps, e.g. we do not need to aplly the filtering in a UI where we display the results.

**Tests**
Because the feature is so small and non-invasive, I looked at existing tests and could only find test_topk, which I don't want to extend with this feature.

**Interaction with other apps**
I am slightly unsure about returning an empty list when filtering out all answers and its effect on consuming apps. I see that in the API we have a [fallback option](https://github.com/deepset-ai/haystack/blob/master/rest_api/controller/search.py#L90) for returning an empty answer list in any case.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests (possibly wont do)
- [ ] Updated documentation
