### PR TITLE
changing the name of the retrievers from es_retriever to retriever

### DIFF
--- a/docs/_src/tutorials/tutorials/11.md
+++ b/docs/_src/tutorials/tutorials/11.md
@@ -110,7 +110,7 @@ document_store.delete_documents()
 document_store.write_documents(got_docs)
 
 # Initialize Sparse retriever
-retriever = BM25Retriever(document_store=document_store)
+bm25_retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
@@ -134,7 +134,7 @@ Here we have an `ExtractiveQAPipeline` (the successor to the now deprecated `Fin
 from haystack.pipelines import ExtractiveQAPipeline
 
 # Prebuilt pipeline
-p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=retriever)
+p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=bm25_retriever)
 res = p_extractive_premade.run(
     query="Who is the father of Arya Stark?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}
 )
@@ -147,7 +147,7 @@ If you want to just do the retrieval step, you can use a `DocumentSearchPipeline
 ```python
 from haystack.pipelines import DocumentSearchPipeline
 
-p_retrieval = DocumentSearchPipeline(retriever)
+p_retrieval = DocumentSearchPipeline(bm25_retriever)
 res = p_retrieval.run(query="Who is the father of Arya Stark?", params={"Retriever": {"top_k": 10}})
 print_documents(res, max_text_len=200)
 ```
@@ -207,7 +207,7 @@ We do this by adding the building blocks that we initialized as nodes in the gra
 ```python
 # Custom built extractive QA pipeline
 p_extractive = Pipeline()
-p_extractive.add_node(component=retriever, name="Retriever", inputs=["Query"])
+p_extractive.add_node(component=bm25_retriever, name="Retriever", inputs=["Query"])
 p_extractive.add_node(component=reader, name="Reader", inputs=["Retriever"])
 
 # Now we can run it
@@ -234,7 +234,7 @@ from haystack.nodes import JoinDocuments
 
 # Create ensembled pipeline
 p_ensemble = Pipeline()
-p_ensemble.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
+p_ensemble.add_node(component=bm25_retriever, name="ESRetriever", inputs=["Query"])
 p_ensemble.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["Query"])
 p_ensemble.add_node(
     component=JoinDocuments(join_mode="concatenate"), name="JoinResults", inputs=["ESRetriever", "EmbeddingRetriever"]
@@ -308,7 +308,7 @@ class CustomQueryClassifier(BaseComponent):
 # Here we build the pipeline
 p_classifier = Pipeline()
 p_classifier.add_node(component=CustomQueryClassifier(), name="QueryClassifier", inputs=["Query"])
-p_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
+p_classifier.add_node(component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
 p_classifier.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_2"])
 p_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
 p_classifier.draw("pipeline_classifier.png")
@@ -336,7 +336,7 @@ You can print out debug information from nodes in your pipelines in a few differ
 
 ```python
 # 1) You can set the `debug` attribute of a given node.
-retriever.debug = True
+bm25_retriever.debug = True
 
 # 2) You can provide `debug` as a parameter when running your pipeline
 result = p_classifier.run(query="Who is the father of Arya Stark?", params={"ESRetriever": {"debug": True}})

--- a/docs/_src/tutorials/tutorials/11.md
+++ b/docs/_src/tutorials/tutorials/11.md
@@ -110,7 +110,7 @@ document_store.delete_documents()
 document_store.write_documents(got_docs)
 
 # Initialize Sparse retriever
-es_retriever = BM25Retriever(document_store=document_store)
+retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
@@ -134,7 +134,7 @@ Here we have an `ExtractiveQAPipeline` (the successor to the now deprecated `Fin
 from haystack.pipelines import ExtractiveQAPipeline
 
 # Prebuilt pipeline
-p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=es_retriever)
+p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=retriever)
 res = p_extractive_premade.run(
     query="Who is the father of Arya Stark?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}
 )
@@ -147,7 +147,7 @@ If you want to just do the retrieval step, you can use a `DocumentSearchPipeline
 ```python
 from haystack.pipelines import DocumentSearchPipeline
 
-p_retrieval = DocumentSearchPipeline(es_retriever)
+p_retrieval = DocumentSearchPipeline(retriever)
 res = p_retrieval.run(query="Who is the father of Arya Stark?", params={"Retriever": {"top_k": 10}})
 print_documents(res, max_text_len=200)
 ```
@@ -207,7 +207,7 @@ We do this by adding the building blocks that we initialized as nodes in the gra
 ```python
 # Custom built extractive QA pipeline
 p_extractive = Pipeline()
-p_extractive.add_node(component=es_retriever, name="Retriever", inputs=["Query"])
+p_extractive.add_node(component=retriever, name="Retriever", inputs=["Query"])
 p_extractive.add_node(component=reader, name="Reader", inputs=["Retriever"])
 
 # Now we can run it
@@ -234,7 +234,7 @@ from haystack.nodes import JoinDocuments
 
 # Create ensembled pipeline
 p_ensemble = Pipeline()
-p_ensemble.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
+p_ensemble.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
 p_ensemble.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["Query"])
 p_ensemble.add_node(
     component=JoinDocuments(join_mode="concatenate"), name="JoinResults", inputs=["ESRetriever", "EmbeddingRetriever"]
@@ -308,7 +308,7 @@ class CustomQueryClassifier(BaseComponent):
 # Here we build the pipeline
 p_classifier = Pipeline()
 p_classifier.add_node(component=CustomQueryClassifier(), name="QueryClassifier", inputs=["Query"])
-p_classifier.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
+p_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
 p_classifier.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_2"])
 p_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
 p_classifier.draw("pipeline_classifier.png")
@@ -336,7 +336,7 @@ You can print out debug information from nodes in your pipelines in a few differ
 
 ```python
 # 1) You can set the `debug` attribute of a given node.
-es_retriever.debug = True
+retriever.debug = True
 
 # 2) You can provide `debug` as a parameter when running your pipeline
 result = p_classifier.run(query="Who is the father of Arya Stark?", params={"ESRetriever": {"debug": True}})

--- a/docs/_src/tutorials/tutorials/14.md
+++ b/docs/_src/tutorials/tutorials/14.md
@@ -124,7 +124,7 @@ document_store.delete_documents()
 document_store.write_documents(got_docs)
 
 # Initialize Sparse retriever
-es_retriever = BM25Retriever(document_store=document_store)
+retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
@@ -159,7 +159,7 @@ sklearn_keyword_classifier.add_node(component=SklearnQueryClassifier(), name="Qu
 sklearn_keyword_classifier.add_node(
     component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
 )
-sklearn_keyword_classifier.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+sklearn_keyword_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
 sklearn_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
 sklearn_keyword_classifier.draw("pipeline_classifier.png")
 ```
@@ -221,7 +221,7 @@ transformer_keyword_classifier.add_node(
 transformer_keyword_classifier.add_node(
     component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
 )
-transformer_keyword_classifier.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+transformer_keyword_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
 transformer_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
 transformer_keyword_classifier.draw("pipeline_classifier.png")
 ```

--- a/docs/_src/tutorials/tutorials/14.md
+++ b/docs/_src/tutorials/tutorials/14.md
@@ -124,7 +124,7 @@ document_store.delete_documents()
 document_store.write_documents(got_docs)
 
 # Initialize Sparse retriever
-retriever = BM25Retriever(document_store=document_store)
+bm25_retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
@@ -159,7 +159,7 @@ sklearn_keyword_classifier.add_node(component=SklearnQueryClassifier(), name="Qu
 sklearn_keyword_classifier.add_node(
     component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
 )
-sklearn_keyword_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+sklearn_keyword_classifier.add_node(component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
 sklearn_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
 sklearn_keyword_classifier.draw("pipeline_classifier.png")
 ```
@@ -221,7 +221,9 @@ transformer_keyword_classifier.add_node(
 transformer_keyword_classifier.add_node(
     component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
 )
-transformer_keyword_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+transformer_keyword_classifier.add_node(
+    component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"]
+)
 transformer_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
 transformer_keyword_classifier.draw("pipeline_classifier.png")
 ```

--- a/haystack/json-schemas/haystack-pipeline-master.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-master.schema.json
@@ -2102,11 +2102,6 @@
             "custom_query": {
               "title": "Custom Query",
               "type": "string"
-            },
-            "scale_score": {
-              "title": "Scale Score",
-              "default": true,
-              "type": "boolean"
             }
           },
           "required": [
@@ -2643,6 +2638,11 @@
             "custom_query": {
               "title": "Custom Query",
               "type": "string"
+            },
+            "scale_score": {
+              "title": "Scale Score",
+              "default": true,
+              "type": "boolean"
             }
           },
           "required": [

--- a/tutorials/Tutorial11_Pipelines.ipynb
+++ b/tutorials/Tutorial11_Pipelines.ipynb
@@ -220,7 +220,7 @@
     "document_store.write_documents(got_docs)\n",
     "\n",
     "# Initialize Sparse retriever\n",
-    "es_retriever = BM25Retriever(document_store=document_store)\n",
+    "retriever = BM25Retriever(document_store=document_store)\n",
     "\n",
     "# Initialize dense retriever\n",
     "embedding_retriever = EmbeddingRetriever(\n",
@@ -263,7 +263,7 @@
     "from haystack.pipelines import ExtractiveQAPipeline\n",
     "\n",
     "# Prebuilt pipeline\n",
-    "p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=es_retriever)\n",
+    "p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=retriever)\n",
     "res = p_extractive_premade.run(\n",
     "    query=\"Who is the father of Arya Stark?\", params={\"Retriever\": {\"top_k\": 10}, \"Reader\": {\"top_k\": 5}}\n",
     ")\n",
@@ -292,7 +292,7 @@
    "source": [
     "from haystack.pipelines import DocumentSearchPipeline\n",
     "\n",
-    "p_retrieval = DocumentSearchPipeline(es_retriever)\n",
+    "p_retrieval = DocumentSearchPipeline(retriever)\n",
     "res = p_retrieval.run(query=\"Who is the father of Arya Stark?\", params={\"Retriever\": {\"top_k\": 10}})\n",
     "print_documents(res, max_text_len=200)"
    ]
@@ -412,7 +412,7 @@
    "source": [
     "# Custom built extractive QA pipeline\n",
     "p_extractive = Pipeline()\n",
-    "p_extractive.add_node(component=es_retriever, name=\"Retriever\", inputs=[\"Query\"])\n",
+    "p_extractive.add_node(component=retriever, name=\"Retriever\", inputs=[\"Query\"])\n",
     "p_extractive.add_node(component=reader, name=\"Reader\", inputs=[\"Retriever\"])\n",
     "\n",
     "# Now we can run it\n",
@@ -458,7 +458,7 @@
     "\n",
     "# Create ensembled pipeline\n",
     "p_ensemble = Pipeline()\n",
-    "p_ensemble.add_node(component=es_retriever, name=\"ESRetriever\", inputs=[\"Query\"])\n",
+    "p_ensemble.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"Query\"])\n",
     "p_ensemble.add_node(component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"Query\"])\n",
     "p_ensemble.add_node(\n",
     "    component=JoinDocuments(join_mode=\"concatenate\"), name=\"JoinResults\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"]\n",
@@ -570,7 +570,7 @@
     "# Here we build the pipeline\n",
     "p_classifier = Pipeline()\n",
     "p_classifier.add_node(component=CustomQueryClassifier(), name=\"QueryClassifier\", inputs=[\"Query\"])\n",
-    "p_classifier.add_node(component=es_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_1\"])\n",
+    "p_classifier.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_1\"])\n",
     "p_classifier.add_node(component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
     "p_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "p_classifier.draw(\"pipeline_classifier.png\")\n",
@@ -627,7 +627,7 @@
    "outputs": [],
    "source": [
     "# 1) You can set the `debug` attribute of a given node.\n",
-    "es_retriever.debug = True\n",
+    "retriever.debug = True\n",
     "\n",
     "# 2) You can provide `debug` as a parameter when running your pipeline\n",
     "result = p_classifier.run(query=\"Who is the father of Arya Stark?\", params={\"ESRetriever\": {\"debug\": True}})\n",

--- a/tutorials/Tutorial11_Pipelines.ipynb
+++ b/tutorials/Tutorial11_Pipelines.ipynb
@@ -220,7 +220,7 @@
     "document_store.write_documents(got_docs)\n",
     "\n",
     "# Initialize Sparse retriever\n",
-    "retriever = BM25Retriever(document_store=document_store)\n",
+    "bm25_retriever = BM25Retriever(document_store=document_store)\n",
     "\n",
     "# Initialize dense retriever\n",
     "embedding_retriever = EmbeddingRetriever(\n",
@@ -263,7 +263,7 @@
     "from haystack.pipelines import ExtractiveQAPipeline\n",
     "\n",
     "# Prebuilt pipeline\n",
-    "p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=retriever)\n",
+    "p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=bm25_retriever)\n",
     "res = p_extractive_premade.run(\n",
     "    query=\"Who is the father of Arya Stark?\", params={\"Retriever\": {\"top_k\": 10}, \"Reader\": {\"top_k\": 5}}\n",
     ")\n",
@@ -292,7 +292,7 @@
    "source": [
     "from haystack.pipelines import DocumentSearchPipeline\n",
     "\n",
-    "p_retrieval = DocumentSearchPipeline(retriever)\n",
+    "p_retrieval = DocumentSearchPipeline(bm25_retriever)\n",
     "res = p_retrieval.run(query=\"Who is the father of Arya Stark?\", params={\"Retriever\": {\"top_k\": 10}})\n",
     "print_documents(res, max_text_len=200)"
    ]
@@ -412,7 +412,7 @@
    "source": [
     "# Custom built extractive QA pipeline\n",
     "p_extractive = Pipeline()\n",
-    "p_extractive.add_node(component=retriever, name=\"Retriever\", inputs=[\"Query\"])\n",
+    "p_extractive.add_node(component=bm25_retriever, name=\"Retriever\", inputs=[\"Query\"])\n",
     "p_extractive.add_node(component=reader, name=\"Reader\", inputs=[\"Retriever\"])\n",
     "\n",
     "# Now we can run it\n",
@@ -458,7 +458,7 @@
     "\n",
     "# Create ensembled pipeline\n",
     "p_ensemble = Pipeline()\n",
-    "p_ensemble.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"Query\"])\n",
+    "p_ensemble.add_node(component=bm25_retriever, name=\"ESRetriever\", inputs=[\"Query\"])\n",
     "p_ensemble.add_node(component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"Query\"])\n",
     "p_ensemble.add_node(\n",
     "    component=JoinDocuments(join_mode=\"concatenate\"), name=\"JoinResults\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"]\n",
@@ -570,7 +570,7 @@
     "# Here we build the pipeline\n",
     "p_classifier = Pipeline()\n",
     "p_classifier.add_node(component=CustomQueryClassifier(), name=\"QueryClassifier\", inputs=[\"Query\"])\n",
-    "p_classifier.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_1\"])\n",
+    "p_classifier.add_node(component=bm25_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_1\"])\n",
     "p_classifier.add_node(component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
     "p_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "p_classifier.draw(\"pipeline_classifier.png\")\n",
@@ -627,7 +627,7 @@
    "outputs": [],
    "source": [
     "# 1) You can set the `debug` attribute of a given node.\n",
-    "retriever.debug = True\n",
+    "bm25_retriever.debug = True\n",
     "\n",
     "# 2) You can provide `debug` as a parameter when running your pipeline\n",
     "result = p_classifier.run(query=\"Who is the father of Arya Stark?\", params={\"ESRetriever\": {\"debug\": True}})\n",

--- a/tutorials/Tutorial11_Pipelines.py
+++ b/tutorials/Tutorial11_Pipelines.py
@@ -29,7 +29,7 @@ def tutorial11_pipelines():
     document_store.write_documents(got_docs)
 
     # Initialize Sparse retriever
-    es_retriever = BM25Retriever(document_store=document_store)
+    retriever = BM25Retriever(document_store=document_store)
 
     # Initialize dense retriever
     embedding_retriever = EmbeddingRetriever(
@@ -51,7 +51,7 @@ def tutorial11_pipelines():
     print("########################")
 
     query = "Who is the father of Arya Stark?"
-    p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=es_retriever)
+    p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=retriever)
     res = p_extractive_premade.run(query=query, params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}})
     print("\nQuery: ", query)
     print("Answers:")
@@ -62,7 +62,7 @@ def tutorial11_pipelines():
     print("##########################")
 
     query = "Who is the father of Arya Stark?"
-    p_retrieval = DocumentSearchPipeline(es_retriever)
+    p_retrieval = DocumentSearchPipeline(retriever)
     res = p_retrieval.run(query=query, params={"Retriever": {"top_k": 10}})
     print()
     print_documents(res, max_text_len=200)
@@ -108,7 +108,7 @@ def tutorial11_pipelines():
 
     # Custom built extractive QA pipeline
     p_extractive = Pipeline()
-    p_extractive.add_node(component=es_retriever, name="Retriever", inputs=["Query"])
+    p_extractive.add_node(component=retriever, name="Retriever", inputs=["Query"])
     p_extractive.add_node(component=reader, name="Reader", inputs=["Retriever"])
 
     # Now we can run it
@@ -125,7 +125,7 @@ def tutorial11_pipelines():
 
     # Create ensembled pipeline
     p_ensemble = Pipeline()
-    p_ensemble.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
+    p_ensemble.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
     p_ensemble.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["Query"])
     p_ensemble.add_node(
         component=JoinDocuments(join_mode="concatenate"),
@@ -166,7 +166,7 @@ def tutorial11_pipelines():
     # Here we build the pipeline
     p_classifier = Pipeline()
     p_classifier.add_node(component=CustomQueryClassifier(), name="QueryClassifier", inputs=["Query"])
-    p_classifier.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
+    p_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
     p_classifier.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_2"])
     p_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
     p_classifier.draw("pipeline_classifier.png")
@@ -193,7 +193,7 @@ def tutorial11_pipelines():
     # You can print out debug information from nodes in your pipelines in a few different ways.
 
     # 1) You can set the `debug` attribute of a given node.
-    es_retriever.debug = True
+    retriever.debug = True
 
     # 2) You can provide `debug` as a parameter when running your pipeline
     result = p_classifier.run(query="Who is the father of Arya Stark?", params={"ESRetriever": {"debug": True}})

--- a/tutorials/Tutorial11_Pipelines.py
+++ b/tutorials/Tutorial11_Pipelines.py
@@ -29,7 +29,7 @@ def tutorial11_pipelines():
     document_store.write_documents(got_docs)
 
     # Initialize Sparse retriever
-    retriever = BM25Retriever(document_store=document_store)
+    bm25_retriever = BM25Retriever(document_store=document_store)
 
     # Initialize dense retriever
     embedding_retriever = EmbeddingRetriever(
@@ -51,7 +51,7 @@ def tutorial11_pipelines():
     print("########################")
 
     query = "Who is the father of Arya Stark?"
-    p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=retriever)
+    p_extractive_premade = ExtractiveQAPipeline(reader=reader, retriever=bm25_retriever)
     res = p_extractive_premade.run(query=query, params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}})
     print("\nQuery: ", query)
     print("Answers:")
@@ -62,7 +62,7 @@ def tutorial11_pipelines():
     print("##########################")
 
     query = "Who is the father of Arya Stark?"
-    p_retrieval = DocumentSearchPipeline(retriever)
+    p_retrieval = DocumentSearchPipeline(bm25_retriever)
     res = p_retrieval.run(query=query, params={"Retriever": {"top_k": 10}})
     print()
     print_documents(res, max_text_len=200)
@@ -108,7 +108,7 @@ def tutorial11_pipelines():
 
     # Custom built extractive QA pipeline
     p_extractive = Pipeline()
-    p_extractive.add_node(component=retriever, name="Retriever", inputs=["Query"])
+    p_extractive.add_node(component=bm25_retriever, name="Retriever", inputs=["Query"])
     p_extractive.add_node(component=reader, name="Reader", inputs=["Retriever"])
 
     # Now we can run it
@@ -125,7 +125,7 @@ def tutorial11_pipelines():
 
     # Create ensembled pipeline
     p_ensemble = Pipeline()
-    p_ensemble.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
+    p_ensemble.add_node(component=bm25_retriever, name="ESRetriever", inputs=["Query"])
     p_ensemble.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["Query"])
     p_ensemble.add_node(
         component=JoinDocuments(join_mode="concatenate"),
@@ -166,7 +166,7 @@ def tutorial11_pipelines():
     # Here we build the pipeline
     p_classifier = Pipeline()
     p_classifier.add_node(component=CustomQueryClassifier(), name="QueryClassifier", inputs=["Query"])
-    p_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
+    p_classifier.add_node(component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_1"])
     p_classifier.add_node(component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_2"])
     p_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
     p_classifier.draw("pipeline_classifier.png")
@@ -193,7 +193,7 @@ def tutorial11_pipelines():
     # You can print out debug information from nodes in your pipelines in a few different ways.
 
     # 1) You can set the `debug` attribute of a given node.
-    retriever.debug = True
+    bm25_retriever.debug = True
 
     # 2) You can provide `debug` as a parameter when running your pipeline
     result = p_classifier.run(query="Who is the father of Arya Stark?", params={"ESRetriever": {"debug": True}})

--- a/tutorials/Tutorial14_Query_Classifier.ipynb
+++ b/tutorials/Tutorial14_Query_Classifier.ipynb
@@ -404,7 +404,7 @@
     "document_store.write_documents(got_docs)\n",
     "\n",
     "# Initialize Sparse retriever\n",
-    "es_retriever = BM25Retriever(document_store=document_store)\n",
+    "retriever = BM25Retriever(document_store=document_store)\n",
     "\n",
     "# Initialize dense retriever\n",
     "embedding_retriever = EmbeddingRetriever(\n",
@@ -464,7 +464,7 @@
     "sklearn_keyword_classifier.add_node(\n",
     "    component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_1\"]\n",
     ")\n",
-    "sklearn_keyword_classifier.add_node(component=es_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
+    "sklearn_keyword_classifier.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
     "sklearn_keyword_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "sklearn_keyword_classifier.draw(\"pipeline_classifier.png\")"
    ]
@@ -557,7 +557,7 @@
     "transformer_keyword_classifier.add_node(\n",
     "    component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_1\"]\n",
     ")\n",
-    "transformer_keyword_classifier.add_node(component=es_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
+    "transformer_keyword_classifier.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
     "transformer_keyword_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "transformer_keyword_classifier.draw(\"pipeline_classifier.png\")"
    ]

--- a/tutorials/Tutorial14_Query_Classifier.ipynb
+++ b/tutorials/Tutorial14_Query_Classifier.ipynb
@@ -557,7 +557,9 @@
     "transformer_keyword_classifier.add_node(\n",
     "    component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_1\"]\n",
     ")\n",
-    "transformer_keyword_classifier.add_node(component=bm25_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
+    "transformer_keyword_classifier.add_node(\n",
+    "    component=bm25_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"]\n",
+    ")\n",
     "transformer_keyword_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "transformer_keyword_classifier.draw(\"pipeline_classifier.png\")"
    ]

--- a/tutorials/Tutorial14_Query_Classifier.ipynb
+++ b/tutorials/Tutorial14_Query_Classifier.ipynb
@@ -404,7 +404,7 @@
     "document_store.write_documents(got_docs)\n",
     "\n",
     "# Initialize Sparse retriever\n",
-    "retriever = BM25Retriever(document_store=document_store)\n",
+    "bm25_retriever = BM25Retriever(document_store=document_store)\n",
     "\n",
     "# Initialize dense retriever\n",
     "embedding_retriever = EmbeddingRetriever(\n",
@@ -464,7 +464,7 @@
     "sklearn_keyword_classifier.add_node(\n",
     "    component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_1\"]\n",
     ")\n",
-    "sklearn_keyword_classifier.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
+    "sklearn_keyword_classifier.add_node(component=bm25_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
     "sklearn_keyword_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "sklearn_keyword_classifier.draw(\"pipeline_classifier.png\")"
    ]
@@ -557,7 +557,7 @@
     "transformer_keyword_classifier.add_node(\n",
     "    component=embedding_retriever, name=\"EmbeddingRetriever\", inputs=[\"QueryClassifier.output_1\"]\n",
     ")\n",
-    "transformer_keyword_classifier.add_node(component=retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
+    "transformer_keyword_classifier.add_node(component=bm25_retriever, name=\"ESRetriever\", inputs=[\"QueryClassifier.output_2\"])\n",
     "transformer_keyword_classifier.add_node(component=reader, name=\"QAReader\", inputs=[\"ESRetriever\", \"EmbeddingRetriever\"])\n",
     "transformer_keyword_classifier.draw(\"pipeline_classifier.png\")"
    ]

--- a/tutorials/Tutorial14_Query_Classifier.py
+++ b/tutorials/Tutorial14_Query_Classifier.py
@@ -34,7 +34,7 @@ def tutorial14_query_classifier():
     document_store.write_documents(got_docs)
 
     # Initialize Sparse retriever
-    es_retriever = BM25Retriever(document_store=document_store)
+    retriever = BM25Retriever(document_store=document_store)
 
     # Initialize dense retriever
     embedding_retriever = EmbeddingRetriever(
@@ -55,7 +55,7 @@ def tutorial14_query_classifier():
     sklearn_keyword_classifier.add_node(
         component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
     )
-    sklearn_keyword_classifier.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+    sklearn_keyword_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
     sklearn_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
     sklearn_keyword_classifier.draw("pipeline_classifier.png")
 
@@ -107,7 +107,7 @@ def tutorial14_query_classifier():
         component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
     )
     transformer_keyword_classifier.add_node(
-        component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"]
+        component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"]
     )
     transformer_keyword_classifier.add_node(
         component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"]

--- a/tutorials/Tutorial14_Query_Classifier.py
+++ b/tutorials/Tutorial14_Query_Classifier.py
@@ -34,7 +34,7 @@ def tutorial14_query_classifier():
     document_store.write_documents(got_docs)
 
     # Initialize Sparse retriever
-    retriever = BM25Retriever(document_store=document_store)
+    bm25_retriever = BM25Retriever(document_store=document_store)
 
     # Initialize dense retriever
     embedding_retriever = EmbeddingRetriever(
@@ -55,7 +55,7 @@ def tutorial14_query_classifier():
     sklearn_keyword_classifier.add_node(
         component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
     )
-    sklearn_keyword_classifier.add_node(component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+    sklearn_keyword_classifier.add_node(component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
     sklearn_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
     sklearn_keyword_classifier.draw("pipeline_classifier.png")
 
@@ -107,7 +107,7 @@ def tutorial14_query_classifier():
         component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
     )
     transformer_keyword_classifier.add_node(
-        component=retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"]
+        component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"]
     )
     transformer_keyword_classifier.add_node(
         component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"]

--- a/tutorials/Tutorial14_Query_Classifier.py
+++ b/tutorials/Tutorial14_Query_Classifier.py
@@ -55,7 +55,9 @@ def tutorial14_query_classifier():
     sklearn_keyword_classifier.add_node(
         component=embedding_retriever, name="EmbeddingRetriever", inputs=["QueryClassifier.output_1"]
     )
-    sklearn_keyword_classifier.add_node(component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+    sklearn_keyword_classifier.add_node(
+        component=bm25_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"]
+    )
     sklearn_keyword_classifier.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "EmbeddingRetriever"])
     sklearn_keyword_classifier.draw("pipeline_classifier.png")
 


### PR DESCRIPTION
Quick fix for the variable names in the tutorials so that they are no longer 'es_retriever'

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
