### PR TITLE
feat: FAISS in OpenSearch: check existing index

### DIFF
--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -443,10 +443,10 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
                             "space_type"
                         ]
 
+                    # Check if desired index settings are equal to settings in existing index
                     embedding_field_similarity = self.space_type_to_similarity[embedding_field_space_type]
-                    if embedding_field_similarity == self.similarity:
-                        self.embeddings_field_supports_similarity = True
-                    else:
+                    if embedding_field_similarity != self.similarity:
+                        self.embeddings_field_supports_similarity = False
                         logger.warning(
                             f"Embedding field '{self.embedding_field}' is optimized for similarity '{embedding_field_similarity}'. "
                             f"Falling back to slow exact vector calculation. "
@@ -454,6 +454,19 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
                             f"or creating a new index optimized for '{self.similarity}' by setting `similarity='{self.similarity}'` the first time you instantiate OpenSearchDocumentStore for the new index, "
                             f"e.g. `OpenSearchDocumentStore(index='my_new_{self.similarity}_index', similarity='{self.similarity}')`."
                         )
+
+                    # Check if desired knn engine is same as engine in existing index
+                    elif mappings["properties"][self.embedding_field]["method"]["engine"] != self.knn_engine:
+                        self.embeddings_field_supports_similarity = False
+                        embedding_field_engine = mappings["properties"][self.embedding_field]["method"]["engine"]
+                        logger.warning(
+                            f"Embedding field '{self.embedding_field}' was initially created with knn_engine "
+                            f"'{embedding_field_engine}', but knn_engine was set to '{self.knn_engine}' when "
+                            f"initializing OpenSearchDocumentStore. "
+                            f"Falling back to slow exact vector calculation."
+                        )
+                    else:
+                        self.embeddings_field_supports_similarity = True
 
                 # Adjust global ef_search setting (nmslib only). If not set, default is 512.
                 ef_search = index_settings.get("knn.algo_param", {"ef_search": 512}).get("ef_search", 512)

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -456,7 +456,10 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
                         )
 
                     # Check if desired knn engine is same as engine in existing index
-                    elif mappings["properties"][self.embedding_field]["method"]["engine"] != self.knn_engine:
+                    elif (
+                        "method" in mappings["properties"][self.embedding_field]
+                        and mappings["properties"][self.embedding_field]["method"]["engine"] != self.knn_engine
+                    ):
                         self.embeddings_field_supports_similarity = False
                         embedding_field_engine = mappings["properties"][self.embedding_field]["method"]["engine"]
                         logger.warning(

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -206,6 +206,20 @@ class TestOpenSearchDocumentStore:
                 # docs with an original embedding should have the new one
                 assert cloned_field_name in meta
 
+    @pytest.mark.integration
+    def test_change_knn_engine(self, ds, caplog):
+        assert ds.embeddings_field_supports_similarity == True
+        index_name = ds.index
+        with caplog.at_level(logging.WARNING):
+            ds = OpenSearchDocumentStore(port=9201, knn_engine="faiss", index=index_name)
+            warning = (
+                "Embedding field 'embedding' was initially created with knn_engine 'nmslib', but knn_engine was "
+                "set to 'faiss' when initializing OpenSearchDocumentStore. Falling back to slow exact vector "
+                "calculation."
+            )
+            assert ds.embeddings_field_supports_similarity == False
+            assert warning in caplog.text
+
     # Unit tests
 
     @pytest.mark.unit


### PR DESCRIPTION
### Related Issues
- fixes #2912

### Proposed Changes:
This PR adds a check whether the `knn_engine` provided at initialization of `OpenSearchDocumentStore` is equal to the `knn_engine` when an already existing index was initially created. If this is the case, we will fall back to slow exact vector calculation. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added a test case for this.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
