### PR TITLE
first version of save_to_remote for HF from FarmReader

### DIFF
--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -691,29 +691,29 @@ class FARMReader(BaseReader):
         self.inferencer.model.save(directory)
         self.inferencer.processor.save(directory)
 
-    def save_to_remote(self, 
-                    model_name: str,
-                    hf_organization: Optional[str] = None,
-                    private: Optional[bool] = None,
-                    commit_message: str = "Add new model to Hugging Face."):
+    def save_to_remote(
+        self,
+        model_name: str,
+        hf_organization: Optional[str] = None,
+        private: Optional[bool] = None,
+        commit_message: str = "Add new model to Hugging Face.",
+    ):
 
         token = HfFolder.get_token()
         if token is None:
-            raise ValueError("You must login to the Hugging Face hub on this computer by typing `transformers-cli login`.")
-        
+            raise ValueError(
+                "You must login to the Hugging Face hub on this computer by typing `transformers-cli login`."
+            )
+
         repo_url = create_repo(
-                token,
-                model_name,
-                organization=hf_organization,
-                private=private,
-                repo_type=None,
-                exist_ok=True)
-        
+            token, model_name, organization=hf_organization, private=private, repo_type=None, exist_ok=True
+        )
+
         transformer_models = self.inferencer.model.convert_to_transformers()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo = Repository(tmp_dir, clone_from=repo_url)
-            
+
             self.save(tmp_dir)
             transformer_models[0].save_pretrained(tmp_dir)
 


### PR DESCRIPTION
Fixes #2416 

This draft PR introduces the `save_to_remote()` function to the `FarmReader` 
It converts a model to the transformer models format using the `convert_to_transformer` method from the `AdaptiveModel` class.
I have tested this by fine-tuning a model and then calling `save_to_remote` - then loading that same model back into `FarmReader` and using it in an `ExtractiveQuestionAnswering` pipeline

(PS: sentence-transformers implements this in their own repo and I was able to reuse their method of tracking files for lfs)

**To do and test**
- I am unsure how this would behave in the case the repo already exists on HF. The `create_repo` method from huggingface_hub has an `exists_ok` argument which I've set to True but this still needs testing
- The draft/default model card
- Testing that this structure of model is ok and can generalise to other types of models(?) that could be trained with FarmReader
- Once we're happy with this, we would need the same for the other two classes: `DensePassageRetriever` and `TableTextRetriever`

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
