### PR TITLE
fix: use 9200 as the default port in `launch_opensearch()`

### DIFF
--- a/haystack/utils/doc_store.py
+++ b/haystack/utils/doc_store.py
@@ -37,7 +37,7 @@ def launch_es(sleep=15, delete_existing=False):
         time.sleep(sleep)
 
 
-def launch_opensearch(sleep=15, delete_existing=False):
+def launch_opensearch(sleep=15, delete_existing=False, local_port=9200):
     """
     Start an OpenSearch server via Docker.
     """
@@ -48,7 +48,7 @@ def launch_opensearch(sleep=15, delete_existing=False):
         _ = subprocess.run([f"docker rm --force {OPENSEARCH_CONTAINER_NAME}"], shell=True, stdout=subprocess.DEVNULL)
     status = subprocess.run(
         [
-            f'docker start {OPENSEARCH_CONTAINER_NAME} > /dev/null 2>&1 || docker run -d -p 9201:9200 -p 9600:9600 -e "discovery.type=single-node" --name {OPENSEARCH_CONTAINER_NAME} opensearchproject/opensearch:1.3.5'
+            f'docker start {OPENSEARCH_CONTAINER_NAME} > /dev/null 2>&1 || docker run -d -p {local_port}:9200 -p 9600:9600 -e "discovery.type=single-node" --name {OPENSEARCH_CONTAINER_NAME} opensearchproject/opensearch:1.3.5'
         ],
         shell=True,
     )

--- a/test/benchmarks/utils.py
+++ b/test/benchmarks/utils.py
@@ -93,7 +93,7 @@ def get_document_store(document_store_type, similarity="dot_product", index="doc
         )
         assert document_store.get_document_count() == 0
     elif document_store_type in ("opensearch_flat", "opensearch_hnsw"):
-        launch_opensearch()
+        launch_opensearch(local_port=9201)
         if document_store_type == "opensearch_flat":
             index_type = "flat"
         elif document_store_type == "opensearch_hnsw":


### PR DESCRIPTION
### Related Issues
- fixes #2631 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Use `9200` as the default port, consistent with the `OpensearchDocumentStore` defaults.
- `launch_opensearch` now takes a `local_port` param that can be used to retain the old behaviour

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
- I fixed the benchmark script because it was relying on the old port

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
