### PR TITLE
fix: Allow less restrictive values for parameters in Pipeline configurations

### DIFF
--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -111,23 +111,15 @@ def validate_config_strings(pipeline_config: Any):
                 # For checking the list of parameters of a node, we only check the parameter names and not the
                 # parameter values, as these can be arbitrary.
                 if key == "params":
-                    # FIXME find a better solution
-                    # Some nodes take parameters that expect JSON input,
-                    # like `ElasticsearchDocumentStore.custom_query`
-                    # These parameters fail validation using the standard input regex,
-                    # so they're validated separately.
-                    #
-                    # Note that these fields are checked by name: if two nodes have a field
-                    # with the same name, one of which is JSON and the other not,
-                    # this hack will break.
-                    if key in JSON_FIELDS:
-                        try:
-                            json.loads(value)
-                        except json.decoder.JSONDecodeError as e:
-                            raise PipelineConfigError(f"'{pipeline_config}' does not contain valid JSON.")
-                    else:
-                        # We only validate parameter names, not their values
-                        validate_config_strings(list(value.keys()))
+                    # We only validate parameter names, not their values
+                    validate_config_strings(list(value.keys()))
+                    # Check JSON fields
+                    for json_field in JSON_FIELDS:
+                        if json_field in value.keys():
+                            try:
+                                json.loads(value[json_field])
+                            except json.decoder.JSONDecodeError as e:
+                                raise PipelineConfigError(f"'{pipeline_config}' does not contain valid JSON.")
                 else:
                     validate_config_strings(key)
                     validate_config_strings(value)

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -126,7 +126,8 @@ def validate_config_strings(pipeline_config: Any):
                         except json.decoder.JSONDecodeError as e:
                             raise PipelineConfigError(f"'{pipeline_config}' does not contain valid JSON.")
                     else:
-                        validate_config_strings(key)
+                        # We only validate parameter names, not their values
+                        validate_config_strings(list(value.keys()))
                 else:
                     validate_config_strings(key)
                     validate_config_strings(value)

--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -129,7 +129,7 @@ def validate_config_strings(pipeline_config: Any, is_value: bool = False):
 
         elif isinstance(pipeline_config, list):
             for value in pipeline_config:
-                validate_config_strings(value)
+                validate_config_strings(value, is_value=True)
 
         else:
             valid_regex = VALID_VALUE_REGEX if is_value else VALID_KEY_REGEX

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -682,7 +682,7 @@ def test_generate_code_can_handle_weak_cyclic_pipelines():
 
 @pytest.mark.parametrize("input", ["\btest", " test", "#test", "+test", "\ttest", "\ntest", "test()"])
 def test_validate_user_input_invalid(input):
-    with pytest.raises(PipelineConfigError, match="is not a valid  or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings(input)
 
 
@@ -738,6 +738,11 @@ def test_validate_pipeline_config_invalid_component_name():
 def test_validate_pipeline_config_invalid_component_type():
     with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings({"components": [{"name": "test", "type": "\btest"}]})
+
+
+def test_validate_pipeline_config_invalid_component_param():
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+        validate_config_strings({"components": [{"name": "test", "type": "test", "params": {"key": "\btest"}}]})
 
 
 def test_validate_pipeline_config_invalid_component_param_key():

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -729,11 +729,6 @@ def test_validate_pipeline_config_invalid_component_type():
         validate_config_strings({"components": [{"name": "test", "type": "\btest"}]})
 
 
-def test_validate_pipeline_config_invalid_component_param():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
-        validate_config_strings({"components": [{"name": "test", "type": "test", "params": {"key": "\btest"}}]})
-
-
 def test_validate_pipeline_config_invalid_component_param_key():
     with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings({"components": [{"name": "test", "type": "test", "params": {"\btest": "test"}}]})

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -682,7 +682,7 @@ def test_generate_code_can_handle_weak_cyclic_pipelines():
 
 @pytest.mark.parametrize("input", ["\btest", " test", "#test", "+test", "\ttest", "\ntest", "test()"])
 def test_validate_user_input_invalid(input):
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid  or value"):
         validate_config_strings(input)
 
 
@@ -708,6 +708,17 @@ def test_validate_pipeline_config_component_with_json_input_valid():
     )
 
 
+def test_validate_pipeline_config_component_with_json_input_invalid_key():
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+        validate_config_strings(
+            {
+                "components": [
+                    {"name": "test", "type": "test", "params": {"another_param": '{"json-key": "json-value"}'}}
+                ]
+            }
+        )
+
+
 def test_validate_pipeline_config_component_with_json_input_invalid_value():
     with pytest.raises(PipelineConfigError, match="does not contain valid JSON"):
         validate_config_strings(
@@ -720,27 +731,27 @@ def test_validate_pipeline_config_component_with_json_input_invalid_value():
 
 
 def test_validate_pipeline_config_invalid_component_name():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings({"components": [{"name": "\btest"}]})
 
 
 def test_validate_pipeline_config_invalid_component_type():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings({"components": [{"name": "test", "type": "\btest"}]})
 
 
 def test_validate_pipeline_config_invalid_component_param_key():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings({"components": [{"name": "test", "type": "test", "params": {"\btest": "test"}}]})
 
 
 def test_validate_pipeline_config_invalid_pipeline_name():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings({"components": [{"name": "test", "type": "test"}], "pipelines": [{"name": "\btest"}]})
 
 
 def test_validate_pipeline_config_invalid_pipeline_node_name():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings(
             {
                 "components": [{"name": "test", "type": "test"}],
@@ -750,7 +761,7 @@ def test_validate_pipeline_config_invalid_pipeline_node_name():
 
 
 def test_validate_pipeline_config_invalid_pipeline_node_inputs():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
         validate_config_strings(
             {
                 "components": [{"name": "test", "type": "test"}],

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -682,7 +682,7 @@ def test_generate_code_can_handle_weak_cyclic_pipelines():
 
 @pytest.mark.parametrize("input", ["\btest", " test", "#test", "+test", "\ttest", "\ntest", "test()"])
 def test_validate_user_input_invalid(input):
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings(input)
 
 

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -708,17 +708,6 @@ def test_validate_pipeline_config_component_with_json_input_valid():
     )
 
 
-def test_validate_pipeline_config_component_with_json_input_invalid_key():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
-        validate_config_strings(
-            {
-                "components": [
-                    {"name": "test", "type": "test", "params": {"another_param": '{"json-key": "json-value"}'}}
-                ]
-            }
-        )
-
-
 def test_validate_pipeline_config_component_with_json_input_invalid_value():
     with pytest.raises(PipelineConfigError, match="does not contain valid JSON"):
         validate_config_strings(

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -709,7 +709,7 @@ def test_validate_pipeline_config_component_with_json_input_valid():
 
 
 def test_validate_pipeline_config_component_with_json_input_invalid_key():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings(
             {
                 "components": [
@@ -731,32 +731,32 @@ def test_validate_pipeline_config_component_with_json_input_invalid_value():
 
 
 def test_validate_pipeline_config_invalid_component_name():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings({"components": [{"name": "\btest"}]})
 
 
 def test_validate_pipeline_config_invalid_component_type():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings({"components": [{"name": "test", "type": "\btest"}]})
 
 
 def test_validate_pipeline_config_invalid_component_param():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings({"components": [{"name": "test", "type": "test", "params": {"key": "\btest"}}]})
 
 
 def test_validate_pipeline_config_invalid_component_param_key():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings({"components": [{"name": "test", "type": "test", "params": {"\btest": "test"}}]})
 
 
 def test_validate_pipeline_config_invalid_pipeline_name():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings({"components": [{"name": "test", "type": "test"}], "pipelines": [{"name": "\btest"}]})
 
 
 def test_validate_pipeline_config_invalid_pipeline_node_name():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings(
             {
                 "components": [{"name": "test", "type": "test"}],
@@ -766,7 +766,7 @@ def test_validate_pipeline_config_invalid_pipeline_node_name():
 
 
 def test_validate_pipeline_config_invalid_pipeline_node_inputs():
-    with pytest.raises(PipelineConfigError, match="is not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="is not a valid variable name"):
         validate_config_strings(
             {
                 "components": [{"name": "test", "type": "test"}],

--- a/test/pipelines/test_pipeline_yaml.py
+++ b/test/pipelines/test_pipeline_yaml.py
@@ -569,45 +569,6 @@ def test_load_yaml_custom_component_with_helper_class_in_init(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
-def test_load_yaml_custom_component_with_helper_class_in_yaml(tmp_path):
-    """
-    This test can work from the perspective of YAML schema validation:
-    HelperClass is picked up correctly and everything gets loaded.
-
-    However, for now we decide to disable this feature.
-    See haystack/_json_schema.py for details.
-    """
-
-    class HelperClass:
-        def __init__(self, another_param: str):
-            self.param = another_param
-
-    class CustomNode(MockNode):
-        def __init__(self, some_exotic_parameter: HelperClass):
-            super().__init__()
-            self.some_exotic_parameter = some_exotic_parameter
-
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: custom_node
-              type: CustomNode
-              params:
-                some_exotic_parameter: HelperClass("hello")
-            pipelines:
-            - name: my_pipeline
-              nodes:
-              - name: custom_node
-                inputs:
-                - Query
-        """
-        )
-    with pytest.raises(PipelineConfigError, match="not a valid variable name"):
-        Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-
-
 def test_load_yaml_custom_component_with_enum_in_init(tmp_path):
     """
     This test can work from the perspective of YAML schema validation:

--- a/test/pipelines/test_pipeline_yaml.py
+++ b/test/pipelines/test_pipeline_yaml.py
@@ -604,7 +604,7 @@ def test_load_yaml_custom_component_with_helper_class_in_yaml(tmp_path):
                 - Query
         """
         )
-    with pytest.raises(PipelineConfigError, match="not a valid variable name or value"):
+    with pytest.raises(PipelineConfigError, match="not a valid variable name"):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 

--- a/test/pipelines/test_pipeline_yaml.py
+++ b/test/pipelines/test_pipeline_yaml.py
@@ -573,6 +573,7 @@ def test_load_yaml_custom_component_with_helper_class_in_yaml(tmp_path):
     """
     This test can work from the perspective of YAML schema validation:
     HelperClass is picked up correctly and everything gets loaded.
+
     However, for now we decide to disable this feature.
     See haystack/_json_schema.py for details.
     """

--- a/test/pipelines/test_pipeline_yaml.py
+++ b/test/pipelines/test_pipeline_yaml.py
@@ -1005,7 +1005,7 @@ def test_load_yaml_unusual_chars_in_values(tmp_path):
         def run_batch(self):
             raise NotImplementedError
 
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+    with open(tmp_path / "tmp_config.yml", "w", encoding="utf-8") as tmp_file:
         tmp_file.write(
             f"""
             version: '1.9.0'


### PR DESCRIPTION
### Related Issues
- fixes #3249

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
Loading Pipelines from a Pipeline configuration with values for parameters that contained non-alphanumeric characters and spaces were failing as we checked them against [this RegEx](https://github.com/deepset-ai/haystack/blob/b84a6b17165dbf10665794b5decdefa113300749/haystack/pipelines/config.py#L24). This is too restrictive given that values can be arbitrary and is especially failing when using words from languages other than English.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I did manual tests. ~~Automatic tests will be added.~~ Unit test has been added.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
I'm not sure if there was a good reason to not allow arbitrary values for parameters. Please let me know if this was the case.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
