### PR TITLE
Make `DeepsetCloudDocumentStore` work with non-existing index

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -259,6 +259,9 @@ jobs:
     - name: Run Elasticsearch
       run: docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx128m" elasticsearch:7.9.2
 
+    - name: Run Opensearch
+      run: docker run -d -p 9201:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:1.2.4
+
     - name: Run Milvus
       run: |
         cd ../../   # Avoid causing permission issues on hashFiles later by creating unreadable folders like "volumes"

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1724,6 +1724,9 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
                              Synonym or Synonym_graph to handle synonyms, including multi-word synonyms correctly during the analysis process.
                              More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-graph-tokenfilter.html
         """
+        self.embeddings_field_supports_similarity = False
+        self.similarity_to_space_type = {"cosine": "cosinesimil", "dot_product": "innerproduct", "l2": "l2"}
+        self.space_type_to_similarity = {v: k for k, v in self.similarity_to_space_type.items()}
         super().__init__(
             scheme=scheme,
             username=username,
@@ -1759,9 +1762,6 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
             synonym_type=synonym_type,
             use_system_proxy=use_system_proxy,
         )
-        self.embeddings_field_supports_similarity = False
-        self.similarity_to_space_type = {"cosine": "cosinesimil", "dot_product": "innerproduct", "l2": "l2"}
-        self.space_type_to_similarity = {v: k for k, v in self.similarity_to_space_type.items()}
 
     def query_by_embedding(
         self,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -408,16 +408,12 @@ def deepset_cloud_fixture():
                     {
                         "name": DC_TEST_INDEX,
                         "status": "DEPLOYED",
-                        "indexing": {
-                            "status": "INDEXED",
-                            "pending_file_count": 0,
-                            "total_file_count": 31
-                        }
+                        "indexing": {"status": "INDEXED", "pending_file_count": 0, "total_file_count": 31},
                     }
                 ],
                 "has_more": False,
-                "total": 1
-            }
+                "total": 1,
+            },
         )
     else:
         responses.add_passthru(DC_API_ENDPOINT)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -399,6 +399,26 @@ def deepset_cloud_fixture():
             json={"indexing": {"status": "INDEXED", "pending_file_count": 0, "total_file_count": 31}},
             status=200,
         )
+        responses.add(
+            method=responses.GET,
+            url=f"{DC_API_ENDPOINT}/workspaces/default/pipelines",
+            match=[responses.matchers.header_matcher({"authorization": f"Bearer {DC_API_KEY}"})],
+            json={
+                "data": [
+                    {
+                        "name": DC_TEST_INDEX,
+                        "status": "DEPLOYED",
+                        "indexing": {
+                            "status": "INDEXED",
+                            "pending_file_count": 0,
+                            "total_file_count": 31
+                        }
+                    }
+                ],
+                "has_more": False,
+                "total": 1
+            }
+        )
     else:
         responses.add_passthru(DC_API_ENDPOINT)
 

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -20,7 +20,12 @@ from .conftest import (
     DC_TEST_INDEX,
     SAMPLES_PATH,
 )
-from haystack.document_stores import WeaviateDocumentStore, DeepsetCloudDocumentStore, InMemoryDocumentStore
+from haystack.document_stores import (
+    OpenSearchDocumentStore,
+    WeaviateDocumentStore,
+    DeepsetCloudDocumentStore,
+    InMemoryDocumentStore,
+)
 from haystack.document_stores.base import BaseDocumentStore
 from haystack.document_stores.es_converter import elasticsearch_index_to_document_store
 from haystack.errors import DuplicateDocumentError
@@ -87,6 +92,11 @@ def test_init_elastic_client():
 
     # api_key +  id
     _ = ElasticsearchDocumentStore(host=["localhost"], port=[9200], api_key="test", api_key_id="test")
+
+
+@pytest.mark.elasticsearch
+def test_init_opensearch_client():
+    OpenSearchDocumentStore(index="test_index", port=9201)
 
 
 @pytest.mark.elasticsearch

--- a/test/test_document_store.py
+++ b/test/test_document_store.py
@@ -1883,6 +1883,56 @@ def test_DeepsetCloudDocumentStore_query_by_embedding(deepset_cloud_document_sto
     assert len(emb_docs) == 0
 
 
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_get_all_docs_without_index():
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert document_store.get_all_documents() == []
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_get_all_docs_generator_without_index():
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert list(document_store.get_all_documents_generator()) == []
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_get_doc_by_id_without_index():
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert document_store.get_document_by_id(id="some id") == None
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_get_docs_by_id_without_index():
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert document_store.get_documents_by_id(ids=["some id"]) == []
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_get_doc_count_without_index():
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert document_store.get_document_count() == 0
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_query_by_emb_without_index():
+    query_emb = np.random.randn(768)
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert document_store.query_by_embedding(query_emb=query_emb) == []
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_DeepsetCloudDocumentStore_query_without_index():
+    document_store = DeepsetCloudDocumentStore(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY, index=None)
+    assert document_store.query(query="some query") == []
+
+
 @pytest.mark.elasticsearch
 def test_elasticsearch_search_field_mapping():
 


### PR DESCRIPTION
**Proposed changes**:
This PR makes the `DeepsetCloudDocumentStore` work with a non-existing index. Non-existing index refers to either `None` (no index specified), or an index/pipeline that is not deployed on deepset Cloud.

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [x] Added tests
- [x] Updated documentation

Closes #2471
