### PR TITLE
Fix: update pyworld pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,8 @@ docstores-gpu = [
   "farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]",
 ]
 audio = [
-  "pyworld<=0.2.12",
+  "pyworld>=0.3.1; python_version >= '3.8'",
+  "pyworld<0.3.1; python_version < '3.8'",
   "espnet",
   "espnet-model-zoo",
   "pydub",


### PR DESCRIPTION
### Related Issues
- fixes #2931

### Proposed Changes:
As deeply discussed in the issue, for compatibility with different python versions,
I apply this pin in pyproject:
```toml
audio = [
  "pyworld>=0.3.1; python_version >= '3.8'",
  "pyworld<0.3.1; python_version < '3.8'",
```

### How did you test it?
Manual verification with different python versions

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
