### PR TITLE
fix docker tag for cuda

### DIFF
--- a/Dockerfile-GPU
+++ b/Dockerfile-GPU
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1-runtime-ubuntu20.04
+FROM nvidia/cuda:11.1.1-runtime-ubuntu20.04
 
 WORKDIR /home/user
 


### PR DESCRIPTION
**Related Issue(s)**:  [failed build](https://github.com/deepset-ai/haystack/runs/7648211441?check_suite_focus=true)

The existing `nvidia/cuda:11.1-runtime-ubuntu20.04` isn't available anymore on Dockerhub and the build is failing. `1.11.1` was published 2 months ago, most likely the `11.1` was recently removed.

**Proposed changes**:
- Use `nvidia/cuda:11.1.1-runtime-ubuntu20.04` instead (this will also pick up the latest bugfix release)

## Pre-flight checklist
- [ ]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [ ] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
