### PR TITLE
feat: Enable isolated node eval for answer generator nodes (incl. OpenAI Node)

### DIFF
--- a/haystack/nodes/answer_generator/base.py
+++ b/haystack/nodes/answer_generator/base.py
@@ -40,7 +40,7 @@ class BaseGenerator(BaseComponent):
 
         # run evaluation with "perfect" labels as node inputs to calculate "upper bound" metrics for just this node
         if add_isolated_node_eval and labels is not None:
-            relevant_documents = {label.document.id: label.document for label in labels.labels}.values()
+            relevant_documents = list({label.document.id: label.document for label in labels.labels}.values())
             results_label_input = self.predict(query=query, documents=relevant_documents, top_k=top_k)
             results["answers_isolated"] = results_label_input["answers"]
 

--- a/haystack/nodes/answer_generator/base.py
+++ b/haystack/nodes/answer_generator/base.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Dict, Union
 from tqdm.auto import tqdm
 
 from haystack.errors import HaystackError
-from haystack.schema import Answer, Document
+from haystack.schema import Answer, Document, MultiLabel, Label
 from haystack.nodes.base import BaseComponent
 
 
@@ -31,12 +31,19 @@ class BaseGenerator(BaseComponent):
         """
         pass
 
-    def run(self, query: str, documents: List[Document], top_k: Optional[int] = None):  # type: ignore
+    def run(self, query: str, documents: List[Document], top_k: Optional[int] = None, labels: Optional[MultiLabel] = None, add_isolated_node_eval: bool = False):  # type: ignore
 
         if documents:
             results = self.predict(query=query, documents=documents, top_k=top_k)
         else:
             results = {"answers": []}
+
+
+        # run evaluation with labels as node inputs
+        if add_isolated_node_eval and labels is not None:
+            relevant_documents = {label.document.id: label.document for label in labels.labels}.values()
+            results_label_input = self.predict(query=query, documents=relevant_documents, top_k=top_k)
+            results["answers_isolated"] = results_label_input["answers"]
 
         return results, "output_1"
 

--- a/haystack/nodes/answer_generator/base.py
+++ b/haystack/nodes/answer_generator/base.py
@@ -38,8 +38,7 @@ class BaseGenerator(BaseComponent):
         else:
             results = {"answers": []}
 
-
-        # run evaluation with labels as node inputs
+        # run evaluation with "perfect" labels as node inputs to calculate "upper bound" metrics for just this node
         if add_isolated_node_eval and labels is not None:
             relevant_documents = {label.document.id: label.document for label in labels.labels}.values()
             results_label_input = self.predict(query=query, documents=relevant_documents, top_k=top_k)

--- a/haystack/nodes/answer_generator/base.py
+++ b/haystack/nodes/answer_generator/base.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Dict, Union
 from tqdm.auto import tqdm
 
 from haystack.errors import HaystackError
-from haystack.schema import Answer, Document, MultiLabel, Label
+from haystack.schema import Answer, Document, MultiLabel
 from haystack.nodes.base import BaseComponent
 
 


### PR DESCRIPTION
### Related Issues
- fixes #3035 

### Proposed Changes:
Making the `BaseGenerator` 's run method more similar to the one from `BaseReader` by
- adding a param `add_isolated_node_eval` 
- in case the mode is active, taking the same approach as in BaseReader [here](https://github.com/deepset-ai/haystack/blob/da7836a9316d5b0369e955f0d226b1ad1f0b35c7/haystack/nodes/reader/base.py#L94). The only difference here is that we are not adding the meta data of documents, as the answers are not extracted from any direct docs but are generated. So a direct link here seems impropropriate from my perspective  

### How did you test it?
- manual test by replacing the reader in our Tutorial 5 by: `reader = OpenAIAnswerGenerator(api_key="<api-key>")`

### Notes for the reviewer
- Let me know if you also agree, that the metadata linking (as done in the BaseReader) doesn't make sense here for the generator
- Just touched the run() method here. Didn't check if run_batch also needs a fix or how the eval mode in batch mode currently works. 
- Don't see big side effects possible here as the new if block is quite isolated from anything else

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
