### PR TITLE
fix healtcheck cmds for annotation tool postgres

### DIFF
--- a/annotation_tool/docker-compose.yml
+++ b/annotation_tool/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: "pg_isready --username=somesafeuser && psql --username=somesafepassword --list"
+      test: "pg_isready --username=somesafeuser --dbname=databasename && psql --username=somesafeuser --list"
       timeout: 3s
       retries: 5
     restart: unless-stopped


### PR DESCRIPTION
**Related Issue(s)**:
- fixes https://github.com/deepset-ai/haystack/issues/2839

**Proposed changes**:
- correct healthcheck commands:
  - add -dbname param to `pg_isready`
  - use actual username for username param of `psql`
