### PR TITLE
fix: Elasticsearch / OpenSearch brownfield function does not incorporate meta

### DIFF
--- a/haystack/document_stores/es_converter.py
+++ b/haystack/document_stores/es_converter.py
@@ -222,25 +222,26 @@ def elasticsearch_index_to_document_store(
         # Get content and metadata of current record
         content = record["_source"].pop(original_content_field, "")
         if content:
-            record_doc = Document(content=content, meta={}, id_hash_keys=id_hash_keys)
-
+            meta = {}
             if original_name_field is not None:
                 if original_name_field in record["_source"]:
-                    record_doc.meta["name"] = record["_source"].pop(original_name_field)
+                    meta["name"] = record["_source"].pop(original_name_field)
             # Only add selected metadata fields
             if included_metadata_fields is not None:
                 for metadata_field in included_metadata_fields:
                     if metadata_field in record["_source"]:
-                        record_doc.meta[metadata_field] = record["_source"][metadata_field]
+                        meta[metadata_field] = record["_source"][metadata_field]
             # Add all metadata fields except for those in excluded_metadata_fields
             else:
                 if excluded_metadata_fields is not None:
                     for metadata_field in excluded_metadata_fields:
                         record["_source"].pop(metadata_field, None)
-                record_doc.meta.update(record["_source"])
+                meta.update(record["_source"])
 
             if store_original_ids:
-                record_doc.meta["_original_es_id"] = record["_id"]
+                meta["_original_es_id"] = record["_id"]
+
+            record_doc = Document(content=content, meta=meta, id_hash_keys=id_hash_keys)
 
             # Apply preprocessor if provided
             preprocessed_docs = [record_doc]

--- a/test/document_stores/test_document_store.py
+++ b/test/document_stores/test_document_store.py
@@ -1279,6 +1279,7 @@ def test_elasticsearch_brownfield_support(document_store_with_docs):
         original_name_field="name",
         included_metadata_fields=["date_field"],
         index="test_brownfield_support",
+        id_hash_keys=["content", "meta"],
     )
 
     original_documents = document_store_with_docs.get_all_documents(index="haystack_test")
@@ -1288,6 +1289,7 @@ def test_elasticsearch_brownfield_support(document_store_with_docs):
     assert all("date_field" in doc.meta for doc in transferred_documents)
     assert all("meta_field" not in doc.meta for doc in transferred_documents)
     assert all("numeric_field" not in doc.meta for doc in transferred_documents)
+    assert all(doc.id == doc._get_id(["content", "meta"]) for doc in transferred_documents)
 
     original_content = set([doc.content for doc in original_documents])
     transferred_content = set([doc.content for doc in transferred_documents])


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/3571

### Proposed Changes:
- fix bug

### How did you test it?
- test adjusted

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
