### PR TITLE
feat: Enable text-embedding-ada-002 for EmbeddingRetriever

### DIFF
--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,15 +400,21 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         model_class: str = next(
             (m for m in ["ada", "babbage", "davinci", "curie"] if m in retriever.embedding_model), "babbage"
         )
+        self._setup_encoding_models(model_class, retriever.embedding_model)
+
+        self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
+
+    def _setup_encoding_models(self, model_class: str, model_name: str):
+        """
+        Setup the encoding models for the retriever.
+        """
         # new generation of embedding models (December 2022), we need to specify the full name
-        if model_class == "ada" and "text-embedding-ada-002" in retriever.embedding_model:
-            self.query_encoder_model = f"text-embedding-ada-002"
-            self.doc_encoder_model = f"text-embedding-ada-002"
+        if "text-embedding" in model_name:
+            self.query_encoder_model = model_name
+            self.doc_encoder_model = model_name
         else:
             self.query_encoder_model = f"text-search-{model_class}-query-001"
             self.doc_encoder_model = f"text-search-{model_class}-doc-001"
-
-        self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
     def _ensure_text_limit(self, text: str) -> str:
         """

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -400,8 +400,14 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         model_class: str = next(
             (m for m in ["ada", "babbage", "davinci", "curie"] if m in retriever.embedding_model), "babbage"
         )
-        self.query_model_encoder_engine = f"text-search-{model_class}-query-001"
-        self.doc_model_encoder_engine = f"text-search-{model_class}-doc-001"
+        # new generation of embedding models (December 2022), we need to specify the full name
+        if model_class == "ada" and "text-embedding-ada-002" in retriever.embedding_model:
+            self.query_encoder_model = f"text-embedding-ada-002"
+            self.doc_encoder_model = f"text-embedding-ada-002"
+        else:
+            self.query_encoder_model = f"text-search-{model_class}-query-001"
+            self.doc_encoder_model = f"text-search-{model_class}-doc-001"
+
         self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
     def _ensure_text_limit(self, text: str) -> str:
@@ -449,10 +455,10 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         return np.concatenate(all_embeddings)
 
     def embed_queries(self, queries: List[str]) -> np.ndarray:
-        return self.embed_batch(self.query_model_encoder_engine, queries)
+        return self.embed_batch(self.query_encoder_model, queries)
 
     def embed_documents(self, docs: List[Document]) -> np.ndarray:
-        return self.embed_batch(self.doc_model_encoder_engine, [d.content for d in docs])
+        return self.embed_batch(self.doc_encoder_model, [d.content for d in docs])
 
     def train(
         self,

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -302,6 +302,21 @@ def test_retribert_embedding(document_store, retriever, docs_with_ids):
         assert isclose(embedding[0], expected_value, rel_tol=0.001)
 
 
+def test_openai_embedding_retriever_selection():
+    # OpenAI released (Dec 2022) a unifying embedding model called text-embedding-ada-002
+    # make sure that we can use it with the retriever selection
+    er = EmbeddingRetriever(embedding_model="text-embedding-ada-002", document_store=None)
+    assert er.model_format == "openai"
+    assert er.embedding_encoder.query_encoder_model == "text-embedding-ada-002"
+    assert er.embedding_encoder.doc_encoder_model == "text-embedding-ada-002"
+
+    # but also support old ada and other text-search-<modelname>-*-001 models
+    er = EmbeddingRetriever(embedding_model="ada", document_store=None)
+    assert er.model_format == "openai"
+    assert er.embedding_encoder.query_encoder_model == "text-search-ada-query-001"
+    assert er.embedding_encoder.doc_encoder_model == "text-search-ada-doc-001"
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["openai", "cohere"], indirect=True)

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -316,6 +316,19 @@ def test_openai_embedding_retriever_selection():
     assert er.embedding_encoder.query_encoder_model == "text-search-ada-query-001"
     assert er.embedding_encoder.doc_encoder_model == "text-search-ada-doc-001"
 
+    # but also support old babbage and other text-search-<modelname>-*-001 models
+    er = EmbeddingRetriever(embedding_model="babbage", document_store=None)
+    assert er.model_format == "openai"
+    assert er.embedding_encoder.query_encoder_model == "text-search-babbage-query-001"
+    assert er.embedding_encoder.doc_encoder_model == "text-search-babbage-doc-001"
+
+    # make sure that we can handle potential unreleased models
+    er = EmbeddingRetriever(embedding_model="text-embedding-babbage-002", document_store=None)
+    assert er.model_format == "openai"
+    assert er.embedding_encoder.query_encoder_model == "text-embedding-babbage-002"
+    assert er.embedding_encoder.doc_encoder_model == "text-embedding-babbage-002"
+    # etc etc.
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)


### PR DESCRIPTION
### Proposed Changes:
Enabled text-embedding-ada-002 for EmbeddingRetriever. See https://openai.com/blog/new-and-improved-embedding-model/ for more details. 

To enable this retriever use the model full name i.e. `text-embedding-ada-002`:
```
retriever = EmbeddingRetriever(
    document_store=document_store,
    embedding_model="text-embedding-ada-002",
    batch_size = 32,
    api_key=api_key,
    max_seq_len = 8191,
)
```
### How did you test it?
Added unit test, ran Colab [notebook](https://colab.research.google.com/drive/1jwwsxJsn_Ch9xU68K3rjYGDyL-Gs1-Km)

### Notes for the reviewer
Have a look at https://beta.openai.com/docs/guides/embeddings/what-are-embeddings 
We now have to deal with two generations of models. The old generation of models - as we have already dealt with them. We'll have users specify the full model name to use the new model. 

Have quick look at the unit test, and run the colab yourself

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
