### PR TITLE
Fix and use delete_index instead of delete_documents in tests

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -359,7 +359,8 @@ jobs:
   test-pinecone:
     needs: build-cache
     runs-on: ubuntu-20.04
-    timeout-minutes: 45
+    # we have to recreate indexes multiple times: that takes a significant amount of time on pinecone
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -2939,7 +2939,8 @@ exists.
 - `isolation_level`: see SQLAlchemy's `isolation_level` parameter for `create_engine()` (https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.isolation_level)
 - `recreate_index`: If set to True, an existing Milvus index will be deleted and a new one will be
 created using the config you are using for initialization. Be aware that all data in the old index will be
-lost if you choose to recreate the index.
+lost if you choose to recreate the index. Be aware that both the document_index and the label_index will
+be recreated.
 
 <a id="milvus2.Milvus2DocumentStore.write_documents"></a>
 
@@ -4415,7 +4416,8 @@ Parameter options:
     - `"fail"`: An error is raised if the document ID of the document being added already exists.
 - `recreate_index`: If set to True, an existing Pinecone index will be deleted and a new one will be
 created using the config you are using for initialization. Be aware that all data in the old index will be
-lost if you choose to recreate the index.
+lost if you choose to recreate the index. Be aware that both the document_index and the label_index will
+be recreated.
 
 <a id="pinecone.PineconeDocumentStore.write_documents"></a>
 

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -2888,7 +2888,7 @@ does not allow these data types (yet).
 #### \_\_init\_\_
 
 ```python
-def __init__(sql_url: str = "sqlite:///", host: str = "localhost", port: str = "19530", connection_pool: str = "SingletonThread", index: str = "document", vector_dim: int = None, embedding_dim: int = 768, index_file_size: int = 1024, similarity: str = "dot_product", index_type: str = "IVF_FLAT", index_param: Optional[Dict[str, Any]] = None, search_param: Optional[Dict[str, Any]] = None, return_embedding: bool = False, embedding_field: str = "embedding", id_field: str = "id", custom_fields: Optional[List[Any]] = None, progress_bar: bool = True, duplicate_documents: str = "overwrite", isolation_level: str = None, consistency_level: int = 0)
+def __init__(sql_url: str = "sqlite:///", host: str = "localhost", port: str = "19530", connection_pool: str = "SingletonThread", index: str = "document", vector_dim: int = None, embedding_dim: int = 768, index_file_size: int = 1024, similarity: str = "dot_product", index_type: str = "IVF_FLAT", index_param: Optional[Dict[str, Any]] = None, search_param: Optional[Dict[str, Any]] = None, return_embedding: bool = False, embedding_field: str = "embedding", id_field: str = "id", custom_fields: Optional[List[Any]] = None, progress_bar: bool = True, duplicate_documents: str = "overwrite", isolation_level: str = None, consistency_level: int = 0, recreate_index: bool = False)
 ```
 
 **Arguments**:
@@ -2937,6 +2937,9 @@ overwrite: Update any existing documents with the same ID when adding documents.
 fail: an error is raised if the document ID of the document being added already
 exists.
 - `isolation_level`: see SQLAlchemy's `isolation_level` parameter for `create_engine()` (https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.isolation_level)
+- `recreate_index`: If set to True, an existing Milvus index will be deleted and a new one will be
+created using the config you are using for initialization. Be aware that all data in the old index will be
+lost if you choose to recreate the index.
 
 <a id="milvus2.Milvus2DocumentStore.write_documents"></a>
 
@@ -3171,7 +3174,7 @@ The current implementation is not supporting the storage of labels, so you canno
 #### \_\_init\_\_
 
 ```python
-def __init__(host: Union[str, List[str]] = "http://localhost", port: Union[int, List[int]] = 8080, timeout_config: tuple = (5, 15), username: str = None, password: str = None, index: str = "Document", embedding_dim: int = 768, content_field: str = "content", name_field: str = "name", similarity: str = "cosine", index_type: str = "hnsw", custom_schema: Optional[dict] = None, return_embedding: bool = False, embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = "overwrite")
+def __init__(host: Union[str, List[str]] = "http://localhost", port: Union[int, List[int]] = 8080, timeout_config: tuple = (5, 15), username: str = None, password: str = None, index: str = "Document", embedding_dim: int = 768, content_field: str = "content", name_field: str = "name", similarity: str = "cosine", index_type: str = "hnsw", custom_schema: Optional[dict] = None, return_embedding: bool = False, embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = "overwrite", recreate_index: bool = False)
 ```
 
 **Arguments**:
@@ -3205,6 +3208,9 @@ Parameter options : ( 'skip','overwrite','fail')
 skip: Ignore the duplicates documents
 overwrite: Update any existing documents with the same ID when adding documents.
 fail: an error is raised if the document ID of the document being added already exists.
+- `recreate_index`: If set to True, an existing Weaviate index will be deleted and a new one will be
+created using the config you are using for initialization. Be aware that all data in the old index will be
+lost if you choose to recreate the index.
 
 <a id="weaviate.WeaviateDocumentStore.get_document_by_id"></a>
 
@@ -4376,7 +4382,7 @@ the vector embeddings and metadata (for filtering) are indexed in a Pinecone Ind
 #### \_\_init\_\_
 
 ```python
-def __init__(api_key: str, environment: str = "us-west1-gcp", sql_url: str = "sqlite:///pinecone_document_store.db", pinecone_index: Optional[pinecone.Index] = None, embedding_dim: int = 768, return_embedding: bool = False, index: str = "document", similarity: str = "cosine", replicas: int = 1, shards: int = 1, embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = "overwrite")
+def __init__(api_key: str, environment: str = "us-west1-gcp", sql_url: str = "sqlite:///pinecone_document_store.db", pinecone_index: Optional[pinecone.Index] = None, embedding_dim: int = 768, return_embedding: bool = False, index: str = "document", similarity: str = "cosine", replicas: int = 1, shards: int = 1, embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = "overwrite", recreate_index: bool = False)
 ```
 
 **Arguments**:
@@ -4407,6 +4413,9 @@ Parameter options:
     - `"skip"`: Ignore the duplicate documents.
     - `"overwrite"`: Update any existing documents with the same ID when adding documents.
     - `"fail"`: An error is raised if the document ID of the document being added already exists.
+- `recreate_index`: If set to True, an existing Pinecone index will be deleted and a new one will be
+created using the config you are using for initialization. Be aware that all data in the old index will be
+lost if you choose to recreate the index.
 
 <a id="pinecone.PineconeDocumentStore.write_documents"></a>
 

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -195,11 +195,10 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                 "Try the OpenSearchDocumentStore instead."
             )
         if recreate_index:
-            self.delete_index(index)
-            self.delete_index(label_index)
-            self._create_document_index(index)
-            self._create_label_index(label_index)
-        elif create_index:
+            self._delete_index(index)
+            self._delete_index(label_index)
+
+        if create_index or recreate_index:
             self._create_document_index(index)
             self._create_label_index(label_index)
 
@@ -1588,6 +1587,9 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
                 f"Deletion of default index '{index}' detected. "
                 f"If you plan to use this index again, please reinstantiate '{self.__class__.__name__}' in order to avoid side-effects."
             )
+        self._delete_index(index)
+
+    def _delete_index(self, index: str):
         self.client.indices.delete(index=index, ignore=[400, 404])
         logger.debug(f"deleted elasticsearch index {index}")
 

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1590,8 +1590,9 @@ class ElasticsearchDocumentStore(KeywordDocumentStore):
         self._delete_index(index)
 
     def _delete_index(self, index: str):
-        self.client.indices.delete(index=index, ignore=[400, 404])
-        logger.debug(f"deleted elasticsearch index {index}")
+        if self.client.indices.exists(index):
+            self.client.indices.delete(index=index, ignore=[400, 404])
+            logger.info(f"Index '{index}' deleted.")
 
 
 class OpenSearchDocumentStore(ElasticsearchDocumentStore):

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -554,6 +554,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             )
         if index in self.faiss_indexes:
             del self.faiss_indexes[index]
