### PR TITLE
refactor: Remove duplicate code in TableReader

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -701,20 +701,11 @@ class RCIReader(BaseReader):
             top_k = self.top_k
 
         answers = []
-        # TODO Update to use _check_documents
-        for document in documents:
-            if document.content_type != "table":
-                logger.warning("Skipping document with id '%s' in RCIReader as it is not of type table.", document.id)
-                continue
-
-            table: pd.DataFrame = document.content
-            if table.shape[0] == 0:
-                logger.warning(
-                    "Skipping document with id '%s' in RCIReader as it does not contain any rows.", document.id
-                )
-                continue
-            table = table.astype(str)
+        table_documents = _check_documents(documents)
+        for document in table_documents:
             # Create row and column representations
+            table: pd.DataFrame = document.content
+            table = table.astype(str)
             row_reps, column_reps = self._create_row_column_representations(table)
 
             # Get row logits

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -175,17 +175,13 @@ class TableReader(BaseReader):
         return self.table_encoder.predict(query=query, documents=documents, top_k=top_k)
 
     def predict_batch(
-        self,
-        queries: List[str],
-        documents: Union[List[Document], List[List[Document]]],
-        top_k: Optional[int] = None,
-        batch_size: Optional[int] = None,
+        self, queries: List[str], documents: Union[List[Document], List[List[Document]]], top_k: Optional[int] = None
     ):
         """
         Use loaded TableQA model to find answers for the supplied queries in the supplied Documents
         of content_type ``'table'``.
 
-        Returns dictionary containing query and list of Answer objects sorted by (desc.) score.
+        Returns dictionary containing query and list of Answer objects sorted by (descending) score.
         WARNING: The answer scores are not reliable, as they are always extremely high, even if
         a question cannot be answered by a given table.
 
@@ -203,33 +199,19 @@ class TableReader(BaseReader):
         :param documents: Single list of Documents or list of lists of Documents in which to search for the answers.
                           Documents should be of content_type ``'table'``.
         :param top_k: The maximum number of answers to return per query.
-        :param batch_size: Not applicable.
         """
-        results: Dict = {"queries": queries, "answers": []}
+        if top_k is None:
+            top_k = self.top_k
 
-        single_doc_list = False
-        # Docs case 1: single list of Documents -> apply each query to all Documents
         if len(documents) > 0 and isinstance(documents[0], Document):
             single_doc_list = True
-            for query in queries:
-                for doc in documents:
-                    if not isinstance(doc, Document):
-                        raise HaystackError(f"doc was of type {type(doc)}, but expected a Document.")
-                    preds = self.predict(query=query, documents=[doc], top_k=top_k)
-                    results["answers"].append(preds["answers"])
+        else:
+            single_doc_list = False
 
-        # Docs case 2: list of lists of Documents -> apply each query to corresponding list of Documents, if queries
-        # contains only one query, apply it to each list of Documents
-        elif len(documents) > 0 and isinstance(documents[0], list):
-            if len(queries) == 1:
-                queries = queries * len(documents)
-            if len(queries) != len(documents):
-                raise HaystackError("Number of queries must be equal to number of provided Document lists.")
-            for query, cur_docs in zip(queries, documents):
-                if not isinstance(cur_docs, list):
-                    raise HaystackError(f"cur_docs was of type {type(cur_docs)}, but expected a list of Documents.")
-                preds = self.predict(query=query, documents=cur_docs, top_k=top_k)
-                results["answers"].append(preds["answers"])
+        inputs = _flatten_inputs(queries, documents)
+        results: Dict = self.table_encoder.predict_batch(
+            queries=inputs["queries"], documents=inputs["docs"], top_k=top_k
+        )
 
         # Group answers by question in case of multiple queries and single doc list
         if single_doc_list and len(queries) > 1:
@@ -243,51 +225,7 @@ class TableReader(BaseReader):
         return results
 
 
