### PR TITLE
Enable CI on tutorials

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,14 +14,14 @@ on:
 
     # Disabled due to branch protection rules. 
     # PRs affecting paths not listed here, or tutorials/, are otherwise unmergeable.
-    paths:
-      - '**/*.py'
-      - '**/*.yml'
-      - '**/*.ipynb'
-      - '**/setup.cfg'
-      - '**/pyproject.toml'
-      - '.github/**/*'
-      - '!tutorials/*'  # See if it's possible to require tutorials.yml on PRs affecting this path.
+    # paths:
+    #   - '**/*.py'
+    #   - '**/*.yml'
+    #   - '**/*.ipynb'
+    #   - '**/setup.cfg'
+    #   - '**/pyproject.toml'
+    #   - '.github/**/*'
+    #   - '!tutorials/*'  # See if it's possible to require tutorials.yml on PRs affecting this path.
 
 
 env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+
+    # Disabled due to branch protection rules. 
+    # PRs affecting paths not listed here, or tutorials/, are otherwise unmergeable.
     paths:
       - '**/*.py'
       - '**/*.yml'
@@ -18,7 +21,7 @@ on:
       - '**/setup.cfg'
       - '**/pyproject.toml'
       - '.github/**/*'
-      # - '!tutorials/*'  Disabled due to branch protection rules. Before re-enabling it, see if it's possible to require tutorials.yml on PRs affecting this path.
+      - '!tutorials/*'  # See if it's possible to require tutorials.yml on PRs affecting this path.
 
 
 env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,18 +12,6 @@ on:
       - synchronize
       - ready_for_review
 
-    # Disabled due to branch protection rules. 
-    # PRs affecting paths not listed here, or tutorials/, are otherwise unmergeable.
-    # paths:
-    #   - '**/*.py'
-    #   - '**/*.yml'
-    #   - '**/*.ipynb'
-    #   - '**/setup.cfg'
-    #   - '**/pyproject.toml'
-    #   - '.github/**/*'
-    #   - '!tutorials/*'  # See if it's possible to require tutorials.yml on PRs affecting this path.
-
-
 env:
   PYTEST_PARAMS: --maxfail=5 --durations=10 --suppress-no-test-exit-code
   SUITES_EXCLUDED_FROM_WINDOWS:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
       - '**/setup.cfg'
       - '**/pyproject.toml'
       - '.github/**/*'
-      - '!tutorials/*'   # This path is excluded, see tutorials.yml
+      # - '!tutorials/*'  Disabled due to branch protection rules. Before re-enabling it, see if it's possible to require tutorials.yml on PRs affecting this path.
 
 
 env:


### PR DESCRIPTION
**Related Issue(s)**:  https://github.com/deepset-ai/haystack/pull/2798 is unmergeable due to branch protection rules.

**Proposed changes**:
- Enable the `tests.yml` workflow on all PRs. Branch protection rules should then be re-evaluated for the corner cases in which tests are unnecessary.

## Pre-flight checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [X] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- ~If this is a code change, I added tests or updated existing ones~
- ~If this is a code change, I updated the docstrings~
