### PR TITLE
Remove logging config from Haystack

### DIFF
--- a/docs/_src/tutorials/tutorials/1.md
+++ b/docs/_src/tutorials/tutorials/1.md
@@ -51,6 +51,7 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 We configure how logging messages should be displayed and which log level should be used before importing Haystack.
 Example log message:
 INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
 
 
 ```python

--- a/docs/_src/tutorials/tutorials/10.md
+++ b/docs/_src/tutorials/tutorials/10.md
@@ -25,6 +25,21 @@ The training of models that translate text queries into SPARQL queries is curren
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,inmemorygraph]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 # Here are some imports that we'll need

--- a/docs/_src/tutorials/tutorials/11.md
+++ b/docs/_src/tutorials/tutorials/11.md
@@ -47,6 +47,21 @@ These lines are to install Haystack through pip
 !pip install pygraphviz
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 If running from Colab or a no Docker environment, you will want to start Elasticsearch from source
 
 

--- a/docs/_src/tutorials/tutorials/12.md
+++ b/docs/_src/tutorials/tutorials/12.md
@@ -37,6 +37,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install -q git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from haystack.utils import convert_files_to_docs, fetch_archive_from_http, clean_wiki_text

--- a/docs/_src/tutorials/tutorials/13.md
+++ b/docs/_src/tutorials/tutorials/13.md
@@ -32,6 +32,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 # Imports needed to run this notebook

--- a/docs/_src/tutorials/tutorials/14.md
+++ b/docs/_src/tutorials/tutorials/14.md
@@ -56,6 +56,21 @@ Next we make sure the latest version of Haystack is installed:
 !pip install pygraphviz
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 ### Trying Some Query Classifiers on their Own
 
 Before integrating query classifiers into our pipelines, let's test them out on their own and see what they actually do. First we initiate a simple, out-of-the-box **keyword vs. question/statement** `SklearnQueryClassifier`:

--- a/docs/_src/tutorials/tutorials/15.md
+++ b/docs/_src/tutorials/tutorials/15.md
@@ -26,6 +26,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !nvidia-smi
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 # Install the latest release of Haystack in your own environment

--- a/docs/_src/tutorials/tutorials/16.md
+++ b/docs/_src/tutorials/tutorials/16.md
@@ -36,6 +36,21 @@ This tutorial will show you how to integrate a classification model into your pr
 !pip install pygraphviz
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 # Here are the imports we need

--- a/docs/_src/tutorials/tutorials/17.md
+++ b/docs/_src/tutorials/tutorials/17.md
@@ -41,6 +41,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,audio]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 ### Setup Elasticsearch
 
 

--- a/docs/_src/tutorials/tutorials/18.md
+++ b/docs/_src/tutorials/tutorials/18.md
@@ -61,6 +61,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install -q git+https://github.com/deepset-ai/haystack.git
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from sentence_transformers import SentenceTransformer, util

--- a/docs/_src/tutorials/tutorials/2.md
+++ b/docs/_src/tutorials/tutorials/2.md
@@ -41,6 +41,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from haystack.nodes import FARMReader

--- a/docs/_src/tutorials/tutorials/3.md
+++ b/docs/_src/tutorials/tutorials/3.md
@@ -41,6 +41,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from haystack.utils import clean_wiki_text, convert_files_to_docs, fetch_archive_from_http, print_answers

--- a/docs/_src/tutorials/tutorials/4.md
+++ b/docs/_src/tutorials/tutorials/4.md
@@ -49,6 +49,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from haystack.document_stores import ElasticsearchDocumentStore

--- a/docs/_src/tutorials/tutorials/5.md
+++ b/docs/_src/tutorials/tutorials/5.md
@@ -38,6 +38,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 ## Start an Elasticsearch server
 You can start Elasticsearch on your local machine instance using Docker. If Docker is not readily available in your environment (eg., in Colab notebooks), then you can manually download and execute Elasticsearch from source.
 

--- a/docs/_src/tutorials/tutorials/6.md
+++ b/docs/_src/tutorials/tutorials/6.md
@@ -82,6 +82,21 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from haystack.utils import clean_wiki_text, convert_files_to_docs, fetch_archive_from_http, print_answers

--- a/docs/_src/tutorials/tutorials/7.md
+++ b/docs/_src/tutorials/tutorials/7.md
@@ -43,6 +43,21 @@ Here are the packages and imports that we'll need:
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab,faiss]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 from typing import List

--- a/docs/_src/tutorials/tutorials/8.md
+++ b/docs/_src/tutorials/tutorials/8.md
@@ -45,6 +45,21 @@ This tutorial will show you all the tools that Haystack provides to help you cas
 # !tar -xvf xpdf-tools-mac-4.03.tar.gz && sudo cp xpdf-tools-mac-4.03/bin64/pdftotext /usr/local/bin
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 # Here are the imports we need

--- a/docs/_src/tutorials/tutorials/9.md
+++ b/docs/_src/tutorials/tutorials/9.md
@@ -24,6 +24,21 @@ This tutorial will guide you through the steps required to create a retriever th
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
+## Logging
+
+We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+Example log message:
+INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+
+
+```python
+import logging
+
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+```
+
 
 ```python
 # Here are some imports that we'll need

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -12,13 +12,7 @@ except (ModuleNotFoundError, ImportError):
 __version__: str = str(metadata.version("farm-haystack"))
 
 
