### PR TITLE
fix: Crawler quits ChromeDriver on destruction

### DIFF
--- a/docs/_src/api/api/crawler.md
+++ b/docs/_src/api/api/crawler.md
@@ -27,16 +27,7 @@ Crawl texts from a website so that we can use them later in Haystack as a corpus
 #### Crawler.\_\_init\_\_
 
 ```python
-def __init__(output_dir: str,
-             urls: Optional[List[str]] = None,
-             crawler_depth: int = 1,
-             filter_urls: Optional[List] = None,
-             overwrite_existing_files=True,
-             id_hash_keys: Optional[List[str]] = None,
-             extract_hidden_text=True,
-             loading_wait_time: Optional[int] = None,
-             crawler_naming_function: Optional[Callable[[str, str],
-                                                        str]] = None)
+def __init__(output_dir: str, urls: Optional[List[str]] = None, crawler_depth: int = 1, filter_urls: Optional[List] = None, overwrite_existing_files=True, id_hash_keys: Optional[List[str]] = None, extract_hidden_text=True, loading_wait_time: Optional[int] = None, crawler_naming_function: Optional[Callable[[str, str], str]] = None)
 ```
 
 Init object with basic params for crawling (can be overwritten later).
@@ -72,17 +63,7 @@ E.g. 1) crawler_naming_function=lambda url, page_content: re.sub("[<>:'/\\|?*\0 
 #### Crawler.crawl
 
 ```python
-def crawl(
-    output_dir: Union[str, Path, None] = None,
-    urls: Optional[List[str]] = None,
-    crawler_depth: Optional[int] = None,
-    filter_urls: Optional[List] = None,
-    overwrite_existing_files: Optional[bool] = None,
-    id_hash_keys: Optional[List[str]] = None,
-    extract_hidden_text: Optional[bool] = None,
-    loading_wait_time: Optional[int] = None,
-    crawler_naming_function: Optional[Callable[[str, str], str]] = None
-) -> List[Path]
+def crawl(output_dir: Union[str, Path, None] = None, urls: Optional[List[str]] = None, crawler_depth: Optional[int] = None, filter_urls: Optional[List] = None, overwrite_existing_files: Optional[bool] = None, id_hash_keys: Optional[List[str]] = None, extract_hidden_text: Optional[bool] = None, loading_wait_time: Optional[int] = None, crawler_naming_function: Optional[Callable[[str, str], str]] = None) -> List[Path]
 ```
 
 Craw URL(s), extract the text from the HTML, create a Haystack Document object out of it and save it (one JSON
@@ -125,18 +106,7 @@ List of paths where the crawled webpages got stored
 #### Crawler.run
 
 ```python
-def run(
-    output_dir: Union[str, Path, None] = None,
-    urls: Optional[List[str]] = None,
-    crawler_depth: Optional[int] = None,
-    filter_urls: Optional[List] = None,
-    overwrite_existing_files: Optional[bool] = None,
-    return_documents: Optional[bool] = False,
-    id_hash_keys: Optional[List[str]] = None,
-    extract_hidden_text: Optional[bool] = True,
-    loading_wait_time: Optional[int] = None,
-    crawler_naming_function: Optional[Callable[[str, str], str]] = None
-) -> Tuple[Dict[str, Union[List[Document], List[Path]]], str]
+def run(output_dir: Union[str, Path, None] = None, urls: Optional[List[str]] = None, crawler_depth: Optional[int] = None, filter_urls: Optional[List] = None, overwrite_existing_files: Optional[bool] = None, return_documents: Optional[bool] = False, id_hash_keys: Optional[List[str]] = None, extract_hidden_text: Optional[bool] = True, loading_wait_time: Optional[int] = None, crawler_naming_function: Optional[Callable[[str, str], str]] = None) -> Tuple[Dict[str, Union[List[Document], List[Path]]], str]
 ```
 
 Method to be executed when the Crawler is used as a Node within a Haystack pipeline.

--- a/docs/_src/api/api/crawler.md
+++ b/docs/_src/api/api/crawler.md
@@ -27,7 +27,16 @@ Crawl texts from a website so that we can use them later in Haystack as a corpus
 #### Crawler.\_\_init\_\_
 
 ```python
-def __init__(output_dir: str, urls: Optional[List[str]] = None, crawler_depth: int = 1, filter_urls: Optional[List] = None, overwrite_existing_files=True, id_hash_keys: Optional[List[str]] = None, extract_hidden_text=True, loading_wait_time: Optional[int] = None, crawler_naming_function: Optional[Callable[[str, str], str]] = None)
+def __init__(output_dir: str,
+             urls: Optional[List[str]] = None,
+             crawler_depth: int = 1,
+             filter_urls: Optional[List] = None,
+             overwrite_existing_files=True,
+             id_hash_keys: Optional[List[str]] = None,
+             extract_hidden_text=True,
+             loading_wait_time: Optional[int] = None,
+             crawler_naming_function: Optional[Callable[[str, str],
+                                                        str]] = None)
 ```
 
 Init object with basic params for crawling (can be overwritten later).
@@ -63,7 +72,17 @@ E.g. 1) crawler_naming_function=lambda url, page_content: re.sub("[<>:'/\\|?*\0 
 #### Crawler.crawl
 
 ```python
-def crawl(output_dir: Union[str, Path, None] = None, urls: Optional[List[str]] = None, crawler_depth: Optional[int] = None, filter_urls: Optional[List] = None, overwrite_existing_files: Optional[bool] = None, id_hash_keys: Optional[List[str]] = None, extract_hidden_text: Optional[bool] = None, loading_wait_time: Optional[int] = None, crawler_naming_function: Optional[Callable[[str, str], str]] = None) -> List[Path]
+def crawl(
+    output_dir: Union[str, Path, None] = None,
+    urls: Optional[List[str]] = None,
+    crawler_depth: Optional[int] = None,
+    filter_urls: Optional[List] = None,
+    overwrite_existing_files: Optional[bool] = None,
+    id_hash_keys: Optional[List[str]] = None,
+    extract_hidden_text: Optional[bool] = None,
+    loading_wait_time: Optional[int] = None,
+    crawler_naming_function: Optional[Callable[[str, str], str]] = None
+) -> List[Path]
 ```
 
 Craw URL(s), extract the text from the HTML, create a Haystack Document object out of it and save it (one JSON
@@ -106,7 +125,18 @@ List of paths where the crawled webpages got stored
 #### Crawler.run
 
 ```python
-def run(output_dir: Union[str, Path, None] = None, urls: Optional[List[str]] = None, crawler_depth: Optional[int] = None, filter_urls: Optional[List] = None, overwrite_existing_files: Optional[bool] = None, return_documents: Optional[bool] = False, id_hash_keys: Optional[List[str]] = None, extract_hidden_text: Optional[bool] = True, loading_wait_time: Optional[int] = None, crawler_naming_function: Optional[Callable[[str, str], str]] = None) -> Tuple[Dict[str, Union[List[Document], List[Path]]], str]
+def run(
+    output_dir: Union[str, Path, None] = None,
+    urls: Optional[List[str]] = None,
+    crawler_depth: Optional[int] = None,
+    filter_urls: Optional[List] = None,
+    overwrite_existing_files: Optional[bool] = None,
+    return_documents: Optional[bool] = False,
+    id_hash_keys: Optional[List[str]] = None,
+    extract_hidden_text: Optional[bool] = True,
+    loading_wait_time: Optional[int] = None,
+    crawler_naming_function: Optional[Callable[[str, str], str]] = None
+) -> Tuple[Dict[str, Union[List[Document], List[Path]]], str]
 ```
 
 Method to be executed when the Crawler is used as a Node within a Haystack pipeline.

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -117,6 +117,9 @@ class Crawler(BaseComponent):
         self.loading_wait_time = loading_wait_time
         self.crawler_naming_function = crawler_naming_function
 
+    def __del__(self):
+        self.driver.quit()
+
     def crawl(
         self,
         output_dir: Union[str, Path, None] = None,


### PR DESCRIPTION
### Related Issues
- fixes #3066 

### Proposed Changes:
Today, Crawler will instantiate ChromeDriver, use it, and it will never close the window or the ChromeDriver itself. 

This change will close the browser window and quit the ChromeDriver instance during object destruction.

### How did you test it?
Tested on all connector node tests.

### Notes for the reviewer
After hundreds of Crawler instances being created, there are hundreds of zombie processes left behind. This leads to huge wasted memory being consumed by unused processes. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
