### PR TITLE
Avoid empty `api_endpoint` in `load_from_deepset_cloud`

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -196,14 +196,12 @@ class Pipeline:
         for component_config in pipeline_config["components"]:
             if component_config["type"] == "DeepsetCloudDocumentStore":
                 params = component_config.get("params", {})
-                params.update(
-                    {
-                        "api_key": api_key,
-                        "api_endpoint": api_endpoint,
-                        "workspace": workspace,
-                        "index": pipeline_config_name,
-                    }
-                )
+                params["index"] = pipeline_config_name
+                params["workspace"] = workspace
+                if api_endpoint is not None:
+                    params["api_endpoint"] = api_endpoint
+                if api_key is not None:
+                    params["api_key"] = api_key
                 component_config["params"] = params
 
         del pipeline_config["name"]  # Would fail validation otherwise


### PR DESCRIPTION
**Proposed changes**:
- do not set `api_endpoint` and `api_key` if they are `None`

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code

closes https://github.com/deepset-ai/haystack/issues/2586