### PR TITLE
Disable a few checks in the pre-commit hook

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  check:
+  black:
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           if [[ `git status --porcelain` ]]; then
             git status
+            echo "###################################################################################################"
             echo "# "
             echo "# CHECK FAILED! OpenAPI specs were not updated."
             echo "# "
@@ -35,10 +36,18 @@ jobs:
             echo "# "
             echo "#     python .github/utils/generate_openapi_specs.py"
             echo "# "
-            echo "# Or see https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md for help."
+            echo "# You need a FULL INSTALLATION of Haystack for this step to work."
+            echo "# "
+            echo "#     pip install -e .[all]"
+            echo "# "
+            echo "# If you cannot do that for any reason, please disable the hook, push "
+            echo "# and let us know in the PR description."
+            echo "# "
+            echo "# See https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md for instructions."
             echo "# "
             echo "# If you have further problems, please open an issue: https://github.com/deepset-ai/haystack/issues"
             echo "# "
+            echo "###################################################################################################"
             exit 1
           fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
     - id: check-json  # checks JSON syntax
     - id: check-yaml  # checks YAML syntax
     - id: check-toml  # checks TOML syntax
-    - id: end-of-file-fixer  # checks there is a newline at the end of the file
-    - id: trailing-whitespace  # trims trailing whitespace
+    #- id: end-of-file-fixer  # checks there is a newline at the end of the file  # FIXME: pydoc-markdown conflicts with this
+    #- id: trailing-whitespace  # trims trailing whitespace                       # FIXME: pydoc-markdown conflicts with this
     - id: check-merge-conflict  # checks for no merge conflict strings
     - id: check-shebang-scripts-are-executable  # checks all shell scripts have executable permissions
     - id: mixed-line-ending  # normalizes line endings
     - id: no-commit-to-branch  # prevents committing to master
-    - id: pretty-format-json  # indents and sorts JSON files
+    #- id: pretty-format-json  # indents and sorts JSON files    # FIXME: JSON schema generator conflicts with this
 
 - repo: https://github.com/psf/black
   rev: 22.6.0  # IMPORTANT: keep this aligned with the black version in setup.cfg


### PR DESCRIPTION
**Related Issue(s)**: 
- https://github.com/deepset-ai/haystack/pull/2903#issuecomment-1199144894 
- https://github.com/deepset-ai/haystack/pull/2910#issuecomment-1199204754
- and other informal reports by @vblagoje 

**Proposed changes**:
- Remove `end-of-file-fixer`, `trailing-whitespace` and `pretty-format-json` from the hook's checks.
  - `end-of-file-fixer`, `trailing-whitespace` seems to conflict with the API generation
  - `pretty-format-json` conflicts with the JSON schema generation
- Both needs further investigation, but for usability issues they should be temporarily disabled in master.
