### PR TITLE
Upgrade torch to 1.12

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -53,4 +53,4 @@ runs:
       pip install .[all]
       pip install rest_api/
       pip install ui/
-      pip install torch-scatter -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
+      pip install torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cpu.html

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -40,7 +40,7 @@ jobs:
           pip install .[all]
           pip install rest_api/
           pip install ui/
-          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
+          pip install torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
 
       - name: Install sndfile
         run: sudo apt update && sudo apt-get install libsndfile1 ffmpeg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,9 @@ jobs:
 
     - name: Setup Python
       uses: ./.github/actions/python_cache/
+      
+    - name: Install torch-scatter
+      run: pip install torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
 
       # TODO Let's try to remove this one from the unit tests
     - name: Install pdftotext

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install .[all]
-        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
+        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
         pip install pygraphviz
         pip install ipython nbformat
 

--- a/.github/workflows/tutorials_nightly.yml
+++ b/.github/workflows/tutorials_nightly.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install .[all]
-        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
+        pip install torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
         pip install pygraphviz
         pip install ipython nbformat
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ setup_requires =
     wheel
 install_requires =
     importlib-metadata; python_version < '3.8'
-    torch>1.9,<1.12
+    torch==1.12
     requests
     pydantic
     transformers==4.20.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ setup_requires =
     wheel
 install_requires =
     importlib-metadata; python_version < '3.8'
-    torch==1.12
+    torch>1.9,<1.13
     requests
     pydantic
     transformers==4.20.1


### PR DESCRIPTION
**Proposed changes**:
- Testing torch 1.12 upgrade
- Before merging, change torch dependency to `torch>1.9,<1.13`

Failing tests currently are about table reader and torch-scatter

```
        if not torch_scatter_installed:
            raise ImportError(
                "Please install torch_scatter to use TableReader. You can follow the instructions here: https://github.com/rusty1s/pytorch_scatter"
            )
        if torch_scatter_wrong_version:
            raise ImportError(
>               "torch_scatter could not be loaded. This could be caused by a mismatch between your cuda version and the one used by torch_scatter."
                "Please try to reinstall torch-scatter. You can follow the instructions here: https://github.com/rusty1s/pytorch_scatter"
            )
E           ImportError: torch_scatter could not be loaded. This could be caused by a mismatch between your cuda version and the one used by torch_scatter.Please try to reinstall torch-scatter. You can follow the instructions here: https://github.com/rusty1s/pytorch_scatter
```

closes #2745 

## Pre-flight checklist
- [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
