### PR TITLE
Handle transformers pipeline flattening lists of length 1

### DIFF
--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -206,6 +206,12 @@ class TransformersReader(BaseReader):
             grouped_inputs.append(inputs[left_idx:right_idx])
             left_idx = right_idx
 
+        # Transformers flattens lists of length 1. This restores the original list structure.
+        if isinstance(predictions, dict):
+            predictions = [[predictions]]
+        else:
+            predictions = [p if isinstance(p, list) else [p] for p in predictions]
+
         results: Dict = {"queries": queries, "answers": [], "no_ans_gaps": []}
         for grouped_pred, grouped_inp in zip(grouped_predictions, grouped_inputs):
             # Add Document ID to predictions to be able to construct Answer objects

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -124,7 +124,7 @@ class TransformersReader(BaseReader):
 
         predictions = self.model(
             inputs,
-            top_k=1,
+            top_k=self.top_k_per_candidate,
             handle_impossible_answer=self.return_no_answers,
             max_seq_len=self.max_seq_len,
             doc_stride=self.doc_stride,

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -209,6 +209,8 @@ class TransformersReader(BaseReader):
         # Transformers flattens lists of length 1. This restores the original list structure.
         if isinstance(predictions, dict):
             predictions = [[predictions]]
+        elif len(number_of_docs) == 1:
+            predictions = [predictions]
         else:
             predictions = [p if isinstance(p, list) else [p] for p in predictions]
 


### PR DESCRIPTION
**Proposed changes**:
The return format of transformers pipelines can vary in edge cases where a list of length 1 would be returned. By default, transformers flattens those lists which breaks our code. This PR checks for this and recreates the expected format.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
