### PR TITLE
feat: Run commands inside docker container as a non root user

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -16,6 +16,8 @@ RUN mkdir -p /opt/file-upload && chown $SERVICE_NAME:$SERVICE_NAME /opt/file-upl
 # Tell rest_api which folder to use for uploads
 ENV FILE_UPLOAD_PATH="/opt/file-upload"
 
+ENV TIKA_LOG_PATH="/var/log/$SERVICE_NAME/"
+
 EXPOSE 8000
 
 USER $SERVICE_NAME

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -2,6 +2,14 @@ ARG base_image_tag
 
 FROM deepset/haystack:${base_image_tag}
 
+ENV SERVICE_NAME="gunicorn-service"
+
+RUN addgroup --gid 1001 $SERVICE_NAME && \
+    adduser --gid 1001 --uid 1001 --shell /bin/false --disabled-password $SERVICE_NAME && \
+    mkdir -p /var/log/$SERVICE_NAME && \
+    chown $SERVICE_NAME:$SERVICE_NAME /var/log/$SERVICE_NAME
+
+
 # Create a folder for the /file-upload API endpoint with write permissions
 RUN mkdir -p /opt/file-upload && chmod 777 /opt/file-upload
 
@@ -10,4 +18,5 @@ ENV FILE_UPLOAD_PATH="/opt/file-upload"
 
 EXPOSE 8000
 
+USER $SERVICE_NAME
 CMD ["gunicorn", "rest_api.application:app",  "-b", "0.0.0.0", "-k", "uvicorn.workers.UvicornWorker", "--workers", "1", "--timeout", "180"]

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -10,8 +10,8 @@ RUN addgroup --gid 1001 $SERVICE_NAME && \
     chown $SERVICE_NAME:$SERVICE_NAME /var/log/$SERVICE_NAME
 
 
-# Create a folder for the /file-upload API endpoint with write permissions
-RUN mkdir -p /opt/file-upload && chmod 777 /opt/file-upload
+# Create a folder for the /file-upload API endpoint with write permissions for the service user only
+RUN mkdir -p /opt/file-upload && chown $SERVICE_NAME:$SERVICE_NAME /opt/file-upload && chmod 600 /opt/file-upload
 
 # Tell rest_api which folder to use for uploads
 ENV FILE_UPLOAD_PATH="/opt/file-upload"


### PR DESCRIPTION
### Related Issues
- fixes #3255 

### Proposed Changes:
Runs gunicorn command inside docker container as a non-root user. This was a requirement from one of the users who had a requirement to run gunicorn non-root. 
Adapted from https://stackoverflow.com/questions/68155641/should-i-run-things-inside-a-docker-container-as-non-root-for-safety

### How did you test it?
I ran the gpu image and didn't notice any issues. Will do another round of tests

### Notes for the reviewer
Try to see if gunicorn behaviour changed somehow

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
