### PR TITLE
bug: fix pdftotext installation verification

### DIFF
--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -54,9 +54,9 @@ class PDFToTextConverter(BaseConverter):
         super().__init__(
             remove_numeric_tables=remove_numeric_tables, valid_languages=valid_languages, id_hash_keys=id_hash_keys
         )
-
-        verify_installation = subprocess.run(["pdftotext -v"], shell=True)
-        if verify_installation.returncode == 127:
+        try:
+            subprocess.run(["pdftotext", "-v"], shell=False, check=False)
+        except FileNotFoundError:
             raise FileNotFoundError(
                 """pdftotext is not installed. It is part of xpdf or poppler-utils software suite.
                 


### PR DESCRIPTION
### Related Issues
- fixes [#3225](https://github.com/deepset-ai/haystack/issues/3225)

### Proposed Changes:
- change verification of `pdftotext` installation to work with Windows

### How did you test it?
Manual tested the line in isolation on Mac and Windows , in environments where `pdftotext` is and isn't available.

### Notes for the reviewer

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
