### PR TITLE
Use cache for hf requests during CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ saved_models
 rest_api/file-upload/*
 **/feedback_squad_direct.json
 .DS_Store
+
+# http cache (requests-cache)
+**/http_cache.sqlite

--- a/setup.cfg
+++ b/setup.cfg
@@ -196,6 +196,7 @@ dev =
     mkdocs 
     jupytercontrib 
     watchdog  #==1.0.2
+    requests-cache
 test = 
     farm-haystack[docstores,crawler,preprocessing,ocr,ray,dev]
 all =

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import List, Optional, Tuple, Dict
 
 import subprocess
@@ -11,6 +12,7 @@ from pathlib import Path
 import os
 
 import pinecone
+import requests_cache
 import responses
 from sqlalchemy import create_engine, text
 import posthog
@@ -80,6 +82,10 @@ MOCK_DC = True
 
 # Disable telemetry reports when running tests
 posthog.disabled = True
+
+# Cache requests (e.g. huggingface model) to circumvent load protection
+# See https://requests-cache.readthedocs.io/en/stable/user_guide/filtering.html
+requests_cache.install_cache(urls_expire_after={"huggingface.co": timedelta(hours=1), "*": requests_cache.DO_NOT_CACHE})
 
 
 def _sql_session_rollback(self, attr):

--- a/test/test_faiss_and_milvus.py
+++ b/test/test_faiss_and_milvus.py
@@ -485,7 +485,6 @@ def test_faiss_passing_index_from_outside(tmp_path):
 @pytest.mark.parametrize("document_store", ["faiss", "milvus1", "milvus", "weaviate"], indirect=True)
 def test_cosine_similarity(document_store):
     # below we will write documents to the store and then query it to see if vectors were normalized
-
     ensure_ids_are_correct_uuids(docs=DOCUMENTS, document_store=document_store)
     document_store.write_documents(documents=DOCUMENTS)
 
@@ -506,7 +505,9 @@ def test_cosine_similarity(document_store):
         original_emb = indexed_docs[doc.content].astype("float32")
 
         # check if the stored embedding was normalized
-        assert np.allclose(original_emb, result_emb, rtol=0.2)  # high tolerance necessary for Milvus 2
+        np.testing.assert_allclose(
+            original_emb, result_emb, rtol=0.2, atol=5e-07
+        )  # high tolerance necessary for Milvus 2
 
         # check if the score is plausible for cosine similarity
         assert 0 <= doc.score <= 1.0


### PR DESCRIPTION
Fixes HTTP 405 during CI

**Proposed changes**:
- use requests-cache for huggingface requests during CI

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
