### PR TITLE
bug: `OpensearchDocumentStore.custom_mapping` should accept JSON strings at validation

### DIFF
--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -97,7 +97,10 @@ def read_pipeline_config_from_yaml(path: Path) -> Dict[str, Any]:
         return yaml.safe_load(stream)
 
 
-JSON_FIELDS = ["custom_query"]  # ElasticsearchDocumentStore.custom_query
+JSON_FIELDS = [
+    "custom_query",  # ElasticsearchDocumentStore.custom_query
+    "custom_mapping",  # ElasticsearchDocumentStore.custom_mapping
+]
 
 
 def validate_config_strings(pipeline_config: Any):

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -687,6 +687,9 @@ def test_validate_pipeline_config_component_with_json_input_valid():
     validate_config_strings(
         {"components": [{"name": "test", "type": "test", "params": {"custom_query": '{"json-key": "json-value"}'}}]}
     )
+    validate_config_strings(
+        {"components": [{"name": "test", "type": "test", "params": {"custom_mapping": '{"json-key": "json-value"}'}}]}
+    )
 
 
 def test_validate_pipeline_config_component_with_json_input_invalid_key():


### PR DESCRIPTION
### Related Issues
- fixes #3064

### Proposed Changes:
Add `custom_mapping` to the list of fields that accept JSON input.

### How did you test it?
Add a line into an existing unit test

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [X] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
