### PR TITLE
Change `repo` with `repository` in `python_cache`

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -25,7 +25,7 @@ runs:
   - name: Checkout
     uses: actions/checkout@v2
     with:
-      repo: ${{ github.event.repository.name }}
+      repository: ${{ github.event.repository.name }}
       ref: ${{ github.head_ref }}
 
   - name: Setup Python


### PR DESCRIPTION
**Related issue(s):** #2729

Fixing the parameter name according to https://github.com/actions/checkout#usage