### PR TITLE
feat: take the list of models to cache instead of hardcoding one

### DIFF
--- a/haystack/utils/docker.py
+++ b/haystack/utils/docker.py
@@ -1,21 +1,25 @@
 import logging
 
 
-def cache_models():
+def cache_models(models=None):
     """
     Small function that caches models and other data.
     Used only in the Dockerfile to include these caches in the images.
     """
+    # Backward compat after adding the `model` param
+    if models is None:
+        models = ["deepset/roberta-base-squad2"]
+
     # download punkt tokenizer
     logging.info("Caching punkt data")
     import nltk
 
     nltk.download("punkt", download_dir="/root/nltk_data")
 
-    # Cache roberta-base-squad2 model
-    logging.info("Caching deepset/roberta-base-squad2")
+    # Cache models
     import transformers
 
-    model_to_cache = "deepset/roberta-base-squad2"
-    transformers.AutoTokenizer.from_pretrained(model_to_cache)
-    transformers.AutoModel.from_pretrained(model_to_cache)
+    for model_to_cache in models:
+        logging.info(f"Caching {model_to_cache}")
+        transformers.AutoTokenizer.from_pretrained(model_to_cache)
+        transformers.AutoModel.from_pretrained(model_to_cache)

--- a/haystack/utils/docker.py
+++ b/haystack/utils/docker.py
@@ -14,7 +14,7 @@ def cache_models(models=None):
     logging.info("Caching punkt data")
     import nltk
 
-    nltk.download("punkt", download_dir="/root/nltk_data")
+    nltk.download("punkt")
 
     # Cache models
     import transformers


### PR DESCRIPTION
### Related Issues
- no issue

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Take in input the list of models to cache instead of hardcoding only one
- Do not target `/root` as the folder to keep nltk cached data, let `nltk` manage that

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
tested in a Docker build

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
Backward compatibility is preserved using a default param

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
