### PR TITLE
Fix reader.eval() and reader.eval_on_file() output

### DIFF
--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -827,9 +827,20 @@ class FARMReader(BaseReader):
 
         eval_results = evaluator.eval(self.inferencer.model)
         results = {
-            "EM": eval_results[0]["EM"],
-            "f1": eval_results[0]["f1"],
-            "top_n_accuracy": eval_results[0]["top_n_accuracy"],
+            "EM": eval_results[0]["EM"] * 100,
+            "f1": eval_results[0]["f1"] * 100,
+            "top_n_accuracy": eval_results[0]["top_n_accuracy"] * 100,
+            "top_n": self.inferencer.model.prediction_heads[0].n_best,
+            "EM_text_answer": eval_results[0]["EM_text_answer"] * 100,
+            "f1_text_answer": eval_results[0]["f1_text_answer"] * 100,
+            "top_n_accuracy_text_answer": eval_results[0]["top_n_accuracy_text_answer"] * 100,
+            "top_n_EM_text_answer": eval_results[0]["top_n_EM_text_answer"] * 100,
+            "top_n_f1_text_answer": eval_results[0]["top_n_f1_text_answer"] * 100,
+            "Total_text_answer": eval_results[0]["Total_text_answer"],
+            "EM_no_answer": eval_results[0]["EM_no_answer"] * 100,
+            "f1_no_answer": eval_results[0]["f1_no_answer"] * 100,
+            "top_n_accuracy_no_answer": eval_results[0]["top_n_accuracy_no_answer"] * 100,
+            "Total_no_answer": eval_results[0]["Total_no_answer"],
         }
         return results
 
@@ -986,7 +997,7 @@ class FARMReader(BaseReader):
             "top_n_accuracy_text_answer": eval_results[0]["top_n_accuracy_text_answer"] * 100,
             "top_n_EM_text_answer": eval_results[0]["top_n_EM_text_answer"] * 100,
             "top_n_f1_text_answer": eval_results[0]["top_n_f1_text_answer"] * 100,
-            "Total_text_answer": eval_results[0]["Total_text_answer"] * 100,
+            "Total_text_answer": eval_results[0]["Total_text_answer"],
             "EM_no_answer": eval_results[0]["EM_no_answer"] * 100,
             "f1_no_answer": eval_results[0]["f1_no_answer"] * 100,
             "top_n_accuracy_no_answer": eval_results[0]["top_n_accuracy_no_answer"] * 100,


### PR DESCRIPTION
**Proposed changes**:
- fix Total_text_answer (was wrongly muliplied by 100)
- return the same output in `reader.eval_on_file()` as in `reader.eval()`

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
