### PR TITLE
fix: discard metadata fields if not set in Weaviate

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -283,7 +283,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         for k, v in props.items():
             if k in (self.content_field, self.embedding_field):
                 continue
-            if not v:
+            if v is None:
                 continue
             meta_data[k] = v
 

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -279,21 +279,21 @@ class WeaviateDocumentStore(BaseDocumentStore):
             props.pop("_additional", None)
 
         # We put all additional data of the doc into meta_data and return it in the API
-        meta_data = {k: v for k, v in props.items() if k not in (self.content_field, self.embedding_field)}
-
-        if return_embedding and embedding:
-            embedding = np.asarray(embedding, dtype=np.float32)
+        meta_data = {}
+        for k, v in props.items():
+            if k in (self.content_field, self.embedding_field):
+                continue
+            if not v:
+                continue
+            meta_data[k] = v
 
         document = Document.from_dict(
-            {
-                "id": id,
-                "content": content,
-                "content_type": content_type,
-                "meta": meta_data,
-                "score": score,
-                "embedding": embedding,
-            }
+            {"id": id, "content": content, "content_type": content_type, "meta": meta_data, "score": score}
         )
+
+        if return_embedding and embedding:
+            document.embedding = np.asarray(embedding, dtype=np.float32)
+
         return document
 
     def _create_document_field_map(self) -> Dict:

--- a/test/document_stores/test_base.py
+++ b/test/document_stores/test_base.py
@@ -86,8 +86,9 @@ class DocumentStoreBaseTestAbstract:
             Document(content="Doc1", id_hash_keys=["content"], meta={"key1": "value1"}),
         ]
         ds.write_documents(duplicate_documents, duplicate_documents="skip")
-        assert len(ds.get_all_documents()) == 1
-        assert ds.get_all_documents()[0] == duplicate_documents[0]
+        results = ds.get_all_documents()
+        assert len(results) == 1
+        assert results[0] == duplicate_documents[0]
         with pytest.raises(Exception):
             ds.write_documents(duplicate_documents, duplicate_documents="fail")
 

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -28,7 +28,7 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
 
     @pytest.fixture
     def ds(self):
-        return WeaviateDocumentStore(index=self.index_name, recreate_index=True)
+        return WeaviateDocumentStore(index=self.index_name, recreate_index=True, return_embedding=True)
 
     @pytest.fixture(scope="class")
     def documents(self):


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/actions?query=workflow:Tests

Weaviate hardcodes certain metadata fields into its index, in this case `name`. When `name` is not present in the original document, and _only if other metadata is set_, after one full roundtrip write/read you end up having `meta["name"] == None` in the resulting doc.

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Drop the `name` field from `meta` if its value is `None`

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
`pytest -m"document_store and integration" test/document_stores/test_weaviate.py -x -vv`

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
While running the tests, another bug was exposed: the `embedding` field in Document was set regardless of the `return_embeddings` init param - this is fixed now. 

I also noticed the original documents passed to `write_documents` are modified when they don't contain embeddings, which I think it's wrong but I guess that goes for another time.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
