### PR TITLE
Fix corrupted csv from `EvaluationResult.save()`

### DIFF
--- a/docs/_src/api/api/primitives.md
+++ b/docs/_src/api/api/primitives.md
@@ -523,7 +523,7 @@ In Question Answering, to enforce that the retrieved document is considered corr
 #### EvaluationResult.save
 
 ```python
-def save(out_dir: Union[str, Path])
+def save(out_dir: Union[str, Path], **to_csv_kwargs)
 ```
 
 Saves the evaluation result.
@@ -533,6 +533,9 @@ The result of each node is saved in a separate csv with file name {node_name}.cs
 **Arguments**:
 
 - `out_dir`: Path to the target folder the csvs will be saved.
+- `to_csv_kwargs`: kwargs to be passed to pd.DataFrame.to_csv(). See https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_csv.html.
+This method uses different default values than pd.DataFrame.to_csv() for the following parameters:
+index=False, quoting=csv.QUOTE_NONNUMERIC (to avoid problems with \r chars)
 
 <a id="schema.EvaluationResult.load"></a>
 
@@ -540,7 +543,7 @@ The result of each node is saved in a separate csv with file name {node_name}.cs
 
 ```python
 @classmethod
-def load(cls, load_dir: Union[str, Path])
+def load(cls, load_dir: Union[str, Path], **read_csv_kwargs)
 ```
 
 Loads the evaluation result from disk. Expects one csv file per node. See save() for further information.
@@ -548,4 +551,9 @@ Loads the evaluation result from disk. Expects one csv file per node. See save()
 **Arguments**:
 
 - `load_dir`: The directory containing the csv files.
+- `read_csv_kwargs`: kwargs to be passed to pd.read_csv(). See https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.
+This method uses different default values than pd.read_csv() for the following parameters:
+header=0, converters=CONVERTERS
+
+where CONVERTERS is a dictionary mapping all array typed columns to ast.literal_eval.
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1384,14 +1384,19 @@ class EvaluationResult:
         load_dir = load_dir if isinstance(load_dir, Path) else Path(load_dir)
         csv_files = [file for file in load_dir.iterdir() if file.is_file() and file.suffix == ".csv"]
         cols_to_convert = [
+            "filters",
             "gold_document_ids",
+            "gold_custom_document_ids",
             "gold_contexts",
             "gold_answers",
+            "gold_documents_id_match",
             "gold_offsets_in_documents",
             "gold_answers_exact_match",
             "gold_answers_f1",
-            "gold_answers_document_id_match",
-            "gold_context_similarity",
+            "gold_answers_sas",
+            "gold_answers_match",
+            "gold_contexts_similarity",
+            "offsets_in_document",
         ]
         converters = dict.fromkeys(cols_to_convert, ast.literal_eval)
         default_read_csv_kwargs = {"converters": converters, "header": 0}

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1365,7 +1365,7 @@ class EvaluationResult:
             target_path = out_dir / f"{node_name}.csv"
             default_to_csv_kwargs = {
                 "index": False,
-                "quoting": csv.QUOTE_NONNUMERIC,  # avoids problems with \r chars in texts
+                "quoting": csv.QUOTE_NONNUMERIC,  # avoids problems with \r chars in texts by enclosing all string values in quotes
             }
             to_csv_kwargs = {**default_to_csv_kwargs, **to_csv_kwargs}
             df.to_csv(target_path, **to_csv_kwargs)
@@ -1379,7 +1379,6 @@ class EvaluationResult:
         :param read_csv_kwargs: kwargs to be passed to pd.read_csv(). See https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.
                                 This method uses different default values than pd.read_csv() for the following parameters:
                                 header=0, converters=CONVERTERS
-
                                 where CONVERTERS is a dictionary mapping all array typed columns to ast.literal_eval.
         """
         load_dir = load_dir if isinstance(load_dir, Path) else Path(load_dir)


### PR DESCRIPTION
**Related Issue(s)**:
- fixes https://github.com/deepset-ai/haystack-private/issues/4

**Proposed changes**:
- quote all strings of the resulting csv from `EvaluationResult.save()`, so \r chars cannot corrupt the file
- pass through pandas csv serialization kwargs to `save()` and `load()` methods: csv serialization can be troublesome, it's almost impossible to foresee any issue, so let's better be flexible on that and provide the user any option there is to mitigate problems.
