### PR TITLE
Make 'ready for review' an event that triggers the tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - master
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     paths:
       - '**/*.py'
       - '**/*.yml'


### PR DESCRIPTION
**Problem**:
- Currently when a PR is in draft, only a subset of the tests is run. Once is converted to ready for review, the whole tree is supposed to run, but the workflow will only trigger as soon as another commit is pushed.

**Solution**
- Make "Ready for review" an event that triggers the tests workflow, so that all PRs ready for review have at least one full run of the tests workflow.