### PR TITLE
Deprecate `Milvus1DocumentStore`

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -2569,6 +2569,10 @@ Usage:
 def __init__(sql_url: str = "sqlite:///", milvus_url: str = "tcp://localhost:19530", connection_pool: str = "SingletonThread", index: str = "document", vector_dim: int = None, embedding_dim: int = 768, index_file_size: int = 1024, similarity: str = "dot_product", index_type: IndexType = IndexType.FLAT, index_param: Optional[Dict[str, Any]] = None, search_param: Optional[Dict[str, Any]] = None, return_embedding: bool = False, embedding_field: str = "embedding", progress_bar: bool = True, duplicate_documents: str = "overwrite", isolation_level: str = None)
 ```
 
+**WARNING:** Milvus1DocumentStore is deprecated and will be removed in a future version. Please switch to Milvus2
+
+or consider using another DocumentStore.
+
 **Arguments**:
 
 - `sql_url`: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
@@ -4436,9 +4440,9 @@ deployment, Postgres is recommended.
 - `embedding_dim`: The embedding vector size.
 - `return_embedding`: Whether to return document embeddings.
 - `index`: Name of index in document store to use.
-- `similarity`: The similarity function used to compare document vectors. `"dot_product"` is the default
-since it is more performant with DPR embeddings. `"cosine"` is recommended if you are using a
-Sentence-Transformer model.
+- `similarity`: The similarity function used to compare document vectors. `"cosine"` is the default
+and is recommended if you are using a Sentence-Transformer model. `"dot_product"` is more performant
+with DPR embeddings.
 In both cases, the returned values in Document.score are normalized to be in range [0,1]:
     - For `"dot_product"`: `expit(np.asarray(raw_score / 100))`
     - For `"cosine"`: `(raw_score + 1) / 2`

--- a/docs/_src/tutorials/tutorials/16.md
+++ b/docs/_src/tutorials/tutorials/16.md
@@ -26,10 +26,10 @@ This tutorial will show you how to integrate a classification model into your pr
 
 # Install the latest master of Haystack
 !pip install --upgrade pip
-!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab, ocr]
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]
 
-!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz
-!tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz
+!tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
 
 # Install  pygraphviz
 !apt install libgraphviz-dev

--- a/haystack/document_stores/milvus1.py
+++ b/haystack/document_stores/milvus1.py
@@ -112,8 +112,7 @@ class Milvus1DocumentStore(SQLDocumentStore):
             "Milvus1DocumentStore is deprecated and will be removed in a future version. "
             "Please consider switching to Milvus2 or to another DocumentStore."
         )
-        warnings.simplefilter("always", DeprecationWarning)
-        warnings.warn(message=deprecation_message, category=DeprecationWarning, stacklevel=3)
+        warnings.warn(message=deprecation_message, category=FutureWarning, stacklevel=3)
 
         super().__init__(
             url=sql_url, index=index, duplicate_documents=duplicate_documents, isolation_level=isolation_level

--- a/haystack/document_stores/milvus1.py
+++ b/haystack/document_stores/milvus1.py
@@ -62,6 +62,9 @@ class Milvus1DocumentStore(SQLDocumentStore):
         isolation_level: str = None,
     ):
         """
+        **WARNING:** Milvus1DocumentStore is deprecated and will be removed in a future version. Please switch to Milvus2
+        or consider using another DocumentStore.
+
         :param sql_url: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
                         deployment, Postgres is recommended. If using MySQL then same server can also be used for
                         Milvus metadata. For more details see https://milvus.io/docs/v1.0.0/data_manage.md.

--- a/haystack/document_stores/milvus1.py
+++ b/haystack/document_stores/milvus1.py
@@ -105,6 +105,11 @@ class Milvus1DocumentStore(SQLDocumentStore):
                                     exists.
         :param isolation_level: see SQLAlchemy's `isolation_level` parameter for `create_engine()` (https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.isolation_level)
         """
+        deprecation_message = "Milvus1DocumentStore is deprecated and will be removed in a future version. " \
+                              "Please consider switching to Milvus2 or to another DocumentStore."
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(message=deprecation_message, category=DeprecationWarning, stacklevel=3)
+
         super().__init__(
             url=sql_url, index=index, duplicate_documents=duplicate_documents, isolation_level=isolation_level
         )

--- a/haystack/document_stores/milvus1.py
+++ b/haystack/document_stores/milvus1.py
@@ -108,9 +108,11 @@ class Milvus1DocumentStore(SQLDocumentStore):
                                     exists.
         :param isolation_level: see SQLAlchemy's `isolation_level` parameter for `create_engine()` (https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.isolation_level)
         """
-        deprecation_message = "Milvus1DocumentStore is deprecated and will be removed in a future version. " \
-                              "Please consider switching to Milvus2 or to another DocumentStore."
-        warnings.simplefilter('always', DeprecationWarning)
+        deprecation_message = (
+            "Milvus1DocumentStore is deprecated and will be removed in a future version. "
+            "Please consider switching to Milvus2 or to another DocumentStore."
+        )
+        warnings.simplefilter("always", DeprecationWarning)
         warnings.warn(message=deprecation_message, category=DeprecationWarning, stacklevel=3)
 
         super().__init__(


### PR DESCRIPTION
**Proposed changes**:
This PR adds a warning message that the `Milvus1DocumentStore` is deprecated. 

In a future PR, when removing `Milvus1DocumentStore` ultimately, we need to make sure to remove everything related to Milvus1, including:
- installation dependencies
- tests
- documentation


**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [ ] Added tests
- [x] Updated documentation

Related to #2417