### PR TITLE
docs: Improve API docs

### DIFF
--- a/.github/utils/add_import_path_to_api.py
+++ b/.github/utils/add_import_path_to_api.py
@@ -16,7 +16,7 @@ def add_import_path(import_paths):
         with open(os.path.join(markdowns_dir, mdf), "r") as f:
             for l in f:
                 l_new = l
-                if l[:2] == "## ":
+                if l[:3] == "## ":
                     classname = l[3:].strip()
                     if classname in import_paths:
                         l_new = l + "{}".format(import_paths[classname]) + "\n"

--- a/.github/utils/add_import_path_to_api.py
+++ b/.github/utils/add_import_path_to_api.py
@@ -1,0 +1,84 @@
+import haystack
+import inspect
+import os
+
+ROOT = "haystack"
+
+ignore_modules = ["logging", "config", "__config__", "np"]
+markdowns_dir = "docs/_src/api/api/temp"
+
+
+def add_import_path(import_paths):
+    """Add a line under the Class API file with the import path for the class"""
+    markdown_files = [x for x in os.listdir(markdowns_dir) if x[-3:] == ".md"]
+    for mdf in markdown_files:
+        lines_new = []
+        with open(os.path.join(markdowns_dir, mdf), "r") as f:
+            for l in f:
+                l_new = l
+                if l[:2] == "## ":
+                    classname = l[3:].strip()
+                    if classname in import_paths:
+                        l_new = l + "{}".format(import_paths[classname]) + "\n"
+                lines_new.append(l_new)
+        with open(os.path.join(markdowns_dir, mdf), "w") as f:
+            f.writelines(lines_new)
+
+
+def generate_shortest_class_imports(python_package):
+    """Recursively go through all modules and classes in a package and find the shortest import path for each class"""
+    shortest_map = {}
+    curr_path = ROOT
+    members_graph = inspect.getmembers(haystack)
+    depth = 0
+    return generate_shortest_class_imports_recursive(python_package, shortest_map, members_graph, curr_path, depth)
+
+
+def generate_shortest_class_imports_recursive(python_package, shortest_map, members_graph, curr_path, depth):
+    """Recursively go through all modules and classes in a package and find the shortest import path for each class"""
+    if depth > 2:
+        return shortest_map
+    for name, member in members_graph:
+        if inspect.isclass(member):
+            add_shortest_path(curr_path, name, shortest_map)
+        elif inspect.ismodule(member):
+            try:
+                members_graph = inspect.getmembers(member)
+                generate_shortest_class_imports_recursive(
+                    python_package, shortest_map, members_graph, curr_path + "." + name, depth + 1
+                )
+            except:
+                pass
+    return shortest_map
+
+
+def add_shortest_path(curr_path, class_name, shortest_map):
+    """Add the shortest import path for a class to the shortest_map provided it is the shortest path"""
+    if class_name not in shortest_map:
+        shortest_map[class_name] = curr_path + "." + class_name
+    elif len(curr_path.split(".")) < len(shortest_map[class_name].split(".")):
+        shortest_map[class_name] = curr_path + "." + class_name
+
+
+def relevant_class(path):
+    """Returns True if the class is only one level deep in the module (e.g. haystack.Document) or if it is from a relevant submodule."""
+    if len(path.split(".")) == 2:
+        return True
+    elif relevant_module(path):
+        return True
+    return False
+
+
+def relevant_module(path):
+    """Returns True if the path is from a relevant submodule."""
+    relevant_haystack_modules = ["pipelines", "nodes", "utils", "document_stores"]
+    for relevant_module in relevant_haystack_modules:
+        if relevant_module in path:
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    shortest_map = generate_shortest_class_imports(haystack)
+    filter_shortest_map = {k: v for k, v in shortest_map.items() if relevant_class(v)}
+    add_import_path(filter_shortest_map)

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Generate API docs
         run: ./.github/utils/pydoc-markdown.sh
 
+      - name: Install Haystack and add import paths to markdown files
+        run: |
+          pip install --upgrade pip
+          pip install .[all]
+          python ./.github/utils/add_import_paths.py
+
       - name: Get current version
         id: current-version
         shell: bash

--- a/docs/_src/api/pydoc/answer-generator.yml
+++ b/docs/_src/api/pydoc/answer-generator.yml
@@ -23,6 +23,7 @@ renderer:
      descriptive_module_title: true
      add_method_class_prefix: true
      add_member_class_prefix: false
+     render_toc: true
      filename: answer_generator_api.md
 
 

--- a/docs/_src/api/pydoc/crawler.yml
+++ b/docs/_src/api/pydoc/crawler.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: crawler_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/document-classifier.yml
+++ b/docs/_src/api/pydoc/document-classifier.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: document_classifier_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/document-store.yml
+++ b/docs/_src/api/pydoc/document-store.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: document_store_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/evaluation.yml
+++ b/docs/_src/api/pydoc/evaluation.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: evaluation_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/extractor.yml
+++ b/docs/_src/api/pydoc/extractor.yml
@@ -24,3 +24,4 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: entity_extractor_api.md
+     render_toc: true

