### PR TITLE
fix: Update env variable for model caching timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -682,7 +682,7 @@ jobs:
         path: ~/.cache/huggingface/transformers/
         key: hf-models
       env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MIN: 15
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 15
 
     - name: Download models
       if: steps.cache-hf-models.outputs.cache-hit != 'true'


### PR DESCRIPTION
The environment variable used to set the timeout for the model caching step had a typo in it from the maintainers of `actions/cache@v3`, which is why it has not been working (see comment [here](https://github.com/actions/cache/issues/810#issuecomment-1281895575)).

### Related Issues
- related to #3146

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Fix the typo in the variable name.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
No easy way to test. We need to wait for a scenario where the timeout will kick in during the CI

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