+            logger.info(f"Index '{index}' deleted.")
         super().delete_index(index)
 
     def query_by_embedding(

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -552,7 +552,8 @@ class FAISSDocumentStore(SQLDocumentStore):
                 f"Deletion of default index '{index}' detected. "
                 f"If you plan to use this index again, please reinstantiate '{self.__class__.__name__}' in order to avoid side-effects."
             )
-        del self.faiss_indexes[index]
+        if index in self.faiss_indexes:
+            del self.faiss_indexes[index]
         super().delete_index(index)
 
     def query_by_embedding(

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -67,7 +67,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         """
         super().__init__()
 
-        self.indexes: Dict[str, Dict] = defaultdict(dict)
+        self.indexes: Dict[str, Dict] = {index: {}}
         self.index: str = index
         self.label_index: str = label_index
         self.embedding_field = embedding_field

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Generator
 import time
 import logging
 from copy import deepcopy
-from collections import defaultdict
 
 import numpy as np
 import torch

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, Generator
 import time
 import logging
 from copy import deepcopy
+from collections import defaultdict
 
 import numpy as np
 import torch
@@ -66,7 +67,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         """
         super().__init__()
 
-        self.indexes: Dict[str, Dict] = {index: {}}
+        self.indexes: Dict[str, Dict] = defaultdict(dict)
         self.index: str = index
         self.label_index: str = label_index
         self.embedding_field = embedding_field
@@ -748,12 +749,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
         :param index: The name of the index to delete.
         :return: None
         """
-        if index == self.index:
-            logger.warning(
-                f"Deletion of default index '{index}' detected. "
-                f"If you plan to use this index again, please reinstantiate '{self.__class__.__name__}' in order to avoid side-effects."
-            )
-        del self.indexes[index]
+        if index in self.indexes:
+            del self.indexes[index]
 
     def delete_labels(
         self,

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -751,6 +751,7 @@ class InMemoryDocumentStore(BaseDocumentStore):
         """
         if index in self.indexes:
             del self.indexes[index]
+            logger.info(f"Index '{index}' deleted.")
 
     def delete_labels(
         self,

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -191,7 +191,7 @@ class Milvus2DocumentStore(SQLDocumentStore):
         custom_fields = self.custom_fields or []
 
         if recreate_index:
-            self.delete_index(index)
+            self._delete_index(index)
 
         has_collection = utility.has_collection(collection_name=index)
         if not has_collection:
@@ -496,6 +496,9 @@ class Milvus2DocumentStore(SQLDocumentStore):
                 f"Deletion of default index '{index}' detected. "
                 f"If you plan to use this index again, please reinstantiate '{self.__class__.__name__}' in order to avoid side-effects."
             )
+        self._delete_index(index)
+
+    def _delete_index(self, index: str):
         if utility.has_collection(collection_name=index):
             utility.drop_collection(collection_name=index)
         super().delete_index(index)

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -128,7 +128,8 @@ class Milvus2DocumentStore(SQLDocumentStore):
         :param isolation_level: see SQLAlchemy's `isolation_level` parameter for `create_engine()` (https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.isolation_level)
         :param recreate_index: If set to True, an existing Milvus index will be deleted and a new one will be
             created using the config you are using for initialization. Be aware that all data in the old index will be
-            lost if you choose to recreate the index.
+            lost if you choose to recreate the index. Be aware that both the document_index and the label_index will
+            be recreated.
         """
         super().__init__(
             url=sql_url, index=index, duplicate_documents=duplicate_documents, isolation_level=isolation_level
@@ -192,6 +193,7 @@ class Milvus2DocumentStore(SQLDocumentStore):
 
         if recreate_index:
             self._delete_index(index)
+            super().delete_labels()
 
         has_collection = utility.has_collection(collection_name=index)
         if not has_collection:

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -496,7 +496,8 @@ class Milvus2DocumentStore(SQLDocumentStore):
                 f"Deletion of default index '{index}' detected. "
                 f"If you plan to use this index again, please reinstantiate '{self.__class__.__name__}' in order to avoid side-effects."
             )
-        utility.drop_collection(collection_name=index)
+        if utility.has_collection(collection_name=index):
+            utility.drop_collection(collection_name=index)
         super().delete_index(index)
 
     def get_all_documents_generator(

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -172,13 +172,19 @@ class Milvus2DocumentStore(SQLDocumentStore):
         self.id_field = id_field
         self.custom_fields = custom_fields
 
-        self.collection = self._create_collection_and_index(self.index, consistency_level, recreate_index=recreate_index)
+        self.collection = self._create_collection_and_index(
+            self.index, consistency_level, recreate_index=recreate_index
+        )
 
         self.return_embedding = return_embedding
         self.progress_bar = progress_bar
 
     def _create_collection_and_index(
-        self, index: Optional[str] = None, consistency_level: int = 0, index_param: Optional[Dict[str, Any]] = None, recreate_index: bool = False
+        self,
+        index: Optional[str] = None,
+        consistency_level: int = 0,
+        index_param: Optional[Dict[str, Any]] = None,
+        recreate_index: bool = False,
     ):
         index = index or self.index
         index_param = index_param or self.index_param

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -501,6 +501,7 @@ class Milvus2DocumentStore(SQLDocumentStore):
     def _delete_index(self, index: str):
         if utility.has_collection(collection_name=index):
             utility.drop_collection(collection_name=index)
+            logger.info(f"Index '{index}' deleted.")
         super().delete_index(index)
 
     def get_all_documents_generator(

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -541,6 +541,12 @@ class PineconeDocumentStore(SQLDocumentStore):
 
         super().delete_documents(index=index, ids=ids, filters=filters)
 
+    def delete_index(self, index: str):
+        index = self._sanitize_index_name(index)
+        if index in self.pinecone_indexes:
+            self.pinecone_indexes[index].delete()
+        super().delete_index(index)
+
     def query_by_embedding(
         self,
         query_emb: np.ndarray,

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -123,7 +123,7 @@ class PineconeDocumentStore(SQLDocumentStore):
                 metric_type=self.metric_type,
                 replicas=self.replicas,
                 shards=self.shards,
-                recreate_index=recreate_index
+                recreate_index=recreate_index,
             )
 
         self.return_embedding = return_embedding
@@ -143,7 +143,7 @@ class PineconeDocumentStore(SQLDocumentStore):
         metric_type: Optional[str] = "cosine",
         replicas: Optional[int] = 1,
         shards: Optional[int] = 1,
-        recreate_index: bool = False
+        recreate_index: bool = False,
     ):
         """
         Create a new index for storing documents in case an
@@ -153,7 +153,7 @@ class PineconeDocumentStore(SQLDocumentStore):
         index = self._sanitize_index_name(index)
 
         if recreate_index:
-            self.delete_index(index) 
+            self.delete_index(index)
 
         # Skip if already exists
         if index in self.pinecone_indexes.keys():
@@ -229,7 +229,7 @@ class PineconeDocumentStore(SQLDocumentStore):
                 metric_type=self.metric_type,
                 replicas=self.replicas,
                 shards=self.shards,
-                recreate_index=False
+                recreate_index=False,
             )
 
         field_map = self._create_document_field_map()

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -83,7 +83,8 @@ class PineconeDocumentStore(SQLDocumentStore):
                 - `"fail"`: An error is raised if the document ID of the document being added already exists.
         :param recreate_index: If set to True, an existing Pinecone index will be deleted and a new one will be
             created using the config you are using for initialization. Be aware that all data in the old index will be
