### PR TITLE
docs:fixed typo (or old documentation) in ipynb tutorial 3

### DIFF
--- a/docs/_src/tutorials/tutorials/3.md
+++ b/docs/_src/tutorials/tutorials/3.md
@@ -105,7 +105,7 @@ docs = convert_files_to_docs(dir_path=doc_dir, clean_func=clean_wiki_text, split
 
 # We now have a list of dictionaries that we can write to our document store.
 # If your texts come from a different source (e.g. a DB), you can of course skip convert_files_to_dicts() and create the dictionaries yourself.
-# The default format here is: {"name": "<some-document-name>, "text": "<the-actual-text>"}
+# The default format here is: {"name": "<some-document-name>", "content": "<the-actual-text>"}
 
 # Let's have a look at the first 3 entries:
 print(docs[:3])

--- a/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
+++ b/tutorials/Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb
@@ -188,7 +188,7 @@
     "\n",
     "# We now have a list of dictionaries that we can write to our document store.\n",
     "# If your texts come from a different source (e.g. a DB), you can of course skip convert_files_to_dicts() and create the dictionaries yourself.\n",
-    "# The default format here is: {\"name\": \"<some-document-name>, \"text\": \"<the-actual-text>\"}\n",
+    "# The default format here is: {\"name\": \"<some-document-name>\", \"content\": \"<the-actual-text>\"}\n",
     "\n",
     "# Let's have a look at the first 3 entries:\n",
     "print(docs[:3])\n",


### PR DESCRIPTION
### Related Issues
- no related issue, if I have to open one I will (I didn't find anything about this in the PR doc)

### Proposed Changes:
I only fixed the key in the document dictionary format so `write_documents()` won't raise an error. By the way the `write_documents()` error is really explanatory. Tutorial updated: `Tutorial3_Basic_QA_Pipeline_without_Elasticsearch.ipynb`, as far as I understood no need to fix anything in the `.py` version

### How did you test it?
No real-test needed I think, but I went trough the notebook executing every cell and I spot this error adding my own documents: changing the dictionary format fixed it.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
