### PR TITLE
Ignore mypy issues regarding files param of requests.post

### DIFF
--- a/haystack/document_stores/graphdb.py
+++ b/haystack/document_stores/graphdb.py
@@ -57,7 +57,7 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
         """
         url = f"{self.url}/rest/repositories"
         files = {"config": open(config_path, "r", encoding="utf-8")}
-        response = requests.post(url, files=files, headers=headers)
+        response = requests.post(url, files=files, headers=headers) # type: ignore
         if response.status_code > 299:
             raise Exception(response.text)
 

--- a/haystack/document_stores/graphdb.py
+++ b/haystack/document_stores/graphdb.py
@@ -57,7 +57,7 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
         """
         url = f"{self.url}/rest/repositories"
         files = {"config": open(config_path, "r", encoding="utf-8")}
-        response = requests.post(url, files=files, headers=headers) # type: ignore
+        response = requests.post(url, files=files, headers=headers)  # type: ignore
         if response.status_code > 299:
             raise Exception(response.text)
 

--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -129,8 +129,8 @@ class ParsrConverter(BaseConverter):
             # Send file to Parsr
             send_response = requests.post(
                 url=f"{self.parsr_url}/api/v1/document",
-                files={
-                    "file": (file_path, pdf_file, "application/pdf"),
+                files={  # type: ignore
+                    "file": (str(file_path), pdf_file, "application/pdf"),
                     "config": ("config", json.dumps(self.config), "application/json"),
                 },
             )


### PR DESCRIPTION
**Proposed changes**:
- fixes mypy CI job

Reason: beginning with types-requests==2.27.21 BufferedReader is not accepted within the `files` param dict for `requests.post` any more

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
