### PR TITLE
Use opensearch-py in OpenSearchDocumentStore

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
           - "pipelines"
           - "modeling"
           - "others"
+          - "document_stores/test_opensearch.py"
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -174,7 +175,6 @@ jobs:
     - name: Setup Elasticsearch
       run: |
         docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx256m" elasticsearch:7.9.2
-        docker run -d -p 9201:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:1.2.4
 
       # TODO Let's try to remove this one from the unit tests
     - name: Install pdftotext
@@ -519,6 +519,8 @@ jobs:
           - "pipelines"
           - "modeling"
           - "others"
+          - "document_stores/test_opensearch.py"
+
     runs-on: ubuntu-latest
 
     steps:
@@ -530,6 +532,9 @@ jobs:
     - name: Run Elasticsearch
       run: |
         docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx256m" elasticsearch:7.9.2
+
+    - name: Run Opensearch
+      run: |
         docker run -d -p 9201:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:1.2.4
 
     - name: Run Milvus

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -250,7 +250,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=faiss
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=faiss --ignore=test_opensearch.py
 
 
   faiss-tests-windows:
@@ -313,7 +313,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=milvus
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=milvus --ignore=test_opensearch.py
 
 
 # FIXME: seems like we can't run containers on Windows
@@ -382,7 +382,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=weaviate
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=weaviate --ignore=test_opensearch.py
 
 # FIXME: seems like we can't run containers on Windows
   # weaviate-tests-windows:
@@ -444,7 +444,7 @@ jobs:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=pinecone
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=pinecone --ignore=test_opensearch.py
 
 
   pinecone-tests-windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -250,7 +250,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=faiss --ignore=test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=faiss --ignore=test/document_stores/test_opensearch.py
 
 
   faiss-tests-windows:
@@ -313,7 +313,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=milvus --ignore=test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=milvus --ignore=test/document_stores/test_opensearch.py
 
 
 # FIXME: seems like we can't run containers on Windows
@@ -382,7 +382,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=weaviate --ignore=test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=weaviate --ignore=test/document_stores/test_opensearch.py
 
 # FIXME: seems like we can't run containers on Windows
   # weaviate-tests-windows:
@@ -444,7 +444,7 @@ jobs:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=pinecone --ignore=test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=pinecone --ignore=test/document_stores/test_opensearch.py
 
 
   pinecone-tests-windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -250,7 +250,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=faiss --ignore=test/document_stores/test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=faiss
 
 
   faiss-tests-windows:
@@ -313,7 +313,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=milvus --ignore=test/document_stores/test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=milvus
 
 
 # FIXME: seems like we can't run containers on Windows
@@ -382,7 +382,7 @@ jobs:
       env:
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=weaviate --ignore=test/document_stores/test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=weaviate
 
 # FIXME: seems like we can't run containers on Windows
   # weaviate-tests-windows:
@@ -444,7 +444,7 @@ jobs:
         PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
         TOKENIZERS_PARALLELISM: 'false'
       run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=pinecone --ignore=test/document_stores/test_opensearch.py
+        pytest ${{ env.PYTEST_PARAMS }} -m "not integration" test/document_stores/ --document_store_type=pinecone
 
 
   pinecone-tests-windows:

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1455,7 +1455,7 @@ More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/ana
 ## OpenSearchDocumentStore
 
 ```python
-class OpenSearchDocumentStore(ElasticsearchDocumentStore)
+class OpenSearchDocumentStore(BaseElasticsearchDocumentStore)
 ```
 
 <a id="opensearch.OpenSearchDocumentStore.__init__"></a>

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -7,8 +7,6 @@ from copy import deepcopy
 import numpy as np
 from tqdm.auto import tqdm
 
-from .elasticsearch import BaseElasticsearchDocumentStore, prepare_hosts
-
 from opensearchpy import OpenSearch, Urllib3HttpConnection, RequestsHttpConnection, NotFoundError, RequestError
 from opensearchpy.helpers import bulk
 
@@ -16,6 +14,7 @@ from haystack.schema import Document
 from haystack.document_stores.base import get_batches_from_generator
 from haystack.document_stores.filter_utils import LogicalFilterClause
 
+from .elasticsearch import BaseElasticsearchDocumentStore, prepare_hosts
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -7,13 +7,14 @@ from copy import deepcopy
 import numpy as np
 from tqdm.auto import tqdm
 
+from .elasticsearch import BaseElasticsearchDocumentStore, prepare_hosts
+
+from opensearchpy import OpenSearch, Urllib3HttpConnection, RequestsHttpConnection, NotFoundError, RequestError
+from opensearchpy.helpers import bulk
+
 from haystack.schema import Document
 from haystack.document_stores.base import get_batches_from_generator
 from haystack.document_stores.filter_utils import LogicalFilterClause
-
-from .elasticsearch import BaseElasticsearchDocumentStore, prepare_hosts
-
-from opensearchpy import OpenSearch, Urllib3HttpConnection, RequestsHttpConnection, NotFoundError
 
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ disable = [
   "use-list-literal",
 
 
-  
+
 
   # To review later
   "cyclic-import",
@@ -106,5 +106,6 @@ markers = [
     "faiss: uses FAISS",
     "milvus: requires a Milvus 2 setup",
     "milvus1: requires a Milvus 1 container",
+    "opensearch"
 ]
 log_cli = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,10 +150,12 @@ graphdb =
     SPARQLWrapper
 inmemorygraph =
     SPARQLWrapper
+opensearch =
+    opensearch-py>=2
 docstores =
-    farm-haystack[faiss,milvus,weaviate,graphdb,inmemorygraph,pinecone]
+    farm-haystack[faiss,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]
 docstores-gpu =
-    farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone]
+    farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]
 
 audio =
     espnet

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -146,7 +146,17 @@ def pytest_collection_modifyitems(config, items):
                 keywords.extend(i.split("-"))
             else:
                 keywords.append(i)
