### PR TITLE
chore: Upgrade and pin transformers to 4.21.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "torch>1.9,<1.13",
   "requests",
   "pydantic",
-  "transformers==4.20.1",
+  "transformers==4.21.2",
   "nltk",
   "pandas",
 


### PR DESCRIPTION
Upgrades and pins transformers to 4.21.2

The most important change for us allowing "mps" devices in [pipelines](https://github.com/huggingface/transformers/pull/18494)
After upgrading and pinning to 4.21.2, we can complete https://github.com/deepset-ai/haystack/pull/3062

### How did you test it?
We'll check whether any tests fail, for example, due to deprecated/discontinued features or breaking changes. We'll also comb through the changelog and check for any changes that might affect Haystack. 

