### PR TITLE
fix: improve Document `__repr__`

### DIFF
--- a/haystack/json-schemas/haystack-pipeline-1.11.0rc0.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-1.11.0rc0.schema.json
@@ -3993,6 +3993,11 @@
             },
             "split_by": {
               "default": "word",
+              "enum": [
+                "word",
+                "sentence",
+                "passage"
+              ],
               "title": "Split By",
               "type": "string"
             },

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -228,16 +228,17 @@ class Document:
         )
 
     def __repr__(self):
-        values = self.to_dict()
-        if values.get("embedding", None) is not None:
-            values["embedding"] = f"<embedding of shape {getattr(values['embedding'], 'shape', '[no shape]')}>"
-        return f"<Document: {str(self.to_dict())}>"
+        doc_dict = self.to_dict()
+        embedding = doc_dict.get("embedding", None)
+        if embedding is not None:
+            doc_dict["embedding"] = f"<embedding of shape {embedding.shape}>"
+        return f"<Document: {str(doc_dict)}>"
 
     def __str__(self):
         # In some cases, self.content is None (therefore not subscriptable)
         if self.content is None:
             return f"<Document: id={self.id}, content=None>"
-        return f"<Document: id={self.id}, content='{self.content[:100]} {'...' if len(self.content) > 100 else ''}'>"
+        return f"<Document: id={self.id}, content='{self.content[:100]}{'...' if len(self.content) > 100 else ''}'>"
 
     def __lt__(self, other):
         """Enable sorting of Documents by score"""
@@ -265,7 +266,7 @@ class SpeechDocument(Document):
         # In some cases, self.content is None (therefore not subscriptable)
         if self.content is None:
             return f"<SpeechDocument: id={self.id}, content=None>"
-        return f"<SpeechDocument: id={self.id}, content='{self.content[:100]} {'...' if len(self.content) > 100 else ''}', content_audio={self.content_audio}>"
+        return f"<SpeechDocument: id={self.id}, content='{self.content[:100]}{'...' if len(self.content) > 100 else ''}', content_audio={self.content_audio}>"
 
     def to_dict(self, field_map={}) -> Dict:
         dictionary = super().to_dict(field_map=field_map)

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -231,7 +231,7 @@ class Document:
         doc_dict = self.to_dict()
         embedding = doc_dict.get("embedding", None)
         if embedding is not None:
-            doc_dict["embedding"] = f"<embedding of shape {embedding.shape}>"
+            doc_dict["embedding"] = f"<embedding of shape {getattr(embedding, 'shape', '[no shape]')}>"
         return f"<Document: {str(doc_dict)}>"
 
     def __str__(self):


### PR DESCRIPTION
### Related Issues
- fixes #3382

### Proposed Changes:
As reported in #3382, there was a minor bug in `__repr__` method of the `Document` class.
Since "The truth value of an array with more than one element is ambiguous.", I check instead that the `embedding` `is not None`.

### How did you test it?
Manual tests

### Notes for the reviewer
Other small fixes

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