-        for cur_doc_store in ["elasticsearch", "faiss", "sql", "memory", "milvus1", "milvus", "weaviate", "pinecone"]:
+        for cur_doc_store in [
+            "elasticsearch",
+            "faiss",
+            "sql",
+            "memory",
+            "milvus1",
+            "milvus",
+            "weaviate",
+            "pinecone",
+            "opensearch",
+        ]:
             if cur_doc_store in keywords and cur_doc_store not in document_store_types_to_run:
                 skip_docstore = pytest.mark.skip(
                     reason=f'{cur_doc_store} is disabled. Enable via pytest --document_store_type="{cur_doc_store}"'

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -235,30 +235,35 @@ class TestOpenSearchDocumentStore:
     def test__init_client_use_system_proxy(self, mocked_open_search_init, _init_client_params):
         _init_client_params["use_system_proxy"] = False
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert mocked_open_search_init.call_args.kwargs["connection_class"] == Urllib3HttpConnection
+        _, kwargs = mocked_open_search_init.call_args
+        assert kwargs["connection_class"] == Urllib3HttpConnection
 
         _init_client_params["use_system_proxy"] = True
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert mocked_open_search_init.call_args.kwargs["connection_class"] == RequestsHttpConnection
+        _, kwargs = mocked_open_search_init.call_args
+        assert kwargs["connection_class"] == RequestsHttpConnection
 
     def test__init_client_auth_methods(self, mocked_open_search_init, _init_client_params):
         # Username/Password
         _init_client_params["username"] = "user"
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert mocked_open_search_init.call_args.kwargs["http_auth"] == ("user", "pass")
+        _, kwargs = mocked_open_search_init.call_args
+        assert kwargs["http_auth"] == ("user", "pass")
 
         # AWS IAM
         _init_client_params["username"] = ""
         _init_client_params["aws4auth"] = "foo"
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert mocked_open_search_init.call_args.kwargs["http_auth"] == "foo"
+        _, kwargs = mocked_open_search_init.call_args
+        assert kwargs["http_auth"] == "foo"
 
         # No authentication
         _init_client_params["username"] = ""
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert "http_auth" not in mocked_open_search_init.call_args.kwargs
+        _, kwargs = mocked_open_search_init.call_args
+        assert "http_auth" not in kwargs
 
     def test_query_by_embedding_raises_if_missing_field(self, mocked_document_store):
         mocked_document_store.embedding_field = ""

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -1,12 +1,186 @@
 import sys
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from haystack.document_stores import OpenSearchDocumentStore
+from haystack.document_stores import OpenSearchDocumentStore, OpenDistroElasticsearchDocumentStore
+from haystack.schema import Document, Label
 
+from opensearchpy import OpenSearch, RequestsHttpConnection, Urllib3HttpConnection
+
+
+# Skip OpenSearchDocumentStore tests on Windows
 pytestmark = pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Opensearch not running on Windows CI")
 
 
-@pytest.mark.elasticsearch
-def test_init_opensearch_client():
-    OpenSearchDocumentStore(index="test_index", port=9201)
+class TestOpenSearchDocumentStore:
+    @pytest.fixture
+    def MockedOpenSearchDocumentStore(self, monkeypatch):
+        """
+        The fixture provides an OpenSearchDocumentStore
+        equipped with a mocked client
+        """
+        klass = OpenSearchDocumentStore
+        monkeypatch.setattr(klass, "_init_client", MagicMock())
+        return klass
+
+    @pytest.fixture
+    def _init_client_params(self):
+        """
+        The fixture provides the required arguments to call OpenSearchDocumentStore._init_client
+        """
+        return {
+            "host": "localhost",
+            "port": 9999,
+            "username": "user",
+            "password": "pass",
+            "aws4auth": None,
+            "scheme": "http",
+            "ca_certs": "ca_certs",
+            "verify_certs": True,
+            "timeout": 42,
+            "use_system_proxy": True,
+        }
+
+    @pytest.fixture
+    def document_store(self):
+        """
+        This fixture provides a working document store and takes care of removing the indices when done
+        """
+        index_name = __name__
+        labels_index_name = f"{index_name}_labels"
+        ds = OpenSearchDocumentStore(index=index_name, label_index=labels_index_name, port=9201, create_index=True)
+        yield ds
+        ds.delete_index(index_name)
+        ds.delete_index(labels_index_name)
+
+    @pytest.fixture
+    def documents(self):
+        return [
+            Document(content="A Foo Document"),
+            Document(content="A Bar Document"),
+            Document(content="A Baz Document"),
+        ]
+
+    @pytest.mark.integration
+    def test___init__(self):
+        OpenSearchDocumentStore(index="default_index", port=9201, create_index=True)
+
+    @pytest.mark.integration
+    def test_write_documents_write_labels(self, document_store, documents):
+        labels = []
+        for d in documents:
+            labels.append(
+                Label(
+                    query="query",
+                    document=d,
+                    is_correct_document=True,
+                    is_correct_answer=False,
+                    origin="user-feedback",
+                    answer=None,
+                )
+            )
+
+        document_store.write_documents(documents)
+        document_store.write_labels(labels)
+
+        docs = document_store.get_all_documents()
+        assert docs == documents
+
+        lbls = document_store.get_all_labels()
+        assert lbls == labels
+
+    @pytest.mark.integration
+    def test_recreate_index(self, document_store, documents):
+        labels = []
+        for d in documents:
+            labels.append(
+                Label(
+                    query="query",
+                    document=d,
+                    is_correct_document=True,
+                    is_correct_answer=False,
+                    origin="user-feedback",
+                    answer=None,
+                )
+            )
+
+        document_store.write_documents(documents)
+        document_store.write_labels(labels)
+
+        # Create another document store on top of the previous one
+        ds = OpenSearchDocumentStore(
+            index=document_store.index, label_index=document_store.label_index, recreate_index=True, port=9201
+        )
+        assert len(ds.get_all_documents(index=document_store.index)) == 0
+        assert len(ds.get_all_labels(index=document_store.label_index)) == 0
+
+    def test___init__api_key_raises_warning(self, MockedOpenSearchDocumentStore):
+        with pytest.warns(UserWarning):
+            MockedOpenSearchDocumentStore(api_key="foo")
+            MockedOpenSearchDocumentStore(api_key_id="bar")
+            MockedOpenSearchDocumentStore(api_key="foo", api_key_id="bar")
+
+    def test___init__connection_test_fails(self, MockedOpenSearchDocumentStore):
+        failing_client = MagicMock()
+        failing_client.indices.get.side_effect = Exception("The client failed!")
+        MockedOpenSearchDocumentStore._init_client.return_value = failing_client
+        with pytest.raises(ConnectionError):
+            MockedOpenSearchDocumentStore()
+
+    def test__init_client_params(self, monkeypatch, _init_client_params):
+        MockedOpenSearch = MagicMock()
+        monkeypatch.setattr(OpenSearch, "__new__", MockedOpenSearch)
+        OpenSearchDocumentStore._init_client(**_init_client_params)
+        assert MockedOpenSearch.call_args.kwargs == {
+            "hosts": [{"host": "localhost", "port": 9999}],
+            "http_auth": ("user", "pass"),
+            "scheme": "http",
+            "ca_certs": "ca_certs",
+            "verify_certs": True,
+            "timeout": 42,
+            "connection_class": RequestsHttpConnection,
+        }
+
+    def test__init_client_use_system_proxy(self, monkeypatch, _init_client_params):
+        MockedOpenSearch = MagicMock()
+        monkeypatch.setattr(OpenSearch, "__new__", MockedOpenSearch)
+
+        _init_client_params["use_system_proxy"] = False
+        OpenSearchDocumentStore._init_client(**_init_client_params)
+        assert MockedOpenSearch.call_args.kwargs["connection_class"] == Urllib3HttpConnection
+
+        _init_client_params["use_system_proxy"] = True
+        OpenSearchDocumentStore._init_client(**_init_client_params)
+        assert MockedOpenSearch.call_args.kwargs["connection_class"] == RequestsHttpConnection
+
+    def test__init_client_auth_methods(self, monkeypatch, _init_client_params):
+        MockedOpenSearch = MagicMock()
+        monkeypatch.setattr(OpenSearch, "__new__", MockedOpenSearch)
+
+        # Username/Password
+        _init_client_params["username"] = "user"
+        _init_client_params["aws4auth"] = None
+        OpenSearchDocumentStore._init_client(**_init_client_params)
+        assert MockedOpenSearch.call_args.kwargs["http_auth"] == ("user", "pass")
+
+        # AWS IAM
+        _init_client_params["username"] = ""
+        _init_client_params["aws4auth"] = "foo"
+        OpenSearchDocumentStore._init_client(**_init_client_params)
+        assert MockedOpenSearch.call_args.kwargs["http_auth"] == "foo"
+
+        # No authentication
+        _init_client_params["username"] = ""
+        _init_client_params["aws4auth"] = None
+        OpenSearchDocumentStore._init_client(**_init_client_params)
+        assert "http_auth" not in MockedOpenSearch.call_args.kwargs
+
+
+class TestOpenDistroElasticsearchDocumentStore:
+    def test_deprecation_notice(self, monkeypatch):
+        klass = OpenDistroElasticsearchDocumentStore
+        monkeypatch.setattr(klass, "_init_client", MagicMock())
+        with pytest.warns(UserWarning):
+            klass()

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -232,12 +232,13 @@ class TestOpenSearchDocumentStore:
             "connection_class": RequestsHttpConnection,
         }
 
