### PR TITLE
fix: disabling telemetry prevents writing config

### DIFF
--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -221,7 +221,7 @@ def _get_or_create_user_id() -> str:
             _write_telemetry_config()
         else:
             # no user_id was previously set and a new one cannot be store because telemetry is disabled
-            return ""
+            return None
     return user_id
 
 

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -151,7 +151,8 @@ def send_custom_event(event: str = "", payload: Dict[str, Any] = {}):
             """
             event_properties = {**(NonPrivateParameters.apply_filter(payload)), **get_or_create_env_meta_data()}
             if user_id is None:
-                raise RuntimeError("User id was not initialized")
+                # do not send any events if user_id is not set because telemetry is disabled from the start
+                return
             try:
                 posthog.capture(distinct_id=user_id, event=event, properties=event_properties)
             except Exception as e:

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -219,6 +219,9 @@ def _get_or_create_user_id() -> str:
             # if user_id cannot be read from config file, create new user_id and write it to config file
             user_id = str(uuid.uuid4())
             _write_telemetry_config()
+        else:
+            # no user_id was previously set and a new one cannot be store because telemetry is disabled
+            return ""
     return user_id
 
 

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -215,7 +215,7 @@ def _get_or_create_user_id() -> str:
     if user_id is None:
         # if user_id is not set, read it from config file
         _read_telemetry_config()
-        if user_id is None:
+        if user_id is None and is_telemetry_enabled():
             # if user_id cannot be read from config file, create new user_id and write it to config file
             user_id = str(uuid.uuid4())
             _write_telemetry_config()

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -151,8 +151,7 @@ def send_custom_event(event: str = "", payload: Dict[str, Any] = {}):
             """
             event_properties = {**(NonPrivateParameters.apply_filter(payload)), **get_or_create_env_meta_data()}
             if user_id is None:
-                # do not send any events if user_id is not set because telemetry is disabled from the start
-                return
+                raise RuntimeError("User id was not initialized")
             try:
                 posthog.capture(distinct_id=user_id, event=event, properties=event_properties)
             except Exception as e:

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -207,9 +207,10 @@ def send_tutorial_event(url: str):
     send_custom_event(event=f"tutorial {dataset_url_to_tutorial.get(url, '?')} executed")
 
 
-def _get_or_create_user_id() -> str:
+def _get_or_create_user_id() -> Optional[str]:
     """
     Randomly generates a user id or loads the id defined in the config file and returns it.
+    Returns None if no id has been set previously and a new one cannot be stored because telemetry is disabled
     """
     global user_id  # pylint: disable=global-statement
     if user_id is None:
@@ -219,9 +220,6 @@ def _get_or_create_user_id() -> str:
             # if user_id cannot be read from config file, create new user_id and write it to config file
             user_id = str(uuid.uuid4())
             _write_telemetry_config()
-        else:
-            # no user_id was previously set and a new one cannot be store because telemetry is disabled
-            return None
     return user_id
 
 


### PR DESCRIPTION
### Related Issues
- fixes #3439 

### Proposed Changes:
This PR adds a check before writing the telemetry config file. If telemetry is disabled, this file is not written. As a consequence no event will be sent (not even a file event that telemetry is turned off).

Previously, if no config file existed and telemetry was disabled via an environment variable, it could happen that a new user id was generated and stored in a config file. As a consequence a final event was sent, which causes the error 
```
ERROR:posthog:error uploading: HTTPSConnectionPool(host='tm.hs.deepset.ai', port=443): Max retries exceeded with url: /batch/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f07b4173c70>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution'))
```
if there is no internet connection.

### How did you test it?
locally by running:
```
rm ~/.haystack/config.yaml
export HAYSTACK_TELEMETRY_ENABLED=False
python
from haystack.document_stores import InMemoryDocumentStore
document_store = InMemoryDocumentStore()
```
### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
