### PR TITLE
fix: generate docs for `search_engine.py`

### DIFF
--- a/docs/_src/api/pydoc/document-store.yml
+++ b/docs/_src/api/pydoc/document-store.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../../haystack/document_stores]
-    modules: ['base', 'elasticsearch', 'opensearch', 'memory', 'sql', 'faiss', 'milvus1', 'milvus2', 'weaviate', 'graphdb', 'deepsetcloud', 'pinecone', 'utils']
+    modules: ['base', 'elasticsearch', 'opensearch', 'memory', 'sql', 'faiss', 'milvus1', 'milvus2', 'weaviate', 'graphdb', 'deepsetcloud', 'pinecone', 'search_engine', 'utils']
     ignore_when_discovered: ['__init__']
 processors:
   - type: filter


### PR DESCRIPTION
### Related Issues
n/a

### Proposed Changes:
- Add docs for `search_engine.py` This class documents many methods used by Elasticsearch and similar docstores.

### How did you test it?
n/a

### Notes for the reviewer
- This is a patch on the fact that such method are not present in the document store classes themselves anymore.
- This is not a complete fix as they are still not very visible as ES methods. Better suggestions welcome.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- ~I documented my code~
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
