### PR TITLE
feat: FAISS in OpenSearch: Support HNSW for dot product and l2

### DIFF
--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1535,8 +1535,8 @@ More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/ana
 - `synonym_type`: Synonym filter type can be passed.
 Synonym or Synonym_graph to handle synonyms, including multi-word synonyms correctly during the analysis process.
 More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-graph-tokenfilter.html
-- `knn_engine`: The engine to use for nearest neighbor search by OpenSearch's KNN plug-in. Values can be "nmslib" or "faiss". Defaults to "nmslib".
-See https://opensearch.org/docs/latest/search-plugins/knn/knn-index/ for more information.
+- `knn_engine`: The engine you want to use for the nearest neighbor search by OpenSearch's KNN plug-in. Possible values: "nmslib" or "faiss". Defaults to "nmslib".
+For more information, see [k-NN Index](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/).
 
 <a id="opensearch.OpenSearchDocumentStore.query_by_embedding"></a>
 

--- a/docs/_src/api/api/document_store.md
+++ b/docs/_src/api/api/document_store.md
@@ -1463,7 +1463,7 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore)
 #### OpenSearchDocumentStore.\_\_init\_\_
 
 ```python
-def __init__(scheme: str = "https", username: str = "admin", password: str = "admin", host: Union[str, List[str]] = "localhost", port: Union[int, List[int]] = 9200, api_key_id: Optional[str] = None, api_key: Optional[str] = None, aws4auth=None, index: str = "document", label_index: str = "label", search_fields: Union[str, list] = "content", content_field: str = "content", name_field: str = "name", embedding_field: str = "embedding", embedding_dim: int = 768, custom_mapping: Optional[dict] = None, excluded_meta_data: Optional[list] = None, analyzer: str = "standard", ca_certs: Optional[str] = None, verify_certs: bool = False, recreate_index: bool = False, create_index: bool = True, refresh_type: str = "wait_for", similarity: str = "dot_product", timeout: int = 30, return_embedding: bool = False, duplicate_documents: str = "overwrite", index_type: str = "flat", scroll: str = "1d", skip_missing_embeddings: bool = True, synonyms: Optional[List] = None, synonym_type: str = "synonym", use_system_proxy: bool = False)
+def __init__(scheme: str = "https", username: str = "admin", password: str = "admin", host: Union[str, List[str]] = "localhost", port: Union[int, List[int]] = 9200, api_key_id: Optional[str] = None, api_key: Optional[str] = None, aws4auth=None, index: str = "document", label_index: str = "label", search_fields: Union[str, list] = "content", content_field: str = "content", name_field: str = "name", embedding_field: str = "embedding", embedding_dim: int = 768, custom_mapping: Optional[dict] = None, excluded_meta_data: Optional[list] = None, analyzer: str = "standard", ca_certs: Optional[str] = None, verify_certs: bool = False, recreate_index: bool = False, create_index: bool = True, refresh_type: str = "wait_for", similarity: str = "dot_product", timeout: int = 30, return_embedding: bool = False, duplicate_documents: str = "overwrite", index_type: str = "flat", scroll: str = "1d", skip_missing_embeddings: bool = True, synonyms: Optional[List] = None, synonym_type: str = "synonym", use_system_proxy: bool = False, knn_engine: str = "nmslib")
 ```
 
 Document Store using OpenSearch (https://opensearch.org/). It is compatible with the AWS Elasticsearch Service.
@@ -1535,6 +1535,8 @@ More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/ana
 - `synonym_type`: Synonym filter type can be passed.
 Synonym or Synonym_graph to handle synonyms, including multi-word synonyms correctly during the analysis process.
 More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-graph-tokenfilter.html
+- `knn_engine`: The engine to use for nearest neighbor search by OpenSearch's KNN plug-in. Values can be "nmslib" or "faiss". Defaults to "nmslib".
+See https://opensearch.org/docs/latest/search-plugins/knn/knn-index/ for more information.
 
 <a id="opensearch.OpenSearchDocumentStore.query_by_embedding"></a>
 

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -61,6 +61,7 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
         synonyms: Optional[List] = None,
         synonym_type: str = "synonym",
         use_system_proxy: bool = False,
+        knn_engine: str = "nmslib",
     ):
         """
         Document Store using OpenSearch (https://opensearch.org/). It is compatible with the AWS Elasticsearch Service.
@@ -130,6 +131,8 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
         :param synonym_type: Synonym filter type can be passed.
                              Synonym or Synonym_graph to handle synonyms, including multi-word synonyms correctly during the analysis process.
                              More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-graph-tokenfilter.html
+        :param knn_engine: The engine to use for nearest neighbor search by OpenSearch's KNN plug-in. Values can be "nmslib" or "faiss". Defaults to "nmslib".
+                        See https://opensearch.org/docs/latest/search-plugins/knn/knn-index/ for more information.
         """
         # These parameters aren't used by Opensearch at the moment but could be in the future, see
         # https://github.com/opensearch-project/security/issues/1504. Let's not deprecate them for
