### PR TITLE
Better check for "DebertaV2" architecture in Trainer.train

### DIFF
--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -252,7 +252,7 @@ class Trainer:
                 vocab_size2=len(self.data_silo.processor.passage_tokenizer),
             )
         elif (
-            self.model.language_model.name.lower() != "debertav2"
+            self.model.language_model.name != "DebertaV2"
         ):  # DebertaV2 has mismatched vocab size on purpose (see https://github.com/huggingface/transformers/issues/12428)
             self.model.verify_vocab_size(vocab_size=len(self.data_silo.processor.tokenizer))
         self.model.train()

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -252,7 +252,7 @@ class Trainer:
                 vocab_size2=len(self.data_silo.processor.passage_tokenizer),
             )
         elif (
-            self.model.language_model.name != "debertav2"
+            self.model.language_model.name.lower() != "debertav2"
         ):  # DebertaV2 has mismatched vocab size on purpose (see https://github.com/huggingface/transformers/issues/12428)
             self.model.verify_vocab_size(vocab_size=len(self.data_silo.processor.tokenizer))
         self.model.train()


### PR DESCRIPTION
**Related Issue(s)**:  None

**Proposed changes**:
- Using `.lower()` when running this check `self.model.language_model.name.lower() != "debertav2"` because the name can be capitalized (e.g. `DebertaV2`)

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
