### PR TITLE
fix: Move entire forward pass of TableQA within `torch.no_grad()`

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -493,9 +493,9 @@ class _TapasScoredEncoder(_BaseTapasEncoder):
         # Forward pass through model
         with torch.no_grad():
             outputs = self.model.tapas(**inputs)
+            table_score = self.model.classifier(outputs.pooler_output)
 
         # Get general table score
-        table_score = self.model.classifier(outputs.pooler_output)
         table_score_softmax = torch.nn.functional.softmax(table_score, dim=1)
         table_relevancy_prob = table_score_softmax[0][1].item()
         no_answer_score = table_score_softmax[0][0].item()


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This moves the entire forward pass of the `_TapasForScoredQA` variant of the TableReader under the `torch.no_grad()` context.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Used existing unit tests.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This is the recommended practice for running pytorch models at inference time because it saves on resource allocations. Specifically it tells Pytorch it does not need to allocate space for keeping track of the gradients of the tensors used in the forward pass, which saves on memory. This change does not affect the output of the model.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
