### PR TITLE
bugfix for TranslationWrapperPipeline

### DIFF
--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -596,7 +596,7 @@ class TranslationWrapperPipeline(BaseStandardPipeline):
         if isinstance(pipeline, QuestionAnswerGenerationPipeline):
             setattr(output_translator, "run", output_translator.run_batch)
 
-        graph = pipeline.pipeline.graph
+        graph = pipeline.graph
         previous_node_name = ["InputTranslator"]
         # Traverse in BFS
         for node in graph.nodes:

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -599,7 +599,7 @@ class TranslationWrapperPipeline(BaseStandardPipeline):
         if hasattr(pipeline, "pipeline"):
             graph = pipeline.pipeline.graph
         else:
-            graph = pipeline.graph
+            graph = pipeline.graph  # type: ignore
         previous_node_name = ["InputTranslator"]
         # Traverse in BFS
         for node in graph.nodes:

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -596,7 +596,10 @@ class TranslationWrapperPipeline(BaseStandardPipeline):
         if isinstance(pipeline, QuestionAnswerGenerationPipeline):
             setattr(output_translator, "run", output_translator.run_batch)
 
-        graph = pipeline.graph
+        if hasattr(pipeline, "pipeline"):
+            graph = pipeline.pipeline.graph
+        else:
+            graph = pipeline.graph
         previous_node_name = ["InputTranslator"]
         # Traverse in BFS
         for node in graph.nodes:


### PR DESCRIPTION
### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

We get this error `AttributeError: 'Pipeline' object has no attribute 'pipeline'` when we try to create a `TranslationWrapperPipeline`. The problem is the extra `pipeline` in this line - the attribute doesn't exist. 

![image](https://user-images.githubusercontent.com/88559987/192663297-a940ba40-98d1-42d4-a895-d88dacd69630.png)


### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manually tested by trying to use this pipeline. Problem goes away with this change.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
