### PR TITLE
bug: adapt UI random question for streamlit 1.12 and pin to streamlit>=1.9.0

### DIFF
--- a/ui/setup.py
+++ b/ui/setup.py
@@ -36,5 +36,5 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.7, <4",
-    install_requires=["streamlit>=1.2.0, <2", "st-annotated-text>=2.0.0, <3", "markdown>=3.3.4, <4"],
+    install_requires=["streamlit>=1.9.0, <2", "st-annotated-text>=2.0.0, <3", "markdown>=3.3.4, <4"],
 )

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -164,7 +164,14 @@ Ask any question on this topic and see if Haystack can find the correct answer t
         st.session_state.random_question_requested = True
         # Re-runs the script setting the random question as the textbox value
         # Unfortunately necessary as the Random Question button is _below_ the textbox
-        raise st.scriptrunner.script_runner.RerunException(st.scriptrunner.script_requests.RerunData(None))
+        if hasattr(st, "scriptrunner"):
+            raise st.scriptrunner.script_runner.RerunException(
+                st.scriptrunner.script_requests.RerunData(widget_states=None)
+            )
+        else:
+            raise st.runtime.scriptrunner.script_runner.RerunException(
+                st.runtime.scriptrunner.script_requests.RerunData(widget_states=None)
+            )
     st.session_state.random_question_requested = False
 
     run_query = (

--- a/ui/webapp.py
+++ b/ui/webapp.py
@@ -168,10 +168,9 @@ Ask any question on this topic and see if Haystack can find the correct answer t
             raise st.scriptrunner.script_runner.RerunException(
                 st.scriptrunner.script_requests.RerunData(widget_states=None)
             )
-        else:
-            raise st.runtime.scriptrunner.script_runner.RerunException(
-                st.runtime.scriptrunner.script_requests.RerunData(widget_states=None)
-            )
+        raise st.runtime.scriptrunner.script_runner.RerunException(
+            st.runtime.scriptrunner.script_requests.RerunData(widget_states=None)
+        )
     st.session_state.random_question_requested = False
 
     run_query = (


### PR DESCRIPTION
### Related Issues
- fixes #3105

### Proposed Changes:
- Check if `streamlit` has `scriptrunner` attribute --> `streamlit`<1.12.0 --> old behavior is ok.
Otherwise --> `streamlit`>=1.12.0 --> use the new `runtime` attribute.

- I also pinned `streamlit`>=1.9.0 in setup.py, because, after the changes in #2566, the webapp is not compatible with `streamlit`<1.9.0 (I verified that it raises an exception with 1.8.0)

### How did you test it?
Manual verification

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
