### PR TITLE
Nvidia GPG key error: fetch nvidia keys

### DIFF
--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -5,6 +5,12 @@ WORKDIR /home/user
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+#Temporary fix until this is fixed: https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+RUN rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list && \
+    apt-key del 7fa2af80 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub 
+
 # Install software dependencies
 RUN apt-get update && apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \

--- a/Dockerfile-GPU-minimal
+++ b/Dockerfile-GPU-minimal
@@ -6,6 +6,12 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV HAYSTACK_DOCKER_CONTAINER="HAYSTACK_MINIMAL_GPU_CONTAINER"
 
+#Temporary fix until this is fixed: https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+RUN rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list && \
+    apt-key del 7fa2af80 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub 
+
 # Install software dependencies
 RUN apt-get update && apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \


### PR DESCRIPTION
Nvidia rotated their keys, s.t. we need to manually update the keys since `apt-get update` will fail since it will pull the old key that results in a GPG error. The long term fix should be either updating the Nvidia base image or just waiting for their fix s.t. the new key is properly published (?)

https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772