### PR TITLE
Update Seq2SeqGenerator API documentation

### DIFF
--- a/docs/_src/api/api/generator.md
+++ b/docs/_src/api/api/generator.md
@@ -206,8 +206,8 @@ class Seq2SeqGenerator(BaseGenerator)
 A generic sequence-to-sequence generator based on HuggingFace's transformers.
 
 This generator supports all [Text2Text](https://huggingface.co/models?pipeline_tag=text2text-generation) models
-from the HuggingFace hub. If the primary interface for the model specified by `model_name_or_path` constructor
-parameter is AutoModelForSeq2SeqLM from HuggingFace, then you can use it in this generator.
+from the Hugging Face hub. If the primary interface for the model specified by `model_name_or_path` constructor
+parameter is AutoModelForSeq2SeqLM from Hugging Face, then you can use it in this Generator.
 
 Moreover, as language models prepare model input in their specific encoding, each model
 specified with model_name_or_path parameter in this Seq2SeqGenerator should have an
@@ -218,7 +218,9 @@ is either already registered or specified on a per-model basis in the Seq2SeqGen
 
 For mode details on custom model input converters refer to _BartEli5Converter
 
-For a list of all text-generation models see https://huggingface.co/models?pipeline_tag=text2text-generation
+For a list of all text2text-generation models, see
+the [Hugging Face Model Hub](https://huggingface.co/models?pipeline_tag=text2text-generation)
+
 
 **Example**
 

--- a/docs/_src/api/api/generator.md
+++ b/docs/_src/api/api/generator.md
@@ -205,9 +205,9 @@ class Seq2SeqGenerator(BaseGenerator)
 
 A generic sequence-to-sequence generator based on HuggingFace's transformers.
 
-Text generation is supported by so called auto-regressive language models like GPT2,
-XLNet, XLM, Bart, T5 and others. In fact, any HuggingFace language model that extends
-GenerationMixin can be used by Seq2SeqGenerator.
+This generator supports all [Text2Text](https://huggingface.co/models?pipeline_tag=text2text-generation) models
+from the HuggingFace hub. If the primary interface for the model specified by `model_name_or_path` constructor
+parameter is AutoModelForSeq2SeqLM from HuggingFace, then you can use it in this generator.
 
 Moreover, as language models prepare model input in their specific encoding, each model
 specified with model_name_or_path parameter in this Seq2SeqGenerator should have an
@@ -218,11 +218,7 @@ is either already registered or specified on a per-model basis in the Seq2SeqGen
 
 For mode details on custom model input converters refer to _BartEli5Converter
 
-
-See https://huggingface.co/transformers/main_classes/model.html?transformers.generation_utils.GenerationMixin#transformers.generation_utils.GenerationMixin
-as well as https://huggingface.co/blog/how-to-generate
-
-For a list of all text-generation models see https://huggingface.co/models?pipeline_tag=text-generation
+For a list of all text-generation models see https://huggingface.co/models?pipeline_tag=text2text-generation
 
 **Example**
 

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -269,8 +269,8 @@ class Seq2SeqGenerator(BaseGenerator):
     A generic sequence-to-sequence generator based on HuggingFace's transformers.
 
     This generator supports all [Text2Text](https://huggingface.co/models?pipeline_tag=text2text-generation) models
-    from the HuggingFace hub. If the primary interface for the model specified by `model_name_or_path` constructor
-    parameter is AutoModelForSeq2SeqLM from HuggingFace, then you can use it in this generator.
+    from the Hugging Face hub. If the primary interface for the model specified by `model_name_or_path` constructor
+    parameter is AutoModelForSeq2SeqLM from Hugging Face, then you can use it in this Generator.
 
     Moreover, as language models prepare model input in their specific encoding, each model
     specified with model_name_or_path parameter in this Seq2SeqGenerator should have an
@@ -281,7 +281,9 @@ class Seq2SeqGenerator(BaseGenerator):
 
     For mode details on custom model input converters refer to _BartEli5Converter
 
-    For a list of all text-generation models see https://huggingface.co/models?pipeline_tag=text2text-generation
+    For a list of all text2text-generation models, see
+    the [Hugging Face Model Hub](https://huggingface.co/models?pipeline_tag=text2text-generation)
+
 
     **Example**
 

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -268,9 +268,9 @@ class Seq2SeqGenerator(BaseGenerator):
     """
     A generic sequence-to-sequence generator based on HuggingFace's transformers.
 
-    Text generation is supported by so called auto-regressive language models like GPT2,
-    XLNet, XLM, Bart, T5 and others. In fact, any HuggingFace language model that extends
-    GenerationMixin can be used by Seq2SeqGenerator.
+    This generator supports all [Text2Text](https://huggingface.co/models?pipeline_tag=text2text-generation) models
+    from the HuggingFace hub. If the primary interface for the model specified by `model_name_or_path` constructor
+    parameter is AutoModelForSeq2SeqLM from HuggingFace, then you can use it in this generator.
 
     Moreover, as language models prepare model input in their specific encoding, each model
     specified with model_name_or_path parameter in this Seq2SeqGenerator should have an
@@ -281,11 +281,7 @@ class Seq2SeqGenerator(BaseGenerator):
 
     For mode details on custom model input converters refer to _BartEli5Converter
 
-
-    See https://huggingface.co/transformers/main_classes/model.html?transformers.generation_utils.GenerationMixin#transformers.generation_utils.GenerationMixin
-    as well as https://huggingface.co/blog/how-to-generate
-
-    For a list of all text-generation models see https://huggingface.co/models?pipeline_tag=text-generation
+    For a list of all text-generation models see https://huggingface.co/models?pipeline_tag=text2text-generation
 
     **Example**
 


### PR DESCRIPTION
**Related Issue(s)**:  #2939 

**Proposed changes**:
It fixes the documentation (it was wrong), clarifies which models can be used in Seq2SeqGenerator, and points the user to the HF hub where he/she can select models.
