### PR TITLE
Add support for aliases in elasticsearch document store

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -312,19 +312,23 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         Create a new index for storing documents. In case if an index with the name already exists, it ensures that
         the embedding_field is present.
         """
+        # Check if index_name refers to an alias
+        if self.client.indices.exists_alias(name=index_name):
+            logger.debug(f"Index name {index_name} is an alias.")
+
         # check if the existing index has the embedding field; if not create it
         if self.client.indices.exists(index=index_name, headers=headers):
             indices = self.client.indices.get(index_name, headers=headers)
-            for index in indices.values():
-                mapping = index["mappings"]
+            for index_id, index_info in indices.items():
+                mapping = index_info["mappings"]
                 if self.search_fields:
                     for search_field in self.search_fields:
                         if search_field in mapping["properties"] and mapping["properties"][search_field]["type"] != "text":
                             raise Exception(
-                                f"The search_field '{search_field}' of index '{index_name}' with type '{mapping['properties'][search_field]['type']}' "
+                                f"The search_field '{search_field}' of index '{index_id}' with type '{mapping['properties'][search_field]['type']}' "
                                 f"does not have the right type 'text' to be queried in fulltext search. Please use only 'text' type properties as search_fields or use another index. "
                                 f"This error might occur if you are trying to use haystack 1.0 and above with an existing elasticsearch index created with a previous version of haystack. "
-                                f'In this case deleting the index with `delete_index(index="{index_name}")` will fix your environment. '
+                                f'In this case deleting the index with `delete_index(index="{index_id}")` will fix your environment. '
                                 f"Note, that all data stored in the index will be lost!"
                             )
                 if self.embedding_field:
@@ -333,12 +337,12 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                         and mapping["properties"][self.embedding_field]["type"] != "dense_vector"
                     ):
                         raise Exception(
-                            f"The '{index_name}' index in Elasticsearch already has a field called '{self.embedding_field}'"
+                            f"The '{index_id}' index in Elasticsearch already has a field called '{self.embedding_field}'"
                             f" with the type '{mapping['properties'][self.embedding_field]['type']}'. Please update the "
                             f"document_store to use a different name for the embedding_field parameter."
                         )
                     mapping["properties"][self.embedding_field] = {"type": "dense_vector", "dims": self.embedding_dim}
-                    self.client.indices.put_mapping(index=index_name, body=mapping, headers=headers)
+                    self.client.indices.put_mapping(index=index_id, body=mapping, headers=headers)
             return
 
         if self.custom_mapping:
@@ -1863,74 +1867,79 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
         """
         Create a new index for storing documents.
         """
+        # Check if index_name refers to an alias
+        if self.client.indices.exists_alias(name=index_name):
+            logger.debug(f"Index name {index_name} is an alias.")
+
         # check if the existing index has the embedding field; if not create it
         if self.client.indices.exists(index=index_name, headers=headers):
-            index_info = self.client.indices.get(index_name, headers=headers)[index_name]
-            mappings = index_info["mappings"]
-            index_settings = index_info["settings"]["index"]
-            if self.search_fields:
-                for search_field in self.search_fields:
-                    if (
-                        search_field in mappings["properties"]
-                        and mappings["properties"][search_field]["type"] != "text"
-                    ):
-                        raise Exception(
-                            f"The search_field '{search_field}' of index '{index_name}' with type '{mappings['properties'][search_field]['type']}' "
-                            f"does not have the right type 'text' to be queried in fulltext search. Please use only 'text' type properties as search_fields or use another index. "
-                            f"This error might occur if you are trying to use haystack 1.0 and above with an existing elasticsearch index created with a previous version of haystack. "
-                            f'In this case deleting the index with `delete_index(index="{index_name}")` will fix your environment. '
-                            f"Note, that all data stored in the index will be lost!"
-                        )
+            indices = self.client.indices.get(index_name, headers=headers)
+            for index_id, index_info in indices.items():
+                mappings = index_info["mappings"]
+                index_settings = index_info["settings"]["index"]
+                if self.search_fields:
+                    for search_field in self.search_fields:
+                        if (
+                            search_field in mappings["properties"]
+                            and mappings["properties"][search_field]["type"] != "text"
+                        ):
+                            raise Exception(
+                                f"The search_field '{search_field}' of index '{index_id}' with type '{mappings['properties'][search_field]['type']}' "
+                                f"does not have the right type 'text' to be queried in fulltext search. Please use only 'text' type properties as search_fields or use another index. "
+                                f"This error might occur if you are trying to use haystack 1.0 and above with an existing elasticsearch index created with a previous version of haystack. "
+                                f'In this case deleting the index with `delete_index(index="{index_id}")` will fix your environment. '
+                                f"Note, that all data stored in the index will be lost!"
+                            )
 
-            # embedding field will be created
-            if self.embedding_field not in mappings["properties"]:
-                mappings["properties"][self.embedding_field] = self._get_embedding_field_mapping(
-                    similarity=self.similarity
-                )
-                self.client.indices.put_mapping(index=self.index, body=mappings, headers=headers)
-                self.embeddings_field_supports_similarity = True
-            else:
-                # bad embedding field
-                if mappings["properties"][self.embedding_field]["type"] != "knn_vector":
-                    raise Exception(
-                        f"The '{index_name}' index in OpenSearch already has a field called '{self.embedding_field}'"
-                        f" with the type '{mappings['properties'][self.embedding_field]['type']}'. Please update the "
-                        f"document_store to use a different name for the embedding_field parameter."
+                # embedding field will be created
+                if self.embedding_field not in mappings["properties"]:
+                    mappings["properties"][self.embedding_field] = self._get_embedding_field_mapping(
+                        similarity=self.similarity
                     )
-                # embedding field with global space_type setting
-                if "method" not in mappings["properties"][self.embedding_field]:
-                    embedding_field_space_type = index_settings["knn.space_type"]
-                # embedding field with local space_type setting
+                    self.client.indices.put_mapping(index=index_id, body=mappings, headers=headers)
+                    self.embeddings_field_supports_similarity = True
                 else:
+                    # bad embedding field
+                    if mappings["properties"][self.embedding_field]["type"] != "knn_vector":
+                        raise Exception(
+                            f"The '{index}' index in OpenSearch already has a field called '{self.embedding_field}'"
+                            f" with the type '{mappings['properties'][self.embedding_field]['type']}'. Please update the "
+                            f"document_store to use a different name for the embedding_field parameter."
+                        )
                     # embedding field with global space_type setting
                     if "method" not in mappings["properties"][self.embedding_field]:
                         embedding_field_space_type = index_settings["knn.space_type"]
                     # embedding field with local space_type setting
                     else:
-                        embedding_field_space_type = mappings["properties"][self.embedding_field]["method"][
-                            "space_type"
-                        ]
+                        # embedding field with global space_type setting
+                        if "method" not in mappings["properties"][self.embedding_field]:
+                            embedding_field_space_type = index_settings["knn.space_type"]
+                        # embedding field with local space_type setting
+                        else:
+                            embedding_field_space_type = mappings["properties"][self.embedding_field]["method"][
+                                "space_type"
+                            ]
 
-                    embedding_field_similarity = self.space_type_to_similarity[embedding_field_space_type]
-                    if embedding_field_similarity == self.similarity:
-                        self.embeddings_field_supports_similarity = True
-                    else:
-                        logger.warning(
-                            f"Embedding field '{self.embedding_field}' is optimized for similarity '{embedding_field_similarity}'. "
-                            f"Falling back to slow exact vector calculation. "
-                            f"Consider cloning the embedding field optimized for '{embedding_field_similarity}' by calling clone_embedding_field(similarity='{embedding_field_similarity}', ...) "
-                            f"or creating a new index optimized for '{self.similarity}' by setting `similarity='{self.similarity}'` the first time you instantiate OpenSearchDocumentStore for the new index, "
-                            f"e.g. `OpenSearchDocumentStore(index='my_new_{self.similarity}_index', similarity='{self.similarity}')`."
-                        )
+                        embedding_field_similarity = self.space_type_to_similarity[embedding_field_space_type]
+                        if embedding_field_similarity == self.similarity:
+                            self.embeddings_field_supports_similarity = True
+                        else:
+                            logger.warning(
+                                f"Embedding field '{self.embedding_field}' is optimized for similarity '{embedding_field_similarity}'. "
+                                f"Falling back to slow exact vector calculation. "
+                                f"Consider cloning the embedding field optimized for '{embedding_field_similarity}' by calling clone_embedding_field(similarity='{embedding_field_similarity}', ...) "
+                                f"or creating a new index optimized for '{self.similarity}' by setting `similarity='{self.similarity}'` the first time you instantiate OpenSearchDocumentStore for the new index, "
+                                f"e.g. `OpenSearchDocumentStore(index='my_new_{self.similarity}_index', similarity='{self.similarity}')`."
+                            )
 
-            # Adjust global ef_search setting. If not set, default is 512.
-            ef_search = index_settings.get("knn.algo_param", {"ef_search": 512}).get("ef_search", 512)
-            if self.index_type == "hnsw" and ef_search != 20:
-                body = {"knn.algo_param.ef_search": 20}
-                self.client.indices.put_settings(index=self.index, body=body, headers=headers)
-            elif self.index_type == "flat" and ef_search != 512:
-                body = {"knn.algo_param.ef_search": 512}
-                self.client.indices.put_settings(index=self.index, body=body, headers=headers)
+                # Adjust global ef_search setting. If not set, default is 512.
+                ef_search = index_settings.get("knn.algo_param", {"ef_search": 512}).get("ef_search", 512)
+                if self.index_type == "hnsw" and ef_search != 20:
+                    body = {"knn.algo_param.ef_search": 20}
+                    self.client.indices.put_settings(index=index_id, body=body, headers=headers)
+                elif self.index_type == "flat" and ef_search != 512:
+                    body = {"knn.algo_param.ef_search": 512}
+                    self.client.indices.put_settings(index=index_id, body=body, headers=headers)
 
             return
 

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -314,29 +314,31 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         """
         # check if the existing index has the embedding field; if not create it
         if self.client.indices.exists(index=index_name, headers=headers):
-            mapping = self.client.indices.get(index_name, headers=headers)[index_name]["mappings"]
-            if self.search_fields:
-                for search_field in self.search_fields:
-                    if search_field in mapping["properties"] and mapping["properties"][search_field]["type"] != "text":
+            indices = self.client.indices.get(index_name, headers=headers)
+            for index in indices.values():
+                mapping = index["mappings"]
+                if self.search_fields:
+                    for search_field in self.search_fields:
+                        if search_field in mapping["properties"] and mapping["properties"][search_field]["type"] != "text":
+                            raise Exception(
+                                f"The search_field '{search_field}' of index '{index_name}' with type '{mapping['properties'][search_field]['type']}' "
+                                f"does not have the right type 'text' to be queried in fulltext search. Please use only 'text' type properties as search_fields or use another index. "
+                                f"This error might occur if you are trying to use haystack 1.0 and above with an existing elasticsearch index created with a previous version of haystack. "
+                                f'In this case deleting the index with `delete_index(index="{index_name}")` will fix your environment. '
+                                f"Note, that all data stored in the index will be lost!"
+                            )
+                if self.embedding_field:
+                    if (
+                        self.embedding_field in mapping["properties"]
+                        and mapping["properties"][self.embedding_field]["type"] != "dense_vector"
+                    ):
                         raise Exception(
-                            f"The search_field '{search_field}' of index '{index_name}' with type '{mapping['properties'][search_field]['type']}' "
-                            f"does not have the right type 'text' to be queried in fulltext search. Please use only 'text' type properties as search_fields or use another index. "
-                            f"This error might occur if you are trying to use haystack 1.0 and above with an existing elasticsearch index created with a previous version of haystack. "
-                            f'In this case deleting the index with `delete_index(index="{index_name}")` will fix your environment. '
-                            f"Note, that all data stored in the index will be lost!"
+                            f"The '{index_name}' index in Elasticsearch already has a field called '{self.embedding_field}'"
+                            f" with the type '{mapping['properties'][self.embedding_field]['type']}'. Please update the "
+                            f"document_store to use a different name for the embedding_field parameter."
                         )
-            if self.embedding_field:
-                if (
-                    self.embedding_field in mapping["properties"]
-                    and mapping["properties"][self.embedding_field]["type"] != "dense_vector"
-                ):
-                    raise Exception(
-                        f"The '{index_name}' index in Elasticsearch already has a field called '{self.embedding_field}'"
-                        f" with the type '{mapping['properties'][self.embedding_field]['type']}'. Please update the "
-                        f"document_store to use a different name for the embedding_field parameter."
-                    )
-                mapping["properties"][self.embedding_field] = {"type": "dense_vector", "dims": self.embedding_dim}
-                self.client.indices.put_mapping(index=index_name, body=mapping, headers=headers)
+                    mapping["properties"][self.embedding_field] = {"type": "dense_vector", "dims": self.embedding_dim}
+                    self.client.indices.put_mapping(index=index_name, body=mapping, headers=headers)
             return
 
         if self.custom_mapping:

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1902,7 +1902,7 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
                     # bad embedding field
                     if mappings["properties"][self.embedding_field]["type"] != "knn_vector":
                         raise Exception(
-                            f"The '{index}' index in OpenSearch already has a field called '{self.embedding_field}'"
+                            f"The '{index_id}' index in OpenSearch already has a field called '{self.embedding_field}'"
                             f" with the type '{mappings['properties'][self.embedding_field]['type']}'. Please update the "
                             f"document_store to use a different name for the embedding_field parameter."
                         )

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -319,6 +319,7 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         # check if the existing index has the embedding field; if not create it
         if self.client.indices.exists(index=index_name, headers=headers):
             indices = self.client.indices.get(index_name, headers=headers)
+            # If the index name is an alias that groups multiple existing indices, each of them must have an embedding_field.
             for index_id, index_info in indices.items():
                 mapping = index_info["mappings"]
                 if self.search_fields:
@@ -1877,6 +1878,7 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
         # check if the existing index has the embedding field; if not create it
         if self.client.indices.exists(index=index_name, headers=headers):
             indices = self.client.indices.get(index_name, headers=headers)
+            # If the index name is an alias that groups multiple existing indices, each of them must have an embedding_field.
             for index_id, index_info in indices.items():
                 mappings = index_info["mappings"]
                 index_settings = index_info["settings"]["index"]

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -9,7 +9,6 @@ import responses
 from responses import matchers
 from unittest.mock import Mock
 from elasticsearch import Elasticsearch
