### PR TITLE
Upgrade xpdf to 4.04 in Exception text

### DIFF
--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -54,8 +54,8 @@ class PDFToTextConverter(BaseConverter):
                 """pdftotext is not installed. It is part of xpdf or poppler-utils software suite.
                 
                    Installation on Linux:
-                   wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz &&
-                   tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+                   wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz &&
+                   tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
                    
                    Installation on MacOS:
                    brew install xpdf


### PR DESCRIPTION
**Proposed changes**:
- Update the Exception text that is shown when xpdf is not installed to point to version 4.04 in accordance with the changes also made in https://github.com/deepset-ai/haystack/pull/2443

closes #2456 