### PR TITLE
Ability to run Ray Serve detached

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -884,13 +884,14 @@ YAML definitions of Ray pipelines are validated at load. For more information, s
 #### RayPipeline.\_\_init\_\_
 
 ```python
-def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None)
+def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: Optional[bool] = False)
 ```
 
 **Arguments**:
 
 - `address`: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
 - `kwargs`: Optional parameters for initializing Ray.
+- `serve_detached`: Optional parameters for initializing Ray Serve with the `detached` option.
 
 <a id="ray.RayPipeline.load_from_yaml"></a>
 
@@ -898,7 +899,7 @@ def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None)
 
 ```python
 @classmethod
-def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True, address: Optional[str] = None, strict_version_check: bool = False, ray_args: Optional[Dict[str, Any]] = None)
+def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True, address: Optional[str] = None, strict_version_check: bool = False, ray_args: Optional[Dict[str, Any]] = None, serve_detached: Optional[bool] = False)
 ```
 
 Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -951,6 +952,7 @@ to change index name param for an ElasticsearchDocumentStore, an env
 variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
 `_` sign must be used to specify nested hierarchical properties.
 - `address`: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
+- `serve_detached`: Optional parameters for initializing Ray Serve with the `detached` option.
 
 <a id="ray._RayDeploymentWrapper"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -891,7 +891,7 @@ def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, ser
 
 - `address`: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
 - `kwargs`: Optional parameters for initializing Ray.
-- `serve_detached`: Optional parameters for initializing Ray Serve with the `detached` option.
+- `serve_detached`: Optional parameter for initializing Ray Serve with the `detached` option.
 
 <a id="ray.RayPipeline.load_from_yaml"></a>
 
@@ -952,7 +952,7 @@ to change index name param for an ElasticsearchDocumentStore, an env
 variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
 `_` sign must be used to specify nested hierarchical properties.
 - `address`: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
-- `serve_detached`: Optional parameters for initializing Ray Serve with the `detached` option.
+- `serve_detached`: Optional parameter for initializing Ray Serve with the `detached` option.
 
 <a id="ray._RayDeploymentWrapper"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -884,14 +884,14 @@ YAML definitions of Ray pipelines are validated at load. For more information, s
 #### RayPipeline.\_\_init\_\_
 
 ```python
-def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: Optional[bool] = False)
+def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: bool = False)
 ```
 
 **Arguments**:
 
 - `address`: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
 - `kwargs`: Optional parameters for initializing Ray.
-- `serve_detached`: Optional parameter for initializing Ray Serve with the `detached` option.
+- `serve_detached`: Whether or not to initialize Ray Serve with the "detached" option.
 
 <a id="ray.RayPipeline.load_from_yaml"></a>
 
@@ -899,7 +899,7 @@ def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, ser
 
 ```python
 @classmethod
-def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True, address: Optional[str] = None, strict_version_check: bool = False, ray_args: Optional[Dict[str, Any]] = None, serve_detached: Optional[bool] = False)
+def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True, address: Optional[str] = None, strict_version_check: bool = False, ray_args: Optional[Dict[str, Any]] = None, serve_detached: bool = False)
 ```
 
 Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -952,7 +952,7 @@ to change index name param for an ElasticsearchDocumentStore, an env
 variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
 `_` sign must be used to specify nested hierarchical properties.
 - `address`: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
-- `serve_detached`: Optional parameter for initializing Ray Serve with the `detached` option.
+- `serve_detached`: Whether or not to initialize Ray Serve with the "detached" option.
 
 <a id="ray._RayDeploymentWrapper"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -884,14 +884,14 @@ YAML definitions of Ray pipelines are validated at load. For more information, s
 #### RayPipeline.\_\_init\_\_
 
 ```python
-def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: bool = False)
+def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_args: Optional[Dict[str, Any]] = None)
 ```
 
 **Arguments**:
 
 - `address`: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
 - `kwargs`: Optional parameters for initializing Ray.
-- `serve_detached`: Whether or not to initialize Ray Serve with the "detached" option.
+- `serve_args`: Optional parameters for initializing Ray Serve.
 
 <a id="ray.RayPipeline.load_from_yaml"></a>
 
