### PR TITLE
Fix knn params for aws managed opensearch

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -2177,8 +2177,9 @@ class OpenSearchDocumentStore(ElasticsearchDocumentStore):
         method: dict = {"space_type": space_type, "name": "hnsw", "engine": "nmslib"}
 
         if self.index_type == "flat":
-            # use default parameters
-            pass
+            # use default parameters from https://opensearch.org/docs/1.2/search-plugins/knn/knn-index/
+            # we need to set them explicitly as aws managed instances starting from version 1.2 do not support empty parameters
+            method["parameters"] = {"ef_construction": 512, "m": 16}
         elif self.index_type == "hnsw":
             method["parameters"] = {"ef_construction": 80, "m": 64}
         else:


### PR DESCRIPTION
Starting with version 1.2 of AWS managed OpenSearch mappings with empty parameters for knn embedding properties using hnsw appear not be accepted anymore

**Proposed changes**:
- set default parameters explicitly

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
