### PR TITLE
fix: pinecone metadata format

### DIFF
--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -515,7 +515,9 @@ class PineconeDocumentStore(BaseDocumentStore):
                 metadata = []
                 ids = []
                 for doc in document_batch:
-                    metadata.append({"content": doc.content, "content_type": doc.content_type, **doc.meta})
+                    metadata.append(
+                        self._meta_for_pinecone({"content": doc.content, "content_type": doc.content_type, **doc.meta})
+                    )
                     ids.append(doc.id)
                 # Update existing vectors in pinecone index
                 self.pinecone_indexes[index].upsert(

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -1334,6 +1334,14 @@ class PineconeDocumentStore(BaseDocumentStore):
     def _meta_for_pinecone(self, meta: Dict[str, Any], parent_key: str = "", labels: bool = False) -> Dict[str, Any]:
         """
         Converts the meta dictionary to a format that can be stored in Pinecone.
+        :param meta: Metadata dictionary to be converted.
+        :param parent_key: Optional, used for recursive calls to keep track of parent keys, for example:
+            ```
+            {"parent1": {"parent2": {"child": "value"}}}
+            ```
+            On the second recursive call, parent_key would be "parent1", and the final key would be "parent1.parent2.child".
+        :param labels: Optional, used to indicate whether the metadata is being stored as a label or not. If True the
+            the flattening of dictionaries is not required.
         """
         items: list = []
         if labels:
@@ -1361,6 +1369,9 @@ class PineconeDocumentStore(BaseDocumentStore):
     def _pinecone_meta_format(self, meta: Dict[str, Any], labels: bool = False) -> Dict[str, Any]:
         """
         Converts the meta extracted from Pinecone into a better format for Python.
+        :param meta: Metadata dictionary to be converted.
+        :param labels: Optional, used to indicate whether the metadata is being stored as a label or not. If True the
+            the flattening of dictionaries is not required.
         """
         new_meta: Dict[str, Any] = {}
 

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -1335,7 +1335,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         """
         Converts the meta dictionary to a format that can be stored in Pinecone.
         """
-        items = []
+        items: list = []
         # Explode dict of dicts into single flattened dict
         for key, value in meta.items():
             # Replace any None values with empty strings
@@ -1356,7 +1356,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         """
         Converts the meta extracted from Pinecone into a better format for Python.
         """
-        new_meta = {}
+        new_meta: Dict[str, Any] = {}
 
         for key, value in meta.items():
             # Replace any empty strings with None values

--- a/test/document_stores/test_pinecone.py
+++ b/test/document_stores/test_pinecone.py
@@ -402,3 +402,18 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
 
         with pytest.raises(FilterError, match="Comparison value for '\$[l|g]te' operation must be a float or int."):
             doc_store_with_docs.get_all_documents(filters=filters)
+
+    @pytest.mark.integration
+    def test_multilayer_dict(self, doc_store_with_docs: PineconeDocumentStore):
+        # TODO add test that multilayer dict can be upserted
+        multilayer_meta = {
+            "parent1": {"parent2": {"parent3": {"child1": 1, "child2": 2}}},
+            "meta_field": "multilayer-test",
+        }
+        doc = Document(content=f"Multilayered dict", meta=multilayer_meta, embedding=[0.0] * 768)
+
+        doc_store_with_docs.write_documents([doc])
+        retrieved_docs = doc_store_with_docs.get_all_documents(filters={"meta_field": {"$eq": "multilayer-test"}})
+
+        assert len(retrieved_docs) == 1
+        assert retrieved_docs[0].meta == multilayer_meta

--- a/test/document_stores/test_pinecone.py
+++ b/test/document_stores/test_pinecone.py
@@ -405,7 +405,7 @@ class TestPineconeDocumentStore(DocumentStoreBaseTestAbstract):
 
     @pytest.mark.integration
     def test_multilayer_dict(self, doc_store_with_docs: PineconeDocumentStore):
-        # TODO add test that multilayer dict can be upserted
+        # Test that multilayer dict can be upserted
         multilayer_meta = {
             "parent1": {"parent2": {"parent3": {"child1": 1, "child2": 2}}},
             "meta_field": "multilayer-test",


### PR DESCRIPTION
### Related Issues
- fixes #3659

### Proposed Changes:
The linked issue is caused by incompatibility for multilevel metadata dictionaries in Pinecone. To fix the issue, I added metadata processing steps to flatten (and 'un-flatten') the metadata dictionaries.

### How did you test it?
Using [this notebook](https://gist.github.com/jamescalam/3d5a219226b46539afbda8982b2bb2dd)

### Notes for the reviewer
N/A

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [X] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