-# Logging is not configured here so that developers using Haystack as a library can configure logging themselves.
-# If Haystack is used as an application, we suggest to use the following configuration:
-# import logging
-# logging.basicConfig(
-#     format="%(levelname)s - %(name)s -  %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.WARNING
-# )
-# logging.getLogger("haystack").setLevel(logging.INFO)
+# Logging is not configured here on purpose, see https://github.com/deepset-ai/haystack/issues/2485
 import logging
 
 import pandas as pd

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -12,13 +12,14 @@ except (ModuleNotFoundError, ImportError):
 __version__: str = str(metadata.version("farm-haystack"))
 
 
-# This configuration must be done before any import to apply to all submodules
+# Logging is not configured here so that developers using Haystack as a library can configure logging themselves.
+# If Haystack is used as an application, we suggest to use the following configuration:
+# import logging
+# logging.basicConfig(
+#     format="%(levelname)s - %(name)s -  %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.WARNING
+# )
+# logging.getLogger("haystack").setLevel(logging.INFO)
 import logging
-
-logging.basicConfig(
-    format="%(levelname)s - %(name)s -  %(message)s", datefmt="%m/%d/%Y %H:%M:%S", level=logging.WARNING
-)
-logging.getLogger("haystack").setLevel(logging.INFO)
 
 import pandas as pd
 

--- a/tutorials/Tutorial10_Knowledge_Graph.ipynb
+++ b/tutorials/Tutorial10_Knowledge_Graph.ipynb
@@ -40,6 +40,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial10_Knowledge_Graph.py
+++ b/tutorials/Tutorial10_Knowledge_Graph.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import subprocess
 import time
 from pathlib import Path
@@ -7,8 +6,6 @@ from pathlib import Path
 from haystack.nodes import Text2SparqlRetriever
 from haystack.document_stores import GraphDBKnowledgeGraph, InMemoryKnowledgeGraph
 from haystack.utils import fetch_archive_from_http
-
-logger = logging.getLogger(__name__)
 
 
 def tutorial10_knowledge_graph():
@@ -34,7 +31,7 @@ def tutorial10_knowledge_graph():
     print(f"The last triple stored in the knowledge graph is: {kg.get_all_triples()[-1]}")
     print(f"There are {len(kg.get_all_triples())} triples stored in the knowledge graph.")
 
-    #               ALTERNATIVE PATH USING GraphDB as knowledge graph
+    # ALTERNATIVE PATH USING GraphDB as knowledge graph
     # LAUNCH_GRAPHDB = os.environ.get("LAUNCH_GRAPHDB", True)
     # # Start a GraphDB server
     # if LAUNCH_GRAPHDB:

--- a/tutorials/Tutorial10_Knowledge_Graph.py
+++ b/tutorials/Tutorial10_Knowledge_Graph.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 import os
 import subprocess
 import time

