### PR TITLE
Print eval reports improvements

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -767,7 +767,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_filter: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -804,7 +804,7 @@ You can select between:
    - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
    The default value is 'any'.
    In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
-:param wrong_examples_filter: A list of node fields to include in the formatting of worst samples.
+:param wrong_examples_fields: A list of fields to include in the worst samples.
 :param max_characters_per_wrong_examples_report: The maximum number of characters to include in the worst samples report.
 
 <a id="base._HaystackBeirRetrieverAdapter"></a>
@@ -1253,7 +1253,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_filter: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1290,7 +1290,7 @@ You can select between:
 - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
 The default value is 'any'.
 In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
-- `wrong_examples_filter`: A list of field names to include in the worst samples.
+- `wrong_examples_fields`: A list of field names to include in the worst samples.
 - `max_characters_per_wrong_examples_report`: The maximum number of characters per wrong example to show.
 
 <a id="standard_pipelines.BaseStandardPipeline.run_batch"></a>

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -767,7 +767,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: List[str] = ["answer", "context", "document_id"], max_characters_per_field: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: List[str] = ["answer", "context", "document_id"], max_characters_per_field: int = 150)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1253,7 +1253,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: List[str] = ["answer", "context", "document_id"], max_characters_per_field: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: List[str] = ["answer", "context", "document_id"], max_characters_per_field: int = 150)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -767,7 +767,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_field: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: List[str] = ["answer", "context", "document_id"], max_characters_per_field: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1253,7 +1253,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_field: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: List[str] = ["answer", "context", "document_id"], max_characters_per_field: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -767,7 +767,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_field: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -805,7 +805,7 @@ You can select between:
    The default value is 'any'.
    In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
 :param wrong_examples_fields: A list of fields to include in the worst samples.
-:param max_characters_per_wrong_examples_report: The maximum number of characters to include in the worst samples report.
+:param max_characters_per_field: The maximum number of characters to include in the worst samples report (per field).
 
 <a id="base._HaystackBeirRetrieverAdapter"></a>
 
@@ -1253,7 +1253,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_fields: Optional[List[str]] = None, max_characters_per_field: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1291,7 +1291,7 @@ You can select between:
 The default value is 'any'.
 In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
 - `wrong_examples_fields`: A list of field names to include in the worst samples.
-- `max_characters_per_wrong_examples_report`: The maximum number of characters per wrong example to show.
+- `max_characters_per_field`: The maximum number of characters per wrong example to show (per field).
 
 <a id="standard_pipelines.BaseStandardPipeline.run_batch"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -767,7 +767,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any")
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_filter: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -796,14 +796,16 @@ You can select between:
 The default value is 'document_id_or_answer'.
 - `answer_scope`: Specifies the scope in which a matching answer is considered correct.
 You can select between:
