### PR TITLE
Allow values that are not dictionaries in the request params in the `/search` endpoint

### DIFF
--- a/rest_api/controller/search.py
+++ b/rest_api/controller/search.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 
+import collections
 import logging
 import time
 import json
@@ -72,7 +73,7 @@ def _process_request(pipeline, request) -> Dict[str, Any]:
 
     # format targeted node filters (e.g. "params": {"Retriever": {"filters": {"value"}}})
     for key in params.keys():
-        if "filters" in params[key].keys():
+        if isinstance(params[key], collections.Mapping) and "filters" in params[key].keys():
             params[key]["filters"] = _format_filters(params[key]["filters"])
 
     result = pipeline.run(query=request.query, params=params, debug=request.debug)

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -15,7 +15,6 @@ from haystack.schema import Label
 from haystack.nodes.file_converter import BaseConverter
 
 from rest_api.utils import get_app
-from rest_api.controller.search import _process_request
 
 
 TEST_QUERY = "Who made the PDF specification?"
@@ -348,6 +347,25 @@ def test_query_with_no_documents_and_no_answers(client):
         assert response_json["answers"] == []
 
 
+def test_query_with_bool_in_params(client):
+    """
+    Ensure items of params can be other types than dictionary, see
+    https://github.com/deepset-ai/haystack/issues/2656
+    """
+    with mock.patch("rest_api.controller.search.query_pipeline") as mocked_pipeline:
+        # `run` must return a dictionary containing a `query` key
+        mocked_pipeline.run.return_value = {"query": TEST_QUERY}
+        request_body = {
+            "query": TEST_QUERY,
+            "params": {"debug": True, "Retriever": {"top_k": 5}, "Reader": {"top_k": 3}},
+        }
+        response = client.post(url="/query", json=request_body)
+        assert 200 == response.status_code
+        response_json = response.json()
+        assert response_json["documents"] == []
+        assert response_json["answers"] == []
+
+
 def test_write_feedback(client, feedback):
     response = client.post(url="/feedback", json=feedback)
     assert 200 == response.status_code
@@ -427,14 +445,3 @@ def test_get_feedback_malformed_query(client, feedback):
     feedback["unexpected_field"] = "misplaced-value"
     response = client.post(url="/feedback", json=feedback)
     assert response.status_code == 422
-
-
-def test__process_request_bool_in_params():
-    """
-    Ensure items of params can be other types than dictionary, see
-    https://github.com/deepset-ai/haystack/issues/2656
-    """
-    pipeline = MagicMock()
-    request = MagicMock()
-    request.params = {"debug": True, "Retriever": {"top_k": 5}, "Reader": {"top_k": 3}}
-    _process_request(pipeline, request)

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -15,6 +15,7 @@ from haystack.schema import Label
 from haystack.nodes.file_converter import BaseConverter
 
 from rest_api.utils import get_app
+from rest_api.controller.search import _process_request
 
 
 TEST_QUERY = "Who made the PDF specification?"
@@ -426,3 +427,14 @@ def test_get_feedback_malformed_query(client, feedback):
     feedback["unexpected_field"] = "misplaced-value"
     response = client.post(url="/feedback", json=feedback)
     assert response.status_code == 422
+
+
+def test__process_request_bool_in_params():
+    """
+    Ensure items of params can be other types than dictionary, see
+    https://github.com/deepset-ai/haystack/issues/2656
+    """
+    pipeline = MagicMock()
+    request = MagicMock()
+    request.params = {"debug": True, "Retriever": {"top_k": 5}, "Reader": {"top_k": 3}}
+    _process_request(pipeline, request)


### PR DESCRIPTION
**Related Issue(s)**: fixes https://github.com/deepset-ai/haystack/issues/2656
The code processing requests to the `/search` endpoint assumes all the items in the `params` dictionary are also dictionaries, which is wrong. For example, users might want to pass `debug: True` to the endpoint.

**Proposed changes**:
- Ensure the item in `params` is a dictionary before accessing its keys.

## Pre-flight checklist
- [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
