### PR TITLE
wait for postgres to be ready before data migrations

### DIFF
--- a/annotation_tool/docker-compose.yml
+++ b/annotation_tool/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
   backend:
     image: deepset/haystack-annotation:latest
-    container_name: haystack-annotation
     environment:
       DEFAULT_ADMIN_EMAIL: "example@example.com"
       DEFAULT_ADMIN_PASSWORD: "DEMO_PASSWORD"
@@ -23,7 +22,6 @@ services:
 
   db:
     image: "postgres:12"
-    container_name: "postgres"
     environment:
       POSTGRES_USER: "somesafeuser"
       POSTGRES_PASSWORD: "somesafepassword"
@@ -34,6 +32,10 @@ services:
       - ./postgres-data:/var/lib/postgresql/data
     networks:
       - app-network
+    healthcheck:
+      test: "pg_isready --username=somesafeuser && psql --username=somesafepassword --list"
+      timeout: 3s
+      retries: 5
     restart: unless-stopped
 
 networks:


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack/issues/2356

**Proposed changes**:
- Wait for postgres for being ready before starting the database migration
- Let docker compose manage the name of the containers to avoid clashes with common names

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
