### PR TITLE
Update scriptrunner module path for streamlit ui

### DIFF
--- a/ui/setup.py
+++ b/ui/setup.py
@@ -36,5 +36,5 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.7, <4",
-    install_requires=["streamlit>=1.2.0, <2", "st-annotated-text>=2.0.0, <3", "markdown>=3.3.4, <4"],
+    install_requires=["streamlit>=1.2.0, <1.9.0", "st-annotated-text>=2.0.0, <3", "markdown>=3.3.4, <4"],
 )

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -36,5 +36,5 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.7, <4",
-    install_requires=["streamlit>=1.2.0, <1.9.0", "st-annotated-text>=2.0.0, <3", "markdown>=3.3.4, <4"],
+    install_requires=["streamlit>=1.2.0, <2", "st-annotated-text>=2.0.0, <3", "markdown>=3.3.4, <4"],
 )

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -164,7 +164,7 @@ Ask any question on this topic and see if Haystack can find the correct answer t
         st.session_state.random_question_requested = True
         # Re-runs the script setting the random question as the textbox value
         # Unfortunately necessary as the Random Question button is _below_ the textbox
-        raise st.script_runner.RerunException(st.script_request_queue.RerunData(None))
+        raise st.scriptrunner.script_runner.RerunException(st.scriptrunner.script_requests.RerunData(None))
     st.session_state.random_question_requested = False
 
     run_query = (


### PR DESCRIPTION
This PR fixes a bug that let the "Random question" button in the public Haystack demo fail every time as reported in #2563 

**Proposed changes:**
- Change scriptrunner module path in streamlit ui according to the changes made in streamlit: 
  - https://github.com/streamlit/streamlit/pull/4503
  - https://github.com/streamlit/streamlit/pull/4557

For reviewing, you can compare the currently deployed demo and a demo with the changes applied in a separate EC2 instance:
- without changes: https://haystack-demo.deepset.ai/
- with changes: http://ec2-54-74-125-170.eu-west-1.compute.amazonaws.com:8501/

closes #2563 

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
