### PR TITLE
feat: Bump python to 3.10 for gpu docker image, use nvidia/cuda 

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -46,5 +46,4 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Importing Haystack will generate and persist the json schema, we do this here for two reasons:
 # - the schema will be already there when the container runs, saving the generation overhead when a container starts
 # - derived images don't need to write the schema and can run with lower user privileges
-RUN python3 -c "from haystack.nodes._json_schema import load_schema; load_schema()"
-
+RUN python3 -c "import haystack"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -46,5 +46,5 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Importing Haystack will generate and persist the json schema, we do this here for two reasons:
 # - the schema will be already there when the container runs, saving the generation overhead when a container starts
 # - derived images don't need to write the schema and can run with lower user privileges
-RUN python3 -c "import haystack"
+RUN python3 -c "from haystack.nodes._json_schema import load_schema; load_schema()"
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,6 +3,7 @@ ARG base_immage
 
 FROM $build_image AS build-image
 
+ARG DEBIAN_FRONTEND=noninteractive
 ARG haystack_version
 ARG haystack_extras
 
@@ -25,10 +26,11 @@ RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-
 WORKDIR /opt/haystack
 
 # Use a virtualenv we can copy over the next build stage
-RUN python -m venv --system-site-packages /opt/venv
+RUN python3 -m venv --system-site-packages /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -U torchaudio && \
     pip install --no-cache-dir .${haystack_extras} && \
     pip install --no-cache-dir ./rest_api
 
@@ -40,3 +42,4 @@ COPY --from=build-image /opt/pdftotext /usr/local/bin
 RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"
+RUN python3 -c "from haystack.nodes._json_schema import load_schema; load_schema()"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -42,4 +42,9 @@ COPY --from=build-image /opt/pdftotext /usr/local/bin
 RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"
-RUN python3 -c "from haystack.nodes._json_schema import load_schema; load_schema()"
+
+# Importing Haystack will generate and persist the json schema, we do this here for two reasons:
+# - the schema will be already there when the container runs, saving the generation overhead when a container starts
+# - derived images don't need to write the schema and can run with lower user privileges
+RUN python3 -c "import haystack"
+

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -54,8 +54,8 @@ target "base-gpu" {
   dockerfile = "Dockerfile.base"
   tags = ["${IMAGE_NAME}:base-gpu-${IMAGE_TAG_SUFFIX}"]
   args = {
-    build_image = "pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
-    base_immage = "pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
+    build_image = "pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime"
+    base_immage = "pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime"
     haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores-gpu,crawler,preprocessing,ocr,onnx-gpu]"
   }

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -54,6 +54,8 @@ target "base-gpu" {
   dockerfile = "Dockerfile.base"
   tags = ["${IMAGE_NAME}:base-gpu-${IMAGE_TAG_SUFFIX}"]
   args = {
+    # pytorch/pytorch:1.13.1-cuda11.6 ships Python 3.10.8
+
     build_image = "pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime"
     base_immage = "pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime"
     haystack_version = "${HAYSTACK_VERSION}"


### PR DESCRIPTION
### Related Issues
- fixes #3303

### Proposed Changes:
Based GPU image on  nvidia/cuda image
Bump GPU image to python to 3.9
CPU image already uses 3.10 - didn't change it

I wanted to update python to 3.10, currently available via  `ppa:deadsnakes/ppa` apt repository. However, the repository hosting the python 3.10 image for ubuntu seems so overwhelmed that the build timed out, waiting for gpg keys multiple times. These timeouts impede the build process and make it less reliable. Python 3.9 is available via more "standard" repositories - let's use those until 3.10 gets released.  

### How did you test it?
Tested by running haystack demo, need to set the right pipeline path, but the containers start ok.


### Notes for the reviewer
Supercedes https://github.com/deepset-ai/haystack/pull/3323
Note how I had to remove beir dependency. Otherwise, I would get 
```
AttributeError: module 'faiss' has no attribute 'swigfaiss'
```

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
