### PR TITLE
CI: install httpx to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -622,8 +622,7 @@ jobs:
 
     - name: Install REST API and UI
       run: |
-        pip install httpx
-        pip install -U rest_api/
+        pip install -U "./rest_api[dev]"
         pip install -U ui/
         pip install .   # -U prevents the schema generation
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -622,6 +622,7 @@ jobs:
 
     - name: Install REST API and UI
       run: |
+        pip install httpx
         pip install -U rest_api/
         pip install -U ui/
         pip install .   # -U prevents the schema generation

--- a/rest_api/pyproject.toml
+++ b/rest_api/pyproject.toml
@@ -35,6 +35,11 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dev = [
+  "httpx"
+]
+
 [project.urls]
 Documentation = "https://github.com/deepset-ai/haystack/tree/main/rest_api#readme"
 Issues = "https://github.com/deepset-ai/haystack/issues"


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/actions?query=workflow:Tests

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Starlette started using `httpx` for their HTTP test client, and this is now required to run the `rest_api` tests.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
