### PR TITLE
bug: didn't clean up model files after running pytest for test_table_text_retriever_training

### DIFF
--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -442,8 +442,9 @@ def test_table_text_retriever_training(tmp_path, document_store):
     )
 
     # Load trained model
-    retriever = TableTextRetriever.load(load_dir=f"{tmp_path}/test_table_text_retriever_train",
-                                        document_store=document_store)
+    retriever = TableTextRetriever.load(
+        load_dir=f"{tmp_path}/test_table_text_retriever_train", document_store=document_store
+    )
 
 
 @pytest.mark.elasticsearch

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -424,7 +424,7 @@ def test_table_text_retriever_saving_and_loading(tmp_path, retriever, document_s
 
 
 @pytest.mark.embedding_dim(128)
-def test_table_text_retriever_training(document_store):
+def test_table_text_retriever_training(tmp_path, document_store):
     retriever = TableTextRetriever(
         document_store=document_store,
         query_embedding_model="deepset/bert-small-mm_retrieval-question_encoder",
@@ -438,11 +438,12 @@ def test_table_text_retriever_training(document_store):
         train_filename="sample.json",
         n_epochs=1,
         n_gpu=0,
-        save_dir="test_table_text_retriever_train",
+        save_dir=f"{tmp_path}/test_table_text_retriever_train",
     )
 
     # Load trained model
-    retriever = TableTextRetriever.load(load_dir="test_table_text_retriever_train", document_store=document_store)
+    retriever = TableTextRetriever.load(load_dir=f"{tmp_path}/test_table_text_retriever_train",
+                                        document_store=document_store)
 
 
 @pytest.mark.elasticsearch


### PR DESCRIPTION
### Description:
Running the test locally for test_table_text_retriever_training didn't clean up model files after running.

### Proposed Changes:
Added tmp_path to the test function args and used it inside the test for model file creation.

### How did you test it?
re-ran the UT locally to make sure the folder isn't remaining

### Notes for the reviewer
If all the tests pass, it should be safe to merge.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
