### PR TITLE
test: Use `random_sample` instead of `ndarray` for random array in `OpenSearchDocumentStore` test

### DIFF
--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -24,7 +24,7 @@ class TestOpenSearchDocumentStore:
 
     # Constants
 
-    query_emb = np.ndarray(shape=(2, 2), dtype=float)
+    query_emb = np.random.random_sample(size=(2, 2))
     index_name = "myindex"
 
     # Fixtures


### PR DESCRIPTION
### Related Issues
- fixes #3082 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR makes a small change to `TestOpenSearchDocumentStore` by creating `query_emb` using `np.random.random_sample` instead of `numpy.ndaray`. This makes sure that there are no `nan` values in `query_emb`.  

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I let the tests for `OpenSearchDocumentStore` run.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
