### PR TITLE
fix: Add 15 min timeout for downloading cached HF models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -643,11 +643,13 @@ jobs:
       with:
         path: ~/.cache/huggingface/transformers/
         key: hf-models
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
 
     - name: Download models
       if: steps.cache-hf-models.outputs.cache-hit != 'true'
       run: |
-         python -c "from transformers import AutoModel;[AutoModel.from_pretrained(model_name) for model_name in ['vblagoje/bart_lfqa','yjernite/bart_eli5', 'google/pegasus-xsum', 'vblagoje/dpr-ctx_encoder-single-lfqa-wiki', 'vblagoje/dpr-question_encoder-single-lfqa-wiki', 'facebook/dpr-question_encoder-single-nq-base', 'facebook/dpr-ctx_encoder-single-nq-base', 'yjernite/retribert-base-uncased']]"
+         python -c "from transformers import AutoModel;[AutoModel.from_pretrained(model_name) for model_name in ['vblagoje/bart_lfqa','yjernite/bart_eli5', 'google/pegasus-xsum', 'vblagoje/dpr-ctx_encoder-single-lfqa-wiki', 'vblagoje/dpr-question_encoder-single-lfqa-wiki', 'facebook/dpr-question_encoder-single-nq-base', 'facebook/dpr-ctx_encoder-single-nq-base']]"
 
 
     - name: Run Elasticsearch


### PR DESCRIPTION
### Related Issues
- fixes #3146 

### Proposed Changes:
There is an ongoing effort to stabilize CI model HF caching. We added `SEGMENT_DOWNLOAD_TIMEOUT_MIN ` env variable and set it to 15 min. If there are download failures, we will get an exception/timeout rather than wait an hour for the task to timeout.  There is an ongoing effort to fix this issue on the GitHub side, and we expect a more permanent fix sometime in September. For more details, see https://github.com/actions/cache/issues/810

### How did you test it?
No tests have been added.

### Notes for the reviewer
See the relevant and referenced issues

