### PR TITLE
bug: Fix launch_milvus() by cd'ing to milvus_dir

### DIFF
--- a/haystack/utils/doc_store.py
+++ b/haystack/utils/doc_store.py
@@ -133,7 +133,7 @@ def launch_milvus(sleep=15, delete_existing=False):
     with open(milvus_dir / "docker-compose.yml", "wb") as f:
         f.write(request.content)
 
-    status = subprocess.run(["cd /home/$USER/milvus/ && docker-compose up -d"], shell=True)
+    status = subprocess.run([f"cd {milvus_dir} && docker-compose up -d"], shell=True)
 
     if status.returncode:
         logger.warning(


### PR DESCRIPTION
### Related Issues
- fixes #3794

### Proposed Changes:
launch_milvus() fails when `Path.home() ` is not same as `/home/$USER/milvus/`

changed
```
status = subprocess.run(["cd /home/$USER/milvus/ && docker-compose up -d"], shell=True)
```
to
```
status = subprocess.run([f"cd {milvus_dir} && docker-compose up -d"], shell=True)
```

### How did you test it?
ran locally

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
