### PR TITLE
feat: Early stopping can be used in Reader and Retriever training

### DIFF
--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -158,7 +158,7 @@ checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is cr
 - `caching`: Whether or not to use caching for the preprocessed dataset.
 - `cache_path`: The Path to cache the preprocessed dataset.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
-- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of the best models.
 
 **Returns**:
 
@@ -238,7 +238,7 @@ checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is cr
 - `tinybert_train_filename`: Filename of training data to use when training the student model with the TinyBERT loss function. To best follow the original paper, this should be an augmented version of the training data created using the augment_squad.py script. If not specified, the training data from the original training is used.
 - `processor`: The processor to use for preprocessing. If None, the default SquadProcessor is used.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
-- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of the best models.
 
 **Returns**:
 
@@ -310,7 +310,7 @@ checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is cr
 - `temperature`: The temperature for distillation. A higher temperature will result in less certainty of teacher outputs. A lower temperature means more certainty. A temperature of 1.0 does not change the certainty of the model.
 - `processor`: The processor to use for preprocessing. If None, the default SquadProcessor is used.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
-- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of the best models.
 
 **Returns**:
 

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -151,13 +151,12 @@ None (Don't use AMP)
 "O2" (Almost FP16)
 "O3" (Pure FP16).
 See details on: https://nvidia.github.io/apex/amp.html
-- `checkpoint_root_dir`: the Path of directory where all train checkpoints are saved. For each individual
+- `checkpoint_root_dir`: The Path of a directory where all train checkpoints are saved. For each individual
 checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
-- `checkpoint_every`: save a train checkpoint after this many steps of training.
-- `checkpoints_to_keep`: maximum number of train checkpoints to save.
-- `caching`: whether or not to use caching for preprocessed dataset
-- `cache_path`: Path to cache the preprocessed dataset
-- `processor`: The processor to use for preprocessing. If None, the default SquadProcessor is used.
+- `checkpoint_every`: Save a train checkpoint after this many steps of training.
+- `checkpoints_to_keep`: The maximum number of train checkpoints to save.
+- `caching`: Whether or not to use caching for the preprocessed dataset.
+- `cache_path`: The Path to cache the preprocessed dataset.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
 - `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
 

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -109,7 +109,7 @@ Additional information can be found here https://huggingface.co/transformers/mai
 #### FARMReader.train
 
 ```python
-def train(data_dir: str, train_filename: str, dev_filename: Optional[str] = None, test_filename: Optional[str] = None, use_gpu: Optional[bool] = None, devices: List[torch.device] = [], batch_size: int = 10, n_epochs: int = 2, learning_rate: float = 1e-5, max_seq_len: Optional[int] = None, warmup_proportion: float = 0.2, dev_split: float = 0, evaluate_every: int = 300, save_dir: Optional[str] = None, num_processes: Optional[int] = None, use_amp: str = None, checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, caching: bool = False, cache_path: Path = Path("cache/data_silo"), grad_acc_steps: int = 1)
+def train(data_dir: str, train_filename: str, dev_filename: Optional[str] = None, test_filename: Optional[str] = None, use_gpu: Optional[bool] = None, devices: List[torch.device] = [], batch_size: int = 10, n_epochs: int = 2, learning_rate: float = 1e-5, max_seq_len: Optional[int] = None, warmup_proportion: float = 0.2, dev_split: float = 0, evaluate_every: int = 300, save_dir: Optional[str] = None, num_processes: Optional[int] = None, use_amp: str = None, checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, caching: bool = False, cache_path: Path = Path("cache/data_silo"), grad_acc_steps: int = 1, early_stopping: Optional[EarlyStopping] = None)
 ```
 
 Fine-tune a model on a QA dataset. Options:
@@ -159,6 +159,7 @@ checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is cr
 - `cache_path`: Path to cache the preprocessed dataset
 - `processor`: The processor to use for preprocessing. If None, the default SquadProcessor is used.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
 
 **Returns**:
 
@@ -169,7 +170,7 @@ None
 #### FARMReader.distil\_prediction\_layer\_from
 
 ```python
-def distil_prediction_layer_from(teacher_model: "FARMReader", data_dir: str, train_filename: str, dev_filename: Optional[str] = None, test_filename: Optional[str] = None, use_gpu: Optional[bool] = None, devices: List[torch.device] = [], student_batch_size: int = 10, teacher_batch_size: Optional[int] = None, n_epochs: int = 2, learning_rate: float = 3e-5, max_seq_len: Optional[int] = None, warmup_proportion: float = 0.2, dev_split: float = 0, evaluate_every: int = 300, save_dir: Optional[str] = None, num_processes: Optional[int] = None, use_amp: str = None, checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, caching: bool = False, cache_path: Path = Path("cache/data_silo"), distillation_loss_weight: float = 0.5, distillation_loss: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "kl_div", temperature: float = 1.0, grad_acc_steps: int = 1)
+def distil_prediction_layer_from(teacher_model: "FARMReader", data_dir: str, train_filename: str, dev_filename: Optional[str] = None, test_filename: Optional[str] = None, use_gpu: Optional[bool] = None, devices: List[torch.device] = [], student_batch_size: int = 10, teacher_batch_size: Optional[int] = None, n_epochs: int = 2, learning_rate: float = 3e-5, max_seq_len: Optional[int] = None, warmup_proportion: float = 0.2, dev_split: float = 0, evaluate_every: int = 300, save_dir: Optional[str] = None, num_processes: Optional[int] = None, use_amp: str = None, checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, caching: bool = False, cache_path: Path = Path("cache/data_silo"), distillation_loss_weight: float = 0.5, distillation_loss: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "kl_div", temperature: float = 1.0, grad_acc_steps: int = 1, early_stopping: Optional[EarlyStopping] = None)
 ```
 
 Fine-tune a model on a QA dataset using logit-based distillation. You need to provide a teacher model that is already finetuned on the dataset
@@ -238,6 +239,7 @@ checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is cr
 - `tinybert_train_filename`: Filename of training data to use when training the student model with the TinyBERT loss function. To best follow the original paper, this should be an augmented version of the training data created using the augment_squad.py script. If not specified, the training data from the original training is used.
 - `processor`: The processor to use for preprocessing. If None, the default SquadProcessor is used.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
 
 **Returns**:
 
@@ -248,7 +250,7 @@ None
 #### FARMReader.distil\_intermediate\_layers\_from
 
 ```python
-def distil_intermediate_layers_from(teacher_model: "FARMReader", data_dir: str, train_filename: str, dev_filename: Optional[str] = None, test_filename: Optional[str] = None, use_gpu: Optional[bool] = None, devices: List[torch.device] = [], batch_size: int = 10, n_epochs: int = 5, learning_rate: float = 5e-5, max_seq_len: Optional[int] = None, warmup_proportion: float = 0.2, dev_split: float = 0, evaluate_every: int = 300, save_dir: Optional[str] = None, num_processes: Optional[int] = None, use_amp: str = None, checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, caching: bool = False, cache_path: Path = Path("cache/data_silo"), distillation_loss: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "mse", temperature: float = 1.0, processor: Optional[Processor] = None, grad_acc_steps: int = 1)
+def distil_intermediate_layers_from(teacher_model: "FARMReader", data_dir: str, train_filename: str, dev_filename: Optional[str] = None, test_filename: Optional[str] = None, use_gpu: Optional[bool] = None, devices: List[torch.device] = [], batch_size: int = 10, n_epochs: int = 5, learning_rate: float = 5e-5, max_seq_len: Optional[int] = None, warmup_proportion: float = 0.2, dev_split: float = 0, evaluate_every: int = 300, save_dir: Optional[str] = None, num_processes: Optional[int] = None, use_amp: str = None, checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, caching: bool = False, cache_path: Path = Path("cache/data_silo"), distillation_loss: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "mse", temperature: float = 1.0, processor: Optional[Processor] = None, grad_acc_steps: int = 1, early_stopping: Optional[EarlyStopping] = None)
 ```
 
 The first stage of distillation finetuning as described in the TinyBERT paper:
@@ -309,6 +311,7 @@ checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is cr
 - `temperature`: The temperature for distillation. A higher temperature will result in less certainty of teacher outputs. A lower temperature means more certainty. A temperature of 1.0 does not change the certainty of the model.
 - `processor`: The processor to use for preprocessing. If None, the default SquadProcessor is used.
 - `grad_acc_steps`: The number of steps to accumulate gradients for before performing a backward pass.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
 
 **Returns**:
 

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -844,7 +844,7 @@ For more information, refer to: https://nvidia.github.io/apex/amp.html
 checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
 - `checkpoint_every`: Save a train checkpoint after this many steps of training.
 - `checkpoints_to_keep`: The maximum number of train checkpoints to save.
-- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of the best models.
 Checkpoints can be stored via setting `checkpoint_every` to a custom number of steps.
 If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
 
@@ -1131,7 +1131,7 @@ For more information, refer to: https://nvidia.github.io/apex/amp.html
 checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
 - `checkpoint_every`: Save a train checkpoint after this many steps of training.
 - `checkpoints_to_keep`: The maximum number of train checkpoints to save.
-- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of the best models.
 
 <a id="dense.TableTextRetriever.save"></a>
 

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -799,7 +799,7 @@ Embeddings of documents / passages shape (batch_size, embedding_dim)
 #### DensePassageRetriever.train
 
 ```python
-def train(data_dir: str, train_filename: str, dev_filename: str = None, test_filename: str = None, max_samples: int = None, max_processes: int = 128, multiprocessing_strategy: Optional[str] = None, dev_split: float = 0, batch_size: int = 2, embed_title: bool = True, num_hard_negatives: int = 1, num_positives: int = 1, n_epochs: int = 3, evaluate_every: int = 1000, n_gpu: int = 1, learning_rate: float = 1e-5, epsilon: float = 1e-08, weight_decay: float = 0.0, num_warmup_steps: int = 100, grad_acc_steps: int = 1, use_amp: str = None, optimizer_name: str = "AdamW", optimizer_correct_bias: bool = True, save_dir: str = "../saved_models/dpr", query_encoder_save_dir: str = "query_encoder", passage_encoder_save_dir: str = "passage_encoder", checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3)
+def train(data_dir: str, train_filename: str, dev_filename: str = None, test_filename: str = None, max_samples: int = None, max_processes: int = 128, multiprocessing_strategy: Optional[str] = None, dev_split: float = 0, batch_size: int = 2, embed_title: bool = True, num_hard_negatives: int = 1, num_positives: int = 1, n_epochs: int = 3, evaluate_every: int = 1000, n_gpu: int = 1, learning_rate: float = 1e-5, epsilon: float = 1e-08, weight_decay: float = 0.0, num_warmup_steps: int = 100, grad_acc_steps: int = 1, use_amp: str = None, optimizer_name: str = "AdamW", optimizer_correct_bias: bool = True, save_dir: str = "../saved_models/dpr", query_encoder_save_dir: str = "query_encoder", passage_encoder_save_dir: str = "passage_encoder", checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, early_stopping: Optional[EarlyStopping] = None)
 ```
 
 train a DensePassageRetrieval model
@@ -840,6 +840,11 @@ For more information, refer to: https://nvidia.github.io/apex/amp.html
 - `save_dir`: directory where models are saved
 - `query_encoder_save_dir`: directory inside save_dir where query_encoder model files are saved
 - `passage_encoder_save_dir`: directory inside save_dir where passage_encoder model files are saved
+- `checkpoint_root_dir`: The Path of a directory where all train checkpoints are saved. For each individual
+checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
+- `checkpoint_every`: Save a train checkpoint after this many steps of training.
+- `checkpoints_to_keep`: The maximum number of train checkpoints to save.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
 Checkpoints can be stored via setting `checkpoint_every` to a custom number of steps.
 If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
 
@@ -1079,7 +1084,7 @@ Embeddings of documents / passages. Shape: (batch_size, embedding_dim)
 #### TableTextRetriever.train
 
 ```python
-def train(data_dir: str, train_filename: str, dev_filename: str = None, test_filename: str = None, max_samples: int = None, max_processes: int = 128, dev_split: float = 0, batch_size: int = 2, embed_meta_fields: List[str] = ["page_title", "section_title", "caption"], num_hard_negatives: int = 1, num_positives: int = 1, n_epochs: int = 3, evaluate_every: int = 1000, n_gpu: int = 1, learning_rate: float = 1e-5, epsilon: float = 1e-08, weight_decay: float = 0.0, num_warmup_steps: int = 100, grad_acc_steps: int = 1, use_amp: str = None, optimizer_name: str = "AdamW", optimizer_correct_bias: bool = True, save_dir: str = "../saved_models/mm_retrieval", query_encoder_save_dir: str = "query_encoder", passage_encoder_save_dir: str = "passage_encoder", table_encoder_save_dir: str = "table_encoder", checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3)
+def train(data_dir: str, train_filename: str, dev_filename: str = None, test_filename: str = None, max_samples: int = None, max_processes: int = 128, dev_split: float = 0, batch_size: int = 2, embed_meta_fields: List[str] = ["page_title", "section_title", "caption"], num_hard_negatives: int = 1, num_positives: int = 1, n_epochs: int = 3, evaluate_every: int = 1000, n_gpu: int = 1, learning_rate: float = 1e-5, epsilon: float = 1e-08, weight_decay: float = 0.0, num_warmup_steps: int = 100, grad_acc_steps: int = 1, use_amp: str = None, optimizer_name: str = "AdamW", optimizer_correct_bias: bool = True, save_dir: str = "../saved_models/mm_retrieval", query_encoder_save_dir: str = "query_encoder", passage_encoder_save_dir: str = "passage_encoder", table_encoder_save_dir: str = "table_encoder", checkpoint_root_dir: Path = Path("model_checkpoints"), checkpoint_every: Optional[int] = None, checkpoints_to_keep: int = 3, early_stopping: Optional[EarlyStopping] = None)
 ```
 
 Train a TableTextRetrieval model.
@@ -1122,6 +1127,11 @@ For more information, refer to: https://nvidia.github.io/apex/amp.html
 - `query_encoder_save_dir`: Directory inside save_dir where query_encoder model files are saved.
 - `passage_encoder_save_dir`: Directory inside save_dir where passage_encoder model files are saved.
 - `table_encoder_save_dir`: Directory inside save_dir where table_encoder model files are saved.
+- `checkpoint_root_dir`: The Path of a directory where all train checkpoints are saved. For each individual
+checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
+- `checkpoint_every`: Save a train checkpoint after this many steps of training.
+- `checkpoints_to_keep`: The maximum number of train checkpoints to save.
+- `early_stopping`: An initialized EarlyStopping object to control early stopping and saving of best models.
 
 <a id="dense.TableTextRetriever.save"></a>
 

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -299,3 +299,64 @@ def get_all_document_titles()
 
 Return all document title strings.
 
+<a id="early_stopping"></a>
+
+# Module early\_stopping
+
+<a id="early_stopping.EarlyStopping"></a>
+
+## EarlyStopping
+
+```python
+class EarlyStopping()
+```
+
+Can be used to control early stopping with a Trainer class. A custom EarlyStopping class can be used instead as long
+as it implements the method check_stopping and provides the attribute save_dir
+
+<a id="early_stopping.EarlyStopping.__init__"></a>
+
+#### EarlyStopping.\_\_init\_\_
+
+```python
+def __init__(head: int = 0, metric: str = "loss", save_dir: Optional[str] = None, mode: str = "min", patience: int = 0, min_delta: float = 0.001, min_evals: int = 0)
+```
+
+**Arguments**:
+
+- `head`: the prediction head referenced by the metric.
+- `save_dir`: the directory where to save the final best model, if None, no saving.
+- `metric`: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
+head, or a function that extracts a value from the trainer dev evaluation result.
+NOTE: This is different from the metric that is specified in the Processor which defines how
+to calculate one or more evaluation metric values from the prediction and target sets. The
+metric variable in this function specifies the name of one particular metric value, or it is a
+method to calculate that value from the result returned by the Processor metric.
+- `mode`: "min" or "max"
+- `patience`: how many evaluations to wait after the best evaluation to stop
+- `min_delta`: minimum difference to a previous best value to count as an improvement.
+- `min_evals`: minimum number of evaluations to wait before using eval value
+
+<a id="early_stopping.EarlyStopping.check_stopping"></a>
+
+#### EarlyStopping.check\_stopping
+
+```python
+def check_stopping(eval_result: List[Dict]) -> Tuple[bool, bool, float]
+```
+
+Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
+
+This will save the model, if necessary.
+
+**Arguments**:
+
+- `eval_result`: The current evaluation result which consists of a list of dictionaries, one for each
+prediction head. Each dictionary contains the metrics and reports generated during
+evaluation.
+
+**Returns**:
+
+A tuple (stopprocessing, savemodel, eval_value) indicating if processing should be stopped
+and if the current model should get saved and the evaluation value used.
+

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -320,7 +320,7 @@ attribute `save_dir`.
 #### EarlyStopping.\_\_init\_\_
 
 ```python
-def __init__(head: int = 0, metric: str = "loss", save_dir: Optional[str] = None, mode: Literal["min", "max"] = "min", patience: int = 0, min_delta: float = 0.001, min_evals: int = 0)
+def __init__(head: int = 0, metric: Union[str, Callable] = "loss", save_dir: Optional[str] = None, mode: Literal["min", "max"] = "min", patience: int = 0, min_delta: float = 0.001, min_evals: int = 0)
 ```
 
 **Arguments**:
@@ -333,6 +333,8 @@ saved.
 - `metric`: The name of a dev set metric to monitor (default: loss) which is extracted from the prediction
 head specified by the variable `head`, or a function that extracts a value from the trainer dev evaluation
 result.
+For FARMReader training some available metrics to choose from are "EM", "f1" and "top_n_accuracy".
+For DensePassageRetriever training some available metrics to choose from are "acc", "f1" and "average_rank".
 NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
 one or more evaluation metric values from the prediction and target sets. The metric variable in this
 function specifies the name of one particular metric value, or it is a method to calculate a value from

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -311,8 +311,8 @@ Return all document title strings.
 class EarlyStopping()
 ```
 
-Can be used to control early stopping with a Trainer class. A custom EarlyStopping class can be used instead as long
-as it implements the method check_stopping and provides the attribute save_dir
+An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom EarlyStopping class can be used instead as long
+as it implements the method `check_stopping()` and provides the attribute `save_dir`.
 
 <a id="early_stopping.EarlyStopping.__init__"></a>
 
@@ -324,18 +324,19 @@ def __init__(head: int = 0, metric: str = "loss", save_dir: Optional[str] = None
 
 **Arguments**:
 
-- `head`: the prediction head referenced by the metric.
-- `save_dir`: the directory where to save the final best model, if None, no saving.
+- `head`: The index of the prediction head that you are evaluating using the metric. 
+In Haystack, the large majority of the models are trained from the one loss signal from a single prediction head and so default of 0 should work in most cases.
+- `save_dir`: The directory where to save the final best model. If you set it to None, the model will not be saved.
 - `metric`: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
 head, or a function that extracts a value from the trainer dev evaluation result.
 NOTE: This is different from the metric that is specified in the Processor which defines how
 to calculate one or more evaluation metric values from the prediction and target sets. The
 metric variable in this function specifies the name of one particular metric value, or it is a
 method to calculate that value from the result returned by the Processor metric.
-- `mode`: "min" or "max"
-- `patience`: how many evaluations to wait after the best evaluation to stop
-- `min_delta`: minimum difference to a previous best value to count as an improvement.
-- `min_evals`: minimum number of evaluations to wait before using eval value
+- `mode`: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
+- `patience`: How many evaluations with no improvement to perform before stopping training.
+- `min_delta`: Minimum difference to a previous best value to count as an improvement.
+- `min_evals`: Minimum number of evaluations to go perform before using eval value.
 
 <a id="early_stopping.EarlyStopping.check_stopping"></a>
 

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -320,7 +320,7 @@ attribute `save_dir`.
 #### EarlyStopping.\_\_init\_\_
 
 ```python
-def __init__(head: int = 0, metric: str = "loss", save_dir: Optional[str] = None, mode: str = "min", patience: int = 0, min_delta: float = 0.001, min_evals: int = 0)
+def __init__(head: int = 0, metric: str = "loss", save_dir: Optional[str] = None, mode: Literal["min", "max"] = "min", patience: int = 0, min_delta: float = 0.001, min_evals: int = 0)
 ```
 
 **Arguments**:

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -311,8 +311,9 @@ Return all document title strings.
 class EarlyStopping()
 ```
 
-An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom EarlyStopping class can be used instead as long
-as it implements the method `check_stopping()` and provides the attribute `save_dir`.
+An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom
+EarlyStopping class can be used instead as long as it implements the method `check_stopping()` and provides the
+attribute `save_dir`.
 
 <a id="early_stopping.EarlyStopping.__init__"></a>
 
@@ -324,19 +325,24 @@ def __init__(head: int = 0, metric: str = "loss", save_dir: Optional[str] = None
 
 **Arguments**:
 
-- `head`: The index of the prediction head that you are evaluating using the metric. 
-In Haystack, the large majority of the models are trained from the one loss signal from a single prediction head and so default of 0 should work in most cases.
-- `save_dir`: The directory where to save the final best model. If you set it to None, the model will not be saved.
-- `metric`: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
-head, or a function that extracts a value from the trainer dev evaluation result.
-NOTE: This is different from the metric that is specified in the Processor which defines how
-to calculate one or more evaluation metric values from the prediction and target sets. The
-metric variable in this function specifies the name of one particular metric value, or it is a
-method to calculate that value from the result returned by the Processor metric.
-- `mode`: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
+- `head`: The index of the prediction head that you are evaluating to determine the chosen `metric`.
+In Haystack, the large majority of the models are trained from the loss signal of a single prediction
+head so the default value of 0 should work in most cases.
+- `save_dir`: The directory where to save the final best model. If you set it to None, the model will not be
+saved.
+- `metric`: The name of a dev set metric to monitor (default: loss) which is extracted from the prediction
+head specified by the variable `head`, or a function that extracts a value from the trainer dev evaluation
+result.
+NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
+one or more evaluation metric values from the prediction and target sets. The metric variable in this
+function specifies the name of one particular metric value, or it is a method to calculate that value from
+the result returned by the Processor metric.
+- `mode`: When set to "min", training stops if the metric does not continue to decrease. When set to "max",
+training stops if the metric does not continue to increase.
 - `patience`: How many evaluations with no improvement to perform before stopping training.
-- `min_delta`: Minimum difference to a previous best value to count as an improvement.
-- `min_evals`: Minimum number of evaluations to go perform before using eval value.
+- `min_delta`: Minimum difference to the previous best value to count as an improvement.
+- `min_evals`: Minimum number of evaluations to perform before checking that the evaluation metric is
+improving.
 
 <a id="early_stopping.EarlyStopping.check_stopping"></a>
 
@@ -348,13 +354,12 @@ def check_stopping(eval_result: List[Dict]) -> Tuple[bool, bool, float]
 
 Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
 
-This will save the model, if necessary.
+This will save the model, if `self.save_dir` has been provided when initializing `EarlyStopping`.
 
 **Arguments**:
 
 - `eval_result`: The current evaluation result which consists of a list of dictionaries, one for each
-prediction head. Each dictionary contains the metrics and reports generated during
-evaluation.
+prediction head. Each dictionary contains the metrics and reports generated during evaluation.
 
 **Returns**:
 

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -311,9 +311,9 @@ Return all document title strings.
 class EarlyStopping()
 ```
 
-An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom
-EarlyStopping class can be used instead as long as it implements the method `check_stopping()` and provides the
-attribute `save_dir`.
+An object you can to control early stopping with a Node's `train()` method or a Trainer class. You can use a custom
+EarlyStopping class instead as long as it implements the method `check_stopping()` and provides the attribute
+`save_dir`.
 
 <a id="early_stopping.EarlyStopping.__init__"></a>
 
@@ -328,13 +328,12 @@ def __init__(head: int = 0, metric: Union[str, Callable] = "loss", save_dir: Opt
 - `head`: The index of the prediction head that you are evaluating to determine the chosen `metric`.
 In Haystack, the large majority of the models are trained from the loss signal of a single prediction
 head so the default value of 0 should work in most cases.
-- `save_dir`: The directory where to save the final best model. If you set it to None, the model will not be
-saved.
+- `save_dir`: The directory where to save the final best model. If you set it to None, the model is not saved.
 - `metric`: The name of a dev set metric to monitor (default: loss) which is extracted from the prediction
 head specified by the variable `head`, or a function that extracts a value from the trainer dev evaluation
 result.
-For FARMReader training some available metrics to choose from are "EM", "f1" and "top_n_accuracy".
-For DensePassageRetriever training some available metrics to choose from are "acc", "f1" and "average_rank".
+For FARMReader training, some available metrics to choose from are "EM", "f1", and "top_n_accuracy".
+For DensePassageRetriever training, some available metrics to choose from are "acc", "f1", and "average_rank".
 NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
 one or more evaluation metric values from the prediction and target sets. The metric variable in this
 function specifies the name of one particular metric value, or it is a method to calculate a value from
@@ -356,7 +355,7 @@ def check_stopping(eval_result: List[Dict]) -> Tuple[bool, bool, float]
 
 Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
 
-This will save the model, if `self.save_dir` has been provided when initializing `EarlyStopping`.
+This saves the model if you provided `self.save_dir` when initializing `EarlyStopping`.
 
 **Arguments**:
 

--- a/docs/_src/api/api/utils.md
+++ b/docs/_src/api/api/utils.md
@@ -335,7 +335,7 @@ head specified by the variable `head`, or a function that extracts a value from 
 result.
 NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
 one or more evaluation metric values from the prediction and target sets. The metric variable in this
-function specifies the name of one particular metric value, or it is a method to calculate that value from
+function specifies the name of one particular metric value, or it is a method to calculate a value from
 the result returned by the Processor metric.
 - `mode`: When set to "min", training stops if the metric does not continue to decrease. When set to "max",
 training stops if the metric does not continue to increase.

--- a/docs/_src/api/pydoc/utils.yml
+++ b/docs/_src/api/pydoc/utils.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../../haystack/utils]
-    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'earl_stopping']
+    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'early_stopping']
     ignore_when_discovered: ['__init__']
 processors:
   - type: filter

