### PR TITLE
fix(translator): write translated text to output documents, while keeping input untouched

### DIFF
--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -18,7 +18,13 @@ Abstract class for a Translator component that translates either a query or a do
 
 ```python
 @abstractmethod
-def translate(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(
+    results: List[Dict[str, Any]] = None,
+    query: Optional[str] = None,
+    documents: Optional[Union[List[Document], List[Answer], List[str],
+                              List[Dict[str, Any]]]] = None,
+    dict_key: Optional[str] = None
+) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Translate the passed query or a list of documents from language A to B.
@@ -28,7 +34,12 @@ Translate the passed query or a list of documents from language A to B.
 #### BaseTranslator.run
 
 ```python
-def run(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None)
+def run(results: List[Dict[str, Any]] = None,
+        query: Optional[str] = None,
+        documents: Optional[Union[List[Document], List[Answer], List[str],
+                                  List[Dict[str, Any]]]] = None,
+        answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        dict_key: Optional[str] = None)
 ```
 
 Method that gets executed when this class is used as a Node in a Haystack Pipeline
@@ -68,7 +79,12 @@ We currently recommend using OPUS models (see __init__() for details)
 #### TransformersTranslator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True, progress_bar: bool = True)
+def __init__(model_name_or_path: str,
+             tokenizer_name: Optional[str] = None,
+             max_seq_len: Optional[int] = None,
+             clean_up_tokenization_spaces: Optional[bool] = True,
+             use_gpu: bool = True,
+             progress_bar: bool = True)
 ```
 
 Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
@@ -100,7 +116,13 @@ tokenizer.
 #### TransformersTranslator.translate
 
 ```python
-def translate(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(
+    results: List[Dict[str, Any]] = None,
+    query: Optional[str] = None,
+    documents: Optional[Union[List[Document], List[Answer], List[str],
+                              List[Dict[str, Any]]]] = None,
+    dict_key: Optional[str] = None
+) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Run the actual translation. You can supply a query or a list of documents. Whatever is supplied will be translated.
@@ -117,7 +139,14 @@ Run the actual translation. You can supply a query or a list of documents. Whate
 #### TransformersTranslator.translate\_batch
 
 ```python
-def translate_batch(queries: Optional[List[str]] = None, documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None, batch_size: Optional[int] = None) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]
+def translate_batch(
+    queries: Optional[List[str]] = None,
+    documents: Optional[Union[List[Document], List[Answer],
+                              List[List[Document]],
+                              List[List[Answer]]]] = None,
+    batch_size: Optional[int] = None
+) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[
+        str, Any]]]]
 ```
 
 Run the actual translation. You can supply a single query, a list of queries or a list (of lists) of documents.

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -18,13 +18,7 @@ Abstract class for a Translator component that translates either a query or a do
 
 ```python
 @abstractmethod
-def translate(
-    results: List[Dict[str, Any]] = None,
-    query: Optional[str] = None,
-    documents: Optional[Union[List[Document], List[Answer], List[str],
-                              List[Dict[str, Any]]]] = None,
-    dict_key: Optional[str] = None
-) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Translate the passed query or a list of documents from language A to B.
@@ -34,12 +28,7 @@ Translate the passed query or a list of documents from language A to B.
 #### BaseTranslator.run
 
 ```python
-def run(results: List[Dict[str, Any]] = None,
-        query: Optional[str] = None,
-        documents: Optional[Union[List[Document], List[Answer], List[str],
-                                  List[Dict[str, Any]]]] = None,
-        answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        dict_key: Optional[str] = None)
+def run(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None)
 ```
 
 Method that gets executed when this class is used as a Node in a Haystack Pipeline
@@ -79,12 +68,7 @@ We currently recommend using OPUS models (see __init__() for details)
 #### TransformersTranslator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str,
-             tokenizer_name: Optional[str] = None,
-             max_seq_len: Optional[int] = None,
-             clean_up_tokenization_spaces: Optional[bool] = True,
-             use_gpu: bool = True,
-             progress_bar: bool = True)
+def __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True, progress_bar: bool = True)
 ```
 
 Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
@@ -116,13 +100,7 @@ tokenizer.
 #### TransformersTranslator.translate
 
 ```python