-- 'any' (default): Any matching answer is considered correct.
-- 'context': The answer is only considered correct if its context matches as well.
-        Uses fuzzy matching (see `pipeline.eval()`'s `context_matching_...` params).
-- 'document_id': The answer is only considered correct if its document ID matches as well.
-        You can specify a custom document ID through `pipeline.eval()`'s `custom_document_id_field` param.
-- 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
-The default value is 'any'.
-In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+   - 'any' (default): Any matching answer is considered correct.
+   - 'context': The answer is only considered correct if its context matches as well.
+           Uses fuzzy matching (see `pipeline.eval()`'s `context_matching_...` params).
+   - 'document_id': The answer is only considered correct if its document ID matches as well.
+           You can specify a custom document ID through `pipeline.eval()`'s `custom_document_id_field` param.
+   - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
+   The default value is 'any'.
+   In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+:param wrong_examples_filter: A list of node fields to include in the formatting of worst samples.
+:param max_characters_per_wrong_examples_report: The maximum number of characters to include in the worst samples report.
 
 <a id="base._HaystackBeirRetrieverAdapter"></a>
 
@@ -1251,7 +1253,7 @@ def print_eval_report(eval_result: EvaluationResult, n_wrong_examples: int = 3, 
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any")
+        ] = "document_id_or_answer", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any", wrong_examples_filter: Optional[List[str]] = None, max_characters_per_wrong_examples_report: int = None)
 ```
 
 Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1288,6 +1290,8 @@ You can select between:
 - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
 The default value is 'any'.
 In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+- `wrong_examples_filter`: A list of field names to include in the worst samples.
+- `max_characters_per_wrong_examples_report`: The maximum number of characters per wrong example to show.
 
 <a id="standard_pipelines.BaseStandardPipeline.run_batch"></a>
 

--- a/docs/_src/api/api/primitives.md
+++ b/docs/_src/api/api/primitives.md
@@ -483,9 +483,9 @@ remarks: there might be a discrepancy between simulated reader metrics and an ac
 values can be: 'recall_single_hit', 'recall_multi_hit', 'mrr', 'map', 'precision'
 - `answer_metric`: the answer metric worst queries are calculated with.
 values can be: 'f1', 'exact_match' and 'sas' if the evaluation was made using a SAS model.
-- `document_metric_threshold`: the threshold for the document metric (only samples above selected metric
+- `document_metric_threshold`: the threshold for the document metric (only samples below selected metric
 threshold will be considered)
-- `answer_metric_threshold`: the threshold for the answer metric (only samples above selected metric
+- `answer_metric_threshold`: the threshold for the answer metric (only samples below selected metric
 threshold will be considered)
 - `eval_mode`: the input on which the node was evaluated on.
 Usually nodes get evaluated on the prediction provided by its predecessor nodes in the pipeline (value='integrated').

--- a/docs/_src/api/api/primitives.md
+++ b/docs/_src/api/api/primitives.md
@@ -463,7 +463,7 @@ def wrong_examples(node: str, n: int = 3, simulated_top_k_reader: int = -1, simu
             "document_id_or_context",
             "answer",
             "document_id_or_answer",
-        ] = "document_id_or_answer", document_metric: str = "recall_single_hit", answer_metric: str = "f1", eval_mode: Literal["integrated", "isolated"] = "integrated", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any") -> List[Dict]
+        ] = "document_id_or_answer", document_metric: str = "recall_single_hit", answer_metric: str = "f1", document_metric_threshold: float = 0.5, answer_metric_threshold: float = 0.5, eval_mode: Literal["integrated", "isolated"] = "integrated", answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any") -> List[Dict]
 ```
 
 Returns the worst performing queries.
@@ -481,8 +481,12 @@ See calculate_metrics() for more information.
 remarks: there might be a discrepancy between simulated reader metrics and an actual pipeline run with retriever top_k
 - `document_metric`: the document metric worst queries are calculated with.
 values can be: 'recall_single_hit', 'recall_multi_hit', 'mrr', 'map', 'precision'
-- `document_metric`: the answer metric worst queries are calculated with.
+- `answer_metric`: the answer metric worst queries are calculated with.
 values can be: 'f1', 'exact_match' and 'sas' if the evaluation was made using a SAS model.
+- `document_metric_threshold`: the threshold for the document metric (only samples above selected metric
+threshold will be considered)
+- `answer_metric_threshold`: the threshold for the answer metric (only samples above selected metric
+threshold will be considered)
 - `eval_mode`: the input on which the node was evaluated on.
 Usually nodes get evaluated on the prediction provided by its predecessor nodes in the pipeline (value='integrated').
 However, as the quality of the node itself can heavily depend on the node's input and thus the predecessor's quality,

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1932,7 +1932,7 @@ class Pipeline:
             "document_id_or_answer",
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
-        wrong_examples_filter: Optional[List[str]] = None,
+        wrong_examples_fields: Optional[List[str]] = None,
         max_characters_per_wrong_examples_report: int = None,
     ):
         """
@@ -1968,7 +1968,7 @@ class Pipeline:
             - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
             The default value is 'any'.
             In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
-         :param wrong_examples_filter: A list of node fields to include in the formatting of worst samples.
+         :param wrong_examples_fields: A list of fields to include in the worst samples.
          :param max_characters_per_wrong_examples_report: The maximum number of characters to include in the worst samples report.
         """
         graph = DiGraph(self.graph.edges)
@@ -1979,7 +1979,7 @@ class Pipeline:
             metrics_filter=metrics_filter,
             document_scope=document_scope,
             answer_scope=answer_scope,
-            wrong_examples_filter=wrong_examples_filter,
+            wrong_examples_fields=wrong_examples_fields,
             max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
         )
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1932,7 +1932,7 @@ class Pipeline:
             "document_id_or_answer",
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
-        wrong_examples_fields: Optional[List[str]] = None,
+        wrong_examples_fields: List[str] = ["answer", "context", "document_id"],
         max_characters_per_field: int = None,
     ):
         """

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1933,7 +1933,7 @@ class Pipeline:
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
         wrong_examples_fields: Optional[List[str]] = None,
-        max_characters_per_wrong_examples_report: int = None,
+        max_characters_per_field: int = None,
     ):
         """
         Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1969,7 +1969,7 @@ class Pipeline:
             The default value is 'any'.
             In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
          :param wrong_examples_fields: A list of fields to include in the worst samples.
-         :param max_characters_per_wrong_examples_report: The maximum number of characters to include in the worst samples report.
+         :param max_characters_per_field: The maximum number of characters to include in the worst samples report (per field).
         """
         graph = DiGraph(self.graph.edges)
         print_eval_report(
@@ -1980,7 +1980,7 @@ class Pipeline:
             document_scope=document_scope,
             answer_scope=answer_scope,
             wrong_examples_fields=wrong_examples_fields,
-            max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
+            max_characters_per_field=max_characters_per_field,
         )
 
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1933,7 +1933,7 @@ class Pipeline:
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
         wrong_examples_fields: List[str] = ["answer", "context", "document_id"],
-        max_characters_per_field: int = None,
+        max_characters_per_field: int = 150,
     ):
         """
         Prints evaluation report containing a metrics funnel and worst queries for further analysis.

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1932,6 +1932,8 @@ class Pipeline:
             "document_id_or_answer",
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
+        wrong_examples_filter: Optional[List[str]] = None,
+        max_characters_per_wrong_examples_report: int = None,
     ):
         """
         Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -1966,6 +1968,8 @@ class Pipeline:
             - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
             The default value is 'any'.
             In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+         :param wrong_examples_filter: A list of node fields to include in the formatting of worst samples.
+         :param max_characters_per_wrong_examples_report: The maximum number of characters to include in the worst samples report.
         """
         graph = DiGraph(self.graph.edges)
         print_eval_report(
@@ -1975,6 +1979,8 @@ class Pipeline:
             metrics_filter=metrics_filter,
             document_scope=document_scope,
             answer_scope=answer_scope,
+            wrong_examples_filter=wrong_examples_filter,
+            max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
         )
 
 

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -232,7 +232,7 @@ class BaseStandardPipeline(ABC):
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
         wrong_examples_fields: List[str] = ["answer", "context", "document_id"],
-        max_characters_per_field: int = None,
+        max_characters_per_field: int = 150,
     ):
         """
         Prints evaluation report containing a metrics funnel and worst queries for further analysis.

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -232,7 +232,7 @@ class BaseStandardPipeline(ABC):
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
         wrong_examples_fields: Optional[List[str]] = None,
-        max_characters_per_wrong_examples_report: int = None,
+        max_characters_per_field: int = None,
     ):
         """
         Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -268,7 +268,7 @@ class BaseStandardPipeline(ABC):
             The default value is 'any'.
             In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
         :param wrong_examples_fields: A list of field names to include in the worst samples.
