### PR TITLE
fix: Convert table cells to strings for compatibility with TableReader

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -373,6 +373,7 @@ class _TapasEncoder:
         table_documents = _check_documents(documents)
         for document in table_documents:
             table: pd.DataFrame = document.content
+            table = table.astype(str)
             model_inputs = self.tokenizer(
                 table=table, queries=query, max_length=self.max_seq_len, return_tensors="pt", truncation=True
             )
@@ -520,6 +521,7 @@ class _TapasScoredEncoder:
         table_documents = _check_documents(documents)
         for document in table_documents:
             table: pd.DataFrame = document.content
+            table = table.astype(str)
             model_inputs = self.tokenizer(
                 table=table, queries=query, max_length=self.max_seq_len, return_tensors="pt", truncation=True
             )

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -247,7 +247,8 @@ class _TapasEncoder:
         self.device = device
 
     def _predict_tapas(self, inputs: BatchEncoding, document: Document) -> Answer:
-        table: pd.DataFrame = document.content
+        orig_table: pd.DataFrame = document.content
+        string_table = orig_table.astype(str)
 
         # Forward query and table through model and convert logits to predictions
         with torch.inference_mode():
@@ -270,7 +271,7 @@ class _TapasEncoder:
         current_answer_coordinates = predicted_answer_coordinates[0]
         current_answer_cells = []
         for coordinate in current_answer_coordinates:
-            current_answer_cells.append(table.iat[coordinate])
+            current_answer_cells.append(string_table.iat[coordinate])
 
         # Get aggregation operator
         if self.model.config.aggregation_labels is not None:
@@ -286,13 +287,13 @@ class _TapasEncoder:
         else:
             answer_str = self._aggregate_answers(current_aggregation_operator, current_answer_cells)
 
-        answer_offsets = _calculate_answer_offsets(current_answer_coordinates, document.content)
+        answer_offsets = _calculate_answer_offsets(current_answer_coordinates, string_table)
 
         answer = Answer(
             answer=answer_str,
             type="extractive",
             score=current_score,
-            context=document.content,
+            context=string_table,
             offsets_in_document=answer_offsets,
             offsets_in_context=answer_offsets,
             document_id=document.id,
@@ -419,7 +420,8 @@ class _TapasScoredEncoder:
         self.return_no_answer = return_no_answer
 
     def _predict_tapas_scored(self, inputs: BatchEncoding, document: Document) -> Tuple[List[Answer], float]:
-        table: pd.DataFrame = document.content
+        orig_table: pd.DataFrame = document.content
+        string_table = orig_table.astype(str)
 
         # Forward pass through model
         with torch.inference_mode():
@@ -495,8 +497,8 @@ class _TapasScoredEncoder:
         answers = []
         for answer_span_idx in top_k_answer_spans.indices:
             current_answer_span = possible_answer_spans[answer_span_idx]
-            answer_str = table.iat[current_answer_span[:2]]
-            answer_offsets = _calculate_answer_offsets([current_answer_span[:2]], document.content)
+            answer_str = string_table.iat[current_answer_span[:2]]
+            answer_offsets = _calculate_answer_offsets([current_answer_span[:2]], string_table)
             # As the general table score is more important for the final score, it is double weighted.
             current_score = ((2 * table_relevancy_prob) + span_logits_softmax[0, answer_span_idx].item()) / 3
 
@@ -505,11 +507,11 @@ class _TapasScoredEncoder:
                     answer=answer_str,
                     type="extractive",
                     score=current_score,
-                    context=document.content,
+                    context=string_table,
                     offsets_in_document=answer_offsets,
                     offsets_in_context=answer_offsets,
                     document_id=document.id,
-                    meta={"aggregation_operator": "NONE", "answer_cells": table.iat[current_answer_span[:2]]},
+                    meta={"aggregation_operator": "NONE", "answer_cells": string_table.iat[current_answer_span[:2]]},
                 )
             )
 
@@ -704,8 +706,8 @@ class RCIReader(BaseReader):
         for document in table_documents:
             # Create row and column representations
             table: pd.DataFrame = document.content
-            table = table.astype(str)
-            row_reps, column_reps = self._create_row_column_representations(table)
+            string_table = table.astype(str)
+            row_reps, column_reps = self._create_row_column_representations(string_table)
 
             # Get row logits
             row_inputs = self.row_tokenizer(
@@ -744,14 +746,14 @@ class RCIReader(BaseReader):
                     current_cell_score = float(row_score + col_score)
                     cell_scores_table[-1].append(current_cell_score)
 
-                    answer_str = table.iloc[row_idx, col_idx]
-                    answer_offsets = self._calculate_answer_offsets(row_idx, col_idx, table)
+                    answer_str = string_table.iloc[row_idx, col_idx]
+                    answer_offsets = self._calculate_answer_offsets(row_idx, col_idx, string_table)
                     current_answers.append(
                         Answer(
                             answer=answer_str,
                             type="extractive",
                             score=current_cell_score,
-                            context=table,
+                            context=string_table,
                             offsets_in_document=[answer_offsets],
                             offsets_in_context=[answer_offsets],
                             document_id=document.id,

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -11,8 +11,8 @@ from haystack.pipelines.base import Pipeline
 def table1():
     data = {
         "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
-        "age": ["58", "47", "60"],
-        "number of movies": ["87", "53", "69"],
+        "age": [58, 47, 60],
+        "number of movies": [87, 53, 69],
         "date of birth": ["18 december 1963", "11 november 1974", "6 may 1961"],
     }
     return pd.DataFrame(data)
@@ -22,8 +22,8 @@ def table1():
 def table2():
     data = {
         "actors": ["chris pratt", "gal gadot", "oprah winfrey"],
-        "age": [45, "36", "65"],
-        "number of movies": ["49", "34", "5"],
+        "age": [45, 36, 65],
+        "number of movies": [49, 34, 5],
         "date of birth": ["12 january 1975", "5 april 1980", "15 september 1960"],
     }
     return pd.DataFrame(data)

--- a/test/nodes/test_table_reader.py
+++ b/test/nodes/test_table_reader.py
@@ -22,7 +22,7 @@ def table1():
 def table2():
     data = {
         "actors": ["chris pratt", "gal gadot", "oprah winfrey"],
-        "age": ["45", "36", "65"],
+        "age": [45, "36", "65"],
         "number of movies": ["49", "34", "5"],
         "date of birth": ["12 january 1975", "5 april 1980", "15 september 1960"],
     }


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
 Add table = table.astype(str) to make sure cells are converted into to strings to be compatible with the TableReader.

This was already being done for the `RCIReader` (another type of TableReader) so I've added it for the Tapas-based `TableReader` as well.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated unit test to include a table that contains integer types.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
