### PR TITLE
ci: Add workflow for tests using InMemoryDocStore and SQLDocStore

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -619,6 +619,66 @@ jobs:
         channel: '#haystack'
       if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
 
+  memorydocstore-tests-linux:
+    needs:
+      - mypy
+      - pylint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+        # TODO Let's try to remove this one from the unit tests
+      - name: Install pdftotext
+        run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz && tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
+
+      - name: Setup Python
+        uses: ./.github/actions/python_cache/
+
+      - name: Install Haystack
+        run: pip install .
+
+      - name: Run tests
+        env:
+          TOKENIZERS_PARALLELISM: 'false'
+        run: |
+          pytest ${{ env.PYTEST_PARAMS }} -m "memory and not integration" test/document_stores/ --document_store_type=memory
+
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          channel: '#haystack'
+        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+
+  sql-tests-linux:
+    needs:
+      - mypy
+      - pylint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+        # TODO Let's try to remove this one from the unit tests
+      - name: Install pdftotext
+        run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz && tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
+
+      - name: Setup Python
+        uses: ./.github/actions/python_cache/
+
+      - name: Install Haystack
+        run: pip install .
+
+      - name: Run tests
+        env:
+          TOKENIZERS_PARALLELISM: 'false'
+        run: |
+          pytest ${{ env.PYTEST_PARAMS }} -m "sql and not integration" test/document_stores/ --document_store_type=sql
+
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          channel: '#haystack'
+        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+
   rest-and-ui:
     needs:
       - mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,6 +347,8 @@ markers = [
   "milvus: requires a Milvus 2 setup",
   "milvus1: requires a Milvus 1 container",
   "opensearch",
+  "memory: requires InMemoryDocumentStore",
+  "sql: requires SQL database",
 ]
 log_cli = true
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -153,6 +153,8 @@ def pytest_collection_modifyitems(config, items):
         # FIXME GraphDB can't be treated as a regular docstore, it fails most of their tests
         "graphdb": [pytest.mark.integration],
         "opensearch": [pytest.mark.opensearch],
+        "memory": [pytest.mark.memory],
+        "sql": [pytest.mark.sql],
     }
     for item in items:
         for name, markers in name_to_markers.items():


### PR DESCRIPTION
### Related Issues
- no issue

### Proposed Changes:
It seems that tests using the `InMemoryDocumentStore`(flagged by `"memory"`) and the `SQLDocumentStore` (flagged by `"sql"`) were not executed in our CI. This PR adds the markers `"memory"` and  `"sql"` and adds a workflow for each one.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
