### PR TITLE
removed deprecated prepare_seq2seq_batch

### DIFF
--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -229,7 +229,8 @@ class RAGenerator(BaseGenerator):
         passage_embeddings = self._prepare_passage_embeddings(docs=documents, embeddings=flat_docs_dict["embedding"])
 
         # Query tokenization
-        input_dict = self.tokenizer.prepare_seq2seq_batch(src_texts=[query], return_tensors="pt")
+        with self.tokenizer.as_target_tokenizer():
+            input_dict = self.tokenizer(src_texts=[query], return_tensors='pt')
         input_ids = input_dict["input_ids"].to(self.devices[0])
         # Query embedding
         query_embedding = self.model.question_encoder(input_ids)[0]

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -229,8 +229,7 @@ class RAGenerator(BaseGenerator):
         passage_embeddings = self._prepare_passage_embeddings(docs=documents, embeddings=flat_docs_dict["embedding"])
 
         # Query tokenization
-        with self.tokenizer.as_target_tokenizer():
-            input_dict = self.tokenizer(src_texts=[query], return_tensors='pt')
+        input_dict = self.tokenizer.prepare_seq2seq_batch(src_texts=[query], return_tensors="pt")
         input_ids = input_dict["input_ids"].to(self.devices[0])
         # Query embedding
         query_embedding = self.model.question_encoder(input_ids)[0]

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -120,7 +120,7 @@ class TransformersTranslator(BaseTranslator):
             text_for_translator: List[str] = [query]  # type: ignore
 
         with self.tokenizer.as_target_tokenizer():
-            batch = self.tokenizer(src_texts=text_for_translator, return_tensors='pt', max_length=self.max_seq_len, padding="longest", truncation=True).to(self.devices[0])
+            batch = self.tokenizer(text=text_for_translator, return_tensors='pt', max_length=self.max_seq_len, padding="longest", truncation=True).to(self.devices[0])
 
         generated_output = self.model.generate(**batch)
         translated_texts = self.tokenizer.batch_decode(

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -120,7 +120,7 @@ class TransformersTranslator(BaseTranslator):
             text_for_translator: List[str] = [query]  # type: ignore
 
         with self.tokenizer.as_target_tokenizer():
-            batch = self.tokenizer(src_texts=text_for_translator, return_tensors='pt', max_length=self.max_seq_len).to(self.devices[0])
+            batch = self.tokenizer(src_texts=text_for_translator, return_tensors='pt', max_length=self.max_seq_len, padding="longest", truncation=True).to(self.devices[0])
 
         generated_output = self.model.generate(**batch)
         translated_texts = self.tokenizer.batch_decode(

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -119,9 +119,9 @@ class TransformersTranslator(BaseTranslator):
         else:
             text_for_translator: List[str] = [query]  # type: ignore
 
-        batch = self.tokenizer.prepare_seq2seq_batch(
-            src_texts=text_for_translator, return_tensors="pt", max_length=self.max_seq_len
-        ).to(self.devices[0])
+        with self.tokenizer.as_target_tokenizer():
+            batch = self.tokenizer(src_texts=text_for_translator, return_tensors='pt', max_length=self.max_seq_len).to(self.devices[0])
+
         generated_output = self.model.generate(**batch)
         translated_texts = self.tokenizer.batch_decode(
             generated_output, skip_special_tokens=True, clean_up_tokenization_spaces=self.clean_up_tokenization_spaces


### PR DESCRIPTION
**Related Issue(s)**:  
I was using the `from haystack.nodes import TransformersTranslator` where I stumbled upon this warning:

.../site-packages/transformers/tokenization_utils_base.py:3538: FutureWarning: 
`prepare_seq2seq_batch` is deprecated and will be removed in version 5 of HuggingFace Transformers. Use the regular
`__call__` method to prepare your inputs and the tokenizer under the `as_target_tokenizer` context manager to prepare

**Proposed changes**:
- I used documentation to rewrite this part and prevent any future errors.

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
