### PR TITLE
refactor: make `TransformersDocumentClassifier` output consistent between different types of classification

### DIFF
--- a/docs/_src/api/api/document_classifier.md
+++ b/docs/_src/api/api/document_classifier.md
@@ -37,7 +37,7 @@ Transformer based model for document classification using the HuggingFace's tran
 While the underlying model can vary (BERT, Roberta, DistilBERT ...), the interface remains the same.
 This node classifies documents and adds the output from the classification step to the document's meta data.
 The meta field of the document is a dictionary with the following format:
-``'meta': {'name': '450_Baelor.txt', 'classification': {'label': 'neutral', 'probability' = 0.9997646, ...} }``
+``'meta': {'name': '450_Baelor.txt', 'classification': {'label': 'love', 'score': 0.960899, 'details': {'love': 0.960899, 'joy': 0.032584, ...}}}``
 
 Classification is run on document's content field by default. If you want it to run on another field,
 set the `classification_field` to one of document's meta fields.
@@ -89,7 +89,7 @@ def __init__(model_name_or_path:
              model_version: Optional[str] = None,
              tokenizer: Optional[str] = None,
              use_gpu: bool = True,
-             return_all_scores: bool = False,
+             top_k: Optional[int] = 1,
              task: str = "text-classification",
              labels: Optional[List[str]] = None,
              batch_size: int = 16,
@@ -120,7 +120,7 @@ See https://huggingface.co/models for full list of available models.
 - `model_version`: The version of model to use from the HuggingFace model hub. Can be tag name, branch name, or commit hash.
 - `tokenizer`: Name of the tokenizer (usually the same as model)
 - `use_gpu`: Whether to use GPU (if available).
-- `return_all_scores`: Whether to return all prediction scores or just the one of the predicted class. Only used for task 'text-classification'.
+- `top_k`: The number of top predictions to return. The default is 1. Enter None to return all the predictions. Only used for task 'text-classification'.
 - `task`: 'text-classification' or 'zero-shot-classification'
 - `labels`: Only used for task 'zero-shot-classification'. List of string defining class labels, e.g.,
 ["positive", "negative"] otherwise None. Given a LABEL, the sequence fed to the model is "<cls> sequence to

--- a/haystack/json-schemas/haystack-pipeline-main.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-main.schema.json
@@ -5823,10 +5823,17 @@
               "default": true,
               "type": "boolean"
             },