--- a/docs/_src/api/pydoc/file-classifier.yml
+++ b/docs/_src/api/pydoc/file-classifier.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: file_classifier_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/file-converters.yml
+++ b/docs/_src/api/pydoc/file-converters.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: file_converters_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/other.yml
+++ b/docs/_src/api/pydoc/other.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: other_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/pipelines.yml
+++ b/docs/_src/api/pydoc/pipelines.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: pipelines_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/preprocessor.yml
+++ b/docs/_src/api/pydoc/preprocessor.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: preprocessor_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/primitives.yml
+++ b/docs/_src/api/pydoc/primitives.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: primitives_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/pseudo-label-generator.yml
+++ b/docs/_src/api/pydoc/pseudo-label-generator.yml
@@ -24,3 +24,4 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: pseudo_label_generator_api.md
+     render_toc: true

--- a/docs/_src/api/pydoc/query-classifier.yml
+++ b/docs/_src/api/pydoc/query-classifier.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: query_classifier_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/question-generator.yml
+++ b/docs/_src/api/pydoc/question-generator.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: question_generator_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/ranker.yml
+++ b/docs/_src/api/pydoc/ranker.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: ranker_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/reader.yml
+++ b/docs/_src/api/pydoc/reader.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: reader_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/retriever.yml
+++ b/docs/_src/api/pydoc/retriever.yml
@@ -24,3 +24,4 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: retriever_api.md
+     render_toc: true

--- a/docs/_src/api/pydoc/summarizer.yml
+++ b/docs/_src/api/pydoc/summarizer.yml
@@ -24,3 +24,5 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: summarizer_api.md
+     render_toc: true
+

--- a/docs/_src/api/pydoc/translator.yml
+++ b/docs/_src/api/pydoc/translator.yml
@@ -24,3 +24,4 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: translator_api.md
+     render_toc: true

--- a/docs/_src/api/pydoc/utils.yml
+++ b/docs/_src/api/pydoc/utils.yml
@@ -24,3 +24,4 @@ renderer:
      add_method_class_prefix: true
      add_member_class_prefix: false
      filename: utils_api.md
+     render_toc: true

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -3,8 +3,8 @@ import io
 import dataclasses
 import docspec
 import typing as t
-from pathlib import Path
-from pydoc_markdown.interfaces import Context, Renderer
+
+from pydoc_markdown.interfaces import Context, Renderer, Resolver
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
 
 
@@ -20,11 +20,26 @@ hidden: false
 """
 
 
+class HaystackMarkdownRenderer(MarkdownRenderer):
+    """
+    Custom Markdown renderer heavily based on the `MarkdownRenderer`,
+    it shows the import path for classes when present.
+
+    This only works in cooperation with a Processor that stores a
+    field called `import_path` into the objects
+    """
+
+    def _render_header(self, fp, level, obj):
+        super()._render_header(fp, level, obj)
+        if hasattr(obj, "import_path"):
+            fp.write(obj.import_path)
+            fp.write("\n\n")
+
+
 @dataclasses.dataclass
 class ReadmeRenderer(Renderer):
     """
-    This custom Renderer is heavily based on the `MarkdownRenderer`,
-    it just prepends a front matter so that the output can be published
+    This custom Renderer prepends a front matter so that the output can be published
     directly to readme.io.
     """
 
@@ -36,7 +51,7 @@ class ReadmeRenderer(Renderer):
     order: int
     # This exposes a special `markdown` settings value that can be used to pass
     # parameters to the underlying `MarkdownRenderer`
-    markdown: MarkdownRenderer = dataclasses.field(default_factory=MarkdownRenderer)
+    markdown: HaystackMarkdownRenderer = dataclasses.field(default_factory=HaystackMarkdownRenderer)
 
     def init(self, context: Context) -> None:
         self.markdown.init(context)
@@ -49,6 +64,14 @@ class ReadmeRenderer(Renderer):
             with io.open(self.markdown.filename, "w", encoding=self.markdown.encoding) as fp:
                 fp.write(self._frontmatter())
                 self.markdown.render_to_stream(modules, t.cast(t.TextIO, fp))
+
+    def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
+        for mod in modules:
+            for m in mod.members:
+                if type(m) == docspec.Class:
+                    # FIXME: we should compute the real import path here
+                    m.import_path = "foo.bar.baz"
+        self.markdown.process(modules, resolver)
 
     def _frontmatter(self) -> str:
         return README_FRONTMATTER.format(


### PR DESCRIPTION
### Proposed Changes:
- Add Table of Contents to each API page by configuring Pydoc Yaml.
![Screenshot from 2022-11-22 15-22-32](https://user-images.githubusercontent.com/33759007/203338395-6f030093-c847-48cb-94ab-81176697a601.png)
- Add shortest import path to each Haystack Class (See the line under BaseGenerator). Done by the `.github/utils/add_import_path_to_api.py` script which:
    - Generates all the shortest import paths for all Haystack classes
    - Looks in the API markdown files and inserts this import path to each entry for each class
![Screenshot from 2022-11-22 15-36-04](https://user-images.githubusercontent.com/33759007/203341367-e3aca033-e72a-487e-8f82-2b3f45e8d5a3.png)
- Integration of the `.github/utils/add_import_path_to_api.py` into the github workflow which updates and syncs API docs to Readme


### How did you test it?
- Manually tested
