### PR TITLE
bug: skip validating empty embeddings

### DIFF
--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -702,6 +702,9 @@ class BaseDocumentStore(BaseComponent):
         :param num_documents: Number of documents the embeddings were generated for
         :param embedding_dim: Number of embedding dimensions to expect
         """
+        if embeddings.size == 0:
+            # Return if there are no embeddings. Otherwise incorrect embedding shape will be inferred
+            return
         num_embeddings, embedding_size = embeddings.shape
         if num_embeddings != num_documents:
             raise DocumentStoreError(

--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -702,9 +702,6 @@ class BaseDocumentStore(BaseComponent):
         :param num_documents: Number of documents the embeddings were generated for
         :param embedding_dim: Number of embedding dimensions to expect
         """
-        if embeddings.size == 0:
-            # Return if there are no embeddings. Otherwise incorrect embedding shape will be inferred
-            return
         num_embeddings, embedding_size = embeddings.shape
         if num_embeddings != num_documents:
             raise DocumentStoreError(

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -505,6 +505,12 @@ class PineconeDocumentStore(BaseDocumentStore):
             for _ in range(0, document_count, batch_size):
                 document_batch = list(islice(documents, batch_size))
                 embeddings = retriever.embed_documents(document_batch)
+                if embeddings.size == 0:
+                    # Skip batch if there are no embeddings. Otherwise, incorrect embedding shape will be inferred and
+                    # Pinecone APi will return a "No vectors provided" Bad Request Error
+                    progress_bar.set_description_str("Documents Processed")
+                    progress_bar.update(batch_size)
+                    continue
                 self._validate_embeddings_shape(
                     embeddings=embeddings, num_documents=len(document_batch), embedding_dim=self.embedding_dim
                 )

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -20,8 +20,6 @@ from haystack.nodes.retriever.base import BaseRetriever
 from haystack.pipelines import DocumentSearchPipeline
 from haystack.schema import Document
 from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
-from haystack.document_stores.faiss import FAISSDocumentStore
-from haystack.document_stores import MilvusDocumentStore
 from haystack.nodes.retriever.dense import DensePassageRetriever, EmbeddingRetriever, TableTextRetriever
 from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
 from haystack.nodes.retriever.multimodal import MultiModalRetriever
@@ -159,6 +157,9 @@ class MockBaseRetriever(MockRetriever):
         scale_score: bool = None,
     ):
         return [[self.mock_document] for _ in range(len(queries))]
+
+    def embed_documents(self, documents: List[Document]):
+        return np.full((len(documents), 768), 0.5)
 
 
 def test_retrieval_empty_query(document_store: BaseDocumentStore):


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/3668
- fixes https://github.com/deepset-ai/haystack/issues/3717

### Proposed Changes:
before validating the shape of embeddings in `_validate_embeddings_shape`, check if list of passed embeddings is non-empty. If it is empty, skip the validation and the updating of the embeddings for that batch and continue with the next batch. Otherwise proceed with validation and updating of the embeddings.

### How did you test it?
tested manually:

```python
from haystack.document_stores import PineconeDocumentStore
from haystack.nodes import EmbeddingRetriever
doc_store = PineconeDocumentStore(api_key="...", similarity="cosine", embedding_dim=384, recreate_index=True)
doc_store.write_documents([{"content":"text"}])
retriever = EmbeddingRetriever(document_store=doc_store, embedding_model='sentence-transformers/all-MiniLM-L6-v2')
doc_store.update_embeddings(retriever)
doc_store.update_embeddings(retriever, update_existing_embeddings=False)
```

### Notes for the reviewer
I thought about adding a test case but I decided against it. It would require sth like
```python
    @pytest.mark.integration
    def test_update_embeddings_without_new_docs(self, doc_store_with_docs: PineconeDocumentStore):
        retriever = EmbeddingRetriever(document_store=doc_store_with_docs,
                                       embedding_model='sentence-transformers/all-MiniLM-L6-v2')
        doc_store_with_docs.update_embeddings(retriever)
        doc_store_with_docs.update_embeddings(retriever, update_existing_embeddings=False)
```
The existing retriever fixture cannot be used as it would automatically default to mocking the pinecone document store.
We could also mock the retriever here. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
