### PR TITLE
docs: Extend utils API docs coverage

### DIFF
--- a/docs/_src/api/pydoc/utils.yml
+++ b/docs/_src/api/pydoc/utils.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../../haystack/utils]
-    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'early_stopping']
+    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'early_stopping', 'cleaning', 'context_matching', 'deepsetcloud', 'docker', 'early_stopping']
     ignore_when_discovered: ['__init__']
 processors:
   - type: filter

--- a/docs/_src/api/pydoc/utils.yml
+++ b/docs/_src/api/pydoc/utils.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../../haystack/utils]
-    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'early_stopping', 'cleaning', 'context_matching', 'deepsetcloud', 'docker', 'early_stopping']
+    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'early_stopping', 'cleaning', 'context_matching', 'deepsetcloud', 'docker']
     ignore_when_discovered: ['__init__']
 processors:
   - type: filter

--- a/haystack/utils/doc_store.py
+++ b/haystack/utils/doc_store.py
@@ -16,7 +16,9 @@ WEAVIATE_CONTAINER_NAME = "weaviate"
 
 
 def launch_es(sleep=15, delete_existing=False):
-    # Start an Elasticsearch server via Docker
+    """
+    Start an Elasticsearch server via Docker.
+    """
 
     logger.debug("Starting Elasticsearch ...")
     if delete_existing:
@@ -37,8 +39,9 @@ def launch_es(sleep=15, delete_existing=False):
 
 
 def launch_opensearch(sleep=15, delete_existing=False):
-    # Start an OpenSearch server via docker
-
+    """
+    Start an OpenSearch server via Docker.
+    """
     logger.debug("Starting OpenSearch...")
     # This line is needed since it is not possible to start a new docker container with the name opensearch if there is a stopped image with the same now
     # docker rm only succeeds if the container is stopped, not if it is running
@@ -60,7 +63,9 @@ def launch_opensearch(sleep=15, delete_existing=False):
 
 
 def launch_weaviate(sleep=15):
-    # Start a Weaviate server via Docker
+    """
+    Start a Weaviate server via Docker.
+    """
 
     logger.debug("Starting Weaviate ...")
     status = subprocess.run(
@@ -121,8 +126,9 @@ def stop_service(document_store, delete_container=False):
 
 
 def launch_milvus(sleep=15, delete_existing=False):
-    # Start a Milvus server via docker
-
+    """
+    Start a Milvus server via docker
+    """
     logger.debug("Starting Milvus ...")
 
     milvus_dir = Path.home() / "milvus"
@@ -146,7 +152,9 @@ def launch_milvus(sleep=15, delete_existing=False):
 
 
 def launch_milvus1(sleep=15):
-    # Start a Milvus (version <2.0.0) server via docker
+    """
+    Start a Milvus (version <2.0.0) server via docker
+    """
 
     logger.debug("Starting Milvus ...")
     logger.warning(

--- a/haystack/utils/doc_store.py
+++ b/haystack/utils/doc_store.py
@@ -127,7 +127,7 @@ def stop_service(document_store, delete_container=False):
 
 def launch_milvus(sleep=15, delete_existing=False):
     """
-    Start a Milvus server via docker
+    Start a Milvus server via Docker
     """
     logger.debug("Starting Milvus ...")
 
@@ -153,7 +153,7 @@ def launch_milvus(sleep=15, delete_existing=False):
 
 def launch_milvus1(sleep=15):
     """
-    Start a Milvus (version <2.0.0) server via docker
+    Start a Milvus (version <2.0.0) server via Docker
     """
 
     logger.debug("Starting Milvus ...")


### PR DESCRIPTION
### Proposed Changes:
- format function docstrings so that they get generated by pydoc markdown (specifically the doc_store util functions)
- increase the number of util modules for which docstrings are being generated

### How did you test it?
- generated api docs locally

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
