### PR TITLE
docs: Add comment about the generation of no-answer samples in FARMReader training

### DIFF
--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -377,6 +377,9 @@ class FARMReader(BaseReader):
         Checkpoints can be stored via setting `checkpoint_every` to a custom number of steps.
         If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
 
+        Note that when performing training with this function, long documents are split into chunks.
+        If a chunk does not contain the answer the question, it is treated as a no-answer sample.
+
         :param data_dir: Path to directory containing your training data in SQuAD style
         :param train_filename: Filename of training data
         :param dev_filename: Filename of dev / eval data

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -378,7 +378,7 @@ class FARMReader(BaseReader):
         If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
 
         Note that when performing training with this function, long documents are split into chunks.
-        If a chunk does not contain the answer to the question, it is treated as a no-answer sample.
+        If a chunk doesn't contain the answer to the question, it is treated as a no-answer sample.
 
         :param data_dir: Path to directory containing your training data in SQuAD style
         :param train_filename: Filename of training data

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -378,7 +378,7 @@ class FARMReader(BaseReader):
         If any checkpoints are stored, a subsequent run of train() will resume training from the latest available checkpoint.
 
         Note that when performing training with this function, long documents are split into chunks.
-        If a chunk does not contain the answer the question, it is treated as a no-answer sample.
+        If a chunk doesn't contain the answer the question, it is treated as a no-answer sample.
 
         :param data_dir: Path to directory containing your training data in SQuAD style
         :param train_filename: Filename of training data


### PR DESCRIPTION
### Related Issues
- #2771 

### Proposed Changes:
- Add comment to explain that no-answer samples are generated by the FARMReader during training if the passage is long

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title

