### PR TITLE
feat: Allow exact list matching with field in Elasticsearch filtering

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1044,6 +1044,7 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
         # Naive retrieval without BM25, only filtering
         if query is None:
             body = {"query": {"bool": {"must": {"match_all": {}}}}}  # type: Dict[str, Any]
+            body["size"] = "10000"  # Set to the ES default max_result_window
             if filters:
                 body["query"]["bool"]["filter"] = LogicalFilterClause.parse(filters).convert_to_elasticsearch()
 

--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -125,7 +125,8 @@ def test_elasticsearch_eq_filter():
         {"content": "some text", "id": "1", "keyword_field": ["x", "y", "z"], "number_field": [1, 2, 3, 4]},
         {"content": "some text", "id": "2", "keyword_field": ["x", "y", "w"], "number_field": [1, 2, 3]},
         {"content": "some text", "id": "3", "keyword_field": ["x", "z"], "number_field": [2, 4]},
-        {"content": "some text", "id": "4", "keyword_field": ["x", "y"], "number_field": [2, 3]},
+        {"content": "some text", "id": "4", "keyword_field": ["z", "x"], "number_field": [5, 6]},
+        {"content": "some text", "id": "5", "keyword_field": ["x", "y"], "number_field": [2, 3]},
     ]
 
     index = "test_elasticsearch_eq_filter"
@@ -134,9 +135,9 @@ def test_elasticsearch_eq_filter():
 
     filter = {"keyword_field": {"$eq": ["z", "x"]}}
     filtered_docs = document_store.get_all_documents(index=index, filters=filter)
-    assert len(filtered_docs) == 1
-    assert filtered_docs[0].meta["keyword_field"] == ["x", "z"]
-    assert filtered_docs[0].id == "3"
+    assert len(filtered_docs) == 2
+    for doc in filtered_docs:
+        assert set(doc.meta["keyword_field"]) == {"x", "z"}
 
     filter = {"number_field": {"$eq": [2, 3]}}
     filtered_docs = document_store.query(query=None, index=index, filters=filter)

--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -143,7 +143,7 @@ def test_elasticsearch_eq_filter():
     filtered_docs = document_store.query(query=None, index=index, filters=filter)
     assert len(filtered_docs) == 1
     assert filtered_docs[0].meta["number_field"] == [2, 3]
-    assert filtered_docs[0].id == "4"
+    assert filtered_docs[0].id == "5"
 
 
 def test_write_with_duplicate_doc_ids(document_store: BaseDocumentStore):

--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -119,6 +119,32 @@ def test_init_elastic_doc_store_with_index_recreation():
     assert len(labels) == 0
 
 
+@pytest.mark.elasticsearch
+def test_elasticsearch_eq_filter():
+    documents = [
+        {"content": "some text", "id": "1", "keyword_field": ["x", "y", "z"], "number_field": [1, 2, 3, 4]},
+        {"content": "some text", "id": "2", "keyword_field": ["x", "y", "w"], "number_field": [1, 2, 3]},
+        {"content": "some text", "id": "3", "keyword_field": ["x", "z"], "number_field": [2, 4]},
+        {"content": "some text", "id": "4", "keyword_field": ["x", "y"], "number_field": [2, 3]},
+    ]
+
+    index = "test_elasticsearch_eq_filter"
+    document_store = ElasticsearchDocumentStore(index=index, recreate_index=True)
+    document_store.write_documents(documents)
+
+    filter = {"keyword_field": {"$eq": ["z", "x"]}}
+    filtered_docs = document_store.get_all_documents(index=index, filters=filter)
+    assert len(filtered_docs) == 1
+    assert filtered_docs[0].meta["keyword_field"] == ["x", "z"]
+    assert filtered_docs[0].id == "3"
+
+    filter = {"number_field": {"$eq": [2, 3]}}
+    filtered_docs = document_store.query(query=None, index=index, filters=filter)
+    assert len(filtered_docs) == 1
+    assert filtered_docs[0].meta["number_field"] == [2, 3]
+    assert filtered_docs[0].id == "4"
+
+
 def test_write_with_duplicate_doc_ids(document_store: BaseDocumentStore):
     duplicate_documents = [
         Document(content="Doc1", id_hash_keys=["content"]),


### PR DESCRIPTION
Rewrite of https://github.com/deepset-ai/haystack/pull/2675#issuecomment-1195487118

### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/2672

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

> Will match a field that contains all values in the list, no more, no less. Order does not matter.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit test

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
