### PR TITLE
Add min_score parameter for the EmbeddingRetriever in combination with Elasticsearch

### DIFF
--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -384,6 +384,7 @@ class BaseDocumentStore(BaseComponent):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -227,6 +227,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -304,6 +305,9 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param headers: Custom HTTP headers to pass to requests
         :return:
         """
+        if min_score:
+            raise NotImplementedError("DeepsetCloudDocumentStore does not support min_score.")
+
         if return_embedding is None:
             return_embedding = self.return_embedding
 

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1081,11 +1081,16 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         documents = [self._convert_es_hit_to_document(hit, return_embedding=self.return_embedding) for hit in result]
         return documents
 
+    @staticmethod
+    def _transform_min_score(min_score):
+        return min_score * 2 - 1 + 1000
+
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -1158,6 +1163,7 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                             }
                             ```
         :param top_k: How many documents to return
+        :param min_score: Only return documents with a score higher than min_score - recommended to set top_k=10000
         :param index: Index name for storing the docs and metadata
         :param return_embedding: To return document embedding
         :param headers: Custom HTTP headers to pass to elasticsearch client (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='})
@@ -1175,6 +1181,10 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
 
         # +1 in similarity to avoid negative numbers (for cosine sim)
         body = {"size": top_k, "query": self._get_vector_similarity_query(query_emb, top_k)}
+
+        if min_score:
+            body['min_score'] = self._transform_min_score(min_score)
+
         if filters:
             filter_ = {"bool": {"filter": LogicalFilterClause.parse(filters).convert_to_elasticsearch()}}
             if body["query"]["script_score"]["query"] == {"match_all": {}}:

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -545,6 +545,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -562,6 +563,8 @@ class FAISSDocumentStore(SQLDocumentStore):
         """
         if headers:
             raise NotImplementedError("FAISSDocumentStore does not support headers.")
+        if min_score:
+            raise NotImplementedError("FAISSDocumentStore does not support min_score.")
 
         if filters:
             logger.warning("Query filters are not implemented for the FAISSDocumentStore.")

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -282,6 +282,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -357,6 +358,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
         """
         if headers:
             raise NotImplementedError("InMemoryDocumentStore does not support headers.")
+        if min_score:
+            raise NotImplementedError("InMemoryDocumentStore does not support min_score.")
 
         index = index or self.index
         if return_embedding is None:

--- a/haystack/document_stores/milvus1.py
+++ b/haystack/document_stores/milvus1.py
@@ -354,6 +354,7 @@ class Milvus1DocumentStore(SQLDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in MilvusDocStore
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -371,6 +372,8 @@ class Milvus1DocumentStore(SQLDocumentStore):
         """
         if headers:
             raise NotImplementedError("MilvusDocumentStore does not support headers.")
+        if min_score:
+            raise NotImplementedError("MilvusDocumentStore does not support min_score.")
 
         if filters:
             logger.warning("Query filters are not implemented for the MilvusDocumentStore.")

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -380,6 +380,7 @@ class Milvus2DocumentStore(SQLDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -397,6 +398,8 @@ class Milvus2DocumentStore(SQLDocumentStore):
         """
         if headers:
             raise NotImplementedError("Milvus2DocumentStore does not support headers.")
+        if min_score:
+            raise NotImplementedError("Milvus2DocumentStore does not support min_score.")
 
         index = index or self.index
         has_collection = utility.has_collection(collection_name=index)

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -550,6 +550,7 @@ class PineconeDocumentStore(SQLDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -625,6 +626,8 @@ class PineconeDocumentStore(SQLDocumentStore):
         """
         if headers:
             raise NotImplementedError("PineconeDocumentStore does not support headers.")
+        if min_score:
+            raise NotImplementedError("Milvus2DocumentStore does not support min_score.")
 
         if return_embedding is None:
             return_embedding = self.return_embedding

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -584,6 +584,7 @@ class SQLDocumentStore(BaseDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[dict] = None,
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -836,6 +836,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         query_emb: np.ndarray,
         filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
         top_k: int = 10,
+        min_score: Optional[float] = None,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -914,6 +915,8 @@ class WeaviateDocumentStore(BaseDocumentStore):
         """
         if headers:
             raise NotImplementedError("WeaviateDocumentStore does not support headers.")
+        if min_score:
+            raise NotImplementedError("WeaviateDocumentStore does not support min_score.")
 
         if return_embedding is None:
             return_embedding = self.return_embedding

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1150,6 +1150,7 @@ class EmbeddingRetriever(BaseRetriever):
         query: str,
         filters: dict = None,
         top_k: Optional[int] = None,
+        min_score: Optional[float] = None,
         index: str = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> List[Document]:
@@ -1160,6 +1161,7 @@ class EmbeddingRetriever(BaseRetriever):
         :param query: The query
         :param filters: A dictionary where the keys specify a metadata field and the value is a list of accepted values for that field
         :param top_k: How many documents to return per query.
+        :param min_score: Only return documents with a score higher than min_score - recommended to set top_k=10000
         :param index: The name of the index in the DocumentStore from which to retrieve documents
         """
         if top_k is None:
@@ -1168,7 +1170,7 @@ class EmbeddingRetriever(BaseRetriever):
             index = self.document_store.index
         query_emb = self.embed_queries(texts=[query])
         documents = self.document_store.query_by_embedding(
-            query_emb=query_emb[0], filters=filters, top_k=top_k, index=index, headers=headers
+            query_emb=query_emb[0], filters=filters, top_k=top_k, min_score=min_score, index=index, headers=headers
         )
         return documents
 

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1161,7 +1161,8 @@ class EmbeddingRetriever(BaseRetriever):
         :param query: The query
         :param filters: A dictionary where the keys specify a metadata field and the value is a list of accepted values for that field
         :param top_k: How many documents to return per query.
-        :param min_score: Only return documents with a score higher than min_score - recommended to set top_k=10000
+        :param min_score: Only return documents with a score higher than min_score - be aware that top_k filter is still
+                applied after the documents have been filtered by the min_score
         :param index: The name of the index in the DocumentStore from which to retrieve documents
         """
         if top_k is None:


### PR DESCRIPTION
closes: https://github.com/deepset-ai/haystack/issues/2353

Contrary to what I said in the issue, I did not set `top_k=10000` whenever the user sets the min_score parameter (I tried to change as little code as possible). But it is recommended to set `top_k=10000` if you want to make sure that you get all the results with a score bigger than min_score (I mention it in the parameter description of the docstring). 

What could happen now is: 
User sets `min_score=0.8` and there are 200 results with a score bigger than 0.8 - but if `top_k=50` the EmbeddingRetriever will only return 50 results.
Therefore the user should set `top_k=10000` and now the EmbeddingRetriever only returns the 200 relevant results, instead of all 10000.

Unfortunately Elasticsearch applies the min_score filter only after the top_k (size) filter. 
 