### PR TITLE
Bug fix Weaviate document deletion

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -1299,13 +1299,13 @@ class WeaviateDocumentStore(BaseDocumentStore):
         index = self._sanitize_index_name(index) or self.index
 
         if not filters and not ids:
-            # Recreate the index
+            # Delete the existing index, then create an empty new one
             self._create_schema_and_index(index, recreate_index=True)
             return
 
         # Create index if it doesn't exist yet
         self._create_schema_and_index(index, recreate_index=False)
-        
+
         if ids and not filters:
             for id in ids:
                 self.weaviate_client.data_object.delete(id)

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -1299,10 +1299,19 @@ class WeaviateDocumentStore(BaseDocumentStore):
         index = self._sanitize_index_name(index) or self.index
 
         if not filters and not ids:
+            # Recreate the index
             self._create_schema_and_index(index, recreate_index=True)
+            return
+
+        # Create index if it doesn't exist yet
+        self._create_schema_and_index(index, recreate_index=False)
+        
+        if ids and not filters:
+            for id in ids:
+                self.weaviate_client.data_object.delete(id)
+
         else:
-            # create index if it doesn't exist yet
-            self._create_schema_and_index(index, recreate_index=False)
+            # Use filters to restrict list of retrieved documents, before checking these against provided ids
             docs_to_delete = self.get_all_documents(index, filters=filters)
             if ids:
                 docs_to_delete = [doc for doc in docs_to_delete if doc.id in ids]


### PR DESCRIPTION
If no filters param is passed in, then the original code retrieves *all* documents before then deleting by their IDs. There's no need for that, since we can delete by their IDs directly.

**Related Issue(s)**:  Closes #2898

**Proposed changes**:
Fix the ability to delete documents within a large Weaviate document store, as described in the issue.

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
