### PR TITLE
switch label variables in test_labels

### DIFF
--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -793,7 +793,7 @@ def test_labels(document_store: BaseDocumentStore):
     assert label2 in labels
 
     # delete filtered label2 by id
-    document_store.delete_labels(ids=[labels[1].id])
+    document_store.delete_labels(ids=[label2.id])
     labels = document_store.get_all_labels()
     assert label == labels[0]
     assert len(labels) == 1
@@ -804,7 +804,7 @@ def test_labels(document_store: BaseDocumentStore):
     assert len(labels) == 2
 
     # delete filtered label2 by query text
-    document_store.delete_labels(filters={"query": [labels[1].query]})
+    document_store.delete_labels(filters={"query": [label2.query]})
     labels = document_store.get_all_labels()
     assert label == labels[0]
     assert len(labels) == 1
@@ -815,7 +815,7 @@ def test_labels(document_store: BaseDocumentStore):
     assert len(labels) == 2
 
     # delete intersection of filters and ids, which is empty
-    document_store.delete_labels(ids=[labels[0].id], filters={"query": [labels[1].query]})
+    document_store.delete_labels(ids=[label.id], filters={"query": [label2.query]})
     labels = document_store.get_all_labels()
     assert len(labels) == 2
     assert label in labels


### PR DESCRIPTION
### Related Issues
- fixes #3010 

### Proposed Changes:
Use `labels` variable in `test_labels` relies on labels being returned from the doc store in a specific order.

### How did you test it?
Manual verification

### Notes for the reviewer
`test/document_stores/test_document_store.py`

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
