### PR TITLE
fix: pin version of pyworld to `0.2.12`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -151,7 +151,7 @@ docstores-gpu =
     farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]
 
 audio =
-    pyworld<=0.2.12; python_version >= '3.10'
+    pyworld<=0.2.12
     espnet
     espnet-model-zoo
     pydub


### PR DESCRIPTION
### Related Issues
- fixes #3046 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Pins pyworld to version `<=0.2.12` so that it does not pin numpy to `<1.20.0` in its [pyproject.toml](https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyproject.toml#L6)

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I created a new python 3.9 environment and ran `GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install -e '.[audio]'` to check for a successful installation. 

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
