### PR TITLE
Rename dataset to evaluation_set when logging to mlflow

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -901,8 +901,8 @@ class Pipeline(BasePipeline):
             )
             tracker.track_params(
                 {
-                    "dataset_label_count": len(evaluation_set_labels),
-                    "dataset": evaluation_set_meta,
+                    "evaluation_set_label_count": len(evaluation_set_labels),
+                    "evaluation_set": evaluation_set_meta,
                     "sas_model_name_or_path": sas_model_name_or_path,
                     "sas_batch_size": sas_batch_size,
                     "sas_use_gpu": sas_use_gpu,


### PR DESCRIPTION
**Proposed changes**:
- rename param "dataset" to "evaluation_set" to be consistent in terminology when logging to mlflow

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
