### PR TITLE
Make sure that `debug=True` and `params={'debug': True}` behaves the same way

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -640,10 +640,10 @@ class Pipeline(BasePipeline):
             # Apply debug attributes to the node input params
             # NOTE: global debug attributes will override the value specified
             # in each node's params dictionary.
-            if debug is None and node_input.get("params", {}).get("debug", None):
+            if debug is None and node_input and node_input.get("params", {}).get("debug", None):
                 debug = node_input["params"]["debug"]
                 
-            if debug is not None or node_input.get("params", {}).get("debug", None):
+            if debug is not None:
                 if not node_input.get("params", None):
                     node_input["params"] = {}
                 if node_id not in node_input["params"].keys():

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -641,7 +641,7 @@ class Pipeline(BasePipeline):
             # NOTE: global debug attributes will override the value specified
             # in each node's params dictionary.
             if debug is None and node_input:
-                if node_input.get("params", None):
+                if node_input.get("params", {}):
                     debug = params.get("debug", None)
             if debug is not None:
                 if not node_input.get("params", None):

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -640,7 +640,12 @@ class Pipeline(BasePipeline):
             # Apply debug attributes to the node input params
             # NOTE: global debug attributes will override the value specified
             # in each node's params dictionary.
-            if debug is not None:
+            if debug is None and node_input.get("params", {}).get("debug", None):
+                debug = node_input["params"]["debug"]
+                
+            if debug is not None or node_input.get("params", {}).get("debug", None):
+                if not node_input.get("params", None):
+                    node_input["params"] = {}
                 if node_id not in node_input["params"].keys():
                     node_input["params"][node_id] = {}
                 node_input["params"][node_id]["debug"] = debug

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -642,7 +642,7 @@ class Pipeline(BasePipeline):
             # in each node's params dictionary.
             if debug is None and node_input:
                 if node_input.get("params", {}):
-                    debug = params.get("debug", None)
+                    debug = params.get("debug", None)  # type: ignore
             if debug is not None:
                 if not node_input.get("params", None):
                     node_input["params"] = {}

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -641,7 +641,8 @@ class Pipeline(BasePipeline):
             # NOTE: global debug attributes will override the value specified
             # in each node's params dictionary.
             if debug is None and node_input:
-                debug = node_input["params"]["debug"] = node_input.get("params", {}).get("debug", None)
+                if node_input.get("params", None):
+                    debug = params.get("debug", None)
             if debug is not None:
                 if not node_input.get("params", None):
                     node_input["params"] = {}

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -640,8 +640,8 @@ class Pipeline(BasePipeline):
             # Apply debug attributes to the node input params
             # NOTE: global debug attributes will override the value specified
             # in each node's params dictionary.
-            if debug is None and node_input and node_input.get("params", {}).get("debug", None):
-                debug = node_input["params"]["debug"]
+            if debug is None and node_input:
+                debug = node_input["params"]["debug"] = node_input.get("params", {}).get("debug", None)
             if debug is not None:
                 if not node_input.get("params", None):
                     node_input["params"] = {}


### PR DESCRIPTION
`pipeline.run(debug=True)` was producing a `_debug` key in the output with the debug information, while `pipeline.run(params={"debug":True})` was not.

This PR restores the same functionality for the second way of asking for debug output.

Closes #2440