### PR TITLE
Linearize tables in EmbeddingRetriever

### DIFF
--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -795,26 +795,6 @@ Create embeddings for a list of documents.
 
 Embeddings, one per input document
 
-<a id="dense.EmbeddingRetriever.linearize_tables"></a>
-
-#### linearize\_tables
-
-```python
-def linearize_tables(docs: List[Document]) -> List[Document]
-```
-
-Turns table documents into text documents by representing the table in csv format.
-
-This allows us to use text embedding models for table retrieval.
-
-**Arguments**:
-
-- `docs`: List of documents to linearize. If the document is not a table, it is returned as is.
-
-**Returns**:
-
-List of documents with linearized tables or original documents if they are not tables.
-
 <a id="text2sparql"></a>
 
 # Module text2sparql

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -795,6 +795,26 @@ Create embeddings for a list of documents.
 
 Embeddings, one per input document
 
+<a id="dense.EmbeddingRetriever.linearize_tables"></a>
+
+#### linearize\_tables
+
+```python
+def linearize_tables(docs: List[Document]) -> List[Document]
+```
+
+Turns table documents into text documents by representing the table in csv format.
+
+This allows us to use text embedding models for table retrieval.
+
+**Arguments**:
+
+- `docs`: List of documents to linearize. If the document is not a table, it is returned as is.
+
+**Returns**:
+
+List of documents with linearized tables or original documents if they are not tables.
+
 <a id="text2sparql"></a>
 
 # Module text2sparql

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1215,7 +1215,8 @@ class EmbeddingRetriever(BaseRetriever):
         for doc in docs:
             if doc.content_type == "table":
                 doc = deepcopy(doc)
-                doc.content = doc.content.to_csv()
+                doc.content = doc.content.to_csv() # type: ignore
+                # necessary to ignore type as we know that doc.content must be a DataFrame, but mypy doesn't
                 doc.content_type = "text"
             linearized_docs.append(doc)
         return linearized_docs

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -11,6 +11,7 @@ from torch.nn import DataParallel
 from torch.utils.data.sampler import SequentialSampler
 import pandas as pd
 
+from haystack.errors import HaystackError
 from haystack.schema import Document
 from haystack.document_stores import BaseDocumentStore
 from haystack.nodes.retriever.base import BaseRetriever
@@ -1214,8 +1215,11 @@ class EmbeddingRetriever(BaseRetriever):
         """
         linearized_docs = []
         for doc in docs:
-            if isinstance(doc.content, pd.DataFrame):
+            if doc.content_type == "table":
                 doc = deepcopy(doc)
-                doc.content = doc.content.to_csv(index=False)
+                if isinstance(doc.content, pd.DataFrame):
+                    doc.content = doc.content.to_csv(index=False)
+                else:
+                    raise HaystackError("Documents of type 'table' need to have a pd.DataFrame as content field")
             linearized_docs.append(doc)
         return linearized_docs

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1200,9 +1200,9 @@ class EmbeddingRetriever(BaseRetriever):
         :param docs: List of documents to embed
         :return: Embeddings, one per input document
         """
-        docs = self.linearize_tables(docs) # linearize tables
+        docs = self.linearize_tables(docs)  # linearize tables
         return self.embedding_encoder.embed_documents(docs)
-    
+
     def linearize_tables(self, docs: List[Document]) -> List[Document]:
         """
         Turns table documents into text documents by representing the table in csv format.

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1215,7 +1215,7 @@ class EmbeddingRetriever(BaseRetriever):
         for doc in docs:
             if doc.content_type == "table":
                 doc = deepcopy(doc)
-                doc.content = doc.content.to_csv() # type: ignore
+                doc.content = doc.content.to_csv()  # type: ignore
                 # necessary to ignore type as we know that doc.content must be a DataFrame, but mypy doesn't
                 doc.content_type = "text"
             linearized_docs.append(doc)


### PR DESCRIPTION
**Proposed changes**:
Using a SOTA sentence transformers model like all-mpnet-base-v2 on linearized tables seems to outperform our existing Tri-Encoder approach. This PR adds this functionality and makes it default for the EmbeddingRetriever.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
