### PR TITLE
bug: Use tqdm auto instead of plain tqdm 

### DIFF
--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -13,7 +13,7 @@ import re
 
 import numpy as np
 import torch
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import rank_bm25
 
 from haystack.schema import Document, Label

--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 import numpy as np
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 try:
     from pymilvus import FieldSchema, CollectionSchema, Collection, connections, utility

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -7,7 +7,7 @@ import hashlib
 import logging
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 try:
     import weaviate

--- a/haystack/modeling/data_handler/data_silo.py
+++ b/haystack/modeling/data_handler/data_silo.py
@@ -7,7 +7,7 @@ import random
 from itertools import groupby
 from pathlib import Path
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import torch
 from torch.utils.data import ConcatDataset, Dataset
 from torch.utils.data.distributed import DistributedSampler

--- a/haystack/modeling/data_handler/processor.py
+++ b/haystack/modeling/data_handler/processor.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 import requests
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from torch.utils.data import TensorDataset
 import transformers
 from transformers import PreTrainedTokenizer, AutoTokenizer

--- a/haystack/modeling/evaluation/eval.py
+++ b/haystack/modeling/evaluation/eval.py
@@ -5,7 +5,7 @@ import numbers
 import torch
 from torch.nn import DataParallel
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from haystack.modeling.evaluation.metrics import compute_metrics, compute_report_metrics
 from haystack.modeling.model.adaptive_model import AdaptiveModel

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Dict, Union, Set, Any
 
 import os
 import logging
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import torch
 from torch.utils.data.sampler import SequentialSampler
 from torch.utils.data import Dataset

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import dill
 import numpy
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import torch
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.nn import MSELoss, Linear, Module, ModuleList, DataParallel

--- a/haystack/nodes/audio/document_to_speech.py
+++ b/haystack/nodes/audio/document_to_speech.py
@@ -1,7 +1,7 @@
 from typing import Union, Optional, List, Dict, Tuple, Any
 
 from pathlib import Path
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from haystack.nodes import BaseComponent
 from haystack.schema import Document, SpeechDocument

--- a/haystack/nodes/retriever/base.py
+++ b/haystack/nodes/retriever/base.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from time import perf_counter
 from functools import wraps
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from haystack.schema import Document, MultiLabel
 from haystack.errors import HaystackError, PipelineError

--- a/haystack/nodes/retriever/multimodal/embedder.py
+++ b/haystack/nodes/retriever/multimodal/embedder.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 
 import torch
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import numpy as np
 from PIL import Image
 

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -26,7 +26,7 @@ import numpy as np
 import pandas as pd
 import networkx as nx
 from pandas.core.frame import DataFrame
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from networkx import DiGraph
 from networkx.drawing.nx_agraph import to_agraph
 

--- a/haystack/utils/augment_squad.py
+++ b/haystack/utils/augment_squad.py
@@ -40,7 +40,7 @@ from torch.nn import functional as F
 from transformers import AutoModelForMaskedLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
 import requests
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 logger = logging.getLogger(__name__)

--- a/haystack/utils/context_matching.py
+++ b/haystack/utils/context_matching.py
@@ -6,7 +6,7 @@ from multiprocessing.pool import Pool
 from collections import namedtuple
 
 from rapidfuzz import fuzz
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 _CandidateScore = namedtuple("_CandidateScore", ["context_id", "candidate_id", "score"])

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -18,7 +18,7 @@ from enum import Enum
 import yaml
 import pandas as pd
 import requests
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from haystack.schema import Label, Document, Answer, EvaluationResult
 

--- a/haystack/utils/squad_data.py
+++ b/haystack/utils/squad_data.py
@@ -4,7 +4,7 @@ import logging
 import json
 import random
 import pandas as pd
-from tqdm import tqdm
+from tqdm.auto import tqdm
 import mmh3
 
 from haystack.schema import Document, Label, Answer

--- a/haystack/utils/squad_to_dpr.py
+++ b/haystack/utils/squad_to_dpr.py
@@ -64,7 +64,7 @@ from time import sleep
 from pathlib import Path
 from itertools import islice
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from elasticsearch import Elasticsearch
 
 from haystack.document_stores.base import BaseDocumentStore


### PR DESCRIPTION
### Related Issues
- There is no related issue

### Proposed Changes:
This is a minor fix making sure we consistently use tqdm.auto instead of tqdm
tqdm.auto renders progress bars appropriately in the detected execution environment i.e. Colab, Ipython etc


### How did you test it?
No unit tests provided

### Notes for the reviewer
Don't integrate, lets first see the CI and try it out. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
