### PR TITLE
Fix bugs in loading code from yaml

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -23,7 +23,7 @@ runs:
     run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
   - name: Checkout
-    uses: actions/checkout@v3
+    uses: actions/checkout@v2
 
   - name: Setup Python
     uses: actions/setup-python@v2
@@ -32,7 +32,7 @@ runs:
 
   - name: Cache
     id: cache-python-env
-    uses: actions/cache@v2
+    uses: actions/cache@v3
     with:
       path: ${{ env.pythonLocation }}
       # The cache will be rebuild every day and at every change of the dependency files

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -23,7 +23,7 @@ runs:
     run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
   - name: Checkout
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
 
   - name: Setup Python
     uses: actions/setup-python@v2
@@ -36,7 +36,7 @@ runs:
     with:
       path: ${{ env.pythonLocation }}
       # The cache will be rebuild every day and at every change of the dependency files
-      key: ${{ inputs.prefix }}-FIXME-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+      key: ${{ inputs.prefix }}-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
   - name: Install dependencies
     # NOTE: this action runs only on cache miss to refresh the dependencies and make sure the next Haystack install will be faster.

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -32,7 +32,7 @@ runs:
 
   - name: Cache
     id: cache-python-env
-    uses: actions/cache@v3
+    uses: actions/cache@v2
     with:
       path: ${{ env.pythonLocation }}
       # The cache will be rebuild every day and at every change of the dependency files

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -36,7 +36,7 @@ runs:
     with:
       path: ${{ env.pythonLocation }}
       # The cache will be rebuild every day and at every change of the dependency files
-      key: ${{ inputs.prefix }}-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
+      key: ${{ inputs.prefix }}-FIXME-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/pyproject.toml') }}
 
   - name: Install dependencies
     # NOTE: this action runs only on cache miss to refresh the dependencies and make sure the next Haystack install will be faster.


### PR DESCRIPTION
**Related Issue(s)**:  no issue, addressing failing tests on `master`

**Proposed changes**:
- Stop relying on `.endswith` to determine if the instance is a leaf of the hierarchy tree. That check would mistakenly consider `BaseElasticsearchDocumentstore.__init__` be the same as `ElasticsearchDocumentstore.__init__`. We now manipulate and compare the actual tokens composing the fully qualified name of a `__init__` method.
- Do not store constructor's parameters for the ancestors of a node instance we want to save/load. This was supposed to fail but thanks to the bug from the point above continued working
- Remove the function `_get_signature` that was used to recursively collect all the params for all the constructors calls chain, the code isn't used anymore.

## Pre-flight checklist
- [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
