### PR TITLE
feat: Use torch.inference_mode() for TableQA

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -766,7 +766,9 @@ class RCIReader(BaseReader):
                 padding=True,
             )
             row_inputs.to(self.devices[0])
-            row_logits = self.row_model(**row_inputs)[0].detach().cpu().numpy()[:, 1]
+            with torch.inference_mode():
+                row_outputs = self.row_model(**row_inputs)
+            row_logits = row_outputs[0].detach().cpu().numpy()[:, 1]
 
             # Get column logits
             column_inputs = self.column_tokenizer(
@@ -778,7 +780,9 @@ class RCIReader(BaseReader):
                 padding=True,
             )
             column_inputs.to(self.devices[0])
-            column_logits = self.column_model(**column_inputs)[0].detach().cpu().numpy()[:, 1]
+            with torch.inference_mode():
+                column_outputs = self.column_model(**column_inputs)
+            column_logits = column_outputs[0].detach().cpu().numpy()[:, 1]
 
             # Calculate cell scores
             current_answers: List[Answer] = []

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -366,9 +366,9 @@ class _TapasEncoder(_BaseTapasEncoder):
     ) -> float:
         # Calculate answer score
         # Values over 88.72284 will overflow when passed through exponential, so logits are truncated.
-        copy_logits = logits.clone()
-        copy_logits[copy_logits < -88.7] = -88.7
-        token_probabilities = 1 / (1 + np.exp(-copy_logits)) * inputs.attention_mask
+        truncated_logits = logits.clone()
+        truncated_logits[truncated_logits < -88.7] = -88.7
+        token_probabilities = 1 / (1 + np.exp(-truncated_logits)) * inputs.attention_mask
         token_types = [
             "segment_ids",
             "column_ids",


### PR DESCRIPTION
### Related Issues
- fixes N/A 
- related to PR #3601 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Swapped out all `torch.no_grad()` calls with `torch.inference_mode()`
- Updated forward pass of `RCIReader` to use `with torch.inference_mode()`

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
