### PR TITLE
Do not copy `_component_config` in `get_components_definitions`

### DIFF
--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -5,7 +5,7 @@ import os
 import json
 import logging
 from pathlib import Path
-from copy import deepcopy
+from copy import copy
 
 import yaml
 import networkx as nx
@@ -68,10 +68,9 @@ def get_component_definitions(
     """
     component_definitions = {}  # definitions of each component from the YAML.
 
-    raw_pipeline_config = pipeline_config["components"]
-
-    for raw_component_definition in raw_pipeline_config:
+    for raw_component_definition in pipeline_config["components"]:
         name = raw_component_definition["name"]
+        # We perform a shallow copy here because of https://github.com/deepset-ai/haystack/issues/2568
         component_definition = {key: copy(value) for key, value in raw_component_definition.items() if key != "name"}
         component_definitions[name] = component_definition
 
@@ -84,7 +83,6 @@ def get_component_definitions(
                     logger.info(
                         f"Param '{param_name}' of component '{name}' overwritten with environment variable '{key}' value '{value}'."
                     )
-
     return component_definitions
 
 

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Optional
 
 import re
 import os
-import copy
 import json
 import logging
 from pathlib import Path

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -77,20 +77,21 @@ def get_component_definitions(
     if overwrite_with_env_variables:
         for component_def in pipeline_config["components"]:
             for key, value in os.environ.items():
-                if key.startswith( f"{component_def['name']}_params_".upper()):
+                if key.startswith(f"{component_def['name']}_params_".upper()):
                     try:
                         raw_pipeline_config = deepcopy(pipeline_config["components"])
                     except Exception as e:
                         raise PipelineError(
                             "Cannot overwrite the pipeline configuration with environment variables "
                             "if such config contains un-copiable objects.\n"
-                            f"Exception raised: {str(e)}") from e
+                            f"Exception raised: {str(e)}"
+                        ) from e
 
     for raw_component_definition in raw_pipeline_config:
         name = raw_component_definition["name"]
         component_definition = {key: value for key, value in raw_component_definition.items() if key != "name"}
         component_definitions[name] = component_definition
-        
+
         if overwrite_with_env_variables:
             for key, value in os.environ.items():
                 if key.startswith(f"{name}_params_".upper()):

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -5,6 +5,7 @@ import os
 import json
 import logging
 from pathlib import Path
+from copy import deepcopy
 
 import yaml
 import networkx as nx
@@ -66,32 +67,40 @@ def get_component_definitions(
                                          `_` sign must be used to specify nested hierarchical properties.
     """
     component_definitions = {}  # definitions of each component from the YAML.
-    for raw_component_definition in pipeline_config["components"]:
+
+    raw_pipeline_config = pipeline_config["components"]
+
+    # If there is at least one env var that needs to be applied to this config,
+    # then try to deep-copy it to avoid mutating the input pipeline_config unexpectedly.
+    # In some cases however the deepcopy can break auth objects (like SSL context),
+    # so we should avoid it as much as possible.
+    if overwrite_with_env_variables:
+        for component_def in pipeline_config["components"]:
+            for key, value in os.environ.items():
+                if key.startswith( f"{component_def['name']}_params_".upper()):
+                    try:
+                        raw_pipeline_config = deepcopy(pipeline_config["components"])
+                    except Exception as e:
+                        raise PipelineError(
+                            "Cannot overwrite the pipeline configuration with environment variables "
+                            "if such config contains un-copiable objects.\n"
+                            f"Exception raised: {str(e)}") from e
+
+    for raw_component_definition in raw_pipeline_config:
         name = raw_component_definition["name"]
         component_definition = {key: value for key, value in raw_component_definition.items() if key != "name"}
         component_definitions[name] = component_definition
+        
         if overwrite_with_env_variables:
-            _overwrite_with_env_variables(component_name=name, component_definition=component_definition)
+            for key, value in os.environ.items():
+                if key.startswith(f"{name}_params_".upper()):
+                    param_name = key.replace(env_prefix, "").lower()
+                    component_definition["params"][param_name] = value
+                    logger.info(
+                        f"Param '{param_name}' of component '{name}' overwritten with environment variable '{key}' value '{value}'."
+                    )
 
     return component_definitions
-
-
-def _overwrite_with_env_variables(component_name: str, component_definition: Dict[str, Any]):
-    """
-    Overwrite the pipeline config with environment variables. For example, to change index name param for an
-    ElasticsearchDocumentStore, an env variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
-    `_` sign must be used to specify nested hierarchical properties.
-
-    :param definition: a dictionary containing the YAML definition of a component.
-    """
-    env_prefix = f"{component_name}_params_".upper()
-    for key, value in os.environ.items():
-        if key.startswith(env_prefix):
-            param_name = key.replace(env_prefix, "").lower()
-            component_definition["params"][param_name] = value
-            logger.info(
-                f"Param '{param_name}' of component '{component_name}' overwritten with environment variable '{key}' value '{value}'."
-            )
 
 
 def read_pipeline_config_from_yaml(path: Path) -> Dict[str, Any]:

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -66,9 +66,10 @@ def get_component_definitions(
                                          `_` sign must be used to specify nested hierarchical properties.
     """
     component_definitions = {}  # definitions of each component from the YAML.
-    for component_definition in pipeline_config["components"]:
-        name = component_definition["name"]
-        component_definitions[name] = {key: value for key, value in component_definition.items() if key != "name"}
+    for raw_component_definition in pipeline_config["components"]:
+        name = raw_component_definition["name"]
+        component_definition = {key: value for key, value in raw_component_definition.items() if key != "name"}
+        component_definitions[name] = component_definition
         if overwrite_with_env_variables:
             _overwrite_with_env_variables(component_name=name, component_definition=component_definition)
 

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -1436,7 +1436,7 @@ def test_pipeline_nodes_can_have_uncopiable_objects_as_args():
     pipeline.add_node(component=node, name="node", inputs=["Query"])
 
     # If the object is getting copied, it will raise TypeError: cannot pickle 'SSLContext' object
-    # get_components_definitions should NOT copy objects to allow this usecase
+    # `get_components_definitions()` should NOT copy objects to allow this usecase
     get_component_definitions(pipeline.get_config())
 
 

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -1476,6 +1476,28 @@ def test_pipeline_env_vars_do_not_modify__component_config(monkeypatch):
     assert new_pipeline_config["components"][0]["params"]["replaceable"] == "init value"
 
 
+def test_pipeline_env_vars_do_not_modify_pipeline_config(monkeypatch):
+    class DummyNode(MockNode):
+        def __init__(self, replaceable: str):
+            self.replaceable = replaceable
+
+    monkeypatch.setenv("NODE_PARAMS_REPLACEABLE", "env value")
+
+    node = DummyNode(replaceable="init value")
+    pipeline = Pipeline()
+    pipeline.add_node(component=node, name="node", inputs=["Query"])
+
+    pipeline_config = pipeline.get_config()
+    original_pipeline_config = deepcopy(pipeline_config)
+
+    get_component_definitions(pipeline_config, overwrite_with_env_variables=True)
+
+    assert original_pipeline_config == pipeline_config
+    assert original_pipeline_config["components"][0]["params"]["replaceable"] == "init value"
+    assert pipeline_config["components"][0]["params"]["replaceable"] == "init value"
+
+
+
 def test_parallel_paths_in_pipeline_graph():
     class A(RootNode):
         def run(self):

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -1454,11 +1454,15 @@ def test_pipeline_env_vars_do_not_modify__component_config(monkeypatch):
     node = DummyNode(replaceable="init value")
     pipeline = Pipeline()
     pipeline.add_node(component=node, name="node", inputs=["Query"])
+
     original_component_config = deepcopy(node._component_config)
+    original_pipeline_config = deepcopy(pipeline.get_config())
 
     no_env_defs = get_component_definitions(pipeline.get_config(), overwrite_with_env_variables=False)
     env_defs = get_component_definitions(pipeline.get_config(), overwrite_with_env_variables=True)
+
     new_component_config = deepcopy(node._component_config)
+    new_pipeline_config = deepcopy(pipeline.get_config())
 
     assert no_env_defs != env_defs
     assert no_env_defs["node"]["params"]["replaceable"] == "init value"
@@ -1467,6 +1471,10 @@ def test_pipeline_env_vars_do_not_modify__component_config(monkeypatch):
     assert original_component_config == new_component_config
     assert original_component_config["params"]["replaceable"] == "init value"
     assert new_component_config["params"]["replaceable"] == "init value"
+
+    assert original_pipeline_config == new_pipeline_config
+    assert original_pipeline_config["components"][0]["params"]["replaceable"] == "init value"
+    assert new_pipeline_config["components"][0]["params"]["replaceable"] == "init value"
 
 
 def test_parallel_paths_in_pipeline_graph():


### PR DESCRIPTION
Closes #2568 

**Problem**:
- `get_component_definitions` used to `deepcopy` the content of `_component_config` to convert it into the proper format and apply env vars. However, some objects contained in that dict are not supposed to be copied: for example the `aws4auth` param of Opensearch, which would trigger a `TypeError` as soon as the method tried to copy the SSL context .

**Solution**:
- The method could be slightly rewritten to avoid that `deepcopy` operation. 
- A test has been added.
