### PR TITLE
fix: pin `espnet` in the `audio` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ docstores-gpu = [
   "farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]",
 ]
 audio = [
+  "torch>1.9,<1.12",
   "pyworld>=0.3.1; python_version >= '3.8'",
   "pyworld<0.3.1; python_version < '3.8'",
   "espnet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ docstores-gpu = [
 audio = [
   "pyworld>=0.3.1; python_version >= '3.8'",
   "pyworld<0.3.1; python_version < '3.8'",
-  "espnet==202209",
+  "espnet==202209", # https://github.com/deepset-ai/haystack/pull/3693
   "espnet-model-zoo",
   "pydub",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,10 +143,9 @@ docstores-gpu = [
   "farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]",
 ]
 audio = [
-  "torch==1.12.1",
   "pyworld>=0.3.1; python_version >= '3.8'",
   "pyworld<0.3.1; python_version < '3.8'",
-  "espnet",
+  "espnet==202209",
   "espnet-model-zoo",
   "pydub",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docstores-gpu = [
   "farm-haystack[faiss-gpu,milvus,weaviate,graphdb,inmemorygraph,pinecone,opensearch]",
 ]
 audio = [
-  "torch>1.9,<1.12",
+  "torch==1.12.1",
   "pyworld>=0.3.1; python_version >= '3.8'",
   "pyworld<0.3.1; python_version < '3.8'",
   "espnet",


### PR DESCRIPTION
### Related Issues
- fixes [CI failure](https://github.com/deepset-ai/haystack/actions/runs/3674242182/jobs/6212348208)

### Proposed Changes:
- Downgrade `espnet` to `202209` to keep the tests green.
- This is a workaround to keep the CI alive until we migrate audio nodes out.

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
