### PR TITLE
Adjust get_type() method for pipelines

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import datetime
+import itertools
 from datetime import timedelta
 from functools import partial
 from hashlib import sha1
-import itertools
 from typing import Dict, List, Optional, Any, Set, Tuple, Union
-
-from haystack.nodes import BaseGenerator, Docs2Answers, BaseReader, BaseSummarizer, BaseTranslator, QuestionGenerator
 
 try:
     from typing import Literal
@@ -49,6 +47,7 @@ from haystack.pipelines.utils import generate_code, print_eval_report
 from haystack.utils import DeepsetCloud, calculate_context_similarity
 from haystack.schema import Answer, EvaluationResult, MultiLabel, Document, Span
 from haystack.errors import HaystackError, PipelineError, PipelineConfigError
+from haystack.nodes import BaseGenerator, Docs2Answers, BaseReader, BaseSummarizer, BaseTranslator, QuestionGenerator
 from haystack.nodes.base import BaseComponent, RootNode
 from haystack.nodes.retriever.base import BaseRetriever
 from haystack.document_stores.base import BaseDocumentStore
@@ -2223,23 +2222,23 @@ class Pipeline:
         # values of the dict are functions evaluating whether components of this pipeline match the pipeline type
         # specified by dict keys
         pipeline_types = {
-            "QuestionGenerationPipeline": lambda x: all([isinstance(x, QuestionGenerator) for x in x.values()]),
-            "GenerativeQAPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
-            and any([isinstance(x, BaseGenerator) for x in x.values()]),
-            "FAQPipeline": lambda x: any([isinstance(x, Docs2Answers) for x in x.values()]),
-            "ExtractiveQAPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
-            and any([isinstance(x, BaseReader) for x in x.values()]),
-            "SearchSummarizationPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
-            and any([isinstance(x, BaseSummarizer) for x in x.values()]),
+            "QuestionGenerationPipeline": lambda x: all(isinstance(x, QuestionGenerator) for x in x.values()),
+            "GenerativeQAPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
+            and any(isinstance(x, BaseGenerator) for x in x.values()),
+            "FAQPipeline": lambda x: any(isinstance(x, Docs2Answers) for x in x.values()),
+            "ExtractiveQAPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
+            and any(isinstance(x, BaseReader) for x in x.values()),
+            "SearchSummarizationPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
+            and any(isinstance(x, BaseSummarizer) for x in x.values()),
             "TranslationWrapperPipeline": lambda x: [isinstance(x, BaseTranslator) for x in x.values()].count(True)
             >= 2,
-            "RetrieverQuestionGenerationPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
-            and any([isinstance(x, QuestionGenerator) for x in x.values()]),
-            "QuestionAnswerGenerationPipeline": lambda x: any([isinstance(x, BaseReader) for x in x.values()])
-            and any([isinstance(x, QuestionGenerator) for x in x.values()]),
+            "RetrieverQuestionGenerationPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
+            and any(isinstance(x, QuestionGenerator) for x in x.values()),
+            "QuestionAnswerGenerationPipeline": lambda x: any(isinstance(x, BaseReader) for x in x.values())
+            and any(isinstance(x, QuestionGenerator) for x in x.values()),
             "MostSimilarDocumentsPipeline": lambda x: len(x.values()) == 1
             and isinstance(list(x.values())[0], BaseDocumentStore),
-            "DocumentSearchPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()]),
+            "DocumentSearchPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values()),
         }
         retrievers = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseRetriever)]
         doc_stores = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseDocumentStore)]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2222,22 +2222,33 @@ class Pipeline:
         # values of the dict are functions evaluating whether components of this pipeline match the pipeline type
         # specified by dict keys
         pipeline_types = {
+            # QuestionGenerationPipeline has only one component, which is a QuestionGenerator
             "QuestionGenerationPipeline": lambda x: all(isinstance(x, QuestionGenerator) for x in x.values()),
+            # GenerativeQAPipeline has at least BaseGenerator and BaseRetriever components
             "GenerativeQAPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
             and any(isinstance(x, BaseGenerator) for x in x.values()),
+            # FAQPipeline has at least one Docs2Answers component
             "FAQPipeline": lambda x: any(isinstance(x, Docs2Answers) for x in x.values()),
+            # ExtractiveQAPipeline has at least one BaseRetriever component and one BaseReader component
             "ExtractiveQAPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
             and any(isinstance(x, BaseReader) for x in x.values()),
+            # ExtractiveQAPipeline has at least one BaseSummarizer component and one BaseRetriever component
             "SearchSummarizationPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
             and any(isinstance(x, BaseSummarizer) for x in x.values()),
+            # TranslationWrapperPipeline has two or more BaseTranslator components
             "TranslationWrapperPipeline": lambda x: [isinstance(x, BaseTranslator) for x in x.values()].count(True)
             >= 2,
+            # RetrieverQuestionGenerationPipeline has at least one BaseRetriever component and one
+            # QuestionGenerator component
             "RetrieverQuestionGenerationPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values())
             and any(isinstance(x, QuestionGenerator) for x in x.values()),
+            # QuestionAnswerGenerationPipeline has at least one BaseReader component and one QuestionGenerator component
             "QuestionAnswerGenerationPipeline": lambda x: any(isinstance(x, BaseReader) for x in x.values())
             and any(isinstance(x, QuestionGenerator) for x in x.values()),
+            # MostSimilarDocumentsPipeline has only BaseDocumentStore component
             "MostSimilarDocumentsPipeline": lambda x: len(x.values()) == 1
             and isinstance(list(x.values())[0], BaseDocumentStore),
+            # DocumentSearchPipeline has at least one BaseRetriever component
             "DocumentSearchPipeline": lambda x: any(isinstance(x, BaseRetriever) for x in x.values()),
         }
         retrievers = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseRetriever)]

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -9,6 +9,7 @@ from hashlib import sha1
 import itertools
 from typing import Dict, List, Optional, Any, Set, Tuple, Union
 
+from haystack.nodes import BaseGenerator, Docs2Answers, BaseReader, BaseSummarizer, BaseTranslator, QuestionGenerator
 
 try:
     from typing import Literal
@@ -2222,17 +2223,23 @@ class Pipeline:
         # values of the dict are functions evaluating whether components of this pipeline match the pipeline type
         # specified by dict keys
         pipeline_types = {
-            "GenerativeQAPipeline": lambda x: {"Generator", "Retriever"} <= set(x.keys()),
-            "FAQPipeline": lambda x: {"Docs2Answers"} <= set(x.keys()),
-            "ExtractiveQAPipeline": lambda x: {"Reader", "Retriever"} <= set(x.keys()),
-            "SearchSummarizationPipeline": lambda x: {"Retriever", "Summarizer"} <= set(x.keys()),
-            "TranslationWrapperPipeline": lambda x: {"InputTranslator", "OutputTranslator"} <= set(x.keys()),
-            "RetrieverQuestionGenerationPipeline": lambda x: {"Retriever", "QuestionGenerator"} <= set(x.keys()),
-            "QuestionAnswerGenerationPipeline": lambda x: {"QuestionGenerator", "Reader"} <= set(x.keys()),
-            "DocumentSearchPipeline": lambda x: {"Retriever"} <= set(x.keys()),
-            "QuestionGenerationPipeline": lambda x: {"QuestionGenerator"} <= set(x.keys()),
+            "QuestionGenerationPipeline": lambda x: all([isinstance(x, QuestionGenerator) for x in x.values()]),
+            "GenerativeQAPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
+            and any([isinstance(x, BaseGenerator) for x in x.values()]),
+            "FAQPipeline": lambda x: any([isinstance(x, Docs2Answers) for x in x.values()]),
+            "ExtractiveQAPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
+            and any([isinstance(x, BaseReader) for x in x.values()]),
+            "SearchSummarizationPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
+            and any([isinstance(x, BaseSummarizer) for x in x.values()]),
+            "TranslationWrapperPipeline": lambda x: [isinstance(x, BaseTranslator) for x in x.values()].count(True)
+            >= 2,
+            "RetrieverQuestionGenerationPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()])
+            and any([isinstance(x, QuestionGenerator) for x in x.values()]),
+            "QuestionAnswerGenerationPipeline": lambda x: any([isinstance(x, BaseReader) for x in x.values()])
+            and any([isinstance(x, QuestionGenerator) for x in x.values()]),
             "MostSimilarDocumentsPipeline": lambda x: len(x.values()) == 1
             and isinstance(list(x.values())[0], BaseDocumentStore),
+            "DocumentSearchPipeline": lambda x: any([isinstance(x, BaseRetriever) for x in x.values()]),
         }
         retrievers = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseRetriever)]
         doc_stores = [type(comp).__name__ for comp in self.components.values() if isinstance(comp, BaseDocumentStore)]


### PR DESCRIPTION
### Related Issues
- partially resolves #3342 

### Proposed Changes:
get_type() misclassified some pipelines as "Unknown pipeline". These pipelines are now properly classified by type.

### How did you test it?
Unit test, see PR diff

### Notes for the reviewer
Any other test cases from telemetry?

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
