### PR TITLE
refactor: Pinecone tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -363,7 +363,7 @@ jobs:
         if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
 
   integration-tests-pinecone:
-    name: Integration / faiss / ${{ matrix.os }}
+    name: Integration / pinecone / ${{ matrix.os }}
     needs:
      - unit-tests
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -324,7 +324,6 @@ jobs:
           channel: '#haystack'
         if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
 
-
   integration-tests-weaviate:
     name: Integration / Weaviate / ${{ matrix.os }}
     needs:
@@ -362,6 +361,37 @@ jobs:
           status: ${{ job.status }}
           channel: '#haystack'
         if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+
+  integration-tests-pinecone:
+    name: Integration / faiss / ${{ matrix.os }}
+    needs:
+     - unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest,macos-latest,windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Python
+      uses: ./.github/actions/python_cache/
+
+    - name: Install Haystack
+      run: pip install .[pinecone]
+
+    - name: Run tests
+      env:
+        PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+      run: |
+        pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_pinecone.py
+
+    - uses: act10ns/slack@v1
+      with:
+        status: ${{ job.status }}
+        channel: '#haystack'
+      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+
 
 #
 # TODO: the following steps need to be revisited
@@ -540,71 +570,7 @@ jobs:
   #       pytest ${{ env.PYTEST_PARAMS }} -m "milvus and not integration" ${{ env.SUITES_EXCLUDED_FROM_WINDOWS }} test/document_stores/ --document_store_type=milvus
 
 
-  pinecone-tests-linux:
-    needs: [mypy, pylint, black]
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'topic:pinecone') || !github.event.pull_request.draft
 
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Setup Python
-      uses: ./.github/actions/python_cache/
-
-      # TODO Let's try to remove this one from the unit tests
-    - name: Install pdftotext
-      run: wget --no-check-certificate https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz && tar -xvf xpdf-tools-linux-4.04.tar.gz && sudo cp xpdf-tools-linux-4.04/bin64/pdftotext /usr/local/bin
-
-    - name: Install Haystack
-      run: pip install .[pinecone]
-
-    - name: Run tests
-      env:
-        PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-        TOKENIZERS_PARALLELISM: 'false'
-      run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "pinecone and not integration" test/document_stores/ --document_store_type=pinecone
-
-    - uses: act10ns/slack@v1
-      with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
-
-  pinecone-tests-windows:
-    needs: [mypy, pylint, black]
-    runs-on: windows-latest
-    if: contains(github.event.pull_request.labels.*.name, 'topic:pinecone') && contains(github.event.pull_request.labels.*.name, 'topic:windows') || !github.event.pull_request.draft
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Setup Python
-      uses: ./.github/actions/python_cache/
-      with:
-        prefix: windows
-
-    - name: Install pdftotext
-      run: |
-        choco install xpdf-utils
-        choco install openjdk11
-        refreshenv
-
-    - name: Install Haystack
-      run: pip install .[pinecone]
-
-    - name: Run tests
-      env:
-        TOKENIZERS_PARALLELISM: 'false'
-        PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-      run: |
-        pytest ${{ env.PYTEST_PARAMS }} -m "pinecone and not integration" ${{ env.SUITES_EXCLUDED_FROM_WINDOWS }} test/document_stores/ --document_store_type=pinecone
-
-    - uses: act10ns/slack@v1
-      with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
 
   rest-and-ui:
     needs: [mypy, pylint, black]

--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--mock-dc", action="store_true", default=True, help="Mock HTTP requests to dC while running tests"
     )
