### PR TITLE
Bug: Fix prompt length computation

### DIFF
--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -174,7 +174,8 @@ class OpenAIAnswerGenerator(BaseGenerator):
 
         n_instruction_tokens = len(self._tokenizer.encode(instruction + qa_prompt + "===\nContext: \n===\n"))
         n_docs_tokens = [len(self._tokenizer.encode(doc.content)) for doc in documents]
-        leftover_token_len = self.MAX_TOKENS_LIMIT - n_instruction_tokens
+        # for length restrictions of prompt see: https://beta.openai.com/docs/api-reference/completions/create#completions/create-max_tokens
+        leftover_token_len = self.MAX_TOKENS_LIMIT - n_instruction_tokens - self.max_tokens
 
         # Add as many Documents as context as fit into the model
         input_docs = []


### PR DESCRIPTION
### Problem
The current prompt for the Answergenerator can exceed the allowed length. The prompt needs to account for the number of generated tokens as well since "The token count of your prompt **plus max_tokens** cannot exceed the model's context length.".

### Proposed Changes:
Subtract max_tokens from leftover_token_len


### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
