### PR TITLE
Fix docs code format for sentence transformers

### DIFF
--- a/docs/_src/api/api/ranker.md
+++ b/docs/_src/api/api/ranker.md
@@ -80,12 +80,14 @@ https://www.sbert.net/docs/pretrained-models/ce-msmarco.html#usage-with-transfor
  - directly get predictions via predict()
 
 Usage example:
-...
-retriever = BM25Retriever(document_store=document_store)
-ranker = SentenceTransformersRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-12-v2")
-p = Pipeline()
-p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
-p.add_node(component=ranker, name="Ranker", inputs=["ESRetriever"])
+
+```python
+|     retriever = BM25Retriever(document_store=document_store)
+|     ranker = SentenceTransformersRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-12-v2")
+|     p = Pipeline()
+|     p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
+|     p.add_node(component=ranker, name="Ranker", inputs=["ESRetriever"])
+```
 
 <a id="sentence_transformers.SentenceTransformersRanker.__init__"></a>
 

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -28,12 +28,14 @@ class SentenceTransformersRanker(BaseRanker):
      - directly get predictions via predict()
 
     Usage example:
-    ...
-    retriever = BM25Retriever(document_store=document_store)
-    ranker = SentenceTransformersRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-12-v2")
-    p = Pipeline()
-    p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
-    p.add_node(component=ranker, name="Ranker", inputs=["ESRetriever"])
+
+    ```python
+    |     retriever = BM25Retriever(document_store=document_store)
+    |     ranker = SentenceTransformersRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-12-v2")
+    |     p = Pipeline()
+    |     p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
+    |     p.add_node(component=ranker, name="Ranker", inputs=["ESRetriever"])
+    ```
     """
 
     def __init__(


### PR DESCRIPTION
**Related Issue(s)**:  Fixes #2683 

**Proposed changes**:
- Add `python` code syntax to format it as the code snippet 

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [ ] If this is a code change, I added tests or updated existing ones 
- [ ] If this is a code change, I updated the docstrings
