### PR TITLE
Testing order in `test_multilabel`

### DIFF
--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -889,7 +889,7 @@ def test_multilabel(document_store: BaseDocumentStore):
     document_store.write_labels(labels)
     # regular labels - not aggregated
     list_labels = document_store.get_all_labels()
-    assert list_labels == labels
+    assert set(list_labels) == set(labels)
     assert len(list_labels) == 5
 
     # Currently we don't enforce writing (missing) docs automatically when adding labels and there's no DB relationship between the two.


### PR DESCRIPTION
### Related Issues
- fixes #3010 but for `test_multilabels`

### Proposed Changes:
* In #3010 noted that order of returned labels should not be important but is tested; this is fixed by #3011 (we could merge these two PRs if preferred, but #3011 has already been approved hence this PR)
* After continuing tests, I found the same issue in `test_multilabel`:

```python
document_store.write_labels(labels)
# regular labels - not aggregated
list_labels = document_store.get_all_labels()
assert list_labels == labels
```

Tests for the order of `list_labels`, changing both to `set` objects fixes the issue:

```python
document_store.write_labels(labels)
# regular labels - not aggregated
list_labels = document_store.get_all_labels()
assert set(list_labels) == set(labels)
```

I've checked the remaining label tests and cannot see any further issues like this

### How did you test it?
Manual tests with #2749 

### Notes for the reviewer
`test/document_stores/test_document_store.py`

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
