### PR TITLE
telemetry changes for tutorial 19

### DIFF
--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -203,6 +203,7 @@ def send_tutorial_event(url: str):
         # "https://nlp.stanford.edu/data/glove.6B.zip": "16",
         "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/preprocessing_tutorial16.zip": "16",
         "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/wiki_gameofthrones_txt17.zip": "17",
+        "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/spirit-animals.zip": "19",
     }
     send_custom_event(event=f"tutorial {dataset_url_to_tutorial.get(url, '?')} executed")
 


### PR DESCRIPTION
### Related Issues
- fixes #3428 

### Proposed Changes:
Added s3 link of the dataset used tutorial 19.

This PR can be merged even before the tutorial PR as it just tracks the download of the zip from S3.

### How did you test it?
Haven't tested yet.

### Notes for the reviewer
Full tutorial at https://github.com/deepset-ai/haystack-tutorials/pull/52

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