-class _BaseTapasEncoder:
-    @staticmethod
-    def _calculate_answer_offsets(answer_coordinates: List[Tuple[int, int]], table: pd.DataFrame) -> List[Span]:
-        """
-        Calculates the answer cell offsets of the linearized table based on the answer cell coordinates.
-        """
-        answer_offsets = []
-        n_rows, n_columns = table.shape
-        for coord in answer_coordinates:
-            answer_cell_offset = (coord[0] * n_columns) + coord[1]
-            answer_offsets.append(Span(start=answer_cell_offset, end=answer_cell_offset + 1))
-        return answer_offsets
-
-    @staticmethod
-    def _check_documents(documents: List[Document]) -> List[Document]:
-        table_documents = []
-        for document in documents:
-            if document.content_type != "table":
-                logger.warning("Skipping document with id '%s' in TableReader as it is not of type table.", document.id)
-                continue
-
-            table: pd.DataFrame = document.content
-            if table.shape[0] == 0:
-                logger.warning(
-                    "Skipping document with id '%s' in TableReader as it does not contain any rows.", document.id
-                )
-                continue
-
-            table_documents.append(document)
-        return table_documents
-
-    @staticmethod
-    def _preprocess(query: str, table: pd.DataFrame, tokenizer, max_seq_len) -> BatchEncoding:
-        """Tokenize the query and table."""
-        model_inputs = tokenizer(
-            table=table, queries=query, max_length=max_seq_len, return_tensors="pt", truncation=True
-        )
-        return model_inputs
-
-    @abstractmethod
-    def predict(self, query: str, documents: List[Document], top_k: int) -> Dict:
-        pass
-
-
-class _TapasEncoder(_BaseTapasEncoder):
+class _TapasEncoder:
     def __init__(
         self,
         device: torch.device,
@@ -347,7 +285,7 @@ class _TapasEncoder(_BaseTapasEncoder):
         else:
             answer_str = self._aggregate_answers(current_aggregation_operator, current_answer_cells)
 
-        answer_offsets = self._calculate_answer_offsets(current_answer_coordinates, document.content)
+        answer_offsets = _calculate_answer_offsets(current_answer_coordinates, document.content)
 
         answer = Answer(
             answer=answer_str,
@@ -430,10 +368,12 @@ class _TapasEncoder(_BaseTapasEncoder):
 
     def predict(self, query: str, documents: List[Document], top_k: int) -> Dict:
         answers = []
-        table_documents = self._check_documents(documents)
+        table_documents = _check_documents(documents)
         for document in table_documents:
             table: pd.DataFrame = document.content
-            model_inputs = self._preprocess(query, table, self.tokenizer, self.max_seq_len)
+            model_inputs = self.tokenizer(
+                table=table, queries=query, max_length=self.max_seq_len, return_tensors="pt", truncation=True
+            )
             model_inputs.to(self.device)
 
             current_answer = self._predict_tapas(model_inputs, document)
@@ -443,8 +383,16 @@ class _TapasEncoder(_BaseTapasEncoder):
         results = {"query": query, "answers": answers[:top_k]}
         return results
 
+    def predict_batch(self, queries, documents, top_k):
+        # [{"table": table, "query": query}, {"table": table, "query": query}]
+        results: Dict = {"queries": queries, "answers": []}
+        for query, docs in zip(queries, documents):
+            preds = self.predict(query=query, documents=docs, top_k=top_k)
+            results["answers"].append(preds["answers"])
+        return results
 
-class _TapasScoredEncoder(_BaseTapasEncoder):
+
+class _TapasScoredEncoder:
     def __init__(
         self,
         device: torch.device,
@@ -546,7 +494,7 @@ class _TapasScoredEncoder(_BaseTapasEncoder):
         for answer_span_idx in top_k_answer_spans.indices:
             current_answer_span = possible_answer_spans[answer_span_idx]
             answer_str = table.iat[current_answer_span[:2]]
-            answer_offsets = self._calculate_answer_offsets([current_answer_span[:2]], document.content)
+            answer_offsets = _calculate_answer_offsets([current_answer_span[:2]], document.content)
             # As the general table score is more important for the final score, it is double weighted.
             current_score = ((2 * table_relevancy_prob) + span_logits_softmax[0, answer_span_idx].item()) / 3
 
@@ -568,10 +516,12 @@ class _TapasScoredEncoder(_BaseTapasEncoder):
     def predict(self, query: str, documents: List[Document], top_k: int) -> Dict:
         answers = []
         no_answer_score = 1.0
-        table_documents = self._check_documents(documents)
+        table_documents = _check_documents(documents)
         for document in table_documents:
             table: pd.DataFrame = document.content
-            model_inputs = self._preprocess(query, table, self.tokenizer, self.max_seq_len)
+            model_inputs = self.tokenizer(
+                table=table, queries=query, max_length=self.max_seq_len, return_tensors="pt", truncation=True
+            )
             model_inputs.to(self.device)
 
             current_answers, current_no_answer_score = self._predict_tapas_scored(model_inputs, document)
@@ -595,6 +545,13 @@ class _TapasScoredEncoder(_BaseTapasEncoder):
 
         answers = sorted(answers, reverse=True)
         results = {"query": query, "answers": answers[:top_k]}
+        return results
+
+    def predict_batch(self, queries, documents, top_k):
+        results: Dict = {"queries": queries, "answers": []}
+        for query, docs in zip(queries, documents):
+            preds = self.predict(query=query, documents=docs, top_k=top_k)
+            results["answers"].append(preds["answers"])
         return results
 
     class _TapasForScoredQA(TapasPreTrainedModel):
@@ -884,3 +841,75 @@ class RCIReader(BaseReader):
             results["answers"] = answers
 
         return results
+
+
+def _calculate_answer_offsets(answer_coordinates: List[Tuple[int, int]], table: pd.DataFrame) -> List[Span]:
+    """
+    Calculates the answer cell offsets of the linearized table based on the answer cell coordinates.
+    """
+    answer_offsets = []
+    n_rows, n_columns = table.shape
+    for coord in answer_coordinates:
+        answer_cell_offset = (coord[0] * n_columns) + coord[1]
+        answer_offsets.append(Span(start=answer_cell_offset, end=answer_cell_offset + 1))
+    return answer_offsets
+
+
+def _check_documents(documents: List[Document]) -> List[Document]:
+    table_documents = []
+    for document in documents:
+        if document.content_type != "table":
+            logger.warning("Skipping document with id '%s' in TableReader as it is not of type table.", document.id)
+            continue
+
+        table: pd.DataFrame = document.content
+        if table.shape[0] == 0:
+            logger.warning(
+                "Skipping document with id '%s' in TableReader as it does not contain any rows.", document.id
+            )
+            continue
+
+        table_documents.append(document)
+    return table_documents
+
+
+def _flatten_inputs(queries: List[str], documents: Union[List[Document], List[List[Document]]]) -> Dict[str, List]:
+    """Flatten (and copy) the queries and documents into lists of equal length.
+
+    - If you provide a list containing a single query...
+        - ... and a single list of Documents, the query will be applied to each Document individually.
+        - ... and a list of lists of Documents, the query will be applied to each list of Documents and the Answers
+          will be aggregated per Document list.
+
+    - If you provide a list of multiple queries...
+        - ... and a single list of Documents, each query will be applied to each Document individually.
+        - ... and a list of lists of Documents, each query will be applied to its corresponding list of Documents
+          and the Answers will be aggregated per query-Document pair.
+
+    :param queries: Single query string or list of queries.
+    :param documents: Single list of Documents or list of lists of Documents in which to search for the answers.
+                      Documents should be of content_type ``'table'``.
+    """
+    # Docs case 1: single list of Documents -> apply each query to all Documents
+    inputs = {"queries": [], "docs": []}
+    if len(documents) > 0 and isinstance(documents[0], Document):
+        for query in queries:
+            for doc in documents:
+                if not isinstance(doc, Document):
+                    raise HaystackError(f"doc was of type {type(doc)}, but expected a Document.")
+                inputs["queries"].append(query)
+                inputs["docs"].append([doc])
+
+    # Docs case 2: list of lists of Documents -> apply each query to corresponding list of Documents, if queries
+    # contains only one query, apply it to each list of Documents
+    elif len(documents) > 0 and isinstance(documents[0], list):
+        if len(queries) == 1:
+            queries = queries * len(documents)
+        if len(queries) != len(documents):
+            raise HaystackError("Number of queries must be equal to number of provided Document lists.")
+        for query, cur_docs in zip(queries, documents):
+            if not isinstance(cur_docs, list):
+                raise HaystackError(f"cur_docs was of type {type(cur_docs)}, but expected a list of Documents.")
+            inputs["queries"].append(query)
+            inputs["docs"].append(cur_docs)
+    return inputs

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -175,7 +175,11 @@ class TableReader(BaseReader):
         return self.table_encoder.predict(query=query, documents=documents, top_k=top_k)
 
     def predict_batch(
-        self, queries: List[str], documents: Union[List[Document], List[List[Document]]], top_k: Optional[int] = None
+        self,
+        queries: List[str],
+        documents: Union[List[Document], List[List[Document]]],
+        top_k: Optional[int] = None,
+        batch_size: Optional[int] = None,
     ):
         """
         Use loaded TableQA model to find answers for the supplied queries in the supplied Documents
@@ -199,6 +203,7 @@ class TableReader(BaseReader):
         :param documents: Single list of Documents or list of lists of Documents in which to search for the answers.
                           Documents should be of content_type ``'table'``.
         :param top_k: The maximum number of answers to return per query.
+        :param batch_size: Not applicable.
         """
         if top_k is None:
             top_k = self.top_k
@@ -383,7 +388,7 @@ class _TapasEncoder:
         results = {"query": query, "answers": answers[:top_k]}
         return results
 
-    def predict_batch(self, queries, documents, top_k):
+    def predict_batch(self, queries: List[str], documents: List[List[Document]], top_k: int):
         # [{"table": table, "query": query}, {"table": table, "query": query}]
         results: Dict = {"queries": queries, "answers": []}
         for query, docs in zip(queries, documents):
@@ -547,7 +552,7 @@ class _TapasScoredEncoder:
         results = {"query": query, "answers": answers[:top_k]}
         return results
 
-    def predict_batch(self, queries, documents, top_k):
+    def predict_batch(self, queries: List[str], documents: List[List[Document]], top_k: int):
         results: Dict = {"queries": queries, "answers": []}
         for query, docs in zip(queries, documents):
             preds = self.predict(query=query, documents=docs, top_k=top_k)

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import List, Optional, Tuple, Dict, Union
 
 try:
@@ -208,10 +207,7 @@ class TableReader(BaseReader):
         if top_k is None:
             top_k = self.top_k
 
-        if len(documents) > 0 and isinstance(documents[0], Document):
-            single_doc_list = True
-        else:
-            single_doc_list = False
+        single_doc_list = bool(len(documents) > 0 and isinstance(documents[0], Document))
 
         inputs = _flatten_inputs(queries, documents)
         results: Dict = self.table_encoder.predict_batch(
@@ -802,10 +798,7 @@ class RCIReader(BaseReader):
         if top_k is None:
             top_k = self.top_k
 
-        if len(documents) > 0 and isinstance(documents[0], Document):
-            single_doc_list = True
-        else:
-            single_doc_list = False
+        single_doc_list = bool(len(documents) > 0 and isinstance(documents[0], Document))
 
         inputs = _flatten_inputs(queries, documents)
 

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -833,6 +833,9 @@ class RCIReader(BaseReader):
 def _calculate_answer_offsets(answer_coordinates: List[Tuple[int, int]], table: pd.DataFrame) -> List[Span]:
     """
     Calculates the answer cell offsets of the linearized table based on the answer cell coordinates.
+
+    :param answer_coordinates: List of answer coordinates.
+    :param table: Table containing the answers in answer coordinates.
     """
     answer_offsets = []
     n_rows, n_columns = table.shape

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -701,6 +701,7 @@ class RCIReader(BaseReader):
             top_k = self.top_k
 
         answers = []
+        # TODO Update to use _check_documents
         for document in documents:
             if document.content_type != "table":
                 logger.warning("Skipping document with id '%s' in RCIReader as it is not of type table.", document.id)
@@ -817,7 +818,7 @@ class RCIReader(BaseReader):
 
         inputs = _flatten_inputs(queries, documents)
 
-        results: Dict = {"queries": queries, "answers": []}
+        results: Dict[str, List] = {"queries": inputs["queries"], "answers": []}
         for query, docs in zip(inputs["queries"], inputs["docs"]):
             preds = self.predict(query=query, documents=docs, top_k=top_k)
             results["answers"].append(preds["answers"])
@@ -902,6 +903,7 @@ def _flatten_inputs(queries: List[str], documents: Union[List[Document], List[Li
     # Docs case 2: list of lists of Documents -> apply each query to corresponding list of Documents, if queries
     # contains only one query, apply it to each list of Documents
     elif len(documents) > 0 and isinstance(documents[0], list):
+        # FIXME Concerned that queries is overwritten here.
         if len(queries) == 1:
             queries = queries * len(documents)
         if len(queries) != len(documents):

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -215,10 +215,10 @@ class TableReader(BaseReader):
 
         # Group answers by question in case of multiple queries and single doc list
         if single_doc_list and len(queries) > 1:
-            answers_per_query = int(len(results["answers"]) / len(queries))
+            num_docs_per_query = int(len(results["answers"]) / len(queries))
             answers = []
-            for i in range(0, len(results["answers"]), answers_per_query):
-                answer_group = results["answers"][i : i + answers_per_query]
+            for i in range(0, len(results["answers"]), num_docs_per_query):
+                answer_group = results["answers"][i : i + num_docs_per_query]
                 answers.append(answer_group)
             results["answers"] = answers
 
@@ -856,6 +856,11 @@ def _calculate_answer_offsets(answer_coordinates: List[Tuple[int, int]], table: 
 
 
 def _check_documents(documents: List[Document]) -> List[Document]:
+    """
+    Check that the content type of all `documents` is of type 'table' otherwise remove that document from the list.
+
+    :param documents: List of documents to be checked.
+    """
     table_documents = []
     for document in documents:
         if document.content_type != "table":

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -903,12 +903,12 @@ def _flatten_inputs(queries: List[str], documents: Union[List[Document], List[Li
     # Docs case 2: list of lists of Documents -> apply each query to corresponding list of Documents, if queries
     # contains only one query, apply it to each list of Documents
     elif len(documents) > 0 and isinstance(documents[0], list):
-        # FIXME Concerned that queries is overwritten here.
-        if len(queries) == 1:
-            queries = queries * len(documents)
-        if len(queries) != len(documents):
+        total_queries = queries.copy()
+        if len(total_queries) == 1:
+            total_queries = queries * len(documents)
+        if len(total_queries) != len(documents):
             raise HaystackError("Number of queries must be equal to number of provided Document lists.")
-        for query, cur_docs in zip(queries, documents):
+        for query, cur_docs in zip(total_queries, documents):
             if not isinstance(cur_docs, list):
                 raise HaystackError(f"cur_docs was of type {type(cur_docs)}, but expected a list of Documents.")
             inputs["queries"].append(query)

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -389,7 +389,6 @@ class _TapasEncoder:
         return results
 
     def predict_batch(self, queries: List[str], documents: List[List[Document]], top_k: int):
-        # [{"table": table, "query": query}, {"table": table, "query": query}]
         results: Dict = {"queries": queries, "answers": []}
         for query, docs in zip(queries, documents):
             preds = self.predict(query=query, documents=docs, top_k=top_k)

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -890,7 +890,7 @@ def _flatten_inputs(queries: List[str], documents: Union[List[Document], List[Li
                       Documents should be of content_type ``'table'``.
     """
     # Docs case 1: single list of Documents -> apply each query to all Documents
-    inputs = {"queries": [], "docs": []}
+    inputs: Dict[str, List] = {"queries": [], "docs": []}
     if len(documents) > 0 and isinstance(documents[0], Document):
         for query in queries:
             for doc in documents:

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -7,9 +7,8 @@ from haystack.schema import Document, Answer
 from haystack.pipelines.base import Pipeline
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
-def test_table_reader(table_reader_and_param):
-    table_reader, param = table_reader_and_param
+@pytest.fixture
+def table1():
     data = {
         "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
         "age": ["58", "47", "60"],
@@ -17,92 +16,118 @@ def test_table_reader(table_reader_and_param):
         "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
     }
     table = pd.DataFrame(data)
-    data2 = {
+    return table
+
+
+@pytest.fixture
+def table2():
+    data = {
         "actors": ["chris pratt", "gal gadot", "oprah winfrey"],
         "age": ["45", "36", "65"],
         "number of movies": ["49", "34", "5"],
         "date of birth": ["12 january 1975", "5 april 1980", "15 september 1960"],
     }
-    table2 = pd.DataFrame(data2)
+    table = pd.DataFrame(data)
+    return table
 
+
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+def test_table_reader(table_reader_and_param, table1, table2):
+    table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
     prediction = table_reader.predict(
         query=query,
-        documents=[Document(content=table, content_type="table"), Document(content=table2, content_type="table")],
+        documents=[Document(content=table1, content_type="table"), Document(content=table2, content_type="table")],
     )
-    scores = {"tapas_small": 1.0, "rci": -6.5301, "tapas_scored": 0.50568}
-    assert prediction["answers"][0].score == pytest.approx(scores[param], rel=1e-3)
+
+    assert prediction["query"] == "When was Di Caprio born?"
+
+    # Check number of answers
+    reference0 = {"tapas_small": {"num_answers": 2}, "rci": {"num_answers": 6}, "tapas_scored": {"num_answers": 6}}
+    assert len(prediction["answers"]) == reference0[param]["num_answers"]
+
+    # Check the first answer in the list
+    reference1 = {"tapas_small": {"score": 1.0}, "rci": {"score": -6.5301}, "tapas_scored": {"score": 0.50568}}
+    assert prediction["answers"][0].score == pytest.approx(reference1[param]["score"], rel=1e-3)
     assert prediction["answers"][0].answer == "11 november 1974"
     assert prediction["answers"][0].offsets_in_context[0].start == 7
     assert prediction["answers"][0].offsets_in_context[0].end == 8
 
-    predictions = {
+    # Check the second answer in the list
+    reference2 = {
         "tapas_small": {"answer": "5 april 1980", "start": 7, "end": 8, "score": 0.86314},
         "rci": {"answer": "47", "start": 5, "end": 6, "score": -6.836},
         "tapas_scored": {"answer": "brad pitt", "start": 0, "end": 1, "score": 0.49078},
     }
-    assert prediction["answers"][1].score == pytest.approx(predictions[param]["score"], rel=1e-3)
-    assert prediction["answers"][1].answer == predictions[param]["answer"]
-    assert prediction["answers"][1].offsets_in_context[0].start == predictions[param]["start"]
-    assert prediction["answers"][1].offsets_in_context[0].end == predictions[param]["end"]
+    assert prediction["answers"][1].score == pytest.approx(reference2[param]["score"], rel=1e-3)
+    assert prediction["answers"][1].answer == reference2[param]["answer"]
+    assert prediction["answers"][1].offsets_in_context[0].start == reference2[param]["start"]
+    assert prediction["answers"][1].offsets_in_context[0].end == reference2[param]["end"]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
-def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param):
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param, table1, table2):
     table_reader, param = table_reader_and_param
-    data = {
-        "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
-        "age": ["58", "47", "60"],
-        "number of movies": ["87", "53", "69"],
-        "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
-    }
-    table = pd.DataFrame(data)
-
-    query = "When was Di Caprio born?"
-    prediction = table_reader.predict_batch(queries=[query], documents=[Document(content=table, content_type="table")])
-    # Expected output: List of lists of answers
-    assert isinstance(prediction["answers"], list)
-    assert isinstance(prediction["answers"][0], list)
-    assert isinstance(prediction["answers"][0][0], Answer)
-    assert len(prediction["answers"]) == 1  # Predictions for 5 docs
-
-
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
-def test_table_reader_batch_single_query_multiple_doc_lists(table_reader_and_param):
-    table_reader, param = table_reader_and_param
-    data = {
-        "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
-        "age": ["58", "47", "60"],
-        "number of movies": ["87", "53", "69"],
-        "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
-    }
-    table = pd.DataFrame(data)
-
     query = "When was Di Caprio born?"
     prediction = table_reader.predict_batch(
-        queries=[query], documents=[[Document(content=table, content_type="table")]]
+        queries=[query],
+        documents=[Document(content=table1, content_type="table"), Document(content=table2, content_type="table")],
     )
     # Expected output: List of lists of answers
     assert isinstance(prediction["answers"], list)
     assert isinstance(prediction["answers"][0], list)
     assert isinstance(prediction["answers"][0][0], Answer)
-    assert len(prediction["answers"]) == 1  # Predictions for 1 collection of docs
+    assert prediction["queries"] == ["When was Di Caprio born?", "When was Di Caprio born?"]
+    assert len(prediction["answers"]) == 2
 
-
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
-def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_param):
-    table_reader, param = table_reader_and_param
-    data = {
-        "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
-        "age": ["58", "47", "60"],
-        "number of movies": ["87", "53", "69"],
-        "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
+    # Check number of answers for each document
+    reference0 = {
+        "tapas_small": {"num_answers": [1, 1]},
+        "rci": {"num_answers": [3, 3]},
+        "tapas_scored": {"num_answers": [3, 3]},
     }
-    table = pd.DataFrame(data)
+    for i, ans_list in enumerate(prediction["answers"]):
+        assert len(ans_list) == reference0[param]["num_answers"][i]
 
+    # Check first answer from the 1ST document
+    reference1 = {"tapas_small": {"score": 1.0}, "rci": {"score": -6.5301}, "tapas_scored": {"score": 0.50568}}
+    assert prediction["answers"][0][0].score == pytest.approx(reference1[param]["score"], rel=1e-3)
+    assert prediction["answers"][0][0].answer == "11 november 1974"
+    assert prediction["answers"][0][0].offsets_in_context[0].start == 7
+    assert prediction["answers"][0][0].offsets_in_context[0].end == 8
+
+    # Check first answer from the 2ND Document
+    reference2 = {
+        "tapas_small": {"answer": "5 april 1980", "start": 7, "end": 8, "score": 0.86314},
+        "rci": {"answer": "47", "start": 5, "end": 6, "score": -6.836},  # TODO Update once have RCI available
+        "tapas_scored": {"answer": "5", "start": 10, "end": 11, "score": 0.11485},
+    }
+    assert prediction["answers"][1][0].score == pytest.approx(reference2[param]["score"], rel=1e-3)
+    assert prediction["answers"][1][0].answer == reference2[param]["answer"]
+    assert prediction["answers"][1][0].offsets_in_context[0].start == reference2[param]["start"]
+    assert prediction["answers"][1][0].offsets_in_context[0].end == reference2[param]["end"]
+
+
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+def test_table_reader_batch_single_query_multiple_doc_lists(table_reader_and_param, table1):
+    table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
     prediction = table_reader.predict_batch(
-        queries=[query, query], documents=[Document(content=table, content_type="table")]
+        queries=[query], documents=[[Document(content=table1, content_type="table")]]
+    )
+    # Expected output: List of lists of answers
+    assert isinstance(prediction["answers"], list)
+    assert isinstance(prediction["answers"][0], list)
+    assert isinstance(prediction["answers"][0][0], Answer)
+    assert len(prediction["answers"]) == 1
+
+
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_param, table1):
+    table_reader, param = table_reader_and_param
+    query = "When was Di Caprio born?"
+    prediction = table_reader.predict_batch(
+        queries=[query, query], documents=[Document(content=table1, content_type="table")]
     )
     # Expected output: List of lists of lists of answers
     assert isinstance(prediction["answers"], list)
@@ -112,21 +137,13 @@ def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_pa
     assert len(prediction["answers"]) == 2  # Predictions for 2 queries
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
-def test_table_reader_batch_multiple_queries_multiple_doc_lists(table_reader_and_param):
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+def test_table_reader_batch_multiple_queries_multiple_doc_lists(table_reader_and_param, table1):
     table_reader, param = table_reader_and_param
-    data = {
-        "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
-        "age": ["58", "47", "60"],
-        "number of movies": ["87", "53", "69"],
-        "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
-    }
-    table = pd.DataFrame(data)
-
     query = "When was Di Caprio born?"
     prediction = table_reader.predict_batch(
         queries=[query, query],
-        documents=[[Document(content=table, content_type="table")], [Document(content=table, content_type="table")]],
+        documents=[[Document(content=table1, content_type="table")], [Document(content=table1, content_type="table")]],
     )
     # Expected output: List of lists answers
     assert isinstance(prediction["answers"], list)
@@ -135,22 +152,14 @@ def test_table_reader_batch_multiple_queries_multiple_doc_lists(table_reader_and
     assert len(prediction["answers"]) == 2  # Predictions for 2 collections of documents
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
-def test_table_reader_in_pipeline(table_reader_and_param):
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+def test_table_reader_in_pipeline(table_reader_and_param, table1):
     table_reader, param = table_reader_and_param
     pipeline = Pipeline()
     pipeline.add_node(table_reader, "TableReader", ["Query"])
-    data = {
-        "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
-        "age": ["58", "47", "60"],
-        "number of movies": ["87", "53", "69"],
-        "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
-    }
-
-    table = pd.DataFrame(data)
     query = "When was Di Caprio born?"
 
-    prediction = pipeline.run(query=query, documents=[Document(content=table, content_type="table")])
+    prediction = pipeline.run(query=query, documents=[Document(content=table1, content_type="table")])
     assert prediction["answers"][0].answer == "11 november 1974"
     assert prediction["answers"][0].offsets_in_context[0].start == 7
     assert prediction["answers"][0].offsets_in_context[0].end == 8
@@ -180,7 +189,7 @@ def test_table_reader_aggregation(table_reader_and_param):
     assert prediction["answers"][0].meta["answer_cells"] == ["8848m", "8,611 m", "8 586m", "8 516 m", "8,485m"]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
 def test_table_without_rows(caplog, table_reader_and_param):
     table_reader, param = table_reader_and_param
     # empty DataFrame
@@ -192,7 +201,7 @@ def test_table_without_rows(caplog, table_reader_and_param):
         assert len(predictions["answers"]) == 0
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
 def test_text_document(caplog, table_reader_and_param):
     table_reader, param = table_reader_and_param
     document = Document(content="text", id="text_doc")

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -104,15 +104,15 @@ def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param,
     assert prediction["answers"][0][0].offsets_in_context[0].end == 8
 
     # Check first answer from the 2ND Document
-    reference2 = {
+    ans_reference = {
         "tapas_small": {"answer": "5 april 1980", "start": 7, "end": 8, "score": 0.86314},
         "rci": {"answer": "15 september 1960", "start": 11, "end": 12, "score": -7.9429},
         "tapas_scored": {"answer": "5", "start": 10, "end": 11, "score": 0.11485},
     }
-    assert prediction["answers"][1][0].score == pytest.approx(reference2[param]["score"], rel=1e-3)
-    assert prediction["answers"][1][0].answer == reference2[param]["answer"]
-    assert prediction["answers"][1][0].offsets_in_context[0].start == reference2[param]["start"]
-    assert prediction["answers"][1][0].offsets_in_context[0].end == reference2[param]["end"]
+    assert prediction["answers"][1][0].score == pytest.approx(ans_reference[param]["score"], rel=1e-3)
+    assert prediction["answers"][1][0].answer == ans_reference[param]["answer"]
+    assert prediction["answers"][1][0].offsets_in_context[0].start == ans_reference[param]["start"]
+    assert prediction["answers"][1][0].offsets_in_context[0].end == ans_reference[param]["end"]
 
 
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
@@ -133,14 +133,14 @@ def test_table_reader_batch_single_query_multiple_doc_lists(table_reader_and_par
     assert prediction["queries"] == ["When was Di Caprio born?", "When was Di Caprio born?"]
 
     # Check number of answers for each document
-    reference0 = {
+    num_ans_reference = {
         "tapas_small": {"num_answers": [2, 1]},
         "rci": {"num_answers": [6, 3]},
         "tapas_scored": {"num_answers": [6, 3]},
     }
     assert len(prediction["answers"]) == 2
     for i, ans_list in enumerate(prediction["answers"]):
-        assert len(ans_list) == reference0[param]["num_answers"][i]
+        assert len(ans_list) == num_ans_reference[param]["num_answers"][i]
 
 
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
@@ -165,7 +165,7 @@ def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_pa
     ]
 
     # Check number of answers for each document
-    reference0 = {
+    num_ans_reference = {
         "tapas_small": {"num_answers": [[1, 1], [1, 1]]},
         "rci": {"num_answers": [[3, 3], [3, 3]]},
         "tapas_scored": {"num_answers": [[3, 3], [3, 3]]},
@@ -173,7 +173,7 @@ def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_pa
     assert len(prediction["answers"]) == 2  # Predictions for 2 queries
     for i, ans_list1 in enumerate(prediction["answers"]):
         for j, ans_list2 in enumerate(ans_list1):
-            assert len(ans_list2) == reference0[param]["num_answers"][i][j]
+            assert len(ans_list2) == num_ans_reference[param]["num_answers"][i][j]
 
 
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
@@ -195,14 +195,14 @@ def test_table_reader_batch_multiple_queries_multiple_doc_lists(table_reader_and
     assert prediction["queries"] == ["When was Di Caprio born?", "Which is the tallest mountain?"]
 
     # Check number of answers for each document
-    reference0 = {
+    num_ans_reference = {
         "tapas_small": {"num_answers": [2, 1]},
-        "rci": {"num_answers": [6, 3]},
+        "rci": {"num_answers": [10, 10]},
         "tapas_scored": {"num_answers": [6, 3]},
     }
     assert len(prediction["answers"]) == 2  # Predictions for 2 collections of documents
     for i, ans_list in enumerate(prediction["answers"]):
-        assert len(ans_list) == reference0[param]["num_answers"][i]
+        assert len(ans_list) == num_ans_reference[param]["num_answers"][i]
 
 
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -89,7 +89,7 @@ def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param,
     # Check number of answers for each document
     num_ans_reference = {
         "tapas_small": {"num_answers": [1, 1]},
-        "rci": {"num_answers": [3, 3]},
+        "rci": {"num_answers": [10, 10]},
         "tapas_scored": {"num_answers": [3, 3]},
     }
     assert len(prediction["answers"]) == 2
@@ -106,7 +106,7 @@ def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param,
     # Check first answer from the 2ND Document
     reference2 = {
         "tapas_small": {"answer": "5 april 1980", "start": 7, "end": 8, "score": 0.86314},
-        "rci": {"answer": "47", "start": 5, "end": 6, "score": -6.836},  # TODO Update once have RCI available
+        "rci": {"answer": "15 september 1960", "start": 11, "end": 12, "score": -7.9429},
         "tapas_scored": {"answer": "5", "start": 10, "end": 11, "score": 0.11485},
     }
     assert prediction["answers"][1][0].score == pytest.approx(reference2[param]["score"], rel=1e-3)

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -38,7 +38,7 @@ def table3():
     return pd.DataFrame(data)
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader(table_reader_and_param, table1, table2):
     table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
@@ -72,7 +72,7 @@ def test_table_reader(table_reader_and_param, table1, table2):
     assert prediction["answers"][1].offsets_in_context[0].end == reference2[param]["end"]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param, table1, table2):
     table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
@@ -115,7 +115,7 @@ def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param,
     assert prediction["answers"][1][0].offsets_in_context[0].end == reference2[param]["end"]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader_batch_single_query_multiple_doc_lists(table_reader_and_param, table1, table2, table3):
     table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
@@ -143,7 +143,7 @@ def test_table_reader_batch_single_query_multiple_doc_lists(table_reader_and_par
         assert len(ans_list) == reference0[param]["num_answers"][i]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_param, table1, table2):
     table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
@@ -176,7 +176,7 @@ def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_pa
             assert len(ans_list2) == reference0[param]["num_answers"][i][j]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader_batch_multiple_queries_multiple_doc_lists(table_reader_and_param, table1, table2, table3):
     table_reader, param = table_reader_and_param
     query = "When was Di Caprio born?"
@@ -205,7 +205,7 @@ def test_table_reader_batch_multiple_queries_multiple_doc_lists(table_reader_and
         assert len(ans_list) == reference0[param]["num_answers"][i]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader_in_pipeline(table_reader_and_param, table1):
     table_reader, param = table_reader_and_param
     pipeline = Pipeline()
@@ -237,7 +237,7 @@ def test_table_reader_aggregation(table_reader_and_param, table3):
     assert prediction["answers"][0].meta["answer_cells"] == ["8848m", "8,611 m", "8 586m", "8 516 m", "8,485m"]
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_without_rows(caplog, table_reader_and_param):
     table_reader, param = table_reader_and_param
     # empty DataFrame
@@ -249,7 +249,7 @@ def test_table_without_rows(caplog, table_reader_and_param):
         assert len(predictions["answers"]) == 0
 
 
-@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "tapas_scored"], indirect=True)
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_text_document(caplog, table_reader_and_param):
     table_reader, param = table_reader_and_param
     document = Document(content="text", id="text_doc")

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -135,7 +135,7 @@ def test_table_reader_batch_single_query_multiple_doc_lists(table_reader_and_par
     # Check number of answers for each document
     num_ans_reference = {
         "tapas_small": {"num_answers": [2, 1]},
-        "rci": {"num_answers": [6, 3]},
+        "rci": {"num_answers": [10, 10]},
         "tapas_scored": {"num_answers": [6, 3]},
     }
     assert len(prediction["answers"]) == 2
@@ -167,7 +167,7 @@ def test_table_reader_batch_multiple_queries_single_doc_list(table_reader_and_pa
     # Check number of answers for each document
     num_ans_reference = {
         "tapas_small": {"num_answers": [[1, 1], [1, 1]]},
-        "rci": {"num_answers": [[3, 3], [3, 3]]},
+        "rci": {"num_answers": [[10, 10], [10, 10]]},
         "tapas_scored": {"num_answers": [[3, 3], [3, 3]]},
     }
     assert len(prediction["answers"]) == 2  # Predictions for 2 queries

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -50,7 +50,7 @@ def test_table_reader(table_reader_and_param, table1, table2):
     assert prediction["query"] == "When was Di Caprio born?"
 
     # Check number of answers
-    reference0 = {"tapas_small": {"num_answers": 2}, "rci": {"num_answers": 6}, "tapas_scored": {"num_answers": 6}}
+    reference0 = {"tapas_small": {"num_answers": 2}, "rci": {"num_answers": 10}, "tapas_scored": {"num_answers": 6}}
     assert len(prediction["answers"]) == reference0[param]["num_answers"]
 
     # Check the first answer in the list
@@ -87,18 +87,18 @@ def test_table_reader_batch_single_query_single_doc_list(table_reader_and_param,
     assert prediction["queries"] == ["When was Di Caprio born?", "When was Di Caprio born?"]
 
     # Check number of answers for each document
-    reference0 = {
+    num_ans_reference = {
         "tapas_small": {"num_answers": [1, 1]},
         "rci": {"num_answers": [3, 3]},
         "tapas_scored": {"num_answers": [3, 3]},
     }
     assert len(prediction["answers"]) == 2
     for i, ans_list in enumerate(prediction["answers"]):
-        assert len(ans_list) == reference0[param]["num_answers"][i]
+        assert len(ans_list) == num_ans_reference[param]["num_answers"][i]
 
     # Check first answer from the 1ST document
-    reference1 = {"tapas_small": {"score": 1.0}, "rci": {"score": -6.5301}, "tapas_scored": {"score": 0.50568}}
-    assert prediction["answers"][0][0].score == pytest.approx(reference1[param]["score"], rel=1e-3)
+    score_reference = {"tapas_small": {"score": 1.0}, "rci": {"score": -6.5301}, "tapas_scored": {"score": 0.50568}}
+    assert prediction["answers"][0][0].score == pytest.approx(score_reference[param]["score"], rel=1e-3)
     assert prediction["answers"][0][0].answer == "11 november 1974"
     assert prediction["answers"][0][0].offsets_in_context[0].start == 7
     assert prediction["answers"][0][0].offsets_in_context[0].end == 8


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I made a small refactor to the TableReader code to help reduce duplicate code and added expanded unit tests. Instead of using a `_BaseTapasEncoder` to inherit from, static utility functions were made instead because they can be useful for all TableReader nodes (e.g. `_TapasEncoder`, `_TapasScoredEncoder`, and `RCIReader`). I also expanded on the unit tests to ensure that the `TableReader.predict_batch` function returned the expected output. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Used existing tests and expanded on the existing tests.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This refactoring does not change the functionality of the TableReader or cause any breaking changes.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
