### PR TITLE
chore: fix typo in API docs

### DIFF
--- a/docs/_src/api/openapi/openapi-1.6.1rc0.json
+++ b/docs/_src/api/openapi/openapi-1.6.1rc0.json
@@ -316,7 +316,7 @@
                     "document"
                 ],
                 "summary": "Get Documents",
-                "description": "This endpoint allows you to retrieve documents contained in your document store.\nYou can filter the documents to delete by metadata (like the document's name),\nor provide an empty JSON object to clear the document store.\n\nExample of filters:\n`'{\"filters\": {{\"name\": [\"some\", \"more\"], \"category\": [\"only_one\"]}}'`\n\nTo get all documents you should provide an empty dict, like:\n`'{\"filters\": {}}'`",
+                "description": "This endpoint allows you to retrieve documents contained in your document store.\nYou can filter the documents to retrieve by metadata (like the document's name),\nor provide an empty JSON object to clear the document store.\n\nExample of filters:\n`'{\"filters\": {{\"name\": [\"some\", \"more\"], \"category\": [\"only_one\"]}}'`\n\nTo get all documents you should provide an empty dict, like:\n`'{\"filters\": {}}'`",
                 "operationId": "get_documents",
                 "requestBody": {
                     "content": {

--- a/docs/_src/api/openapi/openapi.json
+++ b/docs/_src/api/openapi/openapi.json
@@ -316,7 +316,7 @@
                     "document"
                 ],
                 "summary": "Get Documents",
-                "description": "This endpoint allows you to retrieve documents contained in your document store.\nYou can filter the documents to delete by metadata (like the document's name),\nor provide an empty JSON object to clear the document store.\n\nExample of filters:\n`'{\"filters\": {{\"name\": [\"some\", \"more\"], \"category\": [\"only_one\"]}}'`\n\nTo get all documents you should provide an empty dict, like:\n`'{\"filters\": {}}'`",
+                "description": "This endpoint allows you to retrieve documents contained in your document store.\nYou can filter the documents to retrieve by metadata (like the document's name),\nor provide an empty JSON object to clear the document store.\n\nExample of filters:\n`'{\"filters\": {{\"name\": [\"some\", \"more\"], \"category\": [\"only_one\"]}}'`\n\nTo get all documents you should provide an empty dict, like:\n`'{\"filters\": {}}'`",
                 "operationId": "get_documents",
                 "requestBody": {
                     "content": {

--- a/rest_api/controller/document.py
+++ b/rest_api/controller/document.py
@@ -24,7 +24,7 @@ document_store: BaseDocumentStore = get_pipelines().get("document_store", None)
 def get_documents(filters: FilterRequest):
     """
     This endpoint allows you to retrieve documents contained in your document store.
-    You can filter the documents to delete by metadata (like the document's name),
+    You can filter the documents to retrieve by metadata (like the document's name),
     or provide an empty JSON object to clear the document store.
 
     Example of filters:


### PR DESCRIPTION
### Notes for the reviewer
While checking the alignment of Haystack/DC REST APIs I came across what seems to be a tiny copy-paste error in the API documentation.