-from elasticsearch.helpers import bulk
 from elasticsearch.exceptions import RequestError
 
 from .conftest import (
@@ -77,21 +76,17 @@ def test_init_elastic_client():
 
     # list of hosts + list of ports (wrong)
     with pytest.raises(Exception):
-        _ = ElasticsearchDocumentStore(
-            host=["localhost", "127.0.0.1"], port=[9200])
+        _ = ElasticsearchDocumentStore(host=["localhost", "127.0.0.1"], port=[9200])
 
     # list of hosts + list
-    _ = ElasticsearchDocumentStore(
-        host=["localhost", "127.0.0.1"], port=[9200, 9200])
+    _ = ElasticsearchDocumentStore(host=["localhost", "127.0.0.1"], port=[9200, 9200])
 
     # only api_key
     with pytest.raises(Exception):
-        _ = ElasticsearchDocumentStore(
-            host=["localhost"], port=[9200], api_key="test")
+        _ = ElasticsearchDocumentStore(host=["localhost"], port=[9200], api_key="test")
 
     # api_key +  id
-    _ = ElasticsearchDocumentStore(host=["localhost"], port=[
-                                   9200], api_key="test", api_key_id="test")
+    _ = ElasticsearchDocumentStore(host=["localhost"], port=[9200], api_key="test", api_key_id="test")
 
 
 @pytest.mark.elasticsearch
@@ -99,8 +94,7 @@ def test_init_elastic_doc_store_with_index_recreation():
     index_name = "test_index_recreation"
     label_index_name = "test_index_recreation_labels"
 
-    document_store = ElasticsearchDocumentStore(
-        index=index_name, label_index=label_index_name)
+    document_store = ElasticsearchDocumentStore(index=index_name, label_index=label_index_name)
     documents = [Document(content="Doc1")]
     labels = [
         Label(
@@ -115,8 +109,7 @@ def test_init_elastic_doc_store_with_index_recreation():
     document_store.write_documents(documents, index=index_name)
     document_store.write_labels(labels, index=label_index_name)
 
-    document_store = ElasticsearchDocumentStore(
-        index=index_name, label_index=label_index_name, recreate_index=True)
+    document_store = ElasticsearchDocumentStore(index=index_name, label_index=label_index_name, recreate_index=True)
     docs = document_store.get_all_documents(index=index_name)
     labels = document_store.get_all_labels(index=label_index_name)
 
@@ -129,12 +122,10 @@ def test_write_with_duplicate_doc_ids(document_store: BaseDocumentStore):
         Document(content="Doc1", id_hash_keys=["content"]),
         Document(content="Doc1", id_hash_keys=["content"]),
     ]
-    document_store.write_documents(
-        duplicate_documents, duplicate_documents="skip")
+    document_store.write_documents(duplicate_documents, duplicate_documents="skip")
     assert len(document_store.get_all_documents()) == 1
     with pytest.raises(Exception):
-        document_store.write_documents(
-            duplicate_documents, duplicate_documents="fail")
+        document_store.write_documents(duplicate_documents, duplicate_documents="fail")
 
 
 @pytest.mark.parametrize(
@@ -145,14 +136,11 @@ def test_write_with_duplicate_doc_ids_custom_index(document_store: BaseDocumentS
         Document(content="Doc1", id_hash_keys=["content"]),
         Document(content="Doc1", id_hash_keys=["content"]),
     ]
-    document_store.delete_documents(index="haystack_custom_test")
-    document_store.write_documents(
-        duplicate_documents, index="haystack_custom_test", duplicate_documents="skip")
-    assert len(document_store.get_all_documents(
-        index="haystack_custom_test")) == 1
+    document_store.delete_index(index="haystack_custom_test")
+    document_store.write_documents(duplicate_documents, index="haystack_custom_test", duplicate_documents="skip")
+    assert len(document_store.get_all_documents(index="haystack_custom_test")) == 1
     with pytest.raises(DuplicateDocumentError):
-        document_store.write_documents(
-            duplicate_documents, index="haystack_custom_test", duplicate_documents="fail")
+        document_store.write_documents(duplicate_documents, index="haystack_custom_test", duplicate_documents="fail")
 
     # Weaviate manipulates document objects in-place when writing them to an index.
     # It generates a uuid based on the provided id and the index name where the document is added to.
@@ -164,8 +152,7 @@ def test_write_with_duplicate_doc_ids_custom_index(document_store: BaseDocumentS
             Document(content="Doc1", id_hash_keys=["content"]),
         ]
     # writing to the default, empty index should still work
-    document_store.write_documents(
-        duplicate_documents, duplicate_documents="fail")
+    document_store.write_documents(duplicate_documents, duplicate_documents="fail")
 
 
 def test_get_all_documents_without_filters(document_store_with_docs):
@@ -173,18 +160,15 @@ def test_get_all_documents_without_filters(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents()
     assert all(isinstance(d, Document) for d in documents)
     assert len(documents) == 5
-    assert {d.meta["name"] for d in documents} == {
-        "filename1", "filename2", "filename3", "filename4", "filename5"}
-    assert {d.meta["meta_field"] for d in documents} == {
-        "test1", "test2", "test3", "test4", "test5"}
+    assert {d.meta["name"] for d in documents} == {"filename1", "filename2", "filename3", "filename4", "filename5"}
+    assert {d.meta["meta_field"] for d in documents} == {"test1", "test2", "test3", "test4", "test5"}
 
 
 def test_get_all_documents_large_quantities(document_store: BaseDocumentStore):
     # Test to exclude situations like Weaviate not returning more than 100 docs by default
     #   https://github.com/deepset-ai/haystack/issues/1893
     docs_to_write = [
-        {"meta": {"name": f"name_{i}"}, "content": f"text_{i}",
-            "embedding": np.random.rand(768).astype(np.float32)}
+        {"meta": {"name": f"name_{i}"}, "content": f"text_{i}", "embedding": np.random.rand(768).astype(np.float32)}
         for i in range(1000)
     ]
     document_store.write_documents(docs_to_write)
@@ -196,8 +180,7 @@ def test_get_all_documents_large_quantities(document_store: BaseDocumentStore):
 def test_get_all_document_filter_duplicate_text_value(document_store: BaseDocumentStore):
     documents = [
         Document(content="Doc1", meta={"f1": "0"}, id_hash_keys=["meta"]),
-        Document(content="Doc1", meta={
-                 "f1": "1", "meta_id": "0"}, id_hash_keys=["meta"]),
+        Document(content="Doc1", meta={"f1": "1", "meta_id": "0"}, id_hash_keys=["meta"]),
         Document(content="Doc2", meta={"f3": "0"}, id_hash_keys=["meta"]),
     ]
     document_store.write_documents(documents)
@@ -218,13 +201,11 @@ def test_get_all_document_filter_duplicate_text_value(document_store: BaseDocume
 
 
 def test_get_all_documents_with_correct_filters(document_store_with_docs):
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test2"]})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
     assert len(documents) == 1
     assert documents[0].meta["name"] == "filename2"
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test1", "test3"]})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test3"]})
     assert len(documents) == 2
     assert {d.meta["name"] for d in documents} == {"filename1", "filename3"}
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
@@ -235,27 +216,23 @@ def test_get_all_documents_with_correct_filters_legacy_sqlite(test_docs_xs, tmp_
     document_store_with_docs.write_documents(test_docs_xs)
 
     document_store_with_docs.use_windowed_query = False
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test2"]})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
     assert len(documents) == 1
     assert documents[0].meta["name"] == "filename2"
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test1", "test3"]})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test3"]})
     assert len(documents) == 2
     assert {d.meta["name"] for d in documents} == {"filename1", "filename3"}
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
 
 
 def test_get_all_documents_with_incorrect_filter_name(document_store_with_docs):
-    documents = document_store_with_docs.get_all_documents(
-        filters={"incorrect_meta_field": ["test2"]})
+    documents = document_store_with_docs.get_all_documents(filters={"incorrect_meta_field": ["test2"]})
     assert len(documents) == 0
 
 
 def test_get_all_documents_with_incorrect_filter_value(document_store_with_docs):
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["incorrect_value"]})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["incorrect_value"]})
     assert len(documents) == 0
 
 
@@ -264,42 +241,32 @@ def test_get_all_documents_with_incorrect_filter_value(document_store_with_docs)
 )
 def test_extended_filter(document_store_with_docs):
     # Test comparison operators individually
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": {"$eq": "test1"}})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$eq": "test1"}})
     assert len(documents) == 1
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": "test1"})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": "test1"})
     assert len(documents) == 1
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": {"$in": ["test1", "test2", "n.a."]}})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$in": ["test1", "test2", "n.a."]}})
     assert len(documents) == 2
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test1", "test2", "n.a."]})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test2", "n.a."]})
     assert len(documents) == 2
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": {"$ne": "test1"}})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$ne": "test1"}})
     assert len(documents) == 4
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"meta_field": {"$nin": ["test1", "test2", "n.a."]}})
+    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$nin": ["test1", "test2", "n.a."]}})
     assert len(documents) == 3
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"numeric_field": {"$gt": 3.0}})
+    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$gt": 3.0}})
     assert len(documents) == 3
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"numeric_field": {"$gte": 3.0}})
+    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$gte": 3.0}})
     assert len(documents) == 4
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"numeric_field": {"$lt": 3.0}})
+    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$lt": 3.0}})
     assert len(documents) == 1
 
-    documents = document_store_with_docs.get_all_documents(
-        filters={"numeric_field": {"$lte": 3.0}})
+    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$lte": 3.0}})
     assert len(documents) == 2
 
     # Test compound filters
@@ -319,8 +286,7 @@ def test_extended_filter(document_store_with_docs):
         "date_field": {"$lte": "2020-12-31", "$gte": "2019-01-01"},
         "name": ["filename5", "filename3"],
     }
-    documents_simplified_filter = document_store_with_docs.get_all_documents(
-        filters=filters_simplified)
+    documents_simplified_filter = document_store_with_docs.get_all_documents(filters=filters_simplified)
     # Order of returned documents might differ
     assert len(documents) == len(documents_simplified_filter) and all(
         doc in documents_simplified_filter for doc in documents
@@ -338,8 +304,7 @@ def test_extended_filter(document_store_with_docs):
         "date_field": {"$lte": "2020-12-31", "$gte": "2019-01-01"},
         "$or": {"name": ["filename5", "filename3"], "numeric_field": {"$lte": 5.0}},
     }
-    documents_simplified_filter = document_store_with_docs.get_all_documents(
-        filters=filters_simplified)
+    documents_simplified_filter = document_store_with_docs.get_all_documents(filters=filters_simplified)
     assert len(documents) == len(documents_simplified_filter) and all(
         doc in documents_simplified_filter for doc in documents
     )
@@ -362,8 +327,7 @@ def test_extended_filter(document_store_with_docs):
             "$and": {"numeric_field": {"$lte": 5.0}, "$not": {"meta_field": "test2"}},
         },
     }
-    documents_simplified_filter = document_store_with_docs.get_all_documents(
-        filters=filters_simplified)
+    documents_simplified_filter = document_store_with_docs.get_all_documents(filters=filters_simplified)
     assert len(documents) == len(documents_simplified_filter) and all(
         doc in documents_simplified_filter for doc in documents
     )
@@ -386,10 +350,8 @@ def test_extended_filter(document_store_with_docs):
     # Test same logical operator twice on same level
     filters = {
         "$or": [
-            {"$and": {"meta_field": {"$in": ["test1", "test2"]}, "date_field": {
-                "$gte": "2020-01-01"}}},
-            {"$and": {"meta_field": {"$in": ["test3", "test4"]}, "date_field": {
-                "$lt": "2020-01-01"}}},
+            {"$and": {"meta_field": {"$in": ["test1", "test2"]}, "date_field": {"$gte": "2020-01-01"}}},
+            {"$and": {"meta_field": {"$in": ["test3", "test4"]}, "date_field": {"$lt": "2020-01-01"}}},
         ]
     }
     documents = document_store_with_docs.get_all_documents(filters=filters)
@@ -410,14 +372,12 @@ def test_get_documents_by_id(document_store: BaseDocumentStore):
     # generate more documents than the elasticsearch default query size limit of 10
     docs_to_generate = 15
     documents = [{"content": "doc-" + str(i)} for i in range(docs_to_generate)]
-    doc_idx = "green_fields"
-    document_store.write_documents(documents, index=doc_idx)
+    document_store.write_documents(documents)
 
-    all_docs = document_store.get_all_documents(index=doc_idx)
+    all_docs = document_store.get_all_documents()
     all_ids = [doc.id for doc in all_docs]
 
-    retrieved_by_id = document_store.get_documents_by_id(
-        all_ids, index=doc_idx)
+    retrieved_by_id = document_store.get_documents_by_id(all_ids)
     retrieved_ids = [doc.id for doc in retrieved_by_id]
 
     # all documents in the index should be retrieved when passing all document ids in the index
@@ -433,10 +393,8 @@ def test_get_document_count(document_store: BaseDocumentStore):
     ]
     document_store.write_documents(documents)
     assert document_store.get_document_count() == 4
-    assert document_store.get_document_count(
-        filters={"meta_field_for_count": ["a"]}) == 1
-    assert document_store.get_document_count(
-        filters={"meta_field_for_count": ["b"]}) == 3
+    assert document_store.get_document_count(filters={"meta_field_for_count": ["a"]}) == 1
+    assert document_store.get_document_count(filters={"meta_field_for_count": ["b"]}) == 3
 
 
 def test_get_all_documents_generator(document_store: BaseDocumentStore):
@@ -454,22 +412,18 @@ def test_get_all_documents_generator(document_store: BaseDocumentStore):
 
 @pytest.mark.parametrize("update_existing_documents", [True, False])
 def test_update_existing_documents(document_store, update_existing_documents):
-    original_docs = [{"content": "text1_orig",
-                      "id": "1", "meta_field_for_count": "a"}]
+    original_docs = [{"content": "text1_orig", "id": "1", "meta_field_for_count": "a"}]
 
-    updated_docs = [{"content": "text1_new",
-                     "id": "1", "meta_field_for_count": "a"}]
+    updated_docs = [{"content": "text1_new", "id": "1", "meta_field_for_count": "a"}]
 
     document_store.write_documents(original_docs)
     assert document_store.get_document_count() == 1
 
     if update_existing_documents:
-        document_store.write_documents(
-            updated_docs, duplicate_documents="overwrite")
+        document_store.write_documents(updated_docs, duplicate_documents="overwrite")
     else:
         with pytest.raises(Exception):
-            document_store.write_documents(
-                updated_docs, duplicate_documents="fail")
+            document_store.write_documents(updated_docs, duplicate_documents="fail")
 
     stored_docs = document_store.get_all_documents()
     assert len(stored_docs) == 1
@@ -482,11 +436,9 @@ def test_update_existing_documents(document_store, update_existing_documents):
 def test_write_document_meta(document_store: BaseDocumentStore):
     documents = [
         {"content": "dict_without_meta", "id": "1"},
-        {"content": "dict_with_meta", "meta_field": "test2",
-            "name": "filename2", "id": "2"},
+        {"content": "dict_with_meta", "meta_field": "test2", "name": "filename2", "id": "2"},
         Document(content="document_object_without_meta", id="3"),
-        Document(content="document_object_with_meta", meta={
-                 "meta_field": "test4", "name": "filename3"}, id="4"),
+        Document(content="document_object_with_meta", meta={"meta_field": "test4", "name": "filename3"}, id="4"),
     ]
     document_store.write_documents(documents)
     documents_in_store = document_store.get_all_documents()
@@ -499,18 +451,16 @@ def test_write_document_meta(document_store: BaseDocumentStore):
 
 
 def test_write_document_index(document_store: BaseDocumentStore):
-    documents = [{"content": "text1", "id": "1"},
-                 {"content": "text2", "id": "2"}]
+    document_store.delete_index("haystack_test_one")
+    document_store.delete_index("haystack_test_two")
+    documents = [{"content": "text1", "id": "1"}, {"content": "text2", "id": "2"}]
     document_store.write_documents([documents[0]], index="haystack_test_one")
-    assert len(document_store.get_all_documents(
-        index="haystack_test_one")) == 1
+    assert len(document_store.get_all_documents(index="haystack_test_one")) == 1
 
     document_store.write_documents([documents[1]], index="haystack_test_two")
-    assert len(document_store.get_all_documents(
-        index="haystack_test_two")) == 1
+    assert len(document_store.get_all_documents(index="haystack_test_two")) == 1
 
-    assert len(document_store.get_all_documents(
-        index="haystack_test_one")) == 1
+    assert len(document_store.get_all_documents(index="haystack_test_one")) == 1
     assert len(document_store.get_all_documents()) == 0
 
 
