### PR TITLE
[release process] Create new schema when bumping unstable

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -38,7 +38,9 @@ jobs:
           cat VERSION.txt
           pip install --upgrade pip
           pip install .[all]
+          pip install ./ui
           python .github/utils/generate_json_schema.py
+          python .github/utils/generate_openapi_specs.py
           git checkout -b bump-version
           git add .
           git commit -m "Update unstable version and schema"

--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -11,46 +11,39 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pydoc-markdown==4.5.1
+      - name: Setup Python
+        uses: ./.github/actions/python_cache/
 
       - name: Define all versions
         id: versions
         shell: bash
         # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
         run: |
-          git fetch
-          git checkout main
           echo "::set-output name=current_release_minor::$(cat VERSION.txt | cut -d "." -f 1,2)"
 
       - name: Create new version branch
         run: |
-          git checkout -b v${{ steps.versions.outputs.current_release_minor }}.x
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b v${{ steps.versions.outputs.current_release_minor }}.x
           git push -u origin v${{ steps.versions.outputs.current_release_minor }}.x
 
       - name: Bump version on main
-        id: bump-version
+        shell: bash
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch
           git checkout main
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git pull
           cat VERSION.txt | awk -F. '/[0-9]+\./{$2++;print}' OFS=. | tee VERSION.txt
           cat VERSION.txt
+          pip install --upgrade pip
+          pip install .[all]
+          python .github/utils/generate_json_schema.py
           git checkout -b bump-version
-          git add ./VERSION.txt
-          git commit -m "Bump version"
+          git add .
+          git commit -m "Update unstable version and schema"
           git push -u origin bump-version
+          gh pr create -B main -H bump-version --title 'Bump unstable version' --body 'Part of the release process' --label 'ignore-for-release-notes'
 
       # Note that patch versions all sync to the one readme minor version
       # e.g. Haystack 1.9.1 and 1.9.2 both map to Readme 1.9
@@ -68,8 +61,3 @@ jobs:
           git add .
           git commit -m "Update API docs headers and readme_api_sync.yml to sync to new version"
           git push
-
-      - name: Create Pull Request
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr create -B main -H bump-version --title 'Bump unstable version' --body 'Created by Github action'

--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -38,12 +38,11 @@ jobs:
           cat VERSION.txt
           pip install --upgrade pip
           pip install .[all]
-          pip install ./ui
-          python .github/utils/generate_json_schema.py
+          pip install ./rest_api
           python .github/utils/generate_openapi_specs.py
           git checkout -b bump-version
           git add .
-          git commit -m "Update unstable version and schema"
+          git commit -m "Update unstable version and openapi schema"
           git push -u origin bump-version
           gh pr create -B main -H bump-version --title 'Bump unstable version' --body 'Part of the release process' --label 'ignore-for-release-notes'
 


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Simplified a bit the workflow
- Install Haystack[all] and generate the new schema
- Add the schema to the PR that bumps the unstable version on `main`

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Couldn't test it yet as the current release is in progress

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