--- a/docs/_src/api/pydoc/utils.yml
+++ b/docs/_src/api/pydoc/utils.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../../haystack/utils]
-    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data']
+    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'earl_stopping']
     ignore_when_discovered: ['__init__']
 processors:
   - type: filter

--- a/haystack/modeling/training/__init__.py
+++ b/haystack/modeling/training/__init__.py
@@ -1,1 +1,1 @@
-from haystack.modeling.training.base import Trainer, DistillationTrainer, TinyBERTDistillationTrainer
+from haystack.modeling.training.base import Trainer, DistillationTrainer, TinyBERTDistillationTrainer, EarlyStopping

--- a/haystack/modeling/training/__init__.py
+++ b/haystack/modeling/training/__init__.py
@@ -1,1 +1,1 @@
-from haystack.modeling.training.base import Trainer, DistillationTrainer, TinyBERTDistillationTrainer, EarlyStopping
+from haystack.modeling.training.base import Trainer, DistillationTrainer, TinyBERTDistillationTrainer

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -82,7 +82,7 @@ class Trainer:
         :param grad_acc_steps: Number of training steps for which the gradients should be accumulated.
                                Useful to achieve larger effective batch sizes that would not fit in GPU memory.
         :param local_rank: Local rank of process when distributed training via DDP is used.