--- a/tutorials/Tutorial11_Pipelines.ipynb
+++ b/tutorials/Tutorial11_Pipelines.ipynb
@@ -92,6 +92,40 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
     "pycharm": {

--- a/tutorials/Tutorial11_Pipelines.py
+++ b/tutorials/Tutorial11_Pipelines.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.utils import (
     clean_wiki_text,
     print_answers,

--- a/tutorials/Tutorial12_LFQA.ipynb
+++ b/tutorials/Tutorial12_LFQA.ipynb
@@ -57,6 +57,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial12_LFQA.py
+++ b/tutorials/Tutorial12_LFQA.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.utils import convert_files_to_docs, fetch_archive_from_http, clean_wiki_text
 from haystack.nodes import Seq2SeqGenerator
 

--- a/tutorials/Tutorial13_Question_generation.ipynb
+++ b/tutorials/Tutorial13_Question_generation.ipynb
@@ -55,6 +55,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial13_Question_generation.py
+++ b/tutorials/Tutorial13_Question_generation.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from tqdm import tqdm
 from haystack.nodes import QuestionGenerator, BM25Retriever, FARMReader, TransformersTranslator
 from haystack.document_stores import ElasticsearchDocumentStore

--- a/tutorials/Tutorial14_Query_Classifier.ipynb
+++ b/tutorials/Tutorial14_Query_Classifier.ipynb
@@ -91,6 +91,40 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "sJcWRK4Hwyx2"
    },

--- a/tutorials/Tutorial14_Query_Classifier.py
+++ b/tutorials/Tutorial14_Query_Classifier.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.utils import (
     fetch_archive_from_http,
     convert_files_to_docs,

--- a/tutorials/Tutorial15_TableQA.ipynb
+++ b/tutorials/Tutorial15_TableQA.ipynb
@@ -40,6 +40,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial15_TableQA.py
+++ b/tutorials/Tutorial15_TableQA.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 import os
 import json
 import time

--- a/tutorials/Tutorial16_Document_Classifier_at_Index_Time.ipynb
+++ b/tutorials/Tutorial16_Document_Classifier_at_Index_Time.ipynb
@@ -57,6 +57,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/tutorials/Tutorial16_Document_Classifier_at_Index_Time.py
+++ b/tutorials/Tutorial16_Document_Classifier_at_Index_Time.py
@@ -18,9 +18,17 @@
 
 
 # Here are the imports we need
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.nodes import PreProcessor, TransformersDocumentClassifier, FARMReader, BM25Retriever
-from haystack.schema import Document
 from haystack.utils import convert_files_to_docs, fetch_archive_from_http, print_answers, launch_es
 
 

--- a/tutorials/Tutorial17_Audio.ipynb
+++ b/tutorials/Tutorial17_Audio.ipynb
@@ -66,6 +66,40 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "ZCemC4_XB3Se"
    },

--- a/tutorials/Tutorial17_Audio.py
+++ b/tutorials/Tutorial17_Audio.py
@@ -6,6 +6,15 @@
 # In this tutorial, we're going to see how to use `AnswerToSpeech` to convert answers
 # into audio files.
 #
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.utils import fetch_archive_from_http, launch_es, print_answers
 from haystack.nodes import FARMReader, BM25Retriever

--- a/tutorials/Tutorial18_GPL.ipynb
+++ b/tutorials/Tutorial18_GPL.ipynb
@@ -82,6 +82,40 @@
    }
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],