-    def test__init_client_use_system_proxy(self, mocked_open_search_init, _init_client_params):
+    def test__init_client_use_system_proxy_use_sys_proxy(self, mocked_open_search_init, _init_client_params):
         _init_client_params["use_system_proxy"] = False
         OpenSearchDocumentStore._init_client(**_init_client_params)
         _, kwargs = mocked_open_search_init.call_args
         assert kwargs["connection_class"] == Urllib3HttpConnection
 
+    def test__init_client_use_system_proxy_dont_use_sys_proxy(self, mocked_open_search_init, _init_client_params):
         _init_client_params["use_system_proxy"] = True
         OpenSearchDocumentStore._init_client(**_init_client_params)
         _, kwargs = mocked_open_search_init.call_args

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -62,23 +62,24 @@ class TestOpenSearchDocumentStore:
     @pytest.fixture(scope="class")
     def documents(self):
         documents = []
-        for i in range(3):
-            documents.append(
-                Document(
-                    content=f"A Foo Document {i}",
-                    meta={"name": f"name_{i}", "year": "2020", "month": "01"},
-                    embedding=np.random.rand(768).astype(np.float32),
-                )
+        # for i in range(3):
+        i = 0
+        documents.append(
+            Document(
+                content=f"A Foo Document {i}",
+                meta={"name": f"name_{i}", "year": "2020", "month": "01"},
+                embedding=np.random.rand(768).astype(np.float32),
             )
+        )
 
-        for i in range(3):
-            documents.append(
-                Document(
-                    content=f"A Bar Document {i}",
-                    meta={"name": f"name_{i}", "year": "2021", "month": "02"},
-                    embedding=np.random.rand(768).astype(np.float32),
-                )
-            )
+        # for i in range(3):
+        #     documents.append(
+        #         Document(
+        #             content=f"A Bar Document {i}",
+        #             meta={"name": f"name_{i}", "year": "2021", "month": "02"},
+        #             embedding=np.random.rand(768).astype(np.float32),
+        #         )
+        #     )
 
         return documents
 
@@ -89,7 +90,16 @@ class TestOpenSearchDocumentStore:
         OpenSearchDocumentStore(index="default_index", port=9201, create_index=True)
 
     @pytest.mark.integration
-    def test_write_documents_write_labels(self, document_store, documents):
+    def test_write_documents(self, document_store, documents):
+        document_store.write_documents(documents)
+        docs = document_store.get_all_documents()
+        assert len(docs) == len(documents)
+        for i, doc in enumerate(docs):
+            expected = documents[i]
+            assert doc.id == expected.id
+
+    @pytest.mark.integration
+    def test_write_labels(self, document_store, documents):
         labels = []
         for d in documents:
             labels.append(
@@ -103,12 +113,7 @@ class TestOpenSearchDocumentStore:
                 )
             )
 
-        document_store.write_documents(documents)
         document_store.write_labels(labels)
-
-        docs = document_store.get_all_documents()
-        assert docs == documents
-
         lbls = document_store.get_all_labels()
         assert lbls == labels
 

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -243,22 +243,21 @@ class TestOpenSearchDocumentStore:
         _, kwargs = mocked_open_search_init.call_args
         assert kwargs["connection_class"] == RequestsHttpConnection
 
-    def test__init_client_auth_methods(self, mocked_open_search_init, _init_client_params):
-        # Username/Password
+    def test__init_client_auth_methods_username_password(self, mocked_open_search_init, _init_client_params):
         _init_client_params["username"] = "user"
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)
         _, kwargs = mocked_open_search_init.call_args
         assert kwargs["http_auth"] == ("user", "pass")
 
-        # AWS IAM
+    def test__init_client_auth_methods_aws_iam(self, mocked_open_search_init, _init_client_params):
         _init_client_params["username"] = ""
         _init_client_params["aws4auth"] = "foo"
         OpenSearchDocumentStore._init_client(**_init_client_params)
         _, kwargs = mocked_open_search_init.call_args
         assert kwargs["http_auth"] == "foo"
 
-        # No authentication
+    def test__init_client_auth_methods_no_auth(self, mocked_open_search_init, _init_client_params):
         _init_client_params["username"] = ""
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -1,8 +1,7 @@
 import sys
 import logging
 
-from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 import numpy as np

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -22,7 +22,10 @@ from haystack.errors import DocumentStoreError
 # Skip OpenSearchDocumentStore tests on Windows
 pytestmark = pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Opensearch not running on Windows CI")
 
-
+# Being all the tests in this module, ideally we wouldn't need a marker here,
+# but this is to allow this test suite to be skipped when running (e.g.)
+# `pytest test/document_stores --document-store-type=faiss`
+@pytest.mark.opensearch
 class TestOpenSearchDocumentStore:
 
     # Constants

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 
 from unittest import mock
 from unittest.mock import MagicMock, Mock
@@ -12,6 +13,8 @@ from haystack.document_stores.opensearch import (
     OpenDistroElasticsearchDocumentStore,
     RequestsHttpConnection,
     Urllib3HttpConnection,
+    RequestError,
+    tqdm,
 )
 from haystack.schema import Document, Label
 
@@ -25,11 +28,12 @@ class TestOpenSearchDocumentStore:
     # Constants
 
     query_emb = np.ndarray(shape=(2, 2), dtype=float)
+    index_name = "myindex"
 
     # Fixtures
 
     @pytest.fixture
-    def document_store(self):
+    def ds(self):
         """
         This fixture provides a working document store and takes care of removing the indices when done
         """
