### PR TITLE
Add info about execution env to minimal GPU image

### DIFF
--- a/Dockerfile-GPU-minimal
+++ b/Dockerfile-GPU-minimal
@@ -4,6 +4,7 @@ WORKDIR /home/user
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+ENV HAYSTACK_DOCKER_CONTAINER="HAYSTACK_MINIMAL_GPU_CONTAINER"
 
 # Install software dependencies
 RUN apt-get update && apt-get install -y software-properties-common && \


### PR DESCRIPTION
**Proposed changes**:
We didn't set the info about the execution environment yet in the "minimal GPU" image but only in the regular GPU image.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
