### PR TITLE
fix: [rest_api] support TableQA in the endpoint `/documents/get_by_filters`

### DIFF
--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -407,7 +407,7 @@ class Answer:
 
     def __str__(self):
         # self.context might be None (therefore not subscriptable)
-        if not self.context:
+        if self.context is None:
             return f"<Answer: answer='{self.answer}', score={self.score}, context=None>"
         return f"<Answer: answer='{self.answer}', score={self.score}, context='{self.context[:50]}{'...' if len(self.context) > 50 else ''}'>"
 

--- a/rest_api/rest_api/controller/document.py
+++ b/rest_api/rest_api/controller/document.py
@@ -33,9 +33,9 @@ def get_documents(filters: FilterRequest):
     To get all documents you should provide an empty dict, like:
     `'{"filters": {}}'`
     """
-    docs = [doc.to_dict() for doc in document_store.get_all_documents(filters=filters.filters)]
+    docs = document_store.get_all_documents(filters=filters.filters)
     for doc in docs:
-        doc["embedding"] = None
+        doc.embedding = None
     return docs
 
 


### PR DESCRIPTION
### Proposed Changes:
REST API endpoint for search and get_documents does not work for tableQA. Therefore some small changes are needed

### How did you test it?
manually deployed docker and tested

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue

@ZanSara 