@@ -47,8 +51,8 @@ class TestOpenSearchDocumentStore:
         OpenSearchDocumentStore equipped with a mocked client
         """
 
-        # Mock a subclass to avoid messing up the actual class object
         class DSMock(OpenSearchDocumentStore):
+            # We mock a subclass to avoid messing up the actual class object
             pass
 
         DSMock._init_client = MagicMock()
@@ -83,7 +87,6 @@ class TestOpenSearchDocumentStore:
     def documents(self):
         documents = []
         for i in range(3):
-            i = 0
             documents.append(
                 Document(
                     content=f"A Foo Document {i}",
@@ -103,6 +106,38 @@ class TestOpenSearchDocumentStore:
 
         return documents
 
+    @pytest.fixture
+    def index(self):
+        return {
+            "aliases": {},
+            "mappings": {
+                "properties": {
+                    "age": {"type": "integer"},
+                    "occupation": {"type": "text"},
+                    "vec": {
+                        "type": "knn_vector",
+                        "dimension": 768,
+                        "method": {
+                            "engine": "nmslib",
+                            "space_type": "innerproduct",
+                            "name": "hnsw",
+                            "parameters": {"ef_construction": 512, "m": 16},
+                        },
+                    },
+                }
+            },
+            "settings": {
+                "index": {
+                    "creation_date": "1658337984559",
+                    "number_of_shards": "1",
+                    "number_of_replicas": "1",
+                    "uuid": "jU5KPBtXQHOaIn2Cm2d4jg",
+                    "version": {"created": "135238227"},
+                    "provided_name": "fooindex",
+                }
+            },
+        }
+
     # Integration tests
 
     @pytest.mark.integration
@@ -110,16 +145,16 @@ class TestOpenSearchDocumentStore:
         OpenSearchDocumentStore(index="default_index", port=9201, create_index=True)
 
     @pytest.mark.integration
-    def test_write_documents(self, document_store, documents):
-        document_store.write_documents(documents)
-        docs = document_store.get_all_documents()
+    def test_write_documents(self, ds, documents):
+        ds.write_documents(documents)
+        docs = ds.get_all_documents()
         assert len(docs) == len(documents)
         for i, doc in enumerate(docs):
             expected = documents[i]
             assert doc.id == expected.id
 
     @pytest.mark.integration
-    def test_write_labels(self, document_store, documents):
+    def test_write_labels(self, ds, documents):
         labels = []
         for d in documents:
             labels.append(
@@ -133,11 +168,11 @@ class TestOpenSearchDocumentStore:
                 )
             )
 
-        document_store.write_labels(labels)
-        assert document_store.get_all_labels() == labels
+        ds.write_labels(labels)
+        assert ds.get_all_labels() == labels
 
     @pytest.mark.integration
-    def test_recreate_index(self, document_store, documents):
+    def test_recreate_index(self, ds, documents):
         labels = []
         for d in documents:
             labels.append(
@@ -151,33 +186,22 @@ class TestOpenSearchDocumentStore:
                 )
             )
 
-        document_store.write_documents(documents)
-        document_store.write_labels(labels)
+        ds.write_documents(documents)
+        ds.write_labels(labels)
 
         # Create another document store on top of the previous one
-        ds = OpenSearchDocumentStore(
-            index=document_store.index, label_index=document_store.label_index, recreate_index=True, port=9201
-        )
-        assert len(ds.get_all_documents(index=document_store.index)) == 0
-        assert len(ds.get_all_labels(index=document_store.label_index)) == 0
+        ds = OpenSearchDocumentStore(index=ds.index, label_index=ds.label_index, recreate_index=True, port=9201)
+        assert len(ds.get_all_documents(index=ds.index)) == 0
+        assert len(ds.get_all_labels(index=ds.label_index)) == 0
+
+    @pytest.mark.integration
+    def test_clone_embedding_field(self, ds, documents):
+        ds.write_documents(documents)
+        ds.clone_embedding_field("cloned", "cosine")
+        for doc in ds.get_all_documents():
+            assert "cloned" in doc.to_dict()["meta"]
 
     # Unit tests
-
-    def test_query_by_embedding_raises_if_missing_field(self, mocked_document_store):
-        mocked_document_store.embedding_field = ""
-        with pytest.raises(RuntimeError):
-            mocked_document_store.query_by_embedding(self.query_emb)
-
-    def test_query_by_embedding_filters(self, mocked_document_store):
-        expected_filters = {"type": "article", "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"}}
-        mocked_document_store.query_by_embedding(self.query_emb, filters=expected_filters)
-        # Assert the `search` method on the client was called with the filters we provided
-        _, kwargs = mocked_document_store.client.search.call_args
-        actual_filters = kwargs["body"]["query"]["bool"]["filter"]
-        assert actual_filters["bool"]["must"] == [
-            {"term": {"type": "article"}},
-            {"range": {"date": {"gte": "2015-01-01", "lt": "2021-01-01"}}},
-        ]
 
     def test___init___api_key_raises_warning(self, mocked_document_store):
         with pytest.warns(UserWarning):
@@ -236,6 +260,438 @@ class TestOpenSearchDocumentStore:
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)
         assert "http_auth" not in mocked_open_search_init.call_args.kwargs
+
+    def test_query_by_embedding_raises_if_missing_field(self, mocked_document_store):
+        mocked_document_store.embedding_field = ""
+        with pytest.raises(RuntimeError):
+            mocked_document_store.query_by_embedding(self.query_emb)
+
+    def test_query_by_embedding_filters(self, mocked_document_store):
+        expected_filters = {"type": "article", "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"}}
+        mocked_document_store.query_by_embedding(self.query_emb, filters=expected_filters)
+        # Assert the `search` method on the client was called with the filters we provided
+        _, kwargs = mocked_document_store.client.search.call_args
+        actual_filters = kwargs["body"]["query"]["bool"]["filter"]
+        assert actual_filters["bool"]["must"] == [
+            {"term": {"type": "article"}},
+            {"range": {"date": {"gte": "2015-01-01", "lt": "2021-01-01"}}},
+        ]
+
+    def test_query_by_embedding_return_embedding_false(self, mocked_document_store):
+        mocked_document_store.return_embedding = False
+        mocked_document_store.query_by_embedding(self.query_emb)
+        # assert the resulting body is consistent with the `excluded_meta_data` value
+        _, kwargs = mocked_document_store.client.search.call_args
+        assert kwargs["body"]["_source"] == {"excludes": ["embedding"]}
+
+    def test_query_by_embedding_excluded_meta_data_return_embedding_true(self, mocked_document_store):
+        """
+        Test that when `return_embedding==True` the field should NOT be excluded even if it
+        was added to `excluded_meta_data`
+        """
+        mocked_document_store.return_embedding = True
+        mocked_document_store.excluded_meta_data = ["foo", "embedding"]
+        mocked_document_store.query_by_embedding(self.query_emb)
+        _, kwargs = mocked_document_store.client.search.call_args
+        # we expect "embedding" was removed from the final query
+        assert kwargs["body"]["_source"] == {"excludes": ["foo"]}
+
+    def test_query_by_embedding_excluded_meta_data_return_embedding_false(self, mocked_document_store):
+        """
+        Test that when `return_embedding==False`, the final query excludes the `embedding` field
+        even if it wasn't explicitly added to `excluded_meta_data`
+        """
+        mocked_document_store.return_embedding = False
+        mocked_document_store.excluded_meta_data = ["foo"]
+        mocked_document_store.query_by_embedding(self.query_emb)
+        # assert the resulting body is consistent with the `excluded_meta_data` value
+        _, kwargs = mocked_document_store.client.search.call_args
+        assert kwargs["body"]["_source"] == {"excludes": ["foo", "embedding"]}
+
+    def test__create_document_index_with_alias(self, mocked_document_store, caplog):
+        mocked_document_store.client.indices.exists_alias.return_value = True
+
+        with caplog.at_level(logging.DEBUG, logger="haystack.document_stores.opensearch"):
+            mocked_document_store._create_document_index(self.index_name)
+
+        assert f"Index name {self.index_name} is an alias." in caplog.text
+
+    def test__create_document_index_wrong_mapping_raises(self, mocked_document_store, index):
+        """
+        Ensure the method raises if we specify a field in `search_fields` that's not text
+        """
+        mocked_document_store.search_fields = ["age"]
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        with pytest.raises(Exception, match=f"The search_field 'age' of index '{self.index_name}' with type 'integer'"):
+            mocked_document_store._create_document_index(self.index_name)
+
+    def test__create_document_index_create_mapping_if_missing(self, mocked_document_store, index):
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "doesnt_have_a_mapping"
+
+        mocked_document_store._create_document_index(self.index_name)
+
+        # Assert the expected body was passed to the client
+        _, kwargs = mocked_document_store.client.indices.put_mapping.call_args
+        assert kwargs["index"] == self.index_name
+        assert "doesnt_have_a_mapping" in kwargs["body"]["properties"]
+
+    def test__create_document_index_with_bad_field_raises(self, mocked_document_store, index):
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "age"  # this is mapped as integer
+
+        with pytest.raises(
+            Exception, match=f"The '{self.index_name}' index in OpenSearch already has a field called 'age'"
+        ):
+            mocked_document_store._create_document_index(self.index_name)
+
+    def test__create_document_index_with_existing_mapping_but_no_method(self, mocked_document_store, index):
+        """
+        We call the method passing a properly mapped field but without the `method` specified in the mapping
+        """
+        del index["mappings"]["properties"]["vec"]["method"]
+        # FIXME: the method assumes this key is present but it might not always be the case. This test has to pass
+        # without the following line:
+        index["settings"]["index"]["knn.space_type"] = "innerproduct"
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+
+        mocked_document_store._create_document_index(self.index_name)
+        # FIXME: when `method` is missing from the field mapping, embeddings_field_supports_similarity is always
+        # False but I'm not sure this is by design
+        assert mocked_document_store.embeddings_field_supports_similarity is False
+
+    def test__create_document_index_with_existing_mapping_similarity(self, mocked_document_store, index):
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.similarity = "dot_product"
+
+        mocked_document_store._create_document_index(self.index_name)
+        assert mocked_document_store.embeddings_field_supports_similarity is True
+
+    def test__create_document_index_with_existing_mapping_similarity_mismatch(
+        self, mocked_document_store, index, caplog
+    ):
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.similarity = "foo_bar"
+
+        with caplog.at_level(logging.WARN, logger="haystack.document_stores.opensearch"):
+            mocked_document_store._create_document_index(self.index_name)
+        assert "Embedding field 'vec' is optimized for similarity 'dot_product'." in caplog.text
+        assert mocked_document_store.embeddings_field_supports_similarity is False
+
+    def test__create_document_index_with_existing_mapping_adjust_params_hnsw_default(
+        self, mocked_document_store, index
+    ):
+        """
+        Test default values when `knn.algo_param` is missing from the index settings
+        """
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.index_type = "hnsw"
+
+        mocked_document_store._create_document_index(self.index_name)
+
+        # assert the resulting body is contains the adjusted params
+        _, kwargs = mocked_document_store.client.indices.put_settings.call_args
+        assert kwargs["body"] == {"knn.algo_param.ef_search": 20}
+
+    def test__create_document_index_with_existing_mapping_adjust_params_hnsw(self, mocked_document_store, index):
+        """
+        Test a value of `knn.algo_param` that needs to be adjusted
+        """
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.index_type = "hnsw"
+        index["settings"]["index"]["knn.algo_param"] = {"ef_search": 999}
+
+        mocked_document_store._create_document_index(self.index_name)
+
+        # assert the resulting body is contains the adjusted params
+        _, kwargs = mocked_document_store.client.indices.put_settings.call_args
+        assert kwargs["body"] == {"knn.algo_param.ef_search": 20}
+
+    def test__create_document_index_with_existing_mapping_adjust_params_flat_default(
+        self, mocked_document_store, index
+    ):
+        """
+        If `knn.algo_param` is missing, default value needs no adjustments
+        """
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.index_type = "flat"
+
+        mocked_document_store._create_document_index(self.index_name)
+
+        mocked_document_store.client.indices.put_settings.assert_not_called
+
+    def test__create_document_index_with_existing_mapping_adjust_params_hnsw(self, mocked_document_store, index):
+        """
+        Test a value of `knn.algo_param` that needs to be adjusted
+        """
+        mocked_document_store.client.indices.exists.return_value = True
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.index_type = "flat"
+        index["settings"]["index"]["knn.algo_param"] = {"ef_search": 999}
+
+        mocked_document_store._create_document_index(self.index_name)
+
+        # assert the resulting body is contains the adjusted params
+        _, kwargs = mocked_document_store.client.indices.put_settings.call_args
+        assert kwargs["body"] == {"knn.algo_param.ef_search": 512}
+
+    def test__create_document_index_no_index_custom_mapping(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store.custom_mapping = {"mappings": {"properties": {"a_number": {"type": "integer"}}}}
+
+        mocked_document_store._create_document_index(self.index_name)
+        _, kwargs = mocked_document_store.client.indices.create.call_args
+        assert kwargs["body"] == {"mappings": {"properties": {"a_number": {"type": "integer"}}}}
+
+    def test__create_document_index_no_index_no_mapping(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store._create_document_index(self.index_name)
+        _, kwargs = mocked_document_store.client.indices.create.call_args
+        assert kwargs["body"] == {
+            "mappings": {
+                "dynamic_templates": [
+                    {"strings": {"mapping": {"type": "keyword"}, "match_mapping_type": "string", "path_match": "*"}}
+                ],
+                "properties": {
+                    "content": {"type": "text"},
+                    "embedding": {
+                        "dimension": 768,
+                        "method": {
+                            "engine": "nmslib",
+                            "name": "hnsw",
+                            "parameters": {"ef_construction": 512, "m": 16},
+                            "space_type": "innerproduct",
+                        },
+                        "type": "knn_vector",
+                    },
+                    "name": {"type": "keyword"},
+                },
+            },
+            "settings": {"analysis": {"analyzer": {"default": {"type": "standard"}}}, "index": {"knn": True}},
+        }
+
+    def test__create_document_index_no_index_no_mapping_with_synonyms(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store.search_fields = ["occupation"]
+        mocked_document_store.synonyms = ["foo"]
+
+        mocked_document_store._create_document_index(self.index_name)
+        _, kwargs = mocked_document_store.client.indices.create.call_args
+        assert kwargs["body"] == {
+            "mappings": {
+                "properties": {
+                    "name": {"type": "keyword"},
+                    "content": {"type": "text", "analyzer": "synonym"},
+                    "occupation": {"type": "text", "analyzer": "synonym"},
+                    "embedding": {
+                        "type": "knn_vector",
+                        "dimension": 768,
+                        "method": {
+                            "space_type": "innerproduct",
+                            "name": "hnsw",
+                            "engine": "nmslib",
+                            "parameters": {"ef_construction": 512, "m": 16},
+                        },
+                    },
+                },
+                "dynamic_templates": [
+                    {"strings": {"path_match": "*", "match_mapping_type": "string", "mapping": {"type": "keyword"}}}
+                ],
+            },
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "default": {"type": "standard"},
+                        "synonym": {"tokenizer": "whitespace", "filter": ["lowercase", "synonym"]},
+                    },
+                    "filter": {"synonym": {"type": "synonym", "synonyms": ["foo"]}},
+                },
+                "index": {"knn": True},
+            },
+        }
+
+    def test__create_document_index_no_index_no_mapping_with_embedding_field(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store.embedding_field = "vec"
+        mocked_document_store.index_type = "hnsw"
+
+        mocked_document_store._create_document_index(self.index_name)
+        _, kwargs = mocked_document_store.client.indices.create.call_args
+        assert kwargs["body"] == {
+            "mappings": {
+                "properties": {
+                    "name": {"type": "keyword"},
+                    "content": {"type": "text"},
+                    "vec": {
+                        "type": "knn_vector",
+                        "dimension": 768,
+                        "method": {
+                            "space_type": "innerproduct",
+                            "name": "hnsw",
+                            "engine": "nmslib",
+                            "parameters": {"ef_construction": 80, "m": 64},
+                        },
+                    },
+                },
+                "dynamic_templates": [
+                    {"strings": {"path_match": "*", "match_mapping_type": "string", "mapping": {"type": "keyword"}}}
+                ],
+            },
+            "settings": {
+                "analysis": {"analyzer": {"default": {"type": "standard"}}},
+                "index": {"knn": True, "knn.algo_param.ef_search": 20},
+            },
+        }
+
+    def test__create_document_index_client_failure(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store.client.indices.create.side_effect = RequestError
+
+        with pytest.raises(RequestError):
+            mocked_document_store._create_document_index(self.index_name)
+
+    def test__get_embedding_field_mapping_flat(self, mocked_document_store):
+        mocked_document_store.index_type = "flat"
+
+        assert mocked_document_store._get_embedding_field_mapping("dot_product") == {
+            "type": "knn_vector",
+            "dimension": 768,
+            "method": {
+                "space_type": "innerproduct",
+                "name": "hnsw",
+                "engine": "nmslib",
+                "parameters": {"ef_construction": 512, "m": 16},
+            },
+        }
+
+    def test__get_embedding_field_mapping_hnsw(self, mocked_document_store):
+        mocked_document_store.index_type = "hnsw"
+
+        assert mocked_document_store._get_embedding_field_mapping("dot_product") == {
+            "type": "knn_vector",
+            "dimension": 768,
+            "method": {
+                "space_type": "innerproduct",
+                "name": "hnsw",
+                "engine": "nmslib",
+                "parameters": {"ef_construction": 80, "m": 64},
+            },
+        }
+
+    def test__get_embedding_field_mapping_wrong(self, mocked_document_store, caplog):
+        mocked_document_store.index_type = "foo"
+
+        with caplog.at_level(logging.ERROR, logger="haystack.document_stores.opensearch"):
+            retval = mocked_document_store._get_embedding_field_mapping("dot_product")
+
+        assert "Please set index_type to either 'flat' or 'hnsw'" in caplog.text
+        assert retval == {
+            "type": "knn_vector",
+            "dimension": 768,
+            "method": {"space_type": "innerproduct", "name": "hnsw", "engine": "nmslib"},
+        }
+
+    def test__create_label_index_already_exists(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = True
+
+        mocked_document_store._create_label_index("foo")
+        mocked_document_store.client.indices.create.assert_not_called()
+
+    def test__create_label_index_client_error(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store.client.indices.create.side_effect = RequestError
+
+        with pytest.raises(RequestError):
+            mocked_document_store._create_label_index("foo")
+
+    def test__get_vector_similarity_query_support_true(self, mocked_document_store):
+        mocked_document_store.embedding_field = "FooField"
+        mocked_document_store.embeddings_field_supports_similarity = True
+
+        assert mocked_document_store._get_vector_similarity_query(self.query_emb, 3) == {
+            "bool": {"must": [{"knn": {"FooField": {"vector": self.query_emb.tolist(), "k": 3}}}]}
+        }
+
+    def test__get_vector_similarity_query_support_false(self, mocked_document_store):
+        mocked_document_store.embedding_field = "FooField"
+        mocked_document_store.embeddings_field_supports_similarity = False
+        mocked_document_store.similarity = "dot_product"
+
+        assert mocked_document_store._get_vector_similarity_query(self.query_emb, 3) == {
+            "script_score": {
+                "query": {"match_all": {}},
+                "script": {
+                    "source": "knn_score",
+                    "lang": "knn",
+                    "params": {
+                        "field": "FooField",
+                        "query_value": self.query_emb.tolist(),
+                        "space_type": "innerproduct",
+                    },
+                },
+            }
+        }
+
+    def test__get_raw_similarity_score_dot(self, mocked_document_store):
+        mocked_document_store.similarity = "dot_product"
+        assert mocked_document_store._get_raw_similarity_score(2) == 1
+        assert mocked_document_store._get_raw_similarity_score(-2) == 1.5
+
+    def test__get_raw_similarity_score_l2(self, mocked_document_store):
+        mocked_document_store.similarity = "l2"
+        assert mocked_document_store._get_raw_similarity_score(1) == 0
+
+    def test__get_raw_similarity_score_cosine(self, mocked_document_store):
+        mocked_document_store.similarity = "cosine"
+        mocked_document_store.embeddings_field_supports_similarity = True
+        assert mocked_document_store._get_raw_similarity_score(1) == 1
+        mocked_document_store.embeddings_field_supports_similarity = False
+        assert mocked_document_store._get_raw_similarity_score(1) == 0
+
+    def test_clone_embedding_field_duplicate_mapping(self, mocked_document_store, index):
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+        mocked_document_store.index = self.index_name
+        with pytest.raises(Exception, match="age already exists with mapping"):
+            mocked_document_store.clone_embedding_field("age", "cosine")
+
+    def test_clone_embedding_field_update_mapping(self, mocked_document_store, index, monkeypatch):
+        mocked_document_store.client.indices.get.return_value = {self.index_name: index}
+
+        # Mock away tqdm and the batch logic so we can test the mapping update alone
+        mocked_document_store._get_all_documents_in_index = MagicMock(return_value=[])
+        monkeypatch.setattr(tqdm, "__new__", MagicMock())
+
+        mocked_document_store.clone_embedding_field("a_field", "cosine")
+        _, kwargs = mocked_document_store.client.indices.put_mapping.call_args
+        assert kwargs["body"]["properties"]["a_field"] == {
+            "type": "knn_vector",
+            "dimension": 768,
+            "method": {
+                "space_type": "cosinesimil",
+                "name": "hnsw",
+                "engine": "nmslib",
+                "parameters": {"ef_construction": 512, "m": 16},
+            },
+        }
+
+    def test_clone_embedding_field_update_mapping(self, mocked_document_store, index, monkeypatch, documents):
+        pass
 
 
 class TestOpenDistroElasticsearchDocumentStore:

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -1,14 +1,19 @@
 import sys
 
-from unittest.mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 import numpy as np
 
-from haystack.document_stores import OpenSearchDocumentStore, OpenDistroElasticsearchDocumentStore
+from haystack.document_stores.opensearch import (
+    OpenSearch,
+    OpenSearchDocumentStore,
+    OpenDistroElasticsearchDocumentStore,
+    RequestsHttpConnection,
+    Urllib3HttpConnection,
+)
 from haystack.schema import Document, Label
-
-from opensearchpy import OpenSearch, RequestsHttpConnection, Urllib3HttpConnection
 
 
 # Skip OpenSearchDocumentStore tests on Windows
@@ -17,17 +22,44 @@ pytestmark = pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Ope
 
 class TestOpenSearchDocumentStore:
 
+    # Constants
+
+    query_emb = np.ndarray(shape=(2, 2), dtype=float)
+
     # Fixtures
 
     @pytest.fixture
-    def MockedOpenSearchDocumentStore(self, monkeypatch):
+    def document_store(self):
         """
