### PR TITLE
chore: Re-enable pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
     - id: check-json  # checks JSON syntax
     - id: check-yaml  # checks YAML syntax
     - id: check-toml  # checks TOML syntax
-    #- id: end-of-file-fixer  # checks there is a newline at the end of the file  # FIXME: pydoc-markdown conflicts with this
-    #- id: trailing-whitespace  # trims trailing whitespace                       # FIXME: pydoc-markdown conflicts with this
+    - id: end-of-file-fixer  # checks there is a newline at the end of the file  # FIXME: pydoc-markdown conflicts with this
+    - id: trailing-whitespace  # trims trailing whitespace                       # FIXME: pydoc-markdown conflicts with this
     - id: check-merge-conflict  # checks for no merge conflict strings
     - id: check-shebang-scripts-are-executable  # checks all shell scripts have executable permissions
     - id: mixed-line-ending  # normalizes line endings


### PR DESCRIPTION
### Related Issues
- fixes #2930 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Now that we removed the schema generation from the developer workflow, we should be good re-enabling these super fast hooks.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested locally but not sure if there's any major implication I'm not seeing

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
