### PR TITLE
Fix broken `MultiLabel` serialization

### DIFF
--- a/docs/_src/api/api/primitives.md
+++ b/docs/_src/api/api/primitives.md
@@ -272,7 +272,7 @@ class MultiLabel()
 #### MultiLabel.\_\_init\_\_
 
 ```python
-def __init__(labels: List[Label], drop_negative_labels=False, drop_no_answers=False)
+def __init__(labels: List[Label], drop_negative_labels=False, drop_no_answers=False, **kwargs)
 ```
 
 There are often multiple `Labels` associated with a single query. For example, there can be multiple annotated
@@ -288,6 +288,7 @@ underlying Labels provided a text answer and therefore demonstrates that there i
 - `labels`: A list of labels that belong to a similar query and shall be "grouped" together
 - `drop_negative_labels`: Whether to drop negative labels from that group (e.g. thumbs down feedback from UI)
 - `drop_no_answers`: Whether to drop labels that specify the answer is impossible
+- `kwargs`: All additional attributes are ignored. This is just a workaround to enable smooth `to_dict()`-`from_dict()`-(de)serialization.
 
 <a id="schema.EvaluationResult"></a>
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import csv
-from email.policy import default
 import hashlib
 
 import typing

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 import csv
+from email.policy import default
+from functools import partial
 import hashlib
 
 import typing
@@ -16,7 +18,7 @@ import logging
 import time
 import json
 import ast
-from dataclasses import asdict
+from dataclasses import asdict, field
 
 import mmh3
 import numpy as np
@@ -509,15 +511,19 @@ class Label:
 
         self.updated_at = updated_at
         self.query = query
+
+        # TODO: fix MultiLabel serialization without hacking Label
+        # As this is called during pydantic validation when MultiLabel is being serialized, answer might still be a dict
+        if isinstance(answer, dict):
+            answer = Answer.from_dict(answer)
         self.answer = answer
+        if isinstance(document, dict):
+            document = Document.from_dict(document)
         self.document = document
+
         self.is_correct_answer = is_correct_answer
         self.is_correct_document = is_correct_document
         self.origin = origin
-
-        # Remove
-        # self.document_id = document_id
-        # self.offset_start_in_doc = offset_start_in_doc
 
         # If an Answer is provided we need to make sure that it's consistent with the `no_answer` value
         # TODO: reassess if we want to enforce Span.start=0 and Span.end=0 for no_answer=True
@@ -611,7 +617,7 @@ class MultiLabel:
     offsets_in_contexts: List[Dict]
     offsets_in_documents: List[Dict]
 
-    def __init__(self, labels: List[Label], drop_negative_labels=False, drop_no_answers=False):
+    def __init__(self, labels: List[Label], drop_negative_labels=False, drop_no_answers=False, **kwargs):
         """
         There are often multiple `Labels` associated with a single query. For example, there can be multiple annotated
         answers for one question or multiple documents contain the information you want for a query.
@@ -623,6 +629,7 @@ class MultiLabel:
         :param labels: A list of labels that belong to a similar query and shall be "grouped" together
         :param drop_negative_labels: Whether to drop negative labels from that group (e.g. thumbs down feedback from UI)
         :param drop_no_answers: Whether to drop labels that specify the answer is impossible
+        :param kwargs: All additional attributes are ignored. This is just a workaround to enable smooth `to_dict()`-`from_dict()`-(de)serialization.
         """
         # drop duplicate labels and remove negative labels if needed.
         labels = list(dict.fromkeys(labels))
@@ -714,7 +721,7 @@ class MultiLabel:
 def _pydantic_dataclass_from_dict(dict: dict, pydantic_dataclass_type) -> Any:
     """
     Constructs a pydantic dataclass from a dict incl. other nested dataclasses.
-    This allows simple de-serialization of pydentic dataclasses from json.
+    This allows simple de-serialization of pydantic dataclasses from json.
     :param dict: Dict containing all attributes and values for the dataclass.
     :param pydantic_dataclass_type: The class of the dataclass that should be constructed (e.g. Document)
     """

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -513,7 +513,8 @@ class Label:
         self.query = query
 
         # TODO: fix MultiLabel serialization without hacking Label
-        # As this is called during pydantic validation when MultiLabel is being serialized, answer might still be a dict
+        # As this is called during pydantic validation when MultiLabel is being serialized, 
+        # answer might still be a dict breaking the following no_answer validation code.
         if isinstance(answer, dict):
             answer = Answer.from_dict(answer)
         self.answer = answer

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import csv
 from email.policy import default
-from functools import partial
 import hashlib
 
 import typing
@@ -18,7 +17,7 @@ import logging
 import time
 import json
 import ast
-from dataclasses import asdict, field
+from dataclasses import asdict
 
 import mmh3
 import numpy as np
@@ -513,7 +512,7 @@ class Label:
         self.query = query
 
         # TODO: fix MultiLabel serialization without hacking Label
-        # As this is called during pydantic validation when MultiLabel is being serialized, 
+        # As this is called during pydantic validation when MultiLabel is being serialized,
         # answer might still be a dict breaking the following no_answer validation code.
         if isinstance(answer, dict):
             answer = Answer.from_dict(answer)


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/2872

### Proposed Changes:
- add `kwargs` to `MultiLabel` __init__ to pass fully serialized MultiLabel
- parse Answer and Document dicts within `Label`'s __init__ to workaround pydantic validation issue

### How did you test it?
run following script
```python
from haystack import MultiLabel, Label

l = {
    "id": "011079cf-c93f-49e6-83bb-42cd850dce12",
    "query": "When was the final season first shown on TV?",
    "document": {
        "content": "\n\n\n\n\nThe eighth and final season of the fantasy drama television series ''Game of Thrones'', produced by HBO, premiered on April 14, 2019, and concluded on May 19, 2019. Unlike the first six seasons, which consisted of ten episodes each, and the seventh season, which consisted of seven episodes, the eighth season consists of only six episodes.\n\nThe final season depicts the culmination of the series' two primary conflicts: the G",
        "content_type": "text",
        "id": "9c82c97c9dc8ba6895893a53aafa610f",
        "meta": {},
        "score": None,
        "embedding": None,
    },
    "is_correct_answer": True,
    "is_correct_document": True,
    "origin": "user-feedback",
    "answer": {
        "answer": "April 14",
        "type": "extractive",
        "score": None,
        "context": "\n\n\n\n\nThe eighth and final season of the fantasy drama television series ''Game of Thrones'', produced by HBO, premiered on April 14, 2019, and concluded on May 19, 2019. Unlike the first six seasons, which consisted of ten episodes each, and the seventh season, which consisted of seven episodes, the eighth season consists of only six episodes.\n\nThe final season depicts the culmination of the series' two primary conflicts: the G",
        "offsets_in_document": [{"start": 124, "end": 132}],
        "offsets_in_context": None,
        "document_id": None,
        "meta": {},
    },
    "no_answer": False,
    "pipeline_id": None,
    "created_at": "2022-07-22T13:29:33.699781+00:00",
    "updated_at": "2022-07-22T13:29:33.784895+00:00",
    "meta": {"answer_id": "374394", "document_id": "604995", "question_id": "345530"},
    "filters": None,
}

ll = Label.from_dict(l)

m = MultiLabel([ll])

m_dict = m.to_dict()
m = MultiLabel.from_dict(m_dict)

print(m)

```

### Notes for the reviewer
This is just a low-risk hack to fix a DC-related issue. A cleaner fix would require deeper pydantic investigations and probably deeper changes to `MultiLabel` and `Label` (use of pydantic `field` and `__post_init__()`). Hence, the TODO comment

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
