### PR TITLE
bug: fix `UnboundLocalError` in `Pipeline.run_batch()` 

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -600,8 +600,8 @@ class Pipeline:
                 raise PipelineError("For indexing, only a single query can be provided.")
             if isinstance(labels, list):
                 raise PipelineError("For indexing, only one MultiLabel object can be provided as labels.")
+            flattened_documents: List[Document] = []
             if documents and isinstance(documents[0], list):
-                flattened_documents: List[Document] = []
                 for doc_list in documents:
                     assert isinstance(doc_list, list)
                     flattened_documents.extend(doc_list)


### PR DESCRIPTION
### Related Issues
- fixes #2985 

### Proposed Changes:
As explained in #2985, I simply moved `flattened_documents` definition

### How did you test it?
Manual test using the code proposed by @ZanSara in #2985.
Now `UnboundLocalError` is not raised anymore.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue