### PR TITLE
fix: move `azure-core` pin into the dev dependency list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,13 +68,6 @@ install_requires =
     quantulum3  # quantities extraction from text
     posthog # telemetry
     azure-ai-formrecognizer==3.2.0b2  # forms reader
-    # azure-core is a dependency of azure-ai-formrecognizer
-    # In order to stop malicious pip backtracking during pip install farm-haystack[all] documented in https://github.com/deepset-ai/haystack/issues/2280
-    # we have to resolve a dependency version conflict ourself.
-    # azure-core>=1.23 conflicts with pydoc-markdown's dependency on databind>=1.5.0 which itself requires typing-extensions<4.0.0
-    # azure-core>=1.23 needs typing-extensions>=4.0.1
-    # pip unfortunately backtracks into the databind direction ultimately getting lost.
-    azure-core<1.23
     # audio's espnet-model-zoo requires huggingface-hub version <0.8 while we need >=0.5 to be able to use create_repo in FARMReader
     huggingface-hub<0.8.0,>=0.5.0
 
@@ -209,6 +202,13 @@ dev =
     black[jupyter]==22.6.0
     # Documentation
     pydoc-markdown==4.5.1   # FIXME Unpin!
+    # azure-core is a dependency of azure-ai-formrecognizer
+    # In order to stop malicious pip backtracking during pip install farm-haystack[all] documented in https://github.com/deepset-ai/haystack/issues/2280
+    # we have to resolve a dependency version conflict ourself.
+    # azure-core>=1.23 conflicts with pydoc-markdown's dependency on databind>=1.5.0 which itself requires typing-extensions<4.0.0
+    # azure-core>=1.23 needs typing-extensions>=4.0.1
+    # pip unfortunately backtracks into the databind direction ultimately getting lost.
+    azure-core<1.23
     mkdocs
     jupytercontrib
     watchdog  #==1.0.2


### PR DESCRIPTION
### Related Issues
- fixes  #3012

### Proposed Changes:
- Move the `azure-core<1.23` pin from the core dependency list into `dev` with `pydoc-markdown`, to allow Bazel to properly freeze Haystack dependencies on non-development installations.

### How did you test it?
Manual testing by the affected contributor.

### Notes for the reviewer
Wait for @tanertopal to confirm the fix works for them.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- ~I documented my code~
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