-            lost if you choose to recreate the index.
+            lost if you choose to recreate the index. Be aware that both the document_index and the label_index will
+            be recreated.
         """
         # Connect to Pinecone server using python client binding
         pinecone.init(api_key=api_key, environment=environment)
@@ -154,6 +155,7 @@ class PineconeDocumentStore(SQLDocumentStore):
 
         if recreate_index:
             self.delete_index(index)
+            super().delete_labels()
 
         # Skip if already exists
         if index in self.pinecone_indexes.keys():

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -113,7 +113,14 @@ class PineconeDocumentStore(SQLDocumentStore):
 
         # Initialize dictionary of index connections
         self.pinecone_indexes: Dict[str, pinecone.Index] = {}
+        self.return_embedding = return_embedding
+        self.embedding_field = embedding_field
+
+        self.progress_bar = progress_bar
+
         clean_index = self._sanitize_index_name(index)
+        super().__init__(url=sql_url, index=clean_index, duplicate_documents=duplicate_documents)
+
         if pinecone_index:
             self.pinecone_indexes[clean_index] = pinecone_index
         else:
@@ -125,13 +132,6 @@ class PineconeDocumentStore(SQLDocumentStore):
                 shards=self.shards,
                 recreate_index=recreate_index,
             )
-
-        self.return_embedding = return_embedding
-        self.embedding_field = embedding_field
-
-        self.progress_bar = progress_bar
-
-        super().__init__(url=sql_url, index=clean_index, duplicate_documents=duplicate_documents)
 
     def _sanitize_index_name(self, index: str) -> str:
         return index.replace("_", "-").lower()

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -51,6 +51,7 @@ class PineconeDocumentStore(SQLDocumentStore):
         embedding_field: str = "embedding",
         progress_bar: bool = True,
         duplicate_documents: str = "overwrite",
+        recreate_index: bool = False,
     ):
         """
         :param api_key: Pinecone vector database API key ([https://app.pinecone.io](https://app.pinecone.io)).
@@ -80,6 +81,9 @@ class PineconeDocumentStore(SQLDocumentStore):
                 - `"skip"`: Ignore the duplicate documents.
                 - `"overwrite"`: Update any existing documents with the same ID when adding documents.
                 - `"fail"`: An error is raised if the document ID of the document being added already exists.
+        :param recreate_index: If set to True, an existing Pinecone index will be deleted and a new one will be
+            created using the config you are using for initialization. Be aware that all data in the old index will be
+            lost if you choose to recreate the index.
         """
         # Connect to Pinecone server using python client binding
         pinecone.init(api_key=api_key, environment=environment)
@@ -113,12 +117,13 @@ class PineconeDocumentStore(SQLDocumentStore):
         if pinecone_index:
             self.pinecone_indexes[clean_index] = pinecone_index
         else:
-            self.pinecone_indexes[clean_index] = self._create_index_if_not_exist(
+            self.pinecone_indexes[clean_index] = self._create_index(
                 embedding_dim=self.embedding_dim,
                 index=clean_index,
                 metric_type=self.metric_type,
                 replicas=self.replicas,
                 shards=self.shards,
+                recreate_index=recreate_index
             )
 
         self.return_embedding = return_embedding
@@ -131,13 +136,14 @@ class PineconeDocumentStore(SQLDocumentStore):
     def _sanitize_index_name(self, index: str) -> str:
         return index.replace("_", "-").lower()
 
-    def _create_index_if_not_exist(
+    def _create_index(
         self,
         embedding_dim: int,
         index: Optional[str] = None,
         metric_type: Optional[str] = "cosine",
         replicas: Optional[int] = 1,
         shards: Optional[int] = 1,
+        recreate_index: bool = False
     ):
         """
         Create a new index for storing documents in case an
@@ -145,6 +151,9 @@ class PineconeDocumentStore(SQLDocumentStore):
         """
         index = index or self.index
         index = self._sanitize_index_name(index)
+
+        if recreate_index:
+            self.delete_index(index) 
 
         # Skip if already exists
         if index in self.pinecone_indexes.keys():
@@ -214,12 +223,13 @@ class PineconeDocumentStore(SQLDocumentStore):
         ), f"duplicate_documents parameter must be {', '.join(self.duplicate_documents_options)}"
 
         if index not in self.pinecone_indexes:
-            self.pinecone_indexes[index] = self._create_index_if_not_exist(
+            self.pinecone_indexes[index] = self._create_index(
                 embedding_dim=self.embedding_dim,
                 index=index,
                 metric_type=self.metric_type,
                 replicas=self.replicas,
                 shards=self.shards,
+                recreate_index=False
             )
 
         field_map = self._create_document_field_map()
@@ -549,6 +559,8 @@ class PineconeDocumentStore(SQLDocumentStore):
         :return: None
         """
         index = self._sanitize_index_name(index)
+        if index in pinecone.list_indexes():
+            pinecone.delete_index(index)
         if index in self.pinecone_indexes:
             pinecone.delete_index(index)
             del self.pinecone_indexes[index]

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -544,7 +544,8 @@ class PineconeDocumentStore(SQLDocumentStore):
     def delete_index(self, index: str):
         index = self._sanitize_index_name(index)
         if index in self.pinecone_indexes:
-            self.pinecone_indexes[index].delete()
+            pinecone.delete_index(index)
+            del self.pinecone_indexes[index]
         super().delete_index(index)
 
     def query_by_embedding(

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -561,8 +561,8 @@ class PineconeDocumentStore(SQLDocumentStore):
         index = self._sanitize_index_name(index)
         if index in pinecone.list_indexes():
             pinecone.delete_index(index)
+            logger.info(f"Index '{index}' deleted.")
         if index in self.pinecone_indexes:
-            pinecone.delete_index(index)
             del self.pinecone_indexes[index]
         super().delete_index(index)
 

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -542,6 +542,12 @@ class PineconeDocumentStore(SQLDocumentStore):
         super().delete_documents(index=index, ids=ids, filters=filters)
 
     def delete_index(self, index: str):
+        """
+        Delete an existing index. The index including all data will be removed.
+
+        :param index: The name of the index to delete.
+        :return: None
+        """
         index = self._sanitize_index_name(index)
         if index in self.pinecone_indexes:
             pinecone.delete_index(index)

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -664,7 +664,7 @@ class SQLDocumentStore(BaseDocumentStore):
         :param index: The name of the index to delete.
         :return: None
         """
-        self.delete_documents(index)
+        SQLDocumentStore.delete_documents(self, index)
 
     def delete_labels(
         self,

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -1226,6 +1226,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         index = self._sanitize_index_name(index) or index
         if len([c for c in self.weaviate_client.schema.get()["classes"] if c["class"] == index]) > 0:
             self.weaviate_client.schema.delete_class(index)
+            logger.info(f"Index '{index}' deleted.")
 
     def delete_labels(self):
         """

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -70,6 +70,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         embedding_field: str = "embedding",
         progress_bar: bool = True,
         duplicate_documents: str = "overwrite",
+        recreate_index: bool = False,
     ):
         """
         :param host: Weaviate server connection URL for storing and processing documents and vectors.
@@ -101,6 +102,9 @@ class WeaviateDocumentStore(BaseDocumentStore):
                                     skip: Ignore the duplicates documents
                                     overwrite: Update any existing documents with the same ID when adding documents.
                                     fail: an error is raised if the document ID of the document being added already exists.
+        :param recreate_index: If set to True, an existing Weaviate index will be deleted and a new one will be
+            created using the config you are using for initialization. Be aware that all data in the old index will be
+            lost if you choose to recreate the index.
         """
         if similarity != "cosine":
             raise ValueError(f"Weaviate only supports cosine similarity, but you provided {similarity}")
@@ -142,7 +146,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         self.progress_bar = progress_bar
         self.duplicate_documents = duplicate_documents
 
-        self._create_schema_and_index_if_not_exist(self.index)
+        self._create_schema_and_index(self.index, recreate_index=recreate_index)
         self.uuid_format_warning_raised = False
 
     def _sanitize_index_name(self, index: Optional[str]) -> Optional[str]:
@@ -153,7 +157,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         else:
             return index[0].upper() + index[1:]
 
-    def _create_schema_and_index_if_not_exist(self, index: Optional[str] = None):
+    def _create_schema_and_index(self, index: Optional[str] = None, recreate_index: bool = False):
         """
         Create a new index (schema/class in Weaviate) for storing documents in case if an
         index (schema) with the name doesn't exist already.
@@ -182,6 +186,9 @@ class WeaviateDocumentStore(BaseDocumentStore):
                 ]
             }
         if not self.weaviate_client.schema.contains(schema):
+            self.weaviate_client.schema.create(schema)
+        elif recreate_index and index is not None:
+            self.delete_index(index)
             self.weaviate_client.schema.create(schema)
 
     def _convert_weaviate_result_to_document(self, result: dict, return_embedding: bool) -> Document:
@@ -418,7 +425,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
             raise NotImplementedError("WeaviateDocumentStore does not support headers.")
 
         index = self._sanitize_index_name(index) or self.index
-        self._create_schema_and_index_if_not_exist(index)
+        self._create_schema_and_index(index, recreate_index=False)
         field_map = self._create_document_field_map()
 
         duplicate_documents = duplicate_documents or self.duplicate_documents
@@ -1190,13 +1197,11 @@ class WeaviateDocumentStore(BaseDocumentStore):
 
         index = self._sanitize_index_name(index) or self.index
 
-        # create index if it doesn't exist yet
-        self._create_schema_and_index_if_not_exist(index)
-
         if not filters and not ids:
-            self.weaviate_client.schema.delete_class(index)
-            self._create_schema_and_index_if_not_exist(index)
+            self._create_schema_and_index(index, recreate_index=True)
         else:
+            # create index if it doesn't exist yet
+            self._create_schema_and_index(index, recreate_index=False)
             docs_to_delete = self.get_all_documents(index, filters=filters)
             if ids:
                 docs_to_delete = [doc for doc in docs_to_delete if doc.id in ids]

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -1224,7 +1224,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
 
     def _delete_index(self, index: str):
         index = self._sanitize_index_name(index) or index
-        if len([c for c in self.weaviate_client.schema.get()["classes"] if c["class"] == index]) > 0:
+        if any(c for c in self.weaviate_client.schema.get()["classes"] if c["class"] == index):
             self.weaviate_client.schema.delete_class(index)
             logger.info(f"Index '{index}' deleted.")
 

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -188,7 +188,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         if not self.weaviate_client.schema.contains(schema):
             self.weaviate_client.schema.create(schema)
         elif recreate_index and index is not None:
-            self.delete_index(index)
+            self._delete_index(index)
             self.weaviate_client.schema.create(schema)
 
     def _convert_weaviate_result_to_document(self, result: dict, return_embedding: bool) -> Document:
@@ -1220,7 +1220,12 @@ class WeaviateDocumentStore(BaseDocumentStore):
                 f"Deletion of default index '{index}' detected. "
                 f"If you plan to use this index again, please reinstantiate '{self.__class__.__name__}' in order to avoid side-effects."
             )
-        self.weaviate_client.schema.delete_class(index)
+        self._delete_index(index)
+
+    def _delete_index(self, index: str):
+        index = self._sanitize_index_name(index) or index
+        if len([c for c in self.weaviate_client.schema.get()["classes"] if c["class"] == index]) > 0:
+            self.weaviate_client.schema.delete_class(index)
 
     def delete_labels(self):
         """

--- a/haystack/json-schemas/haystack-pipeline-master.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-master.schema.json
@@ -892,6 +892,11 @@
               "title": "Consistency Level",
               "default": 0,
               "type": "integer"
+            },
+            "recreate_index": {
+              "title": "Recreate Index",
+              "default": false,
+              "type": "boolean"
             }
           },
           "additionalProperties": false,
