### PR TITLE
set top_k to 5 in SAS to be consistent

### DIFF
--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -30,8 +30,7 @@
     "**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/deepset-ai/haystack/master/docs/img/colab_gpu_runtime.jpg\">"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -992,7 +991,7 @@
    "outputs": [],
    "source": [
     "advanced_eval_result = pipeline.eval(\n",
-    "    labels=eval_labels, params={\"Retriever\": {\"top_k\": 1}}, sas_model_name_or_path=\"cross-encoder/stsb-roberta-large\"\n",
+    "    labels=eval_labels, params={\"Retriever\": {\"top_k\": 5}}, sas_model_name_or_path=\"cross-encoder/stsb-roberta-large\"\n",
     ")\n",
     "\n",
     "metrics = advanced_eval_result.calculate_metrics()\n",

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -188,7 +188,7 @@ def tutorial5_evaluation():
 
     advanced_eval_result = pipeline.eval(
         labels=eval_labels,
-        params={"Retriever": {"top_k": 1}},
+        params={"Retriever": {"top_k": 5}},
         sas_model_name_or_path="cross-encoder/stsb-roberta-large",
     )
 


### PR DESCRIPTION
-The change refers to the top_k value of the retriever in the Advanced Evaluation Metrics in the Tutorial5_Evaluation.py.

The actual value is set to 1 which is both suboptimal and inconsistent with all the previous utilized values of top_k for the retriever (equal to 5). Trying the script with other values leads to better SAS results. For example, setting it to 5 (to be consistent with the previous values) results in 0.528 compared to 0.443 using top_k = 1.

- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)