### PR TITLE
docs: Fix link directing to tutorials in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can find out more about our PyPi package on our [PyPi page](https://pypi.org
 
 Follow our [introductory tutorial](https://haystack.deepset.ai/tutorials/first-qa-system)
 to setup a question answering system using Python and start performing queries!
-Explore [the rest of our tutorials](https:/haystack.deepset.ai/tutorials)
+Explore [the rest of our tutorials](https://haystack.deepset.ai/tutorials)
 to learn how to tweak pipelines, train models and perform evaluation.
 
 ## :beginner: Quick Demo


### PR DESCRIPTION
### Related Issues
- no related issue

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR fixes the link directing to our tutorials.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manual test.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
