### PR TITLE
feat: add offsets_in_context to evaluation result

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1441,6 +1441,8 @@ class Pipeline:
             "gold_custom_document_ids",  # generic
             "offsets_in_document",  # answer-specific
             "gold_offsets_in_documents",  # answer-specific
+            "offsets_in_context",  # answer-specific
+            "gold_offsets_in_contexts",  # answer-specific
             "gold_answers_exact_match",  # answer-specific
             "gold_answers_f1",  # answer-specific
             "gold_answers_sas",  # answer-specific
@@ -1498,6 +1500,7 @@ class Pipeline:
             # If all labels are no_answers, MultiLabel.answers will be [""] and the other aggregates []
             gold_answers = query_labels.answers
             gold_offsets_in_documents = query_labels.offsets_in_documents
+            gold_offsets_in_contexts = query_labels.offsets_in_contexts
             gold_document_ids = query_labels.document_ids
             gold_custom_document_ids = (
                 [l.document.meta[custom_document_id_field] for l in query_labels.labels if not l.no_answer]
@@ -1529,13 +1532,26 @@ class Pipeline:
                         answers = answers[i]
                     if len(answers) == 0:
                         # add no_answer if there was no answer retrieved, so query does not get lost in dataframe
-                        answers = [Answer(answer="", offsets_in_document=[Span(start=0, end=0)])]
-                    answer_cols_to_keep = ["answer", "document_id", "offsets_in_document", "context"]
+                        answers = [
+                            Answer(
+                                answer="",
+                                offsets_in_document=[Span(start=0, end=0)],
+                                offsets_in_context=[Span(start=0, end=0)],
+                            )
+                        ]
+                    answer_cols_to_keep = [
+                        "answer",
+                        "document_id",
+                        "offsets_in_document",
+                        "offsets_in_context",
+                        "context",
+                    ]
                     df_answers = pd.DataFrame(answers, columns=answer_cols_to_keep)
                     df_answers.map_rows = partial(df_answers.apply, axis=1)
                     df_answers["rank"] = np.arange(1, len(df_answers) + 1)
                     df_answers["gold_answers"] = [gold_answers] * len(df_answers)
                     df_answers["gold_offsets_in_documents"] = [gold_offsets_in_documents] * len(df_answers)
+                    df_answers["gold_offsets_in_contexts"] = [gold_offsets_in_contexts] * len(df_answers)
                     df_answers["gold_document_ids"] = [gold_document_ids] * len(df_answers)
                     df_answers["gold_contexts"] = [gold_contexts] * len(df_answers)
                     df_answers["gold_answers_exact_match"] = df_answers.map_rows(

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -319,6 +319,69 @@ def test_extractive_qa_eval(reader, retriever_with_docs, tmp_path):
     reader_result = eval_result["Reader"]
     retriever_result = eval_result["Retriever"]
 
+    expected_reader_result_columns = [
+        "gold_answers",  # answer-specific
+        "answer",  # answer-specific
+        "exact_match",  # answer-specific
+        "f1",  # answer-specific
+        # "sas",  # answer-specific optional
+        "exact_match_context_scope",  # answer-specific
+        "f1_context_scope",  # answer-specific
+        # "sas_context_scope",  # answer-specific optional
+        "exact_match_document_id_scope",  # answer-specific
+        "f1_document_id_scope",  # answer-specific
+        # "sas_document_id_scope",  # answer-specific optional
+        "exact_match_document_id_and_context_scope",  # answer-specific
+        "f1_document_id_and_context_scope",  # answer-specific
+        # "sas_document_id_and_context_scope",  # answer-specific optional
+        "offsets_in_document",  # answer-specific
+        "gold_offsets_in_documents",  # answer-specific
+        "offsets_in_context",  # answer-specific
+        "gold_offsets_in_contexts",  # answer-specific
+        "gold_answers_exact_match",  # answer-specific
+        "gold_answers_f1",  # answer-specific
+        # "gold_answers_sas",  # answer-specific optional
+    ]
+
+    expected_retriever_result_columns = [
+        "gold_id_match",  # doc-specific
+        "context_match",  # doc-specific
+        "answer_match",  # doc-specific
+        "gold_id_or_answer_match",  # doc-specific
+        "gold_id_and_answer_match",  # doc-specific
+        "gold_id_or_context_match",  # doc-specific
+        "gold_id_and_context_match",  # doc-specific
+        "gold_id_and_context_and_answer_match",  # doc-specific
+        "context_and_answer_match",  # doc-specific
+        "gold_answers_match",  # doc-specific
+    ]
+
+    expected_generic_result_columns = [
+        "multilabel_id",  # generic
+        "query",  # generic
+        "filters",  # generic
+        "context",  # generic
+        "gold_contexts",  # generic
+        "gold_documents_id_match",  # generic
+        "gold_contexts_similarity",  # generic
+        "type",  # generic
+        "node",  # generic
+        "eval_mode",  # generic
+        "rank",  # generic
+        "document_id",  # generic
+        "gold_document_ids",  # generic
+        # "custom_document_id",  # generic optional
+        # "gold_custom_document_ids",  # generic optional
+    ]
+
+    # all expected columns are part of the evaluation result dataframe
+    assert sorted(expected_reader_result_columns + expected_generic_result_columns + ["index"]) == sorted(
+        list(reader_result.columns)
+    )
+    assert sorted(expected_retriever_result_columns + expected_generic_result_columns + ["index"]) == sorted(
+        list(retriever_result.columns)
+    )
+
     assert (
         reader_result[reader_result["rank"] == 1]["answer"].iloc[0]
         in reader_result[reader_result["rank"] == 1]["gold_answers"].iloc[0]


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack-private/issues/23

### Proposed Changes:
Add `gold_offsets_in_contexts` and `offsets_in_context` to evaluation result dataframe.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I extended one of the existing test cases. It now checks that all expected column names are part of the evaluation result dataframes, including `offsets_in_context `.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~~I have updated the related issue with new insights and changes~~
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
