### PR TITLE
feat: Add option to use MultipleNegativesRankingLoss for EmbeddingRetriever training with sentence-transformers

### DIFF
--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -1678,7 +1678,8 @@ def train(training_data: List[Dict[str, Any]],
           learning_rate: float = 2e-5,
           n_epochs: int = 1,
           num_warmup_steps: int = None,
-          batch_size: int = 16) -> None
+          batch_size: int = 16,
+          train_loss: str = "mnrl") -> None
 ```
 
 Trains/adapts the underlying embedding model.
@@ -1697,6 +1698,8 @@ Each training data example is a dictionary with the following keys:
 - `n_epochs` (`int`): The number of epochs
 - `num_warmup_steps` (`int`): The number of warmup steps
 - `batch_size` (`int (optional)`): The batch size to use for the training, defaults to 16
+- `train_loss` (`str (optional)`): The loss to use for training.
+If using sentence-transformers, one of 'mnrl' (Multiple Negatives Ranking Loss) or 'margin_mse' (MarginMSE)
 
 <a id="dense.EmbeddingRetriever.save"></a>
 

--- a/docs/_src/api/api/retriever.md
+++ b/docs/_src/api/api/retriever.md
@@ -1699,7 +1699,8 @@ Each training data example is a dictionary with the following keys:
 - `num_warmup_steps` (`int`): The number of warmup steps
 - `batch_size` (`int (optional)`): The batch size to use for the training, defaults to 16
 - `train_loss` (`str (optional)`): The loss to use for training.
-If using sentence-transformers, one of 'mnrl' (Multiple Negatives Ranking Loss) or 'margin_mse' (MarginMSE)
+If you're using sentence-transformers as embedding_model (which are the only ones that currently support training),
+possible values are 'mnrl' (Multiple Negatives Ranking Loss) or 'margin_mse' (MarginMSE).
 
 <a id="dense.EmbeddingRetriever.save"></a>
 

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -209,7 +209,7 @@ class _SentenceTransformersEmbeddingEncoder(_BaseEmbeddingEncoder):
             missing_attrs = st_loss.required_attrs.difference(set(train_i.keys()))
             if len(missing_attrs) > 0:
                 raise ValueError(
-                    f"Some training examples don't contain the fields {missing_attrs} which is/are necessary when using '{train_loss}' loss."
+                    f"Some training examples don't contain the fields {missing_attrs} which are necessary when using the '{train_loss}' loss."
                 )
 
             texts = [train_i["question"], train_i["pos_doc"]]

--- a/haystack/nodes/retriever/_losses.py
+++ b/haystack/nodes/retriever/_losses.py
@@ -1,0 +1,12 @@
+from collections import namedtuple
+from typing import Callable, Dict
+
+from sentence_transformers import losses
+
+
+SentenceTransformerLoss = namedtuple("SentenceTransformerLoss", "loss required_attrs")
+
+_TRAINING_LOSSES: Dict[str, SentenceTransformerLoss] = {
+    "mnrl": SentenceTransformerLoss(losses.MultipleNegativesRankingLoss, {"question", "pos_doc"}),
+    "margin_mse": SentenceTransformerLoss(losses.MarginMSELoss, {"question", "pos_doc", "neg_doc", "score"}),
+}

--- a/haystack/nodes/retriever/_losses.py
+++ b/haystack/nodes/retriever/_losses.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import Callable, Dict
+from typing import Dict
 
 from sentence_transformers import losses
 

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1863,6 +1863,7 @@ class EmbeddingRetriever(BaseRetriever):
         n_epochs: int = 1,
         num_warmup_steps: int = None,
         batch_size: int = 16,
+        train_loss: str = "mnrl",
     ) -> None:
         """
         Trains/adapts the underlying embedding model.
@@ -1885,6 +1886,9 @@ class EmbeddingRetriever(BaseRetriever):
         :type num_warmup_steps: int
         :param batch_size: The batch size to use for the training, defaults to 16
         :type batch_size: int (optional)
+        :param train_loss: The loss to use for training.
+                           If using sentence-transformers, one of 'mnrl' (Multiple Negatives Ranking Loss) or 'margin_mse' (MarginMSE)
+        :type train_loss: str (optional)
         """
         self.embedding_encoder.train(
             training_data,
@@ -1892,6 +1896,7 @@ class EmbeddingRetriever(BaseRetriever):
             n_epochs=n_epochs,
             num_warmup_steps=num_warmup_steps,
             batch_size=batch_size,
+            train_loss=train_loss,
         )
 
     def save(self, save_dir: Union[Path, str]) -> None:

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1887,7 +1887,8 @@ class EmbeddingRetriever(BaseRetriever):
         :param batch_size: The batch size to use for the training, defaults to 16
         :type batch_size: int (optional)
         :param train_loss: The loss to use for training.
-                           If using sentence-transformers, one of 'mnrl' (Multiple Negatives Ranking Loss) or 'margin_mse' (MarginMSE)
+                           If you're using sentence-transformers as embedding_model (which are the only ones that currently support training),
+                           possible values are 'mnrl' (Multiple Negatives Ranking Loss) or 'margin_mse' (MarginMSE).
         :type train_loss: str (optional)
         """
         self.embedding_encoder.train(


### PR DESCRIPTION
Add option to use MultipleNegativesRankingLoss for EmbeddingRetriever training with sentence-transformers.

### Related Issues
- Resolves #3136 

### Proposed Changes:
Expose an option `train_loss` on `EmbeddingRetriever.train`. It is propagated to `_SentenceTransformersEmbeddingEncoder.train` and determines the loss that's used. Also influences the training data format that can be used/is expected. 

So the API is:
```python
embedding_retriever = EmbeddingRetriever(...)
training_data = [{"question": ..., "pos_doc": ...}, ...]
# Loss can be specified when calling `train`. Options currently: 'mnrl' or 'margin_mse'
embedding_retriever.train(training_data=training_data, train_loss='mnrl') 
```

### How did you test it?
[A Colab notebook](https://colab.research.google.com/drive/1cZxlQN8yl57Yuq77aHlX9YyfJAofVfzl?usp=sharing) with a sample run. Qualitative comparison against the baseline model.

### Notes for the reviewer

Some possible aspects up for discussion
- I exposed the loss option as a string. 
  - Another option could be to directly accept `sentence-transformers` losses (might even be able to say can use any loss in there as long as the data format is correct but would be a big jump). Plus might tie us to keep doing so (which may or may not be a problem). With the string we have the flexibility to later internally swap things out. 
  - We could also construct our own enums or probably better yet loss classes which are thin wrappers around the `sentence-transformers` losses. But probably not needed at this stage.
- Slightly tricky to provide users with list of possible losses. I guess best place is in the `EmbeddingRetriever` docstring, which I went with.
- Any unit or integration tests needed? Any other experiments needed?

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