-        :param early_stopping: an initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         :param log_learning_rate: Whether to log learning rate to experiment tracker (e.g. Mlflow)
         :param log_loss_every: Log current train loss after this many train steps.
         :param checkpoint_on_sigterm: save a checkpoint for the Trainer when a SIGTERM signal is sent. The checkpoint
@@ -639,7 +639,7 @@ class DistillationTrainer(Trainer):
         :param grad_acc_steps: Number of training steps for which the gradients should be accumulated.
                                Useful to achieve larger effective batch sizes that would not fit in GPU memory.
         :param local_rank: Local rank of process when distributed training via DDP is used.
-        :param early_stopping: an initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         :param log_learning_rate: Whether to log learning rate to experiment tracker (e.g. Mlflow)
         :param log_loss_every: Log current train loss after this many train steps.
         :param checkpoint_on_sigterm: save a checkpoint for the Trainer when a SIGTERM signal is sent. The checkpoint
@@ -789,7 +789,7 @@ class TinyBERTDistillationTrainer(Trainer):
         :param grad_acc_steps: Number of training steps for which the gradients should be accumulated.
                                Useful to achieve larger effective batch sizes that would not fit in GPU memory.
         :param local_rank: Local rank of process when distributed training via DDP is used.
-        :param early_stopping: an initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         :param log_learning_rate: Whether to log learning rate to experiment tracker (e.g. Mlflow)
         :param log_loss_every: Log current train loss after this many train steps.
         :param checkpoint_on_sigterm: save a checkpoint for the Trainer when a SIGTERM signal is sent. The checkpoint

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class EarlyStopping:
     """
     Can be used to control early stopping with a Trainer class. Any object can be used instead which
-    implements the method check_stopping and and provides the attribute save_dir
+    implements the method check_stopping and provides the attribute save_dir
     """
 
     def __init__(
@@ -55,7 +55,7 @@ class EarlyStopping:
         :param metric: name of dev set metric to monitor (default: loss) to get extracted from the 0th head or
                        a function that extracts a value from the trainer dev evaluation result.
                        NOTE: this is different from the metric to get specified for the processor which defines how
-                       to calculate one or more evaluation matric values from prediction/target sets, while this
+                       to calculate one or more evaluation metric values from prediction/target sets, while this
                        specifies the name of one particular such metric value or a method to calculate that value
                        from the result returned from a processor metric.
         :param mode: "min" or "max"

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Tuple, List, Callable, Dict
+from typing import Optional, Union, List, Callable
 
 import sys
 import shutil
@@ -21,6 +21,7 @@ from haystack.modeling.model.biadaptive_model import BiAdaptiveModel
 from haystack.modeling.model.optimization import get_scheduler
 from haystack.modeling.utils import GracefulKiller
 from haystack.utils.experiment_tracking import Tracker as tracker
+from haystack.utils.early_stopping import EarlyStopping
 
 try:
     from apex import amp
@@ -31,88 +32,6 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
-
-
-class EarlyStopping:
-    """
-    Can be used to control early stopping with a Trainer class. A custom EarlyStopping class can be used instead as long
-    as it implements the method check_stopping and provides the attribute save_dir
-    """
-
-    def __init__(
-        self,
-        head: int = 0,
-        metric: str = "loss",
-        save_dir: Optional[str] = None,
-        mode: str = "min",
-        patience: int = 0,
-        min_delta: float = 0.001,
-        min_evals: int = 0,
-    ):
-        """
-        :param head: the prediction head referenced by the metric.
-        :param save_dir: the directory where to save the final best model, if None, no saving.
-        :param metric: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
-                       head, or a function that extracts a value from the trainer dev evaluation result.
-                       NOTE: This is different from the metric that is specified in the Processor which defines how
-                       to calculate one or more evaluation metric values from the prediction and target sets. The
-                       metric variable in this function specifies the name of one particular metric value, or it is a
-                       method to calculate that value from the result returned by the Processor metric.
-        :param mode: "min" or "max"
-        :param patience: how many evaluations to wait after the best evaluation to stop
-        :param min_delta: minimum difference to a previous best value to count as an improvement.
-        :param min_evals: minimum number of evaluations to wait before using eval value
-        """
-        self.head = head
-        self.metric = metric
-        self.save_dir = save_dir
-        self.mode = mode
-        self.patience = patience
-        self.min_delta = min_delta
-        self.min_evals = min_evals
-        # for more complex modes
-        self.eval_values = []  # type: List
-        self.n_since_best = None  # type: Optional[int]
-        if mode == "min":
-            self.best_so_far = 1.0e99
-        elif mode == "max":
-            self.best_so_far = -1.0e99
-        else:
-            raise Exception("Mode must be 'min' or 'max'")
-
-    def check_stopping(self, eval_result: List[Dict]) -> Tuple[bool, bool, float]:
-        """
-        Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
-        This will save the model, if necessary.
-
-        :param eval_result: The current evaluation result which consists of a list of dictionaries, one for each
-                            prediction head. Each dictionary contains the metrics and reports generated during
-                            evaluation.
-        :return: A tuple (stopprocessing, savemodel, eval_value) indicating if processing should be stopped
-                 and if the current model should get saved and the evaluation value used.
-        """
-        if isinstance(self.metric, str):
-            eval_value = float(eval_result[self.head][self.metric])
-        else:
-            eval_value = float(self.metric(eval_result))
-        self.eval_values.append(eval_value)
-        stopprocessing, savemodel = False, False
-        if len(self.eval_values) <= self.min_evals:
-            return stopprocessing, savemodel, eval_value
-        if self.mode == "min":
-            delta = self.best_so_far - eval_value
-        else:
-            delta = eval_value - self.best_so_far
-        if delta > self.min_delta:
-            self.best_so_far = eval_value
-            self.n_since_best = 0
-            if self.save_dir:
-                savemodel = True
-        else:
-            self.n_since_best += 1  # type: ignore
-        if self.n_since_best > self.patience:
-            stopprocessing = True
-        return stopprocessing, savemodel, eval_value
 
 
 class Trainer:

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -20,7 +20,7 @@ from haystack.modeling.infer import QAInferencer
 from haystack.modeling.model.optimization import initialize_optimizer
 from haystack.modeling.model.predictions import QAPred, QACandidate
 from haystack.modeling.model.adaptive_model import AdaptiveModel
-from haystack.modeling.training import Trainer, DistillationTrainer, TinyBERTDistillationTrainer
+from haystack.modeling.training import Trainer, DistillationTrainer, TinyBERTDistillationTrainer, EarlyStopping
 from haystack.modeling.evaluation import Evaluator
 from haystack.modeling.utils import set_all_seeds, initialize_device_settings
 
@@ -190,6 +190,7 @@ class FARMReader(BaseReader):
         tinybert: bool = False,
         processor: Optional[Processor] = None,
         grad_acc_steps: int = 1,
+        early_stopping: Optional[EarlyStopping] = None,
     ):
         if dev_filename:
             dev_split = 0
