### PR TITLE
Validate OpenAI response

### DIFF
--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -88,3 +88,9 @@ class AudioNodeError(NodeError):
 
     def __init__(self, message: Optional[str] = None):
         super().__init__(message=message)
+        
+class OpenAIError(NodeError):
+    """Exception for issues that occur in the OpenAI Answer Generator node"""
+
+    def __init__(self, message: Optional[str] = None):
+        super().__init__(message=message)        

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -88,9 +88,10 @@ class AudioNodeError(NodeError):
 
     def __init__(self, message: Optional[str] = None):
         super().__init__(message=message)
-        
+
+
 class OpenAIError(NodeError):
     """Exception for issues that occur in the OpenAI Answer Generator node"""
 
     def __init__(self, message: Optional[str] = None):
-        super().__init__(message=message)        
+        super().__init__(message=message)

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -136,13 +136,15 @@ class OpenAIAnswerGenerator(BaseGenerator):
 
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
         response = requests.request("POST", url, headers=headers, data=json.dumps(payload))
-
         res = json.loads(response.text)
-        generated_answers = [ans["text"] for ans in res["choices"]]
-        answers = self._create_answers(generated_answers, input_docs)
-        result = {"query": query, "answers": answers}
 
-        return result
+        if response.status_code == 200 and 'choices' in res:
+            generated_answers = [ans["text"] for ans in res["choices"]]
+            answers = self._create_answers(generated_answers, input_docs)
+            result = {"query": query, "answers": answers}
+            return result
+        else:
+            raise Exception(f"OpenAI returned an error. \nStatus code: {response.status_code}\nResponse body: {response.text}")
 
     def _build_prompt(self, query: str, documents: List[Document]) -> Tuple[str, List[Document]]:
         """

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -138,13 +138,15 @@ class OpenAIAnswerGenerator(BaseGenerator):
         response = requests.request("POST", url, headers=headers, data=json.dumps(payload))
         res = json.loads(response.text)
 
-        if response.status_code == 200 and 'choices' in res:
+        if response.status_code == 200 and "choices" in res:
             generated_answers = [ans["text"] for ans in res["choices"]]
             answers = self._create_answers(generated_answers, input_docs)
             result = {"query": query, "answers": answers}
             return result
         else:
-            raise Exception(f"OpenAI returned an error. \nStatus code: {response.status_code}\nResponse body: {response.text}")
+            raise Exception(
+                f"OpenAI returned an error. \nStatus code: {response.status_code}\nResponse body: {response.text}"
+            )
 
     def _build_prompt(self, query: str, documents: List[Document]) -> Tuple[str, List[Document]]:
         """

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -138,15 +138,17 @@ class OpenAIAnswerGenerator(BaseGenerator):
         response = requests.request("POST", url, headers=headers, data=json.dumps(payload))
         res = json.loads(response.text)
 
-        if response.status_code == 200 and "choices" in res:
-            generated_answers = [ans["text"] for ans in res["choices"]]
-            answers = self._create_answers(generated_answers, input_docs)
-            result = {"query": query, "answers": answers}
-            return result
-        else:
+        if response.status_code != 200 or "choices" not in res:
             raise Exception(
-                f"OpenAI returned an error. \nStatus code: {response.status_code}\nResponse body: {response.text}"
+                f"OpenAI returned an error.\n"
+                f"Status code: {response.status_code}\n"
+                f"Response body: {response.text}"
             )
+            
+    generated_answers = [ans["text"] for ans in res["choices"]]
+    answers = self._create_answers(generated_answers, input_docs)
+    result = {"query": query, "answers": answers}
+    return result            
 
     def _build_prompt(self, query: str, documents: List[Document]) -> Tuple[str, List[Document]]:
         """

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -144,11 +144,11 @@ class OpenAIAnswerGenerator(BaseGenerator):
                 f"Status code: {response.status_code}\n"
                 f"Response body: {response.text}"
             )
-            
+
     generated_answers = [ans["text"] for ans in res["choices"]]
     answers = self._create_answers(generated_answers, input_docs)
     result = {"query": query, "answers": answers}
-    return result            
+    return result
 
     def _build_prompt(self, query: str, documents: List[Document]) -> Tuple[str, List[Document]]:
         """

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -7,6 +7,7 @@ from transformers import GPT2TokenizerFast
 
 from haystack.nodes.answer_generator import BaseGenerator
 from haystack import Document
+from haystack.errors import OpenAIError
 
 
 logger = logging.getLogger(__name__)
@@ -139,7 +140,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         res = json.loads(response.text)
 
         if response.status_code != 200 or "choices" not in res:
-            raise Exception(
+            raise OpenAIError(
                 f"OpenAI returned an error.\n"
                 f"Status code: {response.status_code}\n"
                 f"Response body: {response.text}"

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -145,10 +145,10 @@ class OpenAIAnswerGenerator(BaseGenerator):
                 f"Response body: {response.text}"
             )
 
-    generated_answers = [ans["text"] for ans in res["choices"]]
-    answers = self._create_answers(generated_answers, input_docs)
-    result = {"query": query, "answers": answers}
-    return result
+        generated_answers = [ans["text"] for ans in res["choices"]]
+        answers = self._create_answers(generated_answers, input_docs)
+        result = {"query": query, "answers": answers}
+        return result
 
     def _build_prompt(self, query: str, documents: List[Document]) -> Tuple[str, List[Document]]:
         """


### PR DESCRIPTION
**Related Issue(s)**:  Closes #2787

**Proposed changes**:
- Before returning the result, we check that the response is valid.
Otherwise, we raise an Exception, such as the following:

> Exception: OpenAI returned an error. 
> Status code: 429
> Response body: {
>     "error": {
>         "message": "You exceeded your current quota, please check your plan and billing details.",
>         "type": "insufficient_quota",
>         "param": null,
>         "code": null
>     }
> }
> 
> ---
> Exception: OpenAI returned an error. 
> Status code: 401
> Response body: {
>     "error": {
>         "message": "Incorrect API key provided: s*******************************************y. You can find your API key at https://beta.openai.com.",
>         "type": "invalid_request_error",
>         "param": null,
>         "code": "invalid_api_key"
>     }
> }


## Pre-flight checklist
- [X]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [X] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
