### PR TITLE
feat: change PipelineConfigError to DocumentStoreError with more details

### DIFF
--- a/test/pipelines/test_pipeline_yaml.py
+++ b/test/pipelines/test_pipeline_yaml.py
@@ -14,7 +14,7 @@ import haystack
 from haystack import Pipeline
 from haystack.nodes import _json_schema
 from haystack.nodes import FileTypeClassifier
-from haystack.errors import HaystackError, PipelineConfigError, PipelineSchemaError
+from haystack.errors import HaystackError, PipelineConfigError, PipelineSchemaError, DocumentStoreError
 from haystack.nodes.base import BaseComponent
 
 from ..conftest import SAMPLES_PATH, MockNode, MockDocumentStore, MockReader, MockRetriever
@@ -139,6 +139,46 @@ def test_load_yaml(tmp_path):
     assert len(pipeline.graph.nodes) == 3
     assert isinstance(pipeline.get_node("retriever"), MockRetriever)
     assert isinstance(pipeline.get_node("reader"), MockReader)
+
+
+def test_load_yaml_elasticsearch_not_responding(tmp_path):
+    # Test if DocumentStoreError is raised if elasticsearch instance is not responding (due to wrong port)
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: ESRetriever
+              type: BM25Retriever
+              params:
+                document_store: DocumentStore
+            - name: DocumentStore
+              type: ElasticsearchDocumentStore
+              params:
+                port: 1234
+            - name: PDFConverter
+              type: PDFToTextConverter
+            - name: Preprocessor
+              type: PreProcessor
+            pipelines:
+            - name: query_pipeline
+              nodes:
+              - name: ESRetriever
+                inputs: [Query]
+            - name: indexing_pipeline
+              nodes:
+              - name: PDFConverter
+                inputs: [File]
+              - name: Preprocessor
+                inputs: [PDFConverter]
+              - name: ESRetriever
+                inputs: [Preprocessor]
+              - name: DocumentStore
+                inputs: [ESRetriever]
+        """
+        )
+    with pytest.raises(DocumentStoreError):
+        Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml", pipeline_name="indexing_pipeline")
 
 
 def test_load_yaml_non_existing_file():


### PR DESCRIPTION
### Related Issues
- fixes #3575

### Proposed Changes:
Raise one DocumentStoreError instead of two PipelineConfigErrors if loading a pipeline from yaml fails because an ElasticsearchDocumentStore can't connect to an elasticsearch instance. (instance not running, wrong hostname, wrong port, etc.)
The new error message is:

> "Failed loading pipeline component 'DocumentStore': 'Initial connection to Elasticsearch failed. Make sure you run an Elasticsearch instance at `[{'host': 'localhost', 'port': 9200}]` and that it has finished the initial ramp up (can take > 30s).'"

Before this PR, two PipelineConfigErrors were raised (not just one) because of recursion. The recursive method is `_load_or_get_component`, which processes pipeline components and their parameters, which can be components themselves. First, the DocumentStore component failed and then the Retriever, which had the DocumentStore as a parameter. Both raised a PipelineConfigError each. Now, we prevent a PipelineConfigError from being re-raised.

I added a new test case to check that a DocumentStoreError is raised if a pipeline containing an ElasticsearchDocumentStore is loaded and no connection to an Elasticsearch instance can be established (due to a wrong port).

One tiny unrelated change: I replaced a function call to `set(...)` with a set literal `{...}`

### How did you test it?
added a new test

### Notes for the reviewer
I thought about whether a ConnectionError could also be raised by other nodes (e.g. API nodes) but I think for now only DocumentStores can cause this. It's definitely by the far the most common PipelineConfigError as can be seen in received telemetry events.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
