### PR TITLE
Tutorial 18:Open in Colab doesn't work in Firefox

### DIFF
--- a/docs/_src/tutorials/tutorials/18.md
+++ b/docs/_src/tutorials/tutorials/18.md
@@ -8,9 +8,10 @@ id: "tutorial18md"
 --->
 
 # Generative Pseudo Labeling for Domain Adaptation of Dense Retrievals
+
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial18_GPL.ipynb)
 
-#### Note: Adapted to Haystack from Nils Riemers' original [notebook](https://colab.research.google.com/gist/jamescalam/d2c888775c87f9882bb7c379a96adbc8/gpl-domain-adaptation.ipynb#scrollTo=183ff7ab)
+*Note: Adapted to Haystack from Nils Riemers' original [notebook](https://colab.research.google.com/gist/jamescalam/d2c888775c87f9882bb7c379a96adbc8/gpl-domain-adaptation.ipynb#scrollTo=183ff7ab)
 
 The NLP models we use every day were trained on a corpus of data that reflects the world from the past. In the meantime, we've experienced world-changing events, like the COVID pandemics, and we'd like our models to know about them. Training a model from scratch is tedious work but what if we could just update the models with new data? Generative Pseudo Labeling comes to the rescue.
 

--- a/tutorials/Tutorial18_GPL.ipynb
+++ b/tutorials/Tutorial18_GPL.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "source": [
     "# Generative Pseudo Labeling for Domain Adaptation of Dense Retrievals\n",
+    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial18_GPL.ipynb)\n",
     "\n",
     "#### Note: Adapted to Haystack from Nils Riemers' original [notebook](https://colab.research.google.com/gist/jamescalam/d2c888775c87f9882bb7c379a96adbc8/gpl-domain-adaptation.ipynb#scrollTo=183ff7ab)\n",

--- a/tutorials/Tutorial18_GPL.ipynb
+++ b/tutorials/Tutorial18_GPL.ipynb
@@ -7,7 +7,7 @@
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepset-ai/haystack/blob/master/tutorials/Tutorial18_GPL.ipynb)\n",
     "\n",
-    "#### Note: Adapted to Haystack from Nils Riemers' original [notebook](https://colab.research.google.com/gist/jamescalam/d2c888775c87f9882bb7c379a96adbc8/gpl-domain-adaptation.ipynb#scrollTo=183ff7ab)\n",
+    "*Note: Adapted to Haystack from Nils Riemers' original [notebook](https://colab.research.google.com/gist/jamescalam/d2c888775c87f9882bb7c379a96adbc8/gpl-domain-adaptation.ipynb#scrollTo=183ff7ab)\n",
     "\n",
     "The NLP models we use every day were trained on a corpus of data that reflects the world from the past. In the meantime, we've experienced world-changing events, like the COVID pandemics, and we'd like our models to know about them. Training a model from scratch is tedious work but what if we could just update the models with new data? Generative Pseudo Labeling comes to the rescue.\n",
     "\n",


### PR DESCRIPTION
It seems that the "Open in Colab" button doesn't work in the Firefox browser because there is no new line break between the title of the section and the link. I am not 100% sure about this claim but that's the only difference I can find between Tutorial 18 and others - where the "Open in Colab" button works in Firefox. @agnieszka-m not sure how we can test this hypothesis before merging. LMK.