-        The fixture provides an OpenSearchDocumentStore
-        equipped with a mocked client
+        This fixture provides a working document store and takes care of removing the indices when done
         """
-        klass = OpenSearchDocumentStore
-        monkeypatch.setattr(klass, "_init_client", MagicMock())
-        return klass
+        index_name = __name__
+        labels_index_name = f"{index_name}_labels"
+        ds = OpenSearchDocumentStore(index=index_name, label_index=labels_index_name, port=9201, create_index=True)
+        yield ds
+        ds.delete_index(index_name)
+        ds.delete_index(labels_index_name)
+
+    @pytest.fixture
+    def mocked_document_store(self):
+        """
+        The fixture provides an instance of a slightly customized
+        OpenSearchDocumentStore equipped with a mocked client
+        """
+
+        # Mock a subclass to avoid messing up the actual class object
+        class DSMock(OpenSearchDocumentStore):
+            pass
+
+        DSMock._init_client = MagicMock()
+        DSMock.client = MagicMock()
+        return DSMock()
+
+    @pytest.fixture
+    def mocked_open_search_init(self, monkeypatch):
+        mocked_init = MagicMock(return_value=None)
+        monkeypatch.setattr(OpenSearch, "__init__", mocked_init)
+        return mocked_init
 
     @pytest.fixture
     def _init_client_params(self):
@@ -47,39 +79,27 @@ class TestOpenSearchDocumentStore:
             "use_system_proxy": True,
         }
 
-    @pytest.fixture
-    def document_store(self):
-        """
-        This fixture provides a working document store and takes care of removing the indices when done
-        """
-        index_name = __name__
-        labels_index_name = f"{index_name}_labels"
-        ds = OpenSearchDocumentStore(index=index_name, label_index=labels_index_name, port=9201, create_index=True)
-        yield ds
-        ds.delete_index(index_name)
-        ds.delete_index(labels_index_name)
-
     @pytest.fixture(scope="class")
     def documents(self):
         documents = []
-        # for i in range(3):
-        i = 0
-        documents.append(
-            Document(
-                content=f"A Foo Document {i}",
-                meta={"name": f"name_{i}", "year": "2020", "month": "01"},
-                embedding=np.random.rand(768).astype(np.float32),
+        for i in range(3):
+            i = 0
+            documents.append(
+                Document(
+                    content=f"A Foo Document {i}",
+                    meta={"name": f"name_{i}", "year": "2020", "month": "01"},
+                    embedding=np.random.rand(768).astype(np.float32),
+                )
             )
-        )
 
-        # for i in range(3):
-        #     documents.append(
-        #         Document(
-        #             content=f"A Bar Document {i}",
-        #             meta={"name": f"name_{i}", "year": "2021", "month": "02"},
-        #             embedding=np.random.rand(768).astype(np.float32),
-        #         )
-        #     )
+        for i in range(3):
+            documents.append(
+                Document(
+                    content=f"A Bar Document {i}",
+                    meta={"name": f"name_{i}", "year": "2021", "month": "02"},
+                    embedding=np.random.rand(768).astype(np.float32),
+                )
+            )
 
         return documents
 
@@ -114,8 +134,7 @@ class TestOpenSearchDocumentStore:
             )
 
         document_store.write_labels(labels)
-        lbls = document_store.get_all_labels()
-        assert lbls == labels
+        assert document_store.get_all_labels() == labels
 
     @pytest.mark.integration
     def test_recreate_index(self, document_store, documents):
@@ -142,31 +161,45 @@ class TestOpenSearchDocumentStore:
         assert len(ds.get_all_documents(index=document_store.index)) == 0
         assert len(ds.get_all_labels(index=document_store.label_index)) == 0
 
-    @pytest.mark.integration
-    def test_query_by_embedding(self, document_store, documents):
-        document_store.write_documents(documents)
-        filters = {"year": "2021"}
-
     # Unit tests
 
-    def test___init__api_key_raises_warning(self, MockedOpenSearchDocumentStore):
-        with pytest.warns(UserWarning):
-            MockedOpenSearchDocumentStore(api_key="foo")
-            MockedOpenSearchDocumentStore(api_key_id="bar")
-            MockedOpenSearchDocumentStore(api_key="foo", api_key_id="bar")
+    def test_query_by_embedding_raises_if_missing_field(self, mocked_document_store):
+        mocked_document_store.embedding_field = ""
+        with pytest.raises(RuntimeError):
+            mocked_document_store.query_by_embedding(self.query_emb)
 
-    def test___init__connection_test_fails(self, MockedOpenSearchDocumentStore):
+    def test_query_by_embedding_filters(self, mocked_document_store):
+        expected_filters = {"type": "article", "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"}}
+        mocked_document_store.query_by_embedding(self.query_emb, filters=expected_filters)
+        # Assert the `search` method on the client was called with the filters we provided
+        _, kwargs = mocked_document_store.client.search.call_args
+        actual_filters = kwargs["body"]["query"]["bool"]["filter"]
+        assert actual_filters["bool"]["must"] == [
+            {"term": {"type": "article"}},
+            {"range": {"date": {"gte": "2015-01-01", "lt": "2021-01-01"}}},
+        ]
+
+    def test___init___api_key_raises_warning(self, mocked_document_store):
+        with pytest.warns(UserWarning):
+            mocked_document_store.__init__(api_key="foo")
+            mocked_document_store.__init__(api_key_id="bar")
+            mocked_document_store.__init__(api_key="foo", api_key_id="bar")
+
+    def test___init___connection_test_fails(self, mocked_document_store):
         failing_client = MagicMock()
         failing_client.indices.get.side_effect = Exception("The client failed!")
-        MockedOpenSearchDocumentStore._init_client.return_value = failing_client
+        mocked_document_store._init_client.return_value = failing_client
         with pytest.raises(ConnectionError):
-            MockedOpenSearchDocumentStore()
+            mocked_document_store.__init__()
 
-    def test__init_client_params(self, monkeypatch, _init_client_params):
-        MockedOpenSearch = MagicMock()
-        monkeypatch.setattr(OpenSearch, "__new__", MockedOpenSearch)
+    def test___init___client_params(self, mocked_open_search_init, _init_client_params):
+        """
+        Ensure the Opensearch-py client was initialized with the right params
+        """
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert MockedOpenSearch.call_args.kwargs == {
+        assert mocked_open_search_init.called
+        _, kwargs = mocked_open_search_init.call_args
+        assert kwargs == {
             "hosts": [{"host": "localhost", "port": 9999}],
             "http_auth": ("user", "pass"),
             "scheme": "http",
@@ -176,39 +209,33 @@ class TestOpenSearchDocumentStore:
             "connection_class": RequestsHttpConnection,
         }
 
-    def test__init_client_use_system_proxy(self, monkeypatch, _init_client_params):
-        MockedOpenSearch = MagicMock()
-        monkeypatch.setattr(OpenSearch, "__new__", MockedOpenSearch)
-
+    def test__init_client_use_system_proxy(self, mocked_open_search_init, _init_client_params):
         _init_client_params["use_system_proxy"] = False
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert MockedOpenSearch.call_args.kwargs["connection_class"] == Urllib3HttpConnection
+        assert mocked_open_search_init.call_args.kwargs["connection_class"] == Urllib3HttpConnection
 
         _init_client_params["use_system_proxy"] = True
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert MockedOpenSearch.call_args.kwargs["connection_class"] == RequestsHttpConnection
+        assert mocked_open_search_init.call_args.kwargs["connection_class"] == RequestsHttpConnection
 
-    def test__init_client_auth_methods(self, monkeypatch, _init_client_params):
-        MockedOpenSearch = MagicMock()
-        monkeypatch.setattr(OpenSearch, "__new__", MockedOpenSearch)
-
+    def test__init_client_auth_methods(self, mocked_open_search_init, _init_client_params):
         # Username/Password
         _init_client_params["username"] = "user"
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert MockedOpenSearch.call_args.kwargs["http_auth"] == ("user", "pass")
+        assert mocked_open_search_init.call_args.kwargs["http_auth"] == ("user", "pass")
 
         # AWS IAM
         _init_client_params["username"] = ""
         _init_client_params["aws4auth"] = "foo"
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert MockedOpenSearch.call_args.kwargs["http_auth"] == "foo"
+        assert mocked_open_search_init.call_args.kwargs["http_auth"] == "foo"
 
         # No authentication
         _init_client_params["username"] = ""
         _init_client_params["aws4auth"] = None
         OpenSearchDocumentStore._init_client(**_init_client_params)
-        assert "http_auth" not in MockedOpenSearch.call_args.kwargs
+        assert "http_auth" not in mocked_open_search_init.call_args.kwargs
 
 
 class TestOpenDistroElasticsearchDocumentStore:

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -147,6 +147,23 @@ class TestOpenSearchDocumentStore:
             },
         }
 
+    @pytest.fixture
+    def labels(self, documents):
+        labels = []
+        for i, d in enumerate(documents):
+            labels.append(
+                Label(
+                    query="query",
+                    document=d,
+                    is_correct_document=True,
+                    is_correct_answer=False,
+                    # create a mix set of labels
+                    origin="user-feedback" if i % 2 else "gold-label",
+                    answer=None if not i else Answer(f"the answer is {i}"),
+                )
+            )
+        return labels
+
     # Integration tests
 
     @pytest.mark.integration
@@ -163,39 +180,12 @@ class TestOpenSearchDocumentStore:
             assert doc.id == expected.id
 
     @pytest.mark.integration
-    def test_write_labels(self, ds, documents):
-        labels = []
-        for i, d in enumerate(documents):
-            labels.append(
-                Label(
-                    query="query",
-                    document=d,
-                    is_correct_document=True,
-                    is_correct_answer=False,
-                    # create a mix set of labels
-                    origin="user-feedback" if i % 2 else "gold-label",
-                    answer=None if not i else Answer(f"the answer is {i}"),
-                )
-            )
-
+    def test_write_labels(self, ds, labels):
         ds.write_labels(labels)
         assert ds.get_all_labels() == labels
 
     @pytest.mark.integration
-    def test_recreate_index(self, ds, documents):
-        labels = []
-        for d in documents:
-            labels.append(
-                Label(
-                    query="query",
-                    document=d,
-                    is_correct_document=True,
-                    is_correct_answer=False,
-                    origin="user-feedback",
-                    answer=None,
-                )
-            )
-
+    def test_recreate_index(self, ds, documents, labels):
         ds.write_documents(documents)
         ds.write_labels(labels)
 


### PR DESCRIPTION
Fixes: https://github.com/deepset-ai/haystack/issues/1764 https://github.com/deepset-ai/haystack/issues/2137 https://github.com/deepset-ai/haystack/issues/2802

**Proposed changes**:
- Use `opensearch-py` in `OpensearchDocumentStore` instead of the Elasticsearch client
- Cover the `OpensearchDocumentStore` logic with tests
- Change testing strategy for document stores to classes

### A note about testing

The tests in this PR follow a new pattern that I'd like to introduce for document stores. Instead of having a complex matrix of fixtures, we use a class hierarchy so that `pytest` will repeat tests defined in the parent classes for every child. Example:

```
                       ┌────────────────────────┐                         
                       │                        │                         
                       │TestKeywordDocumentStore│                         
                       │                        │                         
                       └────────────────────────┘                         
                                    ▲                                     
                                    │                                     
                                    │                                     
                                    │                                     
                  ┌──────────────────────────────────┐                    
                  │                                  │                    
                  │TestBaseElasticsearchDocumentStore│                    
                  │                                  │                    
                  └──────────────────────────────────┘                    
                                    ▲                                     
                                    │                                     
                ┌───────────────────┴─────────────────────┐               
                │                                         │               
                │                                         │               
┌──────────────────────────────┐          ┌──────────────────────────────┐
│                              │          │                              │
│ TestOpenSearchDocumentStore  │          │TestElasticsearchDocumentStore│
│                              │          │                              │
└──────────────────────────────┘          └──────────────────────────────┘
```
In the case above, a test `test_get_all_documents` defined for `TestBaseElasticsearchDocumentStore` would be repeated as part of the suite in `TestOpenSearchDocumentStore` and `TestElasticsearchDocumentStore` using each one its own datastore.

The refactoring would be iterative, introducing new base classes and moving some test cases from `TestOpenSearchDocumentStore` up in the hierarchy as needed.

**Status (please check what you already did)**:
- [ ] First draft (up for discussions & feedback)
- [ ] Final code
- [ ] [Enable actions on your fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] Added tests
- [ ] Updated documentation
