### PR TITLE
fix: build pdftotext from sources 

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - massi/xpdf  # FIXME: remove before merging
     tags:
       - 'v[0-9].[0-9]+.[0-9]+*'
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -7,14 +7,18 @@ ARG haystack_version
 ARG haystack_extras
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential gcc git curl \
+    build-essential gcc git curl cmake \
     tesseract-ocr libtesseract-dev poppler-utils
 
 # Install PDF converter
-RUN curl -O https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz && \
-    tar -xvf xpdf-tools-linux-4.04.tar.gz && \
-    cp xpdf-tools-linux-4.04/bin64/pdftotext /opt && \
-    rm -rf xpdf-tools-linux-4.04
+RUN curl -O https://dl.xpdfreader.com/xpdf-4.04.tar.gz && \
+    tar -xvf xpdf-4.04.tar.gz && \
+    cd xpdf-4.04 && \
+    cmake . && \
+    make && \
+    cp xpdf/pdftotext /opt && \
+    cd .. && \
+    rm -rf xpdf-4.04
 
 # Shallow clone Haystack repo, we'll install from the local sources
 RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-ai/haystack.git /opt/haystack


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/3619

We currently hardcode the installation process for `pdftotext` from xpdf into the base image. To speed up the build, we download and install the binary version distributed for amd_64 - this obviously can't work on the ARM image that we build with the same Dockerfile.

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Instead of downloading and installing the binary version of `pdftotext`, we build it from source. This should work in a cross-platform fashion.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manually tested locally

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
The docker build workflow contains changes I'm using to test this branch that need to be reverted before merging the PR.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
