### PR TITLE
bug: Make `TranslationWrapperPipeline` work with `QuestionAnswerGenerationPipeline`

### DIFF
--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -117,7 +117,7 @@ Run the actual translation. You can supply a query or a list of documents. Whate
 #### TransformersTranslator.translate\_batch
 
 ```python
-def translate_batch(queries: Optional[List[str]] = None, documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None, batch_size: Optional[int] = None) -> Union[str, List[str], List[Document], List[Answer], List[List[Document]], List[List[Answer]]]
+def translate_batch(queries: Optional[List[str]] = None, documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None, batch_size: Optional[int] = None) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]
 ```
 
 Run the actual translation. You can supply a single query, a list of queries or a list (of lists) of documents.

--- a/haystack/nodes/translator/base.py
+++ b/haystack/nodes/translator/base.py
@@ -32,7 +32,7 @@ class BaseTranslator(BaseComponent):
         queries: Optional[List[str]] = None,
         documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None,
         batch_size: Optional[int] = None,
-    ) -> Union[str, List[str], List[Document], List[Answer], List[List[Document]], List[List[Answer]]]:
+    ) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]:
         pass
 
     def run(  # type: ignore

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -161,7 +161,7 @@ class TransformersTranslator(BaseTranslator):
         queries: Optional[List[str]] = None,
         documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None,
         batch_size: Optional[int] = None,
-    ) -> Union[str, List[str], List[Document], List[Answer], List[List[Document]], List[List[Answer]]]:
+    ) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]:
         """
         Run the actual translation. You can supply a single query, a list of queries or a list (of lists) of documents.
 
@@ -188,7 +188,7 @@ class TransformersTranslator(BaseTranslator):
         elif documents:
             # Single list of documents / answers
             if not isinstance(documents[0], list):
-                translated = self.translate(documents=documents)  # type: ignore
+                translated = self.run(documents=documents)  # type: ignore
             # Multiple lists of document / answer lists
             else:
                 translated = []

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -181,7 +181,7 @@ class TransformersTranslator(BaseTranslator):
         if queries:
             translated = []
             for query in tqdm(queries, disable=not self.progress_bar, desc="Translating"):
-                cur_translation = self.run(query=query)
+                cur_translation = self.translate(query=query)
                 translated.append(cur_translation)
 
         # Translate docs / answers

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -188,7 +188,7 @@ class TransformersTranslator(BaseTranslator):
         elif documents:
             # Single list of documents / answers
             if not isinstance(documents[0], list):
-                translated = self.run(documents=documents)  # type: ignore
+                translated = self.translate(documents=documents)  # type: ignore
             # Multiple lists of document / answer lists
             else:
                 translated = []

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -523,6 +523,10 @@ class TranslationWrapperPipeline(BaseStandardPipeline):
 
         self.pipeline = Pipeline()
         self.pipeline.add_node(component=input_translator, name="InputTranslator", inputs=["Query"])
+        # Make use of run_batch instead of run for output_translator if pipeline is a QuestionAnswerGenerationPipeline,
+        # as the reader's run method is overwritten by its run_batch method, which is incompatible with the translator's
+        # run method.
+        setattr(output_translator, "run", output_translator.run_batch)
 
         graph = pipeline.pipeline.graph
         previous_node_name = ["InputTranslator"]

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -526,7 +526,8 @@ class TranslationWrapperPipeline(BaseStandardPipeline):
         # Make use of run_batch instead of run for output_translator if pipeline is a QuestionAnswerGenerationPipeline,
         # as the reader's run method is overwritten by its run_batch method, which is incompatible with the translator's
         # run method.
-        setattr(output_translator, "run", output_translator.run_batch)
+        if isinstance(pipeline, QuestionAnswerGenerationPipeline):
+            setattr(output_translator, "run", output_translator.run_batch)
 
         graph = pipeline.pipeline.graph
         previous_node_name = ["InputTranslator"]


### PR DESCRIPTION
### Related Issues
- fixes #2976

### Proposed Changes:
This PR fixes makes `TranslationWrapperPipeline` work with `QuestionAnswerGenerationPipeline` by overwriting the `output_translator`'s `run` method with its `run_batch` method. This is needed as the `QuestionAnswerGenerationPipeline` overwrites the reader's `run` method with its `run_batch` method as well. The reader's `run_batch` output is not compatible with the translator's `run` method.

### How did you test it?
The bug came up in the last section of Tutorial 13. Therefore, I verified the fix by executing Tutorial 13. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
