### PR TITLE
Fix `StaleElementReferenceException` in Crawler

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -280,7 +280,7 @@ class Crawler(BaseComponent):
         self, base_url: str, filter_urls: Optional[List] = None, existed_links: List = None
     ) -> set:
         self.driver.get(base_url)
-        a_elements = self.driver.find_elements_by_tag_name("a")
+        a_elements = self.driver.find_elements_by_xpath("//a[@href]")
         sub_links = set()
         if not (existed_links and base_url in existed_links):
             if filter_urls:


### PR DESCRIPTION
When trying to crawl for example sub-pages of the following page (`https://taz.de/!s=&OnlineRessort=5097/?search_page=0`), we get the following error:
```
selenium.common.exceptions.StaleElementReferenceException: Message: stale element reference: element is not attached to the page document
```

This PR makes sure that we only try to crawl elements where the `href` attribute is available.