### PR TITLE
Fix `pipeline.eval` with context matching for Table-QA

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1323,8 +1323,8 @@ class Pipeline:
                 df_answers["gold_contexts_similarity"] = df_answers.map_rows(
                     lambda row: [
                         calculate_context_similarity(
-                            gold_context,
-                            row["context"] or "",
+                            str(gold_context),  # could be dataframe
+                            str(row["context"]) if row["context"] is not None else "",  # could be dataframe
                             min_length=context_matching_min_length,
                             boost_split_overlaps=context_matching_boost_split_overlaps,
                         )

--- a/tutorials/Tutorial15_TableQA.py
+++ b/tutorials/Tutorial15_TableQA.py
@@ -141,6 +141,8 @@ def tutorial15_tableqa():
     passages = read_texts(f"{doc_dir}/texts.json")
     document_store.write_documents(passages)
 
+    document_store.update_embeddings(retriever=retriever, update_existing_embeddings=False)
+
     # Example query whose answer resides in a text passage
     predictions = text_table_qa_pipeline.run(query="Which country does the film Macaroni come from?")
     # We can see both text passages and tables as contexts of the predicted answers.


### PR DESCRIPTION
**Proposed changes**:
- before context matching, if context is dataframe convert it to string
- this also adds a missing `update_embeddings` statement to the py file of tutorial 15

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
