### PR TITLE
fix: eval() with `add_isolated_node_eval=True` breaks if no node supports it

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2094,7 +2094,9 @@ class Pipeline:
 
                 # Might be a non-targeted param. Verify that too
                 not_a_node = set(params.keys()) - set(self.graph.nodes)
-                valid_global_params = set(["debug"])  # Debug will be picked up by _dispatch_run, see its code
+                # "debug" will be picked up by _dispatch_run, see its code
+                # "add_isolated_node_eval" is set by pipeline.eval / pipeline.eval_batch
+                valid_global_params = set(["debug", "add_isolated_node_eval"])  
                 for node_id in self.graph.nodes:
                     run_signature_args = self._get_run_node_signature(node_id)
                     valid_global_params |= set(run_signature_args)

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2096,7 +2096,7 @@ class Pipeline:
                 not_a_node = set(params.keys()) - set(self.graph.nodes)
                 # "debug" will be picked up by _dispatch_run, see its code
                 # "add_isolated_node_eval" is set by pipeline.eval / pipeline.eval_batch
-                valid_global_params = set(["debug", "add_isolated_node_eval"])  
+                valid_global_params = set(["debug", "add_isolated_node_eval"])
                 for node_id in self.graph.nodes:
                     run_signature_args = self._get_run_node_signature(node_id)
                     valid_global_params |= set(run_signature_args)

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -1022,6 +1022,43 @@ def test_document_search_calculate_metrics(retriever_with_docs):
 
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
+def test_document_search_isolated(retriever_with_docs):
+    pipeline = DocumentSearchPipeline(retriever=retriever_with_docs)
+    # eval run must not fail even though no node supports add_isolated_node_eval
+    eval_result: EvaluationResult = pipeline.eval(
+        labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}}, add_isolated_node_eval=True
+    )
+
+    metrics = eval_result.calculate_metrics(document_scope="document_id")
+
+    assert "Retriever" in eval_result
+    assert len(eval_result) == 1
+    retriever_result = eval_result["Retriever"]
+    retriever_berlin = retriever_result[retriever_result["query"] == "Who lives in Berlin?"]
+    retriever_munich = retriever_result[retriever_result["query"] == "Who lives in Munich?"]
+
+    assert (
+        retriever_berlin[retriever_berlin["rank"] == 1]["document_id"].iloc[0]
+        in retriever_berlin[retriever_berlin["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert (
+        retriever_munich[retriever_munich["rank"] == 1]["document_id"].iloc[0]
+        not in retriever_munich[retriever_munich["rank"] == 1]["gold_document_ids"].iloc[0]
+    )
+    assert metrics["Retriever"]["mrr"] == 0.5
+    assert metrics["Retriever"]["map"] == 0.5
+    assert metrics["Retriever"]["recall_multi_hit"] == 0.5
+    assert metrics["Retriever"]["recall_single_hit"] == 0.5
+    assert metrics["Retriever"]["precision"] == 0.1
+    assert metrics["Retriever"]["ndcg"] == 0.5
+
+    isolated_metrics = eval_result.calculate_metrics(document_scope="document_id", eval_mode="isolated")
+    # empty metrics for nodes that do not support add_isolated_node_eval
+    assert isolated_metrics["Retriever"] == {}
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_faq_calculate_metrics(retriever_with_docs):
     pipeline = FAQPipeline(retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(labels=EVAL_LABELS, params={"Retriever": {"top_k": 5}})


### PR DESCRIPTION
### Related Issues
If you want to run eval always with isolated mode if one node supports it, it's not practical to investigate the pipeline and set `add_isolated_node_eval` accordingly, especially if you have a ton of different pipelines.
Currently `Pipeline.eval` fails with 
```No node(s) or global parameter(s) named add_isolated_node_eval found in pipeline.```
if there is no node that supports it.

### Proposed Changes:
- add exception for `add_isolated_node_eval` in pipeline's node params validation

### How did you test it?
- added test

### Notes for the reviewer
Downside of this would be that the user would not be notified that there is no node that supports isolated. Eval would be executed and only after calling `calculated_metrics(eval_mode="isolated")` the metrics would be empty.
I think this is acceptable as isolated is only supported by some nodes in the pipeline. So empty metrics for some nodes are a common picture.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
