### PR TITLE
bug: Adds `__init__()` function to `FilterRetriever`

### DIFF
--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -347,6 +347,16 @@ class FilterRetriever(BM25Retriever):
     Helpful for benchmarking, testing and if you want to do QA on small documents without an "active" retriever.
     """
 
+    def __init__(
+        self,
+        document_store: KeywordDocumentStore,
+        top_k: int = 10,
+        all_terms_must_match: bool = False,
+        custom_query: Optional[str] = None,
+        scale_score: bool = True,
+    ):
+        super().__init__(document_store, top_k, all_terms_must_match, custom_query, scale_score)
+
     def retrieve(
         self,
         query: str,


### PR DESCRIPTION
### Related Issues
- fixes #3291 

### Proposed Changes:
It adds the `__init__()` function it was missing (more info in the related issue).

### How did you test it?
Manually, by adding the retriever to a pipeline and checking the config using `get_config()`. In the related issue there's a script to reproduce the previous error, and with this fix we should get `document_store` as parameter of `FilterRetriever` when printing its config (before we were getting nothing).

### Notes for the reviewer
I have not added unit tests for this, although they may be needed for reproducibility in the future.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