+    parser.addoption(
+        "--mock-pinecone", action="store_true", default=True, help="Mock HTTP requests to Pinecone while running tests"
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -1340,11 +1340,6 @@ class PineconeDocumentStore(BaseDocumentStore):
             meta = {
                 "label-id": label.id,
                 "query": label.query,
-                "label-answer-answer": label.answer.answer,
-                "label-answer-type": label.answer.type,
-                "label-answer-score": label.answer.score,
-                "label-answer-context": label.answer.context,
-                "label-answer-document-id": label.answer.document_id,
                 "label-is-correct-answer": label.is_correct_answer,
                 "label-is-correct-document": label.is_correct_document,
                 "label-document-content": label.document.content,
@@ -1355,19 +1350,31 @@ class PineconeDocumentStore(BaseDocumentStore):
                 "label-updated-at": label.updated_at,
                 "label-pipeline-id": label.pipeline_id,
             }
-            # Get offset data
-            if label.answer.offsets_in_document:
-                meta["label-answer-offsets-in-document-start"] = label.answer.offsets_in_document[0].start
-                meta["label-answer-offsets-in-document-end"] = label.answer.offsets_in_document[0].end
-            else:
-                meta["label-answer-offsets-in-document-start"] = None
-                meta["label-answer-offsets-in-document-end"] = None
-            if label.answer.offsets_in_context:
-                meta["label-answer-offsets-in-context-start"] = label.answer.offsets_in_context[0].start
-                meta["label-answer-offsets-in-context-end"] = label.answer.offsets_in_context[0].end
-            else:
-                meta["label-answer-offsets-in-context-start"] = None
-                meta["label-answer-offsets-in-context-end"] = None
+            # Get Answer data
+            if label.answer is not None:
+                meta.update(
+                    {
+                        "label-answer-answer": label.answer.answer,
+                        "label-answer-type": label.answer.type,
+                        "label-answer-score": label.answer.score,
+                        "label-answer-context": label.answer.context,
+                        "label-answer-document-id": label.answer.document_id,
+                    }
+                )
+                # Get offset data
+                if label.answer.offsets_in_document:
+                    meta["label-answer-offsets-in-document-start"] = label.answer.offsets_in_document[0].start
+                    meta["label-answer-offsets-in-document-end"] = label.answer.offsets_in_document[0].end
+                else:
+                    meta["label-answer-offsets-in-document-start"] = None
+                    meta["label-answer-offsets-in-document-end"] = None
+                if label.answer.offsets_in_context:
+                    meta["label-answer-offsets-in-context-start"] = label.answer.offsets_in_context[0].start
+                    meta["label-answer-offsets-in-context-end"] = label.answer.offsets_in_context[0].end
+                else:
+                    meta["label-answer-offsets-in-context-start"] = None
+                    meta["label-answer-offsets-in-context-end"] = None
+
             metadata[label.id] = meta
         metadata = self._meta_for_pinecone(metadata)
         return metadata
@@ -1391,26 +1398,29 @@ class PineconeDocumentStore(BaseDocumentStore):
             # Extract offsets
             offsets: Dict[str, Optional[List[Span]]] = {"document": None, "context": None}
             for mode in offsets.keys():
-                if label_meta[f"label-answer-offsets-in-{mode}-start"] is not None:
+                if label_meta.get(f"label-answer-offsets-in-{mode}-start") is not None:
                     offsets[mode] = [
                         Span(
                             label_meta[f"label-answer-offsets-in-{mode}-start"],
                             label_meta[f"label-answer-offsets-in-{mode}-end"],
                         )
                     ]
-            # if label_meta["label-answer-answer"] is None:
-            #     label_meta["label-answer-answer"] = ""
-            answer = Answer(
-                answer=label_meta["label-answer-answer"]
-                or "",  # If we leave as None a schema validation error will be thrown
-                type=label_meta["label-answer-type"],
-                score=label_meta["label-answer-score"],
-                context=label_meta["label-answer-context"],
-                offsets_in_document=offsets["document"],
-                offsets_in_context=offsets["context"],
-                document_id=label_meta["label-answer-document-id"],
-                meta=other_meta,
-            )
+            # Extract Answer
+            answer = None
+            if label_meta.get("label-answer-answer") is not None:
+                answer = Answer(
+                    answer=label_meta["label-answer-answer"]
+                    or "",  # If we leave as None a schema validation error will be thrown
+                    type=label_meta["label-answer-type"],
+                    score=label_meta["label-answer-score"],
+                    context=label_meta["label-answer-context"],
+                    offsets_in_document=offsets["document"],
+                    offsets_in_context=offsets["context"],
+                    document_id=label_meta["label-answer-document-id"],
+                    meta=other_meta,
+                )
+
+            # Rebuild Label object
             label = Label(
                 id=label_meta["label-id"],
                 query=label_meta["query"],

--- a/test/document_stores/test_base.py
+++ b/test/document_stores/test_base.py
@@ -318,7 +318,7 @@ class DocumentStoreBaseTestAbstract:
 
         ds.write_documents(updated_docs, duplicate_documents="skip")
         for d in ds.get_all_documents():
-            assert d.meta["name"] != "Updated"
+            assert d.meta.get("name") != "Updated"
 
     @pytest.mark.integration
     def test_duplicate_documents_overwrite(self, ds, documents):

--- a/test/document_stores/test_pinecone.py
+++ b/test/document_stores/test_pinecone.py
@@ -46,12 +46,12 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
         )
 
     @pytest.fixture
-    def doc_store_with_docs(self, doc_store: PineconeDocumentStore, documents: List[Document]) -> PineconeDocumentStore:
+    def doc_store_with_docs(self, ds: PineconeDocumentStore, documents: List[Document]) -> PineconeDocumentStore:
         """
         This fixture provides a pre-populated document store and takes care of cleaning up after each test
         """
-        doc_store.write_documents(documents)
-        return doc_store
+        ds.write_documents(documents)
+        return ds
 
     @pytest.fixture
     def docs_all_formats(self) -> List[Union[Document, Dict[str, Any]]]:
@@ -64,6 +64,8 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
                 "date": "2019-10-01",
                 "numeric_field": 5.0,
                 "odd_document": True,
+                "year": "2021",
+                "month": "02",
             },
             # "dict" format
             {
@@ -74,6 +76,8 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
                     "date": "2020-03-01",
                     "numeric_field": 5.5,
                     "odd_document": False,
+                    "year": "2021",
+                    "month": "02",
                 },
             },
             # Document object