@@ -519,30 +469,21 @@ def test_write_document_index(document_store: BaseDocumentStore):
 )
 def test_document_with_embeddings(document_store: BaseDocumentStore):
     documents = [
-        {"content": "text1", "id": "1",
-            "embedding": np.random.rand(768).astype(np.float32)},
-        {"content": "text2", "id": "2",
-            "embedding": np.random.rand(768).astype(np.float64)},
-        {"content": "text3", "id": "3", "embedding": np.random.rand(
-            768).astype(np.float32).tolist()},
-        {"content": "text4", "id": "4",
-            "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
+        {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
+        {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
-    document_store.write_documents(documents, index="haystack_test_one")
-    assert len(document_store.get_all_documents(
-        index="haystack_test_one")) == 4
+    document_store.write_documents(documents)
+    assert len(document_store.get_all_documents()) == 4
 
     if not isinstance(document_store, WeaviateDocumentStore):
         # weaviate is excluded because it would return dummy vectors instead of None
-        documents_without_embedding = document_store.get_all_documents(
-            index="haystack_test_one", return_embedding=False
-        )
+        documents_without_embedding = document_store.get_all_documents(return_embedding=False)
         assert documents_without_embedding[0].embedding is None
 
-    documents_with_embedding = document_store.get_all_documents(
-        index="haystack_test_one", return_embedding=True)
-    assert isinstance(
-        documents_with_embedding[0].embedding, (list, np.ndarray))
+    documents_with_embedding = document_store.get_all_documents(return_embedding=True)
+    assert isinstance(documents_with_embedding[0].embedding, (list, np.ndarray))
 
 
 @pytest.mark.parametrize(
@@ -552,35 +493,25 @@ def test_document_with_embeddings(document_store: BaseDocumentStore):
 def test_update_embeddings(document_store, retriever):
     documents = []
     for i in range(6):
-        documents.append(
-            {"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+        documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
     documents.append({"content": "text_0", "id": "6", "meta_field": "value_0"})
 
-    document_store.write_documents(documents, index="haystack_test_one")
-    document_store.update_embeddings(
-        retriever, index="haystack_test_one", batch_size=3)
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", return_embedding=True)
+    document_store.write_documents(documents)
+    document_store.update_embeddings(retriever, batch_size=3)
+    documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 7
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
 
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_0"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_0"]}, return_embedding=True)
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_0"
-    np.testing.assert_array_almost_equal(
-        documents[0].embedding, documents[1].embedding, decimal=4)
+    np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
 
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_0", "value_5"]}, return_embedding=True
-    )
-    documents_with_value_0 = [
-        doc for doc in documents if doc.meta["meta_field"] == "value_0"]
-    documents_with_value_5 = [
-        doc for doc in documents if doc.meta["meta_field"] == "value_5"]
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_0", "value_5"]}, return_embedding=True)
+    documents_with_value_0 = [doc for doc in documents if doc.meta["meta_field"] == "value_0"]
+    documents_with_value_5 = [doc for doc in documents if doc.meta["meta_field"] == "value_5"]
     np.testing.assert_raises(
         AssertionError,
         np.testing.assert_array_equal,
@@ -594,57 +525,40 @@ def test_update_embeddings(document_store, retriever):
         "meta_field": "value_7",
         "embedding": retriever.embed_queries(texts=["a random string"])[0],
     }
-    document_store.write_documents([doc], index="haystack_test_one")
+    document_store.write_documents([doc])
 
     documents = []
     for i in range(8, 11):
-        documents.append(
-            {"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
-    document_store.write_documents(documents, index="haystack_test_one")
+        documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+    document_store.write_documents(documents)
 
-    doc_before_update = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_7"]}
-    )[0]
+    doc_before_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
     embedding_before_update = doc_before_update.embedding
 
     # test updating only documents without embeddings
     if not isinstance(document_store, WeaviateDocumentStore):
         # All the documents in Weaviate store have an embedding by default. "update_existing_embeddings=False" is not allowed
-        document_store.update_embeddings(
-            retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=False
-        )
-        doc_after_update = document_store.get_all_documents(
-            index="haystack_test_one", filters={"meta_field": ["value_7"]}
-        )[0]
+        document_store.update_embeddings(retriever, batch_size=3, update_existing_embeddings=False)
+        doc_after_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
         embedding_after_update = doc_after_update.embedding
-        np.testing.assert_array_equal(
-            embedding_before_update, embedding_after_update)
+        np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
 
     # test updating with filters
     if isinstance(document_store, FAISSDocumentStore):
         with pytest.raises(Exception):
             document_store.update_embeddings(
-                retriever, index="haystack_test_one", update_existing_embeddings=True, filters={"meta_field": ["value"]}
+                retriever, update_existing_embeddings=True, filters={"meta_field": ["value"]}
             )
     else:
-        document_store.update_embeddings(
-            retriever, index="haystack_test_one", batch_size=3, filters={"meta_field": ["value_0", "value_1"]}
-        )
-        doc_after_update = document_store.get_all_documents(
-            index="haystack_test_one", filters={"meta_field": ["value_7"]}
-        )[0]
+        document_store.update_embeddings(retriever, batch_size=3, filters={"meta_field": ["value_0", "value_1"]})
+        doc_after_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
         embedding_after_update = doc_after_update.embedding
-        np.testing.assert_array_equal(
-            embedding_before_update, embedding_after_update)
+        np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
 
     # test update all embeddings
-    document_store.update_embeddings(
-        retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=True
-    )
-    assert document_store.get_embedding_count(index="haystack_test_one") == 11
-    doc_after_update = document_store.get_all_documents(index="haystack_test_one", filters={"meta_field": ["value_7"]})[
-        0
-    ]
+    document_store.update_embeddings(retriever, batch_size=3, update_existing_embeddings=True)
+    assert document_store.get_embedding_count() == 11
+    doc_after_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
     embedding_after_update = doc_after_update.embedding
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, embedding_before_update, embedding_after_update
@@ -653,17 +567,13 @@ def test_update_embeddings(document_store, retriever):
     # test update embeddings for newly added docs
     documents = []
     for i in range(12, 15):
-        documents.append(
-            {"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
-    document_store.write_documents(documents, index="haystack_test_one")
+        documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+    document_store.write_documents(documents)
 
     if not isinstance(document_store, WeaviateDocumentStore):
         # All the documents in Weaviate store have an embedding by default. "update_existing_embeddings=False" is not allowed
-        document_store.update_embeddings(
-            retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=False
-        )
-        assert document_store.get_embedding_count(
-            index="haystack_test_one") == 14
+        document_store.update_embeddings(retriever, batch_size=3, update_existing_embeddings=False)
+        assert document_store.get_embedding_count() == 14
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
@@ -673,8 +583,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
     documents = []
     for i in range(3):
         documents.append(
-            {"content": f"text_{i}", "id": f"pssg_{i}",
-                "meta_field": f"value_text_{i}", "content_type": "text"}
+            {"content": f"text_{i}", "id": f"pssg_{i}", "meta_field": f"value_text_{i}", "content_type": "text"}
         )
         documents.append(
             {
@@ -684,8 +593,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
                 "content_type": "table",
             }
         )
-    documents.append({"content": "text_0", "id": "pssg_4",
-                     "meta_field": "value_text_0", "content_type": "text"})
+    documents.append({"content": "text_0", "id": "pssg_4", "meta_field": "value_text_0", "content_type": "text"})
     documents.append(
         {
             "content": pd.DataFrame(columns=["col_0", "col_1"], data=[["cell_0", "cell_1"]]),
@@ -695,38 +603,30 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
         }
     )
 
-    document_store.write_documents(documents, index="haystack_test_one")
-    document_store.update_embeddings(
-        retriever, index="haystack_test_one", batch_size=3)
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", return_embedding=True)
+    document_store.write_documents(documents)
+    document_store.update_embeddings(retriever, batch_size=3)
+    documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 8
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
 
     # Check if Documents with same content (text) get same embedding
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_text_0"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_text_0"]}, return_embedding=True)
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_text_0"
-    np.testing.assert_array_almost_equal(
-        documents[0].embedding, documents[1].embedding, decimal=4)
+    np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
 
     # Check if Documents with same content (table) get same embedding
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_table_0"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_table_0"]}, return_embedding=True)
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_table_0"
-    np.testing.assert_array_almost_equal(
-        documents[0].embedding, documents[1].embedding, decimal=4)
+    np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
 
     # Check if Documents wih different content (text) get different embedding
     documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_text_1", "value_text_2"]}, return_embedding=True
+        filters={"meta_field": ["value_text_1", "value_text_2"]}, return_embedding=True
     )
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, documents[0].embedding, documents[1].embedding
@@ -734,7 +634,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
 
     # Check if Documents with different content (table) get different embeddings
     documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_table_1", "value_table_2"]}, return_embedding=True
+        filters={"meta_field": ["value_table_1", "value_table_2"]}, return_embedding=True
     )
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, documents[0].embedding, documents[1].embedding
@@ -742,7 +642,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
 
     # Check if Documents with different content (table + text) get different embeddings
     documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_text_1", "value_table_1"]}, return_embedding=True
+        filters={"meta_field": ["value_text_1", "value_table_1"]}, return_embedding=True
     )
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, documents[0].embedding, documents[1].embedding
@@ -766,8 +666,7 @@ def test_delete_documents(document_store_with_docs):
 
 
 def test_delete_documents_with_filters(document_store_with_docs):
-    document_store_with_docs.delete_documents(
-        filters={"meta_field": ["test1", "test2", "test4", "test5"]})
+    document_store_with_docs.delete_documents(filters={"meta_field": ["test1", "test2", "test4", "test5"]})
     documents = document_store_with_docs.get_all_documents()
     assert len(documents) == 1
     assert documents[0].meta["meta_field"] == "test3"
@@ -781,12 +680,10 @@ def test_delete_documents_by_id(document_store_with_docs):
         filters={"meta_field": ["test1", "test2", "test4", "test5"]}
     )
     logging.info(len(docs_to_delete))
-    docs_not_to_delete = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test3"]})
+    docs_not_to_delete = document_store_with_docs.get_all_documents(filters={"meta_field": ["test3"]})
     logging.info(len(docs_not_to_delete))
 
-    document_store_with_docs.delete_documents(
-        ids=[doc.id for doc in docs_to_delete])
+    document_store_with_docs.delete_documents(ids=[doc.id for doc in docs_to_delete])
     all_docs_left = document_store_with_docs.get_all_documents()
     assert len(all_docs_left) == 1
     assert all_docs_left[0].meta["meta_field"] == "test3"
@@ -796,13 +693,10 @@ def test_delete_documents_by_id(document_store_with_docs):
 
 
 def test_delete_documents_by_id_with_filters(document_store_with_docs):
-    docs_to_delete = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test1", "test2"]})
-    docs_not_to_delete = document_store_with_docs.get_all_documents(
-        filters={"meta_field": ["test3"]})
+    docs_to_delete = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test2"]})
+    docs_not_to_delete = document_store_with_docs.get_all_documents(filters={"meta_field": ["test3"]})
 
-    document_store_with_docs.delete_documents(
-        ids=[doc.id for doc in docs_to_delete], filters={"meta_field": ["test1"]})
+    document_store_with_docs.delete_documents(ids=[doc.id for doc in docs_to_delete], filters={"meta_field": ["test1"]})
 
     all_docs_left = document_store_with_docs.get_all_documents()
     assert len(all_docs_left) == 4
@@ -831,14 +725,20 @@ def test_labels(document_store: BaseDocumentStore):
         no_answer=False,
         origin="gold-label",
     )
-    document_store.write_labels([label], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label])
+    labels = document_store.get_all_labels()
     assert len(labels) == 1
     assert label == labels[0]
 
     # different index
-    labels = document_store.get_all_labels()
+    document_store.write_labels([label], index="another_index")
+    labels = document_store.get_all_labels(index="another_index")
+    assert len(labels) == 1
+    document_store.delete_labels(index="another_index")
+    labels = document_store.get_all_labels(index="another_index")
     assert len(labels) == 0
+    labels = document_store.get_all_labels()
+    assert len(labels) == 1
 
     # write second label + duplicate
     label2 = Label(
@@ -857,8 +757,8 @@ def test_labels(document_store: BaseDocumentStore):
         no_answer=False,
         origin="gold-label",
     )
-    document_store.write_labels([label, label2], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label, label2])
+    labels = document_store.get_all_labels()
 
     # check that second label has been added but not the duplicate
     assert len(labels) == 2
@@ -866,40 +766,37 @@ def test_labels(document_store: BaseDocumentStore):
     assert label2 in labels
 
     # delete filtered label2 by id
-    document_store.delete_labels(
-        index="haystack_test_label", ids=[labels[1].id])
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels(ids=[labels[1].id])
+    labels = document_store.get_all_labels()
     assert label == labels[0]
     assert len(labels) == 1
 
     # re-add label2
-    document_store.write_labels([label2], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label2])
+    labels = document_store.get_all_labels()
     assert len(labels) == 2
 
     # delete filtered label2 by query text
-    document_store.delete_labels(index="haystack_test_label", filters={
-                                 "query": [labels[1].query]})
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels(filters={"query": [labels[1].query]})
+    labels = document_store.get_all_labels()
     assert label == labels[0]
     assert len(labels) == 1
 
     # re-add label2
-    document_store.write_labels([label2], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label2])
+    labels = document_store.get_all_labels()
     assert len(labels) == 2
 
     # delete intersection of filters and ids, which is empty
-    document_store.delete_labels(index="haystack_test_label", ids=[
-                                 labels[0].id], filters={"query": [labels[1].query]})
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels(ids=[labels[0].id], filters={"query": [labels[1].query]})
+    labels = document_store.get_all_labels()
     assert len(labels) == 2
     assert label in labels
     assert label2 in labels
 
     # delete all labels
-    document_store.delete_labels(index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels()
+    labels = document_store.get_all_labels()
     assert len(labels) == 0
 
 
@@ -910,8 +807,7 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="standard",
             query="question",
-            answer=Answer(answer="answer1", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer1", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -922,8 +818,7 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-same-doc",
             query="question",
-            answer=Answer(answer="answer2", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer2", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -934,8 +829,7 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-diff-doc",
             query="question",
-            answer=Answer(answer="answer3", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer3", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some other", id="333"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -946,8 +840,7 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="4-no-answer",
             query="question",
-            answer=Answer(answer="", offsets_in_document=[
-                          Span(start=0, end=0)]),
+            answer=Answer(answer="", offsets_in_document=[Span(start=0, end=0)]),
             document=Document(content="some", id="777"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -958,8 +851,7 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="5-negative",
             query="question",
-            answer=Answer(answer="answer5", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer5", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=False,
             is_correct_document=True,
@@ -967,22 +859,19 @@ def test_multilabel(document_store: BaseDocumentStore):
             origin="gold-label",
         ),
     ]
-    document_store.write_labels(labels, index="haystack_test_multilabel")
+    document_store.write_labels(labels)
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(
-        index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels()
     assert list_labels == labels
     assert len(list_labels) == 5
 
     # Currently we don't enforce writing (missing) docs automatically when adding labels and there's no DB relationship between the two.
     # We should introduce this when we refactored the logic of "index" to be rather a "collection" of labels+documents
-    # docs = document_store.get_all_documents(index="haystack_test_multilabel")
+    # docs = document_store.get_all_documents()
     # assert len(docs) == 3
 
     # Multi labels (open domain)
-    multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True
-    )
+    multi_labels_open = document_store.get_all_labels_aggregated(open_domain=True, drop_negative_labels=True)
 
     # for open-domain we group all together as long as they have the same question
     assert len(multi_labels_open) == 1
@@ -994,7 +883,7 @@ def test_multilabel(document_store: BaseDocumentStore):
 
     # Don't drop the negative label
     multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_no_answers=False, drop_negative_labels=False
+        open_domain=True, drop_no_answers=False, drop_negative_labels=False
     )
     assert len(multi_labels_open[0].labels) == 5
     assert len(multi_labels_open[0].answers) == 4
@@ -1002,27 +891,19 @@ def test_multilabel(document_store: BaseDocumentStore):
 
     # Drop no answer + negative
     multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_no_answers=True, drop_negative_labels=True
+        open_domain=True, drop_no_answers=True, drop_negative_labels=True
     )
     assert len(multi_labels_open[0].labels) == 3
     assert len(multi_labels_open[0].answers) == 3
     assert len(multi_labels_open[0].document_ids) == 3
 
     # for closed domain we group by document so we expect 3 multilabels with 2,1,1 labels each (negative dropped again)
-    multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=False, drop_negative_labels=True
-    )
+    multi_labels = document_store.get_all_labels_aggregated(open_domain=False, drop_negative_labels=True)
     assert len(multi_labels) == 3
     label_counts = set([len(ml.labels) for ml in multi_labels])
     assert label_counts == set([2, 1, 1])
 
     assert len(multi_labels[0].answers) == len(multi_labels[0].document_ids)
-
-    # make sure there' nothing stored in another index
-    multi_labels = document_store.get_all_labels_aggregated()
-    assert len(multi_labels) == 0
-    docs = document_store.get_all_documents()
-    assert len(docs) == 0
 
 
 # exclude weaviate because it does not support storing labels
@@ -1070,15 +951,13 @@ def test_multilabel_no_answer(document_store: BaseDocumentStore):
         ),
     ]
 