-def translate(
-    results: Optional[List[Dict[str, Any]]] = None,
-    query: Optional[str] = None,
-    documents: Optional[Union[List[Document], List[Answer], List[str],
-                              List[Dict[str, Any]]]] = None,
-    dict_key: Optional[str] = None
-) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(results: Optional[List[Dict[str, Any]]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Run the actual translation. You can supply a query or a list of documents. Whatever is supplied will be translated.
@@ -139,14 +117,7 @@ Run the actual translation. You can supply a query or a list of documents. Whate
 #### TransformersTranslator.translate\_batch
 
 ```python
-def translate_batch(
-    queries: Optional[List[str]] = None,
-    documents: Optional[Union[List[Document], List[Answer],
-                              List[List[Document]],
-                              List[List[Answer]]]] = None,
-    batch_size: Optional[int] = None
-) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[
-        str, Any]]]]
+def translate_batch(queries: Optional[List[str]] = None, documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None, batch_size: Optional[int] = None) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]
 ```
 
 Run the actual translation. You can supply a single query, a list of queries or a list (of lists) of documents.

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -117,7 +117,7 @@ tokenizer.
 
 ```python
 def translate(
-    results: List[Dict[str, Any]] = None,
+    results: Optional[List[Dict[str, Any]]] = None,
     query: Optional[str] = None,
     documents: Optional[Union[List[Document], List[Answer], List[str],
                               List[Dict[str, Any]]]] = None,

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -18,13 +18,7 @@ Abstract class for a Translator component that translates either a query or a do
 
 ```python
 @abstractmethod
-def translate(
-    results: List[Dict[str, Any]] = None,
-    query: Optional[str] = None,
-    documents: Optional[Union[List[Document], List[Answer], List[str],
-                              List[Dict[str, Any]]]] = None,
-    dict_key: Optional[str] = None
-) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Translate the passed query or a list of documents from language A to B.
@@ -34,12 +28,7 @@ Translate the passed query or a list of documents from language A to B.
 #### BaseTranslator.run
 
 ```python
-def run(results: List[Dict[str, Any]] = None,
-        query: Optional[str] = None,
-        documents: Optional[Union[List[Document], List[Answer], List[str],
-                                  List[Dict[str, Any]]]] = None,
-        answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-        dict_key: Optional[str] = None)
+def run(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None)
 ```
 
 Method that gets executed when this class is used as a Node in a Haystack Pipeline
@@ -79,12 +68,7 @@ We currently recommend using OPUS models (see __init__() for details)
 #### TransformersTranslator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str,
-             tokenizer_name: Optional[str] = None,
-             max_seq_len: Optional[int] = None,
-             clean_up_tokenization_spaces: Optional[bool] = True,
-             use_gpu: bool = True,
-             progress_bar: bool = True)
+def __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True, progress_bar: bool = True)
 ```
 
 Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
@@ -116,13 +100,7 @@ tokenizer.
 #### TransformersTranslator.translate
 
 ```python
-def translate(
-    results: List[Dict[str, Any]] = None,
-    query: Optional[str] = None,
-    documents: Optional[Union[List[Document], List[Answer], List[str],
-                              List[Dict[str, Any]]]] = None,
-    dict_key: Optional[str] = None
-) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Run the actual translation. You can supply a query or a list of documents. Whatever is supplied will be translated.
@@ -139,14 +117,7 @@ Run the actual translation. You can supply a query or a list of documents. Whate
 #### TransformersTranslator.translate\_batch
 
 ```python
-def translate_batch(
-    queries: Optional[List[str]] = None,
-    documents: Optional[Union[List[Document], List[Answer],
-                              List[List[Document]],
-                              List[List[Answer]]]] = None,
-    batch_size: Optional[int] = None
-) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[
-        str, Any]]]]
+def translate_batch(queries: Optional[List[str]] = None, documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None, batch_size: Optional[int] = None) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]
 ```
 
 Run the actual translation. You can supply a single query, a list of queries or a list (of lists) of documents.

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -18,7 +18,13 @@ Abstract class for a Translator component that translates either a query or a do
 
 ```python
 @abstractmethod
-def translate(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(
+    results: List[Dict[str, Any]] = None,
+    query: Optional[str] = None,
+    documents: Optional[Union[List[Document], List[Answer], List[str],
+                              List[Dict[str, Any]]]] = None,
+    dict_key: Optional[str] = None
+) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Translate the passed query or a list of documents from language A to B.
@@ -28,7 +34,12 @@ Translate the passed query or a list of documents from language A to B.
 #### BaseTranslator.run
 
 ```python
