### PR TITLE
Update contributor's checklists in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Related Issue(s)**: 
+**Related Issue(s)**:  ...
 
 **Proposed changes**:
 - ...
@@ -6,5 +6,5 @@
 ## Pre-flight checklist
 - [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
 - [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
-- [ ] If this is a code change, I added or updated the tests 
+- [ ] If this is a code change, I added tests or updated existing ones 
 - [ ] If this is a code change, I updated the docstrings

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,8 @@
 **Proposed changes**:
 - ...
 
-**Contributor's Checklist**:
-- [ ] Relevant issue(s):
-- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
-- [ ] Add tests
-- [ ] Update docstrings
-
-**Reviewer's Checklist**:
-- [ ] Review labels
-- [ ] Documentation PR (if relevant): (copy here link to PR from the documentation repo)
+## Pre-flight checklist
+- [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
+- [ ] I have [enabled actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
+- [ ] If this is a code change, I have added tests and docstrings
+- [ ] If this is a substantial change, the PR description contains a link to the relevant issue(s)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,12 @@
 **Proposed changes**:
 - ...
 
-**Status (please check what you already did)**:
-- [ ] First draft (up for discussions & feedback)
-- [ ] Final code
+**Contributor's Checklist**:
+- [ ] Relevant issue(s):
 - [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
-- [ ] Added tests
-- [ ] Updated documentation
+- [ ] Add tests
+- [ ] Update docstrings
+
+**Reviewer's Checklist**:
+- [ ] Review labels
+- [ ] Documentation PR (if relevant): (copy here link to PR from the documentation repo)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,10 @@
+**Related Issue(s)**: 
+
 **Proposed changes**:
 - ...
 
 ## Pre-flight checklist
 - [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
-- [ ] I have [enabled actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
-- [ ] If this is a code change, I have added tests and docstrings
-- [ ] If this is a substantial change, the PR description contains a link to the relevant issue(s)
+- [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
+- [ ] If this is a code change, I added or updated the tests 
+- [ ] If this is a code change, I updated the docstrings


### PR DESCRIPTION
**Problem**:
- In external PRs, contributor's seems to often be confused about which checkboxes to tick. In some cases they ignore the list, in others they go ahead and check boxes that we assume were dedicated to reviewers. This makes the checklist itself less effective.

**Solution**:
- I believe splitting the checklist into Contributor's and Reviewer's can bring more clarity and ease the reviewer's job.
- Some checkboxes seemed outdated and therefore removed (the first draft vs final code: now PRs can be marked as Draft, by the reviewers as well if necessary)
- Some checkboxes were added for the reviewers (the labels review)

**Contributor's Checklist**:
- [ ] Relevant issue(s):
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Add tests
- [ ] Update docstrings

**Reviewer's Checklist**:
- [ ] Review labels
- [ ] Documentation PR (if relevant): (copy here link to PR from the documentation repo)
