### PR TITLE
API key check in `OpenAIAnswerGenerator`

### DIFF
--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -36,7 +36,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
     ):
 
         """
-        :param api_key: Your API key from OpenAI
+        :param api_key: Your API key from OpenAI. It is required for this node to work.
         :param model: ID of the engine to use for generating the answer. You can select one of `"text-ada-001"`,
                      `"text-babbage-001"`, `"text-curie-001"`, or `"text-davinci-002"`
                      (from worst to best + cheapest to most expensive). Please refer to the
@@ -71,6 +71,10 @@ class OpenAIAnswerGenerator(BaseGenerator):
         if not stop_words:
             stop_words = ["\n", "<|endoftext|>"]
 
+        if not api_key:
+            raise ValueError("OpenAIAnswerGenerator requires an API key.")
+        
+        self.api_key = api_key
         self.model = model
         self.max_tokens = max_tokens
         self.top_k = top_k
@@ -79,7 +83,6 @@ class OpenAIAnswerGenerator(BaseGenerator):
         self.frequency_penalty = frequency_penalty
         self.examples_context = examples_context
         self.examples = examples
-        self.api_key = api_key
         self.stop_words = stop_words
         self._tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 

--- a/test/nodes/test_generator.py
+++ b/test/nodes/test_generator.py
@@ -128,10 +128,8 @@ def test_lfqa_pipeline_invalid_converter(document_store, retriever, docs_with_tr
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY", None), reason="No OpenAI API key provided.")
 def test_openai_answer_generator(openai_generator, docs):
-    if "OPENAI_API_KEY" in os.environ:
-        prediction = openai_generator.predict(query="Who lives in Berlin?", documents=docs, top_k=1)
-        assert len(prediction["answers"]) == 1
-        assert "Carla" in prediction["answers"][0].answer
-    else:
-        pytest.skip("No API key provided in environment variables.")
+    prediction = openai_generator.predict(query="Who lives in Berlin?", documents=docs, top_k=1)
+    assert len(prediction["answers"]) == 1
+    assert "Carla" in prediction["answers"][0].answer


### PR DESCRIPTION
**Related Issue(s)**:  #2787 (does NOT close it)

**Proposed changes**:
- Make `OpenAIAnswerGenerator` check if the API key was given and raise `ValueError` if it's missing
- Make `OpenAIAnswerGenerator`'s tests skip if such API key is not found among the env vars.

## Pre-flight checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