@@ -1417,6 +1422,11 @@
               "title": "Duplicate Documents",
               "default": "overwrite",
               "type": "string"
+            },
+            "recreate_index": {
+              "title": "Recreate Index",
+              "default": false,
+              "type": "boolean"
             }
           },
           "required": [
@@ -1608,6 +1618,11 @@
               "title": "Duplicate Documents",
               "default": "overwrite",
               "type": "string"
+            },
+            "recreate_index": {
+              "title": "Recreate Index",
+              "default": false,
+              "type": "boolean"
             }
           },
           "additionalProperties": false,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -791,6 +791,7 @@ def get_document_store(
             embedding_dim=embedding_dim,
             embedding_field=embedding_field,
             similarity=similarity,
+            recreate_index=True,
         )
 
     elif document_store_type == "faiss":
@@ -824,10 +825,13 @@ def get_document_store(
             index=index,
             similarity=similarity,
             isolation_level="AUTOCOMMIT",
+            recreate_index=True,
         )
 
     elif document_store_type == "weaviate":
-        document_store = WeaviateDocumentStore(index=index, similarity=similarity, embedding_dim=embedding_dim)
+        document_store = WeaviateDocumentStore(
+            index=index, similarity=similarity, embedding_dim=embedding_dim, recreate_index=True
+        )
 
     elif document_store_type == "pinecone":
         document_store = PineconeDocumentStore(
@@ -836,6 +840,7 @@ def get_document_store(
             embedding_field=embedding_field,
             index=index,
             similarity=similarity,
+            recreate_index=True,
         )
 
     else:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -654,7 +654,7 @@ def document_store_with_docs(request, test_docs_xs, tmp_path):
     )
     document_store.write_documents(test_docs_xs)
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture
@@ -664,16 +664,7 @@ def document_store(request, tmp_path):
         document_store_type=request.param, embedding_dim=embedding_dim.args[0], tmp_path=tmp_path
     )
     yield document_store
