### PR TITLE
Do not show success message on failed evalset upload

### DIFF
--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -889,12 +889,11 @@ class EvaluationSetClient:
             mime_type = guess_type(str(file_path))[0]
             with open(file_path, "rb") as file:
                 self.client.post(url=target_url, files={"file": (file_path.name, file, mime_type)})
-        except Exception as e:
-            logger.exception(f"Error uploading evaluation set file {file_path}")
-
-        logger.info(
-            f"Successfully uploaded evaluation set file {file_path}. You can access it now under evaluation set '{file_path.name}'."
-        )
+            logger.info(
+                f"Successfully uploaded evaluation set file {file_path}. You can access it now under evaluation set '{file_path.name}'."
+            )
+        except DeepsetCloudError as e:
+            logger.error(f"Error uploading evaluation set file {file_path}: {e.args}")
 
     def get_evaluation_set(
         self, evaluation_set: Optional[str] = None, workspace: Optional[str] = None

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -921,7 +921,7 @@ def test_upload_existing_eval_set(caplog):
         responses.add(
             method=responses.POST,
             url=f"{DC_API_ENDPOINT}/workspaces/default/evaluation_sets/import",
-            json={"errors":["Evaluation set with the same name already exists."]},
+            json={"errors": ["Evaluation set with the same name already exists."]},
             status=409,
         )
 

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -912,3 +912,22 @@ def test_upload_eval_set(caplog):
         client.upload_evaluation_set(file_path=SAMPLES_PATH / "dc/matching_test_1.csv")
         assert f"Successfully uploaded evaluation set file" in caplog.text
         assert f"You can access it now under evaluation set 'matching_test_1.csv'." in caplog.text
+
+
+@pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
+@responses.activate
+def test_upload_existing_eval_set(caplog):
+    if MOCK_DC:
+        responses.add(
+            method=responses.POST,
+            url=f"{DC_API_ENDPOINT}/workspaces/default/evaluation_sets/import",
+            json={"errors":["Evaluation set with the same name already exists."]},
+            status=409,
+        )
+
+    client = DeepsetCloud.get_evaluation_set_client(api_endpoint=DC_API_ENDPOINT, api_key=DC_API_KEY)
+    with caplog.at_level(logging.INFO):
+        client.upload_evaluation_set(file_path=SAMPLES_PATH / "dc/matching_test_1.csv")
+        assert f"Successfully uploaded evaluation set file" not in caplog.text
+        assert f"You can access it now under evaluation set 'matching_test_1.csv'." not in caplog.text
+        assert "Evaluation set with the same name already exists." in caplog.text


### PR DESCRIPTION
Currently success message is show even if evalset upload failed (together with the error). This PR fixes this

**Proposed changes**:
- show success message only if upload was successful

**Status (please check what you already did)**:
- [x] First draft (up for discussions & feedback)
- [x] Final code
