### PR TITLE
Fix failing `Crawler` test

### DIFF
--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -1,8 +1,6 @@
 from typing import List
-import os
+
 import json
-import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -21,8 +19,7 @@ def test_url():
 def content_match(crawler: Crawler, url: str, crawled_page: Path):
     """
     :param crawler: the tested Crawler object
-    :param base_url: the URL from test_url fixture
-    :param page_name: the expected page
+    :param url: the URL of the expected page
     :param crawled_page: the output of Crawler (one element of the paths list)
     """
     crawler.driver.get(url)
@@ -40,9 +37,9 @@ def content_in_results(crawler: Crawler, url: str, results: List[Path], expected
     by the crawler.
 
     :param crawler: the tested Crawler object
-    :param url: the URL from test_url fixture
-    :param page_name: the expected page
-    :param crawled_page: the output of Crawler (one element of the paths list)
+    :param url: the URL of the page to find in the results
+    :param results: the crawler's output (list of paths)
+    :param expected_matches_count: how many copies of this page should be present in the results (default 1)
     """
     return sum(content_match(crawler, url, path) for path in results) == expected_matches_count
 

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -1,3 +1,4 @@
+from typing import List
 import os
 import json
 import shutil
@@ -31,6 +32,19 @@ def content_match(crawler: Crawler, url: str, crawled_page: Path):
     with open(crawled_page, "r") as crawled_file:
         page_data = json.load(crawled_file)
         return page_data["content"] == expected_crawled_content
+
+
+def content_in_results(crawler: Crawler, url: str, results: List[Path], expected_matches_count=1):
+    """
+    Makes sure there is exactly one matching page in the list of pages returned
+    by the crawler.
+
+    :param crawler: the tested Crawler object
+    :param url: the URL from test_url fixture
+    :param page_name: the expected page
+    :param crawled_page: the output of Crawler (one element of the paths list)
+    """
+    return sum(content_match(crawler, url, path) for path in results) == expected_matches_count
 
 
 #
@@ -81,17 +95,17 @@ def test_crawler_depth_0_many_urls(test_url, tmp_path):
     _urls = [test_url + "/index.html", test_url + "/page1.html"]
     paths = crawler.crawl(urls=_urls, crawler_depth=0)
     assert len(paths) == 2
-    assert content_match(crawler, test_url + "/index.html", paths[0])
-    assert content_match(crawler, test_url + "/page1.html", paths[1])
+    assert content_in_results(crawler, test_url + "/index.html", paths)
+    assert content_in_results(crawler, test_url + "/page1.html", paths)
 
 
 def test_crawler_depth_1_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=1)
     assert len(paths) == 3
-    assert content_match(crawler, test_url + "/index.html", paths[0])
-    assert content_match(crawler, test_url + "/page1.html", paths[1])
-    assert content_match(crawler, test_url + "/page2.html", paths[2])
+    assert content_in_results(crawler, test_url + "/index.html", paths)
+    assert content_in_results(crawler, test_url + "/page1.html", paths)
+    assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
 def test_crawler_output_file_structure(test_url, tmp_path):


### PR DESCRIPTION
**Problem**
- For some reason, Crawler tests started failing on CI after the merge on master due to the instability of the ordering of crawled pages.

**Solution**:
- Make tests insensitive to ordering of crawled pages.