-        :param max_characters_per_wrong_examples_report: The maximum number of characters per wrong example to show.
+        :param max_characters_per_field: The maximum number of characters per wrong example to show (per field).
         """
         if metrics_filter is None:
             metrics_filter = self.metrics_filter
@@ -279,7 +279,7 @@ class BaseStandardPipeline(ABC):
             document_scope=document_scope,
             answer_scope=answer_scope,
             wrong_examples_fields=wrong_examples_fields,
-            max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
+            max_characters_per_field=max_characters_per_field,
         )
 
     def run_batch(self, queries: List[str], params: Optional[dict] = None, debug: Optional[bool] = None):

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -231,7 +231,7 @@ class BaseStandardPipeline(ABC):
             "document_id_or_answer",
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
-        wrong_examples_fields: Optional[List[str]] = None,
+        wrong_examples_fields: List[str] = ["answer", "context", "document_id"],
         max_characters_per_field: int = None,
     ):
         """

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -231,7 +231,7 @@ class BaseStandardPipeline(ABC):
             "document_id_or_answer",
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
-        wrong_examples_filter: Optional[List[str]] = None,
+        wrong_examples_fields: Optional[List[str]] = None,
         max_characters_per_wrong_examples_report: int = None,
     ):
         """
@@ -267,7 +267,7 @@ class BaseStandardPipeline(ABC):
             - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
             The default value is 'any'.
             In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
-        :param wrong_examples_filter: A list of field names to include in the worst samples.
+        :param wrong_examples_fields: A list of field names to include in the worst samples.
         :param max_characters_per_wrong_examples_report: The maximum number of characters per wrong example to show.
         """
         if metrics_filter is None:
@@ -278,7 +278,7 @@ class BaseStandardPipeline(ABC):
             metrics_filter=metrics_filter,
             document_scope=document_scope,
             answer_scope=answer_scope,
-            wrong_examples_filter=wrong_examples_filter,
+            wrong_examples_fields=wrong_examples_fields,
             max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
         )
 

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -231,6 +231,8 @@ class BaseStandardPipeline(ABC):
             "document_id_or_answer",
         ] = "document_id_or_answer",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
+        wrong_examples_filter: Optional[List[str]] = None,
+        max_characters_per_wrong_examples_report: int = None,
     ):
         """
         Prints evaluation report containing a metrics funnel and worst queries for further analysis.
@@ -265,6 +267,8 @@ class BaseStandardPipeline(ABC):
             - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
             The default value is 'any'.
             In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+        :param wrong_examples_filter: A list of field names to include in the worst samples.
+        :param max_characters_per_wrong_examples_report: The maximum number of characters per wrong example to show.
         """
         if metrics_filter is None:
             metrics_filter = self.metrics_filter
@@ -274,6 +278,8 @@ class BaseStandardPipeline(ABC):
             metrics_filter=metrics_filter,
             document_scope=document_scope,
             answer_scope=answer_scope,
