### PR TITLE
Fix `embeddings_field_supports_similarity` of `OpenSearchDocumentStore` when creating index

### DIFF
--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 
 from unittest.mock import MagicMock
@@ -494,6 +493,7 @@ class TestOpenSearchDocumentStore:
         mocked_document_store._create_document_index(self.index_name)
         _, kwargs = mocked_document_store.client.indices.create.call_args
         assert kwargs["body"] == {"mappings": {"properties": {"a_number": {"type": "integer"}}}}
+        assert mocked_document_store.embeddings_field_supports_similarity is True
 
     @pytest.mark.unit
     def test__create_document_index_no_index_no_mapping(self, mocked_document_store):
@@ -522,6 +522,7 @@ class TestOpenSearchDocumentStore:
             },
             "settings": {"analysis": {"analyzer": {"default": {"type": "standard"}}}, "index": {"knn": True}},
         }
+        assert mocked_document_store.embeddings_field_supports_similarity is True
 
     @pytest.mark.unit
     def test__create_document_index_no_index_no_mapping_with_synonyms(self, mocked_document_store):
@@ -563,6 +564,7 @@ class TestOpenSearchDocumentStore:
                 "index": {"knn": True},
             },
         }
+        assert mocked_document_store.embeddings_field_supports_similarity is True
 
     @pytest.mark.unit
     def test__create_document_index_no_index_no_mapping_with_embedding_field(self, mocked_document_store):
@@ -597,6 +599,7 @@ class TestOpenSearchDocumentStore:
                 "index": {"knn": True, "knn.algo_param.ef_search": 20},
             },
         }
+        assert mocked_document_store.embeddings_field_supports_similarity is True
 
     @pytest.mark.unit
     def test__create_document_index_client_failure(self, mocked_document_store):

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -389,9 +389,7 @@ class TestOpenSearchDocumentStore:
         mocked_document_store.embedding_field = "vec"
 
         mocked_document_store._create_document_index(self.index_name)
-        # FIXME: when `method` is missing from the field mapping, embeddings_field_supports_similarity is always
-        # False but I'm not sure this is by design
-        assert mocked_document_store.embeddings_field_supports_similarity is False
+        assert mocked_document_store.embeddings_field_supports_similarity is True
 
     @pytest.mark.unit
     def test__create_document_index_with_existing_mapping_similarity(self, mocked_document_store, index):


### PR DESCRIPTION
### Related Issues
- fixes #2816

### Proposed Changes:
- set `embeddings_field_supports_similarity=True` when creating index
- refactored duplicate code (probably caused by bad merge)
- fix when `method` is missing from the field mapping, `embeddings_field_supports_similarity` is always `False` (also probably caused by bad merge)

### How did you test it?
- added unit tests

### Notes for the reviewer
- reused existing tests rather than writing new ones

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
