### PR TITLE
Classify pipeline's type based on its components

### DIFF
--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -1017,7 +1017,7 @@ Returns the type of the pipeline.
 def uptime() -> timedelta
 ```
 
-Returns the uptime of the pipeline (seconds).
+Returns the uptime of the pipeline in timedelta.
 
 <a id="base._HaystackBeirRetrieverAdapter"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -1017,7 +1017,7 @@ Returns the type of the pipeline.
 def uptime() -> timedelta
 ```
 
-Returns the uptime of the pipeline.
+Returns the uptime of the pipeline (seconds).
 
 <a id="base._HaystackBeirRetrieverAdapter"></a>
 

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -317,6 +317,7 @@ Set the component for a node in the Pipeline.
 #### Pipeline.run
 
 ```python
+@invocation_counter
 def run(query: Optional[str] = None,
         file_paths: Optional[List[str]] = None,
         labels: Optional[MultiLabel] = None,
@@ -348,6 +349,7 @@ the Nodes received and the output they generated. You can then find all debug in
 #### Pipeline.run\_batch
 
 ```python
+@invocation_counter
 def run_batch(queries: List[str] = None,
               file_paths: Optional[List[str]] = None,
               labels: Optional[Union[MultiLabel, List[MultiLabel]]] = None,

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -1014,7 +1014,7 @@ Returns the type of the pipeline.
 #### Pipeline.uptime
 
 ```python
-def uptime() -> datetime
+def uptime() -> timedelta
 ```
 
 Returns the uptime of the pipeline.

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -317,7 +317,7 @@ Set the component for a node in the Pipeline.
 #### Pipeline.run
 
 ```python
-@invocation_counter
+@pipeline_invocation_counter
 def run(query: Optional[str] = None,
         file_paths: Optional[List[str]] = None,
         labels: Optional[MultiLabel] = None,
@@ -349,7 +349,7 @@ the Nodes received and the output they generated. You can then find all debug in
 #### Pipeline.run\_batch
 
 ```python
-@invocation_counter
+@pipeline_invocation_counter
 def run_batch(queries: List[str] = None,
               file_paths: Optional[List[str]] = None,
               labels: Optional[Union[MultiLabel, List[MultiLabel]]] = None,

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -1007,6 +1007,16 @@ def get_type() -> str
 
 Returns the type of the pipeline.
 
+<a id="base.Pipeline.uptime"></a>
+
+#### Pipeline.uptime
+
+```python
+def uptime() -> datetime
+```
+
+Returns the uptime of the pipeline.
+
 <a id="base._HaystackBeirRetrieverAdapter"></a>
 
 ## \_HaystackBeirRetrieverAdapter

--- a/docs/_src/api/api/pipelines.md
+++ b/docs/_src/api/api/pipelines.md
@@ -997,6 +997,16 @@ You can select between:
 :param wrong_examples_fields: A list of fields to include in the worst samples.
 :param max_characters_per_field: The maximum number of characters to include in the worst samples report (per field).
 
+<a id="base.Pipeline.get_type"></a>
+
+#### Pipeline.get\_type
+
+```python
+def get_type() -> str
+```
+
+Returns the type of the pipeline.
+
 <a id="base._HaystackBeirRetrieverAdapter"></a>
 
 ## \_HaystackBeirRetrieverAdapter
@@ -1402,6 +1412,20 @@ Return the document store object used in the current pipeline.
 **Returns**:
 
 Instance of DocumentStore or None
+
+<a id="standard_pipelines.BaseStandardPipeline.get_type"></a>
+
+#### BaseStandardPipeline.get\_type
+
+```python
+def get_type() -> str
+```
+
+Return the type of the pipeline.
+
+**Returns**:
+
+Type of the pipeline
 
 <a id="standard_pipelines.BaseStandardPipeline.eval"></a>
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2183,12 +2183,12 @@ class Pipeline:
             "GenerativeQAPipeline": lambda x: {"Generator", "Retriever"} <= set(x.keys()),
             "FAQPipeline": lambda x: {"Docs2Answers"} <= set(x.keys()),
             "ExtractiveQAPipeline": lambda x: {"Reader", "Retriever"} <= set(x.keys()),
-            "DocumentSearchPipeline": lambda x: {"Retriever"} <= set(x.keys()),
             "SearchSummarizationPipeline": lambda x: {"Retriever", "Summarizer"} <= set(x.keys()),
             "TranslationWrapperPipeline": lambda x: {"InputTranslator", "OutputTranslator"} <= set(x.keys()),
-            "QuestionGenerationPipeline": lambda x: {"QuestionGenerator"} <= set(x.keys()),
-            "RetrieverQuestionGenerationPipeline": lambda x: {"Retriever", "Question Generator"} <= set(x.keys()),
+            "RetrieverQuestionGenerationPipeline": lambda x: {"Retriever", "QuestionGenerator"} <= set(x.keys()),
             "QuestionAnswerGenerationPipeline": lambda x: {"QuestionGenerator", "Reader"} <= set(x.keys()),
+            "DocumentSearchPipeline": lambda x: {"Retriever"} <= set(x.keys()),
+            "QuestionGenerationPipeline": lambda x: {"QuestionGenerator"} <= set(x.keys()),
             "MostSimilarDocumentsPipeline": lambda x: len(x.values()) == 1
             and isinstance(list(x.values())[0], BaseDocumentStore),
         }

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1,6 +1,8 @@
 # pylint: disable=too-many-public-methods
 
 from __future__ import annotations
+
+import datetime
 from functools import partial
 from typing import Dict, List, Optional, Any, Set, Tuple, Union
 
@@ -66,6 +68,7 @@ class Pipeline:
 
     def __init__(self):
         self.graph = DiGraph()
+        self.init_time = datetime.datetime.now(datetime.timezone.utc)
 
     @property
     def root_node(self) -> Optional[str]:
@@ -2187,6 +2190,12 @@ class Pipeline:
         retrievers_used = retrievers if retrievers else "None"
         doc_stores_used = doc_stores if doc_stores else "None"
         return f"{pipeline_type} (retriever: {retrievers_used}, doc_store: {doc_stores_used})"
+
+    def uptime(self) -> datetime:
+        """
+        Returns the uptime of the pipeline.
+        """
+        return datetime.datetime.now(datetime.timezone.utc) - self.init_time
 
 
 class _HaystackBeirRetrieverAdapter:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import datetime
+from datetime import timedelta
 from functools import partial
 from hashlib import sha1
 from typing import Dict, List, Optional, Any, Set, Tuple, Union
 
-from haystack.utils.reflection import invocation_counter
 
 try:
     from typing import Literal
@@ -45,6 +45,7 @@ from haystack.pipelines.config import (
 )
 from haystack.pipelines.utils import generate_code, print_eval_report
 from haystack.utils import DeepsetCloud, calculate_context_similarity
+from haystack.utils.reflection import invocation_counter
 from haystack.schema import Answer, EvaluationResult, MultiLabel, Document, Span
 from haystack.errors import HaystackError, PipelineError, PipelineConfigError
 from haystack.nodes.base import BaseComponent, RootNode
@@ -2201,7 +2202,7 @@ class Pipeline:
         doc_stores_used = doc_stores if doc_stores else "None"
         return f"{pipeline_type} (retriever: {retrievers_used}, doc_store: {doc_stores_used})"
 
-    def uptime(self) -> datetime:
+    def uptime(self) -> timedelta:
         """
         Returns the uptime of the pipeline.
         """

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2204,7 +2204,7 @@ class Pipeline:
 
     def uptime(self) -> timedelta:
         """
-        Returns the uptime of the pipeline.
+        Returns the uptime of the pipeline (seconds).
         """
         return datetime.datetime.now(datetime.timezone.utc) - self.init_time
 
@@ -2215,7 +2215,7 @@ class Pipeline:
             payload={
                 "fingerprint": fingerprint,
                 "type": self.get_type(),
-                "uptime": self.uptime().total_seconds(),
+                "uptime": int(self.uptime().total_seconds()),
                 "run_total": self.run.counter + self.run_batch.counter,
             },
         )

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -45,7 +45,7 @@ from haystack.pipelines.config import (
 )
 from haystack.pipelines.utils import generate_code, print_eval_report
 from haystack.utils import DeepsetCloud, calculate_context_similarity
