### PR TITLE
docs: Fix the word length splitting; should be set to 100 not 1,000

### DIFF
--- a/docs/_src/tutorials/tutorials/8.md
+++ b/docs/_src/tutorials/tutorials/8.md
@@ -118,7 +118,7 @@ and [Optimization](https://haystack.deepset.ai/docs/latest/optimizationmd) pages
 # This is a default usage of the PreProcessor.
 # Here, it performs cleaning of consecutive whitespaces
 # and splits a single large document into smaller documents.
-# Each document is up to 1000 words long and document breaks cannot fall in the middle of sentences
+# Each document is up to 100 words long and document breaks cannot fall in the middle of sentences
 # Note how the single document passed into the document gets split into 5 smaller documents
 
 preprocessor = PreProcessor(

--- a/tutorials/Tutorial8_Preprocessing.ipynb
+++ b/tutorials/Tutorial8_Preprocessing.ipynb
@@ -286,7 +286,7 @@
     "# This is a default usage of the PreProcessor.\n",
     "# Here, it performs cleaning of consecutive whitespaces\n",
     "# and splits a single large document into smaller documents.\n",
-    "# Each document is up to 1000 words long and document breaks cannot fall in the middle of sentences\n",
+    "# Each document is up to 100 words long and document breaks cannot fall in the middle of sentences\n",
     "# Note how the single document passed into the document gets split into 5 smaller documents\n",
     "\n",
     "preprocessor = PreProcessor(\n",

--- a/tutorials/Tutorial8_Preprocessing.py
+++ b/tutorials/Tutorial8_Preprocessing.py
@@ -77,7 +77,7 @@ def tutorial8_preprocessing():
     # This is a default usage of the PreProcessor.
     # Here, it performs cleaning of consecutive whitespaces
     # and splits a single large document into smaller documents.
-    # Each document is up to 1000 words long and document breaks cannot fall in the middle of sentences
+    # Each document is up to 100 words long and document breaks cannot fall in the middle of sentences
     # Note how the single document passed into the document gets split into 5 smaller documents
 
     preprocessor = PreProcessor(
@@ -85,7 +85,7 @@ def tutorial8_preprocessing():
         clean_whitespace=True,
         clean_header_footer=False,
         split_by="word",
-        split_length=1000,
+        split_length=100,
         split_respect_sentence_boundary=True,
     )
     docs_default = preprocessor.process([doc_txt])


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/discussions/3103 
- fixes #3123 

### Proposed Changes:
In tutorial 8, when referring to splitting a document, we now consistently use 100. Previously it was sometimes 1,000, which is too long for some transformer models.

### How did you test it?
I ran the tutorial locally to ensure it still produced output.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [] - not applicable - I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] - not applicable - I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
