### PR TITLE
Fix: Auth token not passed for EmbeddingRetriever

### DIFF
--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -99,7 +99,9 @@ class _SentenceTransformersEmbeddingEncoder(_BaseEmbeddingEncoder):
 
             _optional_component_not_installed(__name__, "sentence", ie)
 
-        self.embedding_model = SentenceTransformer(retriever.embedding_model, device=str(retriever.devices[0]), use_auth_token=retriever.use_auth_token)
+        self.embedding_model = SentenceTransformer(
+            retriever.embedding_model, device=str(retriever.devices[0]), use_auth_token=retriever.use_auth_token
+        )
         self.batch_size = retriever.batch_size
         self.embedding_model.max_seq_length = retriever.max_seq_len
         self.show_progress_bar = retriever.progress_bar

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -99,7 +99,7 @@ class _SentenceTransformersEmbeddingEncoder(_BaseEmbeddingEncoder):
 
             _optional_component_not_installed(__name__, "sentence", ie)
 
-        self.embedding_model = SentenceTransformer(retriever.embedding_model, device=str(retriever.devices[0]))
+        self.embedding_model = SentenceTransformer(retriever.embedding_model, device=str(retriever.devices[0]), use_auth_token=retriever.use_auth_token)
         self.batch_size = retriever.batch_size
         self.embedding_model.max_seq_length = retriever.max_seq_len
         self.show_progress_bar = retriever.progress_bar


### PR DESCRIPTION
**Proposed changes**:
- The auth token for HF private models is not passed to the EmbeddingRetriever initialization.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ x] Final code
- [ ] Added tests
- [ ] Updated documentation
