### PR TITLE
refactor: remove unused code in `TfidfRetriever`

### DIFF
--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -487,8 +487,6 @@ class TfidfRetriever(BaseRetriever):
         return paragraphs
 
     def _calc_scores(self, queries: List[str], index: str) -> List[Dict[int, float]]:
-        if isinstance(queries, str):
-            queries = [queries]
         question_vector = self.vectorizer.transform(queries)
         doc_scores_per_query = self.tfidf_matrices[index].dot(question_vector.T).T.toarray()
         doc_scores_per_query = [


### PR DESCRIPTION
### Related Issues
- little improvement of #3666

### Proposed Changes:
Previously, in `TfidfRetriever`, the parameter `queries` of the internal method `_calc_scores` was of type `Union[str, List[str]]`.
Now the type of `queries` is only `List[str]`.

In this PR, I remove a superfluous check.

### How did you test it?
CI

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
