### PR TITLE
FARMReader should convert local hf-transformers model to FARM if necessary

### DIFF
--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -177,15 +177,16 @@ class Inferencer:
 
         name = os.path.basename(model_name_or_path)
 
-        # a) either from local dir
-        if os.path.exists(model_name_or_path):
+        # a) either from local dir as a farm model
+        farm_model_bin = os.path.join(model_name_or_path, 'language_model.bin')
+        if os.path.exists(model_name_or_path) and os.path.isfile(farm_model_bin):
             model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=devices[0], strict=strict)
             if task_type == "embeddings":
                 processor = InferenceProcessor.load_from_dir(model_name_or_path)
             else:
                 processor = Processor.load_from_dir(model_name_or_path)
 
-        # b) or from remote transformers model hub
+        # b) or from remote transformers model hub or as a local hf-transformers model
         else:
             if not task_type:
                 raise ValueError(

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -178,7 +178,7 @@ class Inferencer:
         name = os.path.basename(model_name_or_path)
 
         # a) either from local dir as a farm model
-        farm_model_bin = os.path.join(model_name_or_path, 'language_model.bin')
+        farm_model_bin = os.path.join(model_name_or_path, "language_model.bin")
         if os.path.exists(model_name_or_path) and os.path.isfile(farm_model_bin):
             model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=devices[0], strict=strict)
             if task_type == "embeddings":

--- a/haystack/nodes/other/join.py
+++ b/haystack/nodes/other/join.py
@@ -68,7 +68,7 @@ class JoinNode(BaseComponent):
                     "answers": answers,
                 }
             ],
-            top_k_join=top_k_join
+            top_k_join=top_k_join,
         )
 
     @abstractmethod


### PR DESCRIPTION
**Proposed changes**:
Before this change, only remote models in huggingface transformers format could be used by the FARMReader. Sometimes, people might have stored these locally and still want to use them with a FARMReader. This PR infers if the local model is in hf or FARM format from the presence of a FARM specific file and thus allows to also use local models in hf format.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [x ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
