### PR TITLE
Fix loading of tokenizers in DPR

### DIFF
--- a/haystack/modeling/model/tokenization.py
+++ b/haystack/modeling/model/tokenization.py
@@ -308,14 +308,7 @@ class Tokenizer:
         elif "dpr-ctx_encoder" in pretrained_model_name_or_path.lower():
             tokenizer_class = "DPRContextEncoderTokenizer"
         else:
-            raise ValueError(
-                f"Could not infer tokenizer_class from model config or "
-                f"name '{pretrained_model_name_or_path}'. Set arg `tokenizer_class` "
-                f"in Tokenizer.load() to one of: AlbertTokenizer, XLMRobertaTokenizer, "
-                f"RobertaTokenizer, DistilBertTokenizer, BertTokenizer, XLNetTokenizer, "
-                f"CamembertTokenizer, ElectraTokenizer, DPRQuestionEncoderTokenizer,"
-                f"DPRContextEncoderTokenizer."
-            )
+            tokenizer_class = "AutoTokenizer"
 
         return tokenizer_class
 

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -152,7 +152,7 @@ class DensePassageRetriever(BaseRetriever):
             )
 
         self.infer_tokenizer_classes = infer_tokenizer_classes
-        tokenizers_default_classes = {"query": "AutoTokenizer", "passage": "AutoTokenizer"}
+        tokenizers_default_classes = {"query": "DPRQuestionEncoderTokenizer", "passage": "DPRContextEncoderTokenizer"}
         if self.infer_tokenizer_classes:
             tokenizers_default_classes["query"] = None  # type: ignore
             tokenizers_default_classes["passage"] = None  # type: ignore

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -17,7 +17,7 @@ from haystack.document_stores.faiss import FAISSDocumentStore
 from haystack.document_stores import MilvusDocumentStore
 from haystack.nodes.retriever.dense import DensePassageRetriever, EmbeddingRetriever, TableTextRetriever
 from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
-from transformers import DPRContextEncoderTokenizerFast, DPRQuestionEncoderTokenizerFast, PreTrainedTokenizerFast
+from transformers import DPRContextEncoderTokenizerFast, DPRQuestionEncoderTokenizerFast
 
 from ..conftest import SAMPLES_PATH
 
@@ -277,8 +277,8 @@ def test_dpr_saving_and_loading(tmp_path, retriever, document_store):
     assert loaded_retriever.processor.max_seq_len_query == 64
 
     # Tokenizer
-    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizerFast)
-    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizerFast)
+    assert isinstance(loaded_retriever.passage_tokenizer, DPRContextEncoderTokenizerFast)
+    assert isinstance(loaded_retriever.query_tokenizer, DPRQuestionEncoderTokenizerFast)
     assert loaded_retriever.passage_tokenizer.do_lower_case == True
     assert loaded_retriever.query_tokenizer.do_lower_case == True
     assert loaded_retriever.passage_tokenizer.vocab_size == 30522
@@ -320,9 +320,9 @@ def test_table_text_retriever_saving_and_loading(tmp_path, retriever, document_s
     assert loaded_retriever.processor.max_seq_len_query == 64
 
     # Tokenizer
-    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizerFast)
-    assert isinstance(loaded_retriever.table_tokenizer, PreTrainedTokenizerFast)
-    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizerFast)
+    assert isinstance(loaded_retriever.passage_tokenizer, DPRContextEncoderTokenizerFast)
+    assert isinstance(loaded_retriever.table_tokenizer, DPRContextEncoderTokenizerFast)
+    assert isinstance(loaded_retriever.query_tokenizer, DPRQuestionEncoderTokenizerFast)
     assert loaded_retriever.passage_tokenizer.do_lower_case == True
     assert loaded_retriever.table_tokenizer.do_lower_case == True
     assert loaded_retriever.query_tokenizer.do_lower_case == True


### PR DESCRIPTION
**Related Issue(s)**: #2711 

**Proposed changes**:
This PR resets the default tokenizer class for DPR from `AutoTokenizer` to `DPRQuestionEncoderTokenizer` and `DPRContextEncoderTokenizer`, respectively. This is needed, as for example the spanish DPR model [`IIC/dpr-spanish-passage_encoder-allqa-base`](https://huggingface.co/IIC/dpr-spanish-passage_encoder-allqa-base) sets the `tokenizer_class` to `"DPRContextEncoderTokenizer"`, but this can't be loaded using the `AutoTokenizer`. It is missing in transformers [`TOKENIZER_MAPPING_NAMES`](https://github.com/huggingface/transformers/blob/6cb19540c9a5288195445e8355646c06605a64fc/src/transformers/models/auto/tokenization_auto.py#L47), resulting in the error: 
`Tokenizer class DPRContextEncoderTokenizer does not exist or is not currently imported.`

