### PR TITLE
fix: Pass use_auth_token to from_pretrained

### DIFF
--- a/docs/_src/api/api/evaluation.md
+++ b/docs/_src/api/api/evaluation.md
@@ -123,7 +123,7 @@ Print the evaluation results
 #### semantic\_answer\_similarity
 
 ```python
-def semantic_answer_similarity(predictions: List[List[str]], gold_labels: List[List[str]], sas_model_name_or_path: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2", batch_size: int = 32, use_gpu: bool = True) -> Tuple[List[float], List[float], List[List[float]]]
+def semantic_answer_similarity(predictions: List[List[str]], gold_labels: List[List[str]], sas_model_name_or_path: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2", batch_size: int = 32, use_gpu: bool = True, use_auth_token: Optional[Union[str, bool]] = None) -> Tuple[List[float], List[float], List[List[float]]]
 ```
 
 Computes Transformer-based similarity of predicted answer to gold labels to derive a more meaningful metric than EM or F1.
@@ -141,6 +141,11 @@ pointing to downloadable models.
 - `batch_size`: Number of prediction label pairs to encode at once.
 - `use_gpu`: Whether to use a GPU or the CPU for calculating semantic answer similarity.
 Falls back to CPU if no GPU is available.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 **Returns**:
 

--- a/docs/_src/api/api/extractor.md
+++ b/docs/_src/api/api/extractor.md
@@ -24,6 +24,11 @@ The entities extracted by this Node will populate Document.entities
 - `use_gpu`: Whether to use the GPU or not.
 - `batch_size`: The batch size to use for entity extraction.
 - `progress_bar`: Whether to show a progress bar or not.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="entity.EntityExtractor.run"></a>
 

--- a/docs/_src/api/api/generator.md
+++ b/docs/_src/api/api/generator.md
@@ -107,30 +107,30 @@ i.e. the model can easily adjust to domain documents even after training has fin
 **Example**
 
 ```python
-|     query = "who got the first nobel prize in physics?"
-|
-|     # Retrieve related documents from retriever
-|     retrieved_docs = retriever.retrieve(query=query)
-|
-|     # Now generate answer from query and retrieved documents
-|     generator.predict(
-|        query=query,
-|        documents=retrieved_docs,
-|        top_k=1
-|     )
-|
-|     # Answer
-|
-|     {'query': 'who got the first nobel prize in physics',
-|      'answers':
-|          [{'query': 'who got the first nobel prize in physics',
-|            'answer': ' albert einstein',
-|            'meta': { 'doc_ids': [...],
-|                      'doc_scores': [80.42758 ...],
-|                      'doc_probabilities': [40.71379089355469, ...
-|                      'content': ['Albert Einstein was a ...]
-|                      'titles': ['"Albert Einstein"', ...]
-|      }}]}
+query = "who got the first nobel prize in physics?"
+
+# Retrieve related documents from retriever
+retrieved_docs = retriever.retrieve(query=query)
+
+# Now generate answer from query and retrieved documents
+generator.predict(
+   query=query,
+   documents=retrieved_docs,
+   top_k=1
+)
+
+# Answer
+
+{'query': 'who got the first nobel prize in physics',
+ 'answers':
+     [{'query': 'who got the first nobel prize in physics',
+       'answer': ' albert einstein',
+       'meta': { 'doc_ids': [...],
+                 'doc_scores': [80.42758 ...],
+                 'doc_probabilities': [40.71379089355469, ...
+                 'content': ['Albert Einstein was a ...]
+                 'titles': ['"Albert Einstein"', ...]
+ }}]}
 ```
 
 <a id="transformers.RAGenerator.__init__"></a>
@@ -138,7 +138,7 @@ i.e. the model can easily adjust to domain documents even after training has fin
 #### RAGenerator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str = "facebook/rag-token-nq", model_version: Optional[str] = None, retriever: Optional[DensePassageRetriever] = None, generator_type: str = "token", top_k: int = 2, max_length: int = 200, min_length: int = 2, num_beams: int = 2, embed_title: bool = True, prefix: Optional[str] = None, use_gpu: bool = True, progress_bar: bool = True)
+def __init__(model_name_or_path: str = "facebook/rag-token-nq", model_version: Optional[str] = None, retriever: Optional[DensePassageRetriever] = None, generator_type: str = "token", top_k: int = 2, max_length: int = 200, min_length: int = 2, num_beams: int = 2, embed_title: bool = True, prefix: Optional[str] = None, use_gpu: bool = True, progress_bar: bool = True, use_auth_token: Optional[Union[str, bool]] = None)
 ```
 
 Load a RAG model from Transformers along with passage_embedding_model.
@@ -160,6 +160,12 @@ See https://huggingface.co/models for full list of available models.
 - `embed_title`: Embedded the title of passage while generating embedding
 - `prefix`: The prefix used by the generator's tokenizer.
 - `use_gpu`: Whether to use GPU. Falls back on CPU if no GPU is available.
+- `progress_bar`: Whether to show a tqdm progress bar or not.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="transformers.RAGenerator.predict"></a>
 
@@ -225,30 +231,30 @@ the [Hugging Face Model Hub](https://huggingface.co/models?pipeline_tag=text2tex
 **Example**
 
 ```python
