### PR TITLE
refactor: filters type

### DIFF
--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -20,6 +20,10 @@ from haystack.utils.labels import aggregate_labels
 
 logger = logging.getLogger(__name__)
 
+
+FilterType = Optional[Dict[str, Union[Dict[str, Any], List[Any], str, int, float, bool]]]
+
+
 try:
     from numba import njit  # pylint: disable=import-error
 except (ImportError, ModuleNotFoundError):
@@ -103,7 +107,7 @@ class BaseDocumentStore(BaseComponent):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -151,7 +155,7 @@ class BaseDocumentStore(BaseComponent):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -212,17 +216,14 @@ class BaseDocumentStore(BaseComponent):
 
     @abstractmethod
     def get_all_labels(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ) -> List[Label]:
         pass
 
     def get_all_labels_aggregated(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         open_domain: bool = True,
         drop_negative_labels: bool = False,
         drop_no_answers: bool = False,
@@ -302,7 +303,7 @@ class BaseDocumentStore(BaseComponent):
     @abstractmethod
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -350,7 +351,7 @@ class BaseDocumentStore(BaseComponent):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -362,12 +363,7 @@ class BaseDocumentStore(BaseComponent):
     def query_by_embedding_batch(
         self,
         query_embs: Union[List[np.ndarray], np.ndarray],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -381,7 +377,7 @@ class BaseDocumentStore(BaseComponent):
                     " as query_embs or a single filter that will be applied to each query_emb."
                 )
         else:
-            filters = [filters] * len(query_embs) if filters is not None else [{}] * len(query_embs)
+            filters = [filters] * len(query_embs)
         results = []
         for query_emb, filter in zip(query_embs, filters):
             results.append(
@@ -501,10 +497,7 @@ class BaseDocumentStore(BaseComponent):
             logger.error("File needs to be in json or jsonl format.")
 
     def delete_all_documents(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ):
         pass
 
@@ -513,7 +506,7 @@ class BaseDocumentStore(BaseComponent):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         pass
@@ -523,7 +516,7 @@ class BaseDocumentStore(BaseComponent):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         pass
@@ -728,7 +721,7 @@ class KeywordDocumentStore(BaseDocumentStore):
     def query(
         self,
         query: Optional[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -825,12 +818,7 @@ class KeywordDocumentStore(BaseDocumentStore):
     def query_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 
 from haystack.document_stores import KeywordDocumentStore
+from haystack.document_stores.base import FilterType
 from haystack.errors import HaystackError
 from haystack.schema import Document, Label
 from haystack.utils import DeepsetCloud, DeepsetCloudError, args_to_kwargs
@@ -148,7 +149,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -203,7 +204,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -299,7 +300,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
 
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -318,7 +319,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -424,7 +425,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
     def query(
         self,
         query: Optional[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -533,12 +534,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
     def query_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -629,10 +625,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         return self.evaluation_set_client.get_evaluation_sets()
 
     def get_all_labels(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ) -> List[Label]:
         """
         Returns a list of labels for the given index name.
@@ -669,10 +662,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
 
     @disable_and_log
     def delete_all_documents(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ):
         pass
 
@@ -681,7 +671,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         pass
@@ -691,7 +681,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         pass

--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Type, Union, Dict
 from copy import deepcopy
 
 import numpy as np
+from haystack.document_stores.base import FilterType
 
 try:
     from elasticsearch import Elasticsearch, RequestsHttpConnection, Connection, Urllib3HttpConnection
@@ -282,7 +283,7 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -409,7 +410,7 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
     def _construct_dense_query_body(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         return_embedding: Optional[bool] = None,
     ):

--- a/haystack/document_stores/faiss.py
+++ b/haystack/document_stores/faiss.py
@@ -306,7 +306,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         retriever: DenseRetriever,
         index: Optional[str] = None,
         update_existing_embeddings: bool = True,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         batch_size: int = 10_000,
     ):
         """
@@ -377,7 +377,7 @@ class FAISSDocumentStore(SQLDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -394,7 +394,7 @@ class FAISSDocumentStore(SQLDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -445,7 +445,7 @@ class FAISSDocumentStore(SQLDocumentStore):
                     doc.embedding = self.faiss_indexes[index].reconstruct(int(doc.meta["vector_id"]))
         return documents
 
-    def get_embedding_count(self, index: Optional[str] = None, filters: Optional[Dict[str, Any]] = None) -> int:
+    def get_embedding_count(self, index: Optional[str] = None, filters: FilterType = None) -> int:
         """
         Return the count of embeddings in the document store.
         """
@@ -484,7 +484,7 @@ class FAISSDocumentStore(SQLDocumentStore):
     def delete_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -505,7 +505,7 @@ class FAISSDocumentStore(SQLDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -561,7 +561,7 @@ class FAISSDocumentStore(SQLDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in FAISSDocStore
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -19,7 +19,7 @@ import rank_bm25
 from haystack.schema import Document, Label
 from haystack.errors import DuplicateDocumentError, DocumentStoreError
 from haystack.document_stores import KeywordDocumentStore
-from haystack.document_stores.base import get_batches_from_generator
+from haystack.document_stores.base import FilterType, get_batches_from_generator
 from haystack.modeling.utils import initialize_device_settings
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.nodes.retriever import DenseRetriever
@@ -356,7 +356,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -468,7 +468,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self,
         retriever: DenseRetriever,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         update_existing_embeddings: bool = True,
         batch_size: int = 10_000,
     ):
@@ -537,7 +537,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
 
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -566,7 +566,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         for key, value in meta.items():
             self.indexes[index][id].meta[key] = value
 
-    def get_embedding_count(self, filters: Optional[Dict[str, List[str]]] = None, index: Optional[str] = None) -> int:
+    def get_embedding_count(self, filters: FilterType = None, index: Optional[str] = None) -> int:
         """
         Return the count of embeddings in the document store.
         """
@@ -587,7 +587,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def _query(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         only_documents_without_embedding: bool = False,
     ):
@@ -614,7 +614,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -662,7 +662,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -708,7 +708,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def get_all_labels(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
         headers: Optional[Dict[str, str]] = None,
     ) -> List[Label]:
         """
@@ -736,10 +736,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         return result
 
     def delete_all_documents(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ):
         """
         Delete documents in an index. All documents are deleted if no filters are passed.
@@ -786,7 +783,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -856,7 +853,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in InMemoryDocStore
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -907,7 +904,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def query(
         self,
         query: Optional[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -963,12 +960,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def query_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -960,7 +960,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
     def query_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,

--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -326,7 +326,7 @@ class MilvusDocumentStore(SQLDocumentStore):
         index: Optional[str] = None,
         batch_size: int = 10_000,
         update_existing_embeddings: bool = True,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
     ):
         """
         Updates the embeddings in the the document store using the encoding model specified in the retriever.
@@ -390,7 +390,7 @@ class MilvusDocumentStore(SQLDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -456,7 +456,7 @@ class MilvusDocumentStore(SQLDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
         headers: Optional[Dict[str, str]] = None,
         batch_size: int = 10_000,
     ):
@@ -511,7 +511,7 @@ class MilvusDocumentStore(SQLDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -544,7 +544,7 @@ class MilvusDocumentStore(SQLDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in Milvus2DocStore
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -17,7 +17,7 @@ except (ImportError, ModuleNotFoundError) as ie:
 
 from haystack.schema import Document
 from haystack.document_stores.sql import SQLDocumentStore
-from haystack.document_stores.base import get_batches_from_generator
+from haystack.document_stores.base import FilterType, get_batches_from_generator
 from haystack.nodes.retriever import DenseRetriever
 
 
@@ -657,7 +657,7 @@ class MilvusDocumentStore(SQLDocumentStore):
 
         self.collection.delete(expr)
 
-    def get_embedding_count(self, index: Optional[str] = None, filters: Optional[Dict[str, List[str]]] = None) -> int:
+    def get_embedding_count(self, index: Optional[str] = None, filters: FilterType = None) -> int:
         """
         Return the count of embeddings in the document store.
         """

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -16,7 +16,7 @@ except (ImportError, ModuleNotFoundError) as e:
 
 
 from haystack.schema import Document
-from haystack.document_stores.base import get_batches_from_generator
+from haystack.document_stores.base import FilterType, get_batches_from_generator
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.errors import DocumentStoreError
 from haystack.nodes.retriever import DenseRetriever
@@ -345,7 +345,7 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -457,7 +457,7 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
     def _construct_dense_query_body(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         return_embedding: Optional[bool] = None,
     ):

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -6,6 +6,7 @@ from itertools import islice
 import pinecone
 import numpy as np
 from tqdm.auto import tqdm
+from haystack.document_stores.base import FilterType
 
 from haystack.schema import Document, Label, Answer, Span
 from haystack.document_stores import BaseDocumentStore
@@ -220,7 +221,7 @@ class PineconeDocumentStore(BaseDocumentStore):
 
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -421,7 +422,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         retriever: DenseRetriever,
         index: Optional[str] = None,
         update_existing_embeddings: bool = True,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         batch_size: int = 32,
     ):
         """
@@ -519,7 +520,7 @@ class PineconeDocumentStore(BaseDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 32,
         headers: Optional[Dict[str, str]] = None,
@@ -578,7 +579,7 @@ class PineconeDocumentStore(BaseDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 32,
         headers: Optional[Dict[str, str]] = None,
@@ -664,7 +665,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         namespace: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         batch_size: int = 32,
     ) -> List[str]:
         index = self._index_name(index)
@@ -846,9 +847,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         )
         return documents[0]
 
-    def get_embedding_count(
-        self, index: Optional[str] = None, filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None
-    ) -> int:
+    def get_embedding_count(self, index: Optional[str] = None, filters: FilterType = None) -> int:
         """
         Return the count of embeddings in the document store.
 
@@ -906,7 +905,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
         drop_ids: Optional[bool] = True,
         namespace: Optional[str] = None,
@@ -1010,7 +1009,7 @@ class PineconeDocumentStore(BaseDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -1277,13 +1276,7 @@ class PineconeDocumentStore(BaseDocumentStore):
                 progress_bar.set_description_str("Cleaned Namespace")
                 progress_bar.update(1)
 
-    def _get_ids(
-        self,
-        index: str,
-        namespace: str,
-        batch_size: int = 32,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-    ) -> List[str]:
+    def _get_ids(self, index: str, namespace: str, batch_size: int = 32, filters: FilterType = None) -> List[str]:
         """
         Retrieves a list of IDs that satisfy a particular filter condition (or any) using
         a dummy query embedding.
@@ -1460,7 +1453,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
         batch_size: int = 32,
     ):
@@ -1517,7 +1510,7 @@ class PineconeDocumentStore(BaseDocumentStore):
             # Delete the documents
             self.delete_documents(ids=update_ids, index=index, namespace=namespace)
 
-    def get_all_labels(self, index=None, filters: Optional[dict] = None, headers: Optional[Dict[str, str]] = None):
+    def get_all_labels(self, index=None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None):
         """
         Default class method used for getting all labels.
         """

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -883,7 +883,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def query_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -1137,7 +1137,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def query_by_embedding_batch(
         self,
         query_embs: Union[List[np.ndarray], np.ndarray],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -14,7 +14,7 @@ from pydantic.error_wrappers import ValidationError
 
 from haystack.document_stores import KeywordDocumentStore
 from haystack.schema import Document, Label
-from haystack.document_stores.base import get_batches_from_generator
+from haystack.document_stores.base import FilterType, get_batches_from_generator
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.errors import DocumentStoreError, HaystackError
 from haystack.nodes.retriever import DenseRetriever
@@ -136,7 +136,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -267,7 +267,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         self,
         key: str,
         query: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> List[dict]:
@@ -502,7 +502,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
 
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -531,10 +531,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         return self.get_document_count(index=index, headers=headers)
 
     def get_embedding_count(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ) -> int:
         """
         Return the count of embeddings in the document store.
@@ -553,7 +550,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -603,7 +600,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -661,7 +658,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def get_all_labels(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
         batch_size: int = 10_000,
     ) -> List[Label]:
@@ -683,7 +680,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def _get_all_documents_in_index(
         self,
         index: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         batch_size: int = 10_000,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -707,7 +704,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def query(
         self,
         query: Optional[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -886,12 +883,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def query_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         index: Optional[str] = None,
@@ -999,7 +991,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
                     " as queries or a single filter that will be applied to each query."
                 )
         else:
-            filters = [filters] * len(queries) if filters is not None else [{}] * len(queries)
+            filters = [filters] * len(queries)
 
         body = []
         for query, cur_filters in zip(queries, filters):
@@ -1030,7 +1022,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def _construct_query_body(
         self,
         query: Optional[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]],
+        filters: FilterType,
         top_k: int,
         custom_query: Optional[str],
         all_terms_must_match: bool,
@@ -1145,12 +1137,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def query_by_embedding_batch(
         self,
         query_embs: Union[List[np.ndarray], np.ndarray],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -1285,7 +1272,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     def _construct_dense_query_body(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         return_embedding: Optional[bool] = None,
     ):
@@ -1295,7 +1282,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         self,
         retriever: DenseRetriever,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         update_existing_embeddings: bool = True,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -1406,10 +1393,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         return embeddings
 
     def delete_all_documents(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ):
         """
         Delete documents in an index. All documents are deleted if no filters are passed.
@@ -1457,7 +1441,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -1521,7 +1505,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         """

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -32,7 +32,7 @@ except (ImportError, ModuleNotFoundError) as ie:
     _optional_component_not_installed(__name__, "sql", ie)
 
 from haystack.schema import Document, Label, Answer
-from haystack.document_stores.base import BaseDocumentStore
+from haystack.document_stores.base import BaseDocumentStore, FilterType
 from haystack.document_stores.filter_utils import LogicalFilterClause
 
 
@@ -228,7 +228,7 @@ class SQLDocumentStore(BaseDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -246,7 +246,7 @@ class SQLDocumentStore(BaseDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -280,7 +280,7 @@ class SQLDocumentStore(BaseDocumentStore):
     def _query(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,
         vector_ids: Optional[List[str]] = None,
         only_documents_without_embedding: bool = False,
         batch_size: int = 10_000,
@@ -345,7 +345,7 @@ class SQLDocumentStore(BaseDocumentStore):
             documents_map[row.document_id].meta[row.name] = row.value
         return documents_map
 
-    def get_all_labels(self, index=None, filters: Optional[dict] = None, headers: Optional[Dict[str, str]] = None):
+    def get_all_labels(self, index=None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None):
         """
         Return all labels in the document store
         """
@@ -542,7 +542,7 @@ class SQLDocumentStore(BaseDocumentStore):
 
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -614,7 +614,7 @@ class SQLDocumentStore(BaseDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -631,7 +631,7 @@ class SQLDocumentStore(BaseDocumentStore):
     def delete_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -656,7 +656,7 @@ class SQLDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -704,7 +704,7 @@ class SQLDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
+        filters: FilterType = None,  # TODO: Adapt type once we allow extended filters in SQLDocStore
         headers: Optional[Dict[str, str]] = None,
     ):
         """

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -19,7 +19,7 @@ except (ImportError, ModuleNotFoundError) as ie:
 
 from haystack.schema import Document, Label
 from haystack.document_stores import BaseDocumentStore
-from haystack.document_stores.base import get_batches_from_generator
+from haystack.document_stores.base import FilterType, get_batches_from_generator
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.document_stores.utils import convert_date_to_rfc3339
 from haystack.errors import DocumentStoreError
@@ -592,9 +592,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
 
         self.weaviate_client.data_object.update(meta, class_name=index, uuid=id)
 
-    def get_embedding_count(
-        self, filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None, index: Optional[str] = None
-    ) -> int:
+    def get_embedding_count(self, filters: FilterType = None, index: Optional[str] = None) -> int:
         """
         Return the number of embeddings in the document store, which is the same as the number of documents since
         every document has a default embedding.
@@ -603,7 +601,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
 
     def get_document_count(
         self,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         index: Optional[str] = None,
         only_documents_without_embedding: bool = False,
         headers: Optional[Dict[str, str]] = None,
@@ -635,7 +633,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
     def get_all_documents(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -704,7 +702,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
     def _get_all_documents_in_index(
         self,
         index: Optional[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         batch_size: int = 10_000,
         only_documents_without_embedding: bool = False,
     ) -> Generator[dict, None, None]:
@@ -778,7 +776,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
     def get_all_documents_generator(
         self,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         return_embedding: Optional[bool] = None,
         batch_size: int = 10_000,
         headers: Optional[Dict[str, str]] = None,
@@ -852,7 +850,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
     def query(
         self,
         query: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         all_terms_must_match: bool = False,
         custom_query: Optional[str] = None,
@@ -1039,7 +1037,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
     def query_by_embedding(
         self,
         query_emb: np.ndarray,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         index: Optional[str] = None,
         return_embedding: Optional[bool] = None,
@@ -1178,7 +1176,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         self,
         retriever: DenseRetriever,
         index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         update_existing_embeddings: bool = True,
         batch_size: int = 10_000,
     ):
@@ -1254,10 +1252,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
                 self.weaviate_client.data_object.update({}, class_name=index, uuid=doc.id, vector=emb)
 
     def delete_all_documents(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ):
         """
         Delete documents in an index. All documents are deleted if no filters are passed.
@@ -1306,7 +1301,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -1396,7 +1391,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         self,
         index: Optional[str] = None,
         ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         headers: Optional[Dict[str, str]] = None,
     ):
         """
@@ -1407,10 +1402,7 @@ class WeaviateDocumentStore(BaseDocumentStore):
         raise NotImplementedError("Weaviate does not support labels (yet).")
 
     def get_all_labels(
-        self,
-        index: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        self, index: Optional[str] = None, filters: FilterType = None, headers: Optional[Dict[str, str]] = None
     ) -> List[Label]:
         """
         Implemented to respect BaseDocumentStore's contract.

--- a/haystack/nodes/retriever/base.py
+++ b/haystack/nodes/retriever/base.py
@@ -303,7 +303,7 @@ class BaseRetriever(BaseComponent):
         self,
         root_node: str,
         queries: Optional[List[str]] = None,
-        filters: Optional[Union[dict, List[dict]]] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         documents: Optional[Union[List[Document], List[List[Document]]]] = None,
         index: Optional[str] = None,

--- a/haystack/nodes/retriever/base.py
+++ b/haystack/nodes/retriever/base.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from haystack.schema import Document, MultiLabel
 from haystack.errors import HaystackError, PipelineError
 from haystack.nodes.base import BaseComponent
-from haystack.document_stores.base import BaseDocumentStore, BaseKnowledgeGraph
+from haystack.document_stores.base import BaseDocumentStore, BaseKnowledgeGraph, FilterType
 
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class BaseRetriever(BaseComponent):
     def retrieve(
         self,
         query: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -90,7 +90,7 @@ class BaseRetriever(BaseComponent):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -269,7 +269,7 @@ class BaseRetriever(BaseComponent):
         self,
         root_node: str,
         query: Optional[str] = None,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         documents: Optional[List[Document]] = None,
         index: Optional[str] = None,
@@ -336,7 +336,7 @@ class BaseRetriever(BaseComponent):
     def run_query(
         self,
         query: str,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -354,7 +354,7 @@ class BaseRetriever(BaseComponent):
     def run_query_batch(
         self,
         queries: List[str],
-        filters: Optional[dict] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -21,6 +21,7 @@ from transformers import (
     DPRContextEncoderTokenizer,
     DPRQuestionEncoderTokenizer,
 )
+from haystack.document_stores.base import FilterType
 
 from haystack.errors import HaystackError
 from haystack.schema import Document
@@ -241,7 +242,7 @@ class DensePassageRetriever(DenseRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -345,12 +346,7 @@ class DensePassageRetriever(DenseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -452,15 +448,6 @@ class DensePassageRetriever(DenseRetriever):
 
         if batch_size is None:
             batch_size = self.batch_size
-
-        if isinstance(filters, list):
-            if len(filters) != len(queries):
-                raise HaystackError(
-                    "Number of filters does not match number of queries. Please provide as many filters"
-                    " as queries or a single filter that will be applied to each query."
-                )
-        else:
-            filters = [filters] * len(queries) if filters is not None else [{}] * len(queries)
 
         if index is None:
             index = document_store.index
@@ -952,7 +939,7 @@ class TableTextRetriever(DenseRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -979,12 +966,7 @@ class TableTextRetriever(DenseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -1086,15 +1068,6 @@ class TableTextRetriever(DenseRetriever):
 
         if batch_size is None:
             batch_size = self.batch_size
-
-        if isinstance(filters, list):
-            if len(filters) != len(queries):
-                raise HaystackError(
-                    "Number of filters does not match number of queries. Please provide as many filters"
-                    " as queries or a single filter that will be applied to each query."
-                )
-        else:
-            filters = [filters] * len(queries) if filters is not None else [{}] * len(queries)
 
         if index is None:
             index = document_store.index
@@ -1578,7 +1551,7 @@ class EmbeddingRetriever(DenseRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -1682,12 +1655,7 @@ class EmbeddingRetriever(DenseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -1788,15 +1756,6 @@ class EmbeddingRetriever(DenseRetriever):
 
         if batch_size is None:
             batch_size = self.batch_size
-
-        if isinstance(filters, list):
-            if len(filters) != len(queries):
-                raise HaystackError(
-                    "Number of filters does not match number of queries. Please provide as many filters"
-                    " as queries or a single filter that will be applied to each query."
-                )
-        else:
-            filters = [filters] * len(queries) if filters is not None else [{}] * len(queries)
 
         if index is None:
             index = document_store.index
@@ -2041,7 +2000,7 @@ class MultihopEmbeddingRetriever(EmbeddingRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -2138,12 +2097,7 @@ class MultihopEmbeddingRetriever(EmbeddingRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -2254,7 +2208,7 @@ class MultihopEmbeddingRetriever(EmbeddingRetriever):
                     " as queries or a single filter that will be applied to each query."
                 )
         else:
-            filters = [filters] * len(queries) if filters is not None else [{}] * len(queries)
+            filters = [filters] * len(queries)
 
         if index is None:
             index = document_store.index

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -346,7 +346,7 @@ class DensePassageRetriever(DenseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -966,7 +966,7 @@ class TableTextRetriever(DenseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -1655,7 +1655,7 @@ class EmbeddingRetriever(DenseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -2097,7 +2097,7 @@ class MultihopEmbeddingRetriever(EmbeddingRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/nodes/retriever/multimodal/retriever.py
+++ b/haystack/nodes/retriever/multimodal/retriever.py
@@ -5,17 +5,15 @@ from pathlib import Path
 
 import torch
 import numpy as np
+from haystack.document_stores.base import FilterType
 
 from haystack.nodes.retriever import DenseRetriever
 from haystack.document_stores import BaseDocumentStore
 from haystack.schema import ContentTypes, Document
-from haystack.nodes.retriever.multimodal.embedder import MultiModalEmbedder, MultiModalRetrieverError
+from haystack.nodes.retriever.multimodal.embedder import MultiModalEmbedder
 
 
 logger = logging.getLogger(__name__)
-
-
-FilterType = Optional[Dict[str, Union[Dict[str, Any], List[Any], str, int, float, bool]]]
 
 
 class MultiModalRetriever(DenseRetriever):
@@ -112,7 +110,7 @@ class MultiModalRetriever(DenseRetriever):
         self,
         query: Any,
         query_type: ContentTypes = "text",
-        filters: Optional[FilterType] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -152,7 +150,7 @@ class MultiModalRetriever(DenseRetriever):
         self,
         queries: List[Any],
         queries_type: ContentTypes = "text",
-        filters: Union[None, FilterType, List[FilterType]] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -180,17 +178,6 @@ class MultiModalRetriever(DenseRetriever):
                             value range are scaled to a range of [0,1], where 1 means extremely relevant.
                             Otherwise raw similarity scores (for example, cosine or dot_product) are used.
         """
-        filters_list: List[FilterType]
-        if not isinstance(filters, list):
-            filters_list = [filters] * len(queries)
-        else:
-            if len(filters) != len(queries):
-                raise MultiModalRetrieverError(
-                    "The number of filters does not match the number of queries. Provide as many filters "
-                    "as queries, or a single filter that will be applied to all queries."
-                )
-            filters_list = filters
-
         top_k = top_k or self.top_k
         document_store = document_store or self.document_store
         if not document_store:
@@ -208,7 +195,7 @@ class MultiModalRetriever(DenseRetriever):
         documents = document_store.query_by_embedding_batch(
             query_embs=query_embeddings,
             top_k=top_k,
-            filters=filters_list,  # type: ignore
+            filters=filters,
             index=index,
             headers=headers,
             scale_score=scale_score,

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -7,7 +7,7 @@ import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from haystack.schema import Document
-from haystack.document_stores.base import BaseDocumentStore
+from haystack.document_stores.base import BaseDocumentStore, FilterType
 from haystack.document_stores import KeywordDocumentStore
 from haystack.nodes.retriever import BaseRetriever
 from haystack.errors import DocumentStoreError
@@ -116,7 +116,7 @@ class BM25Retriever(BaseRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -232,12 +232,7 @@ class BM25Retriever(BaseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Optional[Union[FilterType, List[FilterType],]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -377,7 +372,7 @@ class FilterRetriever(BM25Retriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -491,12 +486,7 @@ class TfidfRetriever(BaseRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[
-            Union[
-                Dict[str, Union[Dict, List, str, int, float, bool]],
-                List[Dict[str, Union[Dict, List, str, int, float, bool]]],
-            ]
-        ] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -576,7 +566,7 @@ class TfidfRetriever(BaseRetriever):
     def retrieve_batch(
         self,
         queries: Union[str, List[str]],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -232,7 +232,7 @@ class BM25Retriever(BaseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Union[FilterType, List[FilterType],]] = None,
+        filters: Union[FilterType, List[FilterType],] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from typing_extensions import Literal  # type: ignore
 
-from haystack.document_stores.base import BaseDocumentStore
+from haystack.document_stores.base import BaseDocumentStore, FilterType
 from haystack.nodes.answer_generator.base import BaseGenerator
 from haystack.nodes.other.docs2answers import Docs2Answers
 from haystack.nodes.other.document_merger import DocumentMerger
@@ -672,13 +672,7 @@ class MostSimilarDocumentsPipeline(BaseStandardPipeline):
         self.pipeline.add_node(component=document_store, name="DocumentStore", inputs=["Query"])
         self.document_store = document_store
 
-    def run(
-        self,
-        document_ids: List[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        top_k: int = 5,
-        index: Optional[str] = None,
-    ):
+    def run(self, document_ids: List[str], filters: FilterType = None, top_k: int = 5, index: Optional[str] = None):
         """
         :param document_ids: document ids
         :param filters: Optional filters to narrow down the search space to documents whose metadata fulfill certain conditions
@@ -697,11 +691,7 @@ class MostSimilarDocumentsPipeline(BaseStandardPipeline):
         return similar_documents
 
     def run_batch(  # type: ignore
-        self,
-        document_ids: List[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
-        top_k: int = 5,
-        index: Optional[str] = None,
+        self, document_ids: List[str], filters: FilterType = None, top_k: int = 5, index: Optional[str] = None
     ):
         """
         :param document_ids: document ids

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -5,6 +5,8 @@ from mimetypes import guess_type
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
+from haystack.document_stores.base import FilterType
+
 try:
     from typing import Literal
 except ImportError:
@@ -369,7 +371,7 @@ class IndexClient:
     def query(
         self,
         query: Optional[str] = None,
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: FilterType = None,
         top_k: int = 10,
         custom_query: Optional[str] = None,
         query_emb: Optional[List[float]] = None,
@@ -398,7 +400,7 @@ class IndexClient:
     def stream_documents(
         self,
         return_embedding: Optional[bool] = False,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         workspace: Optional[str] = None,
         index: Optional[str] = None,
         headers: Optional[dict] = None,
@@ -426,7 +428,7 @@ class IndexClient:
 
     def count_documents(
         self,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         only_documents_without_embedding: Optional[bool] = False,
         workspace: Optional[str] = None,
         index: Optional[str] = None,

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 from haystack import Document, Answer
 import haystack
+from haystack.document_stores.base import FilterType
 from haystack.nodes import BaseReader, BaseRetriever
 from haystack.document_stores import BaseDocumentStore
 from haystack.schema import Label
@@ -50,7 +51,7 @@ class MockRetriever(BaseRetriever):
     def retrieve(
         self,
         query: str,
-        filters: Optional[dict] = None,
+        filters: FilterType = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -63,7 +64,7 @@ class MockRetriever(BaseRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[dict] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,

--- a/test/mocks/pinecone.py
+++ b/test/mocks/pinecone.py
@@ -257,11 +257,7 @@ class Index:
         return bools
 
     def delete(
-        self,
-        ids: Optional[List[str]] = None,
-        namespace: str = "",
-        filters: Optional[dict] = None,
-        delete_all: bool = False,
+        self, ids: Optional[List[str]] = None, namespace: str = "", filters: FilterType = None, delete_all: bool = False
     ):
         if filters:
             # Get a filtered list of IDs

--- a/test/mocks/pinecone.py
+++ b/test/mocks/pinecone.py
@@ -2,6 +2,8 @@ from typing import Optional, List, Dict, Union
 
 import logging
 
+from haystack.document_stores.base import FilterType
+
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +150,7 @@ class Index:
     def _filter(
         self,
         metadata: dict,
-        filters: Dict[str, Union[str, int, float, bool, list]],
+        filters: Union[FilterType, List[FilterType]],
         mode: Optional[str] = "$and",
         top_level=False,
     ) -> dict:

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -13,7 +13,7 @@ from pandas.testing import assert_frame_equal
 from elasticsearch import Elasticsearch
 from transformers import DPRContextEncoderTokenizerFast, DPRQuestionEncoderTokenizerFast
 
-from haystack.document_stores.base import BaseDocumentStore
+from haystack.document_stores.base import BaseDocumentStore, FilterType
 from haystack.document_stores.memory import InMemoryDocumentStore
 from haystack.document_stores import WeaviateDocumentStore
 from haystack.nodes.retriever.base import BaseRetriever
@@ -123,7 +123,7 @@ class MockBaseRetriever(MockRetriever):
     def retrieve_batch(
         self,
         queries: List[str],
-        filters: Optional[Dict[str, Union[Dict, List, str, int, float, bool]]] = None,
+        filters: Union[FilterType, List[FilterType]] = None,
         top_k: Optional[int] = None,
         index: str = None,
         headers: Optional[Dict[str, str]] = None,
@@ -166,6 +166,29 @@ def test_batch_retrieval_multiple_queries(retriever_with_docs, document_store_wi
         document_store_with_docs.update_embeddings(retriever_with_docs)
 
     res = retriever_with_docs.retrieve_batch(queries=["Who lives in Berlin?", "Who lives in New York?"])
+
+    # Expected return type: list of lists of Documents
+    assert isinstance(res, list)
+    assert isinstance(res[0], list)
+    assert isinstance(res[0][0], Document)
+
+    assert res[0][0].content == "My name is Carla and I live in Berlin"
+    assert len(res[0]) == 5
+    assert res[0][0].meta["name"] == "filename1"
+
+    assert res[1][0].content == "My name is Paul and I live in New York"
+    assert len(res[1]) == 5
+    assert res[1][0].meta["name"] == "filename2"
+
+
+@pytest.mark.parametrize("retriever_with_docs", ["bm25"], indirect=True)
+def test_batch_retrieval_multiple_queries_with_filters(retriever_with_docs, document_store_with_docs):
+    if not isinstance(retriever_with_docs, (BM25Retriever, FilterRetriever)):
+        document_store_with_docs.update_embeddings(retriever_with_docs)
+
+    res = retriever_with_docs.retrieve_batch(
+        queries=["Who lives in Berlin?", "Who lives in New York?"], filters=[{"name": "filename1"}, None]
+    )
 
     # Expected return type: list of lists of Documents
     assert isinstance(res, list)


### PR DESCRIPTION
### Related Issues
`filters` throughout the codebase have inconsistent types. This PR consolidates them

### Proposed Changes:
- take `FilterType` from multimodal retriever and make it the standard filters type

### How did you test it?
- existing tests and additional tests for None values in filters lists

### Notes for the reviewer
- this is a follow-up PR to https://github.com/deepset-ai/haystack/pull/3546 to fix the introduced `# type: ignore`

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
