### PR TITLE
Speficy `ref` in `python_cache` action

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -24,6 +24,8 @@ runs:
 
   - name: Checkout
     uses: actions/checkout@v2
+    with:
+      ref: ${{ github.head_ref }}
 
   - name: Setup Python
     uses: actions/setup-python@v2


### PR DESCRIPTION
- Some repeated code was extracted from `linux_ci.yml` into the `python_cache` action during the CI refactoring.
- `actions/checkout@v2` used to run on a specific PR, but once factored out, started running on master instead
- Given that the cache key is computed over the setup files, from that point on the cache was missing only on changes of setup files  on master
- The tests CI re-installs Haystack actually, but with a different extra, so some dependencies would come from the master's list, and some other from the partial installation, causing several errors to go unnoticed or becoming sticky on unrelated PRs