-def run(results: List[Dict[str, Any]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None)
+def run(results: List[Dict[str, Any]] = None,
+        query: Optional[str] = None,
+        documents: Optional[Union[List[Document], List[Answer], List[str],
+                                  List[Dict[str, Any]]]] = None,
+        answers: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+        dict_key: Optional[str] = None)
 ```
 
 Method that gets executed when this class is used as a Node in a Haystack Pipeline
@@ -68,7 +79,12 @@ We currently recommend using OPUS models (see __init__() for details)
 #### TransformersTranslator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True, progress_bar: bool = True)
+def __init__(model_name_or_path: str,
+             tokenizer_name: Optional[str] = None,
+             max_seq_len: Optional[int] = None,
+             clean_up_tokenization_spaces: Optional[bool] = True,
+             use_gpu: bool = True,
+             progress_bar: bool = True)
 ```
 
 Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
@@ -100,7 +116,13 @@ tokenizer.
 #### TransformersTranslator.translate
 
 ```python
-def translate(results: Optional[List[Dict[str, Any]]] = None, query: Optional[str] = None, documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None, dict_key: Optional[str] = None) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
+def translate(
+    results: Optional[List[Dict[str, Any]]] = None,
+    query: Optional[str] = None,
+    documents: Optional[Union[List[Document], List[Answer], List[str],
+                              List[Dict[str, Any]]]] = None,
+    dict_key: Optional[str] = None
+) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]
 ```
 
 Run the actual translation. You can supply a query or a list of documents. Whatever is supplied will be translated.
@@ -117,7 +139,14 @@ Run the actual translation. You can supply a query or a list of documents. Whate
 #### TransformersTranslator.translate\_batch
 
 ```python
-def translate_batch(queries: Optional[List[str]] = None, documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None, batch_size: Optional[int] = None) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]
+def translate_batch(
+    queries: Optional[List[str]] = None,
+    documents: Optional[Union[List[Document], List[Answer],
+                              List[List[Document]],
+                              List[List[Answer]]]] = None,
+    batch_size: Optional[int] = None
+) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[
+        str, Any]]]]
 ```
 
 Run the actual translation. You can supply a single query, a list of queries or a list (of lists) of documents.

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -145,7 +145,9 @@ class TransformersTranslator(BaseTranslator):
             if isinstance(documents, list) and isinstance(documents[0], str):
                 return [translated_text for translated_text in translated_texts]
 
-            translated_documents: Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]] = []
+            translated_documents: Union[
+                List[Document], List[Answer], List[str], List[Dict[str, Any]]
+            ] = []  # type: ignore
             for translated_text, doc in zip(translated_texts, documents):
                 translated_document = deepcopy(doc)
                 if isinstance(translated_document, Document):

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -145,6 +145,7 @@ class TransformersTranslator(BaseTranslator):
             if isinstance(documents, list) and isinstance(documents[0], str):
                 return [translated_text for translated_text in translated_texts]
 
+            translated_documents = []
             for translated_text, doc in zip(translated_texts, documents):
                 doc = deepcopy(doc)
                 if isinstance(doc, Document):
@@ -153,8 +154,9 @@ class TransformersTranslator(BaseTranslator):
                     doc.answer = translated_text
                 else:
                     doc[dict_key] = translated_text  # type: ignore
+                translated_documents.append(doc)
 
-            return documents
+            return translated_documents
 
         raise AttributeError("Translator need query or documents to perform translation")
 

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
 from tqdm.auto import tqdm
@@ -145,6 +146,7 @@ class TransformersTranslator(BaseTranslator):
                 return [translated_text for translated_text in translated_texts]
 
             for translated_text, doc in zip(translated_texts, documents):
