### PR TITLE
Add sort arg to JoinAnswers

### DIFF
--- a/docs/_src/api/api/other.md
+++ b/docs/_src/api/api/other.md
@@ -70,7 +70,7 @@ A node to join `Answer`s produced by multiple `Reader` nodes.
 #### \_\_init\_\_
 
 ```python
-def __init__(join_mode: str = "concatenate", weights: Optional[List[float]] = None, top_k_join: Optional[int] = None, sort: bool = True)
+def __init__(join_mode: str = "concatenate", weights: Optional[List[float]] = None, top_k_join: Optional[int] = None, sort_by_score: bool = True)
 ```
 
 **Arguments**:
@@ -81,6 +81,9 @@ of individual `Answer`s.
 adjusting `Answer` scores when using the `"merge"` join_mode. By default, equal weight is assigned to each
 `Reader` score. This parameter is not compatible with the `"concatenate"` join_mode.
 - `top_k_join`: Limit `Answer`s to top_k based on the resulting scored of the join.
+- `sort_by_score`: Whether to sort the incoming answers by their score. Set this to True if your Answers
+are coming from a Reader or TableReader. Set to False if any Answers come from a Generator since this assigns
+None as a score to each.
 
 <a id="route_documents"></a>
 

--- a/haystack/json-schemas/haystack-pipeline-master.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-master.schema.json
@@ -2602,8 +2602,8 @@
               "title": "Top K Join",
               "type": "integer"
             },
-            "sort": {
-              "title": "Sort",
+            "sort_by_score": {
+              "title": "Sort By Score",
               "default": true,
               "type": "boolean"
             }

--- a/haystack/nodes/other/join_answers.py
+++ b/haystack/nodes/other/join_answers.py
@@ -14,7 +14,7 @@ class JoinAnswers(BaseComponent):
         join_mode: str = "concatenate",
         weights: Optional[List[float]] = None,
         top_k_join: Optional[int] = None,
-        sort: bool = True
+        sort_by_score: bool = True
     ):
         """
         :param join_mode: `"concatenate"` to combine documents from multiple `Reader`s. `"merge"` to aggregate scores
@@ -23,6 +23,9 @@ class JoinAnswers(BaseComponent):
             adjusting `Answer` scores when using the `"merge"` join_mode. By default, equal weight is assigned to each
             `Reader` score. This parameter is not compatible with the `"concatenate"` join_mode.
         :param top_k_join: Limit `Answer`s to top_k based on the resulting scored of the join.
+        :param sort_by_score: Whether to sort the incoming answers by their score. Set this to True if your Answers
+            are coming from a Reader or TableReader. Set to False if any Answers come from a Generator since this assigns
+            None as a score to each.
         """
 
         assert join_mode in ["concatenate", "merge"], f"JoinAnswers node does not support '{join_mode}' join_mode."
@@ -35,7 +38,7 @@ class JoinAnswers(BaseComponent):
         self.join_mode = join_mode
         self.weights = [float(i) / sum(weights) for i in weights] if weights else None
         self.top_k_join = top_k_join
-        self.sort = sort
+        self.sort_by_score = sort_by_score
 
     def run(self, inputs: List[Dict], top_k_join: Optional[int] = None) -> Tuple[Dict, str]:  # type: ignore
         reader_results = [inp["answers"] for inp in inputs]
@@ -45,7 +48,7 @@ class JoinAnswers(BaseComponent):
 
         if self.join_mode == "concatenate":
             concatenated_answers = [answer for cur_reader_result in reader_results for answer in cur_reader_result]
-            if self.sort:
+            if self.sort_by_score:
                 concatenated_answers = sorted(concatenated_answers, reverse=True)
             concatenated_answers = concatenated_answers[:top_k_join]
             return {"answers": concatenated_answers, "labels": inputs[0].get("labels", None)}, "output_1"
@@ -66,7 +69,7 @@ class JoinAnswers(BaseComponent):
                 if isinstance(answer.score, float):
                     answer.score *= weight
         merged_answers = [answer for cur_reader_result in reader_results for answer in cur_reader_result]
-        if self.sort:
+        if self.sort_by_score:
             merged_answers = sorted(merged_answers, reverse=True)
 
         return sorted([answer for cur_reader_result in reader_results for answer in cur_reader_result], reverse=True)

--- a/haystack/nodes/other/join_answers.py
+++ b/haystack/nodes/other/join_answers.py
@@ -14,7 +14,7 @@ class JoinAnswers(BaseComponent):
         join_mode: str = "concatenate",
         weights: Optional[List[float]] = None,
         top_k_join: Optional[int] = None,
-        sort_by_score: bool = True
+        sort_by_score: bool = True,
     ):
         """
         :param join_mode: `"concatenate"` to combine documents from multiple `Reader`s. `"merge"` to aggregate scores


### PR DESCRIPTION
Add a sort argument to the initialization of JoinAnswers. This allows for joining of answers from a Generator and a Reader. Previously, this was not possible since the Generator returns a score of None. When they are sorted with the Answers coming from the Reader, this error was thrown:
```
 TypeError: '<' not supported between instances of 'NoneType' and 'float'
```
Fixes #2435 
