### PR TITLE
refactor: Using `with open()` to read files

### DIFF
--- a/haystack/modeling/data_handler/processor.py
+++ b/haystack/modeling/data_handler/processor.py
@@ -171,7 +171,8 @@ class Processor(ABC):
         """
         # read config
         processor_config_file = Path(load_dir) / "processor_config.json"
-        config = json.load(open(processor_config_file))
+        with open(processor_config_file) as f:
+            config = json.load(f)
         config["inference"] = True
         # init tokenizer
         if "lower_case" in config.keys():
@@ -927,7 +928,8 @@ class TextSimilarityProcessor(Processor):
         """
         # read config
         processor_config_file = Path(load_dir) / "processor_config.json"
-        config = json.load(open(processor_config_file))
+        with open(processor_config_file) as f:
+            config = json.load(f)
         # init tokenizers
         query_tokenizer_class: Type[PreTrainedTokenizer] = getattr(transformers, config["query_tokenizer"])
         query_tokenizer = query_tokenizer_class.from_pretrained(
@@ -1339,7 +1341,8 @@ class TableTextSimilarityProcessor(Processor):
         """
         # read config
         processor_config_file = Path(load_dir) / "processor_config.json"
-        config = json.load(open(processor_config_file))
+        with open(processor_config_file) as f:
+            config = json.load(f)
         # init tokenizer
         query_tokenizer = AutoTokenizer.from_pretrained(
             load_dir, tokenizer_class=config["query_tokenizer"], subfolder="query"
@@ -1452,7 +1455,8 @@ class TableTextSimilarityProcessor(Processor):
                                     ...]
                         }
         """
-        dicts = json.load(open(file))
+        with open(file) as f:
+            dicts = json.load(f)
         if max_samples:
             dicts = random.sample(dicts, min(max_samples, len(dicts)))
         # convert DPR dictionary to standard dictionary
@@ -1976,7 +1980,8 @@ class InferenceProcessor(TextClassificationProcessor):
         """
         # read config
         processor_config_file = Path(load_dir) / "processor_config.json"
-        config = json.load(open(processor_config_file))
+        with open(processor_config_file) as f:
+            config = json.load(f)
         # init tokenizer
         tokenizer = AutoTokenizer.from_pretrained(load_dir, tokenizer_class=config["tokenizer"])
         # we have to delete the tokenizer string from config, because we pass it as Object
@@ -2168,7 +2173,8 @@ def _read_dpr_json(
             for line in f:
                 dicts.append(json.loads(line))
     else:
-        dicts = json.load(open(file, encoding="utf-8"))
+        with open(file, encoding="utf-8") as f:
+            dicts = json.load(f)
 
     if max_samples:
         dicts = random.sample(dicts, min(max_samples, len(dicts)))

--- a/haystack/modeling/model/feature_extraction.py
+++ b/haystack/modeling/model/feature_extraction.py
@@ -90,7 +90,8 @@ class FeatureExtractor:
         config_file = Path(pretrained_model_name_or_path) / "tokenizer_config.json"
         if os.path.exists(config_file):
             # it's a local directory
-            config = json.load(open(config_file))
+            with open(config_file) as f:
+                config = json.load(f)
             feature_extractor_classname = config["tokenizer_class"]
             logger.debug(f"⛏️ Selected feature extractor: {feature_extractor_classname} (from {config_file})")
             # Use FastTokenizers as much as possible

--- a/haystack/modeling/model/language_model.py
+++ b/haystack/modeling/model/language_model.py
@@ -862,7 +862,8 @@ def get_language_model(
     config_file_exists = os.path.exists(config_file)
     if config_file_exists:
         # it's a local directory in Haystack format
-        config = json.load(open(config_file))
+        with open(config_file) as f:
+            config = json.load(f)
         model_type = config["name"]
 
     if not model_type:

--- a/haystack/modeling/model/prediction_head.py
+++ b/haystack/modeling/model/prediction_head.py
@@ -105,7 +105,8 @@ class PredictionHead(nn.Module):
         :return: PredictionHead
         :rtype: PredictionHead[T]
         """
-        config = json.load(open(config_file))
+        with open(config_file) as f:
+            config = json.load(f)
         prediction_head = cls.subclasses[config["name"]](**config)
         if load_weights:
             model_file = cls._get_model_file(config_file=config_file)

--- a/haystack/utils/squad_data.py
+++ b/haystack/utils/squad_data.py
@@ -57,7 +57,8 @@ class SquadData:
         """
         Create a SquadData object by providing the name of a JSON file in the SQuAD format.
         """
-        data = json.load(open(filename))
+        with open(filename) as f:
+            data = json.load(f)
         return cls(data)
 
     def save(self, filename: str):


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Changed opening of files to use `with open()` context to make sure files are explicitly closed once exiting the context manager. Previously in some places, we were using code like `config = json.load(open(filename))` which doesn't guarantee that the file, `filename`, is closed after use. This can cause warnings to appear which I show below.

To get rid of the warning messages and avoid other potential [pitfalls](https://stackoverflow.com/questions/7395542/is-explicitly-closing-files-important) I updated those code lines to use the `with open()` context manager.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Made sure existing unit tests passed. Also checked locally that these types of warning messages
```python
/home/ubuntu/code/haystack/haystack/modeling/model/language_model.py:865: ResourceWarning: unclosed file <_io.TextIOWrapper name='ver_6/language_model_config.json' mode='r' encoding='UTF-8'>
  config = json.load(open(config_file))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```
no longer appeared.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