-from haystack.utils.reflection import invocation_counter
+from haystack.utils.reflection import pipeline_invocation_counter
 from haystack.schema import Answer, EvaluationResult, MultiLabel, Document, Span
 from haystack.errors import HaystackError, PipelineError, PipelineConfigError
 from haystack.nodes.base import BaseComponent, RootNode
@@ -446,7 +446,7 @@ class Pipeline:
     def _run_node(self, node_id: str, node_input: Dict[str, Any]) -> Tuple[Dict, str]:
         return self.graph.nodes[node_id]["component"]._dispatch_run(**node_input)
 
-    @invocation_counter
+    @pipeline_invocation_counter
     def run(  # type: ignore
         self,
         query: Optional[str] = None,
@@ -571,7 +571,7 @@ class Pipeline:
             self.send_telemetry()
         return node_output
 
-    @invocation_counter
+    @pipeline_invocation_counter
     def run_batch(  # type: ignore
         self,
         queries: List[str] = None,
@@ -2216,8 +2216,7 @@ class Pipeline:
                 "fingerprint": fingerprint,
                 "type": self.get_type(),
                 "uptime": self.uptime().total_seconds(),
-                "run_counter": self.run.counter,
-                "run_batch_counter": self.run_batch.counter,
+                "run_total": self.run.counter + self.run_batch.counter,
             },
         )
         self.last_telemetry_update = datetime.datetime.now(datetime.timezone.utc)

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2190,7 +2190,7 @@ class Pipeline:
             "RetrieverQuestionGenerationPipeline": lambda x: {"Retriever", "Question Generator"} <= set(x.keys()),
             "QuestionAnswerGenerationPipeline": lambda x: {"QuestionGenerator", "Reader"} <= set(x.keys()),
             "MostSimilarDocumentsPipeline": lambda x: len(x.values()) == 1