-    document_store.delete_documents()
-
-    # Make sure to drop Milvus2 collection, required for tests using different embedding dimensions
-    if isinstance(document_store, MilvusDocumentStore) and not milvus1:
-        document_store.collection.drop()
-
-    # Make sure to delete Pinecone indexes, required for tests using different embedding dimensions
-    if isinstance(document_store, PineconeDocumentStore):
-        for index in document_store.pinecone_indexes:
-            pinecone.delete_index(index)
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture(params=["memory", "faiss", "milvus1", "milvus", "elasticsearch", "pinecone"])
@@ -686,7 +677,7 @@ def document_store_dot_product(request, tmp_path):
         tmp_path=tmp_path,
     )
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture(params=["memory", "faiss", "milvus1", "milvus", "elasticsearch", "pinecone"])
@@ -700,7 +691,7 @@ def document_store_dot_product_with_docs(request, test_docs_xs, tmp_path):
     )
     document_store.write_documents(test_docs_xs)
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture(params=["elasticsearch", "faiss", "memory", "milvus1", "pinecone"])
@@ -713,7 +704,7 @@ def document_store_dot_product_small(request, tmp_path):
         tmp_path=tmp_path,
     )
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture(params=["elasticsearch", "faiss", "memory", "milvus1", "milvus", "weaviate", "pinecone"])
@@ -723,7 +714,7 @@ def document_store_small(request, tmp_path):
         document_store_type=request.param, embedding_dim=embedding_dim.args[0], similarity="cosine", tmp_path=tmp_path
     )
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -785,8 +785,6 @@ def get_document_store(
 
     elif document_store_type == "elasticsearch":
         # make sure we start from a fresh index
-        client = Elasticsearch()
-        client.indices.delete(index=index + "*", ignore=[404])
         document_store = ElasticsearchDocumentStore(
             index=index,
             return_embedding=True,
@@ -816,10 +814,6 @@ def get_document_store(
             similarity=similarity,
             isolation_level="AUTOCOMMIT",
         )
-        _, collections = document_store.milvus_server.list_collections()
-        for collection in collections:
-            if collection.startswith(index):
-                document_store.milvus_server.drop_collection(collection)
 
     elif document_store_type == "milvus":
         document_store = MilvusDocumentStore(
@@ -834,8 +828,6 @@ def get_document_store(
 
     elif document_store_type == "weaviate":
         document_store = WeaviateDocumentStore(index=index, similarity=similarity, embedding_dim=embedding_dim)
-        document_store.weaviate_client.schema.delete_all()
-        document_store._create_schema_and_index_if_not_exist()
 
     elif document_store_type == "pinecone":
         document_store = PineconeDocumentStore(

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1211,7 +1211,10 @@ def test_update_meta(document_store: BaseDocumentStore):
 @pytest.mark.parametrize("document_store_type", ["elasticsearch", "memory"])
 def test_custom_embedding_field(document_store_type, tmp_path):
     document_store = get_document_store(
-        document_store_type=document_store_type, tmp_path=tmp_path, embedding_field="custom_embedding_field"
+        document_store_type=document_store_type,
+        tmp_path=tmp_path,
+        embedding_field="custom_embedding_field",
+        index="custom_embedding_field",
     )
     doc_to_write = {"content": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
     document_store.write_documents([doc_to_write])

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -731,8 +731,14 @@ def test_labels(document_store: BaseDocumentStore):
     assert label == labels[0]
 
     # different index
-    labels = document_store.get_all_labels(index="empty_index")
+    document_store.write_labels([label], index="another_index")
+    labels = document_store.get_all_labels(index="another_index")
+    assert len(labels) == 1
+    document_store.delete_labels(index="another_index")
+    labels = document_store.get_all_labels(index="another_index")
     assert len(labels) == 0
+    labels = document_store.get_all_labels()
+    assert len(labels) == 1
 
     # write second label + duplicate
     label2 = Label(
@@ -898,12 +904,6 @@ def test_multilabel(document_store: BaseDocumentStore):
     assert label_counts == set([2, 1, 1])
 
     assert len(multi_labels[0].answers) == len(multi_labels[0].document_ids)
-
-    # make sure there' nothing stored in another index
-    multi_labels = document_store.get_all_labels_aggregated()
-    assert len(multi_labels) == 0
-    docs = document_store.get_all_documents()
-    assert len(docs) == 0
 
 
 # exclude weaviate because it does not support storing labels

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -136,7 +136,7 @@ def test_write_with_duplicate_doc_ids_custom_index(document_store: BaseDocumentS
         Document(content="Doc1", id_hash_keys=["content"]),
         Document(content="Doc1", id_hash_keys=["content"]),
     ]
-    document_store.delete_documents(index="haystack_custom_test")
+    document_store.delete_index(index="haystack_custom_test")
     document_store.write_documents(duplicate_documents, index="haystack_custom_test", duplicate_documents="skip")
     assert len(document_store.get_all_documents(index="haystack_custom_test")) == 1
     with pytest.raises(DuplicateDocumentError):
@@ -372,13 +372,12 @@ def test_get_documents_by_id(document_store: BaseDocumentStore):
     # generate more documents than the elasticsearch default query size limit of 10
     docs_to_generate = 15
     documents = [{"content": "doc-" + str(i)} for i in range(docs_to_generate)]
-    doc_idx = "green_fields"
-    document_store.write_documents(documents, index=doc_idx)
+    document_store.write_documents(documents)
 
-    all_docs = document_store.get_all_documents(index=doc_idx)
+    all_docs = document_store.get_all_documents()
     all_ids = [doc.id for doc in all_docs]
 
-    retrieved_by_id = document_store.get_documents_by_id(all_ids, index=doc_idx)
+    retrieved_by_id = document_store.get_documents_by_id(all_ids)
     retrieved_ids = [doc.id for doc in retrieved_by_id]
 
     # all documents in the index should be retrieved when passing all document ids in the index
@@ -452,6 +451,8 @@ def test_write_document_meta(document_store: BaseDocumentStore):
 
 
 def test_write_document_index(document_store: BaseDocumentStore):
+    document_store.delete_index("haystack_test_one")
+    document_store.delete_index("haystack_test_two")
     documents = [{"content": "text1", "id": "1"}, {"content": "text2", "id": "2"}]
     document_store.write_documents([documents[0]], index="haystack_test_one")
     assert len(document_store.get_all_documents(index="haystack_test_one")) == 1
@@ -473,17 +474,15 @@ def test_document_with_embeddings(document_store: BaseDocumentStore):
         {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
         {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
-    document_store.write_documents(documents, index="haystack_test_one")
-    assert len(document_store.get_all_documents(index="haystack_test_one")) == 4
+    document_store.write_documents(documents)
+    assert len(document_store.get_all_documents()) == 4
 
     if not isinstance(document_store, WeaviateDocumentStore):
         # weaviate is excluded because it would return dummy vectors instead of None
-        documents_without_embedding = document_store.get_all_documents(
-            index="haystack_test_one", return_embedding=False
-        )
+        documents_without_embedding = document_store.get_all_documents(return_embedding=False)
         assert documents_without_embedding[0].embedding is None
 
-    documents_with_embedding = document_store.get_all_documents(index="haystack_test_one", return_embedding=True)
+    documents_with_embedding = document_store.get_all_documents(return_embedding=True)
     assert isinstance(documents_with_embedding[0].embedding, (list, np.ndarray))
 
 
@@ -497,24 +496,20 @@ def test_update_embeddings(document_store, retriever):
         documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
     documents.append({"content": "text_0", "id": "6", "meta_field": "value_0"})
 
-    document_store.write_documents(documents, index="haystack_test_one")
-    document_store.update_embeddings(retriever, index="haystack_test_one", batch_size=3)
-    documents = document_store.get_all_documents(index="haystack_test_one", return_embedding=True)
+    document_store.write_documents(documents)
+    document_store.update_embeddings(retriever, batch_size=3)
+    documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 7
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
 
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_0"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_0"]}, return_embedding=True)
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_0"
     np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
 
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_0", "value_5"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_0", "value_5"]}, return_embedding=True)
     documents_with_value_0 = [doc for doc in documents if doc.meta["meta_field"] == "value_0"]
     documents_with_value_5 = [doc for doc in documents if doc.meta["meta_field"] == "value_5"]
     np.testing.assert_raises(
@@ -530,27 +525,21 @@ def test_update_embeddings(document_store, retriever):
         "meta_field": "value_7",
         "embedding": retriever.embed_queries(texts=["a random string"])[0],
     }
-    document_store.write_documents([doc], index="haystack_test_one")
+    document_store.write_documents([doc])
 
     documents = []
     for i in range(8, 11):
         documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
-    document_store.write_documents(documents, index="haystack_test_one")
+    document_store.write_documents(documents)
 
-    doc_before_update = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_7"]}
-    )[0]
+    doc_before_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
     embedding_before_update = doc_before_update.embedding
 
     # test updating only documents without embeddings
     if not isinstance(document_store, WeaviateDocumentStore):
         # All the documents in Weaviate store have an embedding by default. "update_existing_embeddings=False" is not allowed
-        document_store.update_embeddings(
-            retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=False
-        )
-        doc_after_update = document_store.get_all_documents(
-            index="haystack_test_one", filters={"meta_field": ["value_7"]}
-        )[0]
+        document_store.update_embeddings(retriever, batch_size=3, update_existing_embeddings=False)
+        doc_after_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
         embedding_after_update = doc_after_update.embedding
         np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
 
@@ -558,26 +547,18 @@ def test_update_embeddings(document_store, retriever):
     if isinstance(document_store, FAISSDocumentStore):
         with pytest.raises(Exception):
             document_store.update_embeddings(
-                retriever, index="haystack_test_one", update_existing_embeddings=True, filters={"meta_field": ["value"]}
+                retriever, update_existing_embeddings=True, filters={"meta_field": ["value"]}
             )
     else:
-        document_store.update_embeddings(
-            retriever, index="haystack_test_one", batch_size=3, filters={"meta_field": ["value_0", "value_1"]}
-        )
-        doc_after_update = document_store.get_all_documents(
-            index="haystack_test_one", filters={"meta_field": ["value_7"]}
-        )[0]
+        document_store.update_embeddings(retriever, batch_size=3, filters={"meta_field": ["value_0", "value_1"]})
+        doc_after_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
         embedding_after_update = doc_after_update.embedding
         np.testing.assert_array_equal(embedding_before_update, embedding_after_update)
 
     # test update all embeddings
-    document_store.update_embeddings(
-        retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=True
-    )
-    assert document_store.get_embedding_count(index="haystack_test_one") == 11
-    doc_after_update = document_store.get_all_documents(index="haystack_test_one", filters={"meta_field": ["value_7"]})[
-        0
-    ]
+    document_store.update_embeddings(retriever, batch_size=3, update_existing_embeddings=True)
+    assert document_store.get_embedding_count() == 11
+    doc_after_update = document_store.get_all_documents(filters={"meta_field": ["value_7"]})[0]
     embedding_after_update = doc_after_update.embedding
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, embedding_before_update, embedding_after_update
@@ -587,14 +568,12 @@ def test_update_embeddings(document_store, retriever):
     documents = []
     for i in range(12, 15):
         documents.append({"content": f"text_{i}", "id": str(i), "meta_field": f"value_{i}"})
-    document_store.write_documents(documents, index="haystack_test_one")
+    document_store.write_documents(documents)
 
     if not isinstance(document_store, WeaviateDocumentStore):
         # All the documents in Weaviate store have an embedding by default. "update_existing_embeddings=False" is not allowed
-        document_store.update_embeddings(
-            retriever, index="haystack_test_one", batch_size=3, update_existing_embeddings=False
-        )
-        assert document_store.get_embedding_count(index="haystack_test_one") == 14
+        document_store.update_embeddings(retriever, batch_size=3, update_existing_embeddings=False)
+        assert document_store.get_embedding_count() == 14
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
@@ -624,26 +603,22 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
         }
     )
 
