### PR TITLE
Allow nodes that accept multiple nodes to receive only one

### DIFF
--- a/haystack/nodes/base.py
+++ b/haystack/nodes/base.py
@@ -250,7 +250,9 @@ class BaseComponent(ABC):
             for param_key, parameter in inspect.signature(class_).parameters.items()
         }
         return component_signature
-
+    
+    def _takes_multiple_inputs(self):
+        return "inputs" in inspect.signature(self.run).parameters
 
 class RootNode(BaseComponent):
     """

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -674,24 +674,21 @@ class Pipeline:
                 else:
                     next_nodes = self.get_next_nodes(node_id, stream_id)
                     for n in next_nodes:
-                        if queue.get(n):  # concatenate inputs if it's a join node
-                            existing_input = queue[n]
-                            if "inputs" not in existing_input.keys():
-                                updated_input: Dict = {"inputs": [existing_input, node_output], "params": params}
+                        if self.graph.nodes[n]["component"]._takes_multiple_inputs():  # concatenate inputs if it's a join node
+                            if n not in queue:
+                                new_input = {"inputs": [], "params": params}
                                 if queries:
-                                    updated_input["queries"] = queries
+                                    new_input["queries"] = queries
                                 if file_paths:
-                                    updated_input["file_paths"] = file_paths
+                                    new_input["file_paths"] = file_paths
                                 if labels:
-                                    updated_input["labels"] = labels
+                                    new_input["labels"] = labels
                                 if documents:
-                                    updated_input["documents"] = documents
+                                    new_input["documents"] = documents
                                 if meta:
-                                    updated_input["meta"] = meta
-                            else:
-                                existing_input["inputs"].append(node_output)
-                                updated_input = existing_input
-                            queue[n] = updated_input
+                                    new_input["meta"] = meta
+                            new_input["inputs"].append(node_output)
+                            queue[n] = new_input
                         else:
                             queue[n] = node_output
                 i = 0

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -529,24 +529,21 @@ class Pipeline:
                 else:
                     next_nodes = self.get_next_nodes(node_id, stream_id)
                     for n in next_nodes:  # add successor nodes with corresponding inputs to the queue
-                        if queue.get(n):  # concatenate inputs if it's a join node
-                            existing_input = queue[n]
-                            if "inputs" not in existing_input.keys():
-                                updated_input: dict = {"inputs": [existing_input, node_output], "params": params}
+                        if self.graph.nodes[n]["component"]._takes_multiple_inputs():  # concatenate inputs if it's a join node
+                            if n not in queue:
+                                new_input = {"inputs": [], "params": params}
                                 if query:
-                                    updated_input["query"] = query
+                                    new_input["query"] = query
                                 if file_paths:
-                                    updated_input["file_paths"] = file_paths
+                                    new_input["file_paths"] = file_paths
                                 if labels:
-                                    updated_input["labels"] = labels
+                                    new_input["labels"] = labels
                                 if documents:
-                                    updated_input["documents"] = documents
+                                    new_input["documents"] = documents
                                 if meta:
-                                    updated_input["meta"] = meta
-                            else:
-                                existing_input["inputs"].append(node_output)
-                                updated_input = existing_input
-                            queue[n] = updated_input
+                                    new_input["meta"] = meta
+                            new_input["inputs"].append(node_output)
+                            queue[n] = new_input
                         else:
                             queue[n] = node_output
                 i = 0

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -533,7 +533,7 @@ class Pipeline:
                             "component"
                         ]._takes_multiple_inputs():  # concatenate inputs if it's a join node
                             if n not in queue:
-                                new_input = {"inputs": [], "params": params}
+                                new_input: Dict[str, Any] = {"inputs": [], "params": params}
                                 if query:
                                     new_input["query"] = query
                                 if file_paths:
@@ -678,7 +678,7 @@ class Pipeline:
                     for n in next_nodes:
                         if self.graph.nodes[n]["component"]._takes_multiple_inputs():  # concatenate inputs if it's a join node
                             if n not in queue:
-                                new_input = {"inputs": [], "params": params}
+                                new_input: Dict[str, Any] = {"inputs": [], "params": params}
                                 if queries:
                                     new_input["queries"] = queries
                                 if file_paths:


### PR DESCRIPTION
**Proposed changes**:
This can be useful when experimenting with multiple retrievers.

Instead of determining if a node can have multiple inputs by looking at the actual number of inputs in the graph, it would now look at whether it's taking the `inputs` parameter (already 'magic' parameter for pipelines with multiple inputs). This could theoretically break some custom nodes and create confusing issues, although in practice that is probably unlikely.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
