### PR TITLE
Fix incorrect variable in Ranker

### DIFF
--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -213,7 +213,7 @@ class SentenceTransformersRanker(BaseRanker):
         logits_dim = similarity_scores.shape[1]  # [batch_size, logits_dim]
         if single_list_of_docs:
             sorted_scores_and_documents = sorted(
-                zip(similarity_scores, documents),
+                zip(preds, documents),
                 key=lambda similarity_document_tuple:
                 # assume the last element in logits represents the `has_answer` label
                 similarity_document_tuple[0][-1] if logits_dim >= 2 else similarity_document_tuple[0],


### PR DESCRIPTION
**Related Issue(s)**:  
In SentenceTransformersRanker, running 
```
ranker.predict(query, documents)
```

and 
```
ranker.predict_batch([query], documents)
```

gave completely different results.

At line 216, similarity_scores are used instead of preds, while similarity_scores are the logits of a single batch (and not of all documents which are being sorted in that part of code). 

**Proposed changes**:
- Replace similarity_scores with preds

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