+            wrong_examples_filter=wrong_examples_filter,
+            max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
         )
 
     def run_batch(self, queries: List[str], params: Optional[dict] = None, debug: Optional[bool] = None):

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -280,9 +280,9 @@ def _format_wrong_example(
     gold_answers = f"Gold Answers: \n \t{gold_answers}\n" if len(gold_answers) > 0 else ""
     s = (
         f"Query: \n \t{query['query']}\n"
-        f"{gold_answers[:max_characters_per_field]}\n"
-        f"Gold Document Ids: \n \t{gold_document_ids[:max_characters_per_field]}\n"
-        f"Metrics: \n \t{metrics[:max_characters_per_field]}\n"
+        f"{gold_answers}\n"
+        f"Gold Document Ids: \n \t{gold_document_ids}\n"
+        f"Metrics: \n \t{metrics}\n"
         f"{answers[:max_characters_per_field]}\n"
         f"{documents[:max_characters_per_field]}\n"
         f"_______________________________________________________"

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -178,6 +178,8 @@ def print_eval_report(
         "document_id", "context", "document_id_and_context", "document_id_or_context", "answer", "document_id_or_answer"
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
+    wrong_examples_filter: List[str] = None,
+    max_characters_per_wrong_examples_report: int = None,
 ):
     """
     Prints a report for a given EvaluationResult visualizing metrics per node specified by the pipeline graph.
@@ -187,33 +189,35 @@ def print_eval_report(
     :param n_wrong_examples: The number of examples to show in order to inspect wrong predictions.
                              Defaults to 3.
     :param metrics_filter: Specifies which metrics of eval_result to show in the report.
-        :param document_scope: A criterion for deciding whether documents are relevant or not.
-            You can select between:
-            - 'document_id': Specifies that the document ID must match. You can specify a custom document ID through `pipeline.eval()`'s `custom_document_id_field` param.
-                    A typical use case is Document Retrieval.
-            - 'context': Specifies that the content of the document must match. Uses fuzzy matching (see `pipeline.eval()`'s `context_matching_...` params).
-                    A typical use case is Document-Independent Passage Retrieval.
-            - 'document_id_and_context': A Boolean operation specifying that both `'document_id' AND 'context'` must match.
-                    A typical use case is Document-Specific Passage Retrieval.
-            - 'document_id_or_context': A Boolean operation specifying that either `'document_id' OR 'context'` must match.
-                    A typical use case is Document Retrieval having sparse context labels.
-            - 'answer': Specifies that the document contents must include the answer. The selected `answer_scope` is enforced automatically.
-                    A typical use case is Question Answering.
-            - 'document_id_or_answer' (default): A Boolean operation specifying that either `'document_id' OR 'answer'` must match.
-                    This is intended to be a proper default value in order to support both main use cases:
-                    - Document Retrieval
-                    - Question Answering
-            The default value is 'document_id_or_answer'.
-        :param answer_scope: Specifies the scope in which a matching answer is considered correct.
-            You can select between:
-            - 'any' (default): Any matching answer is considered correct.
-            - 'context': The answer is only considered correct if its context matches as well.
-                    Uses fuzzy matching (see `pipeline.eval()`'s `context_matching_...` params).
-            - 'document_id': The answer is only considered correct if its document ID matches as well.
-                    You can specify a custom document ID through `pipeline.eval()`'s `custom_document_id_field` param.
-            - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
-            The default value is 'any'.
-            In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+    :param document_scope: A criterion for deciding whether documents are relevant or not.
+        You can select between:
+        - 'document_id': Specifies that the document ID must match. You can specify a custom document ID through `pipeline.eval()`'s `custom_document_id_field` param.
+                A typical use case is Document Retrieval.
+        - 'context': Specifies that the content of the document must match. Uses fuzzy matching (see `pipeline.eval()`'s `context_matching_...` params).
+                A typical use case is Document-Independent Passage Retrieval.
+        - 'document_id_and_context': A Boolean operation specifying that both `'document_id' AND 'context'` must match.
+                A typical use case is Document-Specific Passage Retrieval.
+        - 'document_id_or_context': A Boolean operation specifying that either `'document_id' OR 'context'` must match.
+                A typical use case is Document Retrieval having sparse context labels.
+        - 'answer': Specifies that the document contents must include the answer. The selected `answer_scope` is enforced automatically.
+                A typical use case is Question Answering.
+        - 'document_id_or_answer' (default): A Boolean operation specifying that either `'document_id' OR 'answer'` must match.
+                This is intended to be a proper default value in order to support both main use cases:
+                - Document Retrieval
+                - Question Answering
+        The default value is 'document_id_or_answer'.
+    :param answer_scope: Specifies the scope in which a matching answer is considered correct.
+        You can select between:
+        - 'any' (default): Any matching answer is considered correct.
+        - 'context': The answer is only considered correct if its context matches as well.
+                Uses fuzzy matching (see `pipeline.eval()`'s `context_matching_...` params).
+        - 'document_id': The answer is only considered correct if its document ID matches as well.
+                You can specify a custom document ID through `pipeline.eval()`'s `custom_document_id_field` param.
+        - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
+        The default value is 'any'.
+        In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
+    :param wrong_examples_filter: A list of field names that should be included in the wrong examples.
+    :param max_characters_per_wrong_examples_report: The maximum number of characters to show in the wrong examples report.
     """
     if any(degree > 1 for node, degree in graph.out_degree):
         logger.warning("Pipelines with junctions are currently not supported.")
@@ -250,20 +254,24 @@ def print_eval_report(
         n_wrong_examples=n_wrong_examples,
         document_scope=document_scope,
         answer_scope=answer_scope,
+        wrong_examples_filter=wrong_examples_filter,
+        max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
     )
 
     print(f"{pipeline_overview}\n" f"{wrong_examples_report}")
 
 
-def _format_document_answer(document_or_answer: dict):
-    return "\n \t".join(f"{name}: {value}" for name, value in document_or_answer.items())
+def _format_document_answer(document_or_answer: dict, field_filter: List[str] = None) -> str:
+    if field_filter is None or len(field_filter) == 0:
+        field_filter = document_or_answer.keys()
+    return "\n \t".join(f"{name}: {value}" for name, value in document_or_answer.items() if name in field_filter)
 
 
-def _format_wrong_example(query: dict):
+def _format_wrong_example(query: dict, field_filter: List[str] = None) -> str:
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
-    documents = "\n\n \t".join(map(_format_document_answer, query.get("documents", [])))
+    documents = "\n\n \t".join([_format_document_answer(doc, field_filter) for doc in query.get("documents", [])])
     documents = f"Documents: \n \t{documents}\n" if len(documents) > 0 else ""
-    answers = "\n\n \t".join(map(_format_document_answer, query.get("answers", [])))
+    answers = "\n\n \t".join([_format_document_answer(doc, field_filter) for doc in query.get("answers", [])])
     answers = f"Answers: \n \t{answers}\n" if len(answers) > 0 else ""
     gold_document_ids = "\n \t".join(query["gold_document_ids"])
     gold_answers = "\n \t".join(query.get("gold_answers", []))
@@ -297,6 +305,8 @@ def _format_wrong_examples_report(
         "document_id", "context", "document_id_and_context", "document_id_or_context", "answer", "document_id_or_answer"
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
+    wrong_examples_filter: List[str] = None,
+    max_characters_per_wrong_examples_report: int = None,
 ):
     examples = {
         node: eval_result.wrong_examples(
@@ -304,11 +314,13 @@ def _format_wrong_examples_report(
         )
         for node in eval_result.node_results.keys()
     }
-    examples_formatted = {
-        node: "\n".join(map(_format_wrong_example, examples)) for node, examples in examples.items() if any(examples)
-    }
+    examples_formatted = {}
+    for node, examples in examples.items():
+        if any(examples):
+            examples_formatted[node] = "\n".join([_format_wrong_example(e, wrong_examples_filter) for e in examples])
 
-    return "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
+    final_result = "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
+    return final_result[:max_characters_per_wrong_examples_report]
 
 
 def _format_pipeline_node(node: str, calculated_metrics: dict):

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -269,9 +269,9 @@ def _format_document_answer(document_or_answer: dict, field_filter: List[str] = 
 
 def _format_wrong_example(query: dict, max_characters_per_wrong_examples_report: int, field_filter: List[str] = None):
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
-    documents = "\n\n \t".join([_format_document_answer(doc, field_filter) for doc in query.get("documents", [])])
+    documents = "\n\n \t".join(_format_document_answer(doc, field_filter) for doc in query.get("documents", []))
     documents = f"Documents: \n \t{documents}\n" if len(documents) > 0 else ""
-    answers = "\n\n \t".join([_format_document_answer(doc, field_filter) for doc in query.get("answers", [])])
+    answers = "\n\n \t".join(_format_document_answer(doc, field_filter) for doc in query.get("answers", []))
     answers = f"Answers: \n \t{answers}\n" if len(answers) > 0 else ""
     gold_document_ids = "\n \t".join(query["gold_document_ids"])
     gold_answers = "\n \t".join(query.get("gold_answers", []))
@@ -320,8 +320,8 @@ def _format_wrong_examples_report(
     for node, examples in examples.items():  # type: ignore
         if any(examples):
             examples_formatted[node] = "\n".join(
-                [_format_wrong_example(e, max_characters_per_wrong_examples_report, wrong_examples_fields) for e in
-                 examples])  # type: ignore
+                _format_wrong_example(e, max_characters_per_wrong_examples_report, wrong_examples_fields) for e in
+                examples)  # type: ignore
 
     final_result = "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
     return final_result

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -179,7 +179,7 @@ def print_eval_report(
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
     wrong_examples_fields: List[str] = None,
-    max_characters_per_wrong_examples_report: int = None,
+    max_characters_per_field: int = None,
 ):
     """
     Prints a report for a given EvaluationResult visualizing metrics per node specified by the pipeline graph.
@@ -217,7 +217,7 @@ def print_eval_report(
         The default value is 'any'.
         In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
     :param wrong_examples_fields: A list of field names that should be included in the wrong examples.
-    :param max_characters_per_wrong_examples_report: The maximum number of characters to show in the wrong examples report.
+    :param max_characters_per_field: The maximum number of characters to show in the wrong examples report (per field).
     """
     if any(degree > 1 for node, degree in graph.out_degree):
         logger.warning("Pipelines with junctions are currently not supported.")
@@ -255,7 +255,7 @@ def print_eval_report(
         document_scope=document_scope,
         answer_scope=answer_scope,
         wrong_examples_fields=wrong_examples_fields,
-        max_chars=max_characters_per_wrong_examples_report,
+        max_chars=max_characters_per_field,
     )
 
     print(f"{pipeline_overview}\n" f"{wrong_examples_report}")
@@ -268,7 +268,7 @@ def _format_document_answer(document_or_answer: dict, field_filter: List[str] = 
 
 
 def _format_wrong_example(
-    query: dict, max_characters_per_wrong_examples_report: int = None, field_filter: List[str] = None
+    query: dict, max_characters_per_field: int = None, field_filter: List[str] = None
 ):
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
     documents = "\n\n \t".join(_format_document_answer(doc, field_filter) for doc in query.get("documents", []))
@@ -280,11 +280,11 @@ def _format_wrong_example(
     gold_answers = f"Gold Answers: \n \t{gold_answers}\n" if len(gold_answers) > 0 else ""
     s = (
         f"Query: \n \t{query['query']}\n"
-        f"{gold_answers[:max_characters_per_wrong_examples_report]}\n"
-        f"Gold Document Ids: \n \t{gold_document_ids[:max_characters_per_wrong_examples_report]}\n"
-        f"Metrics: \n \t{metrics[:max_characters_per_wrong_examples_report]}\n"
-        f"{answers[:max_characters_per_wrong_examples_report]}\n"
-        f"{documents[:max_characters_per_wrong_examples_report]}\n"
+        f"{gold_answers[:max_characters_per_field]}\n"
+        f"Gold Document Ids: \n \t{gold_document_ids[:max_characters_per_field]}\n"
+        f"Metrics: \n \t{metrics[:max_characters_per_field]}\n"
+        f"{answers[:max_characters_per_field]}\n"
+        f"{documents[:max_characters_per_field]}\n"
         f"_______________________________________________________"
     )
     return s

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -255,7 +255,7 @@ def print_eval_report(
         document_scope=document_scope,
         answer_scope=answer_scope,
         wrong_examples_fields=wrong_examples_fields,
-        max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
+        max_chars=max_characters_per_wrong_examples_report,
     )
 
     print(f"{pipeline_overview}\n" f"{wrong_examples_report}")
@@ -267,7 +267,9 @@ def _format_document_answer(document_or_answer: dict, field_filter: List[str] = 
     return "\n \t".join(f"{name}: {value}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
 
 
-def _format_wrong_example(query: dict, max_characters_per_wrong_examples_report: int, field_filter: List[str] = None):
+def _format_wrong_example(
+    query: dict, max_characters_per_wrong_examples_report: int = None, field_filter: List[str] = None
+):
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
     documents = "\n\n \t".join(_format_document_answer(doc, field_filter) for doc in query.get("documents", []))
     documents = f"Documents: \n \t{documents}\n" if len(documents) > 0 else ""
@@ -306,9 +308,9 @@ def _format_wrong_examples_report(
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
     wrong_examples_fields: List[str] = None,
-    max_characters_per_wrong_examples_report: int = None,
+    max_chars: int = None,
 ):
-    wrong_examples_fields = (
+    fields = (
         ["gold_answers", "answer", "context", "gold_contexts", "document_id", "gold_document_ids"]
         if wrong_examples_fields is None
         else wrong_examples_fields
@@ -322,10 +324,7 @@ def _format_wrong_examples_report(
     examples_formatted = {}
     for node, examples in examples.items():  # type: ignore
         if any(examples):
-            examples_formatted[node] = "\n".join(
-                _format_wrong_example(e, max_characters_per_wrong_examples_report, wrong_examples_fields)
-                for e in examples
-            )  # type: ignore
+            examples_formatted[node] = "\n".join(_format_wrong_example(e, max_chars, fields) for e in examples)  # type: ignore
 
     final_result = "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
     return final_result

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -264,10 +264,10 @@ def print_eval_report(
 def _format_document_answer(document_or_answer: dict, max_chars: int = None, field_filter: List[str] = None):
     if field_filter is None or len(field_filter) == 0:
         field_filter = document_or_answer.keys()  # type: ignore
-    return "\n \t".join(f"{name}: {str(value)[:max_chars]} {'...' if str(value) > max_chars else ''}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
+    return "\n \t".join(f"{name}: {str(value)[:max_chars]} {'...' if len(str(value)) > max_chars else ''}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
 
 
-def _format_wrong_example(query: dict, max_chars: int = None, field_filter: List[str] = None):
+def _format_wrong_example(query: dict, max_chars: int = 150, field_filter: List[str] = None):
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
     documents = "\n\n \t".join(
         _format_document_answer(doc, max_chars, field_filter) for doc in query.get("documents", [])
@@ -308,7 +308,7 @@ def _format_wrong_examples_report(
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
     fields: List[str] = ["answer", "context", "document_id"],
-    max_chars: int = None,
+    max_chars: int = 150,
 ):
     examples = {
         node: eval_result.wrong_examples(

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -310,11 +310,7 @@ def _format_wrong_examples_report(
     wrong_examples_fields: List[str] = None,
     max_chars: int = None,
 ):
-    fields = (
-        ["gold_answers", "answer", "context", "gold_contexts", "document_id", "gold_document_ids"]
-        if wrong_examples_fields is None
-        else wrong_examples_fields
-    )
+    fields = ["answer", "context", "document_id"] if wrong_examples_fields is None else wrong_examples_fields
     examples = {
         node: eval_result.wrong_examples(
             node, document_scope=document_scope, answer_scope=answer_scope, n=n_wrong_examples

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -178,7 +178,7 @@ def print_eval_report(
         "document_id", "context", "document_id_and_context", "document_id_or_context", "answer", "document_id_or_answer"
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
-    wrong_examples_filter: List[str] = None,
+    wrong_examples_fields: List[str] = None,
     max_characters_per_wrong_examples_report: int = None,
 ):
     """
@@ -216,7 +216,7 @@ def print_eval_report(
         - 'document_id_and_context': The answer is only considered correct if its document ID and its context match as well.
         The default value is 'any'.
         In Question Answering, to enforce that the retrieved document is considered correct whenever the answer is correct, set `document_scope` to 'answer' or 'document_id_or_answer'.
-    :param wrong_examples_filter: A list of field names that should be included in the wrong examples.
+    :param wrong_examples_fields: A list of field names that should be included in the wrong examples.
     :param max_characters_per_wrong_examples_report: The maximum number of characters to show in the wrong examples report.
     """
     if any(degree > 1 for node, degree in graph.out_degree):
@@ -254,7 +254,7 @@ def print_eval_report(
         n_wrong_examples=n_wrong_examples,
         document_scope=document_scope,
         answer_scope=answer_scope,
-        wrong_examples_filter=wrong_examples_filter,
+        wrong_examples_fields=wrong_examples_fields,
         max_characters_per_wrong_examples_report=max_characters_per_wrong_examples_report,
     )
 
@@ -305,9 +305,11 @@ def _format_wrong_examples_report(
         "document_id", "context", "document_id_and_context", "document_id_or_context", "answer", "document_id_or_answer"
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
-    wrong_examples_filter: List[str] = None,
+    wrong_examples_fields: List[str] = None,
     max_characters_per_wrong_examples_report: int = None,
 ):
+    wrong_examples_fields = ["gold_answers", "answer", "context", "gold_contexts", "document_id",
+                             "gold_document_ids"] if wrong_examples_fields is None else wrong_examples_fields
     examples = {
         node: eval_result.wrong_examples(
             node, document_scope=document_scope, answer_scope=answer_scope, n=n_wrong_examples
@@ -317,7 +319,7 @@ def _format_wrong_examples_report(
     examples_formatted = {}
     for node, examples in examples.items():  # type: ignore
         if any(examples):
-            examples_formatted[node] = "\n".join([_format_wrong_example(e, wrong_examples_filter) for e in examples])  # type: ignore
+            examples_formatted[node] = "\n".join([_format_wrong_example(e, wrong_examples_fields) for e in examples])  # type: ignore
 
     final_result = "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
     return final_result[:max_characters_per_wrong_examples_report]

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -261,13 +261,13 @@ def print_eval_report(
     print(f"{pipeline_overview}\n" f"{wrong_examples_report}")
 
 
-def _format_document_answer(document_or_answer: dict, field_filter: List[str] = None) -> str:
+def _format_document_answer(document_or_answer: dict, field_filter: List[str] = None):
     if field_filter is None or len(field_filter) == 0:
-        field_filter = document_or_answer.keys()
-    return "\n \t".join(f"{name}: {value}" for name, value in document_or_answer.items() if name in field_filter)
+        field_filter = document_or_answer.keys()  # type: ignore
+    return "\n \t".join(f"{name}: {value}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
 
 
-def _format_wrong_example(query: dict, field_filter: List[str] = None) -> str:
+def _format_wrong_example(query: dict, field_filter: List[str] = None):
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
     documents = "\n\n \t".join([_format_document_answer(doc, field_filter) for doc in query.get("documents", [])])
     documents = f"Documents: \n \t{documents}\n" if len(documents) > 0 else ""
@@ -315,9 +315,9 @@ def _format_wrong_examples_report(
         for node in eval_result.node_results.keys()
     }
     examples_formatted = {}
-    for node, examples in examples.items():
+    for node, examples in examples.items():  # type: ignore
         if any(examples):
-            examples_formatted[node] = "\n".join([_format_wrong_example(e, wrong_examples_filter) for e in examples])
+            examples_formatted[node] = "\n".join([_format_wrong_example(e, wrong_examples_filter) for e in examples])  # type: ignore
 
     final_result = "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
     return final_result[:max_characters_per_wrong_examples_report]

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -179,7 +179,7 @@ def print_eval_report(
     ] = "document_id_or_answer",
     answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
     wrong_examples_fields: List[str] = ["answer", "context", "document_id"],
-    max_characters_per_field: int = None,
+    max_characters_per_field: int = 150,
 ):
     """
     Prints a report for a given EvaluationResult visualizing metrics per node specified by the pipeline graph.
@@ -264,7 +264,7 @@ def print_eval_report(
 def _format_document_answer(document_or_answer: dict, max_chars: int = None, field_filter: List[str] = None):
     if field_filter is None or len(field_filter) == 0:
         field_filter = document_or_answer.keys()  # type: ignore
-    return "\n \t".join(f"{name}: {str(value)[:max_chars]}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
+    return "\n \t".join(f"{name}: {str(value)[:max_chars]} {'...' if str(value) > max_chars else ''}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
 
 
 def _format_wrong_example(query: dict, max_chars: int = None, field_filter: List[str] = None):
@@ -280,11 +280,11 @@ def _format_wrong_example(query: dict, max_chars: int = None, field_filter: List
     gold_answers = f"Gold Answers: \n \t{gold_answers}\n" if len(gold_answers) > 0 else ""
     s = (
         f"Query: \n \t{query['query']}\n"
-        f"{gold_answers}\n"
+        f"{gold_answers}"
         f"Gold Document Ids: \n \t{gold_document_ids}\n"
         f"Metrics: \n \t{metrics}\n"
-        f"{answers}\n"
-        f"{documents}\n"
+        f"{answers}"
+        f"{documents}"
         f"_______________________________________________________"
     )
     return s

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -308,8 +308,11 @@ def _format_wrong_examples_report(
     wrong_examples_fields: List[str] = None,
     max_characters_per_wrong_examples_report: int = None,
 ):
-    wrong_examples_fields = ["gold_answers", "answer", "context", "gold_contexts", "document_id",
-                             "gold_document_ids"] if wrong_examples_fields is None else wrong_examples_fields
+    wrong_examples_fields = (
+        ["gold_answers", "answer", "context", "gold_contexts", "document_id", "gold_document_ids"]
+        if wrong_examples_fields is None
+        else wrong_examples_fields
+    )
     examples = {
         node: eval_result.wrong_examples(
             node, document_scope=document_scope, answer_scope=answer_scope, n=n_wrong_examples
@@ -320,8 +323,9 @@ def _format_wrong_examples_report(
     for node, examples in examples.items():  # type: ignore
         if any(examples):
             examples_formatted[node] = "\n".join(
-                _format_wrong_example(e, max_characters_per_wrong_examples_report, wrong_examples_fields) for e in
-                examples)  # type: ignore
+                _format_wrong_example(e, max_characters_per_wrong_examples_report, wrong_examples_fields)
+                for e in examples
+            )  # type: ignore
 
     final_result = "\n".join(map(_format_wrong_examples_node, examples_formatted.keys(), examples_formatted.values()))
     return final_result

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -267,9 +267,7 @@ def _format_document_answer(document_or_answer: dict, field_filter: List[str] = 
     return "\n \t".join(f"{name}: {value}" for name, value in document_or_answer.items() if name in field_filter)  # type: ignore
 
 
-def _format_wrong_example(
-    query: dict, max_characters_per_field: int = None, field_filter: List[str] = None
-):
+def _format_wrong_example(query: dict, max_characters_per_field: int = None, field_filter: List[str] = None):
     metrics = "\n \t".join(f"{name}: {value}" for name, value in query["metrics"].items())
     documents = "\n\n \t".join(_format_document_answer(doc, field_filter) for doc in query.get("documents", []))
     documents = f"Documents: \n \t{documents}\n" if len(documents) > 0 else ""

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -953,9 +953,9 @@ class EvaluationResult:
             values can be: 'recall_single_hit', 'recall_multi_hit', 'mrr', 'map', 'precision'
         :param answer_metric: the answer metric worst queries are calculated with.
             values can be: 'f1', 'exact_match' and 'sas' if the evaluation was made using a SAS model.
-        :param document_metric_threshold: the threshold for the document metric (only samples above selected metric
+        :param document_metric_threshold: the threshold for the document metric (only samples below selected metric
         threshold will be considered)
-        :param answer_metric_threshold: the threshold for the answer metric (only samples above selected metric
+        :param answer_metric_threshold: the threshold for the answer metric (only samples below selected metric
         threshold will be considered)
         :param eval_mode: the input on which the node was evaluated on.
             Usually nodes get evaluated on the prediction provided by its predecessor nodes in the pipeline (value='integrated').

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -933,6 +933,8 @@ class EvaluationResult:
         ] = "document_id_or_answer",
         document_metric: str = "recall_single_hit",
         answer_metric: str = "f1",
+        document_metric_threshold: float = 0.5,
+        answer_metric_threshold: float = 0.5,
         eval_mode: Literal["integrated", "isolated"] = "integrated",
         answer_scope: Literal["any", "context", "document_id", "document_id_and_context"] = "any",
     ) -> List[Dict]:
@@ -949,8 +951,12 @@ class EvaluationResult:
             remarks: there might be a discrepancy between simulated reader metrics and an actual pipeline run with retriever top_k
         :param document_metric: the document metric worst queries are calculated with.
             values can be: 'recall_single_hit', 'recall_multi_hit', 'mrr', 'map', 'precision'
-        :param document_metric: the answer metric worst queries are calculated with.
+        :param answer_metric: the answer metric worst queries are calculated with.
             values can be: 'f1', 'exact_match' and 'sas' if the evaluation was made using a SAS model.
+        :param document_metric_threshold: the threshold for the document metric (only samples above selected metric
+        threshold will be considered)
+        :param answer_metric_threshold: the threshold for the answer metric (only samples above selected metric
+        threshold will be considered)
         :param eval_mode: the input on which the node was evaluated on.
             Usually nodes get evaluated on the prediction provided by its predecessor nodes in the pipeline (value='integrated').
             However, as the quality of the node itself can heavily depend on the node's input and thus the predecessor's quality,
@@ -1001,19 +1007,26 @@ class EvaluationResult:
             wrong_examples = []
             for multilabel_id, metrics in worst_df.iterrows():
                 query_answers = answers[answers["multilabel_id"] == multilabel_id]
-                query_dict = {
-                    "multilabel_id": query_answers["multilabel_id"].iloc[0],
-                    "query": query_answers["query"].iloc[0],
-                    "filters": query_answers["filters"].iloc[0],
-                    "metrics": metrics.to_dict(),
-                    "answers": query_answers.drop(
-                        ["node", "query", "type", "gold_answers", "gold_offsets_in_documents", "gold_document_ids"],
-                        axis=1,
-                    ).to_dict(orient="records"),
-                    "gold_answers": query_answers["gold_answers"].iloc[0],
-                    "gold_document_ids": query_answers["gold_document_ids"].iloc[0],
-                }
-                wrong_examples.append(query_dict)
+                if answer_metric not in metrics:
+                    logger.warning(
+                        f"You specified an answer_metric={answer_metric} not available in calculated metrics={metrics.keys()}."
+                        f"Skipping collection of worst performing samples."
+                    )
+                    break
+                if metrics[answer_metric] > answer_metric_threshold:
+                    query_dict = {
+                        "multilabel_id": query_answers["multilabel_id"].iloc[0],
+                        "query": query_answers["query"].iloc[0],
+                        "filters": query_answers["filters"].iloc[0],
+                        "metrics": metrics.to_dict(),
+                        "answers": query_answers.drop(
+                            ["node", "query", "type", "gold_answers", "gold_offsets_in_documents", "gold_document_ids"],
+                            axis=1,
+                        ).to_dict(orient="records"),
+                        "gold_answers": query_answers["gold_answers"].iloc[0],
+                        "gold_document_ids": query_answers["gold_document_ids"].iloc[0],
+                    }
+                    wrong_examples.append(query_dict)
             return wrong_examples
 
         documents = node_df[node_df["type"] == "document"]
@@ -1029,19 +1042,26 @@ class EvaluationResult:
             worst_df = metrics_df.sort_values(by=[document_metric]).head(n)
             wrong_examples = []
             for multilabel_id, metrics in worst_df.iterrows():
-                query_documents = documents[documents["multilabel_id"] == multilabel_id]
-                query_dict = {
-                    "multilabel_id": query_documents["multilabel_id"].iloc[0],
-                    "query": query_documents["query"].iloc[0],
-                    "filters": query_documents["filters"].iloc[0],
-                    "metrics": metrics.to_dict(),
-                    "documents": query_documents.drop(
-                        ["node", "query", "multilabel_id", "filters", "type", "gold_document_ids", "gold_contexts"],
-                        axis=1,
-                    ).to_dict(orient="records"),
-                    "gold_document_ids": query_documents["gold_document_ids"].iloc[0],
-                }
-                wrong_examples.append(query_dict)
+                if document_metric not in metrics:
+                    logger.warning(
+                        f"You specified a document_metric={document_metric} not available in calculated metrics={metrics.keys()}."
+                        f"Skipping collection of worst performing samples."
+                    )
+                    break
+                if metrics[document_metric] > document_metric_threshold:
+                    query_documents = documents[documents["multilabel_id"] == multilabel_id]
+                    query_dict = {
+                        "multilabel_id": query_documents["multilabel_id"].iloc[0],
+                        "query": query_documents["query"].iloc[0],
+                        "filters": query_documents["filters"].iloc[0],
+                        "metrics": metrics.to_dict(),
+                        "documents": query_documents.drop(
+                            ["node", "query", "multilabel_id", "filters", "type", "gold_document_ids", "gold_contexts"],
+                            axis=1,
+                        ).to_dict(orient="records"),
+                        "gold_document_ids": query_documents["gold_document_ids"].iloc[0],
+                    }
+                    wrong_examples.append(query_dict)
             return wrong_examples
 
         return []

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1013,7 +1013,7 @@ class EvaluationResult:
                         f"Skipping collection of worst performing samples."
                     )
                     break
-                if metrics[answer_metric] > answer_metric_threshold:
+                if metrics[answer_metric] <= answer_metric_threshold:
                     query_dict = {
                         "multilabel_id": query_answers["multilabel_id"].iloc[0],
                         "query": query_answers["query"].iloc[0],
@@ -1048,7 +1048,7 @@ class EvaluationResult:
                         f"Skipping collection of worst performing samples."
                     )
                     break
-                if metrics[document_metric] > document_metric_threshold:
+                if metrics[document_metric] <= document_metric_threshold:
                     query_documents = documents[documents["multilabel_id"] == multilabel_id]
                     query_dict = {
                         "multilabel_id": query_documents["multilabel_id"].iloc[0],

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1169,8 +1169,10 @@ class EvaluationResult:
             simulated_top_k_retriever=simulated_top_k_retriever,
             answer_scope=answer_scope,
         )
-
-        return {metric: metrics_df[metric].mean() for metric in metrics_df.columns}
+        num_examples_for_eval = len(answers["multilabel_id"].unique())
+        result = {metric: metrics_df[metric].mean() for metric in metrics_df.columns}
+        result["num_examples_for_eval"] = float(num_examples_for_eval)  # formatter requires float
+        return result
 
     def _build_answer_metrics_df(
         self,


### PR DESCRIPTION
**Related Issue(s)**:  Fixes https://github.com/deepset-ai/haystack/issues/2615

**Proposed changes**:

1.  Add wrong_examples_filter parameter to print_eval_report    

- include only certain fields of document/answer listed in wrong examples report
- allows users to print out wrong examples report but only with certain fields

2.  Add max_characters_per_wrong_examples_report parameter to print_eval_report

- include up to max_characters_per_wrong_examples_report in each wrong examples report
- effectively cuts the length of each report to max_characters_per_wrong_examples_report

4.  Add thresholds to print_eval_report

- introduces float threshold value for answer/document metric below which predictions are never shown as wrong examples