@@ -899,7 +899,7 @@ def __init__(address: str = None, ray_args: Optional[Dict[str, Any]] = None, ser
 
 ```python
 @classmethod
-def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True, address: Optional[str] = None, strict_version_check: bool = False, ray_args: Optional[Dict[str, Any]] = None, serve_detached: bool = False)
+def load_from_yaml(cls, path: Path, pipeline_name: Optional[str] = None, overwrite_with_env_variables: bool = True, address: Optional[str] = None, strict_version_check: bool = False, ray_args: Optional[Dict[str, Any]] = None, serve_args: Optional[Dict[str, Any]] = None)
 ```
 
 Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -952,7 +952,7 @@ to change index name param for an ElasticsearchDocumentStore, an env
 variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
 `_` sign must be used to specify nested hierarchical properties.
 - `address`: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
-- `serve_detached`: Whether or not to initialize Ray Serve with the "detached" option.
+- `serve_args`: Optional parameters for initializing Ray Serve.
 
 <a id="ray._RayDeploymentWrapper"></a>
 

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -67,7 +67,7 @@ class RayPipeline(Pipeline):
         """
         :param address: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
         :param kwargs: Optional parameters for initializing Ray.
-        :param serve_detached: Optional parameters for initializing Ray Serve with the `detached` option.
+        :param serve_detached: Optional parameter for initializing Ray Serve with the `detached` option.
         """
         ray_args = ray_args or {}
         ray.init(address=address, **ray_args)
@@ -175,7 +175,7 @@ class RayPipeline(Pipeline):
                                              variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
                                              `_` sign must be used to specify nested hierarchical properties.
         :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
-        :param serve_detached: Optional parameters for initializing Ray Serve with the `detached` option.
+        :param serve_detached: Optional parameter for initializing Ray Serve with the `detached` option.
         """
         pipeline_config = read_pipeline_config_from_yaml(path)
         return RayPipeline.load_from_config(

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -61,13 +61,11 @@ class RayPipeline(Pipeline):
     YAML definitions of Ray pipelines are validated at load. For more information, see [YAML File Definitions](https://haystack-website-git-fork-fstau-dev-287-search-deepset-overnice.vercel.app/components/pipelines#yaml-file-definitions).
     """
 
-    def __init__(
-        self, address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: Optional[bool] = False
-    ):
+    def __init__(self, address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: bool = False):
         """
         :param address: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
         :param kwargs: Optional parameters for initializing Ray.
-        :param serve_detached: Optional parameter for initializing Ray Serve with the `detached` option.
+        :param serve_detached: Whether or not to initialize Ray Serve with the "detached" option.
         """
         ray_args = ray_args or {}
         ray.init(address=address, **ray_args)
@@ -83,7 +81,7 @@ class RayPipeline(Pipeline):
         strict_version_check: bool = False,
         address: Optional[str] = None,
         ray_args: Optional[Dict[str, Any]] = None,
-        serve_detached: Optional[bool] = False,
+        serve_detached: bool = False,
     ):
         validate_config(pipeline_config, strict_version_check=strict_version_check)
 
@@ -125,7 +123,7 @@ class RayPipeline(Pipeline):
         address: Optional[str] = None,
         strict_version_check: bool = False,
         ray_args: Optional[Dict[str, Any]] = None,
-        serve_detached: Optional[bool] = False,
+        serve_detached: bool = False,
     ):
         """
         Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -175,7 +173,7 @@ class RayPipeline(Pipeline):
                                              variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
                                              `_` sign must be used to specify nested hierarchical properties.
         :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
-        :param serve_detached: Optional parameter for initializing Ray Serve with the `detached` option.
+        :param serve_detached: Whether or not to initialize Ray Serve with the "detached" option.
         """
         pipeline_config = read_pipeline_config_from_yaml(path)
         return RayPipeline.load_from_config(

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -74,7 +74,7 @@ class RayPipeline(Pipeline):
         """
         ray_args = ray_args or {}
         ray.init(address=address, **ray_args)
-        serve.start(**serve_args)
+        self._serve_controller_client = serve.start(**serve_args)
         super().__init__()
 
     @classmethod

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -61,15 +61,20 @@ class RayPipeline(Pipeline):
     YAML definitions of Ray pipelines are validated at load. For more information, see [YAML File Definitions](https://haystack-website-git-fork-fstau-dev-287-search-deepset-overnice.vercel.app/components/pipelines#yaml-file-definitions).
     """
 
-    def __init__(self, address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: bool = False):
+    def __init__(
+        self,
+        address: str = None,
+        ray_args: Optional[Dict[str, Any]] = None,
+        serve_args: Optional[Dict[str, Any]] = None,
+    ):
         """
         :param address: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
         :param kwargs: Optional parameters for initializing Ray.
-        :param serve_detached: Whether or not to initialize Ray Serve with the "detached" option.
+        :param serve_args: Optional parameters for initializing Ray Serve.
         """
         ray_args = ray_args or {}
         ray.init(address=address, **ray_args)
-        serve.start(detached=serve_detached)
+        serve.start(**serve_args)
         super().__init__()
 
     @classmethod
@@ -81,7 +86,7 @@ class RayPipeline(Pipeline):
         strict_version_check: bool = False,
         address: Optional[str] = None,
         ray_args: Optional[Dict[str, Any]] = None,
-        serve_detached: bool = False,
+        serve_args: Optional[Dict[str, Any]] = None,
     ):
         validate_config(pipeline_config, strict_version_check=strict_version_check)
 
