### PR TITLE
Revert "Upgrade transformers to 4.20.0"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     torch>1.9,<1.12
     requests
     pydantic
-    transformers==4.20.0
+    transformers==4.19.2
     nltk
     pandas
 


### PR DESCRIPTION
Reverts deepset-ai/haystack#2694

The latest transformers 4.20.0 seems to be incompatible with espnet, which we use in the audio nodes. It seems that the import of `snapshot_download` would need to be changed within espnet. The following warning is triggered when running our tests:

```huggingface_hub/snapshot_download.py:11: FutureWarning: snapshot_download.py has been made private and will no longer be available from version 0.11. Please use `from huggingface_hub import snapshot_download` to import the only public function in this module. Other members of the file may be changed without a deprecation notice.```

And the audio tests are failing with:
```
test/nodes/test_audio.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
haystack/nodes/audio/_text_to_speech.py:46: in __init__
    model_name_or_path, device=devices[0].type, **(transformers_params or {})
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/espnet2/bin/tts_inference.py:277: in from_pretrained
    kwargs.update(**d.download_and_unpack(model_tag))
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/espnet_model_zoo/downloader.py:382: in download_and_unpack
    cache_dir = self.huggingface_download(name=name, version=version, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <espnet_model_zoo.downloader.ModelDownloader object at 0x7fbbe3ad1050>
name = 'espnet/kan-bayashi_ljspeech_vits', version = -1, quiet = False
kwargs = {}, huggingface_id = 'espnet/kan-bayashi_ljspeech_vits'
revision = None
    def huggingface_download(
        self, name: str = None, version: int = -1, quiet: bool = False, **kwargs: str
    ) -> str:
        # Get huggingface_id from table.csv
        if name is None:
            names = self.query(key="name", **kwargs)
            if len(names) == 0:
                message = "Not found models:"
                for key, value in kwargs.items():
                    message += f" {key}={value}"
                raise RuntimeError(message)
            if version < 0:
                version = len(names) + version
            name = list(names)[version]
        if "@" in name:
            huggingface_id, revision = name.split("@", 1)
        else:
            huggingface_id = name
            revision = None
        return snapshot_download(
            huggingface_id,
            revision=revision,
            library_name="espnet",
>           cache_dir=self.cachedir,
        )
E       TypeError: 'module' object is not callable
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/espnet_model_zoo/downloader.py:271: TypeError
```