-|     query = "Why is Dothraki language important?"
-|
-|     # Retrieve related documents from retriever
-|     retrieved_docs = retriever.retrieve(query=query)
-|
-|     # Now generate answer from query and retrieved documents
-|     generator.predict(
-|        query=query,
-|        documents=retrieved_docs,
-|        top_k=1
-|     )
-|
-|     # Answer
-|
-|     {'query': 'who got the first nobel prize in physics',
-|      'answers':
-|          [{'query': 'who got the first nobel prize in physics',
-|            'answer': ' albert einstein',
-|            'meta': { 'doc_ids': [...],
-|                      'doc_scores': [80.42758 ...],
-|                      'doc_probabilities': [40.71379089355469, ...
-|                      'content': ['Albert Einstein was a ...]
-|                      'titles': ['"Albert Einstein"', ...]
-|      }}]}
+query = "Why is Dothraki language important?"
+
+# Retrieve related documents from retriever
+retrieved_docs = retriever.retrieve(query=query)
+
+# Now generate answer from query and retrieved documents
+generator.predict(
+   query=query,
+   documents=retrieved_docs,
+   top_k=1
+)
+
+# Answer
+
+{'query': 'who got the first nobel prize in physics',
+ 'answers':
+     [{'query': 'who got the first nobel prize in physics',
+       'answer': ' albert einstein',
+       'meta': { 'doc_ids': [...],
+                 'doc_scores': [80.42758 ...],
+                 'doc_probabilities': [40.71379089355469, ...
+                 'content': ['Albert Einstein was a ...]
+                 'titles': ['"Albert Einstein"', ...]
+ }}]}
 ```
 
 <a id="transformers.Seq2SeqGenerator.__init__"></a>
@@ -256,7 +262,7 @@ the [Hugging Face Model Hub](https://huggingface.co/models?pipeline_tag=text2tex
 #### Seq2SeqGenerator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str, input_converter: Optional[Callable] = None, top_k: int = 1, max_length: int = 200, min_length: int = 2, num_beams: int = 8, use_gpu: bool = True, progress_bar: bool = True)
+def __init__(model_name_or_path: str, input_converter: Optional[Callable] = None, top_k: int = 1, max_length: int = 200, min_length: int = 2, num_beams: int = 8, use_gpu: bool = True, progress_bar: bool = True, use_auth_token: Optional[Union[str, bool]] = None)
 ```
 
 **Arguments**:
@@ -272,6 +278,12 @@ top_k: Optional[int] = None) -> BatchEncoding:
 - `min_length`: Minimum length of generated text
 - `num_beams`: Number of beams for beam search. 1 means no beam search.
 - `use_gpu`: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
+- `progress_bar`: Whether to show a tqdm progress bar or not.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="transformers.Seq2SeqGenerator.predict"></a>
 

--- a/docs/_src/api/api/question_generator.md
+++ b/docs/_src/api/api/question_generator.md
@@ -23,7 +23,7 @@ come from earlier in the document.
 #### QuestionGenerator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path="valhalla/t5-base-e2e-qg", model_version=None, num_beams=4, max_length=256, no_repeat_ngram_size=3, length_penalty=1.5, early_stopping=True, split_length=50, split_overlap=10, use_gpu=True, prompt="generate questions:", num_queries_per_doc=1, sep_token: str = "<sep>", batch_size: int = 16, progress_bar: bool = True)
+def __init__(model_name_or_path="valhalla/t5-base-e2e-qg", model_version=None, num_beams=4, max_length=256, no_repeat_ngram_size=3, length_penalty=1.5, early_stopping=True, split_length=50, split_overlap=10, use_gpu=True, prompt="generate questions:", num_queries_per_doc=1, sep_token: str = "<sep>", batch_size: int = 16, progress_bar: bool = True, use_auth_token: Optional[Union[str, bool]] = None)
 ```
 
 Uses the valhalla/t5-base-e2e-qg model by default. This class supports any question generation model that is
@@ -39,6 +39,12 @@ See https://huggingface.co/models for full list of available models.
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `use_gpu`: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
 - `batch_size`: Number of documents to process at a time.
+- `progress_bar`: Whether to show a tqdm progress bar or not.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="question_generator.QuestionGenerator.generate_batch"></a>
 

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -712,7 +712,7 @@ With this reader, you can directly get predictions via predict()
 
 ```python
 from haystack import Document
-from haystack.reader import TableReader
+from haystack.nodes import TableReader
 import pandas as pd
 
 table_reader = TableReader(model_name_or_path="google/tapas-base-finetuned-wtq")

--- a/docs/_src/api/api/reader.md
+++ b/docs/_src/api/api/reader.md
@@ -100,9 +100,11 @@ unscaled raw scores.
 - `proxies`: Dict of proxy servers to use for downloading external models. Example: {'http': 'some.proxy:1234', 'http://hostname': 'my.proxy:3111'}
 - `local_files_only`: Whether to force checking for local files only (and forbid downloads)
 - `force_download`: Whether fo force a (re-)download even if the model exists locally in the cache.
-- `use_auth_token`: API token used to download private models from Huggingface. If this parameter is set to `True`,
-the local token will be used, which must be previously created via `transformer-cli login`.
-Additional information can be found here https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="farm.FARMReader.train"></a>
 
@@ -732,7 +734,7 @@ answer = prediction["answers"][0].answer  # "10 june 1996"
 #### TableReader.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str = "google/tapas-base-finetuned-wtq", model_version: Optional[str] = None, tokenizer: Optional[str] = None, use_gpu: bool = True, top_k: int = 10, top_k_per_candidate: int = 3, return_no_answer: bool = False, max_seq_len: int = 256)
+def __init__(model_name_or_path: str = "google/tapas-base-finetuned-wtq", model_version: Optional[str] = None, tokenizer: Optional[str] = None, use_gpu: bool = True, top_k: int = 10, top_k_per_candidate: int = 3, return_no_answer: bool = False, max_seq_len: int = 256, use_auth_token: Optional[Union[str, bool]] = None)
 ```
 
 Load a TableQA model from Transformers.
@@ -768,6 +770,11 @@ the retriever.
 - `max_seq_len`: Max sequence length of one input table for the model. If the number of tokens of
 query + table exceed max_seq_len, the table will be truncated by removing rows until the
 input size fits the model.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="table.TableReader.predict"></a>
 
@@ -861,7 +868,7 @@ Pros and Cons of RCIReader compared to TableReader:
 #### RCIReader.\_\_init\_\_
 
 ```python
-def __init__(row_model_name_or_path: str = "michaelrglass/albert-base-rci-wikisql-row", column_model_name_or_path: str = "michaelrglass/albert-base-rci-wikisql-col", row_model_version: Optional[str] = None, column_model_version: Optional[str] = None, row_tokenizer: Optional[str] = None, column_tokenizer: Optional[str] = None, use_gpu: bool = True, top_k: int = 10, max_seq_len: int = 256)
+def __init__(row_model_name_or_path: str = "michaelrglass/albert-base-rci-wikisql-row", column_model_name_or_path: str = "michaelrglass/albert-base-rci-wikisql-col", row_model_version: Optional[str] = None, column_model_version: Optional[str] = None, row_tokenizer: Optional[str] = None, column_tokenizer: Optional[str] = None, use_gpu: bool = True, top_k: int = 10, max_seq_len: int = 256, use_auth_token: Optional[Union[str, bool]] = None)
 ```
 
 Load an RCI model from Transformers.
@@ -886,6 +893,11 @@ Can be tag name, branch name, or commit hash.
 - `max_seq_len`: Max sequence length of one input table for the model. If the number of tokens of
 query + table exceed max_seq_len, the table will be truncated by removing rows until the
 input size fits the model.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="table.RCIReader.predict"></a>
 

--- a/docs/_src/api/api/translator.md
+++ b/docs/_src/api/api/translator.md
@@ -55,12 +55,12 @@ We currently recommend using OPUS models (see __init__() for details)
 **Example:**
 
 ```python
-|    DOCS = [
-|        Document(content="Heinz von Foerster was an Austrian American scientist combining physics and philosophy,
-|                       and widely attributed as the originator of Second-order cybernetics.")
-|    ]
-|    translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-en-de")
-|    res = translator.translate(documents=DOCS, query=None)
+DOCS = [
+Document(content="Heinz von Foerster was an Austrian American scientist combining physics and philosophy,
+and widely attributed as the originator of Second-order cybernetics.")
+]
+translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-en-de")
+res = translator.translate(documents=DOCS, query=None)
 ```
 
 <a id="transformers.TransformersTranslator.__init__"></a>
@@ -68,7 +68,7 @@ We currently recommend using OPUS models (see __init__() for details)
 #### TransformersTranslator.\_\_init\_\_
 
 ```python
-def __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True, progress_bar: bool = True)
+def __init__(model_name_or_path: str, tokenizer_name: Optional[str] = None, max_seq_len: Optional[int] = None, clean_up_tokenization_spaces: Optional[bool] = True, use_gpu: bool = True, progress_bar: bool = True, use_auth_token: Optional[Union[str, bool]] = None)
 ```
 
 Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
@@ -94,6 +94,11 @@ tokenizer.
 - `clean_up_tokenization_spaces`: Whether or not to clean up the tokenization spaces. (default True)
 - `use_gpu`: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
 - `progress_bar`: Whether to show a progress bar.
+- `use_auth_token`: The API token used to download private models from Huggingface.
+If this parameter is set to `True`, then the token generated when running
+`transformer-cli login` (stored in ~/.huggingface) will be used.
+Additional information can be found here
+https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
 
 <a id="transformers.TransformersTranslator.translate"></a>
 

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -126,7 +126,7 @@ class Inferencer:
         tokenizer_args: Dict = None,
         multithreading_rust: bool = True,
         devices: Optional[List[torch.device]] = None,
-        use_auth_token: Union[bool, str] = None,
+        use_auth_token: Optional[Union[bool, str]] = None,
         **kwargs,
     ):
         """
@@ -167,6 +167,11 @@ class Inferencer:
                                     Note: Enabling multithreading in Rust AND multiprocessing in python might cause
                                     deadlocks.
         :param devices: List of devices to perform inference on. (Currently, only the first device in the list is used.)
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         :return: An instance of the Inferencer.
         """
         if tokenizer_args is None:

--- a/haystack/modeling/model/adaptive_model.py
+++ b/haystack/modeling/model/adaptive_model.py
@@ -305,8 +305,8 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         device: Union[str, torch.device],
         revision: str = None,
         task_type: str = "question_answering",
-        processor: Processor = None,
-        use_auth_token: Union[bool, str] = None,
+        processor: Optional[Processor] = None,
+        use_auth_token: Optional[Union[bool, str]] = None,
         **kwargs,
     ) -> "AdaptiveModel":
         """
@@ -325,6 +325,11 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
                          Right now accepts only 'question_answering'.
         :param processor: populates prediction head with information coming from tasks.
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         :return: AdaptiveModel
         """
 
@@ -343,7 +348,9 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
                 )
 
         if task_type == "question_answering":
-            ph = QuestionAnsweringHead.load(model_name_or_path, revision=revision, **kwargs)
+            ph = QuestionAnsweringHead.load(
+                model_name_or_path, revision=revision, use_auth_token=use_auth_token, **kwargs
+            )
             adaptive_model = cls(
                 language_model=lm,
                 prediction_heads=[ph],

--- a/haystack/modeling/model/language_model.py
+++ b/haystack/modeling/model/language_model.py
@@ -284,7 +284,11 @@ class HFLanguageModel(LanguageModel):
         :param pretrained_model_name_or_path: The path of the saved pretrained model or the name of the model.
         :param model_type: the HuggingFace class name prefix (for example 'Bert', 'Roberta', etc...)
         :param language: the model's language ('multilingual' is also accepted)
-        :param use_auth_token: the HF token or False
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__(model_type=model_type)
 
@@ -391,6 +395,13 @@ class HFLanguageModelWithPooler(HFLanguageModel):
         * A local path of a model trained using Haystack (for example, "some_dir/haystack_model")
 
         :param pretrained_model_name_or_path: The path of the saved pretrained model or its name.
+        :param model_type: the HuggingFace class name prefix (for example 'DebertaV2', 'Electra', etc...)
+        :param language: the model's language ('multilingual' is also accepted)
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
@@ -512,10 +523,13 @@ class DPREncoder(LanguageModel):
 
         :param pretrained_model_name_or_path: The path of the base pretrained language model whose weights are used to initialize DPRQuestionEncoder.
         :param model_type: the type of model (see `HUGGINGFACE_TO_HAYSTACK`)
-        :param model_kwargs: any kwarg to pass to the model at init
         :param language: the model's language. If not given, it will be inferred. Defaults to english.
         :param n_added_tokens: unused for `DPREncoder`
-        :param use_auth_token: useful if the model is from the HF Hub and private
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         :param model_kwargs: any kwarg to pass to the model at init
         """
         super().__init__(model_type=model_type)
@@ -561,15 +575,21 @@ class DPREncoder(LanguageModel):
         :param model_name_or_path: name or path of the model to load
         :param model_class: The HuggingFace model class name
         :param model_kwargs: any kwarg to pass to the model at init
-        :param use_auth_token: useful if the model is from the HF Hub and private
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         original_model_config = AutoConfig.from_pretrained(haystack_lm_config)
         haystack_lm_model = Path(model_name_or_path) / "language_model.bin"
 
         original_model_type = original_model_config.model_type
         if original_model_type and "dpr" in original_model_type.lower():
-            dpr_config = transformers.DPRConfig.from_pretrained(haystack_lm_config)
-            self.model = model_class.from_pretrained(haystack_lm_model, config=dpr_config, **model_kwargs)
+            dpr_config = transformers.DPRConfig.from_pretrained(haystack_lm_config, use_auth_token=use_auth_token)
+            self.model = model_class.from_pretrained(
+                haystack_lm_model, config=dpr_config, use_auth_token=use_auth_token, **model_kwargs
+            )
 
         else:
             self.model = self._init_model_through_config(
@@ -607,7 +627,11 @@ class DPREncoder(LanguageModel):
         :param model_name_or_path: name or path of the model to load
         :param model_class: The HuggingFace model class name
         :param model_kwargs: any kwarg to pass to the model at init
-        :param use_auth_token: useful if the model is from the HF Hub and private
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         :param language: the model's language. If not given, it will be inferred. Defaults to english.
         """
         original_model_config = AutoConfig.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
@@ -842,7 +866,11 @@ def get_language_model(
     :param pretrained_model_name_or_path: The path of the saved pretrained model or its name.
     :param language: The language of the model (i.e english etc).
     :param n_added_tokens: The number of added tokens to the model.
-    :param use_auth_token: Whether to use the huggingface auth token for private repos or not.
+    :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
     :param revision: The version of the model to use from the Hugging Face model hub. This can be a tag name,
     a branch name, or a commit hash.
     :param autoconfig_kwargs: Additional keyword arguments to pass to the autoconfig function.

--- a/haystack/modeling/model/prediction_head.py
+++ b/haystack/modeling/model/prediction_head.py
@@ -286,7 +286,13 @@ class QuestionAnsweringHead(PredictionHead):
         self.use_no_answer_legacy_confidence = use_no_answer_legacy_confidence
 
     @classmethod
-    def load(cls, pretrained_model_name_or_path: Union[str, Path], revision: Optional[str] = None, **kwargs):  # type: ignore
+    def load(
+        cls,
+        pretrained_model_name_or_path: Union[str, Path],
+        revision: Optional[str] = None,
+        use_auth_token: Optional[Union[str, bool]] = None,
+        **kwargs,
+    ):  # type: ignore
         """
         Load a prediction head from a saved Haystack or transformers model. `pretrained_model_name_or_path`
         can be one of the following:
@@ -299,9 +305,13 @@ class QuestionAnsweringHead(PredictionHead):
                                               Exemplary public names:
                                               - distilbert-base-uncased-distilled-squad
                                               - bert-large-uncased-whole-word-masking-finetuned-squad
-
                                               See https://huggingface.co/models for full list
         :param revision: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         if (
             os.path.exists(pretrained_model_name_or_path)
@@ -314,7 +324,7 @@ class QuestionAnsweringHead(PredictionHead):
             # b) transformers style
             # load all weights from model
             full_qa_model = AutoModelForQuestionAnswering.from_pretrained(
-                pretrained_model_name_or_path, revision=revision, **kwargs
+                pretrained_model_name_or_path, revision=revision, use_auth_token=use_auth_token, **kwargs
             )
             # init empty head
             head = cls(layer_dims=[full_qa_model.config.hidden_size, 2], task_name="question_answering")

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -19,7 +19,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
     These can come from a Retriever or be manually supplied.
 
     To use this Node, you need an API key from an active OpenAI account. You can sign-up for an account
-    on the [OpenAI API website](https://openai.com/api/)).
+    on the [OpenAI API website](https://openai.com/api/).
     """
 
     def __init__(
@@ -101,14 +101,14 @@ class OpenAIAnswerGenerator(BaseGenerator):
 
         Example:
          ```python
-            |{
-            |    'query': 'Who is the father of Arya Stark?',
-            |    'answers':[Answer(
-            |                 'answer': 'Eddard,',
-            |                 'score': None,
-            |                 ),...
-            |              ]
-            |}
+            {
+                'query': 'Who is the father of Arya Stark?',
+                'answers':[Answer(
+                             'answer': 'Eddard,',
+                             'score': None,
+                             ),...
+                          ]
+            }
          ```
 
         :param query: Query string

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import logging
 from collections.abc import Callable
@@ -38,30 +38,30 @@ class RAGenerator(BaseGenerator):
     **Example**
 
     ```python
-    |     query = "who got the first nobel prize in physics?"
-    |
-    |     # Retrieve related documents from retriever
-    |     retrieved_docs = retriever.retrieve(query=query)
-    |
-    |     # Now generate answer from query and retrieved documents
-    |     generator.predict(
-    |        query=query,
-    |        documents=retrieved_docs,
-    |        top_k=1
-    |     )
-    |
-    |     # Answer
-    |
-    |     {'query': 'who got the first nobel prize in physics',
-    |      'answers':
-    |          [{'query': 'who got the first nobel prize in physics',
-    |            'answer': ' albert einstein',
-    |            'meta': { 'doc_ids': [...],
-    |                      'doc_scores': [80.42758 ...],
-    |                      'doc_probabilities': [40.71379089355469, ...
-    |                      'content': ['Albert Einstein was a ...]
-    |                      'titles': ['"Albert Einstein"', ...]
-    |      }}]}
+    query = "who got the first nobel prize in physics?"
+
+    # Retrieve related documents from retriever
+    retrieved_docs = retriever.retrieve(query=query)
+
+    # Now generate answer from query and retrieved documents
+    generator.predict(
+       query=query,
+       documents=retrieved_docs,
+       top_k=1
+    )
+
+    # Answer
+
+    {'query': 'who got the first nobel prize in physics',
+     'answers':
+         [{'query': 'who got the first nobel prize in physics',
+           'answer': ' albert einstein',
+           'meta': { 'doc_ids': [...],
+                     'doc_scores': [80.42758 ...],
+                     'doc_probabilities': [40.71379089355469, ...
+                     'content': ['Albert Einstein was a ...]
+                     'titles': ['"Albert Einstein"', ...]
+     }}]}
     ```
     """
 
@@ -79,6 +79,7 @@ class RAGenerator(BaseGenerator):
         prefix: Optional[str] = None,
         use_gpu: bool = True,
         progress_bar: bool = True,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         """
         Load a RAG model from Transformers along with passage_embedding_model.
@@ -97,6 +98,12 @@ class RAGenerator(BaseGenerator):
         :param embed_title: Embedded the title of passage while generating embedding
         :param prefix: The prefix used by the generator's tokenizer.
         :param use_gpu: Whether to use GPU. Falls back on CPU if no GPU is available.
+        :param progress_bar: Whether to show a tqdm progress bar or not.
+        :param use_auth_token:  The API token used to download private models from Huggingface.
+                                If this parameter is set to `True`, then the token generated when running
+                                `transformer-cli login` (stored in ~/.huggingface) will be used.
+                                Additional information can be found here
+                                https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__(progress_bar=progress_bar)
 
@@ -117,15 +124,17 @@ class RAGenerator(BaseGenerator):
 
         self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
 
-        self.tokenizer = RagTokenizer.from_pretrained(model_name_or_path)
+        self.tokenizer = RagTokenizer.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
 
         if self.generator_type == "sequence":
             raise NotImplementedError("RagSequenceForGeneration is not implemented yet")
             # TODO: Enable when transformers have it. Refer https://github.com/huggingface/transformers/issues/7905
             # Also refer refer https://github.com/huggingface/transformers/issues/7829
-            # self.model = RagSequenceForGeneration.from_pretrained(model_name_or_path)
+            # self.model = RagSequenceForGeneration.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
 
-        self.model = RagTokenForGeneration.from_pretrained(model_name_or_path, revision=model_version)
+        self.model = RagTokenForGeneration.from_pretrained(
+            model_name_or_path, revision=model_version, use_auth_token=use_auth_token
+        )
         self.model.to(str(self.devices[0]))
 
     # Copied cat_input_and_doc method from transformers.RagRetriever
@@ -289,30 +298,30 @@ class Seq2SeqGenerator(BaseGenerator):
     **Example**
 
     ```python
-    |     query = "Why is Dothraki language important?"
-    |
-    |     # Retrieve related documents from retriever
-    |     retrieved_docs = retriever.retrieve(query=query)
-    |
-    |     # Now generate answer from query and retrieved documents
-    |     generator.predict(
-    |        query=query,
-    |        documents=retrieved_docs,
-    |        top_k=1
-    |     )
-    |
-    |     # Answer
-    |
-    |     {'query': 'who got the first nobel prize in physics',
-    |      'answers':
-    |          [{'query': 'who got the first nobel prize in physics',
-    |            'answer': ' albert einstein',
-    |            'meta': { 'doc_ids': [...],
-    |                      'doc_scores': [80.42758 ...],
-    |                      'doc_probabilities': [40.71379089355469, ...
-    |                      'content': ['Albert Einstein was a ...]
-    |                      'titles': ['"Albert Einstein"', ...]
-    |      }}]}
+    query = "Why is Dothraki language important?"
+
+    # Retrieve related documents from retriever
+    retrieved_docs = retriever.retrieve(query=query)
+
+    # Now generate answer from query and retrieved documents
+    generator.predict(
+       query=query,
+       documents=retrieved_docs,
+       top_k=1
+    )
+
+    # Answer
+
+    {'query': 'who got the first nobel prize in physics',
+     'answers':
+         [{'query': 'who got the first nobel prize in physics',
+           'answer': ' albert einstein',
+           'meta': { 'doc_ids': [...],
+                     'doc_scores': [80.42758 ...],
+                     'doc_probabilities': [40.71379089355469, ...
+                     'content': ['Albert Einstein was a ...]
+                     'titles': ['"Albert Einstein"', ...]
+     }}]}
     ```
     """
 
@@ -328,6 +337,7 @@ class Seq2SeqGenerator(BaseGenerator):
         num_beams: int = 8,
         use_gpu: bool = True,
         progress_bar: bool = True,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         """
         :param model_name_or_path: a HF model name for auto-regressive language model like GPT2, XLNet, XLM, Bart, T5 etc
@@ -341,6 +351,12 @@ class Seq2SeqGenerator(BaseGenerator):
         :param min_length: Minimum length of generated text
         :param num_beams: Number of beams for beam search. 1 means no beam search.
         :param use_gpu: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
+        :param progress_bar: Whether to show a tqdm progress bar or not.
+        :param use_auth_token:  The API token used to download private models from Huggingface.
+                                If this parameter is set to `True`, then the token generated when running
+                                `transformer-cli login` (stored in ~/.huggingface) will be used.
+                                Additional information can be found here
+                                https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__(progress_bar=progress_bar)
         self.model_name_or_path = model_name_or_path
@@ -358,8 +374,8 @@ class Seq2SeqGenerator(BaseGenerator):
 
         Seq2SeqGenerator._register_converters(model_name_or_path, input_converter)
 
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
-        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
         self.model.to(str(self.devices[0]))
         self.model.eval()
 

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -24,6 +24,11 @@ class EntityExtractor(BaseComponent):
     :param use_gpu: Whether to use the GPU or not.
     :param batch_size: The batch size to use for entity extraction.
     :param progress_bar: Whether to show a progress bar or not.
+    :param use_auth_token: The API token used to download private models from Huggingface.
+                           If this parameter is set to `True`, then the token generated when running
+                           `transformer-cli login` (stored in ~/.huggingface) will be used.
+                           Additional information can be found here
+                           https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
     """
 
     outgoing_edges = 1
@@ -34,6 +39,7 @@ class EntityExtractor(BaseComponent):
         use_gpu: bool = True,
         batch_size: int = 16,
         progress_bar: bool = True,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         super().__init__()
 
@@ -41,8 +47,10 @@ class EntityExtractor(BaseComponent):
         self.batch_size = batch_size
         self.progress_bar = progress_bar
 
-        tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
-        token_classifier = AutoModelForTokenClassification.from_pretrained(model_name_or_path)
+        tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
+        token_classifier = AutoModelForTokenClassification.from_pretrained(
+            model_name_or_path, use_auth_token=use_auth_token
+        )
         token_classifier.to(str(self.devices[0]))
         self.model = pipeline(
             "ner",

--- a/haystack/nodes/question_generator/question_generator.py
+++ b/haystack/nodes/question_generator/question_generator.py
@@ -42,6 +42,7 @@ class QuestionGenerator(BaseComponent):
         sep_token: str = "<sep>",
         batch_size: int = 16,
         progress_bar: bool = True,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         """
         Uses the valhalla/t5-base-e2e-qg model by default. This class supports any question generation model that is
@@ -54,12 +55,18 @@ class QuestionGenerator(BaseComponent):
         :param model_version: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
         :param use_gpu: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
         :param batch_size: Number of documents to process at a time.
+        :param progress_bar: Whether to show a tqdm progress bar or not.
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__()
         self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
-        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
         self.model.to(str(self.devices[0]))
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
         self.num_beams = num_beams
         self.max_length = max_length
         self.no_repeat_ngram_size = no_repeat_ngram_size

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -121,11 +121,11 @@ class FARMReader(BaseReader):
         :param proxies: Dict of proxy servers to use for downloading external models. Example: {'http': 'some.proxy:1234', 'http://hostname': 'my.proxy:3111'}
         :param local_files_only: Whether to force checking for local files only (and forbid downloads)
         :param force_download: Whether fo force a (re-)download even if the model exists locally in the cache.
-        :param use_auth_token:  The API token used to download private models from Huggingface.
-                                If this parameter is set to `True`, then the token generated when running
-                                `transformer-cli login` (stored in ~/.huggingface) will be used.
-                                Additional information can be found here
-                                https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__()
 

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -121,9 +121,11 @@ class FARMReader(BaseReader):
         :param proxies: Dict of proxy servers to use for downloading external models. Example: {'http': 'some.proxy:1234', 'http://hostname': 'my.proxy:3111'}
         :param local_files_only: Whether to force checking for local files only (and forbid downloads)
         :param force_download: Whether fo force a (re-)download even if the model exists locally in the cache.
-        :param use_auth_token:  API token used to download private models from Huggingface. If this parameter is set to `True`,
-                                the local token will be used, which must be previously created via `transformer-cli login`.
-                                Additional information can be found here https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
+        :param use_auth_token:  The API token used to download private models from Huggingface.
+                                If this parameter is set to `True`, then the token generated when running
+                                `transformer-cli login` (stored in ~/.huggingface) will be used.
+                                Additional information can be found here
+                                https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__()
 

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -72,6 +72,7 @@ class TableReader(BaseReader):
         top_k_per_candidate: int = 3,
         return_no_answer: bool = False,
         max_seq_len: int = 256,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         """
         Load a TableQA model from Transformers.
@@ -104,6 +105,11 @@ class TableReader(BaseReader):
         :param max_seq_len: Max sequence length of one input table for the model. If the number of tokens of
                             query + table exceed max_seq_len, the table will be truncated by removing rows until the
                             input size fits the model.
+        :param use_auth_token:  The API token used to download private models from Huggingface.
+                                If this parameter is set to `True`, then the token generated when running
+                                `transformer-cli login` (stored in ~/.huggingface) will be used.
+                                Additional information can be found here
+                                https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         if not torch_scatter_installed:
             raise ImportError(
@@ -117,17 +123,21 @@ class TableReader(BaseReader):
         super().__init__()
 
         self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
-        config = TapasConfig.from_pretrained(model_name_or_path)
+        config = TapasConfig.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
         if config.architectures[0] == "TapasForScoredQA":
-            self.model = self.TapasForScoredQA.from_pretrained(model_name_or_path, revision=model_version)
+            self.model = self.TapasForScoredQA.from_pretrained(
+                model_name_or_path, revision=model_version, use_auth_token=use_auth_token
+            )
         else:
-            self.model = TapasForQuestionAnswering.from_pretrained(model_name_or_path, revision=model_version)
+            self.model = TapasForQuestionAnswering.from_pretrained(
+                model_name_or_path, revision=model_version, use_auth_token=use_auth_token
+            )
         self.model.to(str(self.devices[0]))
 
         if tokenizer is None:
-            self.tokenizer = TapasTokenizer.from_pretrained(model_name_or_path)
+            self.tokenizer = TapasTokenizer.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
         else:
-            self.tokenizer = TapasTokenizer.from_pretrained(tokenizer)
+            self.tokenizer = TapasTokenizer.from_pretrained(tokenizer, use_auth_token=use_auth_token)
 
         self.top_k = top_k
         self.top_k_per_candidate = top_k_per_candidate
@@ -540,6 +550,7 @@ class RCIReader(BaseReader):
         use_gpu: bool = True,
         top_k: int = 10,
         max_seq_len: int = 256,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         """
         Load an RCI model from Transformers.
@@ -563,36 +574,45 @@ class RCIReader(BaseReader):
         :param max_seq_len: Max sequence length of one input table for the model. If the number of tokens of
                             query + table exceed max_seq_len, the table will be truncated by removing rows until the
                             input size fits the model.
+        :param use_auth_token:  The API token used to download private models from Huggingface.
+                                If this parameter is set to `True`, then the token generated when running
+                                `transformer-cli login` (stored in ~/.huggingface) will be used.
+                                Additional information can be found here
+                                https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__()
 
         self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
         self.row_model = AutoModelForSequenceClassification.from_pretrained(
-            row_model_name_or_path, revision=row_model_version
+            row_model_name_or_path, revision=row_model_version, use_auth_token=use_auth_token
         )
         self.column_model = AutoModelForSequenceClassification.from_pretrained(
-            row_model_name_or_path, revision=column_model_version
+            row_model_name_or_path, revision=column_model_version, use_auth_token=use_auth_token
         )
         self.row_model.to(str(self.devices[0]))
         self.column_model.to(str(self.devices[0]))
 
         if row_tokenizer is None:
             try:
-                self.row_tokenizer = AutoTokenizer.from_pretrained(row_model_name_or_path)
+                self.row_tokenizer = AutoTokenizer.from_pretrained(
+                    row_model_name_or_path, use_auth_token=use_auth_token
+                )
             # The existing RCI models on the model hub don't come with tokenizer vocab files.
             except TypeError:
-                self.row_tokenizer = AutoTokenizer.from_pretrained("albert-base-v2")
+                self.row_tokenizer = AutoTokenizer.from_pretrained("albert-base-v2", use_auth_token=use_auth_token)
         else:
-            self.row_tokenizer = AutoTokenizer.from_pretrained(row_tokenizer)
+            self.row_tokenizer = AutoTokenizer.from_pretrained(row_tokenizer, use_auth_token=use_auth_token)
 
         if column_tokenizer is None:
             try:
-                self.column_tokenizer = AutoTokenizer.from_pretrained(column_model_name_or_path)
+                self.column_tokenizer = AutoTokenizer.from_pretrained(
+                    column_model_name_or_path, use_auth_token=use_auth_token
+                )
             # The existing RCI models on the model hub don't come with tokenizer vocab files.
             except TypeError:
-                self.column_tokenizer = AutoTokenizer.from_pretrained("albert-base-v2")
+                self.column_tokenizer = AutoTokenizer.from_pretrained("albert-base-v2", use_auth_token=use_auth_token)
         else:
-            self.column_tokenizer = AutoTokenizer.from_pretrained(column_tokenizer)
+            self.column_tokenizer = AutoTokenizer.from_pretrained(column_tokenizer, use_auth_token=use_auth_token)
 
         self.top_k = top_k
         self.max_seq_len = max_seq_len

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -44,7 +44,7 @@ class TableReader(BaseReader):
     Example:
     ```python
     from haystack import Document
-    from haystack.reader import TableReader
+    from haystack.nodes import TableReader
     import pandas as pd
 
     table_reader = TableReader(model_name_or_path="google/tapas-base-finetuned-wtq")

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -26,12 +26,12 @@ class TransformersTranslator(BaseTranslator):
     **Example:**
 
         ```python
-        |    DOCS = [
-        |        Document(content="Heinz von Foerster was an Austrian American scientist combining physics and philosophy,
-        |                       and widely attributed as the originator of Second-order cybernetics.")
-        |    ]
-        |    translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-en-de")
-        |    res = translator.translate(documents=DOCS, query=None)
+        DOCS = [
+            Document(content="Heinz von Foerster was an Austrian American scientist combining physics and philosophy,
+                           and widely attributed as the originator of Second-order cybernetics.")
+        ]
+        translator = TransformersTranslator(model_name_or_path="Helsinki-NLP/opus-mt-en-de")
+        res = translator.translate(documents=DOCS, query=None)
         ```
     """
 
@@ -43,6 +43,7 @@ class TransformersTranslator(BaseTranslator):
         clean_up_tokenization_spaces: Optional[bool] = True,
         use_gpu: bool = True,
         progress_bar: bool = True,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
         """Initialize the translator with a model that fits your targeted languages. While we support all seq2seq
         models from Hugging Face's model hub, we recommend using the OPUS models from Helsinki NLP. They provide plenty
@@ -64,6 +65,11 @@ class TransformersTranslator(BaseTranslator):
         :param clean_up_tokenization_spaces: Whether or not to clean up the tokenization spaces. (default True)
         :param use_gpu: Whether to use GPU or the CPU. Falls back on CPU if no GPU is available.
         :param progress_bar: Whether to show a progress bar.
+        :param use_auth_token: The API token used to download private models from Huggingface.
+                               If this parameter is set to `True`, then the token generated when running
+                               `transformer-cli login` (stored in ~/.huggingface) will be used.
+                               Additional information can be found here
+                               https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrainedModel.from_pretrained
         """
         super().__init__()
 
@@ -72,8 +78,8 @@ class TransformersTranslator(BaseTranslator):
         self.clean_up_tokenization_spaces = clean_up_tokenization_spaces
         self.progress_bar = progress_bar
         tokenizer_name = tokenizer_name or model_name_or_path
-        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
-        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path)
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, use_auth_token=use_auth_token)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_name_or_path, use_auth_token=use_auth_token)
         self.model.to(str(self.devices[0]))
 
     def translate(

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1162,6 +1162,7 @@ class Pipeline:
                         sas_model_name_or_path=sas_model_name_or_path,
                         batch_size=sas_batch_size,
                         use_gpu=sas_use_gpu,
+                        use_auth_token=None,
                     )
                     df["sas"] = sas
                     df["gold_answers_sas"] = [


### PR DESCRIPTION
### Related Issues
- fixes the issue of not being able to load private models on HF

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/master/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/master/CONTRIBUTING.md#installation) and fixed any issue
