### PR TITLE
Fix typos in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ However, should you prefer to execute them locally, here are a few details about
 
 ### Black
 
-Black runs with no other configuration than an increase line lenght to 120 characters. Its condiguration can be found in `pyproject.toml`.
+Black runs with no other configuration than increasing line length to 120 characters. Its configuration can be found in `pyproject.toml`.
 
 You can run it with `python -m black .` from the root folder.
 


### PR DESCRIPTION
**Related Issue(s)**:  ...
None

**Proposed changes**:
- The CONTRIBUTING.md guidelines file has typos in the description of the Black code style configuration.

## Pre-flight checklist
- [X]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [X] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [N/A] If this is a code change, I added tests or updated existing ones 
- [N/A] If this is a code change, I updated the docstrings
