### PR TITLE
update file_upload with add_page_number option

### DIFF
--- a/rest_api/rest_api/controller/file_upload.py
+++ b/rest_api/rest_api/controller/file_upload.py
@@ -35,6 +35,7 @@ class PreprocessorParams(BaseModel):
     split_length: Optional[int] = None
     split_overlap: Optional[int] = None
     split_respect_sentence_boundary: Optional[bool] = None
+    add_page_number: Optional[bool]=None
 
 
 class Response(BaseModel):


### PR DESCRIPTION
exposes the newly added page numbers option to the rest_api

### Related Issues
- fixes #issue-number

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
