### PR TITLE
refactor: better tests for `TransformersDocumentClassifier`

### DIFF
--- a/test/nodes/test_document_classifier.py
+++ b/test/nodes/test_document_classifier.py
@@ -29,7 +29,8 @@ def test_document_classifier_details(document_classifier):
     results = document_classifier.predict(documents=docs)
     for doc in results:
         assert "details" in doc.meta["classification"]
-        assert len(doc.meta["classification"]["details"]) == 2  # top_k = 2
+        if document_classifier.top_k is not None:
+            assert len(doc.meta["classification"]["details"]) == document_classifier.top_k
 
 
 @pytest.mark.integration
@@ -82,7 +83,7 @@ def test_zero_shot_document_classifier_details(zero_shot_document_classifier):
     results = zero_shot_document_classifier.predict(documents=docs)
     for doc in results:
         assert "details" in doc.meta["classification"]
-        assert len(doc.meta["classification"]["details"]) == 2  # n_labels = 2
+        assert set(doc.meta["classification"]["details"].keys()) == set(zero_shot_document_classifier.labels)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Proposed Changes:
I realized that the tests introduced in #3224 can be made more generic and stable; with the changes made, they will remain valid even if conftest.py changes.

### How did you test it?
CI

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
