### PR TITLE
fix: Added checks for DataParallel and WrappedDataParallel

### DIFF
--- a/haystack/modeling/evaluation/eval.py
+++ b/haystack/modeling/evaluation/eval.py
@@ -72,12 +72,13 @@ class Evaluator:
         for step, batch in enumerate(tqdm(self.data_loader, desc="Evaluating", mininterval=10)):
             batch = {key: batch[key].to(self.device) for key in batch}
 
-            model_type = type(model)
             if isinstance(model, (DataParallel, WrappedDataParallel)):
-                model_type = type(model.module)
+                module = model.module
+            else:
+                module = model
 
             with torch.no_grad():
-                if model_type is AdaptiveModel:
+                if isinstance(module, AdaptiveModel):
                     logits = model.forward(
                         input_ids=batch.get("input_ids", None),
                         segment_ids=batch.get("segment_ids", None),
@@ -85,7 +86,7 @@ class Evaluator:
                         output_hidden_states=batch.get("output_hidden_states", False),
                         output_attentions=batch.get("output_attentions", False),
                     )
-                elif model_type is BiAdaptiveModel:
+                elif isinstance(module, BiAdaptiveModel):
                     logits = model.forward(
                         query_input_ids=batch.get("query_input_ids", None),
                         query_segment_ids=batch.get("query_segment_ids", None),

--- a/haystack/modeling/evaluation/eval.py
+++ b/haystack/modeling/evaluation/eval.py
@@ -73,7 +73,7 @@ class Evaluator:
             batch = {key: batch[key].to(self.device) for key in batch}
 
             model_type = type(model)
-            if isinstance(model, DataParallel) or isinstance(model, WrappedDataParallel):
+            if isinstance(model, (DataParallel, WrappedDataParallel)):
                 model_type = type(model.module)
 
             with torch.no_grad():

--- a/haystack/modeling/evaluation/eval.py
+++ b/haystack/modeling/evaluation/eval.py
@@ -3,12 +3,14 @@ from typing import Dict, List, Optional, Any
 import logging
 import numbers
 import torch
+from torch.nn import DataParallel
 import numpy as np
 from tqdm import tqdm
 
 from haystack.modeling.evaluation.metrics import compute_metrics, compute_report_metrics
 from haystack.modeling.model.adaptive_model import AdaptiveModel
 from haystack.modeling.model.biadaptive_model import BiAdaptiveModel
+from haystack.modeling.model.optimization import WrappedDataParallel
 from haystack.utils.experiment_tracking import Tracker as tracker
 from haystack.modeling.visual import BUSH_SEP
 
@@ -70,9 +72,12 @@ class Evaluator:
         for step, batch in enumerate(tqdm(self.data_loader, desc="Evaluating", mininterval=10)):
             batch = {key: batch[key].to(self.device) for key in batch}
 
-            with torch.no_grad():
+            model_type = type(model)
+            if isinstance(model, DataParallel) or isinstance(model, WrappedDataParallel):
+                model_type = type(model.module)
 
-                if isinstance(model, AdaptiveModel):
+            with torch.no_grad():
+                if model_type is AdaptiveModel:
                     logits = model.forward(
                         input_ids=batch.get("input_ids", None),
                         segment_ids=batch.get("segment_ids", None),
@@ -80,7 +85,7 @@ class Evaluator:
                         output_hidden_states=batch.get("output_hidden_states", False),
                         output_attentions=batch.get("output_attentions", False),
                     )
-                elif isinstance(model, BiAdaptiveModel):
+                elif model_type is BiAdaptiveModel:
                     logits = model.forward(
                         query_input_ids=batch.get("query_input_ids", None),
                         query_segment_ids=batch.get("query_segment_ids", None),

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -293,7 +293,7 @@ class Trainer:
     def compute_loss(self, batch: dict, step: int) -> torch.Tensor:
         # Forward & backward pass through model
         model_type = type(self.model)
-        if isinstance(self.model, DataParallel) or isinstance(self.model, WrappedDataParallel):
+        if isinstance(self.model, (DataParallel, WrappedDataParallel)):
             model_type = type(self.model.module)
 
         if model_type is AdaptiveModel:

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -18,7 +18,7 @@ from haystack.modeling.data_handler.data_silo import DataSilo, DistillationDataS
 from haystack.modeling.evaluation.eval import Evaluator
 from haystack.modeling.model.adaptive_model import AdaptiveModel
 from haystack.modeling.model.biadaptive_model import BiAdaptiveModel
-from haystack.modeling.model.optimization import get_scheduler
+from haystack.modeling.model.optimization import get_scheduler, WrappedDataParallel
 from haystack.modeling.utils import GracefulKiller
 from haystack.utils.experiment_tracking import Tracker as tracker
 from haystack.utils.early_stopping import EarlyStopping
@@ -292,12 +292,16 @@ class Trainer:
 
     def compute_loss(self, batch: dict, step: int) -> torch.Tensor:
         # Forward & backward pass through model
-        if isinstance(self.model, AdaptiveModel):
+        model_type = type(self.model)
+        if isinstance(self.model, DataParallel) or isinstance(self.model, WrappedDataParallel):
+            model_type = type(self.model.module)
+
+        if model_type is AdaptiveModel:
             logits = self.model.forward(
                 input_ids=batch["input_ids"], segment_ids=None, padding_mask=batch["padding_mask"]
             )
 
-        elif isinstance(self.model, BiAdaptiveModel):
+        elif model_type is BiAdaptiveModel:
             logits = self.model.forward(
                 query_input_ids=batch["query_input_ids"],
                 query_segment_ids=batch["query_segment_ids"],

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -292,16 +292,17 @@ class Trainer:
 
     def compute_loss(self, batch: dict, step: int) -> torch.Tensor:
         # Forward & backward pass through model
-        model_type = type(self.model)
         if isinstance(self.model, (DataParallel, WrappedDataParallel)):
-            model_type = type(self.model.module)
+            module = self.model.module
+        else:
+            module = self.model
 
-        if model_type is AdaptiveModel:
+        if isinstance(module, AdaptiveModel):
             logits = self.model.forward(
                 input_ids=batch["input_ids"], segment_ids=None, padding_mask=batch["padding_mask"]
             )
 
-        elif model_type is BiAdaptiveModel:
+        elif isinstance(module, BiAdaptiveModel):
             logits = self.model.forward(
                 query_input_ids=batch["query_input_ids"],
                 query_segment_ids=batch["query_segment_ids"],


### PR DESCRIPTION
### Related Issues
- fixes #3353 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Added checks for `DataParallel` and `WrappedDataParallel` before calling the forward methods of `AdaptiveModel` or `BiAdaptiveModel` in `Trainer.compute_loss` and `Evaluator.eval` so that training works when using Data Parallelism. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I ran multi GPU training of the FARMReader on AWS using 4 GPUs. 

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