-    document_store.write_labels(
-        labels, index="haystack_test_multilabel_no_answer")
+    document_store.write_labels(labels)
 
-    labels = document_store.get_all_labels(
-        index="haystack_test_multilabel_no_answer")
+    labels = document_store.get_all_labels()
     assert len(labels) == 4
 
     multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel_no_answer", open_domain=True, drop_no_answers=False, drop_negative_labels=True
+        open_domain=True, drop_no_answers=False, drop_negative_labels=True
     )
     assert len(multi_labels) == 1
     assert multi_labels[0].no_answer == True
@@ -1086,7 +965,7 @@ def test_multilabel_no_answer(document_store: BaseDocumentStore):
     assert len(multi_labels[0].answers) == 1
 
     multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel_no_answer", open_domain=True, drop_no_answers=False, drop_negative_labels=False
+        open_domain=True, drop_no_answers=False, drop_negative_labels=False
     )
     assert len(multi_labels) == 1
     assert multi_labels[0].no_answer == True
@@ -1103,8 +982,7 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="standard",
             query="question",
-            answer=Answer(answer="answer1", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer1", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1116,8 +994,7 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-same-doc",
             query="question",
-            answer=Answer(answer="answer2", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer2", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1129,8 +1006,7 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-diff-doc",
             query="question",
-            answer=Answer(answer="answer3", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer3", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some other", id="333"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1142,8 +1018,7 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="4-no-answer",
             query="question",
-            answer=Answer(answer="", offsets_in_document=[
-                          Span(start=0, end=0)]),
+            answer=Answer(answer="", offsets_in_document=[Span(start=0, end=0)]),
             document=Document(content="some", id="777"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1155,8 +1030,7 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="5-negative",
             query="question",
-            answer=Answer(answer="answer5", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer5", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=False,
             is_correct_document=True,
@@ -1165,33 +1039,26 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
             filters={"name": ["123"]},
         ),
     ]
-    document_store.write_labels(labels, index="haystack_test_multilabel")
+    document_store.write_labels(labels)
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(
-        index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels()
     assert list_labels == labels
     assert len(list_labels) == 5
 
     # Multi labels (open domain)
-    multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True
-    )
+    multi_labels_open = document_store.get_all_labels_aggregated(open_domain=True, drop_negative_labels=True)
 
     # for open-domain we group all together as long as they have the same question and filters
     assert len(multi_labels_open) == 3
     label_counts = set([len(ml.labels) for ml in multi_labels_open])
     assert label_counts == set([2, 1, 1])
     # all labels are in there except the negative one and the no_answer
-    assert "5-negative" not in [
-        l.id for multi_label in multi_labels_open for l in multi_label.labels]
+    assert "5-negative" not in [l.id for multi_label in multi_labels_open for l in multi_label.labels]
 
-    assert len(multi_labels_open[0].answers) == len(
-        multi_labels_open[0].document_ids)
+    assert len(multi_labels_open[0].answers) == len(multi_labels_open[0].document_ids)
 
     # for closed domain we group by document so we expect the same as with filters
-    multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=False, drop_negative_labels=True
-    )
+    multi_labels = document_store.get_all_labels_aggregated(open_domain=False, drop_negative_labels=True)
     assert len(multi_labels) == 3
     label_counts = set([len(ml.labels) for ml in multi_labels])
     assert label_counts == set([2, 1, 1])
@@ -1207,8 +1074,7 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="standard",
             query="question",
-            answer=Answer(answer="answer1", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer1", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1220,8 +1086,7 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-same-doc",
             query="question",
-            answer=Answer(answer="answer2", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer2", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1233,8 +1098,7 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-diff-doc",
             query="question",
-            answer=Answer(answer="answer3", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer3", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some other", id="333"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1246,8 +1110,7 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="4-no-answer",
             query="question",
-            answer=Answer(answer="", offsets_in_document=[
-                          Span(start=0, end=0)]),
+            answer=Answer(answer="", offsets_in_document=[Span(start=0, end=0)]),
             document=Document(content="some", id="777"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1259,8 +1122,7 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="5-888",
             query="question",
-            answer=Answer(answer="answer5", offsets_in_document=[
-                          Span(start=12, end=18)]),
+            answer=Answer(answer="answer5", offsets_in_document=[Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1269,24 +1131,21 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
             meta={"file_id": ["888"]},
         ),
     ]
-    document_store.write_labels(labels, index="haystack_test_multilabel")
+    document_store.write_labels(labels)
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(
-        index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels()
     assert list_labels == labels
     assert len(list_labels) == 5
 
     # Multi labels (open domain)
-    multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True
-    )
+    multi_labels_open = document_store.get_all_labels_aggregated(open_domain=True, drop_negative_labels=True)
 
     # for open-domain we group all together as long as they have the same question and filters
     assert len(multi_labels_open) == 1
     assert len(multi_labels_open[0].labels) == 5
 
     multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True, aggregate_by_meta="file_id"
+        open_domain=True, drop_negative_labels=True, aggregate_by_meta="file_id"
     )
     assert len(multi_labels) == 4
     label_counts = set([len(ml.labels) for ml in multi_labels])
@@ -1306,10 +1165,8 @@ def test_update_meta(document_store: BaseDocumentStore):
         Document(content="Doc3", meta={"meta_key_1": "3", "meta_key_2": "3"}),
     ]
     document_store.write_documents(documents)
-    document_2 = document_store.get_all_documents(
-        filters={"meta_key_2": ["2"]})[0]
-    document_store.update_document_meta(
-        document_2.id, meta={"meta_key_1": "99", "meta_key_2": "2"})
+    document_2 = document_store.get_all_documents(filters={"meta_key_2": ["2"]})[0]
+    document_store.update_document_meta(document_2.id, meta={"meta_key_1": "99", "meta_key_2": "2"})
     updated_document = document_store.get_document_by_id(document_2.id)
     assert len(updated_document.meta.keys()) == 2
     assert updated_document.meta["meta_key_1"] == "99"
@@ -1319,16 +1176,17 @@ def test_update_meta(document_store: BaseDocumentStore):
 @pytest.mark.parametrize("document_store_type", ["elasticsearch", "memory"])
 def test_custom_embedding_field(document_store_type, tmp_path):
     document_store = get_document_store(
-        document_store_type=document_store_type, tmp_path=tmp_path, embedding_field="custom_embedding_field"
+        document_store_type=document_store_type,
+        tmp_path=tmp_path,
+        embedding_field="custom_embedding_field",
+        index="custom_embedding_field",
     )
-    doc_to_write = {"content": "test", "custom_embedding_field": np.random.rand(
-        768).astype(np.float32)}
+    doc_to_write = {"content": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
     document_store.write_documents([doc_to_write])
     documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 1
     assert documents[0].content == "test"
-    np.testing.assert_array_equal(
-        doc_to_write["custom_embedding_field"], documents[0].embedding)
+    np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
@@ -1347,15 +1205,13 @@ def test_get_meta_values_by_key(document_store: BaseDocumentStore):
         assert bucket["count"] == 1
 
     # test with filters but no query
-    result = document_store.get_metadata_values_by_key(
-        key="meta_key_1", filters={"meta_key_2": ["11", "22"]})
+    result = document_store.get_metadata_values_by_key(key="meta_key_1", filters={"meta_key_2": ["11", "22"]})
     for bucket in result:
         assert bucket["value"] in ["1", "2"]
         assert bucket["count"] == 1
 
     # test with filters & query
-    result = document_store.get_metadata_values_by_key(
-        key="meta_key_1", query="Doc1")
+    result = document_store.get_metadata_values_by_key(key="meta_key_1", query="Doc1")
     for bucket in result:
         assert bucket["value"] in ["1"]
         assert bucket["count"] == 1
@@ -1363,20 +1219,19 @@ def test_get_meta_values_by_key(document_store: BaseDocumentStore):
 
 @pytest.mark.elasticsearch
 def test_elasticsearch_custom_fields():
-    client = Elasticsearch()
-    client.indices.delete(index="haystack_test_custom", ignore=[404])
     document_store = ElasticsearchDocumentStore(
-        index="haystack_test_custom", content_field="custom_text_field", embedding_field="custom_embedding_field"
+        index="haystack_test_custom",
+        content_field="custom_text_field",
+        embedding_field="custom_embedding_field",
+        recreate_index=True,
     )
 
-    doc_to_write = {"custom_text_field": "test",
-                    "custom_embedding_field": np.random.rand(768).astype(np.float32)}
+    doc_to_write = {"custom_text_field": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
     document_store.write_documents([doc_to_write])
     documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 1
     assert documents[0].content == "test"
-    np.testing.assert_array_equal(
-        doc_to_write["custom_embedding_field"], documents[0].embedding)
+    np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
 
 
 @pytest.mark.elasticsearch
@@ -1398,7 +1253,7 @@ def test_elasticsearch_delete_index():
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
-def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store: BaseDocumentStore):
+def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store: ElasticsearchDocumentStore):
     document_store.write_documents(DOCUMENTS)
     document_without_embedding = Document(
         content="Doc without embedding", meta={"name": "name_7", "year": "2021", "month": "04"}
@@ -1410,8 +1265,7 @@ def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store:
         document_store.query_by_embedding(np.random.rand(768), filters=filters)
 
     document_store.skip_missing_embeddings = True
-    documents = document_store.query_by_embedding(
-        np.random.rand(768), filters=filters)
+    documents = document_store.query_by_embedding(np.random.rand(768), filters=filters)
     assert len(documents) == 3
 
 
@@ -1430,8 +1284,7 @@ def test_get_document_count_only_documents_without_embedding_arg():
             "embedding": np.random.rand(768).astype(np.float64),
             "meta_field_for_count": "b",
         },
-        {"content": "text3", "id": "3", "embedding": np.random.rand(
-            768).astype(np.float32).tolist()},
+        {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
         {"content": "text4", "id": "4", "meta_field_for_count": "b"},
         {"content": "text5", "id": "5", "meta_field_for_count": "b"},
         {"content": "text6", "id": "6", "meta_field_for_count": "c"},
@@ -1444,14 +1297,12 @@ def test_get_document_count_only_documents_without_embedding_arg():
     ]
 
     _index: str = "haystack_test_count"
-    document_store = ElasticsearchDocumentStore(index=_index)
-    document_store.delete_documents(index=_index)
+    document_store = ElasticsearchDocumentStore(index=_index, recreate_index=True)
 
     document_store.write_documents(documents)
 
     assert document_store.get_document_count() == 7
-    assert document_store.get_document_count(
-        only_documents_without_embedding=True) == 3
+    assert document_store.get_document_count(only_documents_without_embedding=True) == 3
     assert (
         document_store.get_document_count(
             only_documents_without_embedding=True, filters={"meta_field_for_count": ["c"]}
@@ -1470,26 +1321,20 @@ def test_get_document_count_only_documents_without_embedding_arg():
 def test_skip_missing_embeddings():
     documents = [
         {"content": "text1", "id": "1"},  # a document without embeddings
-        {"content": "text2", "id": "2",
-            "embedding": np.random.rand(768).astype(np.float64)},
-        {"content": "text3", "id": "3", "embedding": np.random.rand(
-            768).astype(np.float32).tolist()},
-        {"content": "text4", "id": "4",
-            "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
+        {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
+        {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
-    document_store = ElasticsearchDocumentStore(
-        index="skip_missing_embedding_index")
+    document_store = ElasticsearchDocumentStore(index="skip_missing_embedding_index", recreate_index=True)
     document_store.write_documents(documents)
 
     document_store.skip_missing_embeddings = True
-    retrieved_docs = document_store.query_by_embedding(
-        np.random.rand(768).astype(np.float32))
+    retrieved_docs = document_store.query_by_embedding(np.random.rand(768).astype(np.float32))
     assert len(retrieved_docs) == 3
 
     document_store.skip_missing_embeddings = False
     with pytest.raises(RequestError):
-        document_store.query_by_embedding(
-            np.random.rand(768).astype(np.float32))
+        document_store.query_by_embedding(np.random.rand(768).astype(np.float32))
 
     # Test scenario with no embeddings for the entire index
     documents = [
@@ -1504,14 +1349,12 @@ def test_skip_missing_embeddings():
 
     document_store.skip_missing_embeddings = True
     with pytest.raises(RequestError):
-        document_store.query_by_embedding(
-            np.random.rand(768).astype(np.float32))
+        document_store.query_by_embedding(np.random.rand(768).astype(np.float32))
 
 
 @pytest.mark.elasticsearch
 def test_elasticsearch_synonyms():
-    synonyms = ["i-pod, i pod, ipod",
-                "sea biscuit, sea biscit, seabiscuit", "foo, foo bar, baz"]
+    synonyms = ["i-pod, i pod, ipod", "sea biscuit, sea biscit, seabiscuit", "foo, foo bar, baz"]
     synonym_type = "synonym_graph"
 
     client = Elasticsearch()
@@ -1519,8 +1362,7 @@ def test_elasticsearch_synonyms():
     document_store = ElasticsearchDocumentStore(
         index="haystack_synonym_arg", synonyms=synonyms, synonym_type=synonym_type
     )
-    indexed_settings = client.indices.get_settings(
-        index="haystack_synonym_arg")
+    indexed_settings = client.indices.get_settings(index="haystack_synonym_arg")
 
     assert (
         synonym_type
@@ -1576,11 +1418,9 @@ def test_custom_headers(document_store_with_docs: BaseDocumentStore):
     custom_headers = {"X-My-Custom-Header": "header-value"}
     if not mock_client:
         with pytest.raises(NotImplementedError):
-            documents = document_store_with_docs.get_all_documents(
-                headers=custom_headers)
+            documents = document_store_with_docs.get_all_documents(headers=custom_headers)
     else:
-        documents = document_store_with_docs.get_all_documents(
-            headers=custom_headers)
+        documents = document_store_with_docs.get_all_documents(headers=custom_headers)
         mock_client.search.assert_called_once()
         args, kwargs = mock_client.search.call_args
         assert "headers" in kwargs
@@ -1591,8 +1431,7 @@ def test_custom_headers(document_store_with_docs: BaseDocumentStore):
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
 @responses.activate
 def test_DeepsetCloudDocumentStore_init_with_dot_product():
-    document_store = DeepsetCloudDocumentStore(
-        api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=DC_TEST_INDEX)
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=DC_TEST_INDEX)
     assert document_store.return_embedding == False
     assert document_store.similarity == "dot_product"
 
@@ -1618,8 +1457,7 @@ def test_DeepsetCloudDocumentStore_invalid_token():
         responses.add(
             method=responses.GET,
             url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}",
-            match=[matchers.header_matcher(
-                {"authorization": "Bearer invalid_token"})],
+            match=[matchers.header_matcher({"authorization": "Bearer invalid_token"})],
             body="Internal Server Error",
             status=500,
         )
@@ -1628,8 +1466,7 @@ def test_DeepsetCloudDocumentStore_invalid_token():
         DeepsetCloudError,
         match=f"Could not connect to Deepset Cloud:\nGET {DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX} failed: HTTP 500 - Internal Server Error",
     ):
-        DeepsetCloudDocumentStore(
-            api_endpoint=DC_API_ENDPOINT, api_key="invalid_token", index=DC_TEST_INDEX)
+        DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key="invalid_token", index=DC_TEST_INDEX)
 
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
@@ -1647,8 +1484,7 @@ def test_DeepsetCloudDocumentStore_invalid_api_endpoint():
         DeepsetCloudError,
         match=f"Could not connect to Deepset Cloud:\nGET {DC_API_ENDPOINT}00/workspaces/default/indexes/{DC_TEST_INDEX} failed: HTTP 404 - Not Found",
     ):
-        DeepsetCloudDocumentStore(
-            api_endpoint=f"{DC_API_ENDPOINT}00", api_key=DC_API_KEY, index=DC_TEST_INDEX)
+        DeepsetCloudDocumentStore(api_endpoint=f"{DC_API_ENDPOINT}00", api_key=DC_API_KEY, index=DC_TEST_INDEX)
 
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
@@ -1666,8 +1502,7 @@ def test_DeepsetCloudDocumentStore_invalid_index():
         DeepsetCloudError,
         match=f"Could not connect to Deepset Cloud:\nGET {DC_API_ENDPOINT}/workspaces/default/indexes/invalid_index failed: HTTP 404 - Not Found",
     ):
-        DeepsetCloudDocumentStore(
-            api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index="invalid_index")
+        DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index="invalid_index")
 
 
 @responses.activate
@@ -1675,12 +1510,9 @@ def test_DeepsetCloudDocumentStore_documents(deepset_cloud_document_store):
     if MOCK_DC:
         with open(SAMPLES_PATH / "dc" / "documents-stream.response", "r") as f:
             documents_stream_response = f.read()
-            docs = [json.loads(l)
-                    for l in documents_stream_response.splitlines()]
-            filtered_docs = [doc for doc in docs if doc["meta"]
-                             ["file_id"] == docs[0]["meta"]["file_id"]]
-            documents_stream_filtered_response = "\n".join(
-                [json.dumps(d) for d in filtered_docs])
+            docs = [json.loads(l) for l in documents_stream_response.splitlines()]
+            filtered_docs = [doc for doc in docs if doc["meta"]["file_id"] == docs[0]["meta"]["file_id"]]
+            documents_stream_filtered_response = "\n".join([json.dumps(d) for d in filtered_docs])
 
             responses.add(
                 method=responses.POST,
@@ -1694,8 +1526,7 @@ def test_DeepsetCloudDocumentStore_documents(deepset_cloud_document_store):
                 url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}/documents-stream",
                 match=[
                     matchers.json_params_matcher(
-                        {"filters": {"file_id": [
-                            docs[0]["meta"]["file_id"]]}, "return_embedding": False}
+                        {"filters": {"file_id": [docs[0]["meta"]["file_id"]]}, "return_embedding": False}
                     )
                 ],
                 body=documents_stream_filtered_response,
@@ -1716,13 +1547,11 @@ def test_DeepsetCloudDocumentStore_documents(deepset_cloud_document_store):
     assert len(docs) > 1
     assert isinstance(docs[0], Document)
 
-    first_doc = next(
-        deepset_cloud_document_store.get_all_documents_generator())
+    first_doc = next(deepset_cloud_document_store.get_all_documents_generator())
     assert isinstance(first_doc, Document)
     assert first_doc.meta["file_id"] is not None
 
-    filtered_docs = deepset_cloud_document_store.get_all_documents(
-        filters={"file_id": [first_doc.meta["file_id"]]})
+    filtered_docs = deepset_cloud_document_store.get_all_documents(filters={"file_id": [first_doc.meta["file_id"]]})
     assert len(filtered_docs) > 0
     assert len(filtered_docs) < len(docs)
 
@@ -1748,14 +1577,12 @@ def test_DeepsetCloudDocumentStore_query(deepset_cloud_document_store):
                 for doc in query_winterfell_docs
                 if doc["meta"]["file_id"] == query_winterfell_docs[0]["meta"]["file_id"]
             ]
-            query_winterfell_filtered_response = json.dumps(
-                query_winterfell_filtered_docs)
+            query_winterfell_filtered_response = json.dumps(query_winterfell_filtered_docs)
 
         responses.add(
             method=responses.POST,
             url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}/documents-query",
-            match=[matchers.json_params_matcher(
-                {"query": "winterfell", "top_k": 50, "all_terms_must_match": False})],
+            match=[matchers.json_params_matcher({"query": "winterfell", "top_k": 50, "all_terms_must_match": False})],
             status=200,
             body=query_winterfell_response,
         )
@@ -1878,8 +1705,7 @@ def test_DeepsetCloudDocumentStore_lists_evaluation_sets(deepset_cloud_document_
             method=responses.GET,
             url=f"{DC_API_ENDPOINT}/workspaces/default/evaluation_sets",
             status=200,
-            body=json.dumps(
-                {"data": [response_evaluation_set], "has_more": False, "total": 1}),
+            body=json.dumps({"data": [response_evaluation_set], "has_more": False, "total": 1}),
         )
     else:
         responses.add_passthru(DC_API_ENDPOINT)
@@ -1941,8 +1767,7 @@ def test_DeepsetCloudDocumentStore_fetches_labels_for_evaluation_set(deepset_clo
     assert labels == [
         Label(
             query="What is berlin?",
-            document=Document(
-                content="Berlin is the biggest city in germany."),
+            document=Document(content="Berlin is the biggest city in germany."),
             is_correct_answer=True,
             is_correct_document=True,
             origin="user-feedback",
@@ -2049,8 +1874,7 @@ def test_elasticsearch_search_field_mapping():
     )
     document_store.write_documents(index_data)
 
-    indexed_settings = client.indices.get_mapping(
-        index="haystack_search_field_mapping")
+    indexed_settings = client.indices.get_mapping(index="haystack_search_field_mapping")
 
     assert indexed_settings["haystack_search_field_mapping"]["mappings"]["properties"]["content"]["type"] == "text"
     assert indexed_settings["haystack_search_field_mapping"]["mappings"]["properties"]["sub_content"]["type"] == "text"
@@ -2143,10 +1967,8 @@ def test_elasticsearch_brownfield_support(document_store_with_docs):
         index="test_brownfield_support",
     )
 
-    original_documents = document_store_with_docs.get_all_documents(
-        index="haystack_test")
-    transferred_documents = new_document_store.get_all_documents(
-        index="test_brownfield_support")
+    original_documents = document_store_with_docs.get_all_documents(index="haystack_test")
+    transferred_documents = new_document_store.get_all_documents(index="test_brownfield_support")
     assert len(original_documents) == len(transferred_documents)
     assert all("name" in doc.meta for doc in transferred_documents)
     assert all("date_field" in doc.meta for doc in transferred_documents)
@@ -2164,15 +1986,12 @@ def test_elasticsearch_brownfield_support(document_store_with_docs):
         original_content_field="content",
         excluded_metadata_fields=["date_field"],
         index="test_brownfield_support_2",
-        preprocessor=PreProcessor(
-            split_length=1, split_respect_sentence_boundary=False),
+        preprocessor=PreProcessor(split_length=1, split_respect_sentence_boundary=False),
     )
-    transferred_documents = new_document_store.get_all_documents(
-        index="test_brownfield_support_2")
+    transferred_documents = new_document_store.get_all_documents(index="test_brownfield_support_2")
     assert all("date_field" not in doc.meta for doc in transferred_documents)
     assert all("name" in doc.meta for doc in transferred_documents)
     assert all("meta_field" in doc.meta for doc in transferred_documents)
     assert all("numeric_field" in doc.meta for doc in transferred_documents)
     # Check if number of transferred_documents is equal to number of unique words.
-    assert len(transferred_documents) == len(
-        set(" ".join(original_content).split()))
+    assert len(transferred_documents) == len(set(" ".join(original_content).split()))

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1886,29 +1886,19 @@ def test_elasticsearch_existing_alias():
     client = Elasticsearch()
     client.indices.delete(index="haystack_existing_alias_1", ignore=[404])
     client.indices.delete(index="haystack_existing_alias_2", ignore=[404])
-    client.indices.delete_alias(
-        index="_all", name="haystack_existing_alias", ignore=[404])
+    client.indices.delete_alias(index="_all", name="haystack_existing_alias", ignore=[404])
 
-    settings = {
-        "mappings": {
-            "properties": {
-                "content": {
-                    "type": "text"
-                }
-            }
-        }
-    }
+    settings = {"mappings": {"properties": {"content": {"type": "text"}}}}
 
     client.indices.create(index="haystack_existing_alias_1", body=settings)
     client.indices.create(index="haystack_existing_alias_2", body=settings)
 
     client.indices.put_alias(
-        index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias")
+        index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias"
+    )
 
     # To be valid, all indices related to the alias must have content field of type text
-    _ = ElasticsearchDocumentStore(
-        index="haystack_existing_alias", search_fields=["content"]
-    )
+    _ = ElasticsearchDocumentStore(index="haystack_existing_alias", search_fields=["content"])
 
 
 @pytest.mark.elasticsearch
@@ -1917,36 +1907,18 @@ def test_elasticsearch_existing_alias_missing_fields():
     client = Elasticsearch()
     client.indices.delete(index="haystack_existing_alias_1", ignore=[404])
     client.indices.delete(index="haystack_existing_alias_2", ignore=[404])
-    client.indices.delete_alias(
-        index="_all", name="haystack_existing_alias", ignore=[404])
+    client.indices.delete_alias(index="_all", name="haystack_existing_alias", ignore=[404])
 
-    right_settings = {
-        "mappings": {
-            "properties": {
-                "content": {
-                    "type": "text"
-                }
-            }
-        }
-    }
+    right_settings = {"mappings": {"properties": {"content": {"type": "text"}}}}
 
-    wrong_settings = {
-        "mappings": {
-            "properties": {
-                "content": {
-                    "type": "histogram"
-                }
-            }
-        }
-    }
+    wrong_settings = {"mappings": {"properties": {"content": {"type": "histogram"}}}}
 
-    client.indices.create(
-        index="haystack_existing_alias_1", body=right_settings)
-    client.indices.create(
-        index="haystack_existing_alias_2", body=wrong_settings)
+    client.indices.create(index="haystack_existing_alias_1", body=right_settings)
+    client.indices.create(index="haystack_existing_alias_2", body=wrong_settings)
 
     client.indices.put_alias(
-        index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias")
+        index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias"
+    )
 
     with pytest.raises(Exception):
         # wrong field type for "content" in index "haystack_existing_alias_2"

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -77,17 +77,21 @@ def test_init_elastic_client():
 
     # list of hosts + list of ports (wrong)
     with pytest.raises(Exception):
-        _ = ElasticsearchDocumentStore(host=["localhost", "127.0.0.1"], port=[9200])
+        _ = ElasticsearchDocumentStore(
+            host=["localhost", "127.0.0.1"], port=[9200])
 
     # list of hosts + list
-    _ = ElasticsearchDocumentStore(host=["localhost", "127.0.0.1"], port=[9200, 9200])
+    _ = ElasticsearchDocumentStore(
+        host=["localhost", "127.0.0.1"], port=[9200, 9200])
 
     # only api_key
     with pytest.raises(Exception):
-        _ = ElasticsearchDocumentStore(host=["localhost"], port=[9200], api_key="test")
+        _ = ElasticsearchDocumentStore(
+            host=["localhost"], port=[9200], api_key="test")
 
     # api_key +  id
-    _ = ElasticsearchDocumentStore(host=["localhost"], port=[9200], api_key="test", api_key_id="test")
+    _ = ElasticsearchDocumentStore(host=["localhost"], port=[
+                                   9200], api_key="test", api_key_id="test")
 
 
 @pytest.mark.elasticsearch
@@ -95,7 +99,8 @@ def test_init_elastic_doc_store_with_index_recreation():
     index_name = "test_index_recreation"
     label_index_name = "test_index_recreation_labels"
 
-    document_store = ElasticsearchDocumentStore(index=index_name, label_index=label_index_name)
+    document_store = ElasticsearchDocumentStore(
+        index=index_name, label_index=label_index_name)
     documents = [Document(content="Doc1")]
     labels = [
         Label(
@@ -110,7 +115,8 @@ def test_init_elastic_doc_store_with_index_recreation():
     document_store.write_documents(documents, index=index_name)
     document_store.write_labels(labels, index=label_index_name)
 
-    document_store = ElasticsearchDocumentStore(index=index_name, label_index=label_index_name, recreate_index=True)
+    document_store = ElasticsearchDocumentStore(
+        index=index_name, label_index=label_index_name, recreate_index=True)
     docs = document_store.get_all_documents(index=index_name)
     labels = document_store.get_all_labels(index=label_index_name)
 
@@ -123,10 +129,12 @@ def test_write_with_duplicate_doc_ids(document_store: BaseDocumentStore):
         Document(content="Doc1", id_hash_keys=["content"]),
         Document(content="Doc1", id_hash_keys=["content"]),
     ]
-    document_store.write_documents(duplicate_documents, duplicate_documents="skip")
+    document_store.write_documents(
+        duplicate_documents, duplicate_documents="skip")
     assert len(document_store.get_all_documents()) == 1
     with pytest.raises(Exception):
-        document_store.write_documents(duplicate_documents, duplicate_documents="fail")
+        document_store.write_documents(
+            duplicate_documents, duplicate_documents="fail")
 
 
 @pytest.mark.parametrize(
@@ -138,10 +146,13 @@ def test_write_with_duplicate_doc_ids_custom_index(document_store: BaseDocumentS
         Document(content="Doc1", id_hash_keys=["content"]),
     ]
     document_store.delete_documents(index="haystack_custom_test")
-    document_store.write_documents(duplicate_documents, index="haystack_custom_test", duplicate_documents="skip")
-    assert len(document_store.get_all_documents(index="haystack_custom_test")) == 1
+    document_store.write_documents(
+        duplicate_documents, index="haystack_custom_test", duplicate_documents="skip")
+    assert len(document_store.get_all_documents(
+        index="haystack_custom_test")) == 1
     with pytest.raises(DuplicateDocumentError):
-        document_store.write_documents(duplicate_documents, index="haystack_custom_test", duplicate_documents="fail")
+        document_store.write_documents(
+            duplicate_documents, index="haystack_custom_test", duplicate_documents="fail")
 
     # Weaviate manipulates document objects in-place when writing them to an index.
     # It generates a uuid based on the provided id and the index name where the document is added to.
@@ -153,7 +164,8 @@ def test_write_with_duplicate_doc_ids_custom_index(document_store: BaseDocumentS
             Document(content="Doc1", id_hash_keys=["content"]),
         ]
     # writing to the default, empty index should still work
-    document_store.write_documents(duplicate_documents, duplicate_documents="fail")
+    document_store.write_documents(
+        duplicate_documents, duplicate_documents="fail")
 
 
 def test_get_all_documents_without_filters(document_store_with_docs):
@@ -161,15 +173,18 @@ def test_get_all_documents_without_filters(document_store_with_docs):
     documents = document_store_with_docs.get_all_documents()
     assert all(isinstance(d, Document) for d in documents)
     assert len(documents) == 5
-    assert {d.meta["name"] for d in documents} == {"filename1", "filename2", "filename3", "filename4", "filename5"}
-    assert {d.meta["meta_field"] for d in documents} == {"test1", "test2", "test3", "test4", "test5"}
+    assert {d.meta["name"] for d in documents} == {
+        "filename1", "filename2", "filename3", "filename4", "filename5"}
+    assert {d.meta["meta_field"] for d in documents} == {
+        "test1", "test2", "test3", "test4", "test5"}
 
 
 def test_get_all_documents_large_quantities(document_store: BaseDocumentStore):
     # Test to exclude situations like Weaviate not returning more than 100 docs by default
     #   https://github.com/deepset-ai/haystack/issues/1893
     docs_to_write = [
-        {"meta": {"name": f"name_{i}"}, "content": f"text_{i}", "embedding": np.random.rand(768).astype(np.float32)}
+        {"meta": {"name": f"name_{i}"}, "content": f"text_{i}",
+            "embedding": np.random.rand(768).astype(np.float32)}
         for i in range(1000)
     ]
     document_store.write_documents(docs_to_write)
@@ -181,7 +196,8 @@ def test_get_all_documents_large_quantities(document_store: BaseDocumentStore):
 def test_get_all_document_filter_duplicate_text_value(document_store: BaseDocumentStore):
     documents = [
         Document(content="Doc1", meta={"f1": "0"}, id_hash_keys=["meta"]),
-        Document(content="Doc1", meta={"f1": "1", "meta_id": "0"}, id_hash_keys=["meta"]),
+        Document(content="Doc1", meta={
+                 "f1": "1", "meta_id": "0"}, id_hash_keys=["meta"]),
         Document(content="Doc2", meta={"f3": "0"}, id_hash_keys=["meta"]),
     ]
     document_store.write_documents(documents)
@@ -202,11 +218,13 @@ def test_get_all_document_filter_duplicate_text_value(document_store: BaseDocume
 
 
 def test_get_all_documents_with_correct_filters(document_store_with_docs):
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test2"]})
     assert len(documents) == 1
     assert documents[0].meta["name"] == "filename2"
 
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test3"]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test1", "test3"]})
     assert len(documents) == 2
     assert {d.meta["name"] for d in documents} == {"filename1", "filename3"}
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
@@ -217,23 +235,27 @@ def test_get_all_documents_with_correct_filters_legacy_sqlite(test_docs_xs, tmp_
     document_store_with_docs.write_documents(test_docs_xs)
 
     document_store_with_docs.use_windowed_query = False
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test2"]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test2"]})
     assert len(documents) == 1
     assert documents[0].meta["name"] == "filename2"
 
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test3"]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test1", "test3"]})
     assert len(documents) == 2
     assert {d.meta["name"] for d in documents} == {"filename1", "filename3"}
     assert {d.meta["meta_field"] for d in documents} == {"test1", "test3"}
 
 
 def test_get_all_documents_with_incorrect_filter_name(document_store_with_docs):
