### PR TITLE
feat: Add exponential backoff for OpenAI API invocations

### DIFF
--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -117,3 +117,15 @@ class OpenAIError(NodeError):
     def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None):
         super().__init__(message=message)
         self.status_code = status_code
+
+
+class OpenAIRateLimitError(OpenAIError):
+    """
+    Rate limit error for OpenAI API (status code 429)
+    See https://help.openai.com/en/articles/5955604-how-can-i-solve-429-too-many-requests-errors
+    See https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits
+    """
+
+    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = 429):
+        super().__init__(message=message)
+        self.status_code = status_code

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -126,6 +126,5 @@ class OpenAIRateLimitError(OpenAIError):
     See https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits
     """
 
-    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = 429):
-        super().__init__(message=message)
-        self.status_code = status_code
+    def __init__(self, message: Optional[str] = None):
+        super().__init__(message=message, status_code=429)

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -112,7 +112,8 @@ class AudioNodeError(NodeError):
 
 
 class OpenAIError(NodeError):
-    """Exception for issues that occur in the OpenAI Answer Generator node"""
+    """Exception for issues that occur in the OpenAI APIs"""
 
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None):
         super().__init__(message=message)
+        self.status_code = status_code

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -409,14 +409,13 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
 
         if response.status_code != 200:
             if response.status_code == 429:
-                raise OpenAIRateLimitError(
-                    f"API rate limit exceeded: {response.text}", status_code=response.status_code
-                )
+                raise OpenAIRateLimitError(f"API rate limit exceeded: {response.text}")
             else:
                 raise OpenAIError(
                     f"OpenAI returned an error.\n"
                     f"Status code: {response.status_code}\n"
-                    f"Response body: {response.text}"
+                    f"Response body: {response.text}",
+                    status_code=response.status_code,
                 )
 
         unordered_embeddings = [(ans["index"], ans["embedding"]) for ans in res["data"]]

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,7 +400,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         tokenized_payload = self.tokenizer(text)
         return self.tokenizer.decode(tokenized_payload["input_ids"][: self.max_seq_len])
 
-    @retry_with_exponential_backoff
+    @retry_with_exponential_backoff(initial_delay=10)
     def embed(self, model: str, text: List[str]) -> np.ndarray:
         payload = {"model": model, "input": text}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,7 +400,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         tokenized_payload = self.tokenizer(text)
         return self.tokenizer.decode(tokenized_payload["input_ids"][: self.max_seq_len])
 
-    @retry_with_exponential_backoff(initial_delay=30, max_retries=3, errors=(OpenAIRateLimitError,))
+    @retry_with_exponential_backoff
     def embed(self, model: str, text: List[str]) -> np.ndarray:
         payload = {"model": model, "input": text}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -4,6 +4,8 @@ import time
 from random import random
 from typing import Any, Dict, Tuple, Callable
 
+from haystack.errors import OpenAIRateLimitError
+
 
 def args_to_kwargs(args: Tuple, func: Callable) -> Dict[str, Any]:
     sig = inspect.signature(func)
@@ -43,7 +45,7 @@ def retry_with_exponential_backoff(
     exponential_base: float = 2,
     jitter: bool = True,
     max_retries: int = 10,
-    errors: tuple = None,
+    errors: tuple = (OpenAIRateLimitError,),
 ):
     """Retry a function with exponential backoff."""
 

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -1,5 +1,7 @@
 import inspect
 import functools
+import time
+from random import random
 from typing import Any, Dict, Tuple, Callable
 
 
@@ -33,3 +35,45 @@ def pipeline_invocation_counter(func):
 
     wrapper_invocation_counter.counter = 0
     return wrapper_invocation_counter
+
+
+def retry_with_exponential_backoff(
+    func,
+    initial_delay: float = 1,
+    exponential_base: float = 2,
+    jitter: bool = True,
+    max_retries: int = 10,
+    errors: tuple = None,
+):
+    """Retry a function with exponential backoff."""
+
+    def wrapper(*args, **kwargs):
+        # Initialize variables
+        num_retries = 0
+        delay = initial_delay
+
+        # Loop until a successful response or max_retries is hit or an exception is raised
+        while True:
+            try:
+                return func(*args, **kwargs)
+
+            # Retry on specified errors
+            except errors as e:
+                # Increment retries
+                num_retries += 1
+
+                # Check if max retries has been reached
+                if num_retries > max_retries:
+                    raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
+
+                # Increment the delay
+                delay *= exponential_base * (1 + jitter * random.random())
+
+                # Sleep for the delay
+                time.sleep(delay)
+
+            # Raise exceptions for any errors not specified
+            except Exception as e:
+                raise e
+
+    return wrapper

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -69,7 +69,7 @@ def retry_with_exponential_backoff(
                     raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
 
                 # Increment the delay
-                delay *= exponential_base * (1 + jitter * random.random())
+                delay *= exponential_base * (1 + jitter * random())
 
                 # Sleep for the delay
                 time.sleep(delay)

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -40,7 +40,7 @@ def pipeline_invocation_counter(func):
 
 
 def retry_with_exponential_backoff(
-    func,
+    function,
     initial_delay: float = 1,
     exponential_base: float = 2,
     jitter: bool = True,
@@ -49,33 +49,36 @@ def retry_with_exponential_backoff(
 ):
     """Retry a function with exponential backoff."""
 
-    def wrapper(*args, **kwargs):
-        # Initialize variables
-        num_retries = 0
-        delay = initial_delay
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            # Initialize variables
+            num_retries = 0
+            delay = initial_delay
 
-        # Loop until a successful response or max_retries is hit or an exception is raised
-        while True:
-            try:
-                return func(*args, **kwargs)
+            # Loop until a successful response or max_retries is hit or an exception is raised
+            while True:
+                try:
+                    return func(*args, **kwargs)
 
-            # Retry on specified errors
-            except errors as e:
-                # Increment retries
-                num_retries += 1
+                # Retry on specified errors
+                except errors as e:
+                    # Increment retries
+                    num_retries += 1
 
-                # Check if max retries has been reached
-                if num_retries > max_retries:
-                    raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
+                    # Check if max retries has been reached
+                    if num_retries > max_retries:
+                        raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
 
-                # Increment the delay
-                delay *= exponential_base * (1 + jitter * random())
+                    # Increment the delay
+                    delay *= exponential_base * (1 + jitter * random())
 
-                # Sleep for the delay
-                time.sleep(delay)
+                    # Sleep for the delay
+                    time.sleep(delay)
 
-            # Raise exceptions for any errors not specified
-            except Exception as e:
-                raise e
+                # Raise exceptions for any errors not specified
+                except Exception as e:
+                    raise e
 
-    return wrapper
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
### Related Issues
Note: This is a draft and a placeholder for additional work. 

### Proposed Changes:
Adds exponential back-off for OpenAI API invocations

### How did you test it?
TBD

### Notes for the reviewer
RBD

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