-            and any(comp for comp in x.values() if isinstance(comp, BaseDocumentStore)),
+            and isinstance(list(x.values())[0], BaseDocumentStore),
         }
         retrievers = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseRetriever)]
         doc_stores = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseDocumentStore)]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2204,7 +2204,7 @@ class Pipeline:
 
     def uptime(self) -> timedelta:
         """
-        Returns the uptime of the pipeline (seconds).
+        Returns the uptime of the pipeline in timedelta.
         """
         return datetime.datetime.now(datetime.timezone.utc) - self.init_time
 

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -654,7 +654,7 @@ class RetrieverQuestionGenerationPipeline(BaseStandardPipeline):
     def __init__(self, retriever: BaseRetriever, question_generator: QuestionGenerator):
         self.pipeline = Pipeline()
         self.pipeline.add_node(component=retriever, name="Retriever", inputs=["Query"])
-        self.pipeline.add_node(component=question_generator, name="Question Generator", inputs=["Retriever"])
+        self.pipeline.add_node(component=question_generator, name="QuestionGenerator", inputs=["Retriever"])
 
     def run(self, query: str, params: Optional[dict] = None, debug: Optional[bool] = None):
         output = self.pipeline.run(query=query, params=params, debug=debug)

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -158,6 +158,14 @@ class BaseStandardPipeline(ABC):
         """
         return self.pipeline.get_document_store()
 
+    def get_type(self) -> str:
+        """
+        Return the type of the pipeline.
+
+        :return: Type of the pipeline
+        """
+        return self.pipeline.get_type()
+
     def eval(
         self,
         labels: List[MultiLabel],

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -283,7 +283,15 @@ def _delete_telemetry_file(file_type_to_delete: TelemetryFileType):
 
 
 class NonPrivateParameters:
-    param_names: List[str] = ["top_k", "model_name_or_path", "add_isolated_node_eval"]
+    param_names: List[str] = [
+        "top_k",
+        "model_name_or_path",
+        "add_isolated_node_eval",
+        "fingerprint",
+        "type",
+        "uptime",
+        "run_total",
+    ]
 
     @classmethod
     def apply_filter(cls, param_dicts: Dict[str, Any]) -> Dict[str, Any]:

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -13,10 +13,22 @@ def args_to_kwargs(args: Tuple, func: Callable) -> Dict[str, Any]:
     return args_as_kwargs
 
 
-def invocation_counter(func):
+def pipeline_invocation_counter(func):
     @functools.wraps(func)
     def wrapper_invocation_counter(*args, **kwargs):
-        wrapper_invocation_counter.counter += 1
+        # single query
+        this_invocation_count = 1
+        # were named arguments used?
+        if "queries" in kwargs:
+            this_invocation_count = len(kwargs["queries"])
+        elif "documents" in kwargs:
+            this_invocation_count = len(kwargs["documents"])
+        else:
+            # positional arguments used? try to infer count from the first parameter in args
+            if args[0] and isinstance(args[0], list):
+                this_invocation_count = len(args[0])
+
+        wrapper_invocation_counter.counter += this_invocation_count
         return func(*args, **kwargs)
 
     wrapper_invocation_counter.counter = 0

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -1,4 +1,5 @@
 import inspect
+import functools
 from typing import Any, Dict, Tuple, Callable
 
 
@@ -10,3 +11,13 @@ def args_to_kwargs(args: Tuple, func: Callable) -> Dict[str, Any]:
         arg_names = arg_names[1 : 1 + len(args)]
     args_as_kwargs = {arg_name: arg for arg, arg_name in zip(args, arg_names)}
     return args_as_kwargs
+
+
+def invocation_counter(func):
+    @functools.wraps(func)
+    def wrapper_invocation_counter(*args, **kwargs):
+        wrapper_invocation_counter.counter += 1
+        return func(*args, **kwargs)
+
+    wrapper_invocation_counter.counter = 0
+    return wrapper_invocation_counter

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -20,9 +20,9 @@ def pipeline_invocation_counter(func):
         this_invocation_count = 1
         # were named arguments used?
         if "queries" in kwargs:
-            this_invocation_count = len(kwargs["queries"])
+            this_invocation_count = len(kwargs["queries"]) if kwargs["queries"] else 1
         elif "documents" in kwargs:
-            this_invocation_count = len(kwargs["documents"])
+            this_invocation_count = len(kwargs["documents"]) if kwargs["documents"] else 1
         else:
             # positional arguments used? try to infer count from the first parameter in args
             if args[0] and isinstance(args[0], list):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,7 @@ import psutil
 import pytest
 import requests
 
+from haystack import Answer
 from haystack.nodes.base import BaseComponent
 
 try:
@@ -49,7 +50,14 @@ except (ImportError, ModuleNotFoundError) as ie:
 
 from haystack.document_stores import BaseDocumentStore, DeepsetCloudDocumentStore, InMemoryDocumentStore
 
-from haystack.nodes import BaseReader, BaseRetriever, OpenAIAnswerGenerator
+from haystack.nodes import (
+    BaseReader,
+    BaseRetriever,
+    OpenAIAnswerGenerator,
+    BaseGenerator,
+    BaseSummarizer,
+    BaseTranslator,
+)
 from haystack.nodes.answer_generator.transformers import Seq2SeqGenerator
 from haystack.nodes.answer_generator.transformers import RAGenerator
 from haystack.nodes.ranker import SentenceTransformersRanker
@@ -263,6 +271,43 @@ class MockRetriever(BaseRetriever):
         pass
 
 
+class MockSeq2SegGenerator(BaseGenerator):
+    def predict(self, query: str, documents: List[Document], top_k: Optional[int]) -> Dict:
+        pass
+
+
+class MockSummarizer(BaseSummarizer):
+    def predict_batch(
+        self,
+        documents: Union[List[Document], List[List[Document]]],
+        generate_single_summary: Optional[bool] = None,
+        batch_size: Optional[int] = None,
+    ) -> Union[List[Document], List[List[Document]]]:
+        pass
+
+    def predict(self, documents: List[Document], generate_single_summary: Optional[bool] = None) -> List[Document]:
+        pass
+
+
+class MockTranslator(BaseTranslator):
+    def translate(
+        self,
+        results: List[Dict[str, Any]] = None,
+        query: Optional[str] = None,
+        documents: Optional[Union[List[Document], List[Answer], List[str], List[Dict[str, Any]]]] = None,
+        dict_key: Optional[str] = None,
+    ) -> Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]:
+        pass
+
+    def translate_batch(
+        self,
+        queries: Optional[List[str]] = None,
+        documents: Optional[Union[List[Document], List[Answer], List[List[Document]], List[List[Answer]]]] = None,
+        batch_size: Optional[int] = None,
+    ) -> List[Union[str, List[Document], List[Answer], List[str], List[Dict[str, Any]]]]:
+        pass
+
+
 class MockDenseRetriever(MockRetriever):
     def __init__(self, document_store: BaseDocumentStore, embedding_dim: int = 768):
         self.embedding_dim = embedding_dim
@@ -273,6 +318,14 @@ class MockDenseRetriever(MockRetriever):
 
     def embed_documents(self, docs):
         return [np.random.rand(self.embedding_dim)] * len(docs)
+
+
+class MockQuestionGenerator(QuestionGenerator):
+    def __init__(self):
+        pass
+
+    def predict(self, query: str, documents: List[Document], top_k: Optional[int]) -> Dict:
+        pass
 
 
 class MockReader(BaseReader):

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -1094,7 +1094,7 @@ def test_question_generation_eval(retriever_with_docs, question_generator):
     metrics = eval_result.calculate_metrics(document_scope="document_id")
 
     assert "Retriever" in eval_result
-    assert "Question Generator" in eval_result
+    assert "QuestionGenerator" in eval_result
     assert len(eval_result) == 2
 
     assert metrics["Retriever"]["mrr"] == 0.5
@@ -1104,12 +1104,12 @@ def test_question_generation_eval(retriever_with_docs, question_generator):
     assert metrics["Retriever"]["precision"] == 0.1
     assert metrics["Retriever"]["ndcg"] == 0.5
 
-    assert metrics["Question Generator"]["mrr"] == 0.5
-    assert metrics["Question Generator"]["map"] == 0.5
-    assert metrics["Question Generator"]["recall_multi_hit"] == 0.5
-    assert metrics["Question Generator"]["recall_single_hit"] == 0.5
-    assert metrics["Question Generator"]["precision"] == 0.1
-    assert metrics["Question Generator"]["ndcg"] == 0.5
+    assert metrics["QuestionGenerator"]["mrr"] == 0.5
+    assert metrics["QuestionGenerator"]["map"] == 0.5
+    assert metrics["QuestionGenerator"]["recall_multi_hit"] == 0.5
+    assert metrics["QuestionGenerator"]["recall_single_hit"] == 0.5
+    assert metrics["QuestionGenerator"]["precision"] == 0.1
+    assert metrics["QuestionGenerator"]["ndcg"] == 0.5
 
 
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -836,7 +836,7 @@ def test_question_generation_eval(retriever_with_docs, question_generator):
     metrics = eval_result.calculate_metrics(document_scope="document_id")
 
     assert "Retriever" in eval_result
-    assert "Question Generator" in eval_result
+    assert "QuestionGenerator" in eval_result
     assert len(eval_result) == 2
 
     assert metrics["Retriever"]["mrr"] == 0.5
@@ -846,12 +846,12 @@ def test_question_generation_eval(retriever_with_docs, question_generator):
     assert metrics["Retriever"]["precision"] == 0.1
     assert metrics["Retriever"]["ndcg"] == 0.5
 
-    assert metrics["Question Generator"]["mrr"] == 0.5
-    assert metrics["Question Generator"]["map"] == 0.5
-    assert metrics["Question Generator"]["recall_multi_hit"] == 0.5
-    assert metrics["Question Generator"]["recall_single_hit"] == 0.5
-    assert metrics["Question Generator"]["precision"] == 0.1
-    assert metrics["Question Generator"]["ndcg"] == 0.5
+    assert metrics["QuestionGenerator"]["mrr"] == 0.5
+    assert metrics["QuestionGenerator"]["map"] == 0.5
+    assert metrics["QuestionGenerator"]["recall_multi_hit"] == 0.5
+    assert metrics["QuestionGenerator"]["recall_single_hit"] == 0.5
+    assert metrics["QuestionGenerator"]["precision"] == 0.1
+    assert metrics["QuestionGenerator"]["ndcg"] == 0.5
 
 
 # Commented out because of the following issue https://github.com/deepset-ai/haystack/issues/2962


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack-private/issues/10
- fixes https://github.com/deepset-ai/haystack-private/issues/11
- fixes https://github.com/deepset-ai/haystack-private/issues/12

The encompassing issue is https://github.com/deepset-ai/haystack-private/issues/9

### Proposed Changes:
Add a method that classifies the type of the pipeline based on components found
### How did you test it?
Repeated invocations from colab notebook on a branch where the update trigger is 2 min instead of 24 hours
Added a unit test for pipeline classification

### Notes for the reviewer
Focus on `pipeline_invocation_counter` decorator in haystack/utils/reflection.py, how the even is triggered (time) and what details are sent to telemetry server  

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behaviour of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
