### PR TITLE
Explicitly specify all parameters to forward call

### DIFF
--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -373,24 +373,24 @@ class Trainer:
     def compute_loss(self, batch: dict, step: int) -> torch.Tensor:
         # Forward & backward pass through model
         if isinstance(self.model, AdaptiveModel):
-            logits = self.model.forward(input_ids=batch["input_ids"],
-                                        segment_ids=None,
-                                        padding_mask=batch["padding_mask"])
+            logits = self.model.forward(
+                input_ids=batch["input_ids"], segment_ids=None, padding_mask=batch["padding_mask"]
+            )
 
         elif isinstance(self.model, BiAdaptiveModel):
-            logits = self.model.forward(query_input_ids=batch["query_input_ids"],
-                                        query_segment_ids=batch["query_segment_ids"],
-                                        query_attention_mask=batch["query_attention_mask"],
-                                        passage_input_ids=batch["passage_input_ids"],
-                                        passage_segment_ids=batch["passage_segment_ids"],
-                                        passage_attention_mask=batch["passage_attention_mask"])
+            logits = self.model.forward(
+                query_input_ids=batch["query_input_ids"],
+                query_segment_ids=batch["query_segment_ids"],
+                query_attention_mask=batch["query_attention_mask"],
+                passage_input_ids=batch["passage_input_ids"],
+                passage_segment_ids=batch["passage_segment_ids"],
+                passage_attention_mask=batch["passage_attention_mask"],
+            )
 
         else:
             logits = self.model.forward(**batch)
 
-        per_sample_loss = self.model.logits_to_loss(logits=logits,
-                                                    global_step=self.global_step,
-                                                    **batch)
+        per_sample_loss = self.model.logits_to_loss(logits=logits, global_step=self.global_step, **batch)
         return self.backward_propagate(per_sample_loss, step)
 
     def backward_propagate(self, loss: torch.Tensor, step: int):

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -17,6 +17,7 @@ from torch.optim import Optimizer
 from haystack.modeling.data_handler.data_silo import DataSilo, DistillationDataSilo
 from haystack.modeling.evaluation.eval import Evaluator
 from haystack.modeling.model.adaptive_model import AdaptiveModel
+from haystack.modeling.model.biadaptive_model import BiAdaptiveModel
 from haystack.modeling.model.optimization import get_scheduler
 from haystack.modeling.utils import GracefulKiller
 from haystack.utils.experiment_tracking import Tracker as tracker
@@ -371,8 +372,25 @@ class Trainer:
 
     def compute_loss(self, batch: dict, step: int) -> torch.Tensor:
         # Forward & backward pass through model
-        logits = self.model.forward(**batch)
-        per_sample_loss = self.model.logits_to_loss(logits=logits, global_step=self.global_step, **batch)
+        if isinstance(self.model, AdaptiveModel):
+            logits = self.model.forward(input_ids=batch["input_ids"],
+                                        segment_ids=None,
+                                        padding_mask=batch["padding_mask"])
+
+        elif isinstance(self.model, BiAdaptiveModel):
+            logits = self.model.forward(query_input_ids=batch["query_input_ids"],
+                                        query_segment_ids=batch["query_segment_ids"],
+                                        query_attention_mask=batch["query_attention_mask"],
+                                        passage_input_ids=batch["passage_input_ids"],
+                                        passage_segment_ids=batch["passage_segment_ids"],
+                                        passage_attention_mask=batch["passage_attention_mask"])
+
+        else:
+            logits = self.model.forward(**batch)
+
+        per_sample_loss = self.model.logits_to_loss(logits=logits,
+                                                    global_step=self.global_step,
+                                                    **batch)
         return self.backward_propagate(per_sample_loss, step)
 
     def backward_propagate(self, loss: torch.Tensor, step: int):

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -26,7 +26,7 @@ from haystack.schema import Document
 from haystack.document_stores import BaseDocumentStore
 from haystack.nodes.retriever.base import BaseRetriever
 from haystack.nodes.retriever._embedding_encoder import _EMBEDDING_ENCODERS
-from haystack.modeling.model.language_model import get_language_model
+from haystack.modeling.model.language_model import get_language_model, DPREncoder
 from haystack.modeling.model.biadaptive_model import BiAdaptiveModel
 from haystack.modeling.model.triadaptive_model import TriAdaptiveModel
 from haystack.modeling.model.prediction_head import TextSimilarityHead
@@ -161,9 +161,9 @@ class DensePassageRetriever(BaseRetriever):
             use_fast=use_fast_tokenizers,
             use_auth_token=use_auth_token,
         )
-        self.query_encoder = get_language_model(
-            pretrained_model_name_or_path=query_embedding_model, revision=model_version, use_auth_token=use_auth_token
-        )
+        self.query_encoder = DPREncoder(pretrained_model_name_or_path=query_embedding_model,
+                                        model_type="DPRQuestionEncoder",
+                                        use_auth_token=use_auth_token)
         self.passage_tokenizer = DPRContextEncoderTokenizerFast.from_pretrained(
             pretrained_model_name_or_path=passage_embedding_model,
             revision=model_version,
@@ -171,9 +171,9 @@ class DensePassageRetriever(BaseRetriever):
             use_fast=use_fast_tokenizers,
             use_auth_token=use_auth_token,
         )
-        self.passage_encoder = get_language_model(
-            pretrained_model_name_or_path=passage_embedding_model, revision=model_version, use_auth_token=use_auth_token
-        )
+        self.passage_encoder = DPREncoder(pretrained_model_name_or_path=passage_embedding_model,
+                                          model_type="DPRContextEncoder",
+                                          use_auth_token=use_auth_token)
 
         self.processor = TextSimilarityProcessor(
             query_tokenizer=self.query_tokenizer,

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -161,9 +161,11 @@ class DensePassageRetriever(BaseRetriever):
             use_fast=use_fast_tokenizers,
             use_auth_token=use_auth_token,
         )
-        self.query_encoder = DPREncoder(pretrained_model_name_or_path=query_embedding_model,
-                                        model_type="DPRQuestionEncoder",
-                                        use_auth_token=use_auth_token)
+        self.query_encoder = DPREncoder(
+            pretrained_model_name_or_path=query_embedding_model,
+            model_type="DPRQuestionEncoder",
+            use_auth_token=use_auth_token,
+        )
         self.passage_tokenizer = DPRContextEncoderTokenizerFast.from_pretrained(
             pretrained_model_name_or_path=passage_embedding_model,
             revision=model_version,
@@ -171,9 +173,11 @@ class DensePassageRetriever(BaseRetriever):
             use_fast=use_fast_tokenizers,
             use_auth_token=use_auth_token,
         )
-        self.passage_encoder = DPREncoder(pretrained_model_name_or_path=passage_embedding_model,
-                                          model_type="DPRContextEncoder",
-                                          use_auth_token=use_auth_token)
+        self.passage_encoder = DPREncoder(
+            pretrained_model_name_or_path=passage_embedding_model,
+            model_type="DPRContextEncoder",
+            use_auth_token=use_auth_token,
+        )
 
         self.processor = TextSimilarityProcessor(
             query_tokenizer=self.query_tokenizer,


### PR DESCRIPTION
**Related Issue(s)**:  
- Fixes #2885 
- Fixes #2881

**Proposed changes**:
In the model forward call, rather than passing kwargs, we explicitly specify all parameters. Similarly, for AdaptiveModel's logits_to_loss function, we explicitly specify only the `labels` parameter rather than passing all parameters. 