### PR TITLE
feat: Change answer offsets in TableQA to be `Span(start=row_idx, end=col_idx)`

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -565,7 +565,7 @@ class _TapasScoredEncoder(_BaseTapasEncoder):
         for answer_span_idx in top_k_answer_spans.indices:
             current_answer_span = possible_answer_spans[answer_span_idx]
             answer_str = table.iat[current_answer_span[:2]]
-            answer_offsets = self._calculate_answer_offsets([current_answer_span[:2]], document.content)
+            answer_offsets = self._calculate_answer_offsets([current_answer_span[:2]])
             # As the general table score is more important for the final score, it is double weighted.
             current_score = ((2 * table_relevancy_prob) + span_logits_softmax[0, answer_span_idx].item()) / 3
 

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -20,8 +20,8 @@ def test_table_reader(table_reader):
     query = "When was Di Caprio born?"
     prediction = table_reader.predict(query=query, documents=[Document(content=table, content_type="table")])
     assert prediction["answers"][0].answer == "11 november 1974"
-    assert prediction["answers"][0].offsets_in_context[0].start == 7
-    assert prediction["answers"][0].offsets_in_context[0].end == 8
+    assert prediction["answers"][0].offsets_in_context[0].start == 1
+    assert prediction["answers"][0].offsets_in_context[0].end == 3
 
 
 @pytest.mark.parametrize("table_reader", ["tapas_small", "rci"], indirect=True)
@@ -125,8 +125,8 @@ def test_table_reader_in_pipeline(table_reader):
     prediction = pipeline.run(query=query, documents=[Document(content=table, content_type="table")])
 
     assert prediction["answers"][0].answer == "11 november 1974"
-    assert prediction["answers"][0].offsets_in_context[0].start == 7
-    assert prediction["answers"][0].offsets_in_context[0].end == 8
+    assert prediction["answers"][0].offsets_in_context[0].start == 1
+    assert prediction["answers"][0].offsets_in_context[0].end == 3
 
 
 @pytest.mark.parametrize("table_reader", ["tapas_base"], indirect=True)


### PR DESCRIPTION
### Related Issues
- fixes #3616 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
When doing tableQA the answer is provided together with [the answer offsets of the linearized table](https://github.com/deepset-ai/haystack/blob/2fadcf2859dcdf7b7ce55dd7040d0955822f955e/haystack/nodes/reader/table.py#L267-L276). However, we discussed in the issue that when using TableQA it is more helpful to provide the location of the answer cell by providing its coordinates in the table (for example the `(row_idx, col_idx)` tuple) since the table is returned in the answer as a pandas dataframe object. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated existing unit tests.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This PR is still in a draft because we are still resolving in the issue the best way to implement this change.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
