### PR TITLE
Remove unused variable

### DIFF
--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -356,7 +356,7 @@ class Trainer:
         if self.early_stopping and self.early_stopping.save_dir:
             logger.info("Restoring best model so far from {}".format(self.early_stopping.save_dir))
             lm_name = self.model.language_model.name
-            self.model = AdaptiveModel.load(self.early_stopping.save_dir, self.device, lm_name=lm_name)
+            self.model = AdaptiveModel.load(self.early_stopping.save_dir, self.device)
             self.model.connect_heads_with_processor(self.data_silo.processor.tasks, require_labels=True)
 
         # Eval on test set


### PR DESCRIPTION
**Related Issue(s)**:  None

**Proposed changes**:
- Removed variable from function call because the variable can no longer be accepted. 

Code snippet for `AdaptiveModel.load` does not take `lm_name`
https://github.com/deepset-ai/haystack/blob/762a12fcb163f80a302c544f791f44d06efbe468/haystack/modeling/model/adaptive_model.py#L260-L266

## Pre-flight checklist
- [x]  I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md)
- [x] I have [enabled actions on my fork](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#forks)
- [x] If this is a code change, I added tests or updated existing ones 
- [x] If this is a code change, I updated the docstrings
