### PR TITLE
fix: allow same `vector_id` in different indexes for SQL-based Document stores

### DIFF
--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -344,7 +344,7 @@ class FAISSDocumentStore(SQLDocumentStore):
             return
 
         logger.info("Updating embeddings for %s docs...", document_count)
-        vector_id = sum(index.ntotal for index in self.faiss_indexes.values())
+        vector_id = self.faiss_indexes[index].ntotal
 
         result = self._query(
             index=index,

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -19,6 +19,7 @@ try:
         text,
         JSON,
         ForeignKeyConstraint,
+        UniqueConstraint,
     )
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import relationship, sessionmaker, validates
@@ -52,9 +53,11 @@ class DocumentORM(ORMBase):
     content_type = Column(Text, nullable=True)
     # primary key in combination with id to allow the same doc in different indices
     index = Column(String(100), nullable=False, primary_key=True)
-    vector_id = Column(String(100), unique=True, nullable=True)
+    vector_id = Column(String(100), nullable=True)
     # speeds up queries for get_documents_by_vector_ids() by having a single query that returns joined metadata
     meta = relationship("MetaDocumentORM", back_populates="documents", lazy="joined")
+
+    __table_args__ = (UniqueConstraint("index", "vector_id", name="index_vector_id_uc"),)
 
 
 class MetaDocumentORM(ORMBase):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -983,7 +983,7 @@ def setup_postgres():
 
     with engine.connect() as connection:
         try:
-            connection.execute(text("DROP SCHEMA public CASCADE"))
+            connection.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
         except Exception as e:
             logging.error(e)
         connection.execute(text("CREATE SCHEMA public;"))

--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -489,7 +489,7 @@ def test_write_document_meta(document_store: BaseDocumentStore):
 
 
 @pytest.mark.parametrize("document_store", ["sql"], indirect=True)
-def test_write_document_sql_invalid_meta(document_store: BaseDocumentStore):
+def test_sql_write_document_invalid_meta(document_store: BaseDocumentStore):
     documents = [
         {
             "content": "dict_with_invalid_meta",
@@ -513,7 +513,7 @@ def test_write_document_sql_invalid_meta(document_store: BaseDocumentStore):
 
 
 @pytest.mark.parametrize("document_store", ["sql"], indirect=True)
-def test_write_different_documents_same_vector_id(document_store: BaseDocumentStore):
+def test_sql_write_different_documents_same_vector_id(document_store: BaseDocumentStore):
     doc1 = {"content": "content 1", "name": "doc1", "id": "1", "vector_id": "vector_id"}
     doc2 = {"content": "content 2", "name": "doc2", "id": "2", "vector_id": "vector_id"}
 

--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -512,6 +512,23 @@ def test_write_document_sql_invalid_meta(document_store: BaseDocumentStore):
     assert document_store.get_document_by_id("2").meta == {"name": "filename2", "valid_meta_field": "test2"}
 
 
+@pytest.mark.parametrize("document_store", ["sql"], indirect=True)
+def test_write_different_documents_same_vector_id(document_store: BaseDocumentStore):
+    doc1 = {"content": "content 1", "name": "doc1", "id": "1", "vector_id": "vector_id"}
+    doc2 = {"content": "content 2", "name": "doc2", "id": "2", "vector_id": "vector_id"}
+
+    document_store.write_documents([doc1], index="index1")
+    documents_in_index1 = document_store.get_all_documents(index="index1")
+    assert len(documents_in_index1) == 1
+    document_store.write_documents([doc2], index="index2")
+    documents_in_index2 = document_store.get_all_documents(index="index2")
+    assert len(documents_in_index2) == 1
+
+    document_store.write_documents([doc1], index="index3")
+    with pytest.raises(Exception, match=r"(?i)unique"):
+        document_store.write_documents([doc2], index="index3")
+
+
 def test_write_document_index(document_store: BaseDocumentStore):
     document_store.delete_index("haystack_test_one")
     document_store.delete_index("haystack_test_two")


### PR DESCRIPTION
### Related Issues
- fixes #3327

### Proposed Changes:
In `SQLDocumentStore`:
- `vector_id` is no longer unique
- added a `UniqueConstraint` for `index` + `vector_id`

In `FAISSDocumentStore`:
- modified `update_embeddings` method to take this change into account.
Now for every index, `vector_id` starts at 0

### How did you test it?
- As suggested by @ZanSara, I locally ran the tests using PostgreSQL with `pytest . --document_store_type="sql,faiss"`
- Added new tests for `SQLDocumentStore` and `FAISSDocumentStore`

### Notes for the reviewer
- Tests can be improved/redesigned. I am open to suggestions.
- New test in test_document_store.py will probably not run until #3332 is merged
- Fixed other little things here and there

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [X] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
