### PR TITLE
feat: utility function to explicitly invoke JSON schema generation

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -34,6 +34,11 @@ RUN pip install --upgrade pip && \
     pip install --no-cache-dir .${haystack_extras} && \
     pip install --no-cache-dir ./rest_api
 
+# The JSON schema is lazily generated at first usage, but we do it explicitly here for two reasons:
+# - the schema will be already there when the container runs, saving the generation overhead when a container starts
+# - derived images don't need to write the schema and can run with lower user privileges
+RUN python3 -c "from haystack.utils.docker import cache_schema; cache_schema()"
+
 FROM $base_immage AS final
 
 COPY --from=build-image /opt/venv /opt/venv
@@ -42,8 +47,3 @@ COPY --from=build-image /opt/pdftotext /usr/local/bin
 RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"
-
-# Importing Haystack will generate and persist the json schema, we do this here for two reasons:
-# - the schema will be already there when the container runs, saving the generation overhead when a container starts
-# - derived images don't need to write the schema and can run with lower user privileges
-RUN python3 -c "import haystack"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -34,10 +34,6 @@ RUN pip install --upgrade pip && \
     pip install --no-cache-dir .${haystack_extras} && \
     pip install --no-cache-dir ./rest_api
 
-# The JSON schema is lazily generated at first usage, but we do it explicitly here for two reasons:
-# - the schema will be already there when the container runs, saving the generation overhead when a container starts
-# - derived images don't need to write the schema and can run with lower user privileges
-RUN python3 -c "from haystack.utils.docker import cache_schema; cache_schema()"
 
 FROM $base_immage AS final
 
@@ -47,3 +43,8 @@ COPY --from=build-image /opt/pdftotext /usr/local/bin
 RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"
+
+# The JSON schema is lazily generated at first usage, but we do it explicitly here for two reasons:
+# - the schema will be already there when the container runs, saving the generation overhead when a container starts
+# - derived images don't need to write the schema and can run with lower user privileges
+RUN python3 -c "from haystack.utils.docker import cache_schema; cache_schema()"

--- a/haystack/utils/docker.py
+++ b/haystack/utils/docker.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Union, Optional
+from nodes._json_schema import load_schema
 
 
 def cache_models(models: Optional[List[str]] = None, use_auth_token: Optional[Union[str, bool]] = None):
@@ -31,3 +32,15 @@ def cache_models(models: Optional[List[str]] = None, use_auth_token: Optional[Un
         logging.info("Caching %s", model_to_cache)
         transformers.AutoTokenizer.from_pretrained(model_to_cache, use_auth_token=use_auth_token)
         transformers.AutoModel.from_pretrained(model_to_cache, use_auth_token=use_auth_token)
+
+
+def cache_schema():
+    """
+    Generate and persist Haystack JSON schema.
+
+    The schema is lazily generated at first usage, but this might not work in Docker containers
+    when the user running Haystack doesn't have write permissions on the Python installation. By
+    calling this function at Docker image build time, the schema is generated once for all.
+    """
+    # Calling load_schema() will generate the schema as a side effect
+    load_schema()

--- a/haystack/utils/docker.py
+++ b/haystack/utils/docker.py
@@ -1,6 +1,6 @@
 import logging
 from typing import List, Union, Optional
-from nodes._json_schema import load_schema
+from haystack.nodes._json_schema import load_schema
 
 
 def cache_models(models: Optional[List[str]] = None, use_auth_token: Optional[Union[str, bool]] = None):


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/pull/3701#issuecomment-1367250204

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add a function that triggers the schema generation, mainly to be used inside Docker containers for caching purposes.

I wrongly called this issue resolved in #3701 but my solution was relying on a side effect that happens only under certain circumstances: this is extremely unreliable and indeed the current `main` Docker images are broken.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Built locally with bake, then run the api container to ensure the schema is there:
```
docker run -ti --entrypoint /bin/sh docker.io/deepset/haystack:cpu-local
$ ls /opt/venv/lib/python3.10/site-packages/haystack/json-schemas
haystack-pipeline-main.schema.json
```

/cc @mayankjobanputra @vblagoje 

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
