### PR TITLE
Fix docker image tag with semantic version for releases

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
 
 jobs:
   build:
@@ -36,12 +38,12 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ matrix.repository }}
           tags: |
-            type=ref,event=tag,prefix=${{ matrix.tagprefix }}                     
+            type=semver,pattern={{version}},prefix=${{ matrix.tagprefix }}
             type=sha,format=long,prefix=${{ matrix.tagprefix }}
             type=sha,format=long,prefix=,enable=${{ matrix.default }}
             type=raw,value=latest,prefix=${{ matrix.tagprefix }}
@@ -57,7 +59,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -64,5 +64,5 @@ jobs:
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true
-          cache-from: type=registry,ref=${{ matrix.repository }}:latest
+          cache-from: type=registry,ref=${{ matrix.repository }}:${{ matrix.tagprefix }}latest
           cache-to: type=inline


### PR DESCRIPTION
The current GHA workflow that builds and pushes docker images is configured to add a tag with the haystack version to the images when there is a new release, but this version tag is never created.

**Proposed changes**:
- Add the missing trigger to the `docker_build` GHA workflow so it runs also when creating tags in the git repository, i.e. on a new version release.
- Replace the docker image tag based on the raw git tag for a rule handling semantic versions.
- Update versions of actions `docker/metadata-action` and `docker/build-push-action`.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
