### PR TITLE
feat: exponential backoff with exp decreasing batch size for opensearch client

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -132,7 +132,7 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
 
     def _split_document_list(
         self, documents: Union[List[dict], List[Document]], number_of_lists: int
-    ) -> Generator[List[Union[List[dict], List[Document]]], None, None]:
+    ) -> Generator[Union[List[dict], List[Document]], None, None]:
         chunk_size = max(int((len(documents) + 1) / number_of_lists), 1)
         for i in range(0, len(documents), chunk_size):
             yield documents[i : i + chunk_size]

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -166,7 +166,7 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
             raise DocumentStoreError("Bulk request failed after 3 retries.")
 
         try:
-            return bulk(self.client, documents, request_timeout=300, refresh=self.refresh_type, headers=headers)
+            bulk(self.client, documents, request_timeout=300, refresh=self.refresh_type, headers=headers)
         except RequestError as e:
             if e.status_code == 429:
                 logger.warning(
@@ -179,7 +179,14 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
 
                 time.sleep(_timeout)
                 for split_docs in self._split_document_list(documents, 2):
-                    self._bulk(split_docs, headers, request_timeout, refresh, _timeout * 2, _remaining_tries - 1)
+                    self._bulk(
+                        documents=split_docs,
+                        headers=headers,
+                        request_timeout=request_timeout,
+                        refresh=refresh,
+                        _timeout=_timeout * 2,
+                        _remaining_tries=_remaining_tries - 1,
+                    )
                 return
             raise e
 

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -553,7 +553,7 @@ class BaseElasticsearchDocumentStore(KeywordDocumentStore):
 
             # Pass batch_size number of labels to bulk
             if len(labels_to_index) % batch_size == 0:
-                self.bulk(labels_to_index, request_timeout=300, refresh=self.refresh_type, headers=headers)
+                self._bulk(labels_to_index, request_timeout=300, refresh=self.refresh_type, headers=headers)
                 labels_to_index = []
 
         if labels_to_index:


### PR DESCRIPTION
### Related Issues
- bugfix

### Proposed Changes:
- add custom `_bulk` insert for opensearch + elasticsearch client 
- add split method to split list into N chunks of (approx) same size
- 

### How did you test it?
- not yet 

### Note to the reviewer

There is also a bulk insert for the `clone_embedding_field` within the openserach document store. Do we also need to update this ? Currently we just inherit the bulk insert for opensearch from elasticsearch. 


### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
