### PR TITLE
fix: Ensure eval mode for TableReader model for predictions

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -250,6 +250,7 @@ class _TapasEncoder:
         table: pd.DataFrame = document.content
 
         # Forward query and table through model and convert logits to predictions
+        self.model.eval()
         with torch.inference_mode():
             outputs = self.model(**inputs)
 
@@ -421,6 +422,7 @@ class _TapasScoredEncoder:
         table: pd.DataFrame = document.content
 
         # Forward pass through model
+        self.model.eval()
         with torch.inference_mode():
             outputs = self.model.tapas(**inputs)
             table_score = self.model.classifier(outputs.pooler_output)
@@ -715,6 +717,7 @@ class RCIReader(BaseReader):
                 padding=True,
             )
             row_inputs.to(self.devices[0])
+            self.row_model.eval()
             with torch.inference_mode():
                 row_outputs = self.row_model(**row_inputs)
             row_logits = row_outputs[0].detach().cpu().numpy()[:, 1]
@@ -729,6 +732,7 @@ class RCIReader(BaseReader):
                 padding=True,
             )
             column_inputs.to(self.devices[0])
+            self.column_model.eval()
             with torch.inference_mode():
                 column_outputs = self.column_model(**column_inputs)
             column_logits = column_outputs[0].detach().cpu().numpy()[:, 1]

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -1,6 +1,7 @@
 import logging
 
 import pandas as pd
+import torch
 import pytest
 
 from haystack.schema import Document, Answer
@@ -42,13 +43,6 @@ def table3():
 def test_table_reader(table_reader_and_param, table1, table2):
     table_reader, param = table_reader_and_param
 
-    # Ensure that if model is put in train mode that predictions are not effected
-    if param != "rci":
-        table_reader.table_encoder.model.train()
-    elif param == "rci":
-        table_reader.row_model.train()
-        table_reader.column_model.train()
-
     query = "When was Di Caprio born?"
     prediction = table_reader.predict(
         query=query,
@@ -78,6 +72,42 @@ def test_table_reader(table_reader_and_param, table1, table2):
     assert prediction["answers"][1].answer == reference2[param]["answer"]
     assert prediction["answers"][1].offsets_in_context[0].start == reference2[param]["start"]
     assert prediction["answers"][1].offsets_in_context[0].end == reference2[param]["end"]
+
+
+@pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
+def test_table_reader_train_mode(table_reader_and_param, table1, table2):
+    table_reader, param = table_reader_and_param
+
+    # Set to deterministic seed
+    old_seed = torch.seed()
+    torch.manual_seed(0)
+
+    # Ensure that if model is put in train mode that predictions are not effected
+    if param != "rci":
+        table_reader.table_encoder.model.train()
+    elif param == "rci":
+        table_reader.row_model.train()
+        table_reader.column_model.train()
+
+    query = "When was Di Caprio born?"
+    prediction = table_reader.predict(
+        query=query,
+        documents=[Document(content=table1, content_type="table"), Document(content=table2, content_type="table")],
+    )
+
+    # Check the second answer in the list
+    reference2 = {
+        "tapas_small": {"answer": "5 april 1980", "start": 7, "end": 8, "score": 0.86314},
+        "rci": {"answer": "47", "start": 5, "end": 6, "score": -6.836},
+        "tapas_scored": {"answer": "brad pitt", "start": 0, "end": 1, "score": 0.49078},
+    }
+    assert prediction["answers"][1].score == pytest.approx(reference2[param]["score"], rel=1e-3)
+    assert prediction["answers"][1].answer == reference2[param]["answer"]
+    assert prediction["answers"][1].offsets_in_context[0].start == reference2[param]["start"]
+    assert prediction["answers"][1].offsets_in_context[0].end == reference2[param]["end"]
+
+    # Set back to old_seed
+    torch.manual_seed(old_seed)
 
 
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -41,6 +41,14 @@ def table3():
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small", "rci", "tapas_scored"], indirect=True)
 def test_table_reader(table_reader_and_param, table1, table2):
     table_reader, param = table_reader_and_param
+
+    # Ensure that if model is put in train mode that predictions are not effected
+    if param != "rci":
+        table_reader.table_encoder.model.train()
+    elif param == "rci":
+        table_reader.row_model.train()
+        table_reader.column_model.train()
+
     query = "When was Di Caprio born?"
     prediction = table_reader.predict(
         query=query,


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I added a call to make sure to set the TableReader model to eval mode when running a prediction. Otherwise, currently, if the model is set to train mode the predictions become random due to layers like BatchNorm and dropout being present in the underlying model architecture. This is something we already do for some of our nodes like the DensePassageRetriever.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added a new unit test to make sure everything works. I did confirm that this unit test fails without the new changes.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This probably was not noticed before because the model is set to eval mode by default when loading it.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
