### PR TITLE
Show search endpoint after deepset Cloud deployment

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -163,7 +163,7 @@ If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment varia
 
 ```python
 @classmethod
-def deploy_on_deepset_cloud(cls, pipeline_config_name: str, workspace: str = "default", api_key: Optional[str] = None, api_endpoint: Optional[str] = None, timeout: int = 60)
+def deploy_on_deepset_cloud(cls, pipeline_config_name: str, workspace: str = "default", api_key: Optional[str] = None, api_endpoint: Optional[str] = None, timeout: int = 60, show_curl_message: bool = True)
 ```
 
 Deploys the pipelines of a pipeline config on Deepset Cloud.
@@ -185,6 +185,7 @@ If not specified, will be read from DEEPSET_CLOUD_API_KEY environment variable.
 If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment variable.
 - `timeout`: The time in seconds to wait until deployment completes.
 If the timeout is exceeded an error will be raised.
+- `show_curl_message`: Whether to print an additional message after successful deployment showing how to query the pipeline using curl.
 
 <a id="base.Pipeline.undeploy_on_deepset_cloud"></a>
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -297,6 +297,7 @@ class Pipeline:
         api_key: Optional[str] = None,
         api_endpoint: Optional[str] = None,
         timeout: int = 60,
+        show_curl_message: bool = True,
     ):
         """
         Deploys the pipelines of a pipeline config on Deepset Cloud.
@@ -315,9 +316,10 @@ class Pipeline:
                              If not specified, will be read from DEEPSET_CLOUD_API_ENDPOINT environment variable.
         :param timeout: The time in seconds to wait until deployment completes.
                         If the timeout is exceeded an error will be raised.
+        :param show_curl_message: Whether to print an additional message after successful deployment showing how to query the pipeline using curl.
         """
         client = DeepsetCloud.get_pipeline_client(api_key=api_key, api_endpoint=api_endpoint, workspace=workspace)
-        client.deploy(pipeline_config_name=pipeline_config_name, timeout=timeout)
+        client.deploy(pipeline_config_name=pipeline_config_name, timeout=timeout, show_curl_message=show_curl_message)
 
     @classmethod
     def undeploy_on_deepset_cloud(

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -471,7 +471,7 @@ class PipelineClient:
         workspace: str = None,
         headers: dict = None,
         timeout: int = 60,
-        show_try_out_message: bool = True,
+        show_curl_message: bool = True,
     ):
         """
         Deploys the pipelines of a pipeline config on deepset Cloud.
@@ -485,7 +485,7 @@ class PipelineClient:
         :param headers: Headers to pass to API call
         :param timeout: The time in seconds to wait until deployment completes.
                         If the timeout is exceeded an error will be raised.
-        :param show_try_out_message: Whether to print a message showing how to query the pipeline using curl.
+        :param show_curl_message: Whether to print an additional message after successful deployment showing how to query the pipeline using curl.
         """
         status, changed = self._transition_pipeline_state(
             target_state=PipelineStatus.DEPLOYED,
@@ -495,11 +495,34 @@ class PipelineClient:
             headers=headers,
         )
 
+        if workspace is None:
+            workspace = self.workspace
+        if pipeline_config_name is None:
+            pipeline_config_name = self.pipeline_config_name
+
+        pipeline_url = f"{self.client.api_endpoint}/workspaces/{workspace}/pipelines/{pipeline_config_name}/search"
+
         if status == PipelineStatus.DEPLOYED:
             if changed:
                 logger.info(f"Pipeline config '{pipeline_config_name}' successfully deployed.")
             else:
                 logger.info(f"Pipeline config '{pipeline_config_name}' is already deployed.")
