### PR TITLE
feat: add Schemas badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
     <a href="https://github.com/deepset-ai/haystack/actions/workflows/tests.yml">
         <img alt="Tests" src="https://github.com/deepset-ai/haystack/workflows/Tests/badge.svg?branch=main">
     </a>
+    <a href="https://github.com/deepset-ai/haystack-json-schema/actions/workflows/schemas.yml">
+        <img alt="Schemas" src="https://github.com/deepset-ai/haystack-json-schema/actions/workflows/schemas.yml/badge.svg">
+    </a>
     <a href="https://haystack.deepset.ai/overview/intro">
         <img alt="Documentation" src="https://img.shields.io/website/http/haystack.deepset.ai/docs/intromd.svg?down_color=red&down_message=offline&up_message=online">
     </a>


### PR DESCRIPTION
### Related Issues
- related to https://github.com/deepset-ai/haystack/issues/3479

### Proposed Changes:
- Add badge for the schema files generation in https://github.com/deepset-ai/haystack-json-schema to `README.md`

### How did you test it?
- Preview

### Notes for the reviewer
- We should also connect it to the Slack bot