@@ -89,7 +94,7 @@ class RayPipeline(Pipeline):
         component_definitions = get_component_definitions(
             pipeline_config=pipeline_config, overwrite_with_env_variables=overwrite_with_env_variables
         )
-        pipeline = cls(address=address, ray_args=ray_args or {}, serve_detached=serve_detached)
+        pipeline = cls(address=address, ray_args=ray_args or {}, serve_args=serve_args or {})
 
         for node_config in pipeline_definition["nodes"]:
             if pipeline.root_node is None:
@@ -123,7 +128,7 @@ class RayPipeline(Pipeline):
         address: Optional[str] = None,
         strict_version_check: bool = False,
         ray_args: Optional[Dict[str, Any]] = None,
-        serve_detached: bool = False,
+        serve_args: Optional[Dict[str, Any]] = None,
     ):
         """
         Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -173,7 +178,7 @@ class RayPipeline(Pipeline):
                                              variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
                                              `_` sign must be used to specify nested hierarchical properties.
         :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
-        :param serve_detached: Whether or not to initialize Ray Serve with the "detached" option.
+        :param serve_args: Optional parameters for initializing Ray Serve.
         """
         pipeline_config = read_pipeline_config_from_yaml(path)
         return RayPipeline.load_from_config(
@@ -183,7 +188,7 @@ class RayPipeline(Pipeline):
             strict_version_check=strict_version_check,
             address=address,
             ray_args=ray_args,
-            serve_detached=serve_detached,
+            serve_args=serve_args,
         )
 
     @classmethod

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -61,14 +61,17 @@ class RayPipeline(Pipeline):
     YAML definitions of Ray pipelines are validated at load. For more information, see [YAML File Definitions](https://haystack-website-git-fork-fstau-dev-287-search-deepset-overnice.vercel.app/components/pipelines#yaml-file-definitions).
     """
 
-    def __init__(self, address: str = None, ray_args: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self, address: str = None, ray_args: Optional[Dict[str, Any]] = None, serve_detached: Optional[bool] = False
+    ):
         """
         :param address: The IP address for the Ray cluster. If set to `None`, a local Ray instance is started.
         :param kwargs: Optional parameters for initializing Ray.
+        :param serve_detached: Optional parameters for initializing Ray Serve with the `detached` option.
         """
         ray_args = ray_args or {}
         ray.init(address=address, **ray_args)
-        serve.start()
+        serve.start(detached=serve_detached)
         super().__init__()
 
     @classmethod
@@ -80,6 +83,7 @@ class RayPipeline(Pipeline):
         strict_version_check: bool = False,
         address: Optional[str] = None,
         ray_args: Optional[Dict[str, Any]] = None,
+        serve_detached: Optional[bool] = False,
     ):
         validate_config(pipeline_config, strict_version_check=strict_version_check)
 
@@ -87,7 +91,7 @@ class RayPipeline(Pipeline):
         component_definitions = get_component_definitions(
             pipeline_config=pipeline_config, overwrite_with_env_variables=overwrite_with_env_variables
         )
-        pipeline = cls(address=address, ray_args=ray_args or {})
+        pipeline = cls(address=address, ray_args=ray_args or {}, serve_detached=serve_detached)
 
         for node_config in pipeline_definition["nodes"]:
             if pipeline.root_node is None:
@@ -121,6 +125,7 @@ class RayPipeline(Pipeline):
         address: Optional[str] = None,
         strict_version_check: bool = False,
         ray_args: Optional[Dict[str, Any]] = None,
+        serve_detached: Optional[bool] = False,
     ):
         """
         Load Pipeline from a YAML file defining the individual components and how they're tied together to form
@@ -170,6 +175,7 @@ class RayPipeline(Pipeline):
                                              variable 'MYDOCSTORE_PARAMS_INDEX=documents-2021' can be set. Note that an
                                              `_` sign must be used to specify nested hierarchical properties.
         :param address: The IP address for the Ray cluster. If set to None, a local Ray instance is started.
+        :param serve_detached: Optional parameters for initializing Ray Serve with the `detached` option.
         """
         pipeline_config = read_pipeline_config_from_yaml(path)
         return RayPipeline.load_from_config(
@@ -179,6 +185,7 @@ class RayPipeline(Pipeline):
             strict_version_check=strict_version_check,
             address=address,
             ray_args=ray_args,
+            serve_detached=serve_detached,
         )
 
     @classmethod

--- a/test/pipelines/test_ray.py
+++ b/test/pipelines/test_ray.py
@@ -28,7 +28,7 @@ def test_load_pipeline(document_store_with_docs, serve_detached):
         SAMPLES_PATH / "pipeline" / "ray.haystack-pipeline.yml",
         pipeline_name="ray_query_pipeline",
         ray_args={"num_cpus": 8},
-        serve_detached=serve_detached,
+        serve_args={"detached": serve_detached},
     )
     prediction = pipeline.run(query="Who lives in Berlin?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}})
 

--- a/test/pipelines/test_ray.py
+++ b/test/pipelines/test_ray.py
@@ -14,6 +14,7 @@ def shutdown_ray():
     try:
         import ray
 
+        ray.serve.shutdown()
         ray.shutdown()
     except:
         pass
@@ -21,11 +22,13 @@ def shutdown_ray():
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_load_pipeline(document_store_with_docs):
+@pytest.mark.parametrize("serve_detached", [(True,), (False,)])
+def test_load_pipeline(document_store_with_docs, serve_detached):
     pipeline = RayPipeline.load_from_yaml(
         SAMPLES_PATH / "pipeline" / "ray.haystack-pipeline.yml",
         pipeline_name="ray_query_pipeline",
         ray_args={"num_cpus": 8},
+        serve_detached=serve_detached,
     )
     prediction = pipeline.run(query="Who lives in Berlin?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}})
 

--- a/test/pipelines/test_ray.py
+++ b/test/pipelines/test_ray.py
@@ -28,7 +28,7 @@ def test_load_pipeline(document_store_with_docs, serve_detached):
         SAMPLES_PATH / "pipeline" / "ray.haystack-pipeline.yml",
         pipeline_name="ray_query_pipeline",
         ray_args={"num_cpus": 8},
-        serve_detached=serve_detached,
+        serve_detached=serve_detached
     )
     prediction = pipeline.run(query="Who lives in Berlin?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}})
 

--- a/test/pipelines/test_ray.py
+++ b/test/pipelines/test_ray.py
@@ -28,7 +28,7 @@ def test_load_pipeline(document_store_with_docs, serve_detached):
         SAMPLES_PATH / "pipeline" / "ray.haystack-pipeline.yml",
         pipeline_name="ray_query_pipeline",
         ray_args={"num_cpus": 8},
-        serve_detached=serve_detached
+        serve_detached=serve_detached,
     )
     prediction = pipeline.run(query="Who lives in Berlin?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}})
 

--- a/test/pipelines/test_ray.py
+++ b/test/pipelines/test_ray.py
@@ -22,7 +22,7 @@ def shutdown_ray():
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-@pytest.mark.parametrize("serve_detached", [(True,), (False,)])
+@pytest.mark.parametrize("serve_detached", [True, False])
 def test_load_pipeline(document_store_with_docs, serve_detached):
     pipeline = RayPipeline.load_from_yaml(
         SAMPLES_PATH / "pipeline" / "ray.haystack-pipeline.yml",
@@ -32,6 +32,7 @@ def test_load_pipeline(document_store_with_docs, serve_detached):
     )
     prediction = pipeline.run(query="Who lives in Berlin?", params={"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}})
 
+    assert pipeline._serve_controller_client._detached == serve_detached
     assert ray.serve.get_deployment(name="ESRetriever").num_replicas == 2
     assert ray.serve.get_deployment(name="Reader").num_replicas == 1
     assert prediction["query"] == "Who lives in Berlin?"


### PR DESCRIPTION
Fixes #2944

Ability to run Ray Serve detached - to allow running multiple instances of the app (HA).

See https://docs.ray.io/en/latest/serve/package-ref.html#core-apis

**Related Issue(s)**:  #2944 

**Proposed changes**:
- Adding a new arg to the Ray Serve pipeline - allowing Ray Serve to run in `detached` mode, which also allows you to run multiple instances of the application all connecting to the same detached Ray Serve instance.
- This will allow running the Haystack application in HA mode (eg more than one instances) while using the same Ray Serve for model serving, by allowing the same Ray Serve instance being used by multiple instances of the same Haystack app.
- The original functionality (`detached` mode is off) has been kept

## Pre-flight checklist
- [ x ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [ x ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ x ] If this is a code change, I added tests or updated existing ones 
- [ x ] If this is a code change, I updated the docstrings
