### PR TITLE
Change split logic to list on PDFToTextConverter

### DIFF
--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -169,8 +169,8 @@ class PDFToTextConverter(BaseConverter):
         if not encoding:
             encoding = self.encoding
 
-        command = f"pdftotext -enc {encoding} {'-layout ' if layout else ''}{str(file_path)} -".split()
-        output = subprocess.run(command, stdout=subprocess.PIPE, shell=False)
+        command = ["pdftotext", "-enc", encoding, {"-layout " if layout else ""}, {str(file_path)}, "-"]
+        output = subprocess.run(command, stdout=subprocess.PIPE, shell=False, check=False)
         document = output.stdout.decode(errors="ignore")
         pages = document.split("\f")
         pages = pages[:-1]  # the last page in the split is always empty.


### PR DESCRIPTION
**Related Issue(s)**:  #2785

**Proposed changes**:
- Change string split logic to a list

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
