### PR TITLE
Wrap opensearch imports into `safe_import`

### DIFF
--- a/haystack/document_stores/__init__.py
+++ b/haystack/document_stores/__init__.py
@@ -14,7 +14,9 @@ from haystack.document_stores.es_converter import (
 )
 
 OpenSearchDocumentStore = safe_import("haystack.document_stores.opensearch", "OpenSearchDocumentStore", "opensearch")
-OpenDistroElasticsearchDocumentStore = safe_import("haystack.document_stores.opensearch", "OpenDistroElasticsearchDocumentStore", "opensearch")
+OpenDistroElasticsearchDocumentStore = safe_import(
+    "haystack.document_stores.opensearch", "OpenDistroElasticsearchDocumentStore", "opensearch"
+)
 SQLDocumentStore = safe_import("haystack.document_stores.sql", "SQLDocumentStore", "sql")
 FAISSDocumentStore = safe_import("haystack.document_stores.faiss", "FAISSDocumentStore", "faiss")
 PineconeDocumentStore = safe_import("haystack.document_stores.pinecone", "PineconeDocumentStore", "pinecone")

--- a/haystack/document_stores/__init__.py
+++ b/haystack/document_stores/__init__.py
@@ -12,8 +12,9 @@ from haystack.document_stores.es_converter import (
     elasticsearch_index_to_document_store,
     open_search_index_to_document_store,
 )
-from haystack.document_stores.opensearch import OpenSearchDocumentStore, OpenDistroElasticsearchDocumentStore
 
+OpenSearchDocumentStore = safe_import("haystack.document_stores.opensearch", "OpenSearchDocumentStore", "opensearch")
+OpenDistroElasticsearchDocumentStore = safe_import("haystack.document_stores.opensearch", "OpenDistroElasticsearchDocumentStore", "opensearch")
 SQLDocumentStore = safe_import("haystack.document_stores.sql", "SQLDocumentStore", "sql")
 FAISSDocumentStore = safe_import("haystack.document_stores.faiss", "FAISSDocumentStore", "faiss")
 PineconeDocumentStore = safe_import("haystack.document_stores.pinecone", "PineconeDocumentStore", "pinecone")


### PR DESCRIPTION
**Related Issue(s)**:  Fixes #2905

**Proposed changes**:
- Wrap opensearch imports into `safe_import` in `haystack/document_stores/__init__.py`