+                doc = deepcopy(doc)
                 if isinstance(doc, Document):
                     doc.content = translated_text
                 elif isinstance(doc, Answer):

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -145,7 +145,7 @@ class TransformersTranslator(BaseTranslator):
             if isinstance(documents, list) and isinstance(documents[0], str):
                 return [translated_text for translated_text in translated_texts]
 
-            translated_documents = []
+            translated_documents: Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]] = []
             for translated_text, doc in zip(translated_texts, documents):
                 translated_document = deepcopy(doc)
                 if isinstance(translated_document, Document):
@@ -154,7 +154,7 @@ class TransformersTranslator(BaseTranslator):
                     translated_document.answer = translated_text
                 else:
                     translated_document[dict_key] = translated_text  # type: ignore
-                translated_documents.append(translated_document)
+                translated_documents.append(translated_document)  # type: ignore
 
             return translated_documents
 

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -147,18 +147,18 @@ class TransformersTranslator(BaseTranslator):
 
             translated_documents = []
             for translated_text, doc in zip(translated_texts, documents):
-                doc = deepcopy(doc)
-                if isinstance(doc, Document):
-                    doc.content = translated_text
-                elif isinstance(doc, Answer):
-                    doc.answer = translated_text
+                translated_document = deepcopy(doc)
+                if isinstance(translated_document, Document):
+                    translated_document.content = translated_text
+                elif isinstance(translated_document, Answer):
+                    translated_document.answer = translated_text
                 else:
-                    doc[dict_key] = translated_text  # type: ignore
-                translated_documents.append(doc)
+                    translated_document[dict_key] = translated_text  # type: ignore
+                translated_documents.append(translated_document)
 
             return translated_documents
 
-        raise AttributeError("Translator need query or documents to perform translation")
+        raise AttributeError("Translator needs query or documents to perform translation")
 
     def translate_batch(
         self,

--- a/test/nodes/test_translator.py
+++ b/test/nodes/test_translator.py
@@ -5,6 +5,8 @@ import pytest
 EXPECTED_OUTPUT = "Ich lebe in Berlin"
 INPUT = "I live in Berlin"
 
+DOCUMENT_INPUT = Document(content=INPUT)
+
 
 def test_translator_with_query(en_to_de_translator):
     assert en_to_de_translator.translate(query=INPUT) == EXPECTED_OUTPUT
@@ -18,8 +20,20 @@ def test_translator_with_document(en_to_de_translator):
     assert en_to_de_translator.translate(documents=[Document(content=INPUT)])[0].content == EXPECTED_OUTPUT
 
 
+def test_translator_with_document_preserves_input(en_to_de_translator):
+    original_document = Document(content=INPUT)
+    en_to_de_translator.translate(documents=[original_document])[0]  # pylint: disable=expression-not-assigned
+    assert original_document.content == INPUT
+
+
 def test_translator_with_dictionary(en_to_de_translator):
     assert en_to_de_translator.translate(documents=[{"content": INPUT}])[0]["content"] == EXPECTED_OUTPUT
+
+
+def test_translator_with_dictionary_preserves_input(en_to_de_translator):
+    original_document = {"content": INPUT}
+    en_to_de_translator.translate(documents=[original_document])[0]  # pylint: disable=expression-not-assigned
+    assert original_document["content"] == INPUT
 
 
 def test_translator_with_dictionary_with_dict_key(en_to_de_translator):


### PR DESCRIPTION
### Related Issues
- fixes #2896

### Proposed Changes:
When you use the TransformersTranslator node, and send a List of Documents, after translation the node correctly output the translated texts. But, it's also changing the input. So, we got **inputs == outputs** after using the node.

Get Translator node to work as all other nodes, and even as itself when related to query and not document. Output translated documents and keep inputs like they were sent.

### How did you test it?
Translator unit tests and two new tests to check that input is not equal to output

### Notes for the reviewer
The main word for this change is decoupling. It's not a good software engineering decision, generally, to allow a method to output something and at the same time change the input to the same data, going backward on the chain. Specially when there is no documentation, a strong and unique rare case where there is no other possibility.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
