### PR TITLE
Add dependency group for TableReader

### DIFF
--- a/haystack/nodes/reader/__init__.py
+++ b/haystack/nodes/reader/__init__.py
@@ -1,4 +1,8 @@
 from haystack.nodes.reader.base import BaseReader
 from haystack.nodes.reader.farm import FARMReader
 from haystack.nodes.reader.transformers import TransformersReader
-from haystack.nodes.reader.table import TableReader, RCIReader
+
+from haystack.utils.import_utils import safe_import
+
+TableReader = safe_import("haystack.nodes.reader.table", "TableReader", "table-reader")
+RCIReader = safe_import("haystack.nodes.reader.table", "RCIReader", "table-reader")

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -21,6 +21,8 @@ from haystack.schema import Document, Answer, Span
 from haystack.nodes.reader.base import BaseReader
 from haystack.modeling.utils import initialize_device_settings
 
+import torch_scatter # transformers library won't raise an error if not installed
+
 
 logger = logging.getLogger(__name__)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -196,12 +196,14 @@ dev =
     jupytercontrib 
     watchdog  #==1.0.2
     requests-cache
+table-reader = 
+    torch-scatter>=2.0.0,<3
 test = 
     farm-haystack[docstores,crawler,preprocessing,ocr,ray,dev]
 all =
-    farm-haystack[docstores,crawler,preprocessing,ocr,ray,dev,onnx,beir]
+    farm-haystack[docstores,crawler,preprocessing,ocr,ray,dev,onnx,beir,table-reader]
 all-gpu =
-    farm-haystack[docstores-gpu,crawler,preprocessing,ocr,ray,dev,onnx-gpu,beir]
+    farm-haystack[docstores-gpu,crawler,preprocessing,ocr,ray,dev,onnx-gpu,beir,table-reader]
 
 
 [tool:pytest]


### PR DESCRIPTION
**Proposed changes**:
To use the Tapas models necessary for the `TableReader`, the transformers library requires the torch-scatter library. This library, however, isn't listed as a dependency of transformers and the transformers library itself silences the [import error](https://github.com/huggingface/transformers/blob/daecae1f1ce02d2dab23742d24f7a66a7d20cb79/src/transformers/models/tapas/modeling_tapas.py#L48) which makes the issue non-obvious to a user.

This PR adds a dependency group called table-reader and adds an import of torch-scatter in table.py so the import error can be caught properly.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
