### PR TITLE
[WIP] Upgrade gpu docker image to use python 3.10

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG build_image
-ARG base_immage
+ARG base_image
 
 FROM $build_image AS build-image
 
@@ -7,9 +7,16 @@ ARG haystack_version
 ARG haystack_extras
 ARG torch_scatter
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc git curl \
     tesseract-ocr libtesseract-dev poppler-utils
+
+RUN apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get install -y --no-install-recommends \
+        python3.10 python3.10-dev python3.10-distutils python3.10-venv && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install PDF converter
 RUN curl -O https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz && \
@@ -22,19 +29,29 @@ RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-
 WORKDIR /opt/haystack
 
 # Use a virtualenv we can copy over the next build stage
-RUN python -m venv --system-site-packages /opt/venv
+RUN python3.10 -m venv --system-site-packages /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN pip install --upgrade pip && \
+    pip install --no-cache-dir torch --extra-index-url https://download.pytorch.org/whl/cu116 && \
     pip install --no-cache-dir .${haystack_extras} && \
     pip install --no-cache-dir ./rest_api && \
     pip install --no-cache-dir torch-scatter -f $torch_scatter
 
-FROM $base_immage AS final
+FROM $base_image AS final
 
 COPY --from=build-image /opt/venv /opt/venv
 COPY --from=build-image /opt/pdftotext /usr/local/bin
+
 # pdftotext requires fontconfig runtime
-RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get install -y --no-install-recommends \
+        python3.10 python3.10-dev python3.10-distutils python3.10-venv && \
+    apt-get install -y libfontconfig && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 10 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10
 
 ENV PATH="/opt/venv/bin:$PATH"

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -45,7 +45,7 @@ target "base-cpu" {
   tags = ["${IMAGE_NAME}:base-cpu-${IMAGE_TAG_SUFFIX}"]
   args = {
     build_image = "python:3.10-slim"
-    base_immage = "python:3.10-slim"
+    base_image = "python:3.10-slim"
     haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores,crawler,preprocessing,ocr,onnx,beir]"
     torch_scatter = "https://data.pyg.org/whl/torch-1.12.0+cpu.html"
@@ -56,8 +56,8 @@ target "base-gpu" {
   dockerfile = "Dockerfile.base"
   tags = ["${IMAGE_NAME}:base-gpu-${IMAGE_TAG_SUFFIX}"]
   args = {
-    build_image = "pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
-    base_immage = "pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
+    build_image = "nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04"
+    base_image = "nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04"
     haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores-gpu,crawler,preprocessing,ocr,onnx-gpu,beir]"
     torch_scatter = "https://data.pyg.org/whl/torch-1.12.1%2Bcu113.html"


### PR DESCRIPTION
### Related Issues
- fixes #3303

### Proposed Changes:
Updated the base docker image to be based on `nvidia/cuda` instead of `pytorch/pytorch` in order to install and use `python3.10` instead of the old `python3.7` that comes with the pytorch image (see: https://github.com/pytorch/pytorch/issues/73714 ). Built and tested locally. It works and starts up the rest api without a problem.

**Please note**: This PR is a work in progress and the current changes probably break the `cpu` image at the moment but since it takes a long time to rebuild the image, I wanted to run it past the haystack team to see if there's interest before fixing and optimizing the images.

cc/ @masci 

### How did you test it?
manual verification for now. pending comments.

### Notes for the reviewer
still a work in progress but looking for comments before proceeding further.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