@@ -288,6 +289,7 @@ class FARMReader(BaseReader):
                 checkpoint_every=checkpoint_every,
                 checkpoints_to_keep=checkpoints_to_keep,
                 grad_acc_steps=grad_acc_steps,
+                early_stopping=early_stopping,
             )
 
         elif (
@@ -311,6 +313,7 @@ class FARMReader(BaseReader):
                 distillation_loss_weight=distillation_loss_weight,
                 temperature=temperature,
                 grad_acc_steps=grad_acc_steps,
+                early_stopping=early_stopping,
             )
         else:
             trainer = Trainer.create_or_load_checkpoint(
@@ -328,6 +331,7 @@ class FARMReader(BaseReader):
                 checkpoint_every=checkpoint_every,
                 checkpoints_to_keep=checkpoints_to_keep,
                 grad_acc_steps=grad_acc_steps,
+                early_stopping=early_stopping,
             )
 
         # 5. Let it grow!
@@ -358,6 +362,7 @@ class FARMReader(BaseReader):
         caching: bool = False,
         cache_path: Path = Path("cache/data_silo"),
         grad_acc_steps: int = 1,
+        early_stopping: Optional[EarlyStopping] = None,
     ):
         """
         Fine-tune a model on a QA dataset. Options:
@@ -404,6 +409,7 @@ class FARMReader(BaseReader):
         :param cache_path: Path to cache the preprocessed dataset
         :param processor: The processor to use for preprocessing. If None, the default SquadProcessor is used.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
         :return: None
         """
         return self._training_procedure(
@@ -429,6 +435,7 @@ class FARMReader(BaseReader):
             caching=caching,
             cache_path=cache_path,
             grad_acc_steps=grad_acc_steps,
+            early_stopping=early_stopping,
         )
 
     def distil_prediction_layer_from(
@@ -460,6 +467,7 @@ class FARMReader(BaseReader):
         distillation_loss: Union[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = "kl_div",
         temperature: float = 1.0,
         grad_acc_steps: int = 1,
+        early_stopping: Optional[EarlyStopping] = None,
     ):
         """
         Fine-tune a model on a QA dataset using logit-based distillation. You need to provide a teacher model that is already finetuned on the dataset
@@ -525,6 +533,7 @@ class FARMReader(BaseReader):
         :param tinybert_train_filename: Filename of training data to use when training the student model with the TinyBERT loss function. To best follow the original paper, this should be an augmented version of the training data created using the augment_squad.py script. If not specified, the training data from the original training is used.
         :param processor: The processor to use for preprocessing. If None, the default SquadProcessor is used.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
         :return: None
         """
         return self._training_procedure(
@@ -555,6 +564,7 @@ class FARMReader(BaseReader):
             distillation_loss=distillation_loss,
             temperature=temperature,
             grad_acc_steps=grad_acc_steps,
+            early_stopping=early_stopping,
         )
 
     def distil_intermediate_layers_from(
@@ -585,6 +595,7 @@ class FARMReader(BaseReader):
         temperature: float = 1.0,
         processor: Optional[Processor] = None,
         grad_acc_steps: int = 1,
+        early_stopping: Optional[EarlyStopping] = None,
     ):
         """
         The first stage of distillation finetuning as described in the TinyBERT paper:
@@ -642,6 +653,7 @@ class FARMReader(BaseReader):
         :param temperature: The temperature for distillation. A higher temperature will result in less certainty of teacher outputs. A lower temperature means more certainty. A temperature of 1.0 does not change the certainty of the model.
         :param processor: The processor to use for preprocessing. If None, the default SquadProcessor is used.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
         :return: None
         """
         return self._training_procedure(
@@ -673,6 +685,7 @@ class FARMReader(BaseReader):
             tinybert=True,
             processor=processor,
             grad_acc_steps=grad_acc_steps,
+            early_stopping=early_stopping,
         )
 
     def update_parameters(

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -20,13 +20,14 @@ from haystack.modeling.infer import QAInferencer
 from haystack.modeling.model.optimization import initialize_optimizer
 from haystack.modeling.model.predictions import QAPred, QACandidate
 from haystack.modeling.model.adaptive_model import AdaptiveModel
-from haystack.modeling.training import Trainer, DistillationTrainer, TinyBERTDistillationTrainer, EarlyStopping
+from haystack.modeling.training import Trainer, DistillationTrainer, TinyBERTDistillationTrainer
 from haystack.modeling.evaluation import Evaluator
 from haystack.modeling.utils import set_all_seeds, initialize_device_settings
 
 from haystack.schema import Document, Answer, Span
 from haystack.document_stores.base import BaseDocumentStore
 from haystack.nodes.reader.base import BaseReader
+from haystack.utils.early_stopping import EarlyStopping
 
 
 logger = logging.getLogger(__name__)
@@ -401,13 +402,12 @@ class FARMReader(BaseReader):
                         "O2" (Almost FP16)
                         "O3" (Pure FP16).
                         See details on: https://nvidia.github.io/apex/amp.html
-        :param checkpoint_root_dir: the Path of directory where all train checkpoints are saved. For each individual
+        :param checkpoint_root_dir: The Path of a directory where all train checkpoints are saved. For each individual
                checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
-        :param checkpoint_every: save a train checkpoint after this many steps of training.
-        :param checkpoints_to_keep: maximum number of train checkpoints to save.
-        :param caching: whether or not to use caching for preprocessed dataset
-        :param cache_path: Path to cache the preprocessed dataset
-        :param processor: The processor to use for preprocessing. If None, the default SquadProcessor is used.
+        :param checkpoint_every: Save a train checkpoint after this many steps of training.
+        :param checkpoints_to_keep: The maximum number of train checkpoints to save.
+        :param caching: Whether or not to use caching for the preprocessed dataset.
+        :param cache_path: The Path to cache the preprocessed dataset.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
         :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
         :return: None

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -409,7 +409,7 @@ class FARMReader(BaseReader):
         :param caching: Whether or not to use caching for the preprocessed dataset.
         :param cache_path: The Path to cache the preprocessed dataset.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
-        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         :return: None
         """
         return self._training_procedure(
@@ -533,7 +533,7 @@ class FARMReader(BaseReader):
         :param tinybert_train_filename: Filename of training data to use when training the student model with the TinyBERT loss function. To best follow the original paper, this should be an augmented version of the training data created using the augment_squad.py script. If not specified, the training data from the original training is used.
         :param processor: The processor to use for preprocessing. If None, the default SquadProcessor is used.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
-        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         :return: None
         """
         return self._training_procedure(
@@ -653,7 +653,7 @@ class FARMReader(BaseReader):
         :param temperature: The temperature for distillation. A higher temperature will result in less certainty of teacher outputs. A lower temperature means more certainty. A temperature of 1.0 does not change the certainty of the model.
         :param processor: The processor to use for preprocessing. If None, the default SquadProcessor is used.
         :param grad_acc_steps: The number of steps to accumulate gradients for before performing a backward pass.
-        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         :return: None
         """
         return self._training_procedure(

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -627,7 +627,7 @@ class DensePassageRetriever(BaseRetriever):
                 checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
         :param checkpoint_every: Save a train checkpoint after this many steps of training.
         :param checkpoints_to_keep: The maximum number of train checkpoints to save.
-        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
 
         Checkpoints can be stored via setting `checkpoint_every` to a custom number of steps.
         If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
@@ -1302,7 +1302,7 @@ class TableTextRetriever(BaseRetriever):
                 checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
         :param checkpoint_every: Save a train checkpoint after this many steps of training.
         :param checkpoints_to_keep: The maximum number of train checkpoints to save.
-        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of the best models.
         """
 
         self.processor.embed_meta_fields = embed_meta_fields

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -26,6 +26,7 @@ from haystack.schema import Document
 from haystack.document_stores import BaseDocumentStore
 from haystack.nodes.retriever.base import BaseRetriever
 from haystack.nodes.retriever._embedding_encoder import _EMBEDDING_ENCODERS
+from haystack.utils.early_stopping import EarlyStopping
 from haystack.modeling.model.language_model import get_language_model, DPREncoder
 from haystack.modeling.model.biadaptive_model import BiAdaptiveModel
 from haystack.modeling.model.triadaptive_model import TriAdaptiveModel
@@ -584,6 +585,7 @@ class DensePassageRetriever(BaseRetriever):
         checkpoint_root_dir: Path = Path("model_checkpoints"),
         checkpoint_every: Optional[int] = None,
         checkpoints_to_keep: int = 3,
+        early_stopping: Optional[EarlyStopping] = None,
     ):
         """
         train a DensePassageRetrieval model
@@ -621,6 +623,11 @@ class DensePassageRetriever(BaseRetriever):
         :param save_dir: directory where models are saved
         :param query_encoder_save_dir: directory inside save_dir where query_encoder model files are saved
         :param passage_encoder_save_dir: directory inside save_dir where passage_encoder model files are saved
+        :param checkpoint_root_dir: The Path of a directory where all train checkpoints are saved. For each individual
+                checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
+        :param checkpoint_every: Save a train checkpoint after this many steps of training.
+        :param checkpoints_to_keep: The maximum number of train checkpoints to save.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
 
         Checkpoints can be stored via setting `checkpoint_every` to a custom number of steps.
         If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
@@ -680,6 +687,7 @@ class DensePassageRetriever(BaseRetriever):
             checkpoint_root_dir=Path(checkpoint_root_dir),
             checkpoint_every=checkpoint_every,
             checkpoints_to_keep=checkpoints_to_keep,
+            early_stopping=early_stopping,
         )
 
         # 7. Let it grow! Watch the tracked metrics live on experiment tracker (e.g. Mlflow)
@@ -1250,6 +1258,7 @@ class TableTextRetriever(BaseRetriever):
         checkpoint_root_dir: Path = Path("model_checkpoints"),
         checkpoint_every: Optional[int] = None,
         checkpoints_to_keep: int = 3,
+        early_stopping: Optional[EarlyStopping] = None,
     ):
         """
         Train a TableTextRetrieval model.
@@ -1289,6 +1298,11 @@ class TableTextRetriever(BaseRetriever):
         :param query_encoder_save_dir: Directory inside save_dir where query_encoder model files are saved.
         :param passage_encoder_save_dir: Directory inside save_dir where passage_encoder model files are saved.
         :param table_encoder_save_dir: Directory inside save_dir where table_encoder model files are saved.
+        :param checkpoint_root_dir: The Path of a directory where all train checkpoints are saved. For each individual
+                checkpoint, a subdirectory with the name epoch_{epoch_num}_step_{step_num} is created.
+        :param checkpoint_every: Save a train checkpoint after this many steps of training.
+        :param checkpoints_to_keep: The maximum number of train checkpoints to save.
+        :param early_stopping: An initialized EarlyStopping object to control early stopping and saving of best models.
         """
 
         self.processor.embed_meta_fields = embed_meta_fields
@@ -1342,6 +1356,7 @@ class TableTextRetriever(BaseRetriever):
             checkpoint_root_dir=Path(checkpoint_root_dir),
             checkpoint_every=checkpoint_every,
             checkpoints_to_keep=checkpoints_to_keep,
+            early_stopping=early_stopping,
         )
 
         # 7. Let it grow! Watch the tracked metrics live on experiment tracker (e.g. Mlflow)

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -27,3 +27,4 @@ from haystack.utils.experiment_tracking import (
     MLflowTrackingHead,
     StdoutTrackingHead,
 )
+from haystack.utils.early_stopping import EarlyStopping

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -23,7 +23,8 @@ class EarlyStopping:
         min_evals: int = 0,
     ):
         """
-        :param head: the prediction head referenced by the metric.
+        :param head: The index of the prediction head that you are evaluating using the metric. 
+                               In Haystack, the large majority of the models are trained from the one loss signal from a single prediction head and so default of 0 should work in most cases.
         :param save_dir: the directory where to save the final best model, if None, no saving.
         :param metric: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
                        head, or a function that extracts a value from the trainer dev evaluation result.

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -1,0 +1,88 @@
+from typing import Optional, Tuple, List, Dict
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class EarlyStopping:
+    """
+    Can be used to control early stopping with a Trainer class. A custom EarlyStopping class can be used instead as long
+    as it implements the method check_stopping and provides the attribute save_dir
+    """
+
+    def __init__(
+        self,
+        head: int = 0,
+        metric: str = "loss",
+        save_dir: Optional[str] = None,
+        mode: str = "min",
+        patience: int = 0,
+        min_delta: float = 0.001,
+        min_evals: int = 0,
+    ):
+        """
+        :param head: the prediction head referenced by the metric.
+        :param save_dir: the directory where to save the final best model, if None, no saving.
+        :param metric: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
+                       head, or a function that extracts a value from the trainer dev evaluation result.
+                       NOTE: This is different from the metric that is specified in the Processor which defines how
+                       to calculate one or more evaluation metric values from the prediction and target sets. The
+                       metric variable in this function specifies the name of one particular metric value, or it is a
+                       method to calculate that value from the result returned by the Processor metric.
+        :param mode: "min" or "max"
+        :param patience: how many evaluations to wait after the best evaluation to stop
+        :param min_delta: minimum difference to a previous best value to count as an improvement.
+        :param min_evals: minimum number of evaluations to wait before using eval value
+        """
+        self.head = head
+        self.metric = metric
+        self.save_dir = save_dir
+        self.mode = mode
+        self.patience = patience
+        self.min_delta = min_delta
+        self.min_evals = min_evals
+        # for more complex modes
+        self.eval_values = []  # type: List
+        self.n_since_best = None  # type: Optional[int]
+        if mode == "min":
+            self.best_so_far = 1.0e99
+        elif mode == "max":
+            self.best_so_far = -1.0e99
+        else:
+            raise Exception("Mode must be 'min' or 'max'")
+
+    def check_stopping(self, eval_result: List[Dict]) -> Tuple[bool, bool, float]:
+        """
+        Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
+        This will save the model, if necessary.
+
+        :param eval_result: The current evaluation result which consists of a list of dictionaries, one for each
+                            prediction head. Each dictionary contains the metrics and reports generated during
+                            evaluation.
+        :return: A tuple (stopprocessing, savemodel, eval_value) indicating if processing should be stopped
+                 and if the current model should get saved and the evaluation value used.
+        """
+        if isinstance(self.metric, str):
+            eval_value = float(eval_result[self.head][self.metric])
+        else:
+            eval_value = float(self.metric(eval_result))
+        self.eval_values.append(eval_value)
+        stopprocessing, savemodel = False, False
+        if len(self.eval_values) <= self.min_evals:
+            return stopprocessing, savemodel, eval_value
+        if self.mode == "min":
+            delta = self.best_so_far - eval_value
+        else:
+            delta = eval_value - self.best_so_far
+        if delta > self.min_delta:
+            self.best_so_far = eval_value
+            self.n_since_best = 0
+            if self.save_dir:
+                savemodel = True
+        else:
+            self.n_since_best += 1  # type: ignore
+        if self.n_since_best > self.patience:
+            stopprocessing = True
+        return stopprocessing, savemodel, eval_value

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -25,7 +25,7 @@ class EarlyStopping:
         """
         :param head: The index of the prediction head that you are evaluating using the metric. 
                                In Haystack, the large majority of the models are trained from the one loss signal from a single prediction head and so default of 0 should work in most cases.
-        :param save_dir: the directory where to save the final best model, if None, no saving.
+        :param save_dir: The directory where to save the final best model. If you set it to None, the model will not be saved.
         :param metric: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
                        head, or a function that extracts a value from the trainer dev evaluation result.
                        NOTE: This is different from the metric that is specified in the Processor which defines how

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -33,7 +33,7 @@ class EarlyStopping:
                        metric variable in this function specifies the name of one particular metric value, or it is a
                        method to calculate that value from the result returned by the Processor metric.
         :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
-        :param patience: how many evaluations to wait after the best evaluation to stop
+        :param patience: How many evaluations with no improvement to perform before stopping training.
         :param min_delta: minimum difference to a previous best value to count as an improvement.
         :param min_evals: minimum number of evaluations to wait before using eval value
         """

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -35,7 +35,7 @@ class EarlyStopping:
         :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
         :param patience: How many evaluations with no improvement to perform before stopping training.
         :param min_delta: Minimum difference to a previous best value to count as an improvement.
-        :param min_evals: minimum number of evaluations to wait before using eval value
+        :param min_evals: Minimum number of evaluations to go perform before using eval value.
         """
         self.head = head
         self.metric = metric

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -34,7 +34,7 @@ class EarlyStopping:
             result.
             NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
             one or more evaluation metric values from the prediction and target sets. The metric variable in this
-            function specifies the name of one particular metric value, or it is a method to calculate that value from
+            function specifies the name of one particular metric value, or it is a method to calculate a value from
             the result returned by the Processor metric.
         :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max",
             training stops if the metric does not continue to increase.

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -32,7 +32,7 @@ class EarlyStopping:
                        to calculate one or more evaluation metric values from the prediction and target sets. The
                        metric variable in this function specifies the name of one particular metric value, or it is a
                        method to calculate that value from the result returned by the Processor metric.
-        :param mode: "min" or "max"
+        :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
         :param patience: how many evaluations to wait after the best evaluation to stop
         :param min_delta: minimum difference to a previous best value to count as an improvement.
         :param min_evals: minimum number of evaluations to wait before using eval value

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -1,6 +1,6 @@
-from typing import Optional, Tuple, List, Dict, Callable, Union
-
 import logging
+
+from typing import Optional, Tuple, List, Dict, Callable, Union
 
 try:
     from typing import Literal

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class EarlyStopping:
     """
-    Can be used to control early stopping with a Trainer class. A custom EarlyStopping class can be used instead as long
+    An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom EarlyStopping class can be used instead as long
     as it implements the method check_stopping and provides the attribute save_dir
     """
 

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class EarlyStopping:
     """
     An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom EarlyStopping class can be used instead as long
-    as it implements the method check_stopping and provides the attribute save_dir
+    as it implements the method `check_stopping()` and provides the attribute `save_dir`.
     """
 
     def __init__(

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -34,7 +34,7 @@ class EarlyStopping:
                        method to calculate that value from the result returned by the Processor metric.
         :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
         :param patience: How many evaluations with no improvement to perform before stopping training.
-        :param min_delta: minimum difference to a previous best value to count as an improvement.
+        :param min_delta: Minimum difference to a previous best value to count as an improvement.
         :param min_evals: minimum number of evaluations to wait before using eval value
         """
         self.head = head

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 
 class EarlyStopping:
     """
-    An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom
-    EarlyStopping class can be used instead as long as it implements the method `check_stopping()` and provides the
-    attribute `save_dir`.
+    An object you can to control early stopping with a Node's `train()` method or a Trainer class. You can use a custom
+    EarlyStopping class instead as long as it implements the method `check_stopping()` and provides the attribute
+    `save_dir`.
     """
 
     def __init__(
@@ -32,13 +32,12 @@ class EarlyStopping:
         :param head: The index of the prediction head that you are evaluating to determine the chosen `metric`.
             In Haystack, the large majority of the models are trained from the loss signal of a single prediction
             head so the default value of 0 should work in most cases.
-        :param save_dir: The directory where to save the final best model. If you set it to None, the model will not be
-            saved.
+        :param save_dir: The directory where to save the final best model. If you set it to None, the model is not saved.
         :param metric: The name of a dev set metric to monitor (default: loss) which is extracted from the prediction
             head specified by the variable `head`, or a function that extracts a value from the trainer dev evaluation
             result.
-            For FARMReader training some available metrics to choose from are "EM", "f1" and "top_n_accuracy".
-            For DensePassageRetriever training some available metrics to choose from are "acc", "f1" and "average_rank".
+            For FARMReader training, some available metrics to choose from are "EM", "f1", and "top_n_accuracy".
+            For DensePassageRetriever training, some available metrics to choose from are "acc", "f1", and "average_rank".
             NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
             one or more evaluation metric values from the prediction and target sets. The metric variable in this
             function specifies the name of one particular metric value, or it is a method to calculate a value from
@@ -70,7 +69,7 @@ class EarlyStopping:
     def check_stopping(self, eval_result: List[Dict]) -> Tuple[bool, bool, float]:
         """
         Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
-        This will save the model, if `self.save_dir` has been provided when initializing `EarlyStopping`.
+        This saves the model if you provided `self.save_dir` when initializing `EarlyStopping`.
 
         :param eval_result: The current evaluation result which consists of a list of dictionaries, one for each
             prediction head. Each dictionary contains the metrics and reports generated during evaluation.

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -8,8 +8,9 @@ logger = logging.getLogger(__name__)
 
 class EarlyStopping:
     """
-    An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom EarlyStopping class can be used instead as long
-    as it implements the method `check_stopping()` and provides the attribute `save_dir`.
+    An object that can be used to control early stopping with a Node's `train()` method or a Trainer class. A custom
+    EarlyStopping class can be used instead as long as it implements the method `check_stopping()` and provides the
+    attribute `save_dir`.
     """
 
     def __init__(
@@ -23,19 +24,24 @@ class EarlyStopping:
         min_evals: int = 0,
     ):
         """
-        :param head: The index of the prediction head that you are evaluating using the metric. 
-                               In Haystack, the large majority of the models are trained from the one loss signal from a single prediction head and so default of 0 should work in most cases.
-        :param save_dir: The directory where to save the final best model. If you set it to None, the model will not be saved.
-        :param metric: The name of dev set metric to monitor (default: loss) which is extracted from the 0th prediction
-                       head, or a function that extracts a value from the trainer dev evaluation result.
-                       NOTE: This is different from the metric that is specified in the Processor which defines how
-                       to calculate one or more evaluation metric values from the prediction and target sets. The
-                       metric variable in this function specifies the name of one particular metric value, or it is a
-                       method to calculate that value from the result returned by the Processor metric.
-        :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max", training stops if the metric does not continue to increase.
+        :param head: The index of the prediction head that you are evaluating to determine the chosen `metric`.
+            In Haystack, the large majority of the models are trained from the loss signal of a single prediction
+            head so the default value of 0 should work in most cases.
+        :param save_dir: The directory where to save the final best model. If you set it to None, the model will not be
+            saved.
+        :param metric: The name of a dev set metric to monitor (default: loss) which is extracted from the prediction
+            head specified by the variable `head`, or a function that extracts a value from the trainer dev evaluation
+            result.
+            NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
+            one or more evaluation metric values from the prediction and target sets. The metric variable in this
+            function specifies the name of one particular metric value, or it is a method to calculate that value from
+            the result returned by the Processor metric.
+        :param mode: When set to "min", training stops if the metric does not continue to decrease. When set to "max",
+            training stops if the metric does not continue to increase.
         :param patience: How many evaluations with no improvement to perform before stopping training.
-        :param min_delta: Minimum difference to a previous best value to count as an improvement.
-        :param min_evals: Minimum number of evaluations to go perform before using eval value.
+        :param min_delta: Minimum difference to the previous best value to count as an improvement.
+        :param min_evals: Minimum number of evaluations to perform before checking that the evaluation metric is
+            improving.
         """
         self.head = head
         self.metric = metric
@@ -57,13 +63,12 @@ class EarlyStopping:
     def check_stopping(self, eval_result: List[Dict]) -> Tuple[bool, bool, float]:
         """
         Provides the evaluation value for the current evaluation. Returns true if stopping should occur.
-        This will save the model, if necessary.
+        This will save the model, if `self.save_dir` has been provided when initializing `EarlyStopping`.
 
         :param eval_result: The current evaluation result which consists of a list of dictionaries, one for each
-                            prediction head. Each dictionary contains the metrics and reports generated during
-                            evaluation.
+            prediction head. Each dictionary contains the metrics and reports generated during evaluation.
         :return: A tuple (stopprocessing, savemodel, eval_value) indicating if processing should be stopped
-                 and if the current model should get saved and the evaluation value used.
+            and if the current model should get saved and the evaluation value used.
         """
         if isinstance(self.metric, str):
             eval_value = float(eval_result[self.head][self.metric])

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Dict
+from typing import Optional, Tuple, List, Dict, Callable, Union
 
 import logging
 
@@ -21,7 +21,7 @@ class EarlyStopping:
     def __init__(
         self,
         head: int = 0,
-        metric: str = "loss",
+        metric: Union[str, Callable] = "loss",
         save_dir: Optional[str] = None,
         mode: Literal["min", "max"] = "min",
         patience: int = 0,
@@ -37,6 +37,8 @@ class EarlyStopping:
         :param metric: The name of a dev set metric to monitor (default: loss) which is extracted from the prediction
             head specified by the variable `head`, or a function that extracts a value from the trainer dev evaluation
             result.
+            For FARMReader training some available metrics to choose from are "EM", "f1" and "top_n_accuracy".
+            For DensePassageRetriever training some available metrics to choose from are "acc", "f1" and "average_rank".
             NOTE: This is different from the metric that is specified in the Processor which defines how to calculate
             one or more evaluation metric values from the prediction and target sets. The metric variable in this
             function specifies the name of one particular metric value, or it is a method to calculate a value from


### PR DESCRIPTION
### Related Issues
No issue

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add option to specify Early Stopping in the Reader trainer. This feature is already present, I just exposed the option to the `FARMReader.train` method. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I've run a Reader training using Early Stopping on AWS and it worked as expected. 

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
