### PR TITLE
Update weaviate schema doc link

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -95,7 +95,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
                            Currently, HSNW is only supported.
                            See: https://weaviate.io/developers/weaviate/current/more-resources/performance.html
         :param custom_schema: Allows to create custom schema in Weaviate, for more details
-                           See https://weaviate.io/developers/weaviate/current/data-schema/schema-configuration.html
+                           See https://weaviate.io/developers/weaviate/current/schema/schema-configuration.html                 
         :param module_name: Vectorization module to convert data into vectors. Default is "text2vec-trasnformers"
                             For more details, See https://weaviate.io/developers/weaviate/current/modules/
         :param return_embedding: To return document embedding.

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -95,7 +95,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
                            Currently, HSNW is only supported.
                            See: https://weaviate.io/developers/weaviate/current/more-resources/performance.html
         :param custom_schema: Allows to create custom schema in Weaviate, for more details
-                           See https://weaviate.io/developers/weaviate/current/schema/schema-configuration.html                 
+                           See https://weaviate.io/developers/weaviate/current/schema/schema-configuration.html
         :param module_name: Vectorization module to convert data into vectors. Default is "text2vec-trasnformers"
                             For more details, See https://weaviate.io/developers/weaviate/current/modules/
         :param return_embedding: To return document embedding.


### PR DESCRIPTION
### Related Issues
- None

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

The current link to the Weaviate's schema documentation is dead and needs to be updated

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I visited the link using a web browser

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

None

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
