### PR TITLE
fix: make pydoc-markdown hook correctly resolve paths relative to repo root

### DIFF
--- a/.github/utils/pydoc-markdown.py
+++ b/.github/utils/pydoc-markdown.py
@@ -22,11 +22,10 @@ def load_search_paths():
             loader = config["loaders"][0]
             # `search_path` is a list but we always have only one item in Haystack
             search_path = loader["search_path"][0]
-            # we only need the relative path from the root, let's call `resolve` to
-            # get rid of the `../../` prefix
-            search_path = str(pathlib.Path(search_path).resolve())
-            # `resolve` will prepend a `/` to the path, remove it
-            paths[search_path[1:]] = fname
+            # we only need the relative path from the root, let's get rid of
+            # the `../../` prefix
+            search_path = search_path.replace("../", "")
+            paths[search_path] = fname
     return paths
 
 

--- a/docs/_src/api/pydoc/primitives.yml
+++ b/docs/_src/api/pydoc/primitives.yml
@@ -1,11 +1,11 @@
 loaders:
   - type: python
-    search_path: [../../../../haystack/]
+    search_path: [../../../../haystack]
     modules: ['schema']
     ignore_when_discovered: ['__init__']
 processors:
   - type: filter
-    expression: 
+    expression:
     documented_only: true
     do_not_filter_modules: false
     skip_empty_modules: true


### PR DESCRIPTION
### Related Issues
- pre-commit hook doesn't invoke `pydoc-markdown` when it's needed

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Use string replacement instead of path resolution

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested locally on another PR where tests were failing because a missing api docs update

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
