### PR TITLE
Documenting output score of JoinDocuments when using concatenation

### DIFF
--- a/docs/_src/api/api/other.md
+++ b/docs/_src/api/api/other.md
@@ -30,6 +30,7 @@ A node to join documents outputted by multiple retriever nodes.
 
 The node allows multiple join modes:
 * concatenate: combine the documents from multiple nodes. Any duplicate documents are discarded.
+               The score is only determined by the last node that outputs the document.
 * merge: merge scores of documents from multiple nodes. Optionally, each input score can be given a different
          `weight` & a `top_k` limit can be set. This mode can also be used for "reranking" retrieved documents.
 * reciprocal_rank_fusion: combines the documents based on their rank in multiple nodes.

--- a/docs/_src/tutorials/tutorials/5.md
+++ b/docs/_src/tutorials/tutorials/5.md
@@ -289,7 +289,7 @@ More info on this metric can be found in our [paper](https://arxiv.org/abs/2108.
 
 ```python
 advanced_eval_result = pipeline.eval(
-    labels=eval_labels, params={"Retriever": {"top_k": 1}}, sas_model_name_or_path="cross-encoder/stsb-roberta-large"
+    labels=eval_labels, params={"Retriever": {"top_k": 5}}, sas_model_name_or_path="cross-encoder/stsb-roberta-large"
 )
 
 metrics = advanced_eval_result.calculate_metrics()

--- a/haystack/nodes/other/join_docs.py
+++ b/haystack/nodes/other/join_docs.py
@@ -12,6 +12,7 @@ class JoinDocuments(BaseComponent):
 
     The node allows multiple join modes:
     * concatenate: combine the documents from multiple nodes. Any duplicate documents are discarded.
+                   The score is only determined by the last node that outputs the document.
     * merge: merge scores of documents from multiple nodes. Optionally, each input score can be given a different
              `weight` & a `top_k` limit can be set. This mode can also be used for "reranking" retrieved documents.
     * reciprocal_rank_fusion: combines the documents based on their rank in multiple nodes.


### PR DESCRIPTION
As discussed in #2558, this PR improves the documentation of the `JoinDocuments` node regarding the score when a document is returned by multiple input nodes and concatenation is used.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
