### PR TITLE
Resolution of deprecation warnings for __floordiv__ 

### DIFF
--- a/haystack/modeling/model/prediction_head.py
+++ b/haystack/modeling/model/prediction_head.py
@@ -14,7 +14,7 @@ from scipy.special import expit
 
 from haystack.modeling.data_handler.samples import SampleBasket
 from haystack.modeling.model.predictions import QACandidate, QAPred
-from haystack.modeling.utils import try_get, all_gather_list
+from haystack.modeling.utils import try_get, all_gather_list, torch_int_div
 
 
 logger = logging.getLogger(__name__)
@@ -480,7 +480,7 @@ class QuestionAnsweringHead(PredictionHead):
 
         # The returned indices are then converted back to the original dimensionality of the matrix.
         # sorted_candidates.shape : (batch_size, max_seq_len^2, 2)
-        start_indices = flat_sorted_indices // max_seq_len
+        start_indices = torch_int_div(flat_sorted_indices, max_seq_len)
         end_indices = flat_sorted_indices % max_seq_len
         sorted_candidates = torch.cat((start_indices, end_indices), dim=2)
 

--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -110,6 +110,17 @@ def flatten_list(nested_list):
         else:
             yield sublist
 
+            
+# Fix from: https://github.com/huggingface/transformers/pull/15180
+def torch_int_div(tensor1, tensor2):
+    """
+    A function that performs integer division across different versions of PyTorch.
+    """
+    if version.parse(torch.__version__) < version.parse("1.8.0"):
+        return tensor1 // tensor2
+    else:
+        return torch.div(tensor1, tensor2, rounding_mode="floor")
+    
 
 def try_get(keys, dictionary):
     try:


### PR DESCRIPTION
**Proposed changes**:
- Resolution of deprecation warnings using transformers applied fix here: https://github.com/huggingface/transformers/pull/15180
 ```
WARNING: C:\Users\user\anaconda3\envs\demo\lib\site-packages\haystack\modeling\model\prediction_head.py:483: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future

version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, r
ounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').
  start_indices = flat_sorted_indices // max_seq_len
```

1. Inclusion of the following in haystack/modeling/utils.py:
```
def torch_int_div(tensor1, tensor2):
    """
    A function that performs integer division across different versions of PyTorch.
    """
    if version.parse(torch.__version__) < version.parse("1.8.0"):
        return tensor1 // tensor2
    else:
        return torch.div(tensor1, tensor2, rounding_mode="floor")
```

2.  Changing the following instances in the code:

```
- start_indices = flat_sorted_indices // max_seq_len
+ start_indices = torch_int_div(flat_sorted_indices, max_seq_len)
```

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
