### PR TITLE
Update Milvus installation instructions to v2

### DIFF
--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -20,7 +20,7 @@ def tutorial6_better_retrieval_via_dpr():
     # It does require a little more setup, however, as it is run through Docker and requires the setup of some config files.
     # See https://milvus.io/docs/v1.0.0/milvus_docker-cpu.md
 
-    # Do not forget to install its dependencies with `pip install farm-haystack[milvus1]`
+    # Do not forget to install its dependencies with `pip install farm-haystack[milvus]`
     # launch_milvus()
     # document_store = MilvusDocumentStore()
 


### PR DESCRIPTION
**Proposed changes**:
- just a small update in tutorial 6, which still had installation instructions for milvus 1 rather than milvus 2
