### PR TITLE
enforce same index values before and after saving/loading eval dataframes

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1002,7 +1002,7 @@ class Pipeline(BasePipeline):
             df["eval_mode"] = "isolated" if "isolated" in field_name else "integrated"
             partial_dfs.append(df)
 
-        return pd.concat(partial_dfs, ignore_index=True)
+        return pd.concat(partial_dfs, ignore_index=True).reset_index()
 
     def get_next_nodes(self, node_id: str, stream_id: str):
         current_node_edges = self.graph.edges(node_id, data=True)


### PR DESCRIPTION
**Proposed changes**:
- call `reset_index()` before returning dataframe

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
