### PR TITLE
fix: Update how schema is ordered

### DIFF
--- a/haystack/json-schemas/haystack-pipeline-1.10.0rc0.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-1.10.0rc0.schema.json
@@ -1189,6 +1189,17 @@
           "additionalProperties": false,
           "description": "Each parameter can reference other components defined in the same YAML file.",
           "properties": {
+            "api_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            },
             "batch_size": {
               "default": 32,
               "title": "Batch Size",
@@ -3043,24 +3054,15 @@
               "title": "Use System Proxy",
               "type": "boolean"
             },
-            "embed_meta_fields": {
-              "title": "Embed Meta Fields",
-              "default": [],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "username": {
+              "default": "admin",
+              "title": "Username",
+              "type": "string"
             },
-            "api_key": {
-              "title": "Api Key",
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+            "verify_certs": {
+              "default": false,
+              "title": "Verify Certs",
+              "type": "boolean"
             }
           },
           "title": "Parameters",

--- a/haystack/json-schemas/haystack-pipeline-main.schema.json
+++ b/haystack/json-schemas/haystack-pipeline-main.schema.json
@@ -1189,6 +1189,17 @@
           "additionalProperties": false,
           "description": "Each parameter can reference other components defined in the same YAML file.",
           "properties": {
+            "api_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Api Key"
+            },
             "batch_size": {
               "default": 32,
               "title": "Batch Size",
@@ -3043,24 +3054,15 @@
               "title": "Use System Proxy",
               "type": "boolean"
             },
-            "embed_meta_fields": {
-              "title": "Embed Meta Fields",
-              "default": [],
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "username": {
+              "default": "admin",
+              "title": "Username",
+              "type": "string"
             },
-            "api_key": {
-              "title": "Api Key",
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+            "verify_certs": {
+              "default": false,
+              "title": "Verify Certs",
+              "type": "boolean"
             }
           },
           "title": "Parameters",

--- a/haystack/json-schemas/haystack-pipeline.schema.json
+++ b/haystack/json-schemas/haystack-pipeline.schema.json
@@ -1,9 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://raw.githubusercontent.com/deepset-ai/haystack/main/haystack/json-schemas/haystack-pipeline.schema.json",
-  "title": "Haystack Pipeline",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. For more info read the docs at: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
-  "type": "object",
   "oneOf": [
     {
       "allOf": [
@@ -229,5 +227,7 @@
         }
       ]
     }
-  ]
+  ],
+  "title": "Haystack Pipeline",
+  "type": "object"
 }

--- a/haystack/nodes/_json_schema.py
+++ b/haystack/nodes/_json_schema.py
@@ -277,8 +277,6 @@ def get_json_schema(filename: str, version: str, modules: List[str] = ["haystack
         schema_definitions.update(node_definition)
         node_refs.append(node_ref)
 
-    schema_definitions = OrderedDict(sorted(schema_definitions.items()))
-
     pipeline_schema = {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": f"{SCHEMA_URL}{filename}",
@@ -385,7 +383,7 @@ def get_json_schema(filename: str, version: str, modules: List[str] = ["haystack
     }
 
     # Leveraging an implementation detail of dict: keys stay in the order they are inserted.
-    pipeline_schema = OrderedDict(sorted(pipeline_schema.items()))
+    pipeline_schema = order_dict(pipeline_schema)
     return pipeline_schema
 
 
@@ -408,6 +406,10 @@ def inject_definition_in_schema(node_class: Type[BaseComponent], schema: Dict[st
     schema["properties"]["components"]["items"]["anyOf"].append(node_ref)
     logger.info("Added definition for %s", getattr(node_class, "__name__"))
     return schema
+
+
+def order_dict(dictionary):
+    return OrderedDict({k: order_dict(v) if isinstance(v, dict) else v for k, v in sorted(dictionary.items())})
 
 
 def update_json_schema(destination_path: Path = JSON_SCHEMAS_PATH):

--- a/haystack/nodes/_json_schema.py
+++ b/haystack/nodes/_json_schema.py
@@ -409,7 +409,21 @@ def inject_definition_in_schema(node_class: Type[BaseComponent], schema: Dict[st
 
 
 def order_dict(dictionary):
-    return OrderedDict({k: order_dict(v) if isinstance(v, dict) else v for k, v in sorted(dictionary.items())})
+    result = {}
+    for k, v in sorted(dictionary.items()):
+        if isinstance(v, dict):
+            result[k] = order_dict(v)
+        elif isinstance(v, list):
+            new_list = []
+            for item in v:
+                if isinstance(item, dict):
+                    new_list.append(order_dict(item))
+                else:
+                    new_list.append(item)
+            result[k] = new_list
+        else:
+            result[k] = v
+    return OrderedDict(result)
 
 
 def update_json_schema(destination_path: Path = JSON_SCHEMAS_PATH):

--- a/haystack/nodes/_json_schema.py
+++ b/haystack/nodes/_json_schema.py
@@ -5,6 +5,7 @@ import json
 import inspect
 import logging
 from pathlib import Path
+from collections import OrderedDict
 
 import pydantic.schema
 from pydantic import BaseConfig, BaseSettings, Required, SecretStr, create_model
@@ -276,6 +277,8 @@ def get_json_schema(filename: str, version: str, modules: List[str] = ["haystack
         schema_definitions.update(node_definition)
         node_refs.append(node_ref)
 
+    schema_definitions = OrderedDict(sorted(schema_definitions.items()))
+
     pipeline_schema = {
         "$schema": "http://json-schema.org/draft-07/schema",
         "$id": f"{SCHEMA_URL}{filename}",
@@ -382,7 +385,7 @@ def get_json_schema(filename: str, version: str, modules: List[str] = ["haystack
     }
 
     # Leveraging an implementation detail of dict: keys stay in the order they are inserted.
-    pipeline_schema = dict(sorted(pipeline_schema.items(), key=lambda pair: pair[0]))
+    pipeline_schema = OrderedDict(sorted(pipeline_schema.items()))
     return pipeline_schema
 
 

--- a/haystack/nodes/_json_schema.py
+++ b/haystack/nodes/_json_schema.py
@@ -147,7 +147,7 @@ def handle_optional_params(param_fields: List[inspect.Parameter], params_schema:
     for param in optional_params:
         param_dict = params_schema["properties"][param.name]
         type_ = param_dict.pop("type", None)
-        if type_:
+        if type_ is not None:
             if "items" in param_dict:
                 items = param_dict.pop("items")
                 param_dict["anyOf"] = [{"type": type_, "items": items}, {"type": "null"}]
@@ -155,7 +155,8 @@ def handle_optional_params(param_fields: List[inspect.Parameter], params_schema:
                 param_dict["anyOf"] = [{"type": type_}, {"type": "null"}]
         else:
             anyof_list = param_dict.pop("anyOf", None)
-            if anyof_list:
+            if anyof_list is not None:
+                anyof_list = list(sorted(anyof_list, key=lambda x: x["type"]))
                 anyof_list.append({"type": "null"})
                 param_dict["anyOf"] = anyof_list
     return params_schema


### PR DESCRIPTION
### Related Issues
- Json schema ordering

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Used the `sort_keys=True` option in the `json.dump` function to order the keys
- Ordered the `anyof_list` which was causing the order of the `"type": "boolean"` and `"type": "string"` to switch depending on which system the schema generation was run

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Got it to pass the CI schema validation

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
