### PR TITLE
New token limit for text-embedding-ada-002

### DIFF
--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -412,6 +412,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         if "text-embedding" in model_name:
             self.query_encoder_model = model_name
             self.doc_encoder_model = model_name
+            self.max_seq_len = min(8191, retriever.max_seq_len)
         else:
             self.query_encoder_model = f"text-search-{model_class}-query-001"
             self.doc_encoder_model = f"text-search-{model_class}-doc-001"


### PR DESCRIPTION
The token limit was raised from 2048 to 8191 with the introduction of ada-002. This should be reflected when picking this model. Just a one line change.
