### PR TITLE
Fix params being changed during pipeline.eval()

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1109,6 +1109,8 @@ class Pipeline:
         if add_isolated_node_eval:
             if params is None:
                 params = {}
+            else:
+                params = params.copy()
             params["add_isolated_node_eval"] = True
 
         # if documents is None, set docs_per_label to None for each label


### PR DESCRIPTION
Currently when setting `add_isolated_node_eval=True` the entry `"add_isolated_node_eval"` is added to the `params` dict. This is confusing as the params dict would be logged to MLflow during `execute_eval_run` having the same information at two places. Additionally we should not change the passed `params` dict during eval.

**Proposed changes**:
- copy params dict before adding `add_isolated_node_eval` to it

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
