### PR TITLE
fix: QuestionGenerator generates wrong document questions for non-default `num_queries_per_doc` parameter

### DIFF
--- a/haystack/nodes/question_generator/question_generator.py
+++ b/haystack/nodes/question_generator/question_generator.py
@@ -98,7 +98,7 @@ class QuestionGenerator(BaseComponent):
         self.split_overlap = split_overlap
         self.preprocessor = PreProcessor()
         self.prompt = prompt
-        self.num_queries_per_doc = max(num_queries_per_doc, 3)
+        self.num_queries_per_doc = min(num_queries_per_doc, 3)
         self.batch_size = batch_size
         self.sep_token = self.tokenizer.sep_token or sep_token
         self.progress_bar = progress_bar

--- a/test/nodes/test_question_generator.py
+++ b/test/nodes/test_question_generator.py
@@ -94,8 +94,8 @@ def test_qg_pipeline_non_default_params():
     assert isinstance(result["documents"], list)
     assert len(result["generated_questions"]) == 2
     assert len(result["documents"]) == 2
-    assert len(result["generated_questions"][0]["questions"]) > 0
-    assert len(result["generated_questions"][1]["questions"]) > 0
+    assert len(result["generated_questions"][0]["questions"]) == 26
+    assert len(result["generated_questions"][1]["questions"]) == 12
 
     # first list of questions should be about Australian punk band
     verify_questions(result["generated_questions"][0]["questions"], keywords)


### PR DESCRIPTION
### Related Issues
- fixes #3380 

### Proposed Changes:
Properly accounts for questions generated and originating documents order

### How did you test it?
Added unit test

### Notes for the reviewer
See if you can find a use case that again breaks the order of questions and documents.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