-    document_store.write_documents(documents, index="haystack_test_one")
-    document_store.update_embeddings(retriever, index="haystack_test_one", batch_size=3)
-    documents = document_store.get_all_documents(index="haystack_test_one", return_embedding=True)
+    document_store.write_documents(documents)
+    document_store.update_embeddings(retriever, batch_size=3)
+    documents = document_store.get_all_documents(return_embedding=True)
     assert len(documents) == 8
     for doc in documents:
         assert type(doc.embedding) is np.ndarray
 
     # Check if Documents with same content (text) get same embedding
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_text_0"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_text_0"]}, return_embedding=True)
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_text_0"
     np.testing.assert_array_almost_equal(documents[0].embedding, documents[1].embedding, decimal=4)
 
     # Check if Documents with same content (table) get same embedding
-    documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_table_0"]}, return_embedding=True
-    )
+    documents = document_store.get_all_documents(filters={"meta_field": ["value_table_0"]}, return_embedding=True)
     assert len(documents) == 2
     for doc in documents:
         assert doc.meta["meta_field"] == "value_table_0"
@@ -651,7 +626,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
 
     # Check if Documents wih different content (text) get different embedding
     documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_text_1", "value_text_2"]}, return_embedding=True
+        filters={"meta_field": ["value_text_1", "value_text_2"]}, return_embedding=True
     )
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, documents[0].embedding, documents[1].embedding
@@ -659,7 +634,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
 
     # Check if Documents with different content (table) get different embeddings
     documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_table_1", "value_table_2"]}, return_embedding=True
+        filters={"meta_field": ["value_table_1", "value_table_2"]}, return_embedding=True
     )
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, documents[0].embedding, documents[1].embedding
@@ -667,7 +642,7 @@ def test_update_embeddings_table_text_retriever(document_store, retriever):
 
     # Check if Documents with different content (table + text) get different embeddings
     documents = document_store.get_all_documents(
-        index="haystack_test_one", filters={"meta_field": ["value_text_1", "value_table_1"]}, return_embedding=True
+        filters={"meta_field": ["value_text_1", "value_table_1"]}, return_embedding=True
     )
     np.testing.assert_raises(
         AssertionError, np.testing.assert_array_equal, documents[0].embedding, documents[1].embedding
@@ -750,13 +725,13 @@ def test_labels(document_store: BaseDocumentStore):
         no_answer=False,
         origin="gold-label",
     )
-    document_store.write_labels([label], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label])
+    labels = document_store.get_all_labels()
     assert len(labels) == 1
     assert label == labels[0]
 
     # different index
-    labels = document_store.get_all_labels()
+    labels = document_store.get_all_labels(index="empty_index")
     assert len(labels) == 0
 
     # write second label + duplicate
@@ -776,8 +751,8 @@ def test_labels(document_store: BaseDocumentStore):
         no_answer=False,
         origin="gold-label",
     )
-    document_store.write_labels([label, label2], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label, label2])
+    labels = document_store.get_all_labels()
 
     # check that second label has been added but not the duplicate
     assert len(labels) == 2
@@ -785,37 +760,37 @@ def test_labels(document_store: BaseDocumentStore):
     assert label2 in labels
 
     # delete filtered label2 by id
-    document_store.delete_labels(index="haystack_test_label", ids=[labels[1].id])
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels(ids=[labels[1].id])
+    labels = document_store.get_all_labels()
     assert label == labels[0]
     assert len(labels) == 1
 
     # re-add label2
-    document_store.write_labels([label2], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label2])
+    labels = document_store.get_all_labels()
     assert len(labels) == 2
 
     # delete filtered label2 by query text
-    document_store.delete_labels(index="haystack_test_label", filters={"query": [labels[1].query]})
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels(filters={"query": [labels[1].query]})
+    labels = document_store.get_all_labels()
     assert label == labels[0]
     assert len(labels) == 1
 
     # re-add label2
-    document_store.write_labels([label2], index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.write_labels([label2])
+    labels = document_store.get_all_labels()
     assert len(labels) == 2
 
     # delete intersection of filters and ids, which is empty
-    document_store.delete_labels(index="haystack_test_label", ids=[labels[0].id], filters={"query": [labels[1].query]})
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels(ids=[labels[0].id], filters={"query": [labels[1].query]})
+    labels = document_store.get_all_labels()
     assert len(labels) == 2
     assert label in labels
     assert label2 in labels
 
     # delete all labels
-    document_store.delete_labels(index="haystack_test_label")
-    labels = document_store.get_all_labels(index="haystack_test_label")
+    document_store.delete_labels()
+    labels = document_store.get_all_labels()
     assert len(labels) == 0
 
 
@@ -878,21 +853,19 @@ def test_multilabel(document_store: BaseDocumentStore):
             origin="gold-label",
         ),
     ]
-    document_store.write_labels(labels, index="haystack_test_multilabel")
+    document_store.write_labels(labels)
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels()
     assert list_labels == labels
     assert len(list_labels) == 5
 
     # Currently we don't enforce writing (missing) docs automatically when adding labels and there's no DB relationship between the two.
     # We should introduce this when we refactored the logic of "index" to be rather a "collection" of labels+documents
-    # docs = document_store.get_all_documents(index="haystack_test_multilabel")
+    # docs = document_store.get_all_documents()
     # assert len(docs) == 3
 
     # Multi labels (open domain)
-    multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True
-    )
+    multi_labels_open = document_store.get_all_labels_aggregated(open_domain=True, drop_negative_labels=True)
 
     # for open-domain we group all together as long as they have the same question
     assert len(multi_labels_open) == 1
