### PR TITLE
Add support for positional args in pipeline.get_config()

### DIFF
--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -45,7 +45,7 @@ def exportable_to_yaml(init_func):
             sig = inspect.signature(init_func)
             parameter_names = list(sig.parameters.keys())
             # we can be sure that the first one is always "self"
-            arg_names = parameter_names[1:1+len(args)]
+            arg_names = parameter_names[1 : 1 + len(args)]
             for arg, arg_name in zip(args, arg_names):
                 self._component_config["params"][arg_name] = arg
 

--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -27,11 +27,6 @@ def exportable_to_yaml(init_func):
         # Call the actuall __init__ function with all the arguments
         init_func(self, *args, **kwargs)
 
-        # Warn for unnamed input params - should be rare
-        if args:
-            logger.warning(
-                "Unnamed __init__ parameters will not be saved to YAML if Pipeline.save_to_yaml() is called!"
-            )
         # Create the configuration dictionary if it doesn't exist yet
         if not self._component_config:
             self._component_config = {"params": {}, "type": type(self).__name__}
@@ -45,6 +40,14 @@ def exportable_to_yaml(init_func):
             # Store all the named input parameters in self._component_config
             for k, v in kwargs.items():
                 self._component_config["params"][k] = v
+
+            # Store unnamed input parameters in self._component_config too by inferring their names
+            sig = inspect.signature(init_func)
+            parameter_names = list(sig.parameters.keys())
+            # we can be sure that the first one is always "self"
+            arg_names = parameter_names[1:1+len(args)]
+            for arg, arg_name in zip(args, arg_names):
+                self._component_config["params"][arg_name] = arg
 
     return wrapper_exportable_to_yaml
 

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -386,21 +386,17 @@ def test_get_config_custom_node_with_params():
     assert pipeline.get_config()["components"][0]["params"] == {"param": 10}
 
 
-def test_get_config_custom_node_with_positional_params(caplog):
+def test_get_config_custom_node_with_positional_params():
     class CustomNode(MockNode):
         def __init__(self, param: int = 1):
             super().__init__()
             self.param = param
 
     pipeline = Pipeline()
-    with caplog.at_level(logging.WARNING):
-        pipeline.add_node(CustomNode(10), name="custom_node", inputs=["Query"])
-        assert (
-            "Unnamed __init__ parameters will not be saved to YAML "
-            "if Pipeline.save_to_yaml() is called" in caplog.text
-        )
+    pipeline.add_node(CustomNode(10), name="custom_node", inputs=["Query"])
+
     assert len(pipeline.get_config()["components"]) == 1
-    assert pipeline.get_config()["components"][0]["params"] == {}
+    assert pipeline.get_config()["components"][0]["params"] == {"param": 10}
 
 
 def test_generate_code_simple_pipeline():


### PR DESCRIPTION
**Proposed changes**:
- support positional args in pipeline.config() (and thus YAML creation)

```python
reader = FARMReader("my-model") # no model_name_or_path="my-model" required anymore
...
pipeline.add_node(name="reader", component=reader, inputs=["retriever"])

# YAML will contain reader's model_name_or_path param
pipeline.save_to_yaml(...)
```

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
