### PR TITLE
build: pin pydantic to 1.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "importlib-metadata; python_version < '3.8'",
   "torch>1.9,<1.13",
   "requests",
-  "pydantic",
+  "pydantic==1.9.2",
   "transformers==4.21.2",
   "nltk",
   "pandas",


### PR DESCRIPTION
### Related Issues
- tests are failing https://github.com/deepset-ai/haystack/actions/workflows/tests.yml?query=branch%3Amain

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Pin pydantic to 1.9.2

Pydantic 1.10 ships a heavy refactoring of the `dataclass` decorator that we use, causing multiple failures. While we investigate the problem, this should bring back the CI to a healthy state.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
