### PR TITLE
Change "text" to "content" as dict key

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1692,8 +1692,8 @@ Indexes documents for later queries.
 **Arguments**:
 
 - `documents`: a list of Python dictionaries or a list of Haystack Document objects.
-For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
-                  Optionally: Include meta data via {"text": "<the-actual-text>",
+For documents as dictionaries, the format is {"content": "<the-actual-text>"}.
+                  Optionally: Include meta data via {"content": "<the-actual-text>",
                   "meta": {"name": "<some-document-name>, "author": "somebody", ...}}
                   It can be used for filtering and is accessible in the responses of the Finder.
 :param index: write documents to a custom namespace. For instance, documents for evaluation can be indexed in a

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -95,8 +95,8 @@ class InMemoryDocumentStore(BaseDocumentStore):
 
 
         :param documents: a list of Python dictionaries or a list of Haystack Document objects.
-                           For documents as dictionaries, the format is {"text": "<the-actual-text>"}.
-                           Optionally: Include meta data via {"text": "<the-actual-text>",
+                           For documents as dictionaries, the format is {"content": "<the-actual-text>"}.
+                           Optionally: Include meta data via {"content": "<the-actual-text>",
                            "meta": {"name": "<some-document-name>, "author": "somebody", ...}}
                            It can be used for filtering and is accessible in the responses of the Finder.
          :param index: write documents to a custom namespace. For instance, documents for evaluation can be indexed in a


### PR DESCRIPTION
Documentation of write_documents mentioned the old dict key (and Document attribute) `text`. This PR replaces the two occurrences of `text` in the docstring with `content`.