### PR TITLE
[CI refactoring] Avoid `ray==1.12.0` on Windows

### DIFF
--- a/docs/_src/tutorials/tutorials/5.md
+++ b/docs/_src/tutorials/tutorials/5.md
@@ -289,7 +289,7 @@ More info on this metric can be found in our [paper](https://arxiv.org/abs/2108.
 
 ```python
 advanced_eval_result = pipeline.eval(
-    labels=eval_labels, params={"Retriever": {"top_k": 1}}, sas_model_name_or_path="cross-encoder/stsb-roberta-large"
+    labels=eval_labels, params={"Retriever": {"top_k": 5}}, sas_model_name_or_path="cross-encoder/stsb-roberta-large"
 )
 
 metrics = advanced_eval_result.calculate_metrics()

--- a/setup.cfg
+++ b/setup.cfg
@@ -169,7 +169,8 @@ onnx-gpu =
     onnxruntime-gpu
     onnxruntime_tools
 ray = 
-    ray>=1.9.1,<2
+    ray>=1.9.1,<2; platform_system != 'Windows'
+    ray>=1.9.1,<2,!=1.12.0; platform_system == 'Windows'  # Avoid 1.12.0 due to https://github.com/ray-project/ray/issues/24169 (fails on windows)
     aiorwlock>=1.3.0,<2
 colab = 
     grpcio==1.43.0


### PR DESCRIPTION
**Problem**:
- Ray 1.12.0 has a bug that prevents it from working properly on Windows (https://github.com/ray-project/ray/issues/24169)

**Solution**
- Conditionally avoid version 1.12.0 if the Haystack is being installed on Windows (should not affect Linux or MacOS installations).