### PR TITLE
fix: `ParsrConverter` fails on pages without text

### DIFF
--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -158,7 +158,6 @@ class ParsrConverter(BaseConverter):
             # Get Parsr output
             result_response = requests.get(url=f"{self.parsr_url}/api/v1/json/{queue_id}")
             parsr_output = json.loads(result_response.content)
-            # print(parsr_output)
 
             # Convert Parsr output to Haystack Documents
             text = ""

--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -158,6 +158,7 @@ class ParsrConverter(BaseConverter):
             # Get Parsr output
             result_response = requests.get(url=f"{self.parsr_url}/api/v1/json/{queue_id}")
             parsr_output = json.loads(result_response.content)
+            # print(parsr_output)
 
             # Convert Parsr output to Haystack Documents
             text = ""
@@ -186,7 +187,7 @@ class ParsrConverter(BaseConverter):
                             id_hash_keys,
                         )
                         tables.append(table)
-                if text[-1] != "\f":
+                if len(text) == 0 or text[-1] != "\f":
                     text += "\f"
 
         if valid_languages:
@@ -207,7 +208,7 @@ class ParsrConverter(BaseConverter):
         if extract_headlines:
             meta["headlines"] = headlines
 
-        docs = tables + [Document(content=text.strip(), meta=meta, id_hash_keys=id_hash_keys)]
+        docs = tables + [Document(content=text, meta=meta, id_hash_keys=id_hash_keys)]
         return docs
 
     def _get_paragraph_string(self, paragraph: Dict[str, Any]) -> str:

--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -207,7 +207,7 @@ class ParsrConverter(BaseConverter):
         if extract_headlines:
             meta["headlines"] = headlines
 
-        docs = tables + [Document(content=text, meta=meta, id_hash_keys=id_hash_keys)]
+        docs = tables + [Document(content=text.strip(), meta=meta, id_hash_keys=id_hash_keys)]
         return docs
 
     def _get_paragraph_string(self, paragraph: Dict[str, Any]) -> str:


### PR DESCRIPTION
### Related Issues
- fixes #3593

### Proposed Changes:
Since #2932, the form feed character ("\f") is used to separate different pages.
In the `ParsConverter`, for each page, there is this check:
https://github.com/deepset-ai/haystack/blob/dc26e6d43ef23c1746722c613347e28f05982eee/haystack/nodes/file_converter/parsr.py#L189-L190

that raises an error if `len(text)==0`. For example, we can have empty pages or pages where there is only a table.
I corrected this little bug.

### How did you test it?
Manual test using [this PDF](https://github.com/camelot-dev/camelot/blob/master/tests/files/medicine.pdf).

### Notes for the reviewer
I also have doubts about https://github.com/deepset-ai/haystack/blob/dc26e6d43ef23c1746722c613347e28f05982eee/haystack/nodes/file_converter/parsr.py#L210

If the first page is blank, "\f" is stripped and page numbers may become incorrect.
@bogdankostic WDYT?

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
