### PR TITLE
Fix typo in `code_and_docs.sh`

### DIFF
--- a/.github/utils/code_and_docs.sh
+++ b/.github/utils/code_and_docs.sh
@@ -5,7 +5,7 @@ black .
 echo
 
 echo "========== Convert tutorial notebooks into webpages ========== "
-python .github/utilsconvert_notebooks_into_webpages.py
+python .github/utils/convert_notebooks_into_webpages.py
 echo
 
 echo "========== Generate OpenAPI docs ========== "

--- a/.github/utils/convert_notebooks_into_webpages.py
+++ b/.github/utils/convert_notebooks_into_webpages.py
@@ -170,5 +170,7 @@ for i, nb in enumerate(notebooks):
         try:
             f.write(headers[i + 1] + "\n\n")
         except IndexError as e:
-            raise IndexError("Can't find the header for this tutorial. Have you added it in '.github/utils/convert_notebooks_into_webpages.py'?")
+            raise IndexError(
+                "Can't find the header for this tutorial. Have you added it in '.github/utils/convert_notebooks_into_webpages.py'?"
+            )
         f.write(body)

--- a/.github/utils/convert_notebooks_into_webpages.py
+++ b/.github/utils/convert_notebooks_into_webpages.py
@@ -133,6 +133,14 @@ slug: "/docs/tutorial16"
 date: "2021-11-05"
 id: "tutorial16md"
 --->""",
+    17: """<!---
+title: "Tutorial 17"
+metaTitle: "Audio Tutorial"
+metaDescription: ""
+slug: "/docs/tutorial17"
+date: "2022-06-15"
+id: "tutorial17md"
+--->""",
 }
 
 
@@ -159,5 +167,8 @@ for i, nb in enumerate(notebooks):
 
     tutorials_path = Path(__file__).parent.parent.parent / "docs" / "_src" / "tutorials" / "tutorials"
     with open(tutorials_path / f"{i + 1}.md", "w", encoding="utf-8") as f:
-        f.write(headers[i + 1] + "\n\n")
+        try:
+            f.write(headers[i + 1] + "\n\n")
+        except IndexError as e:
+            raise IndexError("Can't find the header for this tutorial. Have you added it in '.github/utils/convert_notebooks_into_webpages.py'?")
         f.write(body)

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -43,7 +43,7 @@ jobs:
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
 
       - name: Install sndfile
-        run: sudo apt-get install libsndfile1 ffmpeg
+        run: sudo apt update && sudo apt-get install libsndfile1 ffmpeg
 
       - name: Code and Docs Updates
         run: ./.github/utils/code_and_docs.sh

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -43,7 +43,7 @@ jobs:
           pip install torch-scatter -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
 
       - name: Install sndfile
-        run: sudo apt-get install libsndfile1
+        run: sudo apt-get install libsndfile1 ffmpeg
 
       - name: Code and Docs Updates
         run: ./.github/utils/code_and_docs.sh

--- a/docs/_src/tutorials/tutorials/1.md
+++ b/docs/_src/tutorials/tutorials/1.md
@@ -222,7 +222,7 @@ pipe = ExtractiveQAPipeline(reader, retriever)
 
 
 ```python
-# You can configure how many candidates the reader and retriever shall return
+# You can configure how many candidates the Reader and Retriever shall return
 # The higher top_k_retriever, the better (but also the slower) your answers.
 prediction = pipe.run(
     query="Who is the father of Arya Stark?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}

--- a/docs/_src/tutorials/tutorials/10.md
+++ b/docs/_src/tutorials/tutorials/10.md
@@ -61,18 +61,23 @@ fetch_archive_from_http(url=s3_url, output_dir=model_dir)
 # Unfortunately, there seems to be no good way to run GraphDB in colab environments
 # In your local environment, you could start a GraphDB server with docker
 # Feel free to check GraphDB's website for the free version https://www.ontotext.com/products/graphdb/graphdb-free/
-print("Starting GraphDB ...")
-status = subprocess.run(
-    [
-        "docker run -d -p 7200:7200 --name graphdb-instance-tutorial docker-registry.ontotext.com/graphdb-free:9.4.1-adoptopenjdk11"
-    ],
-    shell=True,
-)
-if status.returncode:
-    raise Exception(
-        "Failed to launch GraphDB. Maybe it is already running or you already have a container with that name that you could start?"
+import os
+
+LAUNCH_GRAPHDB = os.environ.get("LAUNCH_GRAPHDB", False)
+
+if LAUNCH_GRAPHDB:
+    print("Starting GraphDB ...")
+    status = subprocess.run(
+        [
+            "docker run -d -p 7200:7200 --name graphdb-instance-tutorial docker-registry.ontotext.com/graphdb-free:9.4.1-adoptopenjdk11"
+        ],
+        shell=True,
     )
-time.sleep(5)
+    if status.returncode:
+        raise Exception(
+            "Failed to launch GraphDB. Maybe it is already running or you already have a container with that name that you could start?"
+        )
+    time.sleep(5)
 ```
 
 ## Creating a new GraphDB repository (also known as index in haystack's document stores)
@@ -86,10 +91,10 @@ kg = GraphDBKnowledgeGraph(index="tutorial_10_index")
 kg.delete_index()
 
 # Create the index based on a configuration file
-kg.create_index(config_path=Path(graph_dir + "repo-config.ttl"))
+kg.create_index(config_path=Path(graph_dir) / "repo-config.ttl")
 
 # Import triples of subject, predicate, and object statements from a ttl file
-kg.import_from_ttl_file(index="tutorial_10_index", path=Path(graph_dir + "triples.ttl"))
+kg.import_from_ttl_file(index="tutorial_10_index", path=Path(graph_dir) / "triples.ttl")
 print(f"The last triple stored in the knowledge graph is: {kg.get_all_triples()[-1]}")
 print(f"There are {len(kg.get_all_triples())} triples stored in the knowledge graph.")
 ```
@@ -104,7 +109,7 @@ PREFIX hp: <https://deepset.ai/harry_potter/>
 kg.prefixes = prefixes
 
 # Load a pre-trained model that translates text queries to SPARQL queries
-kgqa_retriever = Text2SparqlRetriever(knowledge_graph=kg, model_name_or_path=model_dir + "hp_v3.4")
+kgqa_retriever = Text2SparqlRetriever(knowledge_graph=kg, model_name_or_path=Path(model_dir) / "hp_v3.4")
 ```
 
 ## Query Execution

--- a/docs/_src/tutorials/tutorials/11.md
+++ b/docs/_src/tutorials/tutorials/11.md
@@ -114,9 +114,7 @@ bm25_retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
-    document_store,
-    model_format="sentence_transformers",
-    embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1",
+    document_store, embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1"
 )
 document_store.update_embeddings(embedding_retriever, update_existing_embeddings=False)
 

--- a/docs/_src/tutorials/tutorials/14.md
+++ b/docs/_src/tutorials/tutorials/14.md
@@ -128,9 +128,7 @@ bm25_retriever = BM25Retriever(document_store=document_store)
 
 # Initialize dense retriever
 embedding_retriever = EmbeddingRetriever(
-    document_store=document_store,
-    model_format="sentence_transformers",
-    embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1",
+    document_store=document_store, embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1"
 )
 document_store.update_embeddings(embedding_retriever, update_existing_embeddings=False)
 

--- a/docs/_src/tutorials/tutorials/15.md
+++ b/docs/_src/tutorials/tutorials/15.md
@@ -148,11 +148,7 @@ They use some simple but fast algorithm.
 ```python
 from haystack.nodes.retriever import EmbeddingRetriever
 
-retriever = EmbeddingRetriever(
-    document_store=document_store,
-    embedding_model="deepset/all-mpnet-base-v2-table",
-    model_format="sentence_transformers",
-)
+retriever = EmbeddingRetriever(document_store=document_store, embedding_model="deepset/all-mpnet-base-v2-table")
 ```
 
 
@@ -390,7 +386,7 @@ converter = ParsrConverter()
 
 docs = converter.convert("table.pdf")
 
-tables = [doc for doc in docs if doc["content_type"] == "table"]
+tables = [doc for doc in docs if doc.content_type == "table"]
 ```
 
 

--- a/docs/_src/tutorials/tutorials/17.md
+++ b/docs/_src/tutorials/tutorials/17.md
@@ -1,0 +1,311 @@
+<!---
+title: "Tutorial 17"
+metaTitle: "Audio Tutorial"
+metaDescription: ""
+slug: "/docs/tutorial17"
+date: "2022-06-15"
+id: "tutorial17md"
+--->
+
+# Make Your QA Pipelines Talk!
+
+<img style="float: right;" src="https://upload.wikimedia.org/wikipedia/en/d/d8/Game_of_Thrones_title_card.jpg">
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial17_Audio.ipynb)
+
+Question answering works primarily on text, but Haystack provides some features for audio files that contain speech as well.
+
+In this tutorial, we're going to see how to use `AnswerToSpeech` to convert answers into audio files.
+
+### Prepare environment
+
+#### Colab: Enable the GPU runtime
+Make sure you enable the GPU runtime to experience decent speed in this tutorial.
+**Runtime -> Change Runtime type -> Hardware accelerator -> GPU**
+
+<img src="https://raw.githubusercontent.com/deepset-ai/haystack/master/docs/img/colab_gpu_runtime.jpg">
+
+
+```python
+# Make sure you have a GPU running
+!nvidia-smi
+```
+
+
+```python
+# Install the latest release of Haystack in your own environment
+#! pip install farm-haystack
+
+# Install the latest master of Haystack
+!pip install --upgrade pip
+!pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,audio]
+```
+
+### Setup Elasticsearch
+
+
+
+```python
+# Recommended: Start Elasticsearch using Docker via the Haystack utility function
+from haystack.utils import launch_es
+
+launch_es()
+```
+
+
+```python
+# In Colab / No Docker environments: Start Elasticsearch from source
+! wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.2-linux-x86_64.tar.gz -q
+! tar -xzf elasticsearch-7.9.2-linux-x86_64.tar.gz
+! chown -R daemon:daemon elasticsearch-7.9.2
+
+import os
+from subprocess import Popen, PIPE, STDOUT
+
+es_server = Popen(
+    ["elasticsearch-7.9.2/bin/elasticsearch"], stdout=PIPE, stderr=STDOUT, preexec_fn=lambda: os.setuid(1)  # as daemon
+)
+# wait until ES has started
+! sleep 30
+```
+
+### Populate the document store with `SpeechDocuments`
+
+First of all, we will populate the document store with a simple indexing pipeline. See [Tutorial 1](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb) for more details about these steps.
+
+To the basic version, we can add here a DocumentToSpeech node that also generates an audio file for each of the indexed documents. This will make possible, during querying, to access the audio version of the documents the answers were extracted from without having to generate it on the fly.
+
+**Note**: this additional step can slow down your indexing quite a lot if you are not running on GPU. Experiment with very small corpora to start.
+
+
+```python
+from haystack.document_stores import ElasticsearchDocumentStore
+from haystack.utils import fetch_archive_from_http, launch_es
+from pathlib import Path
+from haystack import Pipeline
+from haystack.nodes import FileTypeClassifier, TextConverter, PreProcessor, DocumentToSpeech
+
+document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
+
+# Get the documents
+documents_path = "data/tutorial17"
+s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt17.zip"
+fetch_archive_from_http(url=s3_url, output_dir=documents_path)
+
+# List all the paths
+file_paths = [p for p in Path(documents_path).glob("**/*")]
+
+# NOTE: In this example we're going to use only one text file from the wiki, as the DocumentToSpeech node is quite slow
+# on CPU machines. Comment out this line to use all documents from the dataset if you machine is powerful enough.
+file_paths = [p for p in file_paths if "Arya_Stark" in p.name]
+
+# Prepare some basic metadata for the files
+files_metadata = [{"name": path.name} for path in file_paths]
+
+# Here we create a basic indexing pipeline
+indexing_pipeline = Pipeline()
+
+# - Makes sure the file is a TXT file (FileTypeClassifier node)
+classifier = FileTypeClassifier()
+indexing_pipeline.add_node(classifier, name="classifier", inputs=["File"])
+
+# - Converts a file into text and performs basic cleaning (TextConverter node)
+text_converter = TextConverter(remove_numeric_tables=True)
+indexing_pipeline.add_node(text_converter, name="text_converter", inputs=["classifier.output_1"])
+
+# - Pre-processes the text by performing splits and adding metadata to the text (Preprocessor node)
+preprocessor = PreProcessor(
+    clean_whitespace=True,
+    clean_empty_lines=True,
+    split_length=100,
+    split_overlap=50,
+    split_respect_sentence_boundary=True,
+)
+indexing_pipeline.add_node(preprocessor, name="preprocessor", inputs=["text_converter"])
+
+#
+# DocumentToSpeech
+#
+# Here is where we convert all documents to be indexed into SpeechDocuments, that will hold not only
+# the text content, but also their audio version.
+#
+# Note that DocumentToSpeech implements a light caching, so if a document's audio have already
+# been generated in a previous pass in the same folder, it will reuse the existing file instead
+# of generating it again.
+doc2speech = DocumentToSpeech(
+    model_name_or_path="espnet/kan-bayashi_ljspeech_vits", generated_audio_dir=Path("./generated_audio_documents")
+)
+indexing_pipeline.add_node(doc2speech, name="doc2speech", inputs=["preprocessor"])
+
+# - Writes the resulting documents into the document store (ElasticsearchDocumentStore node from the previous cell)
+indexing_pipeline.add_node(document_store, name="document_store", inputs=["doc2speech"])
+
+# Then we run it with the documents and their metadata as input
+output = indexing_pipeline.run(file_paths=file_paths, meta=files_metadata)
+```
+
+### Querying
+   
+Now we will create a pipeline very similar to the basic `ExtractiveQAPipeline` of Tutorial 1,
+with the addition of a node that converts our answers into audio files! Once the answer is retrieved, we can also listen to the audio version of the document where the answer came from.
+
+
+```python
+from pathlib import Path
+from haystack import Pipeline
+from haystack.nodes import BM25Retriever, FARMReader, AnswerToSpeech
+
+retriever = BM25Retriever(document_store=document_store)
+reader = FARMReader(model_name_or_path="deepset/roberta-base-squad2-distilled", use_gpu=True)
+answer2speech = AnswerToSpeech(
+    model_name_or_path="espnet/kan-bayashi_ljspeech_vits", generated_audio_dir=Path("./audio_answers")
+)
+
+audio_pipeline = Pipeline()
+audio_pipeline.add_node(retriever, name="Retriever", inputs=["Query"])
+audio_pipeline.add_node(reader, name="Reader", inputs=["Retriever"])
+audio_pipeline.add_node(answer2speech, name="AnswerToSpeech", inputs=["Reader"])
+```
+
+## Ask a question!
+
+
+```python
+# You can configure how many candidates the Reader and Retriever shall return
+# The higher top_k_retriever, the better (but also the slower) your answers.
+prediction = audio_pipeline.run(
+    query="Who is the father of Arya Stark?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}
+)
+```
+
+
+```python
+# Now you can either print the object directly...
+from pprint import pprint
+
+pprint(prediction)
+
+# Sample output:
+# {
+#     'answers': [ <SpeechAnswer:
+#                       answer_audio=PosixPath('generated_audio_answers/fc704210136643b833515ba628eb4b2a.wav'),
+#                       answer="Eddard",
+#                       context_audio=PosixPath('generated_audio_answers/8c562ebd7e7f41e1f9208384957df173.wav'),
+#                       context='...'
+#                       type='extractive', score=0.9919578731060028,
+#                       offsets_in_document=[{'start': 608, 'end': 615}], offsets_in_context=[{'start': 72, 'end': 79}],
+#                       document_id='cc75f739897ecbf8c14657b13dda890e', meta={'name': '43_Arya_Stark.txt'}}  >,
+#                  <SpeechAnswer:
+#                       answer_audio=PosixPath('generated_audio_answers/07d6265486b22356362387c5a098ba7d.wav'),
+#                       answer="Ned",
+#                       context_audio=PosixPath('generated_audio_answers/3f1ca228d6c4cfb633e55f89e97de7ac.wav'),
+#                       context='...'
+#                       type='extractive', score=0.9767240881919861,
+#                       offsets_in_document=[{'start': 3687, 'end': 3801}], offsets_in_context=[{'start': 18, 'end': 132}],
+#                       document_id='9acf17ec9083c4022f69eb4a37187080', meta={'name': '43_Arya_Stark.txt'}}>,
+#                  ...
+#                ]
+#     'documents': [ <SpeechDocument:
+#                        content_type='text', score=0.8034909798951382, meta={'name': '43_Arya_Stark.txt'}, embedding=None, id=d1f36ec7170e4c46cde65787fe125dfe',
+#                        content_audio=PosixPath('generated_audio_documents/07d6265486b22356362387c5a098ba7d.wav'),
+#                        content='\n===\'\'A Game of Thrones\'\'===\nSansa Stark begins the novel by being betrothed to Crown ...'>,
+#                    <SpeechDocument:
+#                        content_type='text', score=0.8002150354529785, meta={'name': '191_Gendry.txt'}, embedding=None, id='dd4e070a22896afa81748d6510006d2',
+#                        content_audio=PosixPath('generated_audio_documents/07d6265486b22356362387c5a098ba7d.wav'),
+#                        content='\n===Season 2===\nGendry travels North with Yoren and other Night's Watch recruits, including Arya ...'>,
+#                    ...
+#                  ],
+#     'no_ans_gap':  11.688868522644043,
+#     'node_id': 'Reader',
+#     'params': {'Reader': {'top_k': 5}, 'Retriever': {'top_k': 5}},
+#     'query': 'Who is the father of Arya Stark?',
+#     'root_node': 'Query'
+# }
+```
+
+
+```python
+from haystack.utils import print_answers
+
+# ...or use a util to simplify the output
+# Change `minimum` to `medium` or `all` to raise the level of detail
+print_answers(prediction, details="minimum")
+
+
+# Sample output:
+#
+# Query: Who is the father of Arya Stark?
+# Answers:
+# [   {   'answer_audio': PosixPath('generated_audio_answers/07d6265486b22356362387c5a098ba7d.wav'),
+#         'answer': 'Eddard',
+#         'context_transcript': PosixPath('generated_audio_answers/3f1ca228d6c4cfb633e55f89e97de7ac.wav'),
+#         'context': ' role of Arya Stark in the television series. '
+#                    'Arya accompanies her father Eddard and her sister '
+#                    'Sansa to King's Landing. Before their departure, Arya's h'},
+#    {   'answer_audio': PosixPath('generated_audio_answers/83c3a02141cac4caffe0718cfd6c405c.wav'),
+#        'answer': 'Lord Eddard Stark',
+#        'context_audio': PosixPath('generated_audio_answers/8c562ebd7e7f41e1f9208384957df173.wav'),
+#        'context': 'ark daughters. During the Tourney of the Hand '
+#                   'to honour her father Lord Eddard Stark, Sansa '
+#                   'Stark is enchanted by the knights performing in '
+#                   'the event.'},
+#    ...
+```
+
+### Hear them out!
+
+
+```python
+from IPython.display import display, Audio
+import soundfile as sf
+```
+
+
+```python
+# The first answer in isolation
+
+print("Answer: ", prediction["answers"][0].answer)
+
+speech, _ = sf.read(prediction["answers"][0].answer_audio)
+display(Audio(speech, rate=24000))
+```
+
+
+```python
+# The context of the first answer
+
+print("Context: ", prediction["answers"][0].context)
+
+speech, _ = sf.read(prediction["answers"][0].context_audio)
+display(Audio(speech, rate=24000))
+```
+
+
+```python
+# The document the first answer was extracted from
+
+document = [doc for doc in prediction["documents"] if doc.id == prediction["answers"][0].document_id][0]
+
+print("Document: ", document.content)
+
+speech, _ = sf.read(document.meta["content_audio"])
+display(Audio(speech, rate=24000))
+```
+
+## About us
+
+This [Haystack](https://github.com/deepset-ai/haystack/) notebook was made with love by [deepset](https://deepset.ai/) in Berlin, Germany
+
+We bring NLP to the industry via open source!  
+Our focus: Industry specific language models & large scale QA systems.  
+  
+Some of our other work: 
+- [German BERT](https://deepset.ai/german-bert)
+- [GermanQuAD and GermanDPR](https://deepset.ai/germanquad)
+- [FARM](https://github.com/deepset-ai/FARM)
+
+Get in touch:
+[Twitter](https://twitter.com/deepset_ai) | [LinkedIn](https://www.linkedin.com/company/deepset-ai/) | [Slack](https://haystack.deepset.ai/community/join) | [GitHub Discussions](https://github.com/deepset-ai/haystack/discussions) | [Website](https://deepset.ai)
+
+By the way: [we're hiring!](https://www.deepset.ai/jobs)
+

--- a/docs/_src/tutorials/tutorials/5.md
+++ b/docs/_src/tutorials/tutorials/5.md
@@ -107,6 +107,7 @@ from haystack.nodes import PreProcessor
 # We first delete the custom tutorial indices to not have duplicate elements
 # and also split our documents into shorter passages using the PreProcessor
 preprocessor = PreProcessor(
+    split_by="word",
     split_length=200,
     split_overlap=0,
     split_respect_sentence_boundary=False,
@@ -145,7 +146,7 @@ retriever = BM25Retriever(document_store=document_store)
 # For more information and suggestions on different models check out the documentation at: https://www.sbert.net/docs/pretrained_models.html
 
 # from haystack.retriever import EmbeddingRetriever, DensePassageRetriever
-# retriever = EmbeddingRetriever(document_store=document_store, model_format="sentence_transformers",
+# retriever = EmbeddingRetriever(document_store=document_store,
 #                                embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1")
 # retriever = DensePassageRetriever(document_store=document_store,
 #                                   query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -313,6 +314,233 @@ eval_result_with_upper_bounds = pipeline.eval(
 pipeline.print_eval_report(eval_result_with_upper_bounds)
 ```
 
+## Advanced Label Scopes
+Answers are considered correct if the predicted answer matches the gold answer in the labels. Documents are considered correct if the predicted document ID matches the gold document ID in the labels. Sometimes, these simple definitions of "correctness" are not sufficient. There are cases where you want to further specify the "scope" within which an answer or a document is considered correct. For this reason, `EvaluationResult.calculate_metrics()` offers the parameters `answer_scope` and `document_scope`.
+
+Say you want to ensure that an answer is only considered correct if it stems from a specific context of surrounding words. This is especially useful if your answer is very short, like a date (for example, "2011") or a place ("Berlin"). Such short answer might easily appear in multiple completely different contexts. Some of those contexts might perfectly fit the actual question and answer it. Some others might not: they don't relate to the question at all but still contain the answer string. In that case, you might want to ensure that only answers that stem from the correct context are considered correct. To do that, specify `answer_scope="context"` in `calculate_metrics()`. 
+
+`answer_scope` takes the following values:
+- `any` (default): Any matching answer is considered correct.
+- `context`: The answer is only considered correct if its context matches as well. It uses fuzzy matching (see `context_matching` parameters of `pipeline.eval()`).
+- `document_id`: The answer is only considered correct if its document ID matches as well. You can specify a custom document ID through the `custom_document_id_field` parameter of `pipeline.eval()`.
+- `document_id_and_context`: The answer is only considered correct if its document ID and its context match as well.
+
+In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to `answer` or `document_id_or_answer`.
+
+`document_scope` takes the following values:
+- `document_id`: Specifies that the document ID must match. You can specify a custom document ID through the `custom_document_id_field` parameter of `pipeline.eval()`.
+- `context`: Specifies that the content of the document must match. It uses fuzzy matching (see the `context_matching` parameters of `pipeline.eval()`).
+- `document_id_and_context`: A Boolean operation specifying that both `'document_id' AND 'context'` must match.
+- `document_id_or_context`: A Boolean operation specifying that either `'document_id' OR 'context'` must match.
+- `answer`: Specifies that the document contents must include the answer. The selected `answer_scope` is enforced.
+- `document_id_or_answer` (default): A Boolean operation specifying that either `'document_id' OR 'answer'` must match.
+
+
+```python
+metrics = saved_eval_result.calculate_metrics(answer_scope="context")
+print(f'Retriever - Recall (single relevant document): {metrics["Retriever"]["recall_single_hit"]}')
+print(f'Retriever - Recall (multiple relevant documents): {metrics["Retriever"]["recall_multi_hit"]}')
+print(f'Retriever - Mean Reciprocal Rank: {metrics["Retriever"]["mrr"]}')
+print(f'Retriever - Precision: {metrics["Retriever"]["precision"]}')
+print(f'Retriever - Mean Average Precision: {metrics["Retriever"]["map"]}')
+
+print(f'Reader - F1-Score: {metrics["Reader"]["f1"]}')
+print(f'Reader - Exact Match: {metrics["Reader"]["exact_match"]}')
+```
+
+
+```python
+document_store.get_all_documents()[0]
+```
+
+
+```python
+# Let's try Document Retrieval on a file level (it's sufficient if the correct file identified by its name (for example, 'Book of Life') was retrieved).
+eval_result_custom_doc_id = pipeline.eval(
+    labels=eval_labels, params={"Retriever": {"top_k": 5}}, custom_document_id_field="name"
+)
+metrics = eval_result_custom_doc_id.calculate_metrics(document_scope="document_id")
+print(f'Retriever - Recall (single relevant document): {metrics["Retriever"]["recall_single_hit"]}')
+print(f'Retriever - Recall (multiple relevant documents): {metrics["Retriever"]["recall_multi_hit"]}')
+print(f'Retriever - Mean Reciprocal Rank: {metrics["Retriever"]["mrr"]}')
+print(f'Retriever - Precision: {metrics["Retriever"]["precision"]}')
+print(f'Retriever - Mean Average Precision: {metrics["Retriever"]["map"]}')
+```
+
+
+```python
+# Let's enforce the context again:
+metrics = eval_result_custom_doc_id.calculate_metrics(document_scope="document_id_and_context")
+print(f'Retriever - Recall (single relevant document): {metrics["Retriever"]["recall_single_hit"]}')
+print(f'Retriever - Recall (multiple relevant documents): {metrics["Retriever"]["recall_multi_hit"]}')
+print(f'Retriever - Mean Reciprocal Rank: {metrics["Retriever"]["mrr"]}')
+print(f'Retriever - Precision: {metrics["Retriever"]["precision"]}')
+print(f'Retriever - Mean Average Precision: {metrics["Retriever"]["map"]}')
+```
+
+## Storing results in MLflow
+Storing evaluation results in CSVs is fine but not enough if you want to compare and track multiple evaluation runs. MLflow is a handy tool when it comes to tracking experiments. So we decided to use it to track all of `Pipeline.eval()` with reproducability of your experiments in mind.
+
+### Host your own MLflow or use deepset's public MLflow
+
+If you don't want to use deepset's public MLflow instance under https://public-mlflow.deepset.ai, you can easily host it yourself.
+
+
+```python
+# !pip install mlflow
+# !mlflow server --serve-artifacts
+```
+
+### Preprocessing the dataset
+Preprocessing the dataset works a bit differently than before. Instead of directly generating documents (and labels) out of a SQuAD file, we first save them to disk. This is necessary to experiment with different indexing pipelines. 
+
+
+```python
+import tempfile
+from pathlib import Path
+from haystack.nodes import PreProcessor
+from haystack.document_stores import InMemoryDocumentStore
+
+document_store = InMemoryDocumentStore()
+
+label_preprocessor = PreProcessor(
+    split_length=200,
+    split_overlap=0,
+    split_respect_sentence_boundary=False,
+    clean_empty_lines=False,
+    clean_whitespace=False,
+)
+
+# The add_eval_data() method converts the given dataset in json format into Haystack document and label objects.
+# Those objects are then indexed in their respective document and label index in the document store.
+# The method can be used with any dataset in SQuAD format.
+# We only use it to get the evaluation set labels and the corpus files.
+document_store.add_eval_data(
+    filename="data/tutorial5/nq_dev_subset_v2.json",
+    doc_index=document_store.index,
+    label_index=document_store.label_index,
+    preprocessor=label_preprocessor,
+)
+
+# the evaluation set to evaluate the pipelines on
+evaluation_set_labels = document_store.get_all_labels_aggregated(drop_negative_labels=True, drop_no_answers=True)
+
+# Pipelines need files as input to be able to test different preprocessors.
+# Even though this looks a bit cumbersome to write the documents back to files we gain a lot of evaluation potential and reproducibility.
+docs = document_store.get_all_documents()
+temp_dir = tempfile.TemporaryDirectory()
+file_paths = []
+for doc in docs:
+    file_name = doc.id + ".txt"
+    file_path = Path(temp_dir.name) / file_name
+    file_paths.append(file_path)
+    with open(file_path, "w") as f:
+        f.write(doc.content)
+file_metas = [d.meta for d in docs]
+```
+
+### Run experiments
+In this experiment we evaluate extractive QA pipelines with two different retrievers on the evaluation set given the corpus:
+**ElasticsearchRetriever vs. EmbeddingRetriever**
+
+
+```python
+from haystack.nodes import BM25Retriever, EmbeddingRetriever, FARMReader, TextConverter
+from haystack.pipelines import Pipeline
+from haystack.document_stores import ElasticsearchDocumentStore
+```
+
+
+```python
+# helper function to create query and index pipeline
+def create_pipelines(document_store, preprocessor, retriever, reader):
+    query_pipeline = Pipeline()
+    query_pipeline.add_node(component=retriever, inputs=["Query"], name="Retriever")
+    query_pipeline.add_node(component=reader, inputs=["Retriever"], name="Reader")
+    index_pipeline = Pipeline()
+    index_pipeline.add_node(component=TextConverter(), inputs=["File"], name="TextConverter")
+    index_pipeline.add_node(component=preprocessor, inputs=["TextConverter"], name="Preprocessor")
+    index_pipeline.add_node(component=retriever, inputs=["Preprocessor"], name="Retriever")
+    index_pipeline.add_node(component=document_store, inputs=["Retriever"], name="DocumentStore")
+    return query_pipeline, index_pipeline
+```
+
+
+```python
+# Name of the experiment in MLflow
+EXPERIMENT_NAME = "haystack-tutorial-5"
+```
+
+#### Run using BM25Retriever
+
+
+```python
+document_store = ElasticsearchDocumentStore(index="sparse_index", recreate_index=True)
+preprocessor = PreProcessor(
+    split_length=200,
+    split_overlap=0,
+    split_respect_sentence_boundary=False,
+    clean_empty_lines=False,
+    clean_whitespace=False,
+)
+es_retriever = BM25Retriever(document_store=document_store)
+reader = FARMReader("deepset/roberta-base-squad2", top_k=3, return_no_answer=True, batch_size=8)
+query_pipeline, index_pipeline = create_pipelines(document_store, preprocessor, es_retriever, reader)
+
+sparse_eval_result = Pipeline.execute_eval_run(
+    index_pipeline=index_pipeline,
+    query_pipeline=query_pipeline,
+    evaluation_set_labels=evaluation_set_labels,
+    corpus_file_paths=file_paths,
+    corpus_file_metas=file_metas,
+    experiment_name=EXPERIMENT_NAME,
+    experiment_run_name="sparse",
+    corpus_meta={"name": "nq_dev_subset_v2.json"},
+    evaluation_set_meta={"name": "nq_dev_subset_v2.json"},
+    pipeline_meta={"name": "sparse-pipeline"},
+    add_isolated_node_eval=True,
+    experiment_tracking_tool="mlflow",
+    experiment_tracking_uri="https://public-mlflow.deepset.ai",
+    reuse_index=True,
+)
+```
+
+#### Run using EmbeddingRetriever
+
+
+```python
+document_store = ElasticsearchDocumentStore(index="dense_index", recreate_index=True)
+emb_retriever = EmbeddingRetriever(
+    document_store=document_store,
+    model_format="sentence_transformers",
+    embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1",
+    batch_size=8,
+)
+query_pipeline, index_pipeline = create_pipelines(document_store, preprocessor, emb_retriever, reader)
+
+dense_eval_result = Pipeline.execute_eval_run(
+    index_pipeline=index_pipeline,
+    query_pipeline=query_pipeline,
+    evaluation_set_labels=evaluation_set_labels,
+    corpus_file_paths=file_paths,
+    corpus_file_metas=file_metas,
+    experiment_name=EXPERIMENT_NAME,
+    experiment_run_name="embedding",
+    corpus_meta={"name": "nq_dev_subset_v2.json"},
+    evaluation_set_meta={"name": "nq_dev_subset_v2.json"},
+    pipeline_meta={"name": "embedding-pipeline"},
+    add_isolated_node_eval=True,
+    experiment_tracking_tool="mlflow",
+    experiment_tracking_uri="https://public-mlflow.deepset.ai",
+    reuse_index=True,
+    answer_scope="context",
+)
+```
+
+You can now open MLflow (e.g. https://public-mlflow.deepset.ai/ if you used the public one hosted by deepset) and look for the haystack-eval-experiment experiment. Try out mlflow's compare function and have fun...
+
+Note that on our public mlflow instance we are not able to log artifacts like the evaluation results or the piplines.yaml file.
+
 ## Evaluation of Individual Components: Retriever
 Sometimes you might want to evaluate individual components, for example, if you don't have a pipeline but only a retriever or a reader with a model that you trained yourself.
 Here we evaluate only the retriever, based on whether the gold_label document is retrieved.
@@ -330,11 +558,11 @@ print("Retriever Mean Avg Precision:", retriever_eval_results["map"])
 ```
 
 Just as a sanity check, we can compare the recall from `retriever.eval()` with the multi hit recall from `pipeline.eval(add_isolated_node_eval=True)`.
-These two recall metrics are only comparable since we chose to filter out no_answer samples when generating eval_labels and setting doc_relevance_col to `"gold_id_match"`. Per default `calculate_metrics()` has doc_relevance_col set to `"gold_id_or_answer_match"` which interprets documents as relevant if they either match the gold_id or contain the answer.
+These two recall metrics are only comparable since we chose to filter out no_answer samples when generating eval_labels and setting document_scope to `"document_id"`. Per default `calculate_metrics()` has document_scope set to `"document_id_or_answer"` which interprets documents as relevant if they either match the gold document ID or contain the answer.
 
 
 ```python
-metrics = eval_result_with_upper_bounds.calculate_metrics(doc_relevance_col="gold_id_match")
+metrics = eval_result_with_upper_bounds.calculate_metrics(document_scope="document_id")
 print(metrics["Retriever"]["recall_multi_hit"])
 ```
 


### PR DESCRIPTION
**Proposed changes**:
- A typo in `code_and_docs.sh` was preventing the tutorial conversion task to run. This PR fixes the typo
- `ffmpeg` should be installed in `autoformat.yml` to prevent a `libsndfile` warning (introduced with the audio nodes PR)
