### PR TITLE
feat: make new sklearn models default in QueryClassifier

### DIFF
--- a/haystack/nodes/query_classifier/sklearn.py
+++ b/haystack/nodes/query_classifier/sklearn.py
@@ -39,19 +39,19 @@ class SklearnQueryClassifier(BaseQueryClassifier):
 
     Pass your own `Sklearn` binary classification model or use one of the following pretrained ones:
     1) Keywords vs. Questions/Statements (Default)
-       query_classifier can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier/model.pickle)
-       query_vectorizer can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier/vectorizer.pickle)
+       query_classifier can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_2022/model.pickle)
+       query_vectorizer can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_2022/vectorizer.pickle)
        output_1 => question/statement
        output_2 => keyword query
-       [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier/readme.txt)
+       [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_2022/readme.txt)
 
 
     2) Questions vs. Statements
-       query_classifier can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements/model.pickle)
-       query_vectorizer can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements/vectorizer.pickle)
+       query_classifier can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements_2022/model.pickle)
+       query_vectorizer can be found [here](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements_2022/vectorizer.pickle)
        output_1 => question
        output_2 => statement
-       [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements/readme.txt)
+       [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements_2022/readme.txt)
 
     See also the [tutorial](https://haystack.deepset.ai/tutorials/pipelines) on pipelines.
 
@@ -61,10 +61,10 @@ class SklearnQueryClassifier(BaseQueryClassifier):
         self,
         model_name_or_path: Union[
             str, Any
-        ] = "https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier/model.pickle",
+        ] = "https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_2022/model.pickle",
         vectorizer_name_or_path: Union[
             str, Any
-        ] = "https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier/vectorizer.pickle",
+        ] = "https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_2022/vectorizer.pickle",
         batch_size: Optional[int] = None,
         progress_bar: bool = True,
     ):

--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -47,14 +47,14 @@ class TransformersQueryClassifier(BaseQueryClassifier):
        model_name_or_path="shahrukhx01/bert-mini-finetune-question-detection"
        output_1 => question/statement
        output_2 => keyword query
-       [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier/readme.txt)
+       [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_2022/readme.txt)
 
 
     2) Questions vs. Statements
     `model_name_or_path`="shahrukhx01/question-vs-statement-classifier"
      output_1 => question
      output_2 => statement
-     [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements/readme.txt)
+     [Readme](https://ext-models-haystack.s3.eu-central-1.amazonaws.com/gradboost_query_classifier_statements_2022/readme.txt)
 
 
     See also the [tutorial](https://haystack.deepset.ai/tutorials/pipelines) on pipelines.


### PR DESCRIPTION
### Related Issues
- related: https://github.com/deepset-ai/haystack/issues/2904 

### Proposed Changes:
Our S3 bucket for scikitlearn models for query classification nodes contains the old version of the models with the original names:
[gradboost_query_classifier_statements/](https://s3.console.aws.amazon.com/s3/buckets/ext-models-haystack?region=eu-central-1&prefix=gradboost_query_classifier_statements/&showversions=false)
[gradboost_query_classifier/](https://s3.console.aws.amazon.com/s3/buckets/ext-models-haystack?region=eu-central-1&prefix=gradboost_query_classifier/&showversions=false)
and also the newly trained models that have better compatibility with new scikit learn versions:
[gradboost_query_classifier_statements_2022/](https://s3.console.aws.amazon.com/s3/buckets/ext-models-haystack?region=eu-central-1&prefix=gradboost_query_classifier_statements_2022/&showversions=false)
[gradboost_query_classifier_2022/](https://s3.console.aws.amazon.com/s3/buckets/ext-models-haystack?region=eu-central-1&prefix=gradboost_query_classifier_2022/&showversions=false)

Currently, the old models are the default and users can manually choose to use the new models.
This PR changes the models used by default to the new models which should ensure that the `SklearnQueryClassifier` node works with recent and future versions of scikit learn.
The predictions made by the models should be exactly the same. It's just about compatibility.

### How did you test it?
- ran test `test_query_keyword_statement_classifier` locally and CI tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
