### PR TITLE
Updating pre-commit-config to remove python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.7
-
 fail_fast: true
 
 repos:


### PR DESCRIPTION
**Related Issue(s)**:  #2882 

**Proposed changes**:
- Remove the python version from the pre-commit-config

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
