### PR TITLE
fix: revert Weaviate query with filters and improve tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       weaviate:
-        image: semitechnologies/weaviate:1.16.0
+        image: semitechnologies/weaviate:1.17.0
         env:
           AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
           PERSISTENCE_DATA_PATH: "/var/lib/weaviate"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -335,7 +335,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       weaviate:
-        image: semitechnologies/weaviate:1.17.0
+        image: semitechnologies/weaviate:latest
         env:
           AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
           PERSISTENCE_DATA_PATH: "/var/lib/weaviate"

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -986,26 +986,28 @@ class WeaviateDocumentStore(BaseDocumentStore):
 
             # Retrieval with BM25 AND filtering
             if filters:
-
-                # Once Weaviate starts supporting filters with BM25:
-                filter_dict = LogicalFilterClause.parse(filters).convert_to_weaviate()
+                raise NotImplementedError(
+                    "Weaviate currently does not support filters WITH inverted index text query (eg BM25)!"
+                )
+                # # Once Weaviate starts supporting filters with BM25:
+                # filter_dict = LogicalFilterClause.parse(filters).convert_to_weaviate()
+                # gql_query = (
+                #     weaviate.gql.get.GetBuilder(
+                #         class_name=index, properties=properties, connection=self.weaviate_client
+                #     )
+                #     .with_near_vector({"vector": [0, 0]})
+                #     .with_where(filter_dict)
+                #     .with_limit(top_k)
+                #     .build()
+                # )
+            else:
+                # BM25 retrieval without filtering
                 gql_query = (
-                    weaviate.gql.get.GetBuilder(
-                        class_name=index, properties=properties, connection=self.weaviate_client
-                    )
+                    gql.get.GetBuilder(class_name=index, properties=properties, connection=self.weaviate_client)
                     .with_near_vector({"vector": [0, 0]})
-                    .with_where(filter_dict)
                     .with_limit(top_k)
                     .build()
                 )
-
-            # BM25 retrieval without filtering
-            gql_query = (
-                gql.get.GetBuilder(class_name=index, properties=properties, connection=self.weaviate_client)
-                .with_near_vector({"vector": [0, 0]})
-                .with_limit(top_k)
-                .build()
-            )
 
             # Build the BM25 part of the GQL manually.
             # Currently the GetBuilder of the Weaviate-client (v3.6.0)

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -985,7 +985,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
             )
 
             # Retrieval with BM25 AND filtering
-            if filters:
+            if filters:  # pylint: disable=no-else-raise
                 raise NotImplementedError(
                     "Weaviate currently does not support filters WITH inverted index text query (eg BM25)!"
                 )

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -180,9 +180,9 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         assert len(docs) == 3
 
         # BM25 retrieval WITH filters is not yet supported as of Weaviate v1.14.1
-        # with pytest.raises(Exception):
-        docs = ds.query(query_text, filters={"name": ["name_1"]})
-        assert len(docs) == 1
+        with pytest.raises(Exception):
+            docs = ds.query(query_text, filters={"name": ["name_1"]})
+            assert len(docs) == 1
 
         docs = ds.query(filters={"name": ["name_0"]})
         assert len(docs) == 3

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -180,9 +180,9 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         assert len(docs) == 3
 
         # BM25 retrieval WITH filters is not yet supported as of Weaviate v1.14.1
-        with pytest.raises(Exception):
-            docs = ds.query(query_text, filters={"name": ["name_1"]})
-            assert len(docs) == 1
+        # Should be from 1.18: https://github.com/semi-technologies/weaviate/issues/2393
+        # docs = ds.query(query_text, filters={"name": ["name_1"]})
+        # assert len(docs) == 1
 
         docs = ds.query(filters={"name": ["name_0"]})
         assert len(docs) == 3

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -181,7 +181,8 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
 
         # BM25 retrieval WITH filters is not yet supported as of Weaviate v1.14.1
         # with pytest.raises(Exception):
-        docs = ds.query(query_text, filters={"name": ["filename2"]})
+        docs = ds.query(query_text, filters={"name": ["name_1"]})
+        assert len(docs) == 1
 
         docs = ds.query(filters={"name": ["name_0"]})
         assert len(docs) == 3


### PR DESCRIPTION
### Related Issues
- fixes [this issue](https://github.com/deepset-ai/haystack/pull/3628#issuecomment-1331269953)

### Proposed Changes:
 - Comment back lines https://github.com/deepset-ai/haystack/blob/main/haystack/document_stores/weaviate.py#L990-L1000
 - Improve the relevant test  https://github.com/deepset-ai/haystack/blob/main/test/document_stores/test_weaviate.py#L182-L184
 - Upgrade Weaviate in CI from `1.16` to `latest`

### How did you test it?
- Locally, CI

### Notes for the reviewer
See the great analysis of the issue by @zoltan-fedor https://github.com/deepset-ai/haystack/pull/3628#issuecomment-1331269953 and vote for this issue on Weaviate: https://github.com/semi-technologies/weaviate/issues/2393

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