-            "return_all_scores": {
-              "title": "Return All Scores",
-              "default": false,
-              "type": "boolean"
+            "top_k": {
+              "title": "Top K",
+              "default": 1,
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "task": {
               "title": "Task",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -621,7 +621,7 @@ def ranker():
 @pytest.fixture
 def document_classifier():
     return TransformersDocumentClassifier(
-        model_name_or_path="bhadresh-savani/distilbert-base-uncased-emotion", use_gpu=False
+        model_name_or_path="bhadresh-savani/distilbert-base-uncased-emotion", use_gpu=False, top_k=2
     )
 
 

--- a/test/document_stores/test_faiss_and_milvus.py
+++ b/test/document_stores/test_faiss_and_milvus.py
@@ -16,7 +16,7 @@ from haystack.document_stores.faiss import FAISSDocumentStore
 from haystack.pipelines import Pipeline
 from haystack.nodes.retriever.dense import EmbeddingRetriever
 
-from ..conftest import document_classifier, ensure_ids_are_correct_uuids, SAMPLES_PATH, MockDenseRetriever
+from ..conftest import ensure_ids_are_correct_uuids, SAMPLES_PATH, MockDenseRetriever
 
 
 DOCUMENTS = [

--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -10,14 +10,11 @@ def test_document_classifier(document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it."""
-            * 700,  # extra long text to check truncation
+            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(
-            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
-        ),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     results = document_classifier.predict(documents=docs)
     expected_labels = ["joy", "sadness"]
@@ -42,9 +39,7 @@ def test_document_classifier_details(document_classifier):
 def test_document_classifier_batch_single_doc_list(document_classifier):
     docs = [
         Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
-        Document(
-            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
-        ),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     results = document_classifier.predict_batch(documents=docs)
     expected_labels = ["joy", "sadness"]
@@ -56,9 +51,7 @@ def test_document_classifier_batch_single_doc_list(document_classifier):
 def test_document_classifier_batch_multiple_doc_lists(document_classifier):
     docs = [
         Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
-        Document(
-            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
-        ),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     results = document_classifier.predict_batch(documents=[docs, docs])
     assert len(results) == 2  # 2 Document lists
@@ -73,14 +66,11 @@ def test_zero_shot_document_classifier(zero_shot_document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it."""
-            * 700,  # extra long text to check truncation
+            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(
-            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
-        ),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     results = zero_shot_document_classifier.predict(documents=docs)
     expected_labels = ["positive", "negative"]
@@ -107,14 +97,11 @@ def test_document_classifier_batch_size(batched_document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it."""
-            * 700,  # extra long text to check truncation
+            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(
-            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
-        ),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     results = batched_document_classifier.predict(documents=docs)
     expected_labels = ["joy", "sadness"]
@@ -128,22 +115,14 @@ def test_document_classifier_as_index_node(indexing_document_classifier):
 
     docs = [
         {
-            "content": """That's good. I like it."""
-            * 700,  # extra long text to check truncation
+            "content": """That's good. I like it.""" * 700,  # extra long text to check truncation
             "meta": {"name": "0"},
             "id": "1",
             "class_field": "That's bad.",
         },
-        {
-            "content": """That's bad. I like it.""",
-            "meta": {"name": "1"},
-            "id": "2",
-            "class_field": "That's good.",
-        },
+        {"content": """That's bad. I like it.""", "meta": {"name": "1"}, "id": "2", "class_field": "That's good."},
     ]
-    output, output_name = indexing_document_classifier.run(
-        documents=docs, root_node="File"
-    )
+    output, output_name = indexing_document_classifier.run(documents=docs, root_node="File")
     expected_labels = ["sadness", "joy"]
     for i, doc in enumerate(output["documents"]):
         assert doc["meta"]["classification"]["label"] == expected_labels[i]
@@ -155,14 +134,11 @@ def test_document_classifier_as_query_node(document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it."""
-            * 700,  # extra long text to check truncation
+            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(
-            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
-        ),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     output, output_name = document_classifier.run(documents=docs, root_node="Query")
     expected_labels = ["joy", "sadness"]

--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -10,11 +10,14 @@ def test_document_classifier(document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
+            content="""That's good. I like it."""
+            * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(
+            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
+        ),
     ]
     results = document_classifier.predict(documents=docs)
     expected_labels = ["joy", "sadness"]
@@ -39,7 +42,9 @@ def test_document_classifier_details(document_classifier):
 def test_document_classifier_batch_single_doc_list(document_classifier):
     docs = [
         Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(
+            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
+        ),
     ]
     results = document_classifier.predict_batch(documents=docs)
     expected_labels = ["joy", "sadness"]
@@ -51,7 +56,9 @@ def test_document_classifier_batch_single_doc_list(document_classifier):
 def test_document_classifier_batch_multiple_doc_lists(document_classifier):
     docs = [
         Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(
+            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
+        ),
     ]
     results = document_classifier.predict_batch(documents=[docs, docs])
     assert len(results) == 2  # 2 Document lists
@@ -66,11 +73,14 @@ def test_zero_shot_document_classifier(zero_shot_document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
+            content="""That's good. I like it."""
+            * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(
+            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
+        ),
     ]
     results = zero_shot_document_classifier.predict(documents=docs)
     expected_labels = ["positive", "negative"]
@@ -97,11 +107,14 @@ def test_document_classifier_batch_size(batched_document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
+            content="""That's good. I like it."""
+            * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(
+            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
+        ),
     ]
     results = batched_document_classifier.predict(documents=docs)
     expected_labels = ["joy", "sadness"]
@@ -115,14 +128,22 @@ def test_document_classifier_as_index_node(indexing_document_classifier):
 
     docs = [
         {
-            "content": """That's good. I like it.""" * 700,  # extra long text to check truncation
+            "content": """That's good. I like it."""
+            * 700,  # extra long text to check truncation
             "meta": {"name": "0"},
             "id": "1",
             "class_field": "That's bad.",
         },
-        {"content": """That's bad. I like it.""", "meta": {"name": "1"}, "id": "2", "class_field": "That's good."},
+        {
+            "content": """That's bad. I like it.""",
+            "meta": {"name": "1"},
+            "id": "2",
+            "class_field": "That's good.",
+        },
     ]
-    output, output_name = indexing_document_classifier.run(documents=docs, root_node="File")
+    output, output_name = indexing_document_classifier.run(
+        documents=docs, root_node="File"
+    )
     expected_labels = ["sadness", "joy"]
     for i, doc in enumerate(output["documents"]):
         assert doc["meta"]["classification"]["label"] == expected_labels[i]
@@ -134,11 +155,14 @@ def test_document_classifier_as_query_node(document_classifier):
 
     docs = [
         Document(
-            content="""That's good. I like it.""" * 700,  # extra long text to check truncation
+            content="""That's good. I like it."""
+            * 700,  # extra long text to check truncation
             meta={"name": "0"},
             id="1",
         ),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(
+            content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"
+        ),
     ]
     output, output_name = document_classifier.run(documents=docs, root_node="Query")
     expected_labels = ["joy", "sadness"]

--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -25,10 +25,7 @@ def test_document_classifier(document_classifier):
 @pytest.mark.integration
 def test_document_classifier_details(document_classifier):
 
-    docs = [
-        Document(content="""That's good. I like it."""),
-        Document(content="""That's bad. I don't like it."""),
-    ]
+    docs = [Document(content="""That's good. I like it."""), Document(content="""That's bad. I don't like it.""")]
     results = document_classifier.predict(documents=docs)
     for doc in results:
         assert "details" in doc.meta["classification"]
@@ -81,10 +78,7 @@ def test_zero_shot_document_classifier(zero_shot_document_classifier):
 @pytest.mark.integration
 def test_zero_shot_document_classifier_details(zero_shot_document_classifier):
 
-    docs = [
-        Document(content="""That's good. I like it."""),
-        Document(content="""That's bad. I don't like it."""),
-    ]
+    docs = [Document(content="""That's good. I like it."""), Document(content="""That's bad. I don't like it.""")]
     results = zero_shot_document_classifier.predict(documents=docs)
     for doc in results:
         assert "details" in doc.meta["classification"]

--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -26,15 +26,13 @@ def test_document_classifier(document_classifier):
 def test_document_classifier_details(document_classifier):
 
     docs = [
-        Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(content="""That's good. I like it."""),
+        Document(content="""That's bad. I don't like it."""),
     ]
     results = document_classifier.predict(documents=docs)
     for doc in results:
-        meta_classification = doc.to_dict()["meta"]["classification"]
-        assert "details" in meta_classification
-        top_k = 2
-        assert len(meta_classification["details"]) == top_k
+        assert "details" in doc.meta["classification"]
+        assert len(doc.meta["classification"]["details"]) == 2  # top_k = 2
 
 
 @pytest.mark.integration
@@ -84,15 +82,13 @@ def test_zero_shot_document_classifier(zero_shot_document_classifier):
 def test_zero_shot_document_classifier_details(zero_shot_document_classifier):
 
     docs = [
-        Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
-        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+        Document(content="""That's good. I like it."""),
+        Document(content="""That's bad. I don't like it."""),
     ]
     results = zero_shot_document_classifier.predict(documents=docs)
     for doc in results:
-        meta_classification = doc.to_dict()["meta"]["classification"]
-        assert "details" in meta_classification
-        n_labels = 2
-        assert len(meta_classification["details"]) == n_labels
+        assert "details" in doc.meta["classification"]
+        assert len(doc.meta["classification"]["details"]) == 2  # n_labels = 2
 
 
 @pytest.mark.integration

--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -23,6 +23,21 @@ def test_document_classifier(document_classifier):
 
 
 @pytest.mark.integration
+def test_document_classifier_details(document_classifier):
+
+    docs = [
+        Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+    ]
+    results = document_classifier.predict(documents=docs)
+    for doc in enumerate(results):
+        meta_classification = doc.to_dict()["meta"]["classification"]
+        assert "details" in meta_classification
+        top_k = 2
+        assert len(meta_classification["details"].keys()) == top_k
+
+
+@pytest.mark.integration
 def test_document_classifier_batch_single_doc_list(document_classifier):
     docs = [
         Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
@@ -63,6 +78,21 @@ def test_zero_shot_document_classifier(zero_shot_document_classifier):
     expected_labels = ["positive", "negative"]
     for i, doc in enumerate(results):
         assert doc.to_dict()["meta"]["classification"]["label"] == expected_labels[i]
+
+
+@pytest.mark.integration
+def test_zero_shot_document_classifier_details(zero_shot_document_classifier):
+
+    docs = [
+        Document(content="""That's good. I like it.""", meta={"name": "0"}, id="1"),
+        Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
+    ]
+    results = zero_shot_document_classifier.predict(documents=docs)
+    for doc in results:
+        meta_classification = doc.to_dict()["meta"]["classification"]
+        assert "details" in meta_classification
+        n_labels = 2
+        assert len(meta_classification["details"].keys()) == n_labels
 
 
 @pytest.mark.integration

--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -30,11 +30,11 @@ def test_document_classifier_details(document_classifier):
         Document(content="""That's bad. I don't like it.""", meta={"name": "1"}, id="2"),
     ]
     results = document_classifier.predict(documents=docs)
-    for doc in enumerate(results):
+    for doc in results:
         meta_classification = doc.to_dict()["meta"]["classification"]
         assert "details" in meta_classification
         top_k = 2
-        assert len(meta_classification["details"].keys()) == top_k
+        assert len(meta_classification["details"]) == top_k
 
 
 @pytest.mark.integration
@@ -92,7 +92,7 @@ def test_zero_shot_document_classifier_details(zero_shot_document_classifier):
         meta_classification = doc.to_dict()["meta"]["classification"]
         assert "details" in meta_classification
         n_labels = 2
-        assert len(meta_classification["details"].keys()) == n_labels
+        assert len(meta_classification["details"]) == n_labels
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues
- fixes #3167

### Proposed Changes:
`TransformersDocumentClassifier` output structure was different between ordinary and zero-shot classification.
Now the output is consistent. For `doc.meta['classification']` we always have a structure like this:
```
{"label": "love",
"score": 0.9608993530273438, 
"details": {"love": 0.9608993530273438, "joy": 0.032584577798843384, ...}}}
```
After the discussion in #3167, I decided to keep the `score` attribute in the first level of `doc.meta['classification']`: I think that it can be useful for filtering.

### How did you test it?
Manual verification.
I can add some tests if you think that's the case.

### Notes for the reviewer
Other refactoring aspects:
- replaced the attribute `return_all_scores` with `top_k`: it mimicked the same attribute of the HF pipeline, which is now deprecated in favor of the latter.
- simplified batched predictions accumulation
- removed document classifier from a test, where it was unused

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
