### PR TITLE
feat: Add exponential backoff decorator; apply it to OpenAI requests

### DIFF
--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -117,3 +117,15 @@ class OpenAIError(NodeError):
     def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None):
         super().__init__(message=message)
         self.status_code = status_code
+
+
+class OpenAIRateLimitError(OpenAIError):
+    """
+    Rate limit error for OpenAI API (status code 429)
+    See https://help.openai.com/en/articles/5955604-how-can-i-solve-429-too-many-requests-errors
+    See https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits
+    """
+
+    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = 429):
+        super().__init__(message=message)
+        self.status_code = status_code

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -126,6 +126,5 @@ class OpenAIRateLimitError(OpenAIError):
     See https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits
     """
 
-    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = 429):
-        super().__init__(message=message)
-        self.status_code = status_code
+    def __init__(self, message: Optional[str] = None):
+        super().__init__(message=message, status_code=429)

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -112,7 +112,8 @@ class AudioNodeError(NodeError):
 
 
 class OpenAIError(NodeError):
-    """Exception for issues that occur in the OpenAI Answer Generator node"""
+    """Exception for issues that occur in the OpenAI APIs"""
 
-    def __init__(self, message: Optional[str] = None):
+    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None):
         super().__init__(message=message)
+        self.status_code = status_code

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -94,7 +94,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         else:
             self.MAX_TOKENS_LIMIT = 2048
 
-    @retry_with_exponential_backoff(initial_delay=10, max_retries=3)
+    @retry_with_exponential_backoff(backoff_in_seconds=10, max_retries=5)
     def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None):
         """
         Use the loaded QA model to generate Answers for a query based on the Documents it receives.

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -409,14 +409,13 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
 
         if response.status_code != 200:
             if response.status_code == 429:
-                raise OpenAIRateLimitError(
-                    f"API rate limit exceeded: {response.text}", status_code=response.status_code
-                )
+                raise OpenAIRateLimitError(f"API rate limit exceeded: {response.text}")
             else:
                 raise OpenAIError(
                     f"OpenAI returned an error.\n"
                     f"Status code: {response.status_code}\n"
-                    f"Response body: {response.text}"
+                    f"Response body: {response.text}",
+                    status_code=response.status_code,
                 )
 
         unordered_embeddings = [(ans["index"], ans["embedding"]) for ans in res["data"]]

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,7 +400,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         tokenized_payload = self.tokenizer(text)
         return self.tokenizer.decode(tokenized_payload["input_ids"][: self.max_seq_len])
 
-    @retry_with_exponential_backoff(initial_delay=10)
+    @retry_with_exponential_backoff(initial_delay=10, max_retries=3)
     def embed(self, model: str, text: List[str]) -> np.ndarray:
         payload = {"model": model, "input": text}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,7 +400,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         tokenized_payload = self.tokenizer(text)
         return self.tokenizer.decode(tokenized_payload["input_ids"][: self.max_seq_len])
 
-    @retry_with_exponential_backoff(initial_delay=10, max_retries=3)
+    @retry_with_exponential_backoff(backoff_in_seconds=10, max_retries=5)
     def embed(self, model: str, text: List[str]) -> np.ndarray:
         payload = {"model": model, "input": text}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,7 +400,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         tokenized_payload = self.tokenizer(text)
         return self.tokenizer.decode(tokenized_payload["input_ids"][: self.max_seq_len])
 
-    @retry_with_exponential_backoff
+    @retry_with_exponential_backoff(initial_delay=10)
     def embed(self, model: str, text: List[str]) -> np.ndarray:
         payload = {"model": model, "input": text}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,7 +400,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         tokenized_payload = self.tokenizer(text)
         return self.tokenizer.decode(tokenized_payload["input_ids"][: self.max_seq_len])
 
-    @retry_with_exponential_backoff(initial_delay=30, max_retries=3, errors=(OpenAIRateLimitError,))
+    @retry_with_exponential_backoff
     def embed(self, model: str, text: List[str]) -> np.ndarray:
         payload = {"model": model, "input": text}
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -408,15 +408,17 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         res = json.loads(response.text)
 
         if response.status_code != 200:
+            openai_error: OpenAIError
             if response.status_code == 429:
-                raise OpenAIRateLimitError(f"API rate limit exceeded: {response.text}")
+                openai_error = OpenAIRateLimitError(f"API rate limit exceeded: {response.text}")
             else:
-                raise OpenAIError(
+                openai_error = OpenAIError(
                     f"OpenAI returned an error.\n"
                     f"Status code: {response.status_code}\n"
                     f"Response body: {response.text}",
                     status_code=response.status_code,
                 )
+            raise openai_error
 
         unordered_embeddings = [(ans["index"], ans["embedding"]) for ans in res["data"]]
         ordered_embeddings = sorted(unordered_embeddings, key=lambda x: x[0])

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -4,6 +4,8 @@ import time
 from random import random
 from typing import Any, Dict, Tuple, Callable
 
+from haystack.errors import OpenAIRateLimitError
+
 
 def args_to_kwargs(args: Tuple, func: Callable) -> Dict[str, Any]:
     sig = inspect.signature(func)
@@ -43,7 +45,7 @@ def retry_with_exponential_backoff(
     exponential_base: float = 2,
     jitter: bool = True,
     max_retries: int = 10,
-    errors: tuple = None,
+    errors: tuple = (OpenAIRateLimitError,),
 ):
     """Retry a function with exponential backoff."""
 

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -40,7 +40,6 @@ def pipeline_invocation_counter(func):
 
 
 def retry_with_exponential_backoff(
-    function,
     initial_delay: float = 1,
     exponential_base: float = 2,
     jitter: bool = True,
@@ -49,7 +48,7 @@ def retry_with_exponential_backoff(
 ):
     """Retry a function with exponential backoff."""
 
-    def decorator(func):
+    def decorator(function):
         def wrapper(*args, **kwargs):
             # Initialize variables
             num_retries = 0
@@ -58,7 +57,7 @@ def retry_with_exponential_backoff(
             # Loop until a successful response or max_retries is hit or an exception is raised
             while True:
                 try:
-                    return func(*args, **kwargs)
+                    return function(*args, **kwargs)
 
                 # Retry on specified errors
                 except errors as e:

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -1,5 +1,7 @@
 import inspect
 import functools
+import time
+from random import random
 from typing import Any, Dict, Tuple, Callable
 
 
@@ -33,3 +35,45 @@ def pipeline_invocation_counter(func):
 
     wrapper_invocation_counter.counter = 0
     return wrapper_invocation_counter
+
+
+def retry_with_exponential_backoff(
+    func,
+    initial_delay: float = 1,
+    exponential_base: float = 2,
+    jitter: bool = True,
+    max_retries: int = 10,
+    errors: tuple = None,
+):
+    """Retry a function with exponential backoff."""
+
+    def wrapper(*args, **kwargs):
+        # Initialize variables
+        num_retries = 0
+        delay = initial_delay
+
+        # Loop until a successful response or max_retries is hit or an exception is raised
+        while True:
+            try:
+                return func(*args, **kwargs)
+
+            # Retry on specified errors
+            except errors as e:
+                # Increment retries
+                num_retries += 1
+
+                # Check if max retries has been reached
+                if num_retries > max_retries:
+                    raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
+
+                # Increment the delay
+                delay *= exponential_base * (1 + jitter * random.random())
+
+                # Sleep for the delay
+                time.sleep(delay)
+
+            # Raise exceptions for any errors not specified
+            except Exception as e:
+                raise e
+
+    return wrapper

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -69,7 +69,7 @@ def retry_with_exponential_backoff(
                     raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
 
                 # Increment the delay
-                delay *= exponential_base * (1 + jitter * random.random())
+                delay *= exponential_base * (1 + jitter * random())
 
                 # Sleep for the delay
                 time.sleep(delay)

--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -40,7 +40,7 @@ def pipeline_invocation_counter(func):
 
 
 def retry_with_exponential_backoff(
-    func,
+    function,
     initial_delay: float = 1,
     exponential_base: float = 2,
     jitter: bool = True,
@@ -49,33 +49,36 @@ def retry_with_exponential_backoff(
 ):
     """Retry a function with exponential backoff."""
 
-    def wrapper(*args, **kwargs):
-        # Initialize variables
-        num_retries = 0
-        delay = initial_delay
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            # Initialize variables
+            num_retries = 0
+            delay = initial_delay
 
-        # Loop until a successful response or max_retries is hit or an exception is raised
-        while True:
-            try:
-                return func(*args, **kwargs)
+            # Loop until a successful response or max_retries is hit or an exception is raised
+            while True:
+                try:
+                    return func(*args, **kwargs)
 
-            # Retry on specified errors
-            except errors as e:
-                # Increment retries
-                num_retries += 1
+                # Retry on specified errors
+                except errors as e:
+                    # Increment retries
+                    num_retries += 1
 
-                # Check if max retries has been reached
-                if num_retries > max_retries:
-                    raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
+                    # Check if max retries has been reached
+                    if num_retries > max_retries:
+                        raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
 
-                # Increment the delay
-                delay *= exponential_base * (1 + jitter * random())
+                    # Increment the delay
+                    delay *= exponential_base * (1 + jitter * random())
 
-                # Sleep for the delay
-                time.sleep(delay)
+                    # Sleep for the delay
+                    time.sleep(delay)
 
-            # Raise exceptions for any errors not specified
-            except Exception as e:
-                raise e
+                # Raise exceptions for any errors not specified
+                except Exception as e:
+                    raise e
 
-    return wrapper
+        return wrapper
+
+    return decorator

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -1209,13 +1209,13 @@ def test_exponential_backoff():
         def greet(name: str):
             if random() < 1.1:
                 raise OpenAIRateLimitError("Too many requests")
-            print(f"Hello {name}")
+            return f"Hello {name}"
 
-        greet("Hello John")
+        greet("John")
 
     # this should not raise exception and should print "Hello John"
     @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=1)
     def greet2(name: str):
-        print(f"Hello {name}")
+        return f"Hello {name}"
 
-    greet2("Hello John")
+    assert greet2("John") == "Hello John"

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -1207,7 +1207,7 @@ def test_exponential_backoff():
 
         @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=2)
         def greet(name: str):
-            if random() < 0.999:
+            if random() < 1.1:
                 raise OpenAIRateLimitError("Too many requests")
             print(f"Hello {name}")
 
@@ -1216,8 +1216,6 @@ def test_exponential_backoff():
     # this should not raise exception and should print "Hello John"
     @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=1)
     def greet2(name: str):
-        if random() < 0.0001:
-            raise OpenAIRateLimitError("Too many requests")
         print(f"Hello {name}")
 
     greet2("Hello John")

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -1,4 +1,6 @@
 import logging
+from random import random
+
 import numpy as np
 import pytest
 import pandas as pd
@@ -6,11 +8,14 @@ from pathlib import Path
 
 import responses
 from responses import matchers
+
+from haystack.errors import OpenAIRateLimitError
 from haystack.utils.deepsetcloud import DeepsetCloud, DeepsetCloudExperiments
 
 from haystack.utils.preprocessing import convert_files_to_docs, tika_convert_files_to_docs
 from haystack.utils.cleaning import clean_wiki_text
 from haystack.utils.augment_squad import augment_squad
+from haystack.utils.reflection import retry_with_exponential_backoff
 from haystack.utils.squad_data import SquadData
 from haystack.utils.context_matching import calculate_context_similarity, match_context, match_contexts
 
@@ -1193,3 +1198,26 @@ def test_get_eval_run_results():
     first_result = node_results.iloc[0]
     assert first_result["exact_match"] == True
     assert first_result["answer"] == "This"
+
+
+def test_exponential_backoff():
+    # Test that the exponential backoff works as expected
+    # should raise exception, check the exception contains the correct message
+    with pytest.raises(Exception, match="retries \(2\)"):
+
+        @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=2)
+        def greet(name: str):
+            if random() < 0.999:
+                raise OpenAIRateLimitError("Too many requests")
+            print(f"Hello {name}")
+
+        greet("Hello John")
+
+    # this should not raise exception and should print "Hello John"
+    @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=1)
+    def greet2(name: str):
+        if random() < 0.0001:
+            raise OpenAIRateLimitError("Too many requests")
+        print(f"Hello {name}")
+
+    greet2("Hello John")


### PR DESCRIPTION
### Proposed Changes:
Adds exponential back-off decorator. This decorator can decorate a method making API invocations and in the case of rate limit errors, it simply attempts further invocations with exponential backoff. When dealing with OpenAI API requests, backoff and retry is a great strategy to minimize latency while avoiding rate limit errors, while being completely transparent to our users. 

### How did you test it?
Manually, not sure how to thoroughly test it with unit tests. Open to ideas.