### PR TITLE
feat: store metadata using JSON in SQLDocumentStore

### DIFF
--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -49,9 +49,12 @@ class ArrayType(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if not isinstance(value, self.valid_metadata_types):
             return json.dumps(value)
-        return value
+        return str(value)
 
     def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+
         try:
             return json.loads(value)
         except json.decoder.JSONDecodeError:
@@ -87,7 +90,7 @@ class MetaDocumentORM(ORMBase):
     __tablename__ = "meta_document"
 
     name = Column(String(100), index=True)
-    value = Column(ArrayType(), index=True)
+    value = Column(ArrayType(100), index=True)
     documents = relationship("DocumentORM", back_populates="meta")
 
     document_id = Column(String(100), nullable=False, index=True)

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -408,29 +408,25 @@ class SQLDocumentStore(BaseDocumentStore):
                 if "classification" in meta_fields:
                     meta_fields = self._flatten_classification_meta_fields(meta_fields)
                 vector_id = meta_fields.pop("vector_id", None)
-                meta_orms = []
-                for key, value in meta_fields.items():
-                    try:
-                        meta_orms.append(MetaDocumentORM(name=key, value=value))
-                    except TypeError as ex:
-                        logger.error("Document %s - %s", doc.id, ex)
-                doc_orm = DocumentORM(
-                    id=doc.id,
-                    content=doc.to_dict()["content"],
-                    content_type=doc.content_type,
-                    vector_id=vector_id,
-                    meta=meta_orms,
-                    index=index,
-                )
+                meta_orms = [MetaDocumentORM(name=key, value=value) for key, value in meta_fields.items()]
+                doc_mapping = {
+                    "id": doc.id,
+                    "content": doc.to_dict()["content"],
+                    "content_type": doc.content_type,
+                    "vector_id": vector_id,
+                    "meta": meta_orms,
+                    "index": index,
+                }
                 if duplicate_documents == "overwrite":
+                    doc_orm = DocumentORM(**doc_mapping)
                     # First old meta data cleaning is required
                     self.session.query(MetaDocumentORM).filter_by(document_id=doc.id).delete()
                     self.session.merge(doc_orm)
                 else:
-                    docs_orm.append(doc_orm)
+                    docs_orm.append(doc_mapping)
 
             if docs_orm:
-                self.session.add_all(docs_orm)
+                self.session.bulk_insert_mappings(DocumentORM, docs_orm)
 
             try:
                 self.session.commit()

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -43,6 +43,7 @@ Base = declarative_base()  # type: Any
 class ArrayType(TypeDecorator):
 
     impl = String
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         return json.dumps(value)


### PR DESCRIPTION
### Related Issues
- fixes #3434

### Proposed Changes:
- Use a JSON marshaller to store metadata values
- Remove the validator so we don't drop unsupported data types anymore
- Emit a warning when passing filters to `query()` as they won't work as expected if metadata have compound data types
 
### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
- I am not sure about the warning on `query()` as it can get verbose, but I also don't want users to have the false perception the `SQLDocumentStore` fully supports lists metadata.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
