### PR TITLE
Exclude `beir` from Windows install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -103,9 +103,6 @@ install_requires =
     # Schema validation
     jsonschema
 
-    # Not found in repo, to review:
-    #uvloop==0.14; sys_platform != 'win32' and sys_platform != 'cygwin'
-
 
 [options.packages.find]
 exclude =
@@ -124,7 +121,7 @@ haystack =
 sql = 
     sqlalchemy>=1.4.2,<2
     sqlalchemy_utils
-    psycopg2-binary; sys_platform != 'win32' and sys_platform != 'cygwin'
+    psycopg2-binary; platform_system != 'Windows'
 only-faiss = 
     faiss-cpu>=1.6.3,<2
 faiss = 
@@ -176,7 +173,7 @@ ray =
 colab = 
     grpcio==1.43.0
 beir = 
-    beir
+    beir; platform_system != 'Windows'
 dev = 
     # Type check
     mypy


### PR DESCRIPTION
**Problem**:
Python `beir` package depends on `pytrec_eval`, which can't be easily installed on Windows. Given that the `beir` dep group is part of the `all` install, this can give trouble in some cases.

**Solution**
`beir` will selectively install only if the platform is not Windows.