### PR TITLE
docs: Change slug and title of utils API pydoc

### DIFF
--- a/docs/_src/api/pydoc/utils.yml
+++ b/docs/_src/api/pydoc/utils.yml
@@ -15,8 +15,8 @@ renderer:
    type: renderers.ReadmeRenderer
    excerpt: Utility functions for Haystack.
    category: 6310ca73c622850ddd3875a2
-   title: Translator API
-   slug: translator-api
+   title: Utils API
+   slug: utils-api
    order: 200
    markdown:
      descriptive_class_title: false


### PR DESCRIPTION
### Proposed Changes:
- Fixes wrong title and slug of Utils API page

### Notes for the reviewer
- This should also be applied to v1.10.x
