### PR TITLE
fix:MostSimilarDocumentsPipeline doesn't have pipeline property

### DIFF
--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -706,6 +706,12 @@ class MostSimilarDocumentsPipeline(BaseStandardPipeline):
 
         :param document_store: Document Store instance with already stored embeddings.
         """
+        # we create a pipeline and add the document store as a node
+        # however, we do not want to use the document store's run method,
+        # but rather the query_by_embedding method
+        # pipeline property is here so the superclass methods that rely on pipeline property work
+        self.pipeline = Pipeline()
+        self.pipeline.add_node(component=document_store, name="DocumentStore", inputs=["Query"])
         self.document_store = document_store
 
     def run(self, document_ids: List[str], top_k: int = 5):

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -813,8 +813,8 @@ def test_pipeline_classify_type():
     )
     pipe.get_type().startswith("TranslationWrapperPipeline")
 
-    # pipe = MostSimilarDocumentsPipeline(document_store=MockDocumentStore())
-    # assert pipe.get_type().startswith("MostSimilarDocumentsPipeline")
+    pipe = MostSimilarDocumentsPipeline(document_store=MockDocumentStore())
+    assert pipe.get_type().startswith("MostSimilarDocumentsPipeline")
 
 
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)

--- a/test/pipelines/test_standard_pipelines.py
+++ b/test/pipelines/test_standard_pipelines.py
@@ -229,6 +229,15 @@ def test_most_similar_documents_pipeline_batch(retriever, document_store):
             assert isinstance(document.content, str)
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+def test_most_similar_documents_pipeline_save(tmpdir, document_store_with_docs):
+    pipeline = MostSimilarDocumentsPipeline(document_store=document_store_with_docs)
+    path = Path(tmpdir, "most_similar_document_pipeline.yml")
+    pipeline.save_to_yaml(path)
+    os.path.exists(path)
+
+
 @pytest.mark.elasticsearch
 @pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
 def test_join_merge_no_weights(document_store_dot_product_with_docs):


### PR DESCRIPTION
### Related Issues
- fixes #3256


### Proposed Changes:
MostSimilarDocumentsPipeline, unlike all other pipelines, doesn't have the underlying pipeline property/field. Any method from the superclass that relies on pipeline (get_type, save_to_yaml) will fail.

I added pipeline property, added document store to pipeline but I left the run methods as is - I don't think we can use BaseDocumentStore run method. @bogdankostic please confirm. 


### How did you test it?
Added a unit test for pipeline classification

### Notes for the reviewer
Should we add unit tests that exercise other BaseStandardPipeline methods that rely on the pipeline?

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
