### PR TITLE
Fix match_context tests in test_utils.py

### DIFF
--- a/haystack/utils/context_matching.py
+++ b/haystack/utils/context_matching.py
@@ -145,6 +145,7 @@ def match_context(
     finally:
         if pool:
             pool.close()
+            pool.join()
 
 
 def match_contexts(
@@ -212,3 +213,4 @@ def match_contexts(
     finally:
         if pool:
             pool.close()
+            pool.join()

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,7 @@ install_requires =
     elastic-apm
 
     # context matching
-    rapidfuzz
+    rapidfuzz==2.0.13
     
     # Schema validation
     jsonschema

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -199,7 +199,7 @@ def test_calculate_context_similarity_on_partially_overlapping_contexts_with_noi
     assert accuracy > 0.99
 
 
-def test_match_context_multi_processes():
+def test_match_context_multi_process():
     whole_document = TEST_CONTEXT[:300]
     min_length = 100
     margin = 5

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -199,14 +199,14 @@ def test_calculate_context_similarity_on_partially_overlapping_contexts_with_noi
     assert accuracy > 0.99
 
 
-def test_match_context():
-    whole_document = TEST_CONTEXT
+def test_match_context_multi_processes():
+    whole_document = TEST_CONTEXT[:300]
     min_length = 100
     margin = 5
     context_size = min_length + margin
     for i in range(len(whole_document) - context_size):
         partial_context = whole_document[i : i + context_size]
-        candidates = ((str(i), TEST_CONTEXT if i == 0 else TEST_CONTEXT_2) for i in range(10))
+        candidates = ((str(i), TEST_CONTEXT if i == 0 else TEST_CONTEXT_2) for i in range(1000))
         results = match_context(partial_context, candidates, min_length=min_length, num_processes=2)
         assert len(results) == 1
         id, score = results[0]
@@ -229,7 +229,7 @@ def test_match_context_single_process():
         assert score == 100.0
 
 
-def test_match_contexts():
+def test_match_contexts_multi_process():
     whole_document = TEST_CONTEXT
     min_length = 100
     margin = 5


### PR DESCRIPTION
**Related Issue(s)**:  ...
- fix failing test_utils.py tests noted in https://github.com/deepset-ai/haystack/pull/2718

**Proposed changes**:
- properly join the multiprocessing pool after closing it
- change the match_contexts test using multiprocessing to finish in a more reasonable time (joining multiprocessing tools takes a good amount of time overhead)
- pin rapidfuzz to version 2.0.13 as 2.0.14 produces different results than before (see https://github.com/maxbachmann/RapidFuzz/issues/231)

## Pre-flight checklist
- [x] If this is a code change, I added tests or updated existing ones 
