### PR TITLE
fix small typo in Document doc string

### DIFF
--- a/docs/_src/api/api/primitives.md
+++ b/docs/_src/api/api/primitives.md
@@ -35,7 +35,7 @@ There's an easy option to convert from/to dicts via `from_dict()` and `to_dict`.
 **Arguments**:
 
 - `content`: Content of the document. For most cases, this will be text, but it can be a table or image.
-- `content_type`: One of "image", "table" or "image". Haystack components can use this to adjust their
+- `content_type`: One of "text", "table" or "image". Haystack components can use this to adjust their
 handling of Documents and check compatibility.
 - `id`: Unique ID for the document. If not supplied by the user, we'll generate one automatically by
 creating a hash from the supplied text. This behaviour can be further adjusted by `id_hash_keys`.

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -74,7 +74,7 @@ class Document:
         There's an easy option to convert from/to dicts via `from_dict()` and `to_dict`.
 
         :param content: Content of the document. For most cases, this will be text, but it can be a table or image.
-        :param content_type: One of "image", "table" or "image". Haystack components can use this to adjust their
+        :param content_type: One of "text", "table" or "image". Haystack components can use this to adjust their
                              handling of Documents and check compatibility.
         :param id: Unique ID for the document. If not supplied by the user, we'll generate one automatically by
                    creating a hash from the supplied text. This behaviour can be further adjusted by `id_hash_keys`.


### PR DESCRIPTION
Was going through the tutorial, then digging through the code and just noticed a small typo

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] Added tests
- [ ] Updated documentation
