### PR TITLE
bug: remove `deepcopy` from `BaseRetriever.run_indexing`

### DIFF
--- a/haystack/nodes/retriever/base.py
+++ b/haystack/nodes/retriever/base.py
@@ -362,7 +362,7 @@ class BaseRetriever(BaseComponent):
 
         return output, "output_1"
 
-    def run_indexing(self, documents: List[Union[dict, Document]]):
+    def run_indexing(self, documents: List[Document]):
         if self.__class__.__name__ in ["DensePassageRetriever", "EmbeddingRetriever"]:
             embeddings = self.embed_documents(documents)  # type: ignore
             for doc, emb in zip(documents, embeddings):

--- a/haystack/nodes/retriever/base.py
+++ b/haystack/nodes/retriever/base.py
@@ -4,7 +4,6 @@ import logging
 from abc import abstractmethod
 from time import perf_counter
 from functools import wraps
-from copy import deepcopy
 
 from tqdm import tqdm
 

--- a/haystack/nodes/retriever/base.py
+++ b/haystack/nodes/retriever/base.py
@@ -364,10 +364,8 @@ class BaseRetriever(BaseComponent):
 
     def run_indexing(self, documents: List[Union[dict, Document]]):
         if self.__class__.__name__ in ["DensePassageRetriever", "EmbeddingRetriever"]:
-            documents = deepcopy(documents)
-            document_objects = [Document.from_dict(doc) if isinstance(doc, dict) else doc for doc in documents]
-            embeddings = self.embed_documents(document_objects)  # type: ignore
-            for doc, emb in zip(document_objects, embeddings):
+            embeddings = self.embed_documents(documents)  # type: ignore
+            for doc, emb in zip(documents, embeddings):
                 doc.embedding = emb
         output = {"documents": documents}
         return output, "output_1"


### PR DESCRIPTION
# UPDATE:  Covered by https://github.com/deepset-ai/haystack/pull/3252

---------------------------------------------------

### Related Issues
- fixes #3242

### Proposed Changes:
- Remove two lines of (seemingly) useless copy operations in `BaseRetriever.run_indexing`: https://github.com/deepset-ai/haystack/blob/8fbccbda8232648be409cdcd66a909bc99928920/haystack/nodes/retriever/base.py#L367-L368

### How did you test it?
- CI

### Notes for the reviewer
- Please run a memory profile on this change if possible

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