--- a/tutorials/Tutorial18_GPL.py
+++ b/tutorials/Tutorial18_GPL.py
@@ -37,6 +37,15 @@ If we search again with the updated model, we get the search results we would ex
 - 94.13	HIV is transmitted via sex or sharing needles
 """
 
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from sentence_transformers import SentenceTransformer, util
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
 from datasets import load_dataset

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -70,7 +70,8 @@
     "\n",
     "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
     "Example log message:\n",
-    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt"
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
    ],
    "metadata": {
     "collapsed": false,

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -75,6 +75,38 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Document Store\n",

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb
@@ -64,21 +64,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from haystack.utils import clean_wiki_text, convert_files_to_docs, fetch_archive_from_http, print_answers\n",
-    "from haystack.nodes import FARMReader, TransformersReader"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "source": [
     "## Logging\n",
     "\n",
-    "We configure how logging messages should be displayed and which log level should be used.\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
     "Example log message:\n",
     "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt"
    ],
@@ -97,6 +87,21 @@
     "import logging\n",
     "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
     "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from haystack.utils import clean_wiki_text, convert_files_to_docs, fetch_archive_from_http, print_answers\n",
+    "from haystack.nodes import FARMReader, TransformersReader"
    ],
    "metadata": {
     "collapsed": false,

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.py
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.py
@@ -14,6 +14,7 @@ import logging
 # We configure how logging messages should be displayed and which log level should be used before importing Haystack.
 # Example log message:
 # INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
 logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
 logging.getLogger("haystack").setLevel(logging.INFO)
 

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.py
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.py
@@ -10,20 +10,19 @@
 # marvellous seven kingdoms.
 
 import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.utils import clean_wiki_text, convert_files_to_docs, fetch_archive_from_http, print_answers, launch_es
 from haystack.nodes import FARMReader, TransformersReader, BM25Retriever
 
 
 def tutorial1_basic_qa_pipeline():
-    # ## Logging
-    #
-    # We configure how logging messages should be displayed and which log level should be used.
-    # Example log message:
-    # INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
-    logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
-    logging.getLogger("haystack").setLevel(logging.INFO)
-
     # ## Document Store
     #
     # Haystack finds answers to queries within the documents stored in a `DocumentStore`. The current implementations of

--- a/tutorials/Tutorial1_Basic_QA_Pipeline.py
+++ b/tutorials/Tutorial1_Basic_QA_Pipeline.py
@@ -16,7 +16,13 @@ from haystack.nodes import FARMReader, TransformersReader, BM25Retriever
 
 
 def tutorial1_basic_qa_pipeline():
-    logger = logging.getLogger(__name__)
+    # ## Logging
+    #
+    # We configure how logging messages should be displayed and which log level should be used.
+    # Example log message:
+    # INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+    logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+    logging.getLogger("haystack").setLevel(logging.INFO)
 
     # ## Document Store
     #

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.ipynb
@@ -60,19 +60,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   },
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "outputs": [],
    "source": [
     "from haystack.nodes import FARMReader\n",
     "from haystack.utils import fetch_archive_from_http"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",

--- a/tutorials/Tutorial2_Finetune_a_model_on_your_data.py
+++ b/tutorials/Tutorial2_Finetune_a_model_on_your_data.py
@@ -7,6 +7,15 @@
 #
 # This tutorial shows you how to fine-tune a pretrained model on your own dataset.
 
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.nodes import FARMReader
 from haystack.utils import augment_squad, fetch_archive_from_http
 

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -60,6 +60,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.py
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.py
@@ -6,6 +6,15 @@
 #
 # If you are interested in more feature-rich Elasticsearch, then please refer to the Tutorial 1.
 
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.document_stores import InMemoryDocumentStore, SQLDocumentStore
 from haystack.nodes import FARMReader, TransformersReader, TfidfRetriever
 from haystack.utils import clean_wiki_text, convert_files_to_docs, fetch_archive_from_http, print_answers

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -68,6 +68,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial4_FAQ_style_QA.ipynb
+++ b/tutorials/Tutorial4_FAQ_style_QA.ipynb
@@ -80,8 +80,7 @@
     "from haystack.document_stores import ElasticsearchDocumentStore\n",
     "\n",
     "from haystack.nodes import EmbeddingRetriever\n",
-    "import pandas as pd\n",
-    "import requests"
+    "import pandas as pd"
    ]
   },
   {

--- a/tutorials/Tutorial4_FAQ_style_QA.py
+++ b/tutorials/Tutorial4_FAQ_style_QA.py
@@ -3,10 +3,6 @@ from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.nodes import EmbeddingRetriever
 from haystack.utils import launch_es, print_answers, fetch_archive_from_http
 import pandas as pd
-import requests
-import logging
-import subprocess
-import time
 
 
 def tutorial4_faq_style_qa():

--- a/tutorials/Tutorial4_FAQ_style_QA.py
+++ b/tutorials/Tutorial4_FAQ_style_QA.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.document_stores import ElasticsearchDocumentStore
 
 from haystack.nodes import EmbeddingRetriever

--- a/tutorials/Tutorial5_Evaluation.ipynb
+++ b/tutorials/Tutorial5_Evaluation.ipynb
@@ -77,6 +77,40 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Start an Elasticsearch server\n",

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 import tempfile
 from pathlib import Path
 

--- a/tutorials/Tutorial5_Evaluation.py
+++ b/tutorials/Tutorial5_Evaluation.py
@@ -1,4 +1,3 @@
-import logging
 import tempfile
 from pathlib import Path
 
@@ -14,9 +13,6 @@ from haystack.nodes import (
 )
 from haystack.utils import fetch_archive_from_http, launch_es
 from haystack.schema import Answer, Document, EvaluationResult, Label, MultiLabel, Span
-
-
-logger = logging.getLogger(__name__)
 
 
 def tutorial5_evaluation():

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.ipynb
@@ -115,6 +115,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
+++ b/tutorials/Tutorial6_Better_Retrieval_via_DPR.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from haystack.document_stores import FAISSDocumentStore, MilvusDocumentStore
 from haystack.utils import clean_wiki_text, print_answers, launch_milvus, convert_files_to_docs, fetch_archive_from_http
 from haystack.nodes import FARMReader, DensePassageRetriever

--- a/tutorials/Tutorial7_RAG_Generator.ipynb
+++ b/tutorials/Tutorial7_RAG_Generator.ipynb
@@ -76,6 +76,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial7_RAG_Generator.py
+++ b/tutorials/Tutorial7_RAG_Generator.py
@@ -1,3 +1,12 @@
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 from typing import List
 import requests
 import pandas as pd

--- a/tutorials/Tutorial8_Preprocessing.ipynb
+++ b/tutorials/Tutorial8_Preprocessing.ipynb
@@ -75,6 +75,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {

--- a/tutorials/Tutorial8_Preprocessing.py
+++ b/tutorials/Tutorial8_Preprocessing.py
@@ -17,6 +17,15 @@ docs = [
 This tutorial will show you all the tools that Haystack provides to help you cast your data into the right format.
 """
 
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
 # Here are the imports we need
 from pathlib import Path
 