@@ -165,6 +168,13 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
                 f"Make sure an Opensearch instance is running at `{host}` and that it has finished booting (can take > 30s)."
             )
 
+        if knn_engine not in {"nmslib", "faiss"}:
+            raise ValueError(f"knn_engine must be either 'nmslib' or 'faiss' but was {knn_engine}")
+
+        if knn_engine == "faiss" and similarity not in ["dot_product", "l2"]:
+            raise ValueError(f"Currently only similarities 'dot_product' and 'l2' are supported for knn_engine='faiss' but was {similarity}")
+
+        self.knn_engine = knn_engine
         self.embeddings_field_supports_similarity = False
         self.similarity_to_space_type = {"cosine": "cosinesimil", "dot_product": "innerproduct", "l2": "l2"}
         self.space_type_to_similarity = {v: k for k, v in self.similarity_to_space_type.items()}
@@ -509,7 +519,7 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
 
     def _get_embedding_field_mapping(self, similarity: str):
         space_type = self.similarity_to_space_type[similarity]
-        method: dict = {"space_type": space_type, "name": "hnsw", "engine": "nmslib"}
+        method: dict = {"space_type": space_type, "name": "hnsw", "engine": self.knn_engine}
 
         if self.index_type == "flat":
             # use default parameters from https://opensearch.org/docs/1.2/search-plugins/knn/knn-index/

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -172,7 +172,9 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
             raise ValueError(f"knn_engine must be either 'nmslib' or 'faiss' but was {knn_engine}")
 
         if knn_engine == "faiss" and similarity not in ["dot_product", "l2"]:
-            raise ValueError(f"Currently only similarities 'dot_product' and 'l2' are supported for knn_engine='faiss' but was {similarity}")
+            raise ValueError(
+                f"Currently only similarities 'dot_product' and 'l2' are supported for knn_engine='faiss' but was {similarity}"
+            )
 
         self.knn_engine = knn_engine
         self.embeddings_field_supports_similarity = False

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -131,8 +131,8 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
         :param synonym_type: Synonym filter type can be passed.
                              Synonym or Synonym_graph to handle synonyms, including multi-word synonyms correctly during the analysis process.
                              More info at https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-graph-tokenfilter.html
