### PR TITLE
Remove `pull_request` from triggers of `Tutorials (nightly)`

### DIFF
--- a/.github/workflows/tutorials_nightly.yml
+++ b/.github/workflows/tutorials_nightly.yml
@@ -2,7 +2,6 @@ name: Tutorials (nightly)
 
 on:
   workflow_dispatch:  # Activate this workflow manually
-  pull_request:
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
**Proposed changes**:
- Now the nightly job for tutorials on CI runs on every PR by mistake. This PR removes the extra trigger.
