### PR TITLE
fix: Trigger pipeline schema update on tagged releases

### DIFF
--- a/.github/workflows/pipeline_schema.yml
+++ b/.github/workflows/pipeline_schema.yml
@@ -1,23 +1,38 @@
 name: YAML Schema
+run-name: Update schema for ref ${{ github.event.workflow_run.head_branch || inputs.ref || 'main' }}
 
 on:
   workflow_dispatch: # Activate this workflow manually
-  push:
-    branches:
-      - main
+    inputs:
+      ref:
+        description: Tag or branch name of Haystack version
+        required: true
+        type: string
+        default: main
+
+  workflow_run:
+    workflows:
+      - Docker image release
+    types:
+      - completed
+
+env:
+  HAYSTACK_REF: ${{ github.event.workflow_run.head_branch || inputs.ref || 'main' }}
 
 jobs:
 
   run:
+    name: Update schema for ref ${{ github.event.workflow_run.head_branch || inputs.ref || 'main' }}
+    if: ${{ !github.event.workflow_run || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      # Start a workflow in https://github.com/deepset-ai/haystack-json-schema 
+      # Start a workflow in https://github.com/deepset-ai/haystack-json-schema
       # https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
-      - name: Dispatch to schemas repository
+      - name: 'Dispatch to schemas repository with ref "${{ env.HAYSTACK_REF }}"'
         run: |
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.HAYSTACK_BOT_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.MY_TOKEN }}" \
           https://api.github.com/repos/deepset-ai/haystack-json-schema/dispatches \
-          -d '{"event_type":"generate-pipeline-schemas","client_payload":{}}'
+          -d '{"event_type":"generate-pipeline-schemas","client_payload":{"ref":"${{ env.HAYSTACK_REF }}"}}'

--- a/.github/workflows/pipeline_schema.yml
+++ b/.github/workflows/pipeline_schema.yml
@@ -33,6 +33,6 @@ jobs:
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.MY_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.HAYSTACK_BOT_TOKEN }}" \
           https://api.github.com/repos/deepset-ai/haystack-json-schema/dispatches \
           -d '{"event_type":"generate-pipeline-schemas","client_payload":{"ref":"${{ env.HAYSTACK_REF }}"}}'


### PR DESCRIPTION
### Related Issues
- fixes #3751

### Proposed Changes:
- Trigger the pipeline schema workflow after every successful docker release workflow and include the source ref in the payload (branch name or tag).
- Support manually running the pipeline schema workflow with a specific ref.

https://github.com/deepset-ai/haystack-json-schema/pull/2 adapts the workflow in the deepset-ai/haystack-json-schema repository to use the released Haystack docker images and get the ref from the dispatch payload to update the pipeline schemas.

### How did you test it?
Manual verification in forked repositories.
