### PR TITLE
Renaming the ElasticsearchFilterOnlyRetriever to FilterRetriever

### DIFF
--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -204,18 +204,18 @@ that are most relevant to the query.
 - `headers`: Custom HTTP headers to pass to elasticsearch client (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='})
 Check out https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html for more information.
 
-<a id="sparse.ElasticsearchFilterOnlyRetriever"></a>
+<a id="sparse.FilterRetriever"></a>
 
-## ElasticsearchFilterOnlyRetriever
+## FilterRetriever
 
 ```python
-class ElasticsearchFilterOnlyRetriever(BM25Retriever)
+class FilterRetriever(BM25Retriever)
 ```
 
 Naive "Retriever" that returns all documents that match the given filters. No impact of query at all.
 Helpful for benchmarking, testing and if you want to do QA on small documents without an "active" retriever.
 
-<a id="sparse.ElasticsearchFilterOnlyRetriever.retrieve"></a>
+<a id="sparse.FilterRetriever.retrieve"></a>
 
 #### retrieve
 

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -112,7 +112,7 @@ def __init__(document_store: KeywordDocumentStore, top_k: int = 10, all_terms_mu
 
 **Arguments**:
 
-- `document_store`: an instance of an ElasticsearchDocumentStore to retrieve documents from.
+- `document_store`: an instance of one of the following DocumentStores to retrieve from: ElasticsearchDocumentStore, OpenSearchDocumentStore and OpenDistroElasticsearchDocumentStore
 - `all_terms_must_match`: Whether all terms of the query must match the document.
 If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
 Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").

--- a/haystack/json-schemas/haystack-pipeline-master.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-master.schema.json
@@ -93,6 +93,9 @@
             "$ref": "#/definitions/FileTypeClassifierComponent"
           },
           {
+            "$ref": "#/definitions/FilterRetrieverComponent"
+          },
+          {
             "$ref": "#/definitions/ImageToTextConverterComponent"
           },
           {
@@ -2560,6 +2563,56 @@
               }
             }
           },
+          "additionalProperties": false,
+          "description": "Each parameter can reference other components defined in the same YAML file."
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "FilterRetrieverComponent": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "Custom name for the component. Helpful for visualization and debugging.",
+          "type": "string"
+        },
+        "type": {
+          "title": "Type",
+          "description": "Haystack Class name for the component.",
+          "type": "string",
+          "const": "FilterRetriever"
+        },
+        "params": {
+          "title": "Parameters",
+          "type": "object",
+          "properties": {
+            "document_store": {
+              "title": "Document Store",
+              "type": "string"
+            },
+            "top_k": {
+              "title": "Top K",
+              "default": 10,
+              "type": "integer"
+            },
+            "all_terms_must_match": {
+              "title": "All Terms Must Match",
+              "default": false,
+              "type": "boolean"
+            },
+            "custom_query": {
+              "title": "Custom Query",
+              "type": "string"
+            }
+          },
+          "required": [
+            "document_store"
+          ],
           "additionalProperties": false,
           "description": "Each parameter can reference other components defined in the same YAML file."
         }

--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -32,6 +32,7 @@ from haystack.nodes.retriever import (
     EmbeddingRetriever,
     BM25Retriever,
     ElasticsearchRetriever,
+    FilterRetriever,
     ElasticsearchFilterOnlyRetriever,
     TfidfRetriever,
     Text2SparqlRetriever,

--- a/haystack/nodes/retriever/__init__.py
+++ b/haystack/nodes/retriever/__init__.py
@@ -4,6 +4,7 @@ from haystack.nodes.retriever.sparse import (
     BM25Retriever,
     ElasticsearchRetriever,
     ElasticsearchFilterOnlyRetriever,
+    FilterRetriever,
     TfidfRetriever,
 )
 from haystack.nodes.retriever.text2sparql import Text2SparqlRetriever

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -24,7 +24,7 @@ class BM25Retriever(BaseRetriever):
         custom_query: Optional[str] = None,
     ):
         """
-        :param document_store: an instance of one of the following DocumentStores to retrieve from: ElasticsearchDocumentStore, OpenSearchDocumentStore and OpenDistroElasticsearchDocumentStore 
+        :param document_store: an instance of one of the following DocumentStores to retrieve from: ElasticsearchDocumentStore, OpenSearchDocumentStore and OpenDistroElasticsearchDocumentStore
         :param all_terms_must_match: Whether all terms of the query must match the document.
                                      If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
                                      Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -181,13 +181,14 @@ class FilterRetriever(BM25Retriever):
         documents = self.document_store.get_all_documents(filters=filters, index=index, headers=headers)
         return documents
 
+
 class ElasticsearchFilterOnlyRetriever(FilterRetriever):
     def __init__(
-    self,
-    document_store: KeywordDocumentStore,
-    top_k: int = 10,
-    all_terms_must_match: bool = False,
-    custom_query: Optional[str] = None,
+        self,
+        document_store: KeywordDocumentStore,
+        top_k: int = 10,
+        all_terms_must_match: bool = False,
+        custom_query: Optional[str] = None,
     ):
         logger.warn("This class is now deprecated. Please use the FilterRetriever instead")
         super().__init__(document_store, top_k, all_terms_must_match, custom_query)

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -24,7 +24,7 @@ class BM25Retriever(BaseRetriever):
         custom_query: Optional[str] = None,
     ):
         """
