### PR TITLE
rearrange contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ M1 Macbooks require some extra depencies in order to install Haystack.
 brew install postgresql
 brew install cmake
 brew install rust
+brew install sentencepiece
 
 # haystack installation
 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install git+https://github.com/deepset-ai/haystack.git

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ M1 Macbooks require some extra depencies in order to install Haystack.
 brew install postgresql
 brew install cmake
 brew install rust
-brew install sentencepiece
 
 # haystack installation
 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install git+https://github.com/deepset-ai/haystack.git


### PR DESCRIPTION
**Proposed changes**:
In the README file, mention `brew install sentencepiece` that was needed when I set up Haystack on M1

For the CONTRIBUTING guidelines, contents were rearranged in a way that feels a bit more natural for a newcomer, in particular:
- I've added explicit mention to how we recommend setting up Haystack in a development environment with `pip install -e`
- The recommended way of running the tests comes first in the corresponding paragraph
- I've removed a few redundant sentences

Best way to review the contributing guidelines is to [look at the preview](https://github.com/deepset-ai/haystack/blob/massi/contributing/CONTRIBUTING.md) as the diff got a bit messy.


**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
