### PR TITLE
fix: Include fontconfig in the base Docker image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -34,5 +34,7 @@ FROM $base_immage AS final
 
 COPY --from=build-image /opt/venv /opt/venv
 COPY --from=build-image /opt/pdftotext /usr/local/bin
+# pdftotext requires fontconfig runtime
+RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -23,7 +23,7 @@ variable "HAYSTACK_EXTRAS" {
 }
 
 group "base" {
-  targets = ["base", "base-gpu"]
+  targets = ["base-cpu", "base-gpu"]
 }
 
 group "api" {
@@ -40,9 +40,9 @@ group "all" {
 
 target "docker-metadata-action" {}
 
-target "base" {
+target "base-cpu" {
   dockerfile = "Dockerfile.base"
-  tags = ["${IMAGE_NAME}:base-${IMAGE_TAG_SUFFIX}"]
+  tags = ["${IMAGE_NAME}:base-cpu-${IMAGE_TAG_SUFFIX}"]
   args = {
     build_image = "python:3.10-slim"
     base_immage = "python:3.10-slim"
@@ -68,7 +68,7 @@ target "cpu" {
   dockerfile = "Dockerfile.api"
   tags = ["${IMAGE_NAME}:cpu-${IMAGE_TAG_SUFFIX}"]
   args = {
-    base_image_tag = "base-${BASE_IMAGE_TAG_SUFFIX}"
+    base_image_tag = "base-cpu-${BASE_IMAGE_TAG_SUFFIX}"
   }
 }
 


### PR DESCRIPTION
### Related Issues
- no issue was reported yet

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Include `fontconfig` in the final image, otherwise `pdftotext` will fail running

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
local docker build

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
Along with this PR:
- There was a clash, `base` was used both for a group and a target, now the target was renamed to `base-cpu`
- Similarly I have renamed the image from `cpu` to `base-cpu` to reflect the target and avoid confusion

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