@@ -904,7 +877,7 @@ def test_multilabel(document_store: BaseDocumentStore):
 
     # Don't drop the negative label
     multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_no_answers=False, drop_negative_labels=False
+        open_domain=True, drop_no_answers=False, drop_negative_labels=False
     )
     assert len(multi_labels_open[0].labels) == 5
     assert len(multi_labels_open[0].answers) == 4
@@ -912,16 +885,14 @@ def test_multilabel(document_store: BaseDocumentStore):
 
     # Drop no answer + negative
     multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_no_answers=True, drop_negative_labels=True
+        open_domain=True, drop_no_answers=True, drop_negative_labels=True
     )
     assert len(multi_labels_open[0].labels) == 3
     assert len(multi_labels_open[0].answers) == 3
     assert len(multi_labels_open[0].document_ids) == 3
 
     # for closed domain we group by document so we expect 3 multilabels with 2,1,1 labels each (negative dropped again)
-    multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=False, drop_negative_labels=True
-    )
+    multi_labels = document_store.get_all_labels_aggregated(open_domain=False, drop_negative_labels=True)
     assert len(multi_labels) == 3
     label_counts = set([len(ml.labels) for ml in multi_labels])
     assert label_counts == set([2, 1, 1])
@@ -980,13 +951,13 @@ def test_multilabel_no_answer(document_store: BaseDocumentStore):
         ),
     ]
 
-    document_store.write_labels(labels, index="haystack_test_multilabel_no_answer")
+    document_store.write_labels(labels)
 
-    labels = document_store.get_all_labels(index="haystack_test_multilabel_no_answer")
+    labels = document_store.get_all_labels()
     assert len(labels) == 4
 
     multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel_no_answer", open_domain=True, drop_no_answers=False, drop_negative_labels=True
+        open_domain=True, drop_no_answers=False, drop_negative_labels=True
     )
     assert len(multi_labels) == 1
     assert multi_labels[0].no_answer == True
@@ -994,7 +965,7 @@ def test_multilabel_no_answer(document_store: BaseDocumentStore):
     assert len(multi_labels[0].answers) == 1
 
     multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel_no_answer", open_domain=True, drop_no_answers=False, drop_negative_labels=False
+        open_domain=True, drop_no_answers=False, drop_negative_labels=False
     )
     assert len(multi_labels) == 1
     assert multi_labels[0].no_answer == True
@@ -1068,16 +1039,14 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
             filters={"name": ["123"]},
         ),
     ]
-    document_store.write_labels(labels, index="haystack_test_multilabel")
+    document_store.write_labels(labels)
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels()
     assert list_labels == labels
     assert len(list_labels) == 5
 
     # Multi labels (open domain)
-    multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True
-    )
+    multi_labels_open = document_store.get_all_labels_aggregated(open_domain=True, drop_negative_labels=True)
 
     # for open-domain we group all together as long as they have the same question and filters
     assert len(multi_labels_open) == 3
@@ -1089,9 +1058,7 @@ def test_multilabel_filter_aggregations(document_store: BaseDocumentStore):
     assert len(multi_labels_open[0].answers) == len(multi_labels_open[0].document_ids)
 
     # for closed domain we group by document so we expect the same as with filters
-    multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=False, drop_negative_labels=True
-    )
+    multi_labels = document_store.get_all_labels_aggregated(open_domain=False, drop_negative_labels=True)
     assert len(multi_labels) == 3
     label_counts = set([len(ml.labels) for ml in multi_labels])
     assert label_counts == set([2, 1, 1])
@@ -1164,23 +1131,21 @@ def test_multilabel_meta_aggregations(document_store: BaseDocumentStore):
             meta={"file_id": ["888"]},
         ),
     ]
-    document_store.write_labels(labels, index="haystack_test_multilabel")
+    document_store.write_labels(labels)
     # regular labels - not aggregated
-    list_labels = document_store.get_all_labels(index="haystack_test_multilabel")
+    list_labels = document_store.get_all_labels()
     assert list_labels == labels
     assert len(list_labels) == 5
 
     # Multi labels (open domain)
-    multi_labels_open = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True
-    )
+    multi_labels_open = document_store.get_all_labels_aggregated(open_domain=True, drop_negative_labels=True)
 
     # for open-domain we group all together as long as they have the same question and filters
     assert len(multi_labels_open) == 1
     assert len(multi_labels_open[0].labels) == 5
 
     multi_labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_multilabel", open_domain=True, drop_negative_labels=True, aggregate_by_meta="file_id"
+        open_domain=True, drop_negative_labels=True, aggregate_by_meta="file_id"
     )
     assert len(multi_labels) == 4
     label_counts = set([len(ml.labels) for ml in multi_labels])
@@ -1254,10 +1219,11 @@ def test_get_meta_values_by_key(document_store: BaseDocumentStore):
 
 @pytest.mark.elasticsearch
 def test_elasticsearch_custom_fields():
-    client = Elasticsearch()
-    client.indices.delete(index="haystack_test_custom", ignore=[404])
     document_store = ElasticsearchDocumentStore(
-        index="haystack_test_custom", content_field="custom_text_field", embedding_field="custom_embedding_field"
+        index="haystack_test_custom",
+        content_field="custom_text_field",
+        embedding_field="custom_embedding_field",
+        recreate_index=True,
     )
 
     doc_to_write = {"custom_text_field": "test", "custom_embedding_field": np.random.rand(768).astype(np.float32)}
@@ -1287,7 +1253,7 @@ def test_elasticsearch_delete_index():
 
 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
-def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store: BaseDocumentStore):
+def test_elasticsearch_query_with_filters_and_missing_embeddings(document_store: ElasticsearchDocumentStore):
     document_store.write_documents(DOCUMENTS)
     document_without_embedding = Document(
         content="Doc without embedding", meta={"name": "name_7", "year": "2021", "month": "04"}
@@ -1331,8 +1297,7 @@ def test_get_document_count_only_documents_without_embedding_arg():
     ]
 
     _index: str = "haystack_test_count"
-    document_store = ElasticsearchDocumentStore(index=_index)
-    document_store.delete_documents(index=_index)
+    document_store = ElasticsearchDocumentStore(index=_index, recreate_index=True)
 
     document_store.write_documents(documents)
 
@@ -1360,7 +1325,7 @@ def test_skip_missing_embeddings():
         {"content": "text3", "id": "3", "embedding": np.random.rand(768).astype(np.float32).tolist()},
         {"content": "text4", "id": "4", "embedding": np.random.rand(768).astype(np.float32)},
     ]
-    document_store = ElasticsearchDocumentStore(index="skip_missing_embedding_index")
+    document_store = ElasticsearchDocumentStore(index="skip_missing_embedding_index", recreate_index=True)
     document_store.write_documents(documents)
 
     document_store.skip_missing_embeddings = True

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -85,21 +85,21 @@ def test_add_eval_data(document_store, batch_size):
     # add eval data (SQUAD format)
     document_store.add_eval_data(
         filename=SAMPLES_PATH / "squad" / "small.json",
-        doc_index="haystack_test_eval_document",
-        label_index="haystack_test_feedback",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
         batch_size=batch_size,
     )
 
-    assert document_store.get_document_count(index="haystack_test_eval_document") == 87
-    assert document_store.get_label_count(index="haystack_test_feedback") == 1214
+    assert document_store.get_document_count() == 87
+    assert document_store.get_label_count() == 1214
 
     # test documents
-    docs = document_store.get_all_documents(index="haystack_test_eval_document", filters={"name": ["Normans"]})
+    docs = document_store.get_all_documents(filters={"name": ["Normans"]})
     assert docs[0].meta["name"] == "Normans"
     assert len(docs[0].meta.keys()) == 1
 
     # test labels
-    labels = document_store.get_all_labels(index="haystack_test_feedback")
+    labels = document_store.get_all_labels()
     label = None
     for l in labels:
         if l.query == "In what country is Normandy located?":