-        :param document_store: an instance of an ElasticsearchDocumentStore to retrieve documents from.
+        :param document_store: an instance of one of the following DocumentStores to retrieve from: ElasticsearchDocumentStore, OpenSearchDocumentStore and OpenDistroElasticsearchDocumentStore 
         :param all_terms_must_match: Whether all terms of the query must match the document.
                                      If true all query terms must be present in a document in order to be retrieved (i.e the AND operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy AND fish AND restaurant").
                                      Otherwise at least one query term must be present in a document in order to be retrieved (i.e the OR operator is being used implicitly between query terms: "cozy fish restaurant" -> "cozy OR fish OR restaurant").

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -151,7 +151,7 @@ class ElasticsearchRetriever(BM25Retriever):
         super().__init__(document_store, top_k, all_terms_must_match, custom_query)
 
 
-class ElasticsearchFilterOnlyRetriever(BM25Retriever):
+class FilterRetriever(BM25Retriever):
     """
     Naive "Retriever" that returns all documents that match the given filters. No impact of query at all.
     Helpful for benchmarking, testing and if you want to do QA on small documents without an "active" retriever.
@@ -180,6 +180,17 @@ class ElasticsearchFilterOnlyRetriever(BM25Retriever):
             index = self.document_store.index
         documents = self.document_store.get_all_documents(filters=filters, index=index, headers=headers)
         return documents
+
+class ElasticsearchFilterOnlyRetriever(FilterRetriever):
+    def __init__(
+    self,
+    document_store: KeywordDocumentStore,
+    top_k: int = 10,
+    all_terms_must_match: bool = False,
+    custom_query: Optional[str] = None,
+    ):
+        logger.warn("This class is now deprecated. Please use the FilterRetriever instead")
+        super().__init__(document_store, top_k, all_terms_must_match, custom_query)
 
 
 # TODO make Paragraph generic for configurable units of text eg, pages, paragraphs, or split by a char_limit

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -54,7 +54,7 @@ from haystack.nodes.answer_generator.transformers import Seq2SeqGenerator
 from haystack.nodes.answer_generator.transformers import RAGenerator
 from haystack.nodes.ranker import SentenceTransformersRanker
 from haystack.nodes.document_classifier.transformers import TransformersDocumentClassifier
-from haystack.nodes.retriever.sparse import ElasticsearchFilterOnlyRetriever, BM25Retriever, TfidfRetriever
+from haystack.nodes.retriever.sparse import FilterRetriever, BM25Retriever, TfidfRetriever
 from haystack.nodes.retriever.dense import DensePassageRetriever, EmbeddingRetriever, TableTextRetriever
 from haystack.nodes.reader.farm import FARMReader
 from haystack.nodes.reader.transformers import TransformersReader
@@ -624,7 +624,7 @@ def get_retriever(retriever_type, document_store):
     elif retriever_type == "elasticsearch":
         retriever = BM25Retriever(document_store=document_store)
     elif retriever_type == "es_filter_only":
-        retriever = ElasticsearchFilterOnlyRetriever(document_store=document_store)
+        retriever = FilterRetriever(document_store=document_store)
     elif retriever_type == "table_text_retriever":
         retriever = TableTextRetriever(
             document_store=document_store,

--- a/test/test_retriever.py
+++ b/test/test_retriever.py
@@ -14,7 +14,7 @@ from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.document_stores.faiss import FAISSDocumentStore
 from haystack.document_stores import MilvusDocumentStore
 from haystack.nodes.retriever.dense import DensePassageRetriever, EmbeddingRetriever, TableTextRetriever
-from haystack.nodes.retriever.sparse import BM25Retriever, ElasticsearchFilterOnlyRetriever, TfidfRetriever
+from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
 from transformers import DPRContextEncoderTokenizerFast, DPRQuestionEncoderTokenizerFast
 
 from .conftest import SAMPLES_PATH
@@ -70,7 +70,7 @@ def docs():
     indirect=True,
 )
 def test_retrieval(retriever_with_docs, document_store_with_docs):
-    if not isinstance(retriever_with_docs, (BM25Retriever, ElasticsearchFilterOnlyRetriever, TfidfRetriever)):
+    if not isinstance(retriever_with_docs, (BM25Retriever, FilterRetriever, TfidfRetriever)):
         document_store_with_docs.update_embeddings(retriever_with_docs)
 
     # test without filters


### PR DESCRIPTION
Similar to the PR renaming the ElasticsearchRetriever, I suggest to rename the ElasticsearchFilterOnlyRetriever to FilterRetriever to better reflect its functionality

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
