### PR TITLE
fix(docker): Use IMAGE_NAME in api image

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,6 +1,7 @@
 ARG base_image_tag
+ARG base_image
 
-FROM deepset/haystack:${base_image_tag}
+FROM ${base_image}:${base_image_tag}
 
 ENV SERVICE_NAME="gunicorn-service"
 

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -66,6 +66,7 @@ target "cpu" {
   dockerfile = "Dockerfile.api"
   tags = ["${IMAGE_NAME}:cpu-${IMAGE_TAG_SUFFIX}"]
   args = {
+    base_image = "${IMAGE_NAME}"
     base_image_tag = "base-cpu-${BASE_IMAGE_TAG_SUFFIX}"
   }
   platforms = ["linux/amd64", "linux/arm64"]
@@ -81,6 +82,7 @@ target "gpu" {
   dockerfile = "Dockerfile.api"
   tags = ["${IMAGE_NAME}:gpu-${IMAGE_TAG_SUFFIX}"]
   args = {
+    base_image = "${IMAGE_NAME}"
     base_image_tag = "base-gpu-${BASE_IMAGE_TAG_SUFFIX}"
   }
   platforms = ["linux/amd64", "linux/arm64"]


### PR DESCRIPTION

### Related Issues
None

### Proposed Changes:
If you set the `IMAGE_NAME` variable, then the base image will be tagged with that name, but the api image would previously use a hardcoded `deepset/haystack` image name in the `FROM` statement. With this PR it will use the name provided with the `IMAGE_NAME` variable in the `FROM` statement.

### How did you test it?
Built a base image and api image with a different name

### Notes for the reviewer
None

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
