### PR TITLE
fix: Removed overlooked torch scatter references

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -52,4 +52,4 @@ runs:
       python -m pip install --upgrade pip
       pip install .[all]
       pip install rest_api/
-      pip install ui
+      pip install ui/

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -52,5 +52,4 @@ runs:
       python -m pip install --upgrade pip
       pip install .[all]
       pip install rest_api/
-      pip install ui/
-      pip install torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+      pip install ui

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -46,7 +46,6 @@ target "base-cpu" {
     base_immage = "python:3.10-slim"
     haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores,crawler,preprocessing,ocr,onnx,beir]"
-    torch_scatter = "https://data.pyg.org/whl/torch-1.12.0+cpu.html"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }
@@ -59,7 +58,6 @@ target "base-gpu" {
     base_immage = "pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
     haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores-gpu,crawler,preprocessing,ocr,onnx-gpu]"
-    torch_scatter = "https://data.pyg.org/whl/torch-1.12.1%2Bcu113.html"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Removes remaining references to torch-scatter that was originally removed as a dependency in Haystack in PR #3703 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
