### PR TITLE
fix: add `servers` to the stable version's openapi spec

### DIFF
--- a/docs/_src/api/openapi/openapi-1.12.0rc0.json
+++ b/docs/_src/api/openapi/openapi-1.12.0rc0.json
@@ -4,6 +4,11 @@
         "title": "Haystack REST API",
         "version": "1.12.0rc0"
     },
+    "servers": [
+        {
+            "url": "http://localhost:8000"
+        }
+    ],
     "paths": {
         "/initialized": {
             "get": {


### PR DESCRIPTION
### Related Issues
No issue created

### Proposed Changes:
* The same changes on #3775 for version 1.12.0rc0, this is the default version currently

### How did you test it?
The similar OpenAPI Schema works for 1.13.0rc0
I uploaded this specs file to the documentation and it works

### Notes for the reviewer
* I followed [OpenAPI Guide](https://swagger.io/docs/specification/api-host-and-base-path/) to create the OpenAPI schema.
* This is generated by changing version info on scripts locally as current scripts use only the latest version (1.13.0rc0)
* **Question:** Should I generate specs for all previous versions and upload them to the documentation?   

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue