### PR TITLE
Update docs of DeepsetCloudDocumentStore

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -3997,8 +3997,9 @@ skip: Ignore the duplicates documents
 overwrite: Update any existing documents with the same ID when adding documents.
 fail: an error is raised if the document ID of the document being added already
 exists.
-- `api_endpoint`: The URL of the Deepset Cloud API. Usually this is: "https://api.cloud.deepset.ai/api/v1".
+- `api_endpoint`: The URL of the Deepset Cloud API.
 If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment variable.
+If DEEPSET_CLOUD_API_ENDPOINT environment variable is not specified either, defaults to "https://api.cloud.deepset.ai/api/v1".
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default since it is
 more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence Transformer model.
 - `label_index`: index for the evaluation set interface

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -3987,18 +3987,20 @@ See https://haystack.deepset.ai/components/document-store for more information.
 
 - `api_key`: Secret value of the API key.
 If not specified, will be read from DEEPSET_CLOUD_API_KEY environment variable.
-- `workspace`: workspace in Deepset Cloud
-- `index`: index to access within the Deepset Cloud workspace
+See docs on how to generate an API key for your workspace: https://docs.cloud.deepset.ai/docs/connect-deepset-cloud-to-your-application
+- `workspace`: workspace name in Deepset Cloud
+- `index`: name of the index to access within the Deepset Cloud workspace. This equals typically the name of your pipeline.
+You can run Pipeline.list_pipelines_on_deepset_cloud() to see all available ones.
 - `duplicate_documents`: Handle duplicates document based on parameter options.
 Parameter options : ( 'skip','overwrite','fail')
 skip: Ignore the duplicates documents
 overwrite: Update any existing documents with the same ID when adding documents.
 fail: an error is raised if the document ID of the document being added already
 exists.
-- `api_endpoint`: The URL of the Deepset Cloud API.
+- `api_endpoint`: The URL of the Deepset Cloud API. Usually this is: "https://api.cloud.deepset.ai/api/v1".
 If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment variable.
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default since it is
-more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
+more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence Transformer model.
 - `label_index`: index for the evaluation set interface
 - `return_embedding`: To return document embedding.
 

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -9,8 +9,6 @@ from haystack.schema import Document, Label
 from haystack.utils import DeepsetCloud
 
 
-DEFAULT_API_ENDPOINT = "https://api.cloud.deepset.ai/api/v1"
-
 logger = logging.getLogger(__name__)
 
 

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -37,8 +37,8 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
                         If not specified, will be read from DEEPSET_CLOUD_API_KEY environment variable.
                         See docs on how to generate an API key for your workspace: https://docs.cloud.deepset.ai/docs/connect-deepset-cloud-to-your-application
         :param workspace: workspace name in Deepset Cloud
-        :param index: name of the index to access within the Deepset Cloud workspace. This equals typically the name of your pipeline. 
-                      You can run Pipeline.list_pipelines_on_deepset_cloud() to see all available ones. 
+        :param index: name of the index to access within the Deepset Cloud workspace. This equals typically the name of your pipeline.
+                      You can run Pipeline.list_pipelines_on_deepset_cloud() to see all available ones.
         :param duplicate_documents: Handle duplicates document based on parameter options.
                                     Parameter options : ( 'skip','overwrite','fail')
                                     skip: Ignore the duplicates documents

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -9,7 +9,7 @@ from haystack.schema import Document, Label
 from haystack.utils import DeepsetCloud
 
 
-DEFAULT_API_ENDPOINT = f"DC_API_PLACEHOLDER/v1"  # TODO
+DEFAULT_API_ENDPOINT = "https://api.cloud.deepset.ai/api/v1"
 
 logger = logging.getLogger(__name__)
 
@@ -35,18 +35,20 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
 
         :param api_key: Secret value of the API key.
                         If not specified, will be read from DEEPSET_CLOUD_API_KEY environment variable.
-        :param workspace: workspace in Deepset Cloud
-        :param index: index to access within the Deepset Cloud workspace
+                        See docs on how to generate an API key for your workspace: https://docs.cloud.deepset.ai/docs/connect-deepset-cloud-to-your-application
+        :param workspace: workspace name in Deepset Cloud
+        :param index: name of the index to access within the Deepset Cloud workspace. This equals typically the name of your pipeline. 
+                      You can run Pipeline.list_pipelines_on_deepset_cloud() to see all available ones. 
         :param duplicate_documents: Handle duplicates document based on parameter options.
                                     Parameter options : ( 'skip','overwrite','fail')
                                     skip: Ignore the duplicates documents
                                     overwrite: Update any existing documents with the same ID when adding documents.
                                     fail: an error is raised if the document ID of the document being added already
                                     exists.
-        :param api_endpoint: The URL of the Deepset Cloud API.
+        :param api_endpoint: The URL of the Deepset Cloud API. Usually this is: "https://api.cloud.deepset.ai/api/v1".
                              If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment variable.
         :param similarity: The similarity function used to compare document vectors. 'dot_product' is the default since it is
-                           more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence BERT model.
+                           more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence Transformer model.
         :param label_index: index for the evaluation set interface
 
         :param return_embedding: To return document embedding.

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -45,8 +45,9 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
                                     overwrite: Update any existing documents with the same ID when adding documents.
                                     fail: an error is raised if the document ID of the document being added already
                                     exists.
-        :param api_endpoint: The URL of the Deepset Cloud API. Usually this is: "https://api.cloud.deepset.ai/api/v1".
+        :param api_endpoint: The URL of the Deepset Cloud API.
                              If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment variable.
+                             If DEEPSET_CLOUD_API_ENDPOINT environment variable is not specified either, defaults to "https://api.cloud.deepset.ai/api/v1".
         :param similarity: The similarity function used to compare document vectors. 'dot_product' is the default since it is
                            more performant with DPR embeddings. 'cosine' is recommended if you are using a Sentence Transformer model.
         :param label_index: index for the evaluation set interface

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -16,7 +16,7 @@ import requests
 from haystack.schema import Label, Document, Answer
 
 
-DEFAULT_API_ENDPOINT = f"DC_API_PLACEHOLDER/v1"  # TODO
+DEFAULT_API_ENDPOINT = "https://api.cloud.deepset.ai/api/v1"
 
 
 class PipelineStatus(Enum):


### PR DESCRIPTION
**Proposed changes**:
Updating a few doc strings of the DeepsetCloudDocumentStore

@tstadel not sure about the usage of "DEFAULT_API_ENDPOINT". Where is this one actually used? Does it make sense to update it to the actual endpoint now?

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
