### PR TITLE
change milvus links from 2.0.0 to 2.0.x

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -2916,10 +2916,10 @@ def __init__(sql_url: str = "sqlite:///", host: str = "localhost", port: str = "
 
 - `sql_url`: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
 deployment, Postgres is recommended. If using MySQL then same server can also be used for
-Milvus metadata. For more details see https://milvus.io/docs/v2.0.x/data_manage.md.
+Milvus metadata. For more details see https://milvus.io/docs/v1.1.0/data_manage.md.
 - `milvus_url`: Milvus server connection URL for storing and processing vectors.
 Protocol, host and port will automatically be inferred from the URL.
-See https://milvus.io/docs/v2.0.x/install_milvus.md for instructions to start a Milvus instance.
+See https://milvus.io/docs/v2.0.x/install_standalone-docker.md for instructions to start a Milvus instance.
 - `connection_pool`: Connection pool type to connect with Milvus server. Default: "SingletonThread".
 - `index`: Index name for text, embedding and metadata (in Milvus terms, this is the "collection name").
 - `vector_dim`: Deprecated. Use embedding_dim instead.

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -2884,10 +2884,10 @@ Therefore, delete_documents() and update_embeddings() won't work yet.
 Differences to 1.x:
 Besides big architectural changes that impact performance and reliability 2.0 supports the filtering by scalar data types.
 For Haystack users this means you can now run a query using vector similarity and filter for some meta data at the same time!
-(See https://milvus.io/docs/v2.0.0/comparison.md for more details)
+(See https://milvus.io/docs/v2.0.x/comparison.md for more details)
 
 Usage:
-1. Start a Milvus service via docker (see https://milvus.io/docs/v2.0.0/install_standalone-docker.md)
+1. Start a Milvus service via docker (see https://milvus.io/docs/v2.0.x/install_standalone-docker.md)
 2. Run pip install farm-haystack[milvus]
 3. Init a MilvusDocumentStore() in Haystack
 
@@ -2916,10 +2916,10 @@ def __init__(sql_url: str = "sqlite:///", host: str = "localhost", port: str = "
 
 - `sql_url`: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
 deployment, Postgres is recommended. If using MySQL then same server can also be used for
-Milvus metadata. For more details see https://milvus.io/docs/v2.0.0/data_manage.md.
+Milvus metadata. For more details see https://milvus.io/docs/v2.0.x/data_manage.md.
 - `milvus_url`: Milvus server connection URL for storing and processing vectors.
 Protocol, host and port will automatically be inferred from the URL.
-See https://milvus.io/docs/v2.0.0/install_milvus.md for instructions to start a Milvus instance.
+See https://milvus.io/docs/v2.0.x/install_milvus.md for instructions to start a Milvus instance.
 - `connection_pool`: Connection pool type to connect with Milvus server. Default: "SingletonThread".
 - `index`: Index name for text, embedding and metadata (in Milvus terms, this is the "collection name").
 - `vector_dim`: Deprecated. Use embedding_dim instead.
@@ -2929,24 +2929,24 @@ When the size of newly inserted vectors reaches the specified volume, Milvus pac
 Milvus creates one index file for each segment. When conducting a vector search, Milvus searches all index files one by one.
 As a rule of thumb, we would see a 30% ~ 50% increase in the search performance after changing the value of index_file_size from 1024 to 2048.
 Note that an overly large index_file_size value may cause failure to load a segment into the memory or graphics memory.
-(From https://milvus.io/docs/v2.0.0/performance_faq.md)
+(From https://milvus.io/docs/v2.0.x/performance_faq.md)
 - `similarity`: The similarity function used to compare document vectors. 'dot_product' is the default and recommended for DPR embeddings.
 'cosine' is recommended for Sentence Transformers, but is not directly supported by Milvus.
 However, you can normalize your embeddings and use `dot_product` to get the same results.
-See https://milvus.io/docs/v2.0.0/metric.md.
+See https://milvus.io/docs/v2.0.x/metric.md.
 - `index_type`: Type of approximate nearest neighbour (ANN) index used. The choice here determines your tradeoff between speed and accuracy.
 Some popular options:
 - FLAT (default): Exact method, slow
 - IVF_FLAT, inverted file based heuristic, fast
 - HSNW: Graph based, fast
 - ANNOY: Tree based, fast
-See: https://milvus.io/docs/v2.0.0/index.md
+See: https://milvus.io/docs/v2.0.x/index.md
 - `index_param`: Configuration parameters for the chose index_type needed at indexing time.
 For example: {"nlist": 16384} as the number of cluster units to create for index_type IVF_FLAT.
-See https://milvus.io/docs/v2.0.0/index.md
+See https://milvus.io/docs/v2.0.x/index.md
 - `search_param`: Configuration parameters for the chose index_type needed at query time
 For example: {"nprobe": 10} as the number of cluster units to query for index_type IVF_FLAT.
-See https://milvus.io/docs/v2.0.0/index.md
+See https://milvus.io/docs/v2.0.x/index.md
 - `return_embedding`: To return document embedding.
 - `embedding_field`: Name of field containing an embedding vector.
 - `progress_bar`: Whether to show a tqdm progress bar or not.
@@ -4436,9 +4436,9 @@ deployment, Postgres is recommended.
 - `embedding_dim`: The embedding vector size.
 - `return_embedding`: Whether to return document embeddings.
 - `index`: Name of index in document store to use.
-- `similarity`: The similarity function used to compare document vectors. `"dot_product"` is the default
-since it is more performant with DPR embeddings. `"cosine"` is recommended if you are using a
-Sentence-Transformer model.
+- `similarity`: The similarity function used to compare document vectors. `"cosine"` is the default
+and is recommended if you are using a Sentence-Transformer model. `"dot_product"` is more performant
+with DPR embeddings.
 In both cases, the returned values in Document.score are normalized to be in range [0,1]:
     - For `"dot_product"`: `expit(np.asarray(raw_score / 100))`
     - For `"cosine"`: `(raw_score + 1) / 2`

--- a/docs/_src/tutorials/tutorials/16.md
+++ b/docs/_src/tutorials/tutorials/16.md
@@ -26,10 +26,10 @@ This tutorial will show you how to integrate a classification model into your pr
 
 # Install the latest master of Haystack
 !pip install --upgrade pip
-!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab, ocr]
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,ocr]
 
-!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz
-!tar -xvf xpdf-tools-linux-4.03.tar.gz && sudo cp xpdf-tools-linux-4.03/bin64/pdftotext /usr/local/bin
+!wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz
+!tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
 
 # Install  pygraphviz
 !apt install libgraphviz-dev

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -83,10 +83,10 @@ class Milvus2DocumentStore(SQLDocumentStore):
         """
         :param sql_url: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
                         deployment, Postgres is recommended. If using MySQL then same server can also be used for
-                        Milvus metadata. For more details see https://milvus.io/docs/v2.0.x/data_manage.md.
+                        Milvus metadata. For more details see https://milvus.io/docs/v1.1.0/data_manage.md.
         :param milvus_url: Milvus server connection URL for storing and processing vectors.
                            Protocol, host and port will automatically be inferred from the URL.
-                           See https://milvus.io/docs/v2.0.x/install_milvus.md for instructions to start a Milvus instance.
+                           See https://milvus.io/docs/v2.0.x/install_standalone-docker.md for instructions to start a Milvus instance.
         :param connection_pool: Connection pool type to connect with Milvus server. Default: "SingletonThread".
         :param index: Index name for text, embedding and metadata (in Milvus terms, this is the "collection name").
         :param vector_dim: Deprecated. Use embedding_dim instead.

--- a/haystack/document_stores/milvus2.py
+++ b/haystack/document_stores/milvus2.py
@@ -35,10 +35,10 @@ class Milvus2DocumentStore(SQLDocumentStore):
     Differences to 1.x:
     Besides big architectural changes that impact performance and reliability 2.0 supports the filtering by scalar data types.
     For Haystack users this means you can now run a query using vector similarity and filter for some meta data at the same time!
-    (See https://milvus.io/docs/v2.0.0/comparison.md for more details)
+    (See https://milvus.io/docs/v2.0.x/comparison.md for more details)
 
     Usage:
-    1. Start a Milvus service via docker (see https://milvus.io/docs/v2.0.0/install_standalone-docker.md)
+    1. Start a Milvus service via docker (see https://milvus.io/docs/v2.0.x/install_standalone-docker.md)
     2. Run pip install farm-haystack[milvus]
     3. Init a MilvusDocumentStore() in Haystack
 
@@ -83,10 +83,10 @@ class Milvus2DocumentStore(SQLDocumentStore):
         """
         :param sql_url: SQL connection URL for storing document texts and metadata. It defaults to a local, file based SQLite DB. For large scale
                         deployment, Postgres is recommended. If using MySQL then same server can also be used for
-                        Milvus metadata. For more details see https://milvus.io/docs/v2.0.0/data_manage.md.
+                        Milvus metadata. For more details see https://milvus.io/docs/v2.0.x/data_manage.md.
         :param milvus_url: Milvus server connection URL for storing and processing vectors.
                            Protocol, host and port will automatically be inferred from the URL.
-                           See https://milvus.io/docs/v2.0.0/install_milvus.md for instructions to start a Milvus instance.
+                           See https://milvus.io/docs/v2.0.x/install_milvus.md for instructions to start a Milvus instance.
         :param connection_pool: Connection pool type to connect with Milvus server. Default: "SingletonThread".
         :param index: Index name for text, embedding and metadata (in Milvus terms, this is the "collection name").
         :param vector_dim: Deprecated. Use embedding_dim instead.
@@ -96,24 +96,24 @@ class Milvus2DocumentStore(SQLDocumentStore):
          Milvus creates one index file for each segment. When conducting a vector search, Milvus searches all index files one by one.
          As a rule of thumb, we would see a 30% ~ 50% increase in the search performance after changing the value of index_file_size from 1024 to 2048.
          Note that an overly large index_file_size value may cause failure to load a segment into the memory or graphics memory.
-         (From https://milvus.io/docs/v2.0.0/performance_faq.md)
+         (From https://milvus.io/docs/v2.0.x/performance_faq.md)
         :param similarity: The similarity function used to compare document vectors. 'dot_product' is the default and recommended for DPR embeddings.
                            'cosine' is recommended for Sentence Transformers, but is not directly supported by Milvus.
                            However, you can normalize your embeddings and use `dot_product` to get the same results.
-                           See https://milvus.io/docs/v2.0.0/metric.md.
+                           See https://milvus.io/docs/v2.0.x/metric.md.
         :param index_type: Type of approximate nearest neighbour (ANN) index used. The choice here determines your tradeoff between speed and accuracy.
                            Some popular options:
                            - FLAT (default): Exact method, slow
                            - IVF_FLAT, inverted file based heuristic, fast
                            - HSNW: Graph based, fast
                            - ANNOY: Tree based, fast
-                           See: https://milvus.io/docs/v2.0.0/index.md
+                           See: https://milvus.io/docs/v2.0.x/index.md
         :param index_param: Configuration parameters for the chose index_type needed at indexing time.
                             For example: {"nlist": 16384} as the number of cluster units to create for index_type IVF_FLAT.
-                            See https://milvus.io/docs/v2.0.0/index.md
+                            See https://milvus.io/docs/v2.0.x/index.md
         :param search_param: Configuration parameters for the chose index_type needed at query time
                              For example: {"nprobe": 10} as the number of cluster units to query for index_type IVF_FLAT.
-                             See https://milvus.io/docs/v2.0.0/index.md
+                             See https://milvus.io/docs/v2.0.x/index.md
         :param return_embedding: To return document embedding.
         :param embedding_field: Name of field containing an embedding vector.
         :param progress_bar: Whether to show a tqdm progress bar or not.


### PR DESCRIPTION
**Proposed changes**:
- Change version number in links to milvus website from 2.0.0 to 2.0.x as the old links are not working anymore

**Old link**
<img width="970" alt="image" src="https://user-images.githubusercontent.com/4181769/166682044-7fd73a11-e29a-45f6-8162-3f7d2cd0aed0.png">

**Updated link**
<img width="831" alt="image" src="https://user-images.githubusercontent.com/4181769/166682078-788f4367-84d2-43c9-b21e-ff4c77baf9ca.png">

