### PR TITLE
feat: add progressbar to upload_files() for deepset Cloud client

### DIFF
--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -16,6 +16,7 @@ from enum import Enum
 import yaml
 import pandas as pd
 import requests
+from tqdm import tqdm
 
 from haystack.schema import Label, Document, Answer, EvaluationResult
 
@@ -977,7 +978,7 @@ class FileClient:
             metas = [{} for _ in file_paths]
 
         file_ids = []
-        for file_path, meta in zip(file_paths, metas):
+        for file_path, meta in tqdm(zip(file_paths, metas), total=len(file_paths)):
             try:
                 mime_type = guess_type(str(file_path))[0]
                 with open(file_path, "rb") as file:


### PR DESCRIPTION
### Proposed Changes:
Add a tqdm progress bar to `upload_files()` so that users get an better idea of the progress and remaining time until their files are uploaded to deepset Cloud. 

### How did you test it?
Manual testing

### Notes for the reviewer
Tiny change to have a standard progress bar

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