-    documents = document_store_with_docs.get_all_documents(filters={"incorrect_meta_field": ["test2"]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"incorrect_meta_field": ["test2"]})
     assert len(documents) == 0
 
 
 def test_get_all_documents_with_incorrect_filter_value(document_store_with_docs):
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["incorrect_value"]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["incorrect_value"]})
     assert len(documents) == 0
 
 
@@ -242,32 +264,42 @@ def test_get_all_documents_with_incorrect_filter_value(document_store_with_docs)
 )
 def test_extended_filter(document_store_with_docs):
     # Test comparison operators individually
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$eq": "test1"}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": {"$eq": "test1"}})
     assert len(documents) == 1
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": "test1"})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": "test1"})
     assert len(documents) == 1
 
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$in": ["test1", "test2", "n.a."]}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": {"$in": ["test1", "test2", "n.a."]}})
     assert len(documents) == 2
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test2", "n.a."]})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test1", "test2", "n.a."]})
     assert len(documents) == 2
 
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$ne": "test1"}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": {"$ne": "test1"}})
     assert len(documents) == 4
 
-    documents = document_store_with_docs.get_all_documents(filters={"meta_field": {"$nin": ["test1", "test2", "n.a."]}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"meta_field": {"$nin": ["test1", "test2", "n.a."]}})
     assert len(documents) == 3
 
