### PR TITLE
Set CI job timeout to 45 minutes

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -18,6 +18,7 @@ jobs:
 
   code-and-docs-updates:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
 
       - uses: actions/checkout@v2

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false

--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -29,6 +29,7 @@ jobs:
 
   build-cache:
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     steps:
       - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
@@ -59,6 +60,7 @@ jobs:
 
   type-check:
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -95,6 +97,7 @@ jobs:
 
   linter:
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     steps:
 
       - uses: actions/checkout@v2
@@ -132,6 +135,7 @@ jobs:
   code-and-docs-check:
     needs: build-cache
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: ${{ github.event_name }} != "push"
 
     steps:
@@ -217,6 +221,7 @@ jobs:
   prepare-matrix:
     needs: build-cache
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
@@ -230,6 +235,7 @@ jobs:
   tests:
     needs: prepare-matrix
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     strategy:
       matrix:
         test-path: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
@@ -304,6 +310,7 @@ jobs:
   test-milvus1:
     needs: build-cache
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v2
@@ -350,6 +357,7 @@ jobs:
   test-pinecone:
     needs: build-cache
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   type-check:
     runs-on: windows-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -23,6 +24,7 @@ jobs:
   build-cache:
     needs: type-check
     runs-on: windows-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v2
@@ -55,6 +57,7 @@ jobs:
     needs: build-cache
     # With Windows it gives error, also this step only listing test files only
     runs-on: ubuntu-20.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - id: set-matrix
@@ -66,6 +69,7 @@ jobs:
   build:
     needs: prepare-build
     runs-on: windows-latest
+    timeout-minutes: 45
     strategy:
       matrix:
         test-path: ${{fromJson(needs.prepare-build.outputs.matrix)}}


### PR DESCRIPTION
Job https://github.com/deepset-ai/haystack/runs/5968089344?check_suite_focus=true got stuck occupying all available workers for over 4 hours. To prevent this we set down the timeout of jobs to 45 minutes.

**Proposed changes**:
- set individual job timeouts to 45 minutes

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
