### PR TITLE
Tutorial 4: Set similarity to `"cosine"` in DocStore initialization

### DIFF
--- a/docs/_src/tutorials/tutorials/4.md
+++ b/docs/_src/tutorials/tutorials/4.md
@@ -116,7 +116,10 @@ We can use the `EmbeddingRetriever` for this purpose and specify a model that we
 
 ```python
 retriever = EmbeddingRetriever(
-    document_store=document_store, embedding_model="sentence-transformers/all-MiniLM-L6-v2", use_gpu=True
+    document_store=document_store,
+    embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+    use_gpu=True,
+    scale_score=False,
 )
 ```
 

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -167,6 +167,7 @@
     "    embedding_field=\"question_emb\",\n",
     "    embedding_dim=384,\n",
     "    excluded_meta_data=[\"question_emb\"],\n",
+    "    similarity=\"cosine\",\n",
     ")"
    ]
   },

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -194,7 +194,10 @@
    "outputs": [],
    "source": [
     "retriever = EmbeddingRetriever(\n",
-    "    document_store=document_store, embedding_model=\"sentence-transformers/all-MiniLM-L6-v2\", use_gpu=True\n",
+    "    document_store=document_store,\n",
+    "    embedding_model=\"sentence-transformers/all-MiniLM-L6-v2\",\n",
+    "    use_gpu=True,\n",
+    "    scale_score=False,\n",
     ")"
    ]
   },

--- a/tutorials/Tutorial4_FAQ_style_QA.py
+++ b/tutorials/Tutorial4_FAQ_style_QA.py
@@ -48,7 +48,10 @@ def tutorial4_faq_style_qa():
     # We can use the `EmbeddingRetriever` for this purpose and specify a model that we use for the embeddings.
     #
     retriever = EmbeddingRetriever(
-        document_store=document_store, embedding_model="sentence-transformers/all-MiniLM-L6-v2", use_gpu=True
+        document_store=document_store,
+        embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+        use_gpu=True,
+        scale_score=False,
     )
 
     # Download a csv containing some FAQ data


### PR DESCRIPTION
In Tutorial 4 we are initializing the DocumentStore without setting the `similarity` parameter. Therefore, the default value `"dot_product"` is used. However, as we are using a sentence-transformers model, we should use `"cosine"` similarity instead. This PR fixes this by explicitly setting `similarity="cosine"` when initializing the `ElasticsearchDocumentStore`.
(We are already doing this in the `.py` version of the tutorial.)