### PR TITLE
feat: add SQLDocumentStore tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,7 @@ jobs:
         uses: ./.github/actions/python_cache/
 
       - name: Install Haystack
-        run: pip install -U .[docstores]
+        run: pip install -U .[sql]
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,8 +141,6 @@ jobs:
           ES_JAVA_OPTS: "-Xms128m -Xmx256m"
         ports:
           - 9200:9200
-    # env:
-    #   ELASTICSEARCH_HOST: "elasticsearch"
     steps:
       - uses: actions/checkout@v3
 
@@ -155,6 +153,34 @@ jobs:
       - name: Run tests
         run: |
           pytest -x -m "document_store and integration" test/document_stores/test_elasticsearch.py
+
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          channel: '#haystack'
+        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+
+  integration-tests-sql:
+    name: Integration / SQL / ${{ matrix.os }}
+    needs:
+     - unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest,macos-latest,windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: ./.github/actions/python_cache/
+
+      - name: Install Haystack
+        run: pip install -U .[docstores]
+
+      - name: Run tests
+        run: |
+          pytest -x -m "document_store and integration" test/document_stores/test_sql.py
 
       - uses: act10ns/slack@v1
         with:
@@ -179,8 +205,6 @@ jobs:
           ES_JAVA_OPTS: "-Xms128m -Xmx256m"
         ports:
           - 9200:9200
-    # env:
-    #   OPENSEARCH_HOST: "opensearch"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -x -m "document_store and integration" test/document_stores/test_elasticsearch.py
+          pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_elasticsearch.py
 
       - uses: act10ns/slack@v1
         with:
@@ -180,7 +180,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -x -m "document_store and integration" test/document_stores/test_sql.py
+          pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_sql.py
 
       - uses: act10ns/slack@v1
         with:
@@ -216,7 +216,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -x -m "document_store and integration" test/document_stores/test_opensearch.py
+          pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_opensearch.py
 
       - uses: act10ns/slack@v1
         with:

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -596,7 +596,7 @@ class SQLDocumentStore(BaseDocumentStore):
 
         label = Label(
             query=row.query,
-            answer=answer,  # type: ignore
+            answer=answer,
             document=Document.from_json(row.document),
             is_correct_answer=row.is_correct_answer,
             is_correct_document=row.is_correct_document,

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -460,16 +460,30 @@ class SQLDocumentStore(BaseDocumentStore):
             # self.write_documents(documents=[label.document], index=index, duplicate_documents="skip")
 
             # TODO: Handle label meta data
+
+            # Sanitize fields to adhere to SQL constraints
+            answer = label.answer
+            if answer is not None:
+                answer = answer.to_json()
+
+            no_answer = label.no_answer
+            if label.no_answer is None:
+                no_answer = False
+
+            document = label.document
+            if document is not None:
+                document = document.to_json()
+
             label_orm = LabelORM(
                 id=label.id,
-                no_answer=label.no_answer,
+                no_answer=no_answer,
                 # document_id=label.document.id,
-                document=label.document.to_json(),
+                document=document,
                 origin=label.origin,
                 query=label.query,
                 is_correct_answer=label.is_correct_answer,
                 is_correct_document=label.is_correct_document,
-                answer=label.answer.to_json(),
+                answer=answer,
                 pipeline_id=label.pipeline_id,
                 index=index,
             )
@@ -576,11 +590,13 @@ class SQLDocumentStore(BaseDocumentStore):
         return document
 
     def _convert_sql_row_to_label(self, row) -> Label:
-        # doc = self._convert_sql_row_to_document(row.document)
+        answer = row.answer
+        if answer is not None:
+            answer = Answer.from_json(answer)
 
         label = Label(
             query=row.query,
-            answer=Answer.from_json(row.answer),  # type: ignore
+            answer=answer,  # type: ignore
             document=Document.from_json(row.document),
             is_correct_answer=row.is_correct_answer,
             is_correct_document=row.is_correct_document,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1013,10 +1013,7 @@ def get_document_store(
     recreate_index: bool = True,
 ):  # cosine is default similarity as dot product is not supported by Weaviate
     document_store: BaseDocumentStore
-    if document_store_type == "sql":
-        document_store = SQLDocumentStore(url=get_sql_url(tmp_path), index=index, isolation_level="AUTOCOMMIT")
-
-    elif document_store_type == "memory":
+    if document_store_type == "memory":
         document_store = InMemoryDocumentStore(
             return_embedding=True,
             embedding_dim=embedding_dim,

--- a/test/document_stores/test_base.py
+++ b/test/document_stores/test_base.py
@@ -251,6 +251,7 @@ class DocumentStoreBaseTestAbstract:
         """
         Test nested logical operations within "$not", important as we apply De Morgan's laws in WeaviateDocumentstore
         """
+        ds.write_documents(documents)
         filters = {
             "$not": {
                 "$or": {

--- a/test/document_stores/test_base.py
+++ b/test/document_stores/test_base.py
@@ -70,8 +70,8 @@ class DocumentStoreBaseTestAbstract:
         ds.write_documents(documents)
         docs = ds.get_all_documents()
         assert len(docs) == len(documents)
-        ids = set(doc.id for doc in documents)
-        expected_ids = set(doc.id for doc in docs)
+        expected_ids = set(doc.id for doc in documents)
+        ids = set(doc.id for doc in docs)
         assert ids == expected_ids
 
     @pytest.mark.integration

--- a/test/document_stores/test_sql.py
+++ b/test/document_stores/test_sql.py
@@ -1,6 +1,7 @@
 import pytest
 
 from haystack.document_stores.sql import SQLDocumentStore
+from haystack.schema import Document
 
 from .test_base import DocumentStoreBaseTestAbstract
 
@@ -22,6 +23,44 @@ class TestSQLDocumentStore(DocumentStoreBaseTestAbstract):
         assert ds.get_document_count(index="custom_index") == len(documents)
         ds.delete_index(index="custom_index")
         assert ds.get_document_count(index="custom_index") == 0
+
+    @pytest.mark.integration
+    def test_sql_write_document_invalid_meta(self, ds):
+        documents = [
+            {
+                "content": "dict_with_invalid_meta",
+                "valid_meta_field": "test1",
+                "invalid_meta_field": [1, 2, 3],
+                "name": "filename1",
+                "id": "1",
+            },
+            Document(
+                content="document_object_with_invalid_meta",
+                meta={"valid_meta_field": "test2", "invalid_meta_field": [1, 2, 3], "name": "filename2"},
+                id="2",
+            ),
+        ]
+        ds.write_documents(documents)
+        documents_in_store = ds.get_all_documents()
+        assert len(documents_in_store) == 2
+        assert ds.get_document_by_id("1").meta == {"name": "filename1", "valid_meta_field": "test1"}
+        assert ds.get_document_by_id("2").meta == {"name": "filename2", "valid_meta_field": "test2"}
+
+    @pytest.mark.integration
+    def test_sql_write_different_documents_same_vector_id(self, ds):
+        doc1 = {"content": "content 1", "name": "doc1", "id": "1", "vector_id": "vector_id"}
+        doc2 = {"content": "content 2", "name": "doc2", "id": "2", "vector_id": "vector_id"}
+
+        ds.write_documents([doc1], index="index1")
+        documents_in_index1 = ds.get_all_documents(index="index1")
+        assert len(documents_in_index1) == 1
+        ds.write_documents([doc2], index="index2")
+        documents_in_index2 = ds.get_all_documents(index="index2")
+        assert len(documents_in_index2) == 1
+
+        ds.write_documents([doc1], index="index3")
+        with pytest.raises(Exception, match=r"(?i)unique"):
+            ds.write_documents([doc2], index="index3")
 
     # NOTE: the SQLDocumentStore behaves differently to the others when filters are applied.
     # While this should be considered a bug, the relative tests are skipped in the meantime

--- a/test/document_stores/test_sql.py
+++ b/test/document_stores/test_sql.py
@@ -1,0 +1,64 @@
+import pytest
+
+from haystack.document_stores.sql import SQLDocumentStore
+
+from .test_base import DocumentStoreBaseTestAbstract
+
+
+class TestSQLDocumentStore(DocumentStoreBaseTestAbstract):
+    # Constants
+
+    index_name = __name__
+
+    @pytest.fixture
+    def ds(self, tmp_path):
+        db_url = f"sqlite:///{tmp_path}/haystack_test.db"
+        return SQLDocumentStore(url=db_url, index=self.index_name, isolation_level="AUTOCOMMIT")
+
+    @pytest.mark.integration
+    def test_delete_index(self, ds, documents):
+        """Contrary to other Document Stores, SQLDocumentStore doesn't raise if the index is empty"""
+        ds.write_documents(documents, index="custom_index")
+        assert ds.get_document_count(index="custom_index") == len(documents)
+        ds.delete_index(index="custom_index")
+        assert ds.get_document_count(index="custom_index") == 0
+
+    # NOTE: the SQLDocumentStore behaves differently to the others when filters are applied.
+    # While this should be considered a bug, the relative tests are skipped in the meantime
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_ne_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nin_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_comparison_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nested_condition_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nested_condition_not_filters(self, ds, documents):
+        pass
+
+    # NOTE: labels metadata are not supported
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_delete_labels_by_filter(self, ds, labels):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_delete_labels_by_filter_id(self, ds, labels):
+        pass


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Run the `DocumentStoreBaseTestAbstract` with `SQLDocumentStore` 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tests are running in the CI

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
The `SQLDocumentStore` is buggy and partially implemented in several parts, so a bunch of the base tests were failing. I have skipped the failing tests in this PR as filling the feature gap would require quite an implementation effort.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