+            logger.info(f"Search endpoint for pipeline config '{pipeline_config_name}' is up and running for you under {pipeline_url}")
+            if show_curl_message:
+                curl_cmd = (
+                    f"curl -X 'POST' \\\n"
+                    f"  '{pipeline_url}' \\\n"
+                    f"  -H 'accept: application/json' \\\n"
+                    f"  -H 'Authorization: Bearer <INSERT_TOKEN_HERE>' \\\n"
+                    f"  -H 'Content-Type: application/json' \\\n"
+                    f"  -d '{{\n"
+                    f'  "queries": [\n'
+                    f'    "Is there an answer to this question?"\n'
+                    f"  ]\n"
+                    f"}}'"
+                )
+                logger.info(f"Try it out using the following curl command:\n{curl_cmd}")
+
         elif status == PipelineStatus.DEPLOYED_UNHEALTHY:
             logger.warning(
                 f"Deployment of pipeline config '{pipeline_config_name}' succeeded. But '{pipeline_config_name}' is unhealthy."
@@ -514,25 +537,6 @@ class PipelineClient:
             raise DeepsetCloudError(
                 f"Deployment of pipeline config '{pipeline_config_name} ended in unexpected status: {status.value}"
             )
-
-        if show_try_out_message and status in [PipelineStatus.DEPLOYED, PipelineStatus.DEPLOYED_UNHEALTHY]:
-            if workspace is None:
-                workspace = self.workspace
-            if pipeline_config_name is None:
-                pipeline_config_name = self.pipeline_config_name
-            curl_cmd = (
-                f"curl -X 'POST' \\\n"
-                f"  'https://api.test.cloud.deepset.ai/api/v1/workspaces/{workspace}/pipelines/{pipeline_config_name}/search' \\\n"
-                f"  -H 'accept: application/json' \\\n"
-                f"  -H 'Authorization: Bearer <INSERT_TOKEN_HERE>' \\\n"
-                f"  -H 'Content-Type: application/json' \\\n"
-                f"  -d '{{\n"
-                f'  "queries": [\n'
-                f'    "Is there an answer to this question?"\n'
-                f"  ]\n"
-                f"}}'"
-            )
-            logger.info(f"Try it out:\n{curl_cmd}")
 
     def undeploy(
         self, pipeline_config_name: Optional[str] = None, workspace: str = None, headers: dict = None, timeout: int = 60

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -507,7 +507,9 @@ class PipelineClient:
                 logger.info(f"Pipeline config '{pipeline_config_name}' successfully deployed.")
             else:
                 logger.info(f"Pipeline config '{pipeline_config_name}' is already deployed.")
-            logger.info(f"Search endpoint for pipeline config '{pipeline_config_name}' is up and running for you under {pipeline_url}")
+            logger.info(
+                f"Search endpoint for pipeline config '{pipeline_config_name}' is up and running for you under {pipeline_url}"
+            )
             if show_curl_message:
                 curl_cmd = (
                     f"curl -X 'POST' \\\n"

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -977,7 +977,7 @@ def test_undeploy_on_deepset_cloud_non_existing_pipeline():
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
 @responses.activate
-def test_deploy_on_deepset_cloud():
+def test_deploy_on_deepset_cloud(caplog):
     if MOCK_DC:
         responses.add(
             method=responses.POST,
@@ -996,9 +996,48 @@ def test_deploy_on_deepset_cloud():
                 status=200,
             )
 
-    Pipeline.deploy_on_deepset_cloud(
-        pipeline_config_name="test_new_non_existing_pipeline", api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY
-    )
+    with caplog.at_level(logging.INFO):
+        pipeline_url = f"{DC_API_ENDPOINT}/workspaces/default/pipelines/test_new_non_existing_pipeline/search"
+        Pipeline.deploy_on_deepset_cloud(
+            pipeline_config_name="test_new_non_existing_pipeline", api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY
+        )
+        assert "Pipeline config 'test_new_non_existing_pipeline' successfully deployed." in caplog.text
+        assert pipeline_url in caplog.text
+        assert "curl" in caplog.text
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_deploy_on_deepset_cloud_no_curl_message(caplog):
+    if MOCK_DC:
+        responses.add(
+            method=responses.POST,
+            url=f"{DC_API_ENDPOINT}/workspaces/default/pipelines/test_new_non_existing_pipeline/deploy",
+            json={"status": "DEPLOYMENT_SCHEDULED"},
+            status=200,
+        )
+
+        # status will be first undeployed, after deploy() it's in progress twice and the third time deployed
+        status_flow = ["UNDEPLOYED", "DEPLOYMENT_IN_PROGRESS", "DEPLOYMENT_IN_PROGRESS", "DEPLOYED"]
+        for status in status_flow:
+            responses.add(
+                method=responses.GET,
+                url=f"{DC_API_ENDPOINT}/workspaces/default/pipelines/test_new_non_existing_pipeline",
+                json={"status": status},
+                status=200,
+            )
+
+    with caplog.at_level(logging.INFO):
+        pipeline_url = f"{DC_API_ENDPOINT}/workspaces/default/pipelines/test_new_non_existing_pipeline/search"
+        Pipeline.deploy_on_deepset_cloud(
+            pipeline_config_name="test_new_non_existing_pipeline",
+            api_endpoint=DC_API_ENDPOINT,
+            api_key=DC_API_KEY,
+            show_curl_message=False,
+        )
+        assert "Pipeline config 'test_new_non_existing_pipeline' successfully deployed." in caplog.text
+        assert pipeline_url in caplog.text
+        assert "curl" not in caplog.text
 
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)


### PR DESCRIPTION
**Proposed changes**:
- show search endpoint after deployment
- show curl try out message after deployment
- add flag to omit curl message

Success output will be:
```
INFO - haystack.utils.deepsetcloud -  Pipeline config 'test_qa_pipeline_2' successfully deployed.
INFO - haystack.utils.deepsetcloud -  Search endpoint for pipeline config 'test_qa_pipeline_2' is up and running for you under https://api.test.cloud.deepset.ai/api/v1/workspaces/default/pipelines/test_qa_pipeline_2/search
INFO - haystack.utils.deepsetcloud -  Try it out using the following curl command:
curl -X 'POST' \
  'https://api.test.cloud.deepset.ai/api/v1/workspaces/default/pipelines/test_qa_pipeline_2/search' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <INSERT_TOKEN_HERE>' \
  -H 'Content-Type: application/json' \
  -d '{
  "queries": [
    "Is there an answer to this question?"
  ]
}'
```

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
- [x] Added tests
- [ ] Updated documentation

closes https://github.com/deepset-ai/haystack/issues/2474