### PR TITLE
feat: warn users if they're calling `get_all_labels` on a document index and vice-versa (Elasticsearch & Opensearch only)

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -11,6 +11,7 @@ from string import Template
 import numpy as np
 from scipy.special import expit
 from tqdm.auto import tqdm
+from pydantic.error_wrappers import ValidationError
 
 try:
     from elasticsearch import Elasticsearch, RequestsHttpConnection, Connection, Urllib3HttpConnection
@@ -686,7 +687,12 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
         result = list(
             self._get_all_documents_in_index(index=index, filters=filters, batch_size=batch_size, headers=headers)
         )
-        labels = [Label.from_dict({**hit["_source"], "id": hit["_id"]}) for hit in result]
+        try:
+            labels = [Label.from_dict({**hit["_source"], "id": hit["_id"]}) for hit in result]
+        except ValidationError as e:
+            raise DocumentStoreError(
+                f"Failed to create labels from the content of index '{index}'. Are you sure this index contains labels?"
+            )
         return labels
 
     def _get_all_documents_in_index(
@@ -1280,45 +1286,49 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
         self, hit: dict, return_embedding: bool, adapt_score_for_embedding: bool = False, scale_score: bool = True
     ) -> Document:
         # We put all additional data of the doc into meta_data and return it in the API
-        meta_data = {
-            k: v
-            for k, v in hit["_source"].items()
-            if k not in (self.content_field, "content_type", self.embedding_field)
-        }
-        name = meta_data.pop(self.name_field, None)
-        if name:
-            meta_data["name"] = name
+        try:
+            meta_data = {
+                k: v
+                for k, v in hit["_source"].items()
+                if k not in (self.content_field, "content_type", self.embedding_field)
+            }
+            name = meta_data.pop(self.name_field, None)
+            if name:
+                meta_data["name"] = name
 
-        if "highlight" in hit:
-            meta_data["highlighted"] = hit["highlight"]
+            if "highlight" in hit:
+                meta_data["highlighted"] = hit["highlight"]
 
-        score = hit["_score"]
-        if score:
-            if adapt_score_for_embedding:
-                score = self._get_raw_similarity_score(score)
-
-            if scale_score:
+            score = hit["_score"]
+            if score:
                 if adapt_score_for_embedding:
-                    score = self.scale_to_unit_interval(score, self.similarity)
-                else:
-                    score = float(expit(np.asarray(score / 8)))  # scaling probability from TFIDF/BM25
+                    score = self._get_raw_similarity_score(score)
 
-        embedding = None
-        if return_embedding:
-            embedding_list = hit["_source"].get(self.embedding_field)
-            if embedding_list:
-                embedding = np.asarray(embedding_list, dtype=np.float32)
+                if scale_score:
+                    if adapt_score_for_embedding:
+                        score = self.scale_to_unit_interval(score, self.similarity)
+                    else:
+                        score = float(expit(np.asarray(score / 8)))  # scaling probability from TFIDF/BM25
 
-        doc_dict = {
-            "id": hit["_id"],
-            "content": hit["_source"].get(self.content_field),
-            "content_type": hit["_source"].get("content_type", None),
-            "meta": meta_data,
-            "score": score,
-            "embedding": embedding,
-        }
-        document = Document.from_dict(doc_dict)
+            embedding = None
+            if return_embedding:
+                embedding_list = hit["_source"].get(self.embedding_field)
+                if embedding_list:
+                    embedding = np.asarray(embedding_list, dtype=np.float32)
 
+            doc_dict = {
+                "id": hit["_id"],
+                "content": hit["_source"].get(self.content_field),
+                "content_type": hit["_source"].get("content_type", None),
+                "meta": meta_data,
+                "score": score,
+                "embedding": embedding,
+            }
+            document = Document.from_dict(doc_dict)
+        except (KeyError, ValidationError) as e:
+            raise DocumentStoreError(
+                f"Failed to create documents from the content of the document store. make sure the index you specified contains documents."
+            ) from e
         return document
 
     def _get_raw_similarity_score(self, score):

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -1327,7 +1327,7 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
             document = Document.from_dict(doc_dict)
         except (KeyError, ValidationError) as e:
             raise DocumentStoreError(
-                f"Failed to create documents from the content of the document store. make sure the index you specified contains documents."
+                f"Failed to create documents from the content of the document store. Make sure the index you specified contains documents."
             ) from e
         return document
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -587,7 +587,7 @@ class Label:
         )
 
     def __repr__(self):
-        return str(self.to_dict())
+        return f"<Label: {self.to_dict()}>"
 
     def __str__(self):
         return f"<Label: {self.to_dict()}>"
@@ -704,7 +704,7 @@ class MultiLabel:
         return cls.from_dict(data)
 
     def __repr__(self):
-        return str(self.to_dict())
+        return f"<MultiLabel: {self.to_dict()}>"
 
     def __str__(self):
         return f"<MultiLabel: {self.to_dict()}>"


### PR DESCRIPTION
### Related Issues
- related to #2989 (not sufficient to fix it, the bug affects all docstores).

### Proposed Changes:
- Add a warning into `ElasticsearchDocumentStore` in case of validation errors with the data extracted from the ES index.
- Includes a small change in the `str` method of `Label` and `MultiLabel` that was extremely useful in debugging. Can remove if it's too out-of-scope for the PR.

### How did you test it?
- The docstore behavior is unchanged and we usually don't test warnings. Tests will be added on request of the reviewer.

### Notes for the reviewer
N / A

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