@@ -119,7 +119,7 @@ def test_add_eval_data(document_store, batch_size):
     assert label.answer.document_id == label.document.id
 
     # check combination
-    doc = document_store.get_document_by_id(label.document.id, index="haystack_test_eval_document")
+    doc = document_store.get_document_by_id(label.document.id)
     start = label.answer.offsets_in_document[0].start
     end = label.answer.offsets_in_document[0].end
     assert end == start + len(label.answer.answer)
@@ -129,22 +129,22 @@ def test_add_eval_data(document_store, batch_size):
 @pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus1"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 @pytest.mark.parametrize("use_confidence_scores", [True, False])
-def test_eval_reader(reader, document_store: BaseDocumentStore, use_confidence_scores):
+def test_eval_reader(reader, document_store, use_confidence_scores):
     # add eval data (SQUAD format)
     document_store.add_eval_data(
         filename=SAMPLES_PATH / "squad" / "tiny.json",
-        doc_index="haystack_test_eval_document",
-        label_index="haystack_test_feedback",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
     )
-    assert document_store.get_document_count(index="haystack_test_eval_document") == 2
+    assert document_store.get_document_count() == 2
 
     reader.use_confidence_scores = use_confidence_scores
 
     # eval reader
     reader_eval_results = reader.eval(
         document_store=document_store,
-        label_index="haystack_test_feedback",
-        doc_index="haystack_test_eval_document",
+        label_index=document_store.label_index,
+        doc_index=document_store.index,
         device="cpu",
     )
 
@@ -162,18 +162,18 @@ def test_eval_reader(reader, document_store: BaseDocumentStore, use_confidence_s
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 @pytest.mark.parametrize("open_domain", [True, False])
 @pytest.mark.parametrize("retriever", ["elasticsearch"], indirect=True)
-def test_eval_elastic_retriever(document_store: BaseDocumentStore, open_domain, retriever):
+def test_eval_elastic_retriever(document_store, open_domain, retriever):
     # add eval data (SQUAD format)
     document_store.add_eval_data(
         filename=SAMPLES_PATH / "squad" / "tiny.json",
-        doc_index="haystack_test_eval_document",
-        label_index="haystack_test_feedback",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
     )
-    assert document_store.get_document_count(index="haystack_test_eval_document") == 2
+    assert document_store.get_document_count() == 2
 
     # eval retriever
     results = retriever.eval(
-        top_k=1, label_index="haystack_test_feedback", doc_index="haystack_test_eval_document", open_domain=open_domain
+        top_k=1, label_index=document_store.label_index, doc_index=document_store.index, open_domain=open_domain
     )
     assert results["recall"] == 1.0
     assert results["mrr"] == 1.0
@@ -186,24 +186,22 @@ def test_eval_elastic_retriever(document_store: BaseDocumentStore, open_domain, 
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 @pytest.mark.parametrize("retriever", ["elasticsearch"], indirect=True)
-def test_eval_pipeline(document_store: BaseDocumentStore, reader, retriever):
+def test_eval_pipeline(document_store, reader, retriever):
     # add eval data (SQUAD format)
     document_store.add_eval_data(
         filename=SAMPLES_PATH / "squad" / "tiny.json",
-        doc_index="haystack_test_eval_document",
-        label_index="haystack_test_feedback",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
     )
 
-    labels = document_store.get_all_labels_aggregated(
-        index="haystack_test_feedback", drop_negative_labels=True, drop_no_answers=False
-    )
+    labels = document_store.get_all_labels_aggregated(drop_negative_labels=True, drop_no_answers=False)
 
     eval_retriever = EvalDocuments()
     eval_reader = EvalAnswers(sas_model="sentence-transformers/paraphrase-MiniLM-L3-v2", debug=True)
     eval_reader_cross = EvalAnswers(sas_model="cross-encoder/stsb-TinyBERT-L-4", debug=True)
     eval_reader_vanila = EvalAnswers()
 
-    assert document_store.get_document_count(index="haystack_test_eval_document") == 2
+    assert document_store.get_document_count() == 2
     p = Pipeline()
     p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
     p.add_node(component=eval_retriever, name="EvalDocuments", inputs=["ESRetriever"])
@@ -236,12 +234,12 @@ def test_eval_data_split_word(document_store):
 
     document_store.add_eval_data(
         filename=SAMPLES_PATH / "squad" / "tiny.json",
-        doc_index="haystack_test_eval_document",
-        label_index="haystack_test_feedback",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
         preprocessor=preprocessor,
     )
-    labels = document_store.get_all_labels_aggregated(index="haystack_test_feedback")
-    docs = document_store.get_all_documents(index="haystack_test_eval_document")
+    labels = document_store.get_all_labels_aggregated()
+    docs = document_store.get_all_documents()
     assert len(docs) == 5
     assert len(set(labels[0].document_ids)) == 2
 
@@ -261,11 +259,11 @@ def test_eval_data_split_passage(document_store):
 
     document_store.add_eval_data(
         filename=SAMPLES_PATH / "squad" / "tiny_passages.json",
-        doc_index="haystack_test_eval_document",
-        label_index="haystack_test_feedback",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
         preprocessor=preprocessor,
     )
-    docs = document_store.get_all_documents(index="haystack_test_eval_document")
+    docs = document_store.get_all_documents()
     assert len(docs) == 2
     assert len(docs[1].content) == 56
 

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -210,7 +210,7 @@ def test_eval_pipeline(document_store, reader, retriever):
     p.add_node(component=eval_reader_cross, name="EvalAnswers_cross", inputs=["QAReader"])
     p.add_node(component=eval_reader_vanila, name="EvalAnswers_vanilla", inputs=["QAReader"])
     for l in labels:
-        res = p.run(query=l.query, labels=l, params={"ESRetriever": {"index": "haystack_test_eval_document"}})
+        res = p.run(query=l.query, labels=l)
     assert eval_retriever.recall == 1.0
     assert round(eval_reader.top_k_f1, 4) == 0.8333
     assert eval_reader.top_k_em == 0.5

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -192,9 +192,7 @@ def test_retribert_embedding(document_store, retriever, docs):
     if isinstance(document_store, WeaviateDocumentStore):
         # Weaviate sets the embedding dimension to 768 as soon as it is initialized.
         # We need 128 here and therefore initialize a new WeaviateDocumentStore.
-        document_store = WeaviateDocumentStore(index="haystack_test", embedding_dim=128)
-        document_store.weaviate_client.schema.delete_all()
-        document_store._create_schema_and_index_if_not_exist()
+        document_store = WeaviateDocumentStore(index="haystack_test", embedding_dim=128, recreate_index=True)
     document_store.return_embedding = True
     document_store.write_documents(docs)
     document_store.update_embeddings(retriever=retriever)

--- a/test/test_weaviate.py
+++ b/test/test_weaviate.py
@@ -50,14 +50,14 @@ def document_store_with_docs(request, tmp_path):
     document_store = get_document_store(request.param, tmp_path=tmp_path)
     document_store.write_documents(DOCUMENTS_XS)
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.fixture(params=["weaviate"])
 def document_store(request, tmp_path):
     document_store = get_document_store(request.param, tmp_path=tmp_path)
     yield document_store
-    document_store.delete_documents()
+    document_store.delete_index(document_store.index)
 
 
 @pytest.mark.weaviate


### PR DESCRIPTION
To reset the document store for tests `delete_index` is cleaner than `delete_documents` as the latter does not remove properties that have been selected at index creation time (e.g. field mapping, embedding dimensions, similarity spaces). Additionally fixture `document_store` implements index deletion on its own for Milvus and Pinecone.

This PR facilitates and standardizes index cleaning in tests. 

**Proposed changes**:
- use `delete_index` instead of `delete_documents` in tests
- properly implement `delete_index` for all document stores
- add `recreate_index` param to Pincone, Milvus and Weaviate

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
