### PR TITLE
Feat: allow decreasing size of datasets loaded from BEIR

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -770,7 +770,7 @@ class Pipeline:
         corpus, queries, qrels = GenericDataLoader(data_path).load(split="test")  # or split = "train" or "dev"
 
         # crop dataset if `dataset_size` is provided and is valid
-        if num_documents is not None and num_documents > 0 and num_documents < len(corpus):
+        if num_documents is not None and 0 < num_documents < len(corpus):
             logger.info(f"Cropping dataset from {len(corpus)} to {num_documents} documents")
             corpus = dict(itertools.islice(corpus.items(), num_documents))
             # Remove queries that don't contain the remaining documents


### PR DESCRIPTION
### Related Issues
- fixes #3387 

### Proposed Changes:
When evaluating pipelines the user normally would use the in-built [eval_beir()](https://github.com/deepset-ai/haystack/blob/7290196c32abf44e269caa03e1d2178c77992b0e/haystack/pipelines/base.py#L727) method. This method doesn't contain a way of cropping the dataset of choice and for quick tests or reduced benchmarks when the dataset is huge that is a big plus.

This PR introduces a cropping feature (a new parameter) to allow this.

### How did you test it?
**Manually since there are no tests for `eval_beir()`.**

It can be manually tested with the following script (having enabled `Elasticsearch`):
```python
from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
from haystack import Pipeline
from haystack.nodes.retriever import BM25Retriever
from haystack.nodes.file_converter import TextConverter

es_endpoint = "127.0.0.1"
es_port = 9200
index = "documents_test"
dataset = "nfcorpus"
dataset_size = 300

document_store = ElasticsearchDocumentStore(host=es_endpoint, port=es_port, similarity="dot_product", index=index)
es_retriever = BM25Retriever(document_store=(document_store))
text_converter = TextConverter()

# INDEXING PIPELINE
index_pipeline = Pipeline()
index_pipeline.add_node(text_converter, name="TextConverter", inputs=["File"])
index_pipeline.add_node(document_store, name="DocumentStore", inputs=["TextConverter"])

# SEARCH PIPELINE
search_pipeline = Pipeline()
search_pipeline.add_node(es_retriever, name="ESRetriever", inputs=["Query"])

Pipeline.eval_beir(
    index_pipeline=index_pipeline, query_pipeline=search_pipeline, dataset=dataset, dataset_size=dataset_size
)
```

You will see that the logging is saying that is indexing 300 documents instead of all of them (more than 3000)

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
