### PR TITLE
fix: remove `beir` from `all-gpu`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,8 @@ all = [
   "farm-haystack[docstores,audio,crawler,preprocessing,ocr,ray,dev,onnx,beir]",
 ]
 all-gpu = [
-  "farm-haystack[docstores-gpu,audio,crawler,preprocessing,ocr,ray,dev,onnx-gpu,beir]",
+  # beir is incompatible with faiss-gpu: https://github.com/beir-cellar/beir/issues/71
+  "farm-haystack[docstores-gpu,audio,crawler,preprocessing,ocr,ray,dev,onnx-gpu]",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Related Issues
- fixes #3218
- Related to https://github.com/beir-cellar/beir/issues/71

### Proposed Changes:
- Remove the `beir` extra from the `all-gpu` extra. 
     - `faiss-cpu` is hardcoded as a dependency of `beir`: https://github.com/beir-cellar/beir/blob/c3334fd5b336dba03c5e3e605a82fcfb1bdf667d/setup.py#L26
     - and is incompatible with `faiss-gpu` https://github.com/facebookresearch/faiss/blob/main/INSTALL.md
- See https://github.com/beir-cellar/beir/issues/71

### How did you test it?
- Local installation
- CI

### Notes for the reviewer
n/a

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
