### PR TITLE
Replace torch.device("cuda") with torch.device("cuda:0") in devices initialization

### DIFF
--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -96,6 +96,12 @@ def initialize_device_settings(
         n_gpu = 1
         # Initializes the distributed backend which will take care of sychronizing nodes/GPUs
         torch.distributed.init_process_group(backend="nccl")
+
+    # HF transformers v4.21.2 pipeline object doesn't accept torch.device("cuda"), it has to be an indexed cuda device
+    # TODO eventually remove once the limitation is fixed in HF transformers
+    device_to_replace = torch.device("cuda")
+    devices_to_use = [torch.device("cuda:0") if device == device_to_replace else device for device in devices_to_use]
+
     logger.info(f"Using devices: {', '.join([str(device) for device in devices_to_use]).upper()}")
     logger.info(f"Number of GPUs: {n_gpu}")
     return devices_to_use, n_gpu


### PR DESCRIPTION

### Related Issues
- fixes #3160 

### Proposed Changes:
As version 4.21.2 in their pipelines, HF transformers only accept indexed Cuda devices. Therefore, we needed to replace instances of `torch.device("cuda")` with `torch.device("cuda:0")` in devices initialization util function.

### How did you test it?
A fix is trivial; I tried a small unit test in an interpreter but didn't add any additional unit tests 

### Notes for the reviewer
Think of a potential scenario where the proposed fix breaks. 

