### PR TITLE
fix: Pin faiss-cpu as 1.7.3 seems to have problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ sql = [
   "psycopg2-binary; platform_system != 'Windows'",
 ]
 only-faiss = [
-  "faiss-cpu>=1.6.3,<2",
+  "faiss-cpu>=1.6.3,<=1.7.2",
 ]
 faiss = [
   "farm-haystack[sql,only-faiss]",


### PR DESCRIPTION
### Related Issues
- mitigation of https://github.com/deepset-ai/haystack/issues/3600

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- pin `faiss-cpu` to the latest working version while we investigate why 1.7.3 fails with `https://github.com/deepset-ai/haystack/issues/3600`

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
