### PR TITLE
fix: Fix `predict_batch` in `TransformersReader` for single nested Document list

### DIFF
--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -153,7 +153,7 @@ class TransformersReader(BaseReader):
             max_seq_len=self.max_seq_len,
             doc_stride=self.doc_stride,
         )
-        # Transformers gives different output dependiing on top_k_per_candidate and number of inputs
+        # Transformers gives different output depending on top_k_per_candidate and number of inputs
         if isinstance(predictions, dict):
             predictions = [[predictions]]
         elif len(inputs) == 1:
@@ -224,7 +224,7 @@ class TransformersReader(BaseReader):
         # Transformers flattens lists of length 1. This restores the original list structure.
         if isinstance(predictions, dict):
             predictions = [[predictions]]
-        elif len(number_of_docs) == 1:
+        elif len(inputs) == 1:
             predictions = [predictions]
         else:
             predictions = [p if isinstance(p, list) else [p] for p in predictions]

--- a/test/nodes/test_reader.py
+++ b/test/nodes/test_reader.py
@@ -104,6 +104,18 @@ def test_output_batch_multiple_queries_multiple_doc_lists(reader, docs):
     assert len(prediction["answers"][0]) == 5  # top-k of 5 for collection of docs
 
 
+def test_output_batch_single_query_single_nested_doc_list(reader, docs):
+    prediction = reader.predict_batch(queries=["Who lives in Berlin?"], documents=[docs], top_k=5)
+    assert prediction is not None
+    assert prediction["queries"] == ["Who lives in Berlin?"]
+    # Expected output: List of lists answers
+    assert isinstance(prediction["answers"], list)
+    assert isinstance(prediction["answers"][0], list)
+    assert isinstance(prediction["answers"][0][0], Answer)
+    assert len(prediction["answers"]) == 1  # Predictions for 1 collections of documents
+    assert len(prediction["answers"][0]) == 5  # top-k of 5 for collection of docs
+
+
 @pytest.mark.integration
 def test_no_answer_output(no_answer_reader, docs):
     no_answer_prediction = no_answer_reader.predict(query="What is the meaning of life?", documents=docs, top_k=5)

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -118,7 +118,7 @@ EVAL_LABELS = [
 
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
-@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+@pytest.mark.parametrize("reader", ["farm", "transformers"], indirect=True)
 def test_extractive_qa_eval(reader, retriever_with_docs, tmp_path):
     labels = EVAL_LABELS[:1]
 


### PR DESCRIPTION
### Related Issues
- fixes #3707

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR fixes the `predict_batch` of `TransformersReader` when the input is a single query and a single nested list of Documents. If the number of provided Document lists was 1, we further nested the returned predictions coming from transformers into a third list. This was wrong. We should only nest the returned predictions into a list if the returned predictions are not a already a nested list. This is only the case when the number of inputs we provide to transformers is 1.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added the `transformers` fixture for `test_extractive_qa_eval` in `test_eval_batch.py` and created a new test `test_output_batch_single_query_single_nested_doc_list` in `test_reader.py`.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
