### PR TITLE
chore: add topic tags to auto generation of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,17 @@ changelog:
     - title: Pipeline
       labels:
         - topic:pipeline
+        - topic:DPR
+        - topic:reader
+        - topic:retriever
+        - topic:tableQA
+        - topic:file_converter
+        - topic:preprocessing
+        - topic:crawler
+        - topic:images
+        - topic:audio
+        - topic:eval
+        - topic:other_nodes
     - title: Models
       labels:
         - topic:models
@@ -21,6 +32,8 @@ changelog:
         - topic:weaviate
         - topic:pinecone
         - topic:sql
+        - topic:knowledge_graph
+        - topic:graphdb
     - title: REST API
       labels:
         - topic:api
@@ -32,7 +45,7 @@ changelog:
         - type:documentation
     - title: Tutorials
       labels:
-        - type:tutorial
+        - topic:tutorials
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
This PR adds several topic tags to the auto generation of release notes. Main change is that all node tags will automatically move the PR to the "Pipeline" section in the release notes. Further, the PR adds knowledge graph tags to the "DocumentStore" section and fixes type:tutorial -> topic:tutorials.

I close https://github.com/deepset-ai/haystack/pull/2768 in favor of this PR here as unrelated tests were failing due to changes in the PR requirements and merging master didn't really help. 