### PR TITLE
Use telemetry to identify most common errors

### DIFF
--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -16,7 +16,9 @@ class HaystackError(Exception):
     The messages of errors that might contain user-specific information will not be sent, e.g., DocumentStoreError or OpenAIError.
     """
 
-    def __init__(self, message: Optional[str] = None, docs_link: Optional[str] = None, send_message_in_event: bool =True):
+    def __init__(
+        self, message: Optional[str] = None, docs_link: Optional[str] = None, send_message_in_event: bool = True
+    ):
         payload = {"message": message} if send_message_in_event else {}
         send_custom_event(event=f"{type(self).__name__} raised", payload=payload)
         super().__init__()
@@ -117,7 +119,9 @@ class AudioNodeError(NodeError):
 class OpenAIError(NodeError):
     """Exception for issues that occur in the OpenAI APIs"""
 
-    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event: bool = False):
+    def __init__(
+        self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event: bool = False
+    ):
         super().__init__(message=message, send_message_in_event=send_message_in_event)
         self.status_code = status_code
 
@@ -136,6 +140,8 @@ class OpenAIRateLimitError(OpenAIError):
 class CohereError(NodeError):
     """Exception for issues that occur in the Cohere APIs"""
 
-    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event: bool = False):
+    def __init__(
+        self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event: bool = False
+    ):
         super().__init__(message=message, send_message_in_event=send_message_in_event)
         self.status_code = status_code

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -16,7 +16,7 @@ class HaystackError(Exception):
     The messages of errors that might contain user-specific information will not be sent, e.g., DocumentStoreError or OpenAIError.
     """
 
-    def __init__(self, message: Optional[str] = None, docs_link: Optional[str] = None, send_message_in_event=True):
+    def __init__(self, message: Optional[str] = None, docs_link: Optional[str] = None, send_message_in_event: bool =True):
         payload = {"message": message} if send_message_in_event else {}
         send_custom_event(event=f"{type(self).__name__} raised", payload=payload)
         super().__init__()
@@ -75,7 +75,7 @@ class PipelineConfigError(PipelineError):
 class DocumentStoreError(HaystackError):
     """Exception for issues that occur in a document store"""
 
-    def __init__(self, message: Optional[str] = None, send_message_in_event=False):
+    def __init__(self, message: Optional[str] = None, send_message_in_event: bool = False):
         super().__init__(message=message, send_message_in_event=send_message_in_event)
 
 
@@ -103,8 +103,8 @@ class DuplicateDocumentError(DocumentStoreError, ValueError):
 class NodeError(HaystackError):
     """Exception for issues that occur in a node"""
 
-    def __init__(self, message: Optional[str] = None):
-        super().__init__(message=message)
+    def __init__(self, message: Optional[str] = None, send_message_in_event: bool = True):
+        super().__init__(message=message, send_message_in_event=send_message_in_event)
 
 
 class AudioNodeError(NodeError):
@@ -117,7 +117,7 @@ class AudioNodeError(NodeError):
 class OpenAIError(NodeError):
     """Exception for issues that occur in the OpenAI APIs"""
 
-    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event=False):
+    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event: bool = False):
         super().__init__(message=message, send_message_in_event=send_message_in_event)
         self.status_code = status_code
 
@@ -129,13 +129,13 @@ class OpenAIRateLimitError(OpenAIError):
     See https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits
     """
 
-    def __init__(self, message: Optional[str] = None, send_message_in_event=False):
+    def __init__(self, message: Optional[str] = None, send_message_in_event: bool = False):
         super().__init__(message=message, status_code=429, send_message_in_event=send_message_in_event)
 
 
 class CohereError(NodeError):
     """Exception for issues that occur in the Cohere APIs"""
 
-    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event=False):
+    def __init__(self, message: Optional[str] = None, status_code: Optional[int] = None, send_message_in_event: bool = False):
         super().__init__(message=message, send_message_in_event=send_message_in_event)
         self.status_code = status_code

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -17,7 +17,7 @@ class HaystackError(Exception):
     """
 
     def __init__(self, message: Optional[str] = None, docs_link: Optional[str] = None, send_message_in_event=True):
-        payload = {"message": message} if send_message_in_event else None
+        payload = {"message": message} if send_message_in_event else {}
         send_custom_event(event=f"{type(self).__name__} raised", payload=payload)
         super().__init__()
         if message:

--- a/haystack/errors.py
+++ b/haystack/errors.py
@@ -15,7 +15,7 @@ class HaystackError(Exception):
     """
 
     def __init__(self, message: Optional[str] = None, docs_link: Optional[str] = None):
-        send_custom_event(event=f"{type(self).__name__} raised")
+        send_custom_event(event=f"{type(self).__name__} raised", payload={"message": message})
         super().__init__()
         if message:
             self.message = message

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -294,6 +294,7 @@ class NonPrivateParameters:
         "uptime",
         "run_total",
         "run_total_window",
+        "message",
     ]
 
     @classmethod


### PR DESCRIPTION
### Related Issues
- related to #3309

### Proposed Changes:
Added a message field to all HaystackError(s) raised. If set message property will be visible in telemetry

### How did you test it?
Manual verification, there is no other way.

### Notes for the reviewer
Someone familiar with telemetry needs to review. Otherwise, the context is rather big and requires time to pick up. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