-    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$gt": 3.0}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"numeric_field": {"$gt": 3.0}})
     assert len(documents) == 3
 
-    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$gte": 3.0}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"numeric_field": {"$gte": 3.0}})
     assert len(documents) == 4
 
-    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$lt": 3.0}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"numeric_field": {"$lt": 3.0}})
     assert len(documents) == 1
 
-    documents = document_store_with_docs.get_all_documents(filters={"numeric_field": {"$lte": 3.0}})
+    documents = document_store_with_docs.get_all_documents(
+        filters={"numeric_field": {"$lte": 3.0}})
     assert len(documents) == 2
 
     # Test compound filters
@@ -287,7 +319,8 @@ def test_extended_filter(document_store_with_docs):
         "date_field": {"$lte": "2020-12-31", "$gte": "2019-01-01"},
         "name": ["filename5", "filename3"],
     }
-    documents_simplified_filter = document_store_with_docs.get_all_documents(filters=filters_simplified)
+    documents_simplified_filter = document_store_with_docs.get_all_documents(
+        filters=filters_simplified)
     # Order of returned documents might differ
     assert len(documents) == len(documents_simplified_filter) and all(
         doc in documents_simplified_filter for doc in documents
@@ -305,7 +338,8 @@ def test_extended_filter(document_store_with_docs):
         "date_field": {"$lte": "2020-12-31", "$gte": "2019-01-01"},
         "$or": {"name": ["filename5", "filename3"], "numeric_field": {"$lte": 5.0}},
     }
-    documents_simplified_filter = document_store_with_docs.get_all_documents(filters=filters_simplified)
+    documents_simplified_filter = document_store_with_docs.get_all_documents(
+        filters=filters_simplified)
     assert len(documents) == len(documents_simplified_filter) and all(
         doc in documents_simplified_filter for doc in documents
     )
@@ -328,7 +362,8 @@ def test_extended_filter(document_store_with_docs):
             "$and": {"numeric_field": {"$lte": 5.0}, "$not": {"meta_field": "test2"}},
         },
     }
-    documents_simplified_filter = document_store_with_docs.get_all_documents(filters=filters_simplified)
+    documents_simplified_filter = document_store_with_docs.get_all_documents(
+        filters=filters_simplified)
     assert len(documents) == len(documents_simplified_filter) and all(
         doc in documents_simplified_filter for doc in documents
     )
@@ -351,8 +386,10 @@ def test_extended_filter(document_store_with_docs):
     # Test same logical operator twice on same level
     filters = {
         "$or": [
-            {"$and": {"meta_field": {"$in": ["test1", "test2"]}, "date_field": {"$gte": "2020-01-01"}}},
-            {"$and": {"meta_field": {"$in": ["test3", "test4"]}, "date_field": {"$lt": "2020-01-01"}}},
+            {"$and": {"meta_field": {"$in": ["test1", "test2"]}, "date_field": {
+                "$gte": "2020-01-01"}}},
+            {"$and": {"meta_field": {"$in": ["test3", "test4"]}, "date_field": {
+                "$lt": "2020-01-01"}}},
         ]
     }
     documents = document_store_with_docs.get_all_documents(filters=filters)
@@ -379,7 +416,8 @@ def test_get_documents_by_id(document_store: BaseDocumentStore):
     all_docs = document_store.get_all_documents(index=doc_idx)
     all_ids = [doc.id for doc in all_docs]
 
-    retrieved_by_id = document_store.get_documents_by_id(all_ids, index=doc_idx)
+    retrieved_by_id = document_store.get_documents_by_id(
+        all_ids, index=doc_idx)
     retrieved_ids = [doc.id for doc in retrieved_by_id]
 
     # all documents in the index should be retrieved when passing all document ids in the index
@@ -395,8 +433,10 @@ def test_get_document_count(document_store: BaseDocumentStore):
     ]
     document_store.write_documents(documents)
     assert document_store.get_document_count() == 4
-    assert document_store.get_document_count(filters={"meta_field_for_count": ["a"]}) == 1
-    assert document_store.get_document_count(filters={"meta_field_for_count": ["b"]}) == 3
+    assert document_store.get_document_count(
+        filters={"meta_field_for_count": ["a"]}) == 1
+    assert document_store.get_document_count(
+        filters={"meta_field_for_count": ["b"]}) == 3
 
 
 def test_get_all_documents_generator(document_store: BaseDocumentStore):
@@ -414,18 +454,22 @@ def test_get_all_documents_generator(document_store: BaseDocumentStore):
 
 @pytest.mark.parametrize("update_existing_documents", [True, False])
 def test_update_existing_documents(document_store, update_existing_documents):
-    original_docs = [{"content": "text1_orig", "id": "1", "meta_field_for_count": "a"}]
+    original_docs = [{"content": "text1_orig",
+                      "id": "1", "meta_field_for_count": "a"}]
 
-    updated_docs = [{"content": "text1_new", "id": "1", "meta_field_for_count": "a"}]
+    updated_docs = [{"content": "text1_new",
+                     "id": "1", "meta_field_for_count": "a"}]
 
     document_store.write_documents(original_docs)
     assert document_store.get_document_count() == 1
 
     if update_existing_documents:
-        document_store.write_documents(updated_docs, duplicate_documents="overwrite")
+        document_store.write_documents(
+            updated_docs, duplicate_documents="overwrite")
     else:
         with pytest.raises(Exception):
-            document_store.write_documents(updated_docs, duplicate_documents="fail")
+            document_store.write_documents(
+                updated_docs, duplicate_documents="fail")
 
     stored_docs = document_store.get_all_documents()
     assert len(stored_docs) == 1
@@ -438,9 +482,11 @@ def test_update_existing_documents(document_store, update_existing_documents):
 def test_write_document_meta(document_store: BaseDocumentStore):
     documents = [
         {"content": "dict_without_meta", "id": "1"},
-        {"content": "dict_with_meta", "meta_field": "test2", "name": "filename2", "id": "2"},
+        {"content": "dict_with_meta", "meta_field": "test2",
+            "name": "filename2", "id": "2"},
         Document(content="document_object_without_meta", id="3"),
-        Document(content="document_object_with_meta", meta={"meta_field": "test4", "name": "filename3"}, id="4"),
+        Document(content="document_object_with_meta", meta={
+                 "meta_field": "test4", "name": "filename3"}, id="4"),
     ]
     document_store.write_documents(documents)
     documents_in_store = document_store.get_all_documents()
@@ -453,14 +499,18 @@ def test_write_document_meta(document_store: BaseDocumentStore):
 
 
 def test_write_document_index(document_store: BaseDocumentStore):
-    documents = [{"content": "text1", "id": "1"}, {"content": "text2", "id": "2"}]
+    documents = [{"content": "text1", "id": "1"},
+                 {"content": "text2", "id": "2"}]
     document_store.write_documents([documents[0]], index="haystack_test_one")
-    assert len(document_store.get_all_documents(index="haystack_test_one")) == 1
+    assert len(document_store.get_all_documents(
+        index="haystack_test_one")) == 1
 
     document_store.write_documents([documents[1]], index="haystack_test_two")
-    assert len(document_store.get_all_documents(index="haystack_test_two")) == 1
+    assert len(document_store.get_all_documents(
+        index="haystack_test_two")) == 1
 
-    assert len(document_store.get_all_documents(index="haystack_test_one")) == 1
+    assert len(document_store.get_all_documents(
+        index="haystack_test_one")) == 1
     assert len(document_store.get_all_documents()) == 0
 
 
@@ -469,13 +519,18 @@ def test_write_document_index(document_store: BaseDocumentStore):
 )
 def test_document_with_embeddings(document_store: BaseDocumentStore):
     documents = [
-        {"content": "text1", "id": "1", "embedding": np.random.rand(768).astype(np.float32)},
-        {"content": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
-        {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
-        {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text1", "id": "1",
+            "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text2", "id": "2",
+            "embedding": np.random.rand(768).astype(np.float64)},
+        {"content": "text3", "id": "3", "embedding": np.random.rand(
+            768).astype(np.float32).tolist()},
+        {"content": "text4", "id": "4",
+            "embedding": np.random.rand(768).astype(np.float32)},
     ]
     document_store.write_documents(documents, index="haystack_test_one")
-    assert len(document_store.get_all_documents(index="haystack_test_one")) == 4
+    assert len(document_store.get_all_documents(
+        index="haystack_test_one")) == 4
 
     if not isinstance(document_store, WeaviateDocumentStore):
         # weaviate is excluded because it would return dummy vectors instead of None
@@ -484,8 +539,10 @@ def test_document_with_embeddings(document_store: BaseDocumentStore):
         )
         assert documents_without_embedding[0].embedding is None
 
-    documents_with_embedding = document_store.get_all_documents(index="haystack_test_one", return_embedding=True)
-    assert isinstance(documents_with_embedding[0].embedding, (list, np.ndarray))
+    documents_with_embedding = document_store.get_all_documents(
+        index="haystack_test_one", return_embedding=True)
+    assert isinstance(
+        documents_with_embedding[0].embedding, (list, np.ndarray))
 
 
 @pytest.mark.parametrize(
@@ -495,12 +552,15 @@ def test_document_with_embeddings(document_store: BaseDocumentStore):
 def test_update_embeddings(document_store, retriever):
     documents = []
     for i in range(6):
-        documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+        documents.append(
+            {"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
     documents.append({"content": "text_0", "id": "6", "meta_field": "value_0"})
 
     document_store.write_documents(documents, index="haystack_test_one")
-    document_store.update_embeddings(retriever, index="haystack_test_one", batch_size=3)
-    documents = document_store.get_all_documents(index="haystack_test_one", return_embedding=True)
+    document_store.update_embeddings(
+        retriever, index="haystack_test_one", batch_size=3)
+    documents = document_store.get_all_documents(
+        index="haystack_test_one", return_embedding=True)
     assert len(documents) == 7
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
@@ -511,13 +571,16 @@ def test_update_embeddings(document_store, retriever):
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_0"
-    np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
+    np.testing.assert_array_almost_equal(
+        documents[0].embedding, documents[1].embedding, decimal=4)
 
     documents = document_store.get_all_documents(
         index="haystack_test_one", filters={"meta_field": ["value_0", "value_5"]}, return_embedding=True
     )
-    documents_with_value_0 = [doc for doc in documents if doc.meta["meta_field"] == "value_0"]
-    documents_with_value_5 = [doc for doc in documents if doc.meta["meta_field"] == "value_5"]
+    documents_with_value_0 = [
+        doc for doc in documents if doc.meta["meta_field"] == "value_0"]
+    documents_with_value_5 = [
+        doc for doc in documents if doc.meta["meta_field"] == "value_5"]
     np.testing.assert_raises(
         AssertionError,
         np.testing.assert_array_equal,
@@ -535,7 +598,8 @@ def test_update_embeddings(document_store, retriever):
 
     documents = []
     for i in range(8, 11):
-        documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+        documents.append(
+            {"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
     document_store.write_documents(documents, index="haystack_test_one")
 
     doc_before_update = document_store.get_all_documents(
@@ -553,7 +617,8 @@ def test_update_embeddings(document_store, retriever):
             index="haystack_test_one", filters={"meta_field": ["value_7"]}
         )[0]
         embedding_after_update = doc_after_update.embedding
-        np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
+        np.testing.assert_array_equal(
+            embedding_before_update, embedding_after_update)
 
     # test updating with filters
     if isinstance(document_store, FAISSDocumentStore):
@@ -569,7 +634,8 @@ def test_update_embeddings(document_store, retriever):
             index="haystack_test_one", filters={"meta_field": ["value_7"]}
         )[0]
         embedding_after_update = doc_after_update.embedding
-        np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
+        np.testing.assert_array_equal(
+            embedding_before_update, embedding_after_update)
 
     # test update all embeddings
     document_store.update_embeddings(
@@ -587,7 +653,8 @@ def test_update_embeddings(document_store, retriever):
     # test update embeddings for newly added docs
     documents = []
     for i in range(12, 15):
-        documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
+        documents.append(
+            {"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
     document_store.write_documents(documents, index="haystack_test_one")
 
     if not isinstance(document_store, WeaviateDocumentStore):
@@ -595,7 +662,8 @@ def test_update_embeddings(document_store, retriever):
         document_store.update_embeddings(
             retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=False
         )
-        assert document_store.get_embedding_count(index="haystack_test_one") == 14
+        assert document_store.get_embedding_count(
+            index="haystack_test_one") == 14
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
@@ -605,7 +673,8 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
     documents = []
     for i in range(3):
         documents.append(
-            {"content": f"text_{i}", "id": f"pssg_{i}", "meta_field": f"value_text_{i}", "content_type": "text"}
+            {"content": f"text_{i}", "id": f"pssg_{i}",
+                "meta_field": f"value_text_{i}", "content_type": "text"}
         )
         documents.append(
             {
@@ -615,7 +684,8 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
                 "content_type": "table",
             }
         )
-    documents.append({"content": "text_0", "id": "pssg_4", "meta_field": "value_text_0", "content_type": "text"})
+    documents.append({"content": "text_0", "id": "pssg_4",
+                     "meta_field": "value_text_0", "content_type": "text"})
     documents.append(
         {
             "content": pd.DataFrame(columns=["col_0", "col_1"], data=[["cell_0", "cell_1"]]),
@@ -626,8 +696,10 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
     )
 
     document_store.write_documents(documents, index="haystack_test_one")
-    document_store.update_embeddings(retriever, index="haystack_test_one", batch_size=3)
-    documents = document_store.get_all_documents(index="haystack_test_one", return_embedding=True)
+    document_store.update_embeddings(
+        retriever, index="haystack_test_one", batch_size=3)
+    documents = document_store.get_all_documents(
+        index="haystack_test_one", return_embedding=True)
     assert len(documents) == 8
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
@@ -639,7 +711,8 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_text_0"
-    np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
+    np.testing.assert_array_almost_equal(
+        documents[0].embedding, documents[1].embedding, decimal=4)
 
     # Check if Documents with same content (table) get same embedding
     documents = document_store.get_all_documents(
@@ -648,7 +721,8 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_table_0"
-    np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
+    np.testing.assert_array_almost_equal(
+        documents[0].embedding, documents[1].embedding, decimal=4)
 
     # Check if Documents wih different content (text) get different embedding
     documents = document_store.get_all_documents(
@@ -692,7 +766,8 @@ def test_delete_documents(document_store_with_docs):
 
 
 def test_delete_documents_with_filters(document_store_with_docs):
-    document_store_with_docs.delete_documents(filters={"meta_field": ["test1", "test2", "test4", "test5"]})
+    document_store_with_docs.delete_documents(
+        filters={"meta_field": ["test1", "test2", "test4", "test5"]})
     documents = document_store_with_docs.get_all_documents()
     assert len(documents) == 1
     assert documents[0].meta["meta_field"] == "test3"
@@ -706,10 +781,12 @@ def test_delete_documents_by_id(document_store_with_docs):
         filters={"meta_field": ["test1", "test2", "test4", "test5"]}
     )
     logging.info(len(docs_to_delete))
-    docs_not_to_delete = document_store_with_docs.get_all_documents(filters={"meta_field": ["test3"]})
+    docs_not_to_delete = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test3"]})
     logging.info(len(docs_not_to_delete))
 
-    document_store_with_docs.delete_documents(ids=[doc.id for doc in docs_to_delete])
+    document_store_with_docs.delete_documents(
+        ids=[doc.id for doc in docs_to_delete])
     all_docs_left = document_store_with_docs.get_all_documents()
     assert len(all_docs_left) == 1
     assert all_docs_left[0].meta["meta_field"] == "test3"
@@ -719,10 +796,13 @@ def test_delete_documents_by_id(document_store_with_docs):
 
 
 def test_delete_documents_by_id_with_filters(document_store_with_docs):
-    docs_to_delete = document_store_with_docs.get_all_documents(filters={"meta_field": ["test1", "test2"]})
-    docs_not_to_delete = document_store_with_docs.get_all_documents(filters={"meta_field": ["test3"]})
+    docs_to_delete = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test1", "test2"]})
+    docs_not_to_delete = document_store_with_docs.get_all_documents(
+        filters={"meta_field": ["test3"]})
 
-    document_store_with_docs.delete_documents(ids=[doc.id for doc in docs_to_delete], filters={"meta_field": ["test1"]})
+    document_store_with_docs.delete_documents(
+        ids=[doc.id for doc in docs_to_delete], filters={"meta_field": ["test1"]})
 
     all_docs_left = document_store_with_docs.get_all_documents()
     assert len(all_docs_left) == 4
@@ -786,7 +866,8 @@ def test_labels(document_store: BaseDocumentStore):
     assert label2 in labels
 
     # delete filtered label2 by id
-    document_store.delete_labels(index="haystack_test_label", ids=[labels[1].id])
+    document_store.delete_labels(
+        index="haystack_test_label", ids=[labels[1].id])
     labels = document_store.get_all_labels(index="haystack_test_label")
     assert label == labels[0]
     assert len(labels) == 1
@@ -797,7 +878,8 @@ def test_labels(document_store: BaseDocumentStore):
     assert len(labels) == 2
 
     # delete filtered label2 by query text
-    document_store.delete_labels(index="haystack_test_label", filters={"query": [labels[1].query]})
+    document_store.delete_labels(index="haystack_test_label", filters={
+                                 "query": [labels[1].query]})
     labels = document_store.get_all_labels(index="haystack_test_label")
     assert label == labels[0]
     assert len(labels) == 1
@@ -808,7 +890,8 @@ def test_labels(document_store: BaseDocumentStore):
     assert len(labels) == 2
 
     # delete intersection of filters and ids, which is empty
-    document_store.delete_labels(index="haystack_test_label", ids=[labels[0].id], filters={"query": [labels[1].query]})
+    document_store.delete_labels(index="haystack_test_label", ids=[
+                                 labels[0].id], filters={"query": [labels[1].query]})
     labels = document_store.get_all_labels(index="haystack_test_label")
     assert len(labels) == 2
     assert label in labels
@@ -827,7 +910,8 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="standard",
             query="question",
-            answer=Answer(answer="answer1", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer1", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -838,7 +922,8 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-same-doc",
             query="question",
-            answer=Answer(answer="answer2", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer2", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -849,7 +934,8 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-diff-doc",
             query="question",
-            answer=Answer(answer="answer3", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer3", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some other", id="333"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -860,7 +946,8 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="4-no-answer",
             query="question",
-            answer=Answer(answer="", offsets_in_document=[Span(start=0, end=0)]),
+            answer=Answer(answer="", offsets_in_document=[
+                          Span(start=0, end=0)]),
             document=Document(content="some", id="777"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -871,7 +958,8 @@ def test_multilabel(document_store: BaseDocumentStore):
         Label(
             id="5-negative",
             query="question",
-            answer=Answer(answer="answer5", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer5", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=False,
             is_correct_document=True,
@@ -881,7 +969,8 @@ def test_multilabel(document_store: BaseDocumentStore):
     ]
     document_store.write_labels(labels, index="haystack_test_multilabel")
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels(
+        index="haystack_test_multilabel")
     assert list_labels == labels
     assert len(list_labels) == 5
 
@@ -981,9 +1070,11 @@ def test_multilabel_no_answer(document_store: BaseDocumentStore):
         ),
     ]
 
-    document_store.write_labels(labels, index="haystack_test_multilabel_no_answer")
+    document_store.write_labels(
+        labels, index="haystack_test_multilabel_no_answer")
 
-    labels = document_store.get_all_labels(index="haystack_test_multilabel_no_answer")
+    labels = document_store.get_all_labels(
+        index="haystack_test_multilabel_no_answer")
     assert len(labels) == 4
 
     multi_labels = document_store.get_all_labels_aggregated(
@@ -1012,7 +1103,8 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="standard",
             query="question",
-            answer=Answer(answer="answer1", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer1", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1024,7 +1116,8 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-same-doc",
             query="question",
-            answer=Answer(answer="answer2", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer2", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1036,7 +1129,8 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-diff-doc",
             query="question",
-            answer=Answer(answer="answer3", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer3", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some other", id="333"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1048,7 +1142,8 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="4-no-answer",
             query="question",
-            answer=Answer(answer="", offsets_in_document=[Span(start=0, end=0)]),
+            answer=Answer(answer="", offsets_in_document=[
+                          Span(start=0, end=0)]),
             document=Document(content="some", id="777"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1060,7 +1155,8 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
         Label(
             id="5-negative",
             query="question",
-            answer=Answer(answer="answer5", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer5", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=False,
             is_correct_document=True,
@@ -1071,7 +1167,8 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
     ]
     document_store.write_labels(labels, index="haystack_test_multilabel")
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels(
+        index="haystack_test_multilabel")
     assert list_labels == labels
     assert len(list_labels) == 5
 
@@ -1085,9 +1182,11 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
     label_counts = set([len(ml.labels) for ml in multi_labels_open])
     assert label_counts == set([2, 1, 1])
     # all labels are in there except the negative one and the no_answer
-    assert "5-negative" not in [l.id for multi_label in multi_labels_open for l in multi_label.labels]
+    assert "5-negative" not in [
+        l.id for multi_label in multi_labels_open for l in multi_label.labels]
 
-    assert len(multi_labels_open[0].answers) == len(multi_labels_open[0].document_ids)
+    assert len(multi_labels_open[0].answers) == len(
+        multi_labels_open[0].document_ids)
 
     # for closed domain we group by document so we expect the same as with filters
     multi_labels = document_store.get_all_labels_aggregated(
@@ -1108,7 +1207,8 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="standard",
             query="question",
-            answer=Answer(answer="answer1", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer1", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1120,7 +1220,8 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-same-doc",
             query="question",
-            answer=Answer(answer="answer2", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer2", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1132,7 +1233,8 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="diff-answer-diff-doc",
             query="question",
-            answer=Answer(answer="answer3", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer3", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some other", id="333"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1144,7 +1246,8 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="4-no-answer",
             query="question",
-            answer=Answer(answer="", offsets_in_document=[Span(start=0, end=0)]),
+            answer=Answer(answer="", offsets_in_document=[
+                          Span(start=0, end=0)]),
             document=Document(content="some", id="777"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1156,7 +1259,8 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
         Label(
             id="5-888",
             query="question",
-            answer=Answer(answer="answer5", offsets_in_document=[Span(start=12, end=18)]),
+            answer=Answer(answer="answer5", offsets_in_document=[
+                          Span(start=12, end=18)]),
             document=Document(content="some", id="123"),
             is_correct_answer=True,
             is_correct_document=True,
@@ -1167,7 +1271,8 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
     ]
     document_store.write_labels(labels, index="haystack_test_multilabel")
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels(
+        index="haystack_test_multilabel")
     assert list_labels == labels
     assert len(list_labels) == 5
 
@@ -1201,8 +1306,10 @@ def test_update_meta(document_store: BaseDocumentStore):
         Document(content="Doc3", meta={"meta_key_1": "3", "meta_key_2": "3"}),
     ]
     document_store.write_documents(documents)
-    document_2 = document_store.get_all_documents(filters={"meta_key_2": ["2"]})[0]
-    document_store.update_document_meta(document_2.id, meta={"meta_key_1": "99", "meta_key_2": "2"})
+    document_2 = document_store.get_all_documents(
+        filters={"meta_key_2": ["2"]})[0]
+    document_store.update_document_meta(
+        document_2.id, meta={"meta_key_1": "99", "meta_key_2": "2"})
     updated_document = document_store.get_document_by_id(document_2.id)
     assert len(updated_document.meta.keys()) == 2
     assert updated_document.meta["meta_key_1"] == "99"
@@ -1214,12 +1321,14 @@ def test_custom_embedding_field(document_store_type, tmp_path):
     document_store = get_document_store(
         document_store_type=document_store_type, tmp_path=tmp_path, embedding_field="custom_embedding_field"
     )
-    doc_to_write = {"content": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
+    doc_to_write = {"content": "test", "custom_embedding_field": np.random.rand(
+        768).astype(np.float32)}
     document_store.write_documents([doc_to_write])
     documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 1
     assert documents[0].content == "test"
-    np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
+    np.testing.assert_array_equal(
+        doc_to_write["custom_embedding_field"], documents[0].embedding)
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
@@ -1238,13 +1347,15 @@ def test_get_meta_values_by_key(document_store: BaseDocumentStore):
         assert bucket["count"] == 1
 
     # test with filters but no query
-    result = document_store.get_metadata_values_by_key(key="meta_key_1", filters={"meta_key_2": ["11", "22"]})
+    result = document_store.get_metadata_values_by_key(
+        key="meta_key_1", filters={"meta_key_2": ["11", "22"]})
     for bucket in result:
         assert bucket["value"] in ["1", "2"]
         assert bucket["count"] == 1
 
     # test with filters & query
-    result = document_store.get_metadata_values_by_key(key="meta_key_1", query="Doc1")
+    result = document_store.get_metadata_values_by_key(
+        key="meta_key_1", query="Doc1")
     for bucket in result:
         assert bucket["value"] in ["1"]
         assert bucket["count"] == 1
@@ -1258,12 +1369,14 @@ def test_elasticsearch_custom_fields():
         index="haystack_test_custom", content_field="custom_text_field", embedding_field="custom_embedding_field"
     )
 
-    doc_to_write = {"custom_text_field": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
+    doc_to_write = {"custom_text_field": "test",
+                    "custom_embedding_field": np.random.rand(768).astype(np.float32)}
     document_store.write_documents([doc_to_write])
     documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 1
     assert documents[0].content == "test"
-    np.testing.assert_array_equal(doc_to_write["custom_embedding_field"], documents[0].embedding)
+    np.testing.assert_array_equal(
+        doc_to_write["custom_embedding_field"], documents[0].embedding)
 
 
 @pytest.mark.elasticsearch
@@ -1297,7 +1410,8 @@ def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store:
         document_store.query_by_embedding(np.random.rand(768), filters=filters)
 
     document_store.skip_missing_embeddings = True
-    documents = document_store.query_by_embedding(np.random.rand(768), filters=filters)
+    documents = document_store.query_by_embedding(
+        np.random.rand(768), filters=filters)
     assert len(documents) == 3
 
 
@@ -1316,7 +1430,8 @@ def test_get_document_count_only_documents_without_embedding_arg():
             "embedding": np.random.rand(768).astype(np.float64),
             "meta_field_for_count": "b",
         },
-        {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
+        {"content": "text3", "id": "3", "embedding": np.random.rand(
+            768).astype(np.float32).tolist()},
         {"content": "text4", "id": "4", "meta_field_for_count": "b"},
         {"content": "text5", "id": "5", "meta_field_for_count": "b"},
         {"content": "text6", "id": "6", "meta_field_for_count": "c"},
@@ -1335,7 +1450,8 @@ def test_get_document_count_only_documents_without_embedding_arg():
     document_store.write_documents(documents)
 
     assert document_store.get_document_count() == 7
-    assert document_store.get_document_count(only_documents_without_embedding=True) == 3
+    assert document_store.get_document_count(
+        only_documents_without_embedding=True) == 3
     assert (
         document_store.get_document_count(
             only_documents_without_embedding=True, filters={"meta_field_for_count": ["c"]}
@@ -1354,20 +1470,26 @@ def test_get_document_count_only_documents_without_embedding_arg():
 def test_skip_missing_embeddings():
     documents = [
         {"content": "text1", "id": "1"},  # a document without embeddings
-        {"content": "text2", "id": "2", "embedding": np.random.rand(768).astype(np.float64)},
-        {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
-        {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
+        {"content": "text2", "id": "2",
+            "embedding": np.random.rand(768).astype(np.float64)},
+        {"content": "text3", "id": "3", "embedding": np.random.rand(
+            768).astype(np.float32).tolist()},
+        {"content": "text4", "id": "4",
+            "embedding": np.random.rand(768).astype(np.float32)},
     ]
-    document_store = ElasticsearchDocumentStore(index="skip_missing_embedding_index")
+    document_store = ElasticsearchDocumentStore(
+        index="skip_missing_embedding_index")
     document_store.write_documents(documents)
 
     document_store.skip_missing_embeddings = True
-    retrieved_docs = document_store.query_by_embedding(np.random.rand(768).astype(np.float32))
+    retrieved_docs = document_store.query_by_embedding(
+        np.random.rand(768).astype(np.float32))
     assert len(retrieved_docs) == 3
 
     document_store.skip_missing_embeddings = False
     with pytest.raises(RequestError):
-        document_store.query_by_embedding(np.random.rand(768).astype(np.float32))
+        document_store.query_by_embedding(
+            np.random.rand(768).astype(np.float32))
 
     # Test scenario with no embeddings for the entire index
     documents = [
@@ -1382,12 +1504,14 @@ def test_skip_missing_embeddings():
 
     document_store.skip_missing_embeddings = True
     with pytest.raises(RequestError):
-        document_store.query_by_embedding(np.random.rand(768).astype(np.float32))
+        document_store.query_by_embedding(
+            np.random.rand(768).astype(np.float32))
 
 
 @pytest.mark.elasticsearch
 def test_elasticsearch_synonyms():
-    synonyms = ["i-pod, i pod, ipod", "sea biscuit, sea biscit, seabiscuit", "foo, foo bar, baz"]
+    synonyms = ["i-pod, i pod, ipod",
+                "sea biscuit, sea biscit, seabiscuit", "foo, foo bar, baz"]
     synonym_type = "synonym_graph"
 
     client = Elasticsearch()
@@ -1395,7 +1519,8 @@ def test_elasticsearch_synonyms():
     document_store = ElasticsearchDocumentStore(
         index="haystack_synonym_arg", synonyms=synonyms, synonym_type=synonym_type
     )
-    indexed_settings = client.indices.get_settings(index="haystack_synonym_arg")
+    indexed_settings = client.indices.get_settings(
+        index="haystack_synonym_arg")
 
     assert (
         synonym_type
@@ -1451,9 +1576,11 @@ def test_custom_headers(document_store_with_docs: BaseDocumentStore):
     custom_headers = {"X-My-Custom-Header": "header-value"}
     if not mock_client:
         with pytest.raises(NotImplementedError):
-            documents = document_store_with_docs.get_all_documents(headers=custom_headers)
+            documents = document_store_with_docs.get_all_documents(
+                headers=custom_headers)
     else:
-        documents = document_store_with_docs.get_all_documents(headers=custom_headers)
+        documents = document_store_with_docs.get_all_documents(
+            headers=custom_headers)
         mock_client.search.assert_called_once()
         args, kwargs = mock_client.search.call_args
         assert "headers" in kwargs
@@ -1464,7 +1591,8 @@ def test_custom_headers(document_store_with_docs: BaseDocumentStore):
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
 @responses.activate
 def test_DeepsetCloudDocumentStore_init_with_dot_product():
-    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=DC_TEST_INDEX)
+    document_store = DeepsetCloudDocumentStore(
+        api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=DC_TEST_INDEX)
     assert document_store.return_embedding == False
     assert document_store.similarity == "dot_product"
 
@@ -1490,7 +1618,8 @@ def test_DeepsetCloudDocumentStore_invalid_token():
         responses.add(
             method=responses.GET,
             url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}",
-            match=[matchers.header_matcher({"authorization": "Bearer invalid_token"})],
+            match=[matchers.header_matcher(
+                {"authorization": "Bearer invalid_token"})],
             body="Internal Server Error",
             status=500,
         )
@@ -1499,7 +1628,8 @@ def test_DeepsetCloudDocumentStore_invalid_token():
         DeepsetCloudError,
         match=f"Could not connect to Deepset Cloud:\nGET {DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX} failed: HTTP 500 - Internal Server Error",
     ):
-        DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key="invalid_token", index=DC_TEST_INDEX)
+        DeepsetCloudDocumentStore(
+            api_endpoint=DC_API_ENDPOINT, api_key="invalid_token", index=DC_TEST_INDEX)
 
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
@@ -1517,7 +1647,8 @@ def test_DeepsetCloudDocumentStore_invalid_api_endpoint():
         DeepsetCloudError,
         match=f"Could not connect to Deepset Cloud:\nGET {DC_API_ENDPOINT}00/workspaces/default/indexes/{DC_TEST_INDEX} failed: HTTP 404 - Not Found",
     ):
-        DeepsetCloudDocumentStore(api_endpoint=f"{DC_API_ENDPOINT}00", api_key=DC_API_KEY, index=DC_TEST_INDEX)
+        DeepsetCloudDocumentStore(
+            api_endpoint=f"{DC_API_ENDPOINT}00", api_key=DC_API_KEY, index=DC_TEST_INDEX)
 
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
@@ -1535,7 +1666,8 @@ def test_DeepsetCloudDocumentStore_invalid_index():
         DeepsetCloudError,
         match=f"Could not connect to Deepset Cloud:\nGET {DC_API_ENDPOINT}/workspaces/default/indexes/invalid_index failed: HTTP 404 - Not Found",
     ):
-        DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index="invalid_index")
+        DeepsetCloudDocumentStore(
+            api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index="invalid_index")
 
 
 @responses.activate
@@ -1543,9 +1675,12 @@ def test_DeepsetCloudDocumentStore_documents(deepset_cloud_document_store):
     if MOCK_DC:
         with open(SAMPLES_PATH / "dc" / "documents-stream.response", "r") as f:
             documents_stream_response = f.read()
-            docs = [json.loads(l) for l in documents_stream_response.splitlines()]
-            filtered_docs = [doc for doc in docs if doc["meta"]["file_id"] == docs[0]["meta"]["file_id"]]
-            documents_stream_filtered_response = "\n".join([json.dumps(d) for d in filtered_docs])
+            docs = [json.loads(l)
+                    for l in documents_stream_response.splitlines()]
+            filtered_docs = [doc for doc in docs if doc["meta"]
+                             ["file_id"] == docs[0]["meta"]["file_id"]]
+            documents_stream_filtered_response = "\n".join(
+                [json.dumps(d) for d in filtered_docs])
 
             responses.add(
                 method=responses.POST,
@@ -1559,7 +1694,8 @@ def test_DeepsetCloudDocumentStore_documents(deepset_cloud_document_store):
                 url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}/documents-stream",
                 match=[
                     matchers.json_params_matcher(
-                        {"filters": {"file_id": [docs[0]["meta"]["file_id"]]}, "return_embedding": False}
+                        {"filters": {"file_id": [
+                            docs[0]["meta"]["file_id"]]}, "return_embedding": False}
                     )
                 ],
                 body=documents_stream_filtered_response,
@@ -1580,11 +1716,13 @@ def test_DeepsetCloudDocumentStore_documents(deepset_cloud_document_store):
     assert len(docs) > 1
     assert isinstance(docs[0], Document)
 
-    first_doc = next(deepset_cloud_document_store.get_all_documents_generator())
+    first_doc = next(
+        deepset_cloud_document_store.get_all_documents_generator())
     assert isinstance(first_doc, Document)
     assert first_doc.meta["file_id"] is not None
 
-    filtered_docs = deepset_cloud_document_store.get_all_documents(filters={"file_id": [first_doc.meta["file_id"]]})
+    filtered_docs = deepset_cloud_document_store.get_all_documents(
+        filters={"file_id": [first_doc.meta["file_id"]]})
     assert len(filtered_docs) > 0
     assert len(filtered_docs) < len(docs)
 
@@ -1610,12 +1748,14 @@ def test_DeepsetCloudDocumentStore_query(deepset_cloud_document_store):
                 for doc in query_winterfell_docs
                 if doc["meta"]["file_id"] == query_winterfell_docs[0]["meta"]["file_id"]
             ]
-            query_winterfell_filtered_response = json.dumps(query_winterfell_filtered_docs)
+            query_winterfell_filtered_response = json.dumps(
+                query_winterfell_filtered_docs)
 
         responses.add(
             method=responses.POST,
             url=f"{DC_API_ENDPOINT}/workspaces/default/indexes/{DC_TEST_INDEX}/documents-query",
-            match=[matchers.json_params_matcher({"query": "winterfell", "top_k": 50, "all_terms_must_match": False})],
+            match=[matchers.json_params_matcher(
+                {"query": "winterfell", "top_k": 50, "all_terms_must_match": False})],
             status=200,
             body=query_winterfell_response,
         )
@@ -1738,7 +1878,8 @@ def test_DeepsetCloudDocumentStore_lists_evaluation_sets(deepset_cloud_document_
             method=responses.GET,
             url=f"{DC_API_ENDPOINT}/workspaces/default/evaluation_sets",
             status=200,
-            body=json.dumps({"data": [response_evaluation_set], "has_more": False, "total": 1}),
+            body=json.dumps(
+                {"data": [response_evaluation_set], "has_more": False, "total": 1}),
         )
     else:
         responses.add_passthru(DC_API_ENDPOINT)
@@ -1800,7 +1941,8 @@ def test_DeepsetCloudDocumentStore_fetches_labels_for_evaluation_set(deepset_clo
     assert labels == [
         Label(
             query="What is berlin?",
-            document=Document(content="Berlin is the biggest city in germany."),
+            document=Document(
+                content="Berlin is the biggest city in germany."),
             is_correct_answer=True,
             is_correct_document=True,
             origin="user-feedback",
@@ -1907,7 +2049,8 @@ def test_elasticsearch_search_field_mapping():
     )
     document_store.write_documents(index_data)
 
-    indexed_settings = client.indices.get_mapping(index="haystack_search_field_mapping")
+    indexed_settings = client.indices.get_mapping(
+        index="haystack_search_field_mapping")
 
     assert indexed_settings["haystack_search_field_mapping"]["mappings"]["properties"]["content"]["type"] == "text"
     assert indexed_settings["haystack_search_field_mapping"]["mappings"]["properties"]["sub_content"]["type"] == "text"
@@ -1919,34 +2062,30 @@ def test_elasticsearch_existing_alias():
     client = Elasticsearch()
     client.indices.delete(index="haystack_existing_alias_1", ignore=[404])
     client.indices.delete(index="haystack_existing_alias_2", ignore=[404])
-    client.indices.delete_alias(index="_all", name="haystack_existing_alias", ignore=[404])
+    client.indices.delete_alias(
+        index="_all", name="haystack_existing_alias", ignore=[404])
 
-    index_data = [
-        {
-            "_index": "haystack_existing_alias_1",
-            "_op_type": "index",
-            "_id": "1",
-            "title": "Green tea components",
-            "content": "The green tea plant contains a range of healthy compounds that make it into the final drink",
-        },
-        {
-            "_index": "haystack_existing_alias_2",
-            "_op_type": "index",
-            "_id": "1",
-            "title": "Minerals in Green tea",
-            "content": "Green tea also has small amounts of minerals that can benefit your health.",
-        },
-    ]
+    settings = {
+        "mappings": {
+            "properties": {
+                "content": {
+                    "type": "text"
+                }
+            }
+        }
+    }
 
-    client.indices.create(index="haystack_existing_alias_1")
-    client.indices.create(index="haystack_existing_alias_2")
-    bulk(client, index_data)
+    client.indices.create(index="haystack_existing_alias_1", body=settings)
+    client.indices.create(index="haystack_existing_alias_2", body=settings)
 
-    client.indices.put_alias(index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias")
+    client.indices.put_alias(
+        index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias")
 
-    ElasticsearchDocumentStore(
-        index="haystack_existing_alias", search_fields=["content"], content_field="title"
+    # To be valid, all indices related to the alias must have content field of type text
+    _ = ElasticsearchDocumentStore(
+        index="haystack_existing_alias", search_fields=["content"]
     )
+
 
 @pytest.mark.elasticsearch
 def test_elasticsearch_existing_alias_missing_fields():
@@ -1954,33 +2093,40 @@ def test_elasticsearch_existing_alias_missing_fields():
     client = Elasticsearch()
     client.indices.delete(index="haystack_existing_alias_1", ignore=[404])
     client.indices.delete(index="haystack_existing_alias_2", ignore=[404])
-    client.indices.delete_alias(index="_all", name="haystack_existing_alias", ignore=[404])
+    client.indices.delete_alias(
+        index="_all", name="haystack_existing_alias", ignore=[404])
 
-    index_data = [
-        {
-            "_index": "haystack_existing_alias_1",
-            "_op_type": "index",
-            "_id": "1",
-            "title": "Green tea components",
-        },
-        {
-            "_index": "haystack_existing_alias_2",
-            "_op_type": "index",
-            "_id": "1",
-            "title": "Minerals in Green tea",
-            "content": "Green tea also has small amounts of minerals that can benefit your health.",
-        },
-    ]
+    right_settings = {
+        "mappings": {
+            "properties": {
+                "content": {
+                    "type": "text"
+                }
+            }
+        }
+    }
 
-    client.indices.create(index="haystack_existing_alias_1")
-    client.indices.create(index="haystack_existing_alias_2")
-    bulk(client, index_data)
+    wrong_settings = {
+        "mappings": {
+            "properties": {
+                "content": {
+                    "type": "histogram"
+                }
+            }
+        }
+    }
 
-    client.indices.put_alias(index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias")
+    client.indices.create(
+        index="haystack_existing_alias_1", body=right_settings)
+    client.indices.create(
+        index="haystack_existing_alias_2", body=wrong_settings)
+
+    client.indices.put_alias(
+        index="haystack_existing_alias_1,haystack_existing_alias_2", name="haystack_existing_alias")
 
     with pytest.raises(Exception):
-        # missing field "content" in index "haystack_existing_alias_1"
-        ElasticsearchDocumentStore(
+        # wrong field type for "content" in index "haystack_existing_alias_2"
+        _ = ElasticsearchDocumentStore(
             index="haystack_existing_alias", search_fields=["content"], content_field="title"
         )
 
@@ -1997,8 +2143,10 @@ def test_elasticsearch_brownfield_support(document_store_with_docs):
         index="test_brownfield_support",
     )
 
-    original_documents = document_store_with_docs.get_all_documents(index="haystack_test")
-    transferred_documents = new_document_store.get_all_documents(index="test_brownfield_support")
+    original_documents = document_store_with_docs.get_all_documents(
+        index="haystack_test")
+    transferred_documents = new_document_store.get_all_documents(
+        index="test_brownfield_support")
     assert len(original_documents) == len(transferred_documents)
     assert all("name" in doc.meta for doc in transferred_documents)
     assert all("date_field" in doc.meta for doc in transferred_documents)
@@ -2016,12 +2164,15 @@ def test_elasticsearch_brownfield_support(document_store_with_docs):
         original_content_field="content",
         excluded_metadata_fields=["date_field"],
         index="test_brownfield_support_2",
-        preprocessor=PreProcessor(split_length=1, split_respect_sentence_boundary=False),
+        preprocessor=PreProcessor(
+            split_length=1, split_respect_sentence_boundary=False),
     )
-    transferred_documents = new_document_store.get_all_documents(index="test_brownfield_support_2")
+    transferred_documents = new_document_store.get_all_documents(
+        index="test_brownfield_support_2")
     assert all("date_field" not in doc.meta for doc in transferred_documents)
     assert all("name" in doc.meta for doc in transferred_documents)
     assert all("meta_field" in doc.meta for doc in transferred_documents)
     assert all("numeric_field" in doc.meta for doc in transferred_documents)
     # Check if number of transferred_documents is equal to number of unique words.
-    assert len(transferred_documents) == len(set(" ".join(original_content).split()))
+    assert len(transferred_documents) == len(
+        set(" ".join(original_content).split()))


### PR DESCRIPTION
**Proposed changes**:
- Add the support for alias in elasticsearch. indices.get() method from elasticsearch python library doesn't return alias name as key, but return indexes grouped by the alias, so we have to loop over all keys to check that every indices are correct

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
