### PR TITLE
chore: fix return type of `aggregate_labels`

### DIFF
--- a/haystack/utils/labels.py
+++ b/haystack/utils/labels.py
@@ -10,7 +10,7 @@ def aggregate_labels(
     add_meta_filters: Optional[Union[str, list]] = None,
     drop_negative_labels: bool = False,
     drop_no_answers: bool = False,
-):
+) -> List[MultiLabel]:
     """
     Aggregates Labels into MultiLabel objects (e.g. for evaluation with `Pipeline.eval()`).
 


### PR DESCRIPTION
### Proposed Changes:
 - add correct type hints to `aggregate_labels`

### How did you test it?
- existing tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
