### PR TITLE
Fix audio dependency chain issue on Python 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -156,6 +156,7 @@ docstores-gpu =
     farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone]
 
 audio =
+    pyworld<=0.2.12; python_version >= '3.10'
     espnet
     espnet-model-zoo
     pydub


### PR DESCRIPTION
**Related Issue(s)**:   #2901
- Currently, when doing a **full haystack install** on a **Python 3.10** environment, an error is throw when installing the audio dependencies. 

**Proposed changes**:
- All this was caused by some dependency pinning **NumPy** to a version lower then [1.21.0](https://numpy.org/doc/stable/release/1.21.0-notes.html), which was the first to support Python 3.10. After some investigation, the problem was found to be on an _espnet dependency_, **pyworld**. After looking forward into the [pyworld source code](https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/commits/v0.3.0) I noticed the latest version is mainly a formal commit, with minor changes. As so, I pinned **pyworld** to version **0.2.12** (the one just before 0.3.0, where NumPy was pinned and the issue with haystack got introduced).
- Haystack environments on Python >= 3.7 and <= 3.10 behaviors are the same. No functionality changes.


## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
