### PR TITLE
Reduce num REST API workers to accommodate smaller machines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     depends_on:
       - elasticsearch
     # Starts REST API with only 2 workers so that it can be run on systems with just 4GB of memory
+    # If you need to handle large loads of incoming requests and have memory to spare, consider increasing the number of workers
     command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 2 --timeout 180'"
   elasticsearch:
     # This will start an empty elasticsearch instance (so you have to add your documents yourself)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - CONCURRENT_REQUEST_PER_WORKER
     depends_on:
       - elasticsearch
-    command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 8 --timeout 180'"
+    # Starts REST API with only 2 workers so that it can be run on systems with just 4GB of memory
+    command: "/bin/bash -c 'sleep 10 && gunicorn rest_api.application:app -b 0.0.0.0 -k uvicorn.workers.UvicornWorker --workers 2 --timeout 180'"
   elasticsearch:
     # This will start an empty elasticsearch instance (so you have to add your documents yourself)
     #image: "elasticsearch:7.9.2"


### PR DESCRIPTION
**Proposed changes**:
Reduces number of REST API workers from 8 to 2 to reduce memory consumption of the REST API docker. This is in response to #2399 
