### PR TITLE
build: upgrade torch and let transformers pick the version 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,9 @@ classifiers = [
 ]
 dependencies = [
   "importlib-metadata; python_version < '3.8'",
-  "torch==1.13.1",
   "requests",
   "pydantic",
-  "transformers==4.25.1",
+  "transformers[torch]==4.25.1",
   "nltk",
   "pandas",
   "rank_bm25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 ]
 dependencies = [
   "importlib-metadata; python_version < '3.8'",
-  "torch>1.9,<1.13",
+  "torch==1.13.1",
   "requests",
   "pydantic",
   "transformers==4.25.1",


### PR DESCRIPTION
### Related Issues
- fixes #3683
- related issue #3521

### Proposed Changes:
- PyTorch 1.13.1 was released today and CI test passed. Version 1.13.0 and 1.13.1 both work now with Haystack so it is save to upgrade. Let's upgrade! We will use the same version range as transformers so we let transformers install torch as one of it's dependencies.

 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
CI and so manual tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
