### PR TITLE
feat: add batch evaluation method for pipelines

### DIFF
--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -466,7 +466,7 @@ Otherwise raw similarity scores (e.g. cosine or dot_product) will be used.
 #### TfidfRetriever.retrieve\_batch
 
 ```python
-def retrieve_batch(queries: List[str], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: Optional[int] = None, index: str = None, headers: Optional[Dict[str, str]] = None, batch_size: Optional[int] = None, scale_score: bool = None) -> List[List[Document]]
+def retrieve_batch(queries: Union[str, List[str]], filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, top_k: Optional[int] = None, index: str = None, headers: Optional[Dict[str, str]] = None, batch_size: Optional[int] = None, scale_score: bool = None) -> List[List[Document]]
 ```
 
 Scan through documents in DocumentStore and return a small number documents

--- a/haystack/nodes/reader/base.py
+++ b/haystack/nodes/reader/base.py
@@ -110,7 +110,7 @@ class BaseReader(BaseComponent):
         top_k: Optional[int] = None,
         batch_size: Optional[int] = None,
         labels: Optional[List[MultiLabel]] = None,
-        add_isolated_node_eval: bool = False
+        add_isolated_node_eval: bool = False,
     ):
         self.query_count += len(queries) if isinstance(queries, list) else 1
         if not documents:
@@ -148,7 +148,9 @@ class BaseReader(BaseComponent):
             answer_iterator = itertools.chain.from_iterable(results_label_input["answers"])
             if isinstance(documents[0], Document):
                 if isinstance(queries, list):
-                    answer_iterator = itertools.chain.from_iterable(itertools.chain.from_iterable(results_label_input["answers"]))
+                    answer_iterator = itertools.chain.from_iterable(
+                        itertools.chain.from_iterable(results_label_input["answers"])
+                    )
             flattened_documents = []
             for doc_list in documents:
                 if isinstance(doc_list, list):

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -532,7 +532,7 @@ class TfidfRetriever(BaseRetriever):
 
     def retrieve_batch(
         self,
-        queries: List[str],
+        queries: Union[str, List[str]],
         filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
         top_k: Optional[int] = None,
         index: str = None,

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1249,18 +1249,18 @@ class Pipeline:
 
     @send_event
     def eval_batch(
-            self,
-            labels: List[MultiLabel],
-            documents: Optional[List[List[Document]]] = None,
-            params: Optional[dict] = None,
-            sas_model_name_or_path: str = None,
-            sas_batch_size: int = 32,
-            sas_use_gpu: bool = True,
-            add_isolated_node_eval: bool = False,
-            custom_document_id_field: Optional[str] = None,
-            context_matching_min_length: int = 100,
-            context_matching_boost_split_overlaps: bool = True,
-            context_matching_threshold: float = 65.0,
+        self,
+        labels: List[MultiLabel],
+        documents: Optional[List[List[Document]]] = None,
+        params: Optional[dict] = None,
+        sas_model_name_or_path: str = None,
+        sas_batch_size: int = 32,
+        sas_use_gpu: bool = True,
+        add_isolated_node_eval: bool = False,
+        custom_document_id_field: Optional[str] = None,
+        context_matching_min_length: int = 100,
+        context_matching_boost_split_overlaps: bool = True,
+        context_matching_threshold: float = 65.0,
     ) -> EvaluationResult:
         """
         Evaluates the pipeline by running the pipeline in batches in debug mode
@@ -1331,14 +1331,14 @@ class Pipeline:
         for node_name in predictions_batches["_debug"].keys():
             node_output = predictions_batches["_debug"][node_name]["output"]
             df = self._build_eval_dataframe_from_batches(
-               queries=predictions_batches["queries"],
-               query_labels=predictions_batches["labels"],
-               node_name=node_name,
-               node_output=node_output,
-               custom_document_id_field=custom_document_id_field,
-               context_matching_threshold=context_matching_threshold,
-               context_matching_boost_split_overlaps=context_matching_boost_split_overlaps,
-               context_matching_min_length=context_matching_min_length,
+                queries=predictions_batches["queries"],
+                query_labels=predictions_batches["labels"],
+                node_name=node_name,
+                node_output=node_output,
+                custom_document_id_field=custom_document_id_field,
+                context_matching_threshold=context_matching_threshold,
+                context_matching_boost_split_overlaps=context_matching_boost_split_overlaps,
+                context_matching_min_length=context_matching_min_length,
             )
             eval_result.append(node_name, df)
 
@@ -1764,14 +1764,18 @@ class Pipeline:
                 field_value = node_output.get(field_name, None)
                 if field_value is not None:
                     partial_node_output[field_name] = field_value[i]
-            partial_dfs.append(self._build_eval_dataframe(query=queries[i],
-                                          query_labels=query_labels[i],
-                                          node_name=node_name,
-                                          node_output=partial_node_output,
-                                          custom_document_id_field=custom_document_id_field,
-                                          context_matching_min_length=context_matching_min_length,
-                                          context_matching_boost_split_overlaps=context_matching_boost_split_overlaps,
-                                          context_matching_threshold=context_matching_threshold))
+            partial_dfs.append(
+                self._build_eval_dataframe(
+                    query=queries[i],
+                    query_labels=query_labels[i],
+                    node_name=node_name,
+                    node_output=partial_node_output,
+                    custom_document_id_field=custom_document_id_field,
+                    context_matching_min_length=context_matching_min_length,
+                    context_matching_boost_split_overlaps=context_matching_boost_split_overlaps,
+                    context_matching_threshold=context_matching_threshold,
+                )
+            )
 
         return pd.concat(partial_dfs, ignore_index=True).reset_index()
 

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -217,6 +217,65 @@ class BaseStandardPipeline(ABC):
         )
         return output
 
+    def eval_batch(
+        self,
+        labels: List[MultiLabel],
+        params: Optional[dict] = None,
+        sas_model_name_or_path: Optional[str] = None,
+        sas_batch_size: int = 32,
+        sas_use_gpu: bool = True,
+        add_isolated_node_eval: bool = False,
+        custom_document_id_field: Optional[str] = None,
+        context_matching_min_length: int = 100,
+        context_matching_boost_split_overlaps: bool = True,
+        context_matching_threshold: float = 65.0,
+    ) -> EvaluationResult:
+
+        """
+        Evaluates the pipeline by running the pipeline once per query in debug mode
+        and putting together all data that is needed for evaluation, e.g. calculating metrics.
+
+        If you want to calculate SAS (Semantic Answer Similarity) metrics, you have to specify `sas_model_name_or_path`.
+
+        You will be able to control the scope within which an answer or a document is considered correct afterwards (See `document_scope` and `answer_scope` params in `EvaluationResult.calculate_metrics()`).
+        Some of these scopes require additional information that already needs to be specified during `eval()`:
+        - `custom_document_id_field` param to select a custom document ID from document's meta data for ID matching (only affects 'document_id' scopes)
+        - `context_matching_...` param to fine-tune the fuzzy matching mechanism that determines whether some text contexts match each other (only affects 'context' scopes, default values should work most of the time)
+
+        :param labels: The labels to evaluate on
+        :param params: Params for the `retriever` and `reader`. For instance,
+                       params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 5}}
+        :param sas_model_name_or_path: SentenceTransformers semantic textual similarity model to be used for sas value calculation,
+                                    should be path or string pointing to downloadable models.
+        :param sas_batch_size: Number of prediction label pairs to encode at once by CrossEncoder or SentenceTransformer while calculating SAS.
+        :param sas_use_gpu: Whether to use a GPU or the CPU for calculating semantic answer similarity.
+                            Falls back to CPU if no GPU is available.
+        :param add_isolated_node_eval: Whether to additionally evaluate the reader based on labels as input instead of output of previous node in pipeline
+        :param custom_document_id_field: Custom field name within `Document`'s `meta` which identifies the document and is being used as criterion for matching documents to labels during evaluation.
+                                         This is especially useful if you want to match documents on other criteria (e.g. file names) than the default document ids as these could be heavily influenced by preprocessing.
+                                         If not set (default) the `Document`'s `id` is being used as criterion for matching documents to labels.
+        :param context_matching_min_length: The minimum string length context and candidate need to have in order to be scored.
+                           Returns 0.0 otherwise.
+        :param context_matching_boost_split_overlaps: Whether to boost split overlaps (e.g. [AB] <-> [BC]) that result from different preprocessing params.
+                                 If we detect that the score is near a half match and the matching part of the candidate is at its boundaries
+                                 we cut the context on the same side, recalculate the score and take the mean of both.
+                                 Thus [AB] <-> [BC] (score ~50) gets recalculated with B <-> B (score ~100) scoring ~75 in total.
+        :param context_matching_threshold: Score threshold that candidates must surpass to be included into the result list. Range: [0,100]
+        """
+        output = self.pipeline.eval_batch(
+            labels=labels,
+            params=params,
+            sas_model_name_or_path=sas_model_name_or_path,
+            sas_batch_size=sas_batch_size,
+            sas_use_gpu=sas_use_gpu,
+            add_isolated_node_eval=add_isolated_node_eval,
+            custom_document_id_field=custom_document_id_field,
+            context_matching_boost_split_overlaps=context_matching_boost_split_overlaps,
+            context_matching_min_length=context_matching_min_length,
+            context_matching_threshold=context_matching_threshold,
+        )
+        return output
+
     def print_eval_report(
         self,
         eval_result: EvaluationResult,

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -1,0 +1,1229 @@
+import logging
+import pytest
+import sys
+from haystack.document_stores.memory import InMemoryDocumentStore
+from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
+from haystack.nodes.preprocessor import PreProcessor
+from haystack.nodes.evaluator import EvalAnswers, EvalDocuments
+from haystack.nodes.query_classifier.transformers import TransformersQueryClassifier
+from haystack.nodes.retriever.dense import DensePassageRetriever
+from haystack.nodes.retriever.sparse import BM25Retriever
+from haystack.nodes.summarizer.transformers import TransformersSummarizer
+from haystack.pipelines.base import Pipeline
+from haystack.pipelines import ExtractiveQAPipeline, GenerativeQAPipeline, SearchSummarizationPipeline
+from haystack.pipelines.standard_pipelines import (
+    DocumentSearchPipeline,
+    FAQPipeline,
+    RetrieverQuestionGenerationPipeline,
+    TranslationWrapperPipeline,
+)
+from haystack.nodes.translator.transformers import TransformersTranslator
+from haystack.schema import Answer, Document, EvaluationResult, Label, MultiLabel, Span
+
+from ..conftest import SAMPLES_PATH
+
+
+@pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Causes OOM on windows github runner")
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("retriever_with_docs", ["embedding"], indirect=True)
+def test_generativeqa_calculate_metrics(
+    document_store_with_docs: InMemoryDocumentStore, rag_generator, retriever_with_docs
+):
+    document_store_with_docs.update_embeddings(retriever=retriever_with_docs)
+    pipeline = GenerativeQAPipeline(generator=rag_generator, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "Retriever" in eval_result
+    assert "Generator" in eval_result
+    assert len(eval_result) == 2
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+    assert metrics["Generator"]["exact_match"] == 0.0
+    assert metrics["Generator"]["f1"] == 1.0 / 3
+
+
+@pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Causes OOM on windows github runner")
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("retriever_with_docs", ["embedding"], indirect=True)
+def test_summarizer_calculate_metrics(document_store_with_docs: ElasticsearchDocumentStore, retriever_with_docs):
+    document_store_with_docs.update_embeddings(retriever=retriever_with_docs)
+    summarizer = TransformersSummarizer(model_name_or_path="sshleifer/distill-pegasus-xsum-16-4", use_gpu=-1)
+    pipeline = SearchSummarizationPipeline(
+        retriever=retriever_with_docs, summarizer=summarizer, return_in_answer_format=True
+    )
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}}, context_matching_min_length=10
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="context")
+
+    assert "Retriever" in eval_result
+    assert "Summarizer" in eval_result
+    assert len(eval_result) == 2
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == pytest.approx(0.9167, 1e-4)
+    assert metrics["Retriever"]["recall_multi_hit"] == pytest.approx(0.9167, 1e-4)
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 1.0
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.9461, 1e-4)
+    assert metrics["Summarizer"]["mrr"] == 1.0
+    assert metrics["Summarizer"]["map"] == 0.735
+    assert metrics["Summarizer"]["recall_multi_hit"] == 0.8
+    assert metrics["Summarizer"]["recall_single_hit"] == 1.0
+    assert metrics["Summarizer"]["precision"] == 0.8
+    assert metrics["Summarizer"]["ndcg"] == pytest.approx(0.8422, 1e-4)
+
+
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus1"], indirect=True)
+@pytest.mark.parametrize("batch_size", [None, 20])
+def test_add_eval_data(document_store, batch_size):
+    # add eval data (SQUAD format)
+    document_store.add_eval_data(
+        filename=SAMPLES_PATH / "squad" / "small.json",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
+        batch_size=batch_size,
+    )
+
+    assert document_store.get_document_count() == 87
+    assert document_store.get_label_count() == 1214
+
+    # test documents
+    docs = document_store.get_all_documents(filters={"name": ["Normans"]})
+    assert docs[0].meta["name"] == "Normans"
+    assert len(docs[0].meta.keys()) == 1
+
+    # test labels
+    labels = document_store.get_all_labels()
+    label = None
+    for l in labels:
+        if l.query == "In what country is Normandy located?":
+            label = l
+            break
+    assert label.answer.answer == "France"
+    assert label.no_answer == False
+    assert label.is_correct_answer == True
+    assert label.is_correct_document == True
+    assert label.query == "In what country is Normandy located?"
+    assert label.origin == "gold-label"
+    assert label.answer.offsets_in_document[0].start == 159
+    assert (
+        label.answer.context[label.answer.offsets_in_context[0].start : label.answer.offsets_in_context[0].end]
+        == "France"
+    )
+    assert label.answer.document_id == label.document.id
+
+    # check combination
+    doc = document_store.get_document_by_id(label.document.id)
+    start = label.answer.offsets_in_document[0].start
+    end = label.answer.offsets_in_document[0].end
+    assert end == start + len(label.answer.answer)
+    assert doc.content[start:end] == "France"
+
+
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus1"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+@pytest.mark.parametrize("use_confidence_scores", [True, False])
+def test_eval_reader(reader, document_store, use_confidence_scores):
+    # add eval data (SQUAD format)
+    document_store.add_eval_data(
+        filename=SAMPLES_PATH / "squad" / "tiny.json",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
+    )
+    assert document_store.get_document_count() == 2
+
+    reader.use_confidence_scores = use_confidence_scores
+
+    # eval reader
+    reader_eval_results = reader.eval(
+        document_store=document_store,
+        label_index=document_store.label_index,
+        doc_index=document_store.index,
+        device="cpu",
+    )
+
+    if use_confidence_scores:
+        assert reader_eval_results["f1"] == 50
+        assert reader_eval_results["EM"] == 50
+        assert reader_eval_results["top_n_accuracy"] == 100.0
+    else:
+        assert 66.67 > reader_eval_results["f1"] > 66.65
+        assert reader_eval_results["EM"] == 50
+        assert reader_eval_results["top_n_accuracy"] == 100.0
+
+
+@pytest.mark.elasticsearch
+@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("open_domain", [True, False])
+@pytest.mark.parametrize("retriever", ["elasticsearch"], indirect=True)
+def test_eval_elastic_retriever(document_store, open_domain, retriever):
+    # add eval data (SQUAD format)
+    document_store.add_eval_data(
+        filename=SAMPLES_PATH / "squad" / "tiny.json",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
+    )
+    assert document_store.get_document_count() == 2
+
+    # eval retriever
+    results = retriever.eval(
+        top_k=1, label_index=document_store.label_index, doc_index=document_store.index, open_domain=open_domain
+    )
+    assert results["recall"] == 1.0
+    assert results["mrr"] == 1.0
+    if not open_domain:
+        assert results["map"] == 1.0
+
+
+# TODO simplify with a mock retriever and make it independent of elasticsearch documentstore
+@pytest.mark.elasticsearch
+@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+@pytest.mark.parametrize("retriever", ["elasticsearch"], indirect=True)
+def test_eval_pipeline(document_store, reader, retriever):
+    # add eval data (SQUAD format)
+    document_store.add_eval_data(
+        filename=SAMPLES_PATH / "squad" / "tiny.json",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
+    )
+
+    labels = document_store.get_all_labels_aggregated(drop_negative_labels=True, drop_no_answers=False)
+
+    eval_retriever = EvalDocuments()
+    eval_reader = EvalAnswers(sas_model="sentence-transformers/paraphrase-MiniLM-L3-v2", debug=True)
+    eval_reader_cross = EvalAnswers(sas_model="cross-encoder/stsb-TinyBERT-L-4", debug=True)
+    eval_reader_vanila = EvalAnswers()
+
+    assert document_store.get_document_count() == 2
+    p = Pipeline()
+    p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
+    p.add_node(component=eval_retriever, name="EvalDocuments", inputs=["ESRetriever"])
+    p.add_node(component=reader, name="QAReader", inputs=["EvalDocuments"])
+    p.add_node(component=eval_reader, name="EvalAnswers", inputs=["QAReader"])
+    p.add_node(component=eval_reader_cross, name="EvalAnswers_cross", inputs=["QAReader"])
+    p.add_node(component=eval_reader_vanila, name="EvalAnswers_vanilla", inputs=["QAReader"])
+    for l in labels:
+        res = p.run(query=l.query, labels=l)
+    assert eval_retriever.recall == 1.0
+    assert round(eval_reader.top_k_f1, 4) == 0.8333
+    assert eval_reader.top_k_em == 0.5
+    assert round(eval_reader.top_k_sas, 3) == 0.800
+    assert round(eval_reader_cross.top_k_sas, 3) == 0.671
+    assert eval_reader.top_k_em == eval_reader_vanila.top_k_em
+
+
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus1"], indirect=True)
+def test_eval_data_split_word(document_store):
+    # splitting by word
+    preprocessor = PreProcessor(
+        clean_empty_lines=False,
+        clean_whitespace=False,
+        clean_header_footer=False,
+        split_by="word",
+        split_length=4,
+        split_overlap=0,
+        split_respect_sentence_boundary=False,
+    )
+
+    document_store.add_eval_data(
+        filename=SAMPLES_PATH / "squad" / "tiny.json",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
+        preprocessor=preprocessor,
+    )
+    labels = document_store.get_all_labels_aggregated()
+    docs = document_store.get_all_documents()
+    assert len(docs) == 5
+    assert len(set(labels[0].document_ids)) == 2
+
+
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory", "milvus1"], indirect=True)
+def test_eval_data_split_passage(document_store):
+    # splitting by passage
+    preprocessor = PreProcessor(
+        clean_empty_lines=False,
+        clean_whitespace=False,
+        clean_header_footer=False,
+        split_by="passage",
+        split_length=1,
+        split_overlap=0,
+        split_respect_sentence_boundary=False,
+    )
+
+    document_store.add_eval_data(
+        filename=SAMPLES_PATH / "squad" / "tiny_passages.json",
+        doc_index=document_store.index,
+        label_index=document_store.label_index,
+        preprocessor=preprocessor,
+    )
+    docs = document_store.get_all_documents()
+    assert len(docs) == 2
+    assert len(docs[1].content) == 56
+
+
+EVAL_LABELS = [
+    MultiLabel(
+        labels=[
+            Label(
+                query="Who lives in Berlin?",
+                answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]),
+                document=Document(
+                    id="a0747b83aea0b60c4b114b15476dd32d",
+                    content_type="text",
+                    content="My name is Carla and I live in Berlin",
+                ),
+                is_correct_answer=True,
+                is_correct_document=True,
+                origin="gold-label",
+            )
+        ]
+    ),
+    MultiLabel(
+        labels=[
+            Label(
+                query="Who lives in Munich?",
+                answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]),
+                document=Document(
+                    id="something_else", content_type="text", content="My name is Carla and I live in Munich"
+                ),
+                is_correct_answer=True,
+                is_correct_document=True,
+                origin="gold-label",
+            )
+        ]
+    ),
+]
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval(reader, retriever_with_docs, tmp_path):
+    labels = EVAL_LABELS[:1]
+
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result = pipeline.eval_batch(labels=labels, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    reader_result = eval_result["Reader"]
+    retriever_result = eval_result["Retriever"]
+
+    assert (
+        reader_result[reader_result["rank"] == 1]["answer"].iloc[0]
+        in reader_result[reader_result["rank"] == 1]["gold_answers"].iloc[0]
+    )
+    assert (
+        retriever_result[retriever_result["rank"] == 1]["document_id"].iloc[0]
+        in retriever_result[retriever_result["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["recall_multi_hit"] == 1.0
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 0.2
+    assert metrics["Retriever"]["map"] == 1.0
+    assert metrics["Retriever"]["ndcg"] == 1.0
+
+    eval_result.save(tmp_path)
+    saved_eval_result = EvaluationResult.load(tmp_path)
+    metrics = saved_eval_result.calculate_metrics(document_scope="document_id")
+
+    assert (
+        reader_result[reader_result["rank"] == 1]["answer"].iloc[0]
+        in reader_result[reader_result["rank"] == 1]["gold_answers"].iloc[0]
+    )
+    assert (
+        retriever_result[retriever_result["rank"] == 1]["document_id"].iloc[0]
+        in retriever_result[retriever_result["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["recall_multi_hit"] == 1.0
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 0.2
+    assert metrics["Retriever"]["map"] == 1.0
+    assert metrics["Retriever"]["ndcg"] == 1.0
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_multiple_queries(reader, retriever_with_docs, tmp_path):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    reader_result = eval_result["Reader"]
+    retriever_result = eval_result["Retriever"]
+
+    reader_berlin = reader_result[reader_result["query"] == "Who lives in Berlin?"]
+    reader_munich = reader_result[reader_result["query"] == "Who lives in Munich?"]
+
+    retriever_berlin = retriever_result[retriever_result["query"] == "Who lives in Berlin?"]
+    retriever_munich = retriever_result[retriever_result["query"] == "Who lives in Munich?"]
+
+    assert (
+        reader_berlin[reader_berlin["rank"] == 1]["answer"].iloc[0]
+        in reader_berlin[reader_berlin["rank"] == 1]["gold_answers"].iloc[0]
+    )
+    assert (
+        retriever_berlin[retriever_berlin["rank"] == 1]["document_id"].iloc[0]
+        in retriever_berlin[retriever_berlin["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert (
+        reader_munich[reader_munich["rank"] == 1]["answer"].iloc[0]
+        not in reader_munich[reader_munich["rank"] == 1]["gold_answers"].iloc[0]
+    )
+    assert (
+        retriever_munich[retriever_munich["rank"] == 1]["document_id"].iloc[0]
+        not in retriever_munich[retriever_munich["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+    eval_result.save(tmp_path)
+    saved_eval_result = EvaluationResult.load(tmp_path)
+    metrics = saved_eval_result.calculate_metrics(document_scope="document_id")
+
+    assert (
+        reader_berlin[reader_berlin["rank"] == 1]["answer"].iloc[0]
+        in reader_berlin[reader_berlin["rank"] == 1]["gold_answers"].iloc[0]
+    )
+    assert (
+        retriever_berlin[retriever_berlin["rank"] == 1]["document_id"].iloc[0]
+        in retriever_berlin[retriever_berlin["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert (
+        reader_munich[reader_munich["rank"] == 1]["answer"].iloc[0]
+        not in reader_munich[reader_munich["rank"] == 1]["gold_answers"].iloc[0]
+    )
+    assert (
+        retriever_munich[retriever_munich["rank"] == 1]["document_id"].iloc[0]
+        not in retriever_munich[retriever_munich["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_sas(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        params={"Retriever": {"top_k": 5}},
+        sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+    assert "sas" in metrics["Reader"]
+    assert metrics["Reader"]["sas"] == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_reader_eval_in_pipeline(reader):
+    pipeline = Pipeline()
+    pipeline.add_node(component=reader, name="Reader", inputs=["Query"])
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        documents=[[label.document for label in multilabel.labels] for multilabel in EVAL_LABELS],
+        params={},
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_document_scope(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        params={"Retriever": {"top_k": 5}},
+        context_matching_min_length=20,  # artificially set down min_length to see if context matching is working properly
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+    metrics = eval_result.calculate_metrics(document_scope="context")
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == pytest.approx(0.9167, 1e-4)
+    assert metrics["Retriever"]["recall_multi_hit"] == pytest.approx(0.9167, 1e-4)
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 1.0
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.9461, 1e-4)
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id_and_context")
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id_or_context")
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == pytest.approx(0.9167, 1e-4)
+    assert metrics["Retriever"]["recall_multi_hit"] == pytest.approx(0.9167, 1e-4)
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 1.0
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.9461, 1e-4)
+
+    metrics = eval_result.calculate_metrics(document_scope="answer")
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == 0.75
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.75
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 0.2
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.8066, 1e-4)
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id_or_answer")
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == 0.75
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.75
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 0.2
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.8066, 1e-4)
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_answer_scope(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        params={"Retriever": {"top_k": 5}},
+        sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
+        context_matching_min_length=20,  # artificially set down min_length to see if context matching is working properly
+    )
+
+    metrics = eval_result.calculate_metrics(answer_scope="any")
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == 0.75
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.75
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 0.2
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.8066, 1e-4)
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Reader"]["sas"] == pytest.approx(1.0)
+
+    metrics = eval_result.calculate_metrics(answer_scope="context")
+
+    assert metrics["Retriever"]["mrr"] == 1.0
+    assert metrics["Retriever"]["map"] == 0.75
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.75
+    assert metrics["Retriever"]["recall_single_hit"] == 1.0
+    assert metrics["Retriever"]["precision"] == 0.2
+    assert metrics["Retriever"]["ndcg"] == pytest.approx(0.8066, 1e-4)
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Reader"]["sas"] == pytest.approx(1.0)
+
+    metrics = eval_result.calculate_metrics(answer_scope="document_id")
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+    assert metrics["Reader"]["exact_match"] == 0.5
+    assert metrics["Reader"]["f1"] == 0.5
+    assert metrics["Reader"]["sas"] == pytest.approx(0.5)
+
+    metrics = eval_result.calculate_metrics(answer_scope="document_id_and_context")
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+    assert metrics["Reader"]["exact_match"] == 0.5
+    assert metrics["Reader"]["f1"] == 0.5
+    assert metrics["Reader"]["sas"] == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_answer_document_scope_combinations(reader, retriever_with_docs, caplog):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        params={"Retriever": {"top_k": 5}},
+        sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
+        context_matching_min_length=20,  # artificially set down min_length to see if context matching is working properly
+    )
+
+    # valid values for non default answer_scopes
+    with caplog.at_level(logging.WARNING):
+        metrics = eval_result.calculate_metrics(document_scope="document_id_or_answer", answer_scope="context")
+        metrics = eval_result.calculate_metrics(document_scope="answer", answer_scope="context")
+        assert "You specified a non-answer document_scope together with a non-default answer_scope" not in caplog.text
+
+    with caplog.at_level(logging.WARNING):
+        metrics = eval_result.calculate_metrics(document_scope="document_id", answer_scope="context")
+        assert "You specified a non-answer document_scope together with a non-default answer_scope" in caplog.text
+
+    with caplog.at_level(logging.WARNING):
+        metrics = eval_result.calculate_metrics(document_scope="context", answer_scope="context")
+        assert "You specified a non-answer document_scope together with a non-default answer_scope" in caplog.text
+
+    with caplog.at_level(logging.WARNING):
+        metrics = eval_result.calculate_metrics(document_scope="document_id_and_context", answer_scope="context")
+        assert "You specified a non-answer document_scope together with a non-default answer_scope" in caplog.text
+
+    with caplog.at_level(logging.WARNING):
+        metrics = eval_result.calculate_metrics(document_scope="document_id_or_context", answer_scope="context")
+        assert "You specified a non-answer document_scope together with a non-default answer_scope" in caplog.text
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_simulated_top_k_reader(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        params={"Retriever": {"top_k": 5}},
+        sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
+    )
+
+    metrics_top_1 = eval_result.calculate_metrics(simulated_top_k_reader=1, document_scope="document_id")
+
+    assert metrics_top_1["Reader"]["exact_match"] == 0.5
+    assert metrics_top_1["Reader"]["f1"] == 0.5
+    assert metrics_top_1["Reader"]["sas"] == pytest.approx(0.5833, abs=1e-4)
+    assert metrics_top_1["Retriever"]["mrr"] == 0.5
+    assert metrics_top_1["Retriever"]["map"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["precision"] == 0.1
+    assert metrics_top_1["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_2 = eval_result.calculate_metrics(simulated_top_k_reader=2, document_scope="document_id")
+
+    assert metrics_top_2["Reader"]["exact_match"] == 0.5
+    assert metrics_top_2["Reader"]["f1"] == 0.5
+    assert metrics_top_2["Reader"]["sas"] == pytest.approx(0.5833, abs=1e-4)
+    assert metrics_top_2["Retriever"]["mrr"] == 0.5
+    assert metrics_top_2["Retriever"]["map"] == 0.5
+    assert metrics_top_2["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_2["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_2["Retriever"]["precision"] == 0.1
+    assert metrics_top_2["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_3 = eval_result.calculate_metrics(simulated_top_k_reader=3, document_scope="document_id")
+
+    assert metrics_top_3["Reader"]["exact_match"] == 1.0
+    assert metrics_top_3["Reader"]["f1"] == 1.0
+    assert metrics_top_3["Reader"]["sas"] == pytest.approx(1.0, abs=1e-4)
+    assert metrics_top_3["Retriever"]["mrr"] == 0.5
+    assert metrics_top_3["Retriever"]["map"] == 0.5
+    assert metrics_top_3["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_3["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_3["Retriever"]["precision"] == 0.1
+    assert metrics_top_3["Retriever"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_simulated_top_k_retriever(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics_top_10 = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert metrics_top_10["Reader"]["exact_match"] == 1.0
+    assert metrics_top_10["Reader"]["f1"] == 1.0
+    assert metrics_top_10["Retriever"]["mrr"] == 0.5
+    assert metrics_top_10["Retriever"]["map"] == 0.5
+    assert metrics_top_10["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_10["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_10["Retriever"]["precision"] == 0.1
+    assert metrics_top_10["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_1 = eval_result.calculate_metrics(simulated_top_k_retriever=1, document_scope="document_id")
+
+    assert metrics_top_1["Reader"]["exact_match"] == 1.0
+    assert metrics_top_1["Reader"]["f1"] == 1.0
+    assert metrics_top_1["Retriever"]["mrr"] == 0.5
+    assert metrics_top_1["Retriever"]["map"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["precision"] == 0.5
+    assert metrics_top_1["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_2 = eval_result.calculate_metrics(simulated_top_k_retriever=2, document_scope="document_id")
+
+    assert metrics_top_2["Reader"]["exact_match"] == 1.0
+    assert metrics_top_2["Reader"]["f1"] == 1.0
+    assert metrics_top_2["Retriever"]["mrr"] == 0.5
+    assert metrics_top_2["Retriever"]["map"] == 0.5
+    assert metrics_top_2["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_2["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_2["Retriever"]["precision"] == 0.25
+    assert metrics_top_2["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_3 = eval_result.calculate_metrics(simulated_top_k_retriever=3, document_scope="document_id")
+
+    assert metrics_top_3["Reader"]["exact_match"] == 1.0
+    assert metrics_top_3["Reader"]["f1"] == 1.0
+    assert metrics_top_3["Retriever"]["mrr"] == 0.5
+    assert metrics_top_3["Retriever"]["map"] == 0.5
+    assert metrics_top_3["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_3["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_3["Retriever"]["precision"] == 1.0 / 6
+    assert metrics_top_3["Retriever"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 10}})
+
+    metrics_top_10 = eval_result.calculate_metrics(simulated_top_k_reader=1, document_scope="document_id")
+
+    assert metrics_top_10["Reader"]["exact_match"] == 0.5
+    assert metrics_top_10["Reader"]["f1"] == 0.5
+    assert metrics_top_10["Retriever"]["mrr"] == 0.5
+    assert metrics_top_10["Retriever"]["map"] == 0.5
+    assert metrics_top_10["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_10["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_10["Retriever"]["precision"] == 0.1
+    assert metrics_top_10["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_1 = eval_result.calculate_metrics(
+        simulated_top_k_reader=1, simulated_top_k_retriever=1, document_scope="document_id"
+    )
+
+    assert metrics_top_1["Reader"]["exact_match"] == 1.0
+    assert metrics_top_1["Reader"]["f1"] == 1.0
+
+    assert metrics_top_1["Retriever"]["mrr"] == 0.5
+    assert metrics_top_1["Retriever"]["map"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["precision"] == 0.5
+    assert metrics_top_1["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_2 = eval_result.calculate_metrics(
+        simulated_top_k_reader=1, simulated_top_k_retriever=2, document_scope="document_id"
+    )
+
+    assert metrics_top_2["Reader"]["exact_match"] == 0.5
+    assert metrics_top_2["Reader"]["f1"] == 0.5
+    assert metrics_top_2["Retriever"]["mrr"] == 0.5
+    assert metrics_top_2["Retriever"]["map"] == 0.5
+    assert metrics_top_2["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_2["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_2["Retriever"]["precision"] == 0.25
+    assert metrics_top_2["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_3 = eval_result.calculate_metrics(
+        simulated_top_k_reader=1, simulated_top_k_retriever=3, document_scope="document_id"
+    )
+
+    assert metrics_top_3["Reader"]["exact_match"] == 0.5
+    assert metrics_top_3["Reader"]["f1"] == 0.5
+    assert metrics_top_3["Retriever"]["mrr"] == 0.5
+    assert metrics_top_3["Retriever"]["map"] == 0.5
+    assert metrics_top_3["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_3["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_3["Retriever"]["precision"] == 1.0 / 6
+    assert metrics_top_3["Retriever"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=EVAL_LABELS,
+        sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
+        add_isolated_node_eval=True,
+    )
+
+    metrics_top_1 = eval_result.calculate_metrics(simulated_top_k_reader=1, document_scope="document_id")
+
+    assert metrics_top_1["Reader"]["exact_match"] == 0.5
+    assert metrics_top_1["Reader"]["f1"] == 0.5
+    assert metrics_top_1["Reader"]["sas"] == pytest.approx(0.5833, abs=1e-4)
+    assert metrics_top_1["Retriever"]["mrr"] == 0.5
+    assert metrics_top_1["Retriever"]["map"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics_top_1["Retriever"]["precision"] == 1.0 / 10
+    assert metrics_top_1["Retriever"]["ndcg"] == 0.5
+
+    metrics_top_1 = eval_result.calculate_metrics(simulated_top_k_reader=1, eval_mode="isolated")
+
+    assert metrics_top_1["Reader"]["exact_match"] == 1.0
+    assert metrics_top_1["Reader"]["f1"] == 1.0
+    assert metrics_top_1["Reader"]["sas"] == pytest.approx(1.0, abs=1e-4)
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_wrong_examples(reader, retriever_with_docs):
+
+    labels = [
+        MultiLabel(
+            labels=[
+                Label(
+                    query="Who lives in Berlin?",
+                    answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]),
+                    document=Document(
+                        id="a0747b83aea0b60c4b114b15476dd32d",
+                        content_type="text",
+                        content="My name is Carla and I live in Berlin",
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        ),
+        MultiLabel(
+            labels=[
+                Label(
+                    query="Who lives in Munich?",
+                    answer=Answer(answer="Pete", offsets_in_context=[Span(11, 16)]),
+                    document=Document(
+                        id="something_else", content_type="text", content="My name is Pete and I live in Munich"
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        ),
+    ]
+
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=labels, params={"Retriever": {"top_k": 5}})
+
+    wrongs_retriever = eval_result.wrong_examples(node="Retriever", n=1)
+    wrongs_reader = eval_result.wrong_examples(node="Reader", n=1)
+
+    assert len(wrongs_retriever) == 1
+    assert len(wrongs_reader) == 1
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
+
+    labels = [
+        MultiLabel(
+            labels=[
+                Label(
+                    query="Who lives in Berlin?",
+                    answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]),
+                    document=Document(
+                        id="a0747b83aea0b60c4b114b15476dd32d",
+                        content_type="text",
+                        content="My name is Carla and I live in Berlin",
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        ),
+        MultiLabel(
+            labels=[
+                Label(
+                    query="Who lives in Munich?",
+                    answer=Answer(answer="Pete", offsets_in_context=[Span(11, 16)]),
+                    document=Document(
+                        id="something_else", content_type="text", content="My name is Pete and I live in Munich"
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        ),
+    ]
+
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=labels, params={"Retriever": {"top_k": 5}})
+    pipeline.print_eval_report(eval_result)
+
+    # in addition with labels as input to reader node rather than output of retriever node
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=labels, params={"Retriever": {"top_k": 5}}, add_isolated_node_eval=True
+    )
+    pipeline.print_eval_report(eval_result)
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+def test_document_search_calculate_metrics(retriever_with_docs):
+    pipeline = DocumentSearchPipeline(retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "Retriever" in eval_result
+    assert len(eval_result) == 1
+    retriever_result = eval_result["Retriever"]
+    retriever_berlin = retriever_result[retriever_result["query"] == "Who lives in Berlin?"]
+    retriever_munich = retriever_result[retriever_result["query"] == "Who lives in Munich?"]
+
+    assert (
+        retriever_berlin[retriever_berlin["rank"] == 1]["document_id"].iloc[0]
+        in retriever_berlin[retriever_berlin["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert (
+        retriever_munich[retriever_munich["rank"] == 1]["document_id"].iloc[0]
+        not in retriever_munich[retriever_munich["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+def test_faq_calculate_metrics(retriever_with_docs):
+    pipeline = FAQPipeline(retriever=retriever_with_docs)
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "Retriever" in eval_result
+    assert "Docs2Answers" in eval_result
+    assert len(eval_result) == 2
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+    assert metrics["Docs2Answers"]["exact_match"] == 0.0
+    assert metrics["Docs2Answers"]["f1"] == 0.0
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_extractive_qa_eval_translation(reader, retriever_with_docs):
+
+    # FIXME it makes no sense to have DE->EN input and DE->EN output, right?
+    #  Yet switching direction breaks the test. TO BE FIXED.
+    input_translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-de-en")
+    output_translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-de-en")
+
+    pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
+    pipeline = TranslationWrapperPipeline(
+        input_translator=input_translator, output_translator=output_translator, pipeline=pipeline
+    )
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "Retriever" in eval_result
+    assert "Reader" in eval_result
+    assert "OutputTranslator" in eval_result
+    assert len(eval_result) == 3
+
+    assert metrics["Reader"]["exact_match"] == 1.0
+    assert metrics["Reader"]["f1"] == 1.0
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+    assert metrics["OutputTranslator"]["exact_match"] == 1.0
+    assert metrics["OutputTranslator"]["f1"] == 1.0
+    assert metrics["OutputTranslator"]["mrr"] == 0.5
+    assert metrics["OutputTranslator"]["map"] == 0.5
+    assert metrics["OutputTranslator"]["recall_multi_hit"] == 0.5
+    assert metrics["OutputTranslator"]["recall_single_hit"] == 0.5
+    assert metrics["OutputTranslator"]["precision"] == 0.1
+    assert metrics["OutputTranslator"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+def test_question_generation_eval(retriever_with_docs, question_generator):
+    pipeline = RetrieverQuestionGenerationPipeline(retriever=retriever_with_docs, question_generator=question_generator)
+
+    eval_result: EvaluationResult = pipeline.eval_batch(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "Retriever" in eval_result
+    assert "Question Generator" in eval_result
+    assert len(eval_result) == 2
+
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+    assert metrics["Question Generator"]["mrr"] == 0.5
+    assert metrics["Question Generator"]["map"] == 0.5
+    assert metrics["Question Generator"]["recall_multi_hit"] == 0.5
+    assert metrics["Question Generator"]["recall_single_hit"] == 0.5
+    assert metrics["Question Generator"]["precision"] == 0.1
+    assert metrics["Question Generator"]["ndcg"] == 0.5
+
+
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_qa_multi_retriever_pipeline_eval(document_store_with_docs, reader):
+    es_retriever = BM25Retriever(document_store=document_store_with_docs)
+    dpr_retriever = DensePassageRetriever(document_store_with_docs)
+    document_store_with_docs.update_embeddings(retriever=dpr_retriever)
+
+    # QA Pipeline with two retrievers, we always want QA output
+    pipeline = Pipeline()
+    pipeline.add_node(component=TransformersQueryClassifier(), name="QueryClassifier", inputs=["Query"])
+    pipeline.add_node(component=dpr_retriever, name="DPRRetriever", inputs=["QueryClassifier.output_1"])
+    pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+    pipeline.add_node(component=reader, name="QAReader", inputs=["ESRetriever", "DPRRetriever"])
+
+    # EVAL_QUERIES: 2 go dpr way
+    # in Berlin goes es way
+    labels = EVAL_LABELS + [
+        MultiLabel(
+            labels=[
+                Label(
+                    query="in Berlin",
+                    answer=Answer(answer="Carla", offsets_in_context=[Span(11, 16)]),
+                    document=Document(
+                        id="a0747b83aea0b60c4b114b15476dd32d",
+                        content_type="text",
+                        content="My name is Carla and I live in Berlin",
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        )
+    ]
+
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=labels, params={"ESRetriever": {"top_k": 5}, "DPRRetriever": {"top_k": 5}}
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "ESRetriever" in eval_result
+    assert "DPRRetriever" in eval_result
+    assert "QAReader" in eval_result
+    assert len(eval_result) == 3
+
+    assert metrics["DPRRetriever"]["mrr"] == 0.5
+    assert metrics["DPRRetriever"]["map"] == 0.5
+    assert metrics["DPRRetriever"]["recall_multi_hit"] == 0.5
+    assert metrics["DPRRetriever"]["recall_single_hit"] == 0.5
+    assert metrics["DPRRetriever"]["precision"] == 0.1
+    assert metrics["DPRRetriever"]["ndcg"] == 0.5
+
+    assert metrics["ESRetriever"]["mrr"] == 1.0
+    assert metrics["ESRetriever"]["map"] == 1.0
+    assert metrics["ESRetriever"]["recall_multi_hit"] == 1.0
+    assert metrics["ESRetriever"]["recall_single_hit"] == 1.0
+    assert metrics["ESRetriever"]["precision"] == 0.2
+    assert metrics["ESRetriever"]["ndcg"] == 1.0
+
+    assert metrics["QAReader"]["exact_match"] == 1.0
+    assert metrics["QAReader"]["f1"] == 1.0
+
+
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+def test_multi_retriever_pipeline_eval(document_store_with_docs):
+    es_retriever = BM25Retriever(document_store=document_store_with_docs)
+    dpr_retriever = DensePassageRetriever(document_store_with_docs)
+    document_store_with_docs.update_embeddings(retriever=dpr_retriever)
+
+    # QA Pipeline with two retrievers, no QA output
+    pipeline = Pipeline()
+    pipeline.add_node(component=TransformersQueryClassifier(), name="QueryClassifier", inputs=["Query"])
+    pipeline.add_node(component=dpr_retriever, name="DPRRetriever", inputs=["QueryClassifier.output_1"])
+    pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+
+    # EVAL_QUERIES: 2 go dpr way
+    # in Berlin goes es way
+    labels = EVAL_LABELS + [
+        MultiLabel(
+            labels=[
+                Label(
+                    query="in Berlin",
+                    answer=None,
+                    document=Document(
+                        id="a0747b83aea0b60c4b114b15476dd32d",
+                        content_type="text",
+                        content="My name is Carla and I live in Berlin",
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        )
+    ]
+
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=labels, params={"ESRetriever": {"top_k": 5}, "DPRRetriever": {"top_k": 5}}
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "ESRetriever" in eval_result
+    assert "DPRRetriever" in eval_result
+    assert len(eval_result) == 2
+
+    assert metrics["DPRRetriever"]["mrr"] == 0.5
+    assert metrics["DPRRetriever"]["map"] == 0.5
+    assert metrics["DPRRetriever"]["recall_multi_hit"] == 0.5
+    assert metrics["DPRRetriever"]["recall_single_hit"] == 0.5
+    assert metrics["DPRRetriever"]["precision"] == 0.1
+    assert metrics["DPRRetriever"]["ndcg"] == 0.5
+
+    assert metrics["ESRetriever"]["mrr"] == 1.0
+    assert metrics["ESRetriever"]["map"] == 1.0
+    assert metrics["ESRetriever"]["recall_multi_hit"] == 1.0
+    assert metrics["ESRetriever"]["recall_single_hit"] == 1.0
+    assert metrics["ESRetriever"]["precision"] == 0.2
+    assert metrics["ESRetriever"]["ndcg"] == 1.0
+
+
+@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+def test_multi_retriever_pipeline_with_asymmetric_qa_eval(document_store_with_docs, reader):
+    es_retriever = BM25Retriever(document_store=document_store_with_docs)
+    dpr_retriever = DensePassageRetriever(document_store_with_docs)
+    document_store_with_docs.update_embeddings(retriever=dpr_retriever)
+
+    # QA Pipeline with two retrievers, we only get QA output from dpr
+    pipeline = Pipeline()
+    pipeline.add_node(component=TransformersQueryClassifier(), name="QueryClassifier", inputs=["Query"])
+    pipeline.add_node(component=dpr_retriever, name="DPRRetriever", inputs=["QueryClassifier.output_1"])
+    pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["QueryClassifier.output_2"])
+    pipeline.add_node(component=reader, name="QAReader", inputs=["DPRRetriever"])
+
+    # EVAL_QUERIES: 2 go dpr way
+    # in Berlin goes es way
+    labels = EVAL_LABELS + [
+        MultiLabel(
+            labels=[
+                Label(
+                    query="in Berlin",
+                    answer=None,
+                    document=Document(
+                        id="a0747b83aea0b60c4b114b15476dd32d",
+                        content_type="text",
+                        content="My name is Carla and I live in Berlin",
+                    ),
+                    is_correct_answer=True,
+                    is_correct_document=True,
+                    origin="gold-label",
+                )
+            ]
+        )
+    ]
+
+    eval_result: EvaluationResult = pipeline.eval_batch(
+        labels=labels, params={"ESRetriever": {"top_k": 5}, "DPRRetriever": {"top_k": 5}}
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "ESRetriever" in eval_result
+    assert "DPRRetriever" in eval_result
+    assert "DPRRetriever" in eval_result
+    assert "QAReader" in eval_result
+    assert len(eval_result) == 3
+
+    assert metrics["DPRRetriever"]["mrr"] == 0.5
+    assert metrics["DPRRetriever"]["map"] == 0.5
+    assert metrics["DPRRetriever"]["recall_multi_hit"] == 0.5
+    assert metrics["DPRRetriever"]["recall_single_hit"] == 0.5
+    assert metrics["DPRRetriever"]["precision"] == 0.1
+    assert metrics["DPRRetriever"]["ndcg"] == 0.5
+
+    assert metrics["ESRetriever"]["mrr"] == 1.0
+    assert metrics["ESRetriever"]["map"] == 1.0
+    assert metrics["ESRetriever"]["recall_multi_hit"] == 1.0
+    assert metrics["ESRetriever"]["recall_single_hit"] == 1.0
+    assert metrics["ESRetriever"]["precision"] == 0.2
+    assert metrics["ESRetriever"]["ndcg"] == 1.0
+
+    assert metrics["QAReader"]["exact_match"] == 1.0
+    assert metrics["QAReader"]["f1"] == 1.0


### PR DESCRIPTION
**Related Issue(s)**: 
closes #2636 

**Proposed changes**:
- add a `pipeline.eval_batch` method
- add a `_build_eval_dataframe_from_batches` method that calls `_build_eval_dataframe` internally
  - I went for this solution to keep code duplication to a minimum. `_build_eval_dataframe` is very complex already (the method comprises >300 lines of code and would need some refactoring to be simplified)

**Limitations**:
- Should standard_pipelines.eval and .eval_batch have a documents parameter that they pass on?

- `run_batch` does not support different filters (or more generally speaking any different params per query) and thus `eval_batch` cannot support filters that differ per query and its label. Thus, labels must not have filters, for example test case `test_extractive_qa_labels_with_filters` won’t work with eval_batch


There is a bug that causes queries in batch processing to contain:
`'queries': [({'query': 'Who Lives in Berlin?'}, 'output_1'), ({'query': 'Who Lives in Munich?'}, 'output_1')]`
instead of being just of type `List[str]`.


For testing I used the following but we'll need to fix the bug before continuing with this PR.
```
def _calc_scores(self, queries: Union[str, List[str]]) -> List[Dict[int, float]]:
    if isinstance(queries, str):
        queries = [queries]
    if isinstance(queries[0], tuple):
        queries = [query[0]["query"] for query in queries]
```

## Pre-flight checklist
- [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
