### PR TITLE
Add enhanced pydoc-markdown pre-hook

### DIFF
--- a/.github/utils/pydoc-markdown.py
+++ b/.github/utils/pydoc-markdown.py
@@ -1,0 +1,56 @@
+import argparse
+import sys
+import os
+import glob
+import pathlib
+import subprocess
+from typing import Sequence
+
+import yaml
+
+
+def load_search_paths():
+    """
+    Load the search path for each pydoc configuration file and return
+    a map {search_path -> config_file}
+    """
+    paths = dict()
+    for fname in glob.glob("docs/_src/api/pydoc/*.yml"):
+        with open(fname) as f:
+            config = yaml.safe_load(f.read())
+            # we always have only one loader in Haystack
+            loader = config["loaders"][0]
+            # `search_path` is a list but we always have only one item in Haystack
+            search_path = loader["search_path"][0]
+            # we only need the relative path from the root, let's call `resolve` to
+            # get rid of the `../../` prefix
+            search_path = str(pathlib.Path(search_path).resolve())
+            # `resolve` will prepend a `/` to the path, remove it
+            paths[search_path[1:]] = fname
+    return paths
+
+
+def main(argv: Sequence[str] = sys.argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
+    args = parser.parse_args(argv)
+
+    search_paths = load_search_paths()
+
+    for filename in args.filenames:
+        search_path = str(pathlib.Path(filename).parent)
+        print("search_path", search_path)
+        if search_path not in search_paths:
+            continue
+
+        config_yml = os.path.abspath(pathlib.Path(search_paths[search_path]))
+        print("config_yml", config_yml)
+        res = subprocess.run(["pydoc-markdown", config_yml], cwd="docs/_src/api/api/")
+        if res.returncode != 0:
+            return res.returncode
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/utils/pydoc-markdown.py
+++ b/.github/utils/pydoc-markdown.py
@@ -38,13 +38,16 @@ def main(argv: Sequence[str] = sys.argv):
     search_paths = load_search_paths()
 
     for filename in args.filenames:
+        # for each file in the commit queue, check if its path belongs
+        # to any search path known to pydoc. If not, skip to the next one.
         search_path = str(pathlib.Path(filename).parent)
-        print("search_path", search_path)
         if search_path not in search_paths:
             continue
 
+        # if we get here, we need to build the docs: get the full path to the
+        # config file and shell out `pydoc-markdown` after changing the current
+        # working dir to the destination path.
         config_yml = os.path.abspath(pathlib.Path(search_paths[search_path]))
-        print("config_yml", config_yml)
         res = subprocess.run(["pydoc-markdown", config_yml], cwd="docs/_src/api/api/")
         if res.returncode != 0:
             return res.returncode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,10 @@ repos:
 - repo: local
   hooks:
     - id: pydoc-markdown
-      name: Update API documentation (slow)
-      entry: .github/utils/pydoc-markdown.sh
-      language: script
-      types: [bash]
-      pass_filenames: false
-      always_run: true
+      name: Update API documentation
+      entry: python .github/utils/pydoc-markdown.py
+      language: system
+      types: [python]
 
 
 # TODO we can make mypy and pylint run at this stage too, once their execution gets normalized


### PR DESCRIPTION
### Related Issues
- No issue, just the pre-commit hook was too slow

### Proposed Changes:
Instead of building all the docs at every commit to ensure docs were updated, this pre-hook script will only try to build the API docs corresponding to the files actually changed, and skip the build altogether if the changed files aren't relevant for a documentation change.

### How did you test it?
Just check out my branch, try changing a documented API and run `pre-commit` or try to actual make the commit.

### Notes for the reviewer
This check makes several assumptions:
- The source of truth about whether or not we should build docs is the `search_path` field inside the pydoc config files
- For each pydoc config file, there is always one and only one entry in the `search_path` array

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
