### PR TITLE
Validate `custom_mapping` as an object

### DIFF
--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -21,7 +21,7 @@ from haystack.errors import PipelineError, PipelineConfigError, PipelineSchemaEr
 logger = logging.getLogger(__name__)
 
 
-VALID_INPUT_REGEX = re.compile(r"^[-a-zA-Z0-9_/\\.:]+$")
+VALID_INPUT_REGEX = re.compile(r"^[-a-zA-Z0-9_/\\.:*]+$")
 VALID_ROOT_NODES = ["Query", "File"]
 
 
@@ -99,7 +99,6 @@ def read_pipeline_config_from_yaml(path: Path) -> Dict[str, Any]:
 
 JSON_FIELDS = [
     "custom_query",  # ElasticsearchDocumentStore.custom_query
-    "custom_mapping",  # ElasticsearchDocumentStore.custom_mapping
 ]
 
 


### PR DESCRIPTION
### Related Issues
- Direct report by @ArzelaAscoIi of `OpenSearchDocumentStore.custom_mapping` being impossible to validate for values other than `None`.

### Proposed Changes:
- `OpenSearchDocumentStore.custom_mapping` now takes an object as input instead of a JSON string

### How did you test it?
- Manual tests on a simple (JSON) example:
```yaml
{
    "version": "main",
    "components": [
        {
            "name": "DocumentStore",
            "type": "OpenSearchDocumentStore",
            "params": {
                "port": 9200,
                "index": "678ffded-fd00-45c1-95eb-9a75264fc376-af50a903-c5e3-40cd-98c9-d404f925fdb9-f1b9c75b-76ef-4fea-b3d5-0e28858345ae",
                "scheme": "https",
                "verify_certs": false,
                "create_index": true,
                "content_field": "content",
                "search_fields": "content",
                "embedding_dim": 768,
                "embedding_field": "embedding",
                "custom_mapping": {
                  "mappings": {
                    "dynamic_templates": [
                        {
                            "strings": {
                                "path_match": "*",
                                "match_mapping_type": "string",
                                "mapping": {
                                    "type": "keyword"
                                }
                            }
                        }
                    ],
                    "properties": {
                        "content": {
                            "type": "text"
                        },
                        "embedding": {
                            "type": "knn_vector",
                            "dimension": 768,
                            "method": {
                                "engine": "nmslib",
                                "space_type": "innerproduct",
                                "name": "hnsw",
                                "parameters": {
                                    "ef_construction": 512,
                                    "m": 16
                                }
                            }
                        },
                        "name": {
                            "type": "keyword"
                        }
                    }
                  }
                },
                "host": "opensearch",
                "username": "admin",
                "password": "admin"
            }
        },
        {
            "name": "Retriever",
            "type": "ElasticsearchRetriever",
            "params": {
                "document_store": "DocumentStore",
                "top_k": 5
            }
        }
    ],
    "pipelines": [
        {
            "name": "query",
            "nodes": [
                {
                    "name": "Retriever",
                    "inputs": [
                        "Query"
                    ]
                }
            ]
        }
    ]
}
```
- CI

### Notes for the reviewer
- `*` was added to the list of valid chars in string fields. I believe this has no implications for security wrt to the previous list.
- We should also consider addressing the whole situation with these complex nested fields a bit better, keeping in mind security considerations

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
