### PR TITLE
Upgrade xpdf to 4.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 # Install PDF converter
-RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz && \
-    tar -xvf xpdf-tools-linux-4.03.tar.gz && cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+RUN wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz && \
+    tar -xvf xpdf-tools-linux-4.04.tar.gz && cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
 
 # Copy Haystack code
 COPY haystack /home/user/haystack/

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
 # Install PDF converter
-RUN curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.03/bin64/pdftotext
+RUN curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.03/bin64/pdftotext
 
 # Set default Python version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \

--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
 # Install PDF converter
-RUN curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.03/bin64/pdftotext
+RUN curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.04/bin64/pdftotext
 
 # Set default Python version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \

--- a/Dockerfile-GPU-minimal
+++ b/Dockerfile-GPU-minimal
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y software-properties-common && \
     rm -rf /var/lib/apt/lists/* && \
     # Install PDF converter
     curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz \
-    | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.03/bin64/pdftotext
+    | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.04/bin64/pdftotext
 
 # Copy Haystack package files but not the source code
 COPY setup.py setup.cfg pyproject.toml VERSION.txt LICENSE README.md /home/user/

--- a/Dockerfile-GPU-minimal
+++ b/Dockerfile-GPU-minimal
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y software-properties-common && \
     # Cleanup apt cache
     rm -rf /var/lib/apt/lists/* && \
     # Install PDF converter
-    curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz \
+    curl -s https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz \
     | tar -xvzf - -C /usr/local/bin --strip-components=2 xpdf-tools-linux-4.03/bin64/pdftotext
 
 # Copy Haystack package files but not the source code


### PR DESCRIPTION
**Proposed changes**:
xpdf [released](http://www.xpdfreader.com/download.html) a new version on Apr 18th. As they only host the latest version of command line tools, our docker builds failed as the old tar was not available anymore. 

Upgraded it quickly to 4.0.4 but haven't verified if there were any breaking changes in their release. 


**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
