### PR TITLE
feat: Add warnings to PineconeDocumentStore about indexing metadata if filters return no documents

### DIFF
--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -357,6 +357,12 @@ class PineconeDocumentStore(SQLDocumentStore):
             filters=filters,
             only_documents_without_embedding=not update_existing_embeddings,
         )
+
+        if filters and result is None:
+            logger.warning(
+                "This query might have been done without metadata indexed and thus no results were retrieved. Make sure the desired metadata you want to filter with is indexed."
+            )
+
         batched_documents = get_batches_from_generator(result, batch_size)
         with tqdm(
             total=document_count, disable=not self.progress_bar, position=0, unit=" docs", desc="Updating Embedding"
@@ -452,6 +458,11 @@ class PineconeDocumentStore(SQLDocumentStore):
         documents = super(PineconeDocumentStore, self).get_all_documents_generator(
             index=index, filters=filters, batch_size=batch_size, return_embedding=False
         )
+
+        if filters and documents is None:
+            logger.warning(
+                "This query might have been done without metadata indexed and thus no results were retrieved. Make sure the desired metadata you want to filter with is indexed."
+            )
 
         for doc in documents:
             if return_embedding:
@@ -700,6 +711,11 @@ class PineconeDocumentStore(SQLDocumentStore):
             score_matrix.append(match["score"])
             vector_id_matrix.append(match["id"])
         documents = self.get_documents_by_id(vector_id_matrix, index=index, return_embedding=return_embedding)
+
+        if filters and documents is None:
+            logger.warning(
+                "This query might have been done without metadata indexed and thus no results were retrieved. Make sure the desired metadata you want to filter with is indexed."
+            )
 
         # assign query score to each document
         scores_for_vector_ids: Dict[str, float] = {str(v_id): s for v_id, s in zip(vector_id_matrix, score_matrix)}


### PR DESCRIPTION
### Related Issues
- fixes #3031

### Proposed Changes:
This pull request adds a warning for `query_by_embedding`, `update_embeddings` and `get_all_documents_generator` in **PineconeDocumentStore** when a filter is used through an user action but no results are obtained. As it is referenced in this issue #3021, there's no way to know which metadata fields are indexed currently, so these warnings serve as a hint for users to revisit their queries in the circumstances referenced above (used a filter + no results obtained).  

### How did you test it?
Still to be tested.

### Notes for the reviewer
I have preemptively opened the pull request as it is encouraged in the CONTRIBUTING sectio.
I am still exploring the framework and this is my first os pull request so bear with me 😅.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
