### PR TITLE
Align TransformersReader defaults with FARMReader

### DIFF
--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -564,7 +564,7 @@ With this reader, you can directly get predictions via predict()
 #### \_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: Optional[str] = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: bool = True, top_k: int = 10, top_k_per_candidate: int = 4, return_no_answers: bool = True, max_seq_len: int = 256, doc_stride: int = 128)
+def __init__(model_name_or_path: str = "distilbert-base-uncased-distilled-squad", model_version: Optional[str] = None, tokenizer: Optional[str] = None, context_window_size: int = 70, use_gpu: bool = True, top_k: int = 10, top_k_per_candidate: int = 3, return_no_answers: bool = False, max_seq_len: int = 256, doc_stride: int = 128)
 ```
 
 Load a QA model from Transformers.

--- a/haystack/json-schemas/haystack-pipeline-master.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-master.schema.json
@@ -2102,11 +2102,6 @@
             "custom_query": {
               "title": "Custom Query",
               "type": "string"
-            },
-            "scale_score": {
-              "title": "Scale Score",
-              "default": true,
-              "type": "boolean"
             }
           },
           "required": [
@@ -2643,6 +2638,11 @@
             "custom_query": {
               "title": "Custom Query",
               "type": "string"
+            },
+            "scale_score": {
+              "title": "Scale Score",
+              "default": true,
+              "type": "boolean"
             }
           },
           "required": [
@@ -4174,12 +4174,12 @@
             },
             "top_k_per_candidate": {
               "title": "Top K Per Candidate",
-              "default": 4,
+              "default": 3,
               "type": "integer"
             },
             "return_no_answers": {
               "title": "Return No Answers",
-              "default": true,
+              "default": false,
               "type": "boolean"
             },
             "max_seq_len": {

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -26,8 +26,8 @@ class TransformersReader(BaseReader):
         context_window_size: int = 70,
         use_gpu: bool = True,
         top_k: int = 10,
-        top_k_per_candidate: int = 4,
-        return_no_answers: bool = True,
+        top_k_per_candidate: int = 3,
+        return_no_answers: bool = False,
         max_seq_len: int = 256,
         doc_stride: int = 128,
     ):


### PR DESCRIPTION
**Proposed changes**:
- Set TransformersReader's default value for `return_no_answer` to False and for `top_k_per_candidate` to 3 to align it with the default values of FARMReader.

closes #2446 

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [ ] Updated documentation
