### PR TITLE
Added macos version of xpdf in tutorial 8

### DIFF
--- a/tutorials/Tutorial8_Preprocessing.ipynb
+++ b/tutorials/Tutorial8_Preprocessing.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "# For Macos machines\n",
     "# !wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz\n",
-    "# !tar -xvf xpdf-tools-max-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin"
+    "# !tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin"
    ]
   },
   {

--- a/tutorials/Tutorial8_Preprocessing.ipynb
+++ b/tutorials/Tutorial8_Preprocessing.ipynb
@@ -65,8 +65,13 @@
     "!pip install --upgrade pip\n",
     "!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]\n",
     "\n",
+    "# For Colab/linux based machines\n",
     "!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz\n",
-    "!tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin"
+    "!tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin\n",
+    "\n",
+    "# For Macos machines\n",
+    "# !wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz\n",
+    "# !tar -xvf xpdf-tools-max-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin"
    ]
   },
   {


### PR DESCRIPTION
**Proposed changes**:
- I added two lines to download xpdf for the mac version, so that the pdftotext converter can be used and preprocssed
- The additional code is 'commented out'

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation

Thank you.