### PR TITLE
fix: warning if doc store similarity function is incompatible with Sentence Transformers model

### DIFF
--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -17,6 +17,7 @@ from haystack.errors import OpenAIError, OpenAIRateLimitError
 from haystack.modeling.data_handler.dataloader import NamedDataLoader
 from haystack.modeling.data_handler.dataset import convert_features_to_dataset, flatten_rename
 from haystack.modeling.infer import Inferencer
+from haystack.nodes import retriever
 from haystack.nodes.retriever._losses import _TRAINING_LOSSES
 from haystack.schema import Document
 from haystack.utils.reflection import retry_with_exponential_backoff
@@ -89,6 +90,33 @@ class _BaseEmbeddingEncoder:
         """
         pass
 
+    def _check_docstore_similarity_function(self, retriever: "EmbeddingRetriever"):
+        """
+        Check that document_store uses a similarity function
+        compatible with the embedding model
+        """
+        docstore_similarity = retriever.document_store.similarity
+        model_name = retriever.embedding_model
+
+        if "sentence-transformers" in model_name.lower():
+            model_similarity = None
+            if "-cos-" in model_name.lower():
+                model_similarity = "cosine"
+            elif "-dot-" in model_name.lower():
+                model_similarity = "dot_product"
+
+            if model_similarity is not None and docstore_similarity != model_similarity:
+                logger.warning(
+                    f"You seem to be using {model_name} model with the {docstore_similarity} function instead of the recommended {model_similarity}. "
+                    f"This can be set when initializing the DocumentStore"
+                )
+        elif "dpr" in model_name.lower() and docstore_similarity != "dot_product":
+            logger.warning(
+                f"You seem to be using a DPR model with the {docstore_similarity} function. "
+                f"We recommend using dot_product instead. "
+                f"This can be set when initializing the DocumentStore"
+            )
+
 
 class _DefaultEmbeddingEncoder(_BaseEmbeddingEncoder):
     def __init__(self, retriever: "EmbeddingRetriever"):
@@ -105,21 +133,7 @@ class _DefaultEmbeddingEncoder(_BaseEmbeddingEncoder):
             num_processes=0,
             use_auth_token=retriever.use_auth_token,
         )
-        # Check that document_store has the right similarity function
-        similarity = retriever.document_store.similarity
-        # If we are using a sentence transformer model
-        if "sentence" in retriever.embedding_model.lower() and similarity != "cosine":
-            logger.warning(
-                f"You seem to be using a Sentence Transformer with the {similarity} function. "
-                f"We recommend using cosine instead. "
-                f"This can be set when initializing the DocumentStore"
-            )
-        elif "dpr" in retriever.embedding_model.lower() and similarity != "dot_product":
-            logger.warning(
-                f"You seem to be using a DPR model with the {similarity} function. "
-                f"We recommend using dot_product instead. "
-                f"This can be set when initializing the DocumentStore"
-            )
+        self._check_docstore_similarity_function(retriever)
 
     def embed(self, texts: Union[List[List[str]], List[str], str]) -> np.ndarray:
         # TODO: FARM's `sample_to_features_text` need to fix following warning -
@@ -182,13 +196,7 @@ class _SentenceTransformersEmbeddingEncoder(_BaseEmbeddingEncoder):
         self.batch_size = retriever.batch_size
         self.embedding_model.max_seq_length = retriever.max_seq_len
         self.show_progress_bar = retriever.progress_bar
-        document_store = retriever.document_store
-        if document_store.similarity != "cosine":
-            logger.warning(
-                f"You are using a Sentence Transformer with the {document_store.similarity} function. "
-                f"We recommend using cosine instead. "
-                f"This can be set when initializing the DocumentStore"
-            )
+        self._check_docstore_similarity_function(retriever)
 
     def embed(self, texts: Union[List[List[str]], List[str], str]) -> np.ndarray:
         # texts can be a list of strings or a list of [title, text]

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -17,7 +17,6 @@ from haystack.errors import OpenAIError, OpenAIRateLimitError
 from haystack.modeling.data_handler.dataloader import NamedDataLoader
 from haystack.modeling.data_handler.dataset import convert_features_to_dataset, flatten_rename
 from haystack.modeling.infer import Inferencer
-from haystack.nodes import retriever
 from haystack.nodes.retriever._losses import _TRAINING_LOSSES
 from haystack.schema import Document
 from haystack.utils.reflection import retry_with_exponential_backoff


### PR DESCRIPTION
### Related Issues
- fixes #3436 

### Proposed Changes:
Check that Document store uses a similarity function compatible with the Sentence Transformers embedding model
(we can deduce it from the model name).
If the similarity function is incompatible, show a warning.

### How did you test it?
Some manual tests

### Notes for the reviewer
The topic of the Sentence Transformers nomenclature is a bit tricky.
So, if there is "-cos-" in the model name, we can undoubtedly say that the model is compatible with the cosine similarity, but it might also be compatible with the dot_product.
The solution I propose seems to me to be a good compromise, while the current warning is misleading.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
