### PR TITLE
fix: Set Reader and Retriever models to eval mode for predictions

### DIFF
--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -354,6 +354,7 @@ class Inferencer:
                         Example: QA - input string to convert the predicted answer from indices back to string space
         :return: list of predictions
         """
+        self.model.eval()
         samples = [s for b in baskets for s in b.samples]
 
         data_loader = NamedDataLoader(
@@ -390,6 +391,7 @@ class Inferencer:
                         Example: QA - input string to convert the predicted answer from indices back to string space
         :return: list of predictions
         """
+        self.model.eval()
         data_loader = NamedDataLoader(
             dataset=dataset, sampler=SequentialSampler(dataset), batch_size=self.batch_size, tensor_names=tensor_names
         )  # type ignore

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -815,6 +815,7 @@ class FARMReader(BaseReader):
         :param top_k: Number of returned answers per query.
         :param batch_size: Number of query-document pairs to be processed at a time.
         """
+        self.inferencer.model.eval()
         if top_k is None:
             top_k = self.top_k
 
@@ -882,6 +883,7 @@ class FARMReader(BaseReader):
         :param top_k: The maximum number of answers to return
         :return: Dict containing query and answers
         """
+        self.inferencer.model.eval()
         if top_k is None:
             top_k = self.top_k
         # convert input to FARM format

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -135,6 +135,7 @@ class TransformersReader(BaseReader):
         :param top_k: The maximum number of answers to return
         :return: Dict containing query and answers
         """
+        self.model.model.eval()
         if top_k is None:
             top_k = self.top_k
 
@@ -201,6 +202,7 @@ class TransformersReader(BaseReader):
         :param top_k: Number of returned answers per query.
         :param batch_size: Number of query-document pairs to be processed at a time.
         """
+        self.model.model.eval()
         if top_k is None:
             top_k = self.top_k
 

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -138,6 +138,7 @@ class _DefaultEmbeddingEncoder(_BaseEmbeddingEncoder):
     def embed(self, texts: Union[List[List[str]], List[str], str]) -> np.ndarray:
         # TODO: FARM's `sample_to_features_text` need to fix following warning -
         # tokenization_utils.py:460: FutureWarning: `is_pretokenized` is deprecated and will be removed in a future version, use `is_split_into_words` instead.
+        self.embedding_model.model.eval()
         emb = self.embedding_model.inference_from_dicts(dicts=[{"text": t} for t in texts])
         emb = np.stack([r["vec"] for r in emb])
         return emb

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -297,6 +297,7 @@ class _RetribertEmbeddingEncoder(_BaseEmbeddingEncoder):
         :param queries: List of queries to embed.
         :return: Embeddings, one per input query, shape: (queries, embedding_dim)
         """
+        self.embedding_model.eval()
         query_text = [{"text": q} for q in queries]
         dataloader = self._create_dataloader(query_text)
 
@@ -324,6 +325,7 @@ class _RetribertEmbeddingEncoder(_BaseEmbeddingEncoder):
         :param docs: List of documents to embed.
         :return: Embeddings, one per input document, shape: (documents, embedding_dim)
         """
+        self.embedding_model.eval()
         doc_text = [{"text": d.content} for d in docs]
         dataloader = self._create_dataloader(doc_text)
 

--- a/test/nodes/test_reader.py
+++ b/test/nodes/test_reader.py
@@ -5,6 +5,7 @@ from shutil import rmtree
 
 import pytest
 
+import torch
 from huggingface_hub import snapshot_download
 from haystack.modeling.data_handler.inputs import QAInput, Question
 
@@ -53,6 +54,44 @@ def test_output(reader, docs):
     assert 0 <= prediction["answers"][0].score <= 1
     assert prediction["answers"][0].context == "My name is Carla and I live in Berlin"
     assert len(prediction["answers"]) == 5
+
+
+def test_output_train_mode(reader, docs):
+    # Set to deterministic seed
+    old_seed = torch.seed()
+    torch.manual_seed(0)
+
+    pred_default = reader.predict(query="Who lives in Berlin?", documents=docs, top_k=5)
+    if isinstance(reader, FARMReader):
+        reader.inferencer.model.train()
+    else:
+        reader.model.model.train()
+    pred_train_mode = reader.predict(query="Who lives in Berlin?", documents=docs, top_k=5)
+
+    assert pred_default["query"] == pred_train_mode["query"]
+    assert pred_default["answers"][0].answer == pred_train_mode["answers"][0].answer
+    assert (
+        pred_default["answers"][0].offsets_in_context[0].start
+        == pred_train_mode["answers"][0].offsets_in_context[0].start
+    )
+    assert (
+        pred_default["answers"][0].offsets_in_context[0].end == pred_train_mode["answers"][0].offsets_in_context[0].end
+    )
+    assert (
+        pred_default["answers"][0].offsets_in_document[0].start
+        == pred_train_mode["answers"][0].offsets_in_document[0].start
+    )
+    assert (
+        pred_default["answers"][0].offsets_in_document[0].end
+        == pred_train_mode["answers"][0].offsets_in_document[0].end
+    )
+    assert pred_default["answers"][0].type == pred_train_mode["answers"][0].type
+    assert math.isclose(pred_default["answers"][0].score, pred_train_mode["answers"][0].score, rel_tol=1e-4)
+    assert pred_default["answers"][0].context == pred_train_mode["answers"][0].context
+    assert len(pred_default["answers"]) == len(pred_train_mode["answers"])
+
+    # Set back to old_seed
+    torch.manual_seed(old_seed)
 
 
 def test_output_batch_single_query_single_doc_list(reader, docs):

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -21,7 +21,7 @@ from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.nodes.retriever.dense import DensePassageRetriever, EmbeddingRetriever, TableTextRetriever
 from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
 from haystack.nodes.retriever.multimodal import MultiModalRetriever
-from haystack.nodes.retriever._embedding_encoder import _RetribertEmbeddingEncoder
+from haystack.nodes.retriever._embedding_encoder import _DefaultEmbeddingEncoder
 
 from ..conftest import SAMPLES_PATH, MockRetriever
 
@@ -310,17 +310,17 @@ def test_dpr_embedding(document_store: BaseDocumentStore, retriever, docs_with_i
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
-@pytest.mark.parametrize("retriever", ["embedding", "retribert"], indirect=True)
+@pytest.mark.parametrize("retriever", ["embedding", "retribert", "embedding_sbert"], indirect=True)
 def test_embedding_train_mode(retriever, docs_with_ids):
     # Set to deterministic seed
     old_seed = torch.seed()
     torch.manual_seed(0)
 
     embeddings_default_mode = retriever.embed_documents(documents=docs_with_ids)
-    if isinstance(retriever.embedding_encoder, _RetribertEmbeddingEncoder):
-        retriever.embedding_encoder.embedding_model.train()
-    else:
+    if isinstance(retriever.embedding_encoder, _DefaultEmbeddingEncoder):
         retriever.embedding_encoder.embedding_model.model.train()
+    else:
+        retriever.embedding_encoder.embedding_model.train()
     embeddings_train_mode = retriever.embed_documents(documents=docs_with_ids)
 
     for emb1, emb2 in zip(embeddings_train_mode, embeddings_default_mode):

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -21,6 +21,7 @@ from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.nodes.retriever.dense import DensePassageRetriever, EmbeddingRetriever, TableTextRetriever
 from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
 from haystack.nodes.retriever.multimodal import MultiModalRetriever
+from haystack.nodes.retriever._embedding_encoder import _RetribertEmbeddingEncoder
 
 from ..conftest import SAMPLES_PATH, MockRetriever
 
@@ -309,14 +310,17 @@ def test_dpr_embedding(document_store: BaseDocumentStore, retriever, docs_with_i
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
-@pytest.mark.parametrize("retriever", ["embedding"], indirect=True)
+@pytest.mark.parametrize("retriever", ["embedding", "retribert"], indirect=True)
 def test_embedding_train_mode(retriever, docs_with_ids):
     # Set to deterministic seed
     old_seed = torch.seed()
     torch.manual_seed(0)
 
     embeddings_default_mode = retriever.embed_documents(documents=docs_with_ids)
-    retriever.embedding_encoder.embedding_model.model.train()
+    if isinstance(retriever.embedding_encoder, _RetribertEmbeddingEncoder):
+        retriever.embedding_encoder.embedding_model.train()
+    else:
+        retriever.embedding_encoder.embedding_model.model.train()
     embeddings_train_mode = retriever.embed_documents(documents=docs_with_ids)
 
     for emb1, emb2 in zip(embeddings_train_mode, embeddings_default_mode):


### PR DESCRIPTION
### Related Issues
- fixes N/A
- Related to PR #3743 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I added `model.eval()` calls to make sure to set the models in `FARMReader`, `TransformerReader`, `EmbeddingRetriever` (both with the `_RetribertEmbeddingEncoder` and `_DefaultEmbeddingEncoder`) model to eval mode when running an inference prediction. Otherwise, currently, if the model is set to train mode the predictions become random due to layers like dropout, and BatchNormalization being present in the underlying model architecture. This is something we already do for some of our nodes like the DensePassageRetriever.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added two new unit tests to make sure the Reader and Retriever nodes provide correct results even if they are set to train mode before running a prediction. I did confirm that these unit tests fail without the new changes.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This probably was not noticed before because the model is set to eval mode by default when loading it. However, this error could have occurred when using the nodes right after training. For example, using the `predict` function of the FARMReader right after training. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
