### PR TITLE
[Weaviate] Exit the while loop when we query less documents than available

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -708,7 +708,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
                 raise ValueError(f"Weaviate raised an exception: {e}")
 
             if "errors" in result:
-                raise ValueError(f"Query results contain errors: {result.get('errors')}")
+                raise ValueError(f"Query results contain errors: {result['errors']}")
 
             # If `query.do` didn't raise and `result` doesn't contain errors,
             # we are good accessing data

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -724,6 +724,11 @@ class WeaviateDocumentStore(BaseDocumentStore):
             # than QUERY_MAXIMUM_RESULTS.
             # See: https://weaviate.io/developers/weaviate/current/graphql-references/filters.html#offset-argument-pagination
             if not docs:
+                logger.warning(
+                    "The query returned less documents than expected: this can happen when "
+                    "the value of QUERY_MAXIMUM_RESULTS is lower than the total number of "
+                    "documents stored."
+                )
                 break
 
             all_docs += docs

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -22,10 +22,15 @@ from haystack.document_stores import BaseDocumentStore
 from haystack.document_stores.base import get_batches_from_generator
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.document_stores.utils import convert_date_to_rfc3339
+from haystack.errors import DocumentStoreError
 
 
 logger = logging.getLogger(__name__)
 UUID_PATTERN = re.compile(r"^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$", re.IGNORECASE)
+
+
+class WeaviateDocumentStoreError(DocumentStoreError):
+    pass
 
 
 class WeaviateDocumentStore(BaseDocumentStore):
@@ -705,10 +710,10 @@ class WeaviateDocumentStore(BaseDocumentStore):
             try:
                 result = query.do()
             except Exception as e:
-                raise ValueError(f"Weaviate raised an exception: {e}")
+                raise WeaviateDocumentStoreError(f"Weaviate raised an exception: {e}")
 
             if "errors" in result:
-                raise ValueError(f"Query results contain errors: {result['errors']}")
+                raise WeaviateDocumentStoreError(f"Query results contain errors: {result['errors']}")
 
             # If `query.do` didn't raise and `result` doesn't contain errors,
             # we are good accessing data

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -726,8 +726,9 @@ class WeaviateDocumentStore(BaseDocumentStore):
             if not docs:
                 logger.warning(
                     "The query returned less documents than expected: this can happen when "
-                    "the value of QUERY_MAXIMUM_RESULTS is lower than the total number of "
-                    "documents stored."
+                    "the value of the QUERY_MAXIMUM_RESULTS environment variable is lower than "
+                    "the total number of documents stored. See Weaviate documentation for "
+                    "more details."
                 )
                 break
 

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -1,8 +1,12 @@
+import uuid
+from unittest.mock import patch
+
 import numpy as np
 import pytest
+
 from haystack.schema import Document
 from ..conftest import get_document_store
-import uuid
+
 
 embedding_dim = 768
 
@@ -105,3 +109,14 @@ def test_query(document_store_with_docs):
 
     docs = document_store_with_docs.query(filters={"content": ["live"]})
     assert len(docs) == 3
+
+
+@pytest.mark.weaviate
+@pytest.mark.parametrize("document_store_with_docs", ["weaviate"], indirect=True)
+def test_get_all_documents(document_store_with_docs):
+    # Ensure the method works no matter the value of QUERY_MAXIMUM_RESULTS
+    # see https://github.com/deepset-ai/haystack/issues/2517
+    with patch.object(document_store_with_docs, "get_document_count") as count:
+        count.return_value = 13_000
+        docs = document_store_with_docs.get_all_documents()
+        assert len(docs) == 3

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -111,12 +111,11 @@ def test_query(document_store_with_docs):
     assert len(docs) == 3
 
 
-@pytest.mark.weaviate
-@pytest.mark.parametrize("document_store_with_docs", ["weaviate"], indirect=True)
-def test_get_all_documents(document_store_with_docs):
-    # Ensure the method works no matter the value of QUERY_MAXIMUM_RESULTS
-    # see https://github.com/deepset-ai/haystack/issues/2517
-    with patch.object(document_store_with_docs, "get_document_count") as count:
-        count.return_value = 13_000
-        docs = document_store_with_docs.get_all_documents()
-        assert len(docs) == 3
+def test_get_all_documents_unaffected_by_QUERY_MAXIMUM_RESULTS(document_store_with_docs, monkeypatch):
+    """
+    Ensure `get_all_documents` works no matter the value of QUERY_MAXIMUM_RESULTS
+    see https://github.com/deepset-ai/haystack/issues/2517
+    """
+    monkeypatch.setattr(document_store_with_docs, "get_document_count", lambda **kwargs: 13_000)
+    docs = document_store_with_docs.get_all_documents()
+    assert len(docs) == 3

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -111,6 +111,7 @@ def test_query(document_store_with_docs):
     assert len(docs) == 3
 
 
+@pytest.mark.weaviate
 def test_get_all_documents_unaffected_by_QUERY_MAXIMUM_RESULTS(document_store_with_docs, monkeypatch):
     """
     Ensure `get_all_documents` works no matter the value of QUERY_MAXIMUM_RESULTS

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest.mock import patch
 
 import numpy as np
 import pytest


### PR DESCRIPTION
fixes #2517 

When a query returns less documents than available in the store (e.g. when there are more documents than `QUERY_MAXIMUM_RESULTS` (see [Weaviate docs](https://weaviate.io/developers/weaviate/current/graphql-references/filters.html#offset-argument-pagination)), the `while` loop paginating the results never exits. This is because the offset increases as we fetch more documents, but after `QUERY_MAXIMUM_RESULTS` docs, the query starts returning an empty list, the offset stays the same and we get stuck.

**Proposed changes**:
- While paginating results, we exit the loop if the query returns an empty list of documents.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
