### PR TITLE
fix: opensearch script score with filters

### DIFF
--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -429,9 +429,11 @@ class OpenSearchDocumentStore(BaseElasticsearchDocumentStore):
         # +1 in similarity to avoid negative numbers (for cosine sim)
         body: Dict[str, Any] = {"size": top_k, "query": self._get_vector_similarity_query(query_emb, top_k)}
         if filters:
-            if not "bool" in body["query"]:
-                body["query"]["bool"] = {}
-            body["query"]["bool"]["filter"] = LogicalFilterClause.parse(filters).convert_to_elasticsearch()
+            filter_ = LogicalFilterClause.parse(filters).convert_to_elasticsearch()
+            if "script_score" in body["query"]:
+                body["query"]["script_score"]["query"] = {"bool": {"filter": filter_}}
+            else:
+                body["query"]["bool"]["filter"] = filter_
 
         excluded_meta_data: Optional[list] = None
 

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -307,11 +307,25 @@ class TestOpenSearchDocumentStore:
 
     @pytest.mark.unit
     def test_query_by_embedding_filters(self, mocked_document_store):
+        mocked_document_store.embeddings_field_supports_similarity = True
         expected_filters = {"type": "article", "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"}}
         mocked_document_store.query_by_embedding(self.query_emb, filters=expected_filters)
         # Assert the `search` method on the client was called with the filters we provided
         _, kwargs = mocked_document_store.client.search.call_args
         actual_filters = kwargs["body"]["query"]["bool"]["filter"]
+        assert actual_filters["bool"]["must"] == [
+            {"term": {"type": "article"}},
+            {"range": {"date": {"gte": "2015-01-01", "lt": "2021-01-01"}}},
+        ]
+
+    @pytest.mark.unit
+    def test_query_by_embedding_script_score_filters(self, mocked_document_store):
+        mocked_document_store.embeddings_field_supports_similarity = False
+        expected_filters = {"type": "article", "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"}}
+        mocked_document_store.query_by_embedding(self.query_emb, filters=expected_filters)
+        # Assert the `search` method on the client was called with the filters we provided
+        _, kwargs = mocked_document_store.client.search.call_args
+        actual_filters = kwargs["body"]["query"]["script_score"]["query"]["bool"]["filter"]
         assert actual_filters["bool"]["must"] == [
             {"term": {"type": "article"}},
             {"range": {"date": {"gte": "2015-01-01", "lt": "2021-01-01"}}},


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/3320

### Proposed Changes:
set filter properly according to https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script/

### How did you test it?
- ran locally against opensearch
- adjusted unittests

### Notes for the reviewer
I thought about adding the filters logic to `_get_vector_similarity_query`, however this also need refactoring of `ElastisearchDocumentStore`. Given that there is already a PR for better `script_score` support underway in https://github.com/deepset-ai/haystack/pull/3284 I kept the changes to a minimum.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
