### PR TITLE
feat: Enable GPU support for Apple M-silicon using mps

### DIFF
--- a/docs/v1.0.0/_src/tutorials/tutorials/5.md
+++ b/docs/v1.0.0/_src/tutorials/tutorials/5.md
@@ -41,10 +41,10 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 # restart the runtime after installing haystack.
 ```
 
-
 ```python
 from haystack.modeling.utils import initialize_device_settings
-devices, n_gpu = initialize_device_settings(use_cuda=True)
+
+devices, n_gpu = initialize_device_settings(use_gpu=True)
 ```
 
 ## Start an Elasticsearch server

--- a/docs/v1.1.0/_src/tutorials/tutorials/5.md
+++ b/docs/v1.1.0/_src/tutorials/tutorials/5.md
@@ -41,10 +41,10 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 # restart the runtime after installing haystack.
 ```
 
-
 ```python
 from haystack.modeling.utils import initialize_device_settings
-devices, n_gpu = initialize_device_settings(use_cuda=True)
+
+devices, n_gpu = initialize_device_settings(use_gpu=True)
 ```
 
 ## Start an Elasticsearch server

--- a/docs/v1.2.0/_src/tutorials/tutorials/5.md
+++ b/docs/v1.2.0/_src/tutorials/tutorials/5.md
@@ -38,11 +38,10 @@ Make sure you enable the GPU runtime to experience decent speed in this tutorial
 !pip install git+https://github.com/deepset-ai/haystack.git#egg=farm-haystack[colab]
 ```
 
-
 ```python
 from haystack.modeling.utils import initialize_device_settings
 
-devices, n_gpu = initialize_device_settings(use_cuda=True)
+devices, n_gpu = initialize_device_settings(use_gpu=True)
 ```
 
 ## Start an Elasticsearch server

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -107,7 +107,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self.bm25_parameters = bm25_parameters
         self.bm25: Dict[str, rank_bm25.BM25] = {}
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=self.use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=self.use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -74,7 +74,7 @@ class Inferencer:
 
         """
         # Init device and distributed settings
-        self.devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)
+        self.devices, n_gpu = initialize_device_settings(devices=devices, use_gpu=gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "
@@ -183,7 +183,7 @@ class Inferencer:
         if tokenizer_args is None:
             tokenizer_args = {}
 
-        devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)
+        devices, n_gpu = initialize_device_settings(devices=devices, use_gpu=gpu, multi_gpu=False)
         if len(devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in Inferencer, " f"using the first device {devices[0]}."

--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -8,7 +8,6 @@ import signal
 from functools import wraps
 from copy import deepcopy
 from itertools import islice
-import os
 
 import numpy as np
 import torch

--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -8,6 +8,7 @@ import signal
 from functools import wraps
 from copy import deepcopy
 from itertools import islice
+import os
 
 import numpy as np
 import torch
@@ -75,7 +76,7 @@ def set_all_seeds(seed: int, deterministic_cudnn: bool = False) -> None:
 
 
 def initialize_device_settings(
-    use_cuda: Optional[bool] = None,
+    use_gpu: Optional[bool] = None,
     local_rank: int = -1,
     multi_gpu: bool = True,
     devices: Optional[List[Union[str, torch.device]]] = None,
@@ -83,17 +84,17 @@ def initialize_device_settings(
     """
     Returns a list of available devices.
 
-    :param use_cuda: Whether to make use of CUDA GPUs (if available).
+    :param use_gpu: Whether to make use of CUDA or MPS GPUs (if available).
     :param local_rank: Ordinal of device to be used. If -1 and `multi_gpu` is True, all devices will be used.
-                       Unused if `devices` is set or `use_cuda` is False.
+                       Unused if `devices` is set or `use_gpu` is False or 'mps' device is present and 'cuda' is not
     :param multi_gpu: Whether to make use of all GPUs (if available).
-                      Unused if `devices` is set or `use_cuda` is False.
+                      Unused if `devices` is set or `use_gpu` is False.
     :param devices: List of torch devices (e.g. cuda, cpu, mps) to limit inference to specific devices.
                         A list containing torch device objects and/or strings is supported (For example
                         [torch.device('cuda:0'), "mps", "cuda:1"]). When specifying `use_gpu=False` the devices
                         parameter is not used and a single cpu device is used for inference.
     """
-    if use_cuda is False:  # Note that it could be None, in which case we also want to just skip this step.
+    if use_gpu is False:  # Note that it could be None, in which case we also want to just skip this step.
         devices_to_use = [torch.device("cpu")]
         n_gpu = 0
     elif devices:
@@ -105,6 +106,13 @@ def initialize_device_settings(
         else:
             devices_to_use = devices
         n_gpu = sum(1 for device in devices_to_use if "cpu" not in device.type)
+    elif not torch.cuda.is_available() and torch.backends.mps.is_available():
+        devices_to_use = [torch.device("mps:0")]
+        n_gpu = 1
+
+        # MPS device do not support all operators, enable CPU fallback [https://github.com/pytorch/pytorch/issues/77764]
+        # TODO eventually remove once the limitation is fixed in MPS device
+        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
     elif local_rank == -1:
         if torch.cuda.is_available():
             if multi_gpu:

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -128,7 +128,7 @@ class RAGenerator(BaseGenerator):
 
         self.top_k = top_k
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "
@@ -386,7 +386,7 @@ class Seq2SeqGenerator(BaseGenerator):
 
         self.top_k = top_k
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/audio/_text_to_speech.py
+++ b/haystack/nodes/audio/_text_to_speech.py
@@ -49,7 +49,7 @@ class TextToSpeech:
         """
         super().__init__()
 
-        resolved_devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        resolved_devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(resolved_devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/document_classifier/transformers.py
+++ b/haystack/nodes/document_classifier/transformers.py
@@ -127,7 +127,7 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
                 f"zero-shot-classification to use labels."
             )
 
-        resolved_devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        resolved_devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(resolved_devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -120,7 +120,7 @@ class EntityExtractor(BaseComponent):
     ):
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/label_generator/pseudo_label_generator.py
+++ b/haystack/nodes/label_generator/pseudo_label_generator.py
@@ -116,7 +116,7 @@ class PseudoLabelGenerator(BaseComponent):
                 )
         else:
             raise ValueError("Provide either a QuestionGenerator or a non-empty list of questions/document pairs.")
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -235,7 +235,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         super().__init__(model_name_or_path, max_length)
         self.use_auth_token = use_auth_token
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -97,7 +97,7 @@ class TransformersQueryClassifier(BaseQueryClassifier):
                         parameter is not used and a single cpu device is used for inference.
         """
         super().__init__()
-        resolved_devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        resolved_devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(resolved_devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/question_generator/question_generator.py
+++ b/haystack/nodes/question_generator/question_generator.py
@@ -78,7 +78,7 @@ class QuestionGenerator(BaseComponent):
 
         """
         super().__init__()
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -77,7 +77,7 @@ class SentenceTransformersRanker(BaseRanker):
 
         self.top_k = top_k
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=True)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=True)
 
         self.progress_bar = progress_bar
         self.transformer_model = AutoModelForSequenceClassification.from_pretrained(

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -131,7 +131,7 @@ class FARMReader(BaseReader):
         """
         super().__init__()
 
-        self.devices, self.n_gpu = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=True)
+        self.devices, self.n_gpu = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=True)
         self.return_no_answers = return_no_answer
         self.top_k = top_k
         self.top_k_per_candidate = top_k_per_candidate
@@ -212,7 +212,7 @@ class FARMReader(BaseReader):
         if max_seq_len is None:
             max_seq_len = self.max_seq_len
 
-        devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        devices, n_gpu = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
 
         if not save_dir:
             save_dir = f"../../saved_models/{self.inferencer.model.language_model.name}"

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -113,7 +113,7 @@ class TableReader(BaseReader):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "
@@ -637,7 +637,7 @@ class RCIReader(BaseReader):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -82,7 +82,7 @@ class TransformersReader(BaseReader):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
 
         if len(self.devices) > 1:
             logger.warning(

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -164,7 +164,7 @@ class DensePassageRetriever(DenseRetriever):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=True)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=True)
 
         if batch_size < len(self.devices):
             logger.warning("Batch size is less than the number of devices. All gpus will not be utilized.")
@@ -852,7 +852,7 @@ class TableTextRetriever(DenseRetriever):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=True)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=True)
 
         if batch_size < len(self.devices):
             logger.warning("Batch size is less than the number of devices.All gpus will not be utilized.")
@@ -1503,7 +1503,7 @@ class EmbeddingRetriever(DenseRetriever):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=True)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=True)
 
         if batch_size < len(self.devices):
             logger.warning("Batch size is less than the number of devices.All gpus will not be utilized.")

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -93,7 +93,7 @@ class TransformersSummarizer(BaseSummarizer):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -80,7 +80,7 @@ class TransformersTranslator(BaseTranslator):
         """
         super().__init__()
 
-        self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        self.devices, _ = initialize_device_settings(devices=devices, use_gpu=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(
                 f"Multiple devices are not supported in {self.__class__.__name__} inference, "

--- a/test/modeling/test_dpr.py
+++ b/test/modeling/test_dpr.py
@@ -29,7 +29,7 @@ def test_dpr_modules(caplog=None):
         caplog.set_level(logging.CRITICAL)
 
     set_all_seeds(seed=42)
-    devices, n_gpu = initialize_device_settings(use_cuda=True)
+    devices, n_gpu = initialize_device_settings(use_gpu=True)
 
     # 1.Create question and passage tokenizers
     query_tokenizer = AutoTokenizer.from_pretrained(

--- a/test/modeling/test_prediction_head.py
+++ b/test/modeling/test_prediction_head.py
@@ -11,7 +11,7 @@ def test_prediction_head_load_save(tmp_path, caplog=None):
         caplog.set_level(logging.CRITICAL)
 
     set_all_seeds(seed=42)
-    devices, n_gpu = initialize_device_settings(use_cuda=False)
+    devices, n_gpu = initialize_device_settings(use_gpu=False)
     lang_model = "bert-base-german-cased"
 
     language_model = get_language_model(lang_model)


### PR DESCRIPTION
### Related Issues
- fixes #3796

### Proposed Changes:
- Enabled GPU support for Apple M-silicon using MPS
- Replaced use_cuda flag with use_gpu flag in  [initialize_device_settings](https://github.com/deepset-ai/haystack/blob/main/haystack/modeling/utils.py#:~:text=def%20initialize_device_settings) 
- `if use_gpu == True and not torch.cuda.is_available() and torch.backends.mps.is_available()'  then `devices_to_use = [torch.device("mps:0")]`

### How did you test it?
- Manually tested on Mac M1-pro and observed 15X speed-up as compared to CPU
```
from haystack.nodes import EmbeddingRetriever
retriever = EmbeddingRetriever(document_store=document_store
                               ,embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1"
                               ,model_format="sentence_transformers"
                              )
document_store.update_embeddings(retriever)
```

### Notes for the reviewer
MPS device do not support all operators, enable CPU fallback, [open issue](https://github.com/pytorch/pytorch/issues/77764). Hence enabled CPU fallback using
```
# TODO eventually remove once the limitation is fixed in MPS device
        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
```

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