@@ -85,6 +89,8 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
                     "date": "2018-10-01",
                     "numeric_field": 4.5,
                     "odd_document": True,
+                    "year": "2020",
+                    "month": "02",
                 },
             ),
             Document(
@@ -95,6 +101,7 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
                     "date": "2021-02-01",
                     "numeric_field": 3.0,
                     "odd_document": False,
+                    "year": "2020",
                 },
             ),
             Document(
@@ -105,38 +112,100 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
                     "date": "2019-01-01",
                     "numeric_field": 0.0,
                     "odd_document": True,
+                    "year": "2020",
+                },
+            ),
+            Document(
+                content="My name is Adele and I live in London",
+                meta={
+                    "meta_field": "test-5",
+                    "name": "file_5.txt",
+                    "date": "2019-01-01",
+                    "numeric_field": 0.0,
+                    "odd_document": True,
+                    "year": "2021",
                 },
             ),
             # Without meta
             Document(content="My name is Ahmed and I live in Cairo"),
+            Document(content="My name is Bruce and I live in Gotham"),
+            Document(content="My name is Peter and I live in Quahog"),
         ]
 
     @pytest.fixture
     def documents(self, docs_all_formats: List[Union[Document, Dict[str, Any]]]) -> List[Document]:
         return [Document.from_dict(doc) if isinstance(doc, dict) else doc for doc in docs_all_formats]
 
-    # @pytest.fixture
-    # def labels(self, documents):
-    #     """Labels must have an Answer"""
-    #     labels = []
-    #     for i, d in enumerate(documents):
-    #         labels.append(
-    #             Label(
-    #                 query=f"query_{i}",
-    #                 document=d,
-    #                 is_correct_document=True,
-    #                 is_correct_answer=False,
-    #                 # create a mix set of labels
-    #                 origin="user-feedback" if i % 2 else "gold-label",
-    #                 answer=None if not i else Answer(f"the answer is {i}"),
-    #                 meta={"name": f"label_{i}", "year": f"{2020 + i}"},
-    #             )
-    #         )
-    #     return labels
-
     #
     #  Tests
     #
+
+    @pytest.mark.integration
+    def test_ne_filters(self, ds, documents):
+        ds.write_documents(documents)
+
+        result = ds.get_all_documents(filters={"year": {"$ne": "2020"}})
+        assert len(result) == 3
+
+    @pytest.mark.integration
+    def test_get_label_count(self, ds, labels):
+        with pytest.raises(NotImplementedError):
+            ds.get_label_count()
+
+    # NOTE: the SQLDocumentStore behaves differently to the others when filters are applied.
+    # While this should be considered a bug, the relative tests are skipped in the meantime
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_compound_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nin_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_ne_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nin_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_comparison_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nested_condition_filters(self, ds, documents):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_nested_condition_not_filters(self, ds, documents):
+        pass
+
+    # NOTE: labels metadata are not supported
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_delete_labels_by_filter(self, ds, labels):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_delete_labels_by_filter_id(self, ds, labels):
+        pass
+
+    @pytest.mark.skip
+    @pytest.mark.integration
+    def test_simplified_filters(self, ds, documents):
+        pass
 
     # NOTE: Pinecone does not support dates, so it can't do lte or gte on date fields. When a new release introduces this feature,
     # the entire family of test_get_all_documents_extended_filter_* tests will become identical to the one present in the

--- a/test/document_stores/test_pinecone.py
+++ b/test/document_stores/test_pinecone.py
@@ -6,7 +6,7 @@ from inspect import getmembers, isclass, isfunction
 import pytest
 
 from haystack.document_stores.pinecone import PineconeDocumentStore
-from haystack.schema import Document, Label, Answer
+from haystack.schema import Document
 from haystack.errors import FilterError
 
 
@@ -152,7 +152,7 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
         with pytest.raises(NotImplementedError):
             ds.get_label_count()
 
-    # NOTE: the SQLDocumentStore behaves differently to the others when filters are applied.
+    # NOTE: the PineconeDocumentStore behaves differently to the others when filters are applied.
     # While this should be considered a bug, the relative tests are skipped in the meantime
 
     @pytest.mark.skip


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
- Implement Pinecone tests as a subclass of `DocumentStoreBaseTestAbstract`
- Fix Label metadata management: it was ignored before, probably a sign that's not a feature Pinecone users rely on very much, still had to fix it in order for the tests to pass.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
`pytest -m"document_store and integration" test/document_stores/test_pinecone.py`

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
Tests run on Linux, Win and MacOS because the storage is mocked. Mock can be disabled passing `--mock-pinecone=false` so the test suite is still to be considered of kind "integration".

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
