### PR TITLE
fix: do not reference package directory in `PDFToTextOCRConverter.convert()`

### DIFF
--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -1,6 +1,5 @@
 from typing import List, Optional, Dict, Any
 
-import os
 import logging
 import tempfile
 import subprocess

--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -251,8 +251,12 @@ class PDFToTextOCRConverter(BaseConverter):
         pages = []
         try:
             images = convert_from_path(file_path)
+            logger.error("##########################################################", images)
             for image in images:
-                temp_img = tempfile.NamedTemporaryFile(dir=os.path.dirname(os.path.realpath(__file__)), suffix=".jpeg")
+                temp_img = tempfile.NamedTemporaryFile(suffix=".jpeg")
+
+                logger.error("##########################################################", temp_img)
+
                 image.save(temp_img.name)
                 pages.append(self.image_2_text.convert(file_path=temp_img.name)[0].content)
         except Exception as exception:

--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -251,12 +251,8 @@ class PDFToTextOCRConverter(BaseConverter):
         pages = []
         try:
             images = convert_from_path(file_path)
-            logger.error("##########################################################", images)
             for image in images:
                 temp_img = tempfile.NamedTemporaryFile(suffix=".jpeg")
-
-                logger.error("##########################################################", temp_img)
-
                 image.save(temp_img.name)
                 pages.append(self.image_2_text.convert(file_path=temp_img.name)[0].content)
         except Exception as exception:


### PR DESCRIPTION
### Related Issues
- fixes #3477

### Proposed Changes:
- Remove path referencing the package folder from https://github.com/deepset-ai/haystack/blob/5ca96357ff526bf11aefa7fe4aa24fd11135cd0c/haystack/nodes/file_converter/pdf.py#L255
- This path causes issues if the package folder is not writable (non editable installs with Conda on Windows, just to name an example)

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- ~I documented my code~
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