-        :param knn_engine: The engine to use for nearest neighbor search by OpenSearch's KNN plug-in. Values can be "nmslib" or "faiss". Defaults to "nmslib".
-                        See https://opensearch.org/docs/latest/search-plugins/knn/knn-index/ for more information.
+        :param knn_engine: The engine you want to use for the nearest neighbor search by OpenSearch's KNN plug-in. Possible values: "nmslib" or "faiss". Defaults to "nmslib".
+                        For more information, see [k-NN Index](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/).
         """
         # These parameters aren't used by Opensearch at the moment but could be in the future, see
         # https://github.com/opensearch-project/security/issues/1504. Let's not deprecate them for
@@ -173,7 +173,7 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
 
         if knn_engine == "faiss" and similarity not in {"dot_product", "l2"}:
             raise ValueError(
-                f"Currently only 'dot_product' and 'l2' similarities are supported for knn_engine='faiss' but was {similarity}"
+                f"knn_engine=`faiss` was set to similarity {similarity}. Currently, we only support 'dot_product' and 'l2' similarities. Set the similarity to one of the supported values."
             )
 
         self.knn_engine = knn_engine

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -171,9 +171,9 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
         if knn_engine not in {"nmslib", "faiss"}:
             raise ValueError(f"knn_engine must be either 'nmslib' or 'faiss' but was {knn_engine}")
 
-        if knn_engine == "faiss" and similarity not in ["dot_product", "l2"]:
+        if knn_engine == "faiss" and similarity not in {"dot_product", "l2"}:
             raise ValueError(
-                f"Currently only similarities 'dot_product' and 'l2' are supported for knn_engine='faiss' but was {similarity}"
+                f"Currently only 'dot_product' and 'l2' similarities are supported for knn_engine='faiss' but was {similarity}"
             )
 
         self.knn_engine = knn_engine

--- a/haystack/json-schemas/haystack-pipeline-master.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-master.schema.json
@@ -1474,6 +1474,11 @@
               "title": "Use System Proxy",
               "default": false,
               "type": "boolean"
+            },
+            "knn_engine": {
+              "title": "Knn Engine",
+              "default": "nmslib",
+              "type": "string"
             }
           },
           "additionalProperties": false,

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -166,6 +166,10 @@ class TestOpenSearchDocumentStore:
         OpenSearchDocumentStore(index="default_index", port=9201, create_index=True)
 
     @pytest.mark.integration
+    def test___init___faiss(self):
+        OpenSearchDocumentStore(index="faiss_index", port=9201, create_index=True, knn_engine="faiss")
+
+    @pytest.mark.integration
     def test_write_documents(self, ds, documents):
         ds.write_documents(documents)
         docs = ds.get_all_documents()
@@ -599,6 +603,35 @@ class TestOpenSearchDocumentStore:
         }
 
     @pytest.mark.unit
+    def test__create_document_index_no_index_no_mapping_faiss(self, mocked_document_store):
+        mocked_document_store.client.indices.exists.return_value = False
+        mocked_document_store.knn_engine = "faiss"
+        mocked_document_store._create_document_index(self.index_name)
+        _, kwargs = mocked_document_store.client.indices.create.call_args
+        assert kwargs["body"] == {
+            "mappings": {
+                "dynamic_templates": [
+                    {"strings": {"mapping": {"type": "keyword"}, "match_mapping_type": "string", "path_match": "*"}}
+                ],
+                "properties": {
+                    "content": {"type": "text"},
+                    "embedding": {
+                        "dimension": 768,
+                        "method": {
+                            "engine": "faiss",
+                            "name": "hnsw",
+                            "parameters": {"ef_construction": 512, "m": 16},
+                            "space_type": "innerproduct",
+                        },
+                        "type": "knn_vector",
+                    },
+                    "name": {"type": "keyword"},
+                },
+            },
+            "settings": {"analysis": {"analyzer": {"default": {"type": "standard"}}}, "index": {"knn": True}},
+        }
+
+    @pytest.mark.unit
     def test__create_document_index_client_failure(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = False
         mocked_document_store.client.indices.create.side_effect = RequestError
@@ -632,6 +665,22 @@ class TestOpenSearchDocumentStore:
                 "space_type": "innerproduct",
                 "name": "hnsw",
                 "engine": "nmslib",
+                "parameters": {"ef_construction": 80, "m": 64},
+            },
+        }
+
+    @pytest.mark.unit
+    def test__get_embedding_field_mapping_hnsw_faiss(self, mocked_document_store):
+        mocked_document_store.index_type = "hnsw"
+        mocked_document_store.knn_engine = "faiss"
+
+        assert mocked_document_store._get_embedding_field_mapping("dot_product") == {
+            "type": "knn_vector",
+            "dimension": 768,
+            "method": {
+                "space_type": "innerproduct",
+                "name": "hnsw",
+                "engine": "faiss",
                 "parameters": {"ef_construction": 80, "m": 64},
             },
         }

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -681,7 +681,7 @@ class TestOpenSearchDocumentStore:
                 "space_type": "innerproduct",
                 "name": "hnsw",
                 "engine": "faiss",
-                "parameters": {"ef_construction": 80, "m": 64},
+                "parameters": {"ef_construction": 80, "m": 64, "ef_search": 20},
             },
         }
 


### PR DESCRIPTION
### Related Issues
- solves https://github.com/deepset-ai/haystack/issues/2911

### Proposed Changes:
- [x] add param `knn_engine` with default "nmslib" to constructor
- [x] set index mappings: use the same hnsw params as for nmslib
- [x] throw on other similarity types

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