--- a/tutorials/Tutorial9_DPR_training.ipynb
+++ b/tutorials/Tutorial9_DPR_training.ipynb
@@ -37,6 +37,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "## Logging\n",
+    "\n",
+    "We configure how logging messages should be displayed and which log level should be used before importing Haystack.\n",
+    "Example log message:\n",
+    "INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt\n",
+    "Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(format=\"%(levelname)s - %(name)s -  %(message)s\", level=logging.WARNING)\n",
+    "logging.getLogger(\"haystack\").setLevel(logging.INFO)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/Tutorial9_DPR_training.py
+++ b/tutorials/Tutorial9_DPR_training.py
@@ -1,11 +1,22 @@
+# Training Your Own "Dense Passage Retrieval" Model
+
+# Here are some imports that we'll need
+
+import logging
+
+# We configure how logging messages should be displayed and which log level should be used before importing Haystack.
+# Example log message:
+# INFO - haystack.utils.preprocessing -  Converting data/tutorial1/218_Olenna_Tyrell.txt
+# Default log level in basicConfig is WARNING so the explicit parameter is not necessary but can be changed easily:
+logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+logging.getLogger("haystack").setLevel(logging.INFO)
+
+from haystack.nodes import DensePassageRetriever
+from haystack.utils import fetch_archive_from_http
+from haystack.document_stores import InMemoryDocumentStore
+
+
 def tutorial9_dpr_training():
-    # Training Your Own "Dense Passage Retrieval" Model
-
-    # Here are some imports that we'll need
-
-    from haystack.nodes import DensePassageRetriever
-    from haystack.utils import fetch_archive_from_http
-    from haystack.document_stores import InMemoryDocumentStore
 
     # Download original DPR data
     # WARNING: the train set is 7.4GB and the dev set is 800MB


### PR DESCRIPTION
**Related Issue(s)**:  closes #2485 

**Proposed changes**:

https://docs.python-guide.org/writing/logging/#logging-in-a-library 

> the user, not the library, should dictate what happens when a logging event occurs

However up to this PR, Haystack itself defined with a basicConfig how logging messages should be formatted. This behavior is not wanted if Haystack is used as a library instead of an application. To this end, this PR removes the basicConfig formatting from Haystack's `__init__.py` and instead moves that code to the tutorials ("application"). For the discussion of this PR, I only added the change to tutorial 1 but before merging this PR, I would add it to all tutorials.

Downside of that changed behavior is that beginners who might miss adding the log config themselves in their prototype code won't see most logging messages as the default log level is warning (and not info).

Another small change of this PR is that I removed unused imports from some of the tutorials.
Further, I didn't add any labels to this PR because it should appear in the "Other" section in the release notes.

Tutorial 1 can be tried out here: https://colab.research.google.com/github/deepset-ai/haystack/blob/configure-logging/tutorials/Tutorial1_Basic_QA_Pipeline.ipynb

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
