### PR TITLE
fix: Fix newlines in docstring during markdown generation

### DIFF
--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -4,9 +4,9 @@ import dataclasses
 import docspec
 import typing as t
 from pathlib import Path
-from pydoc_markdown.interfaces import Context, Renderer
+from pydoc_markdown.interfaces import Context, Renderer, Resolver
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
-
+import html
 
 README_FRONTMATTER = """---
 title: {title}
@@ -18,6 +18,19 @@ hidden: false
 ---
 
 """
+
+
+class HaystackMarkdownRenderer(MarkdownRenderer):
+    """
+    Custom Markdown renderer heavily based on the `MarkdownRenderer`
+    """
+
+    def _render_object(self, fp, level, obj):
+        """
+        This is where docstrings for a certain object are processed,
+        we need to override it in order to better manage new lines.
+        """
+        super()._render_object(fp, level, obj)
 
 
 @dataclasses.dataclass
@@ -36,7 +49,7 @@ class ReadmeRenderer(Renderer):
     order: int
     # This exposes a special `markdown` settings value that can be used to pass
     # parameters to the underlying `MarkdownRenderer`
-    markdown: MarkdownRenderer = dataclasses.field(default_factory=MarkdownRenderer)
+    markdown: HaystackMarkdownRenderer = dataclasses.field(default_factory=HaystackMarkdownRenderer)
 
     def init(self, context: Context) -> None:
         self.markdown.init(context)

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -19,10 +19,12 @@ hidden: false
 
 """
 
+
 class HaystackMarkdownRenderer(MarkdownRenderer):
     """
     Custom Markdown renderer heavily based on the `MarkdownRenderer`
     """
+
     def _render_object(self, fp, level, obj):
         """
         This is where docstrings for a certain object are processed,
@@ -55,6 +57,7 @@ class HaystackMarkdownRenderer(MarkdownRenderer):
                 lines = ["> " + x for x in lines]
             fp.write("\n".join(lines))
             fp.write("\n\n")
+
 
 @dataclasses.dataclass
 class ReadmeRenderer(Renderer):

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -19,7 +19,6 @@ hidden: false
 
 """
 
-
 class HaystackMarkdownRenderer(MarkdownRenderer):
     """
     Custom Markdown renderer heavily based on the `MarkdownRenderer`
@@ -47,13 +46,15 @@ class HaystackMarkdownRenderer(MarkdownRenderer):
                 fp.write(source_string + "\n\n")
 
         if obj.docstring:
-            docstring = html.escape(obj.docstring.content).replace("**Arguments**", "\n**Arguments**") if self.escape_html_in_docstring else obj.docstring.content.replace("**Arguments**", "\n**Arguments**")
+            docstring = html.escape(obj.docstring.content) if self.escape_html_in_docstring else obj.docstring.content
+            docstring = docstring.replace("**Arguments**", "\n\n**Arguments**")
+            docstring = docstring.replace("**Returns**", "\n\n**Returns**")
+            docstring = docstring.replace("**Raises**", "\n\n**Raises**")
             lines = docstring.split("\n\n")
             if self.docstrings_as_blockquote:
                 lines = ["> " + x for x in lines]
             fp.write("\n".join(lines))
             fp.write("\n\n")
-
 
 @dataclasses.dataclass
 class ReadmeRenderer(Renderer):


### PR DESCRIPTION
### Related Issues
- fixes #issue-number

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
From the root of the repo:
```
$ ./.github/utils/pydoc-markdown.sh 
```
this will create a folder called `temp` under `docs/_src/api/api/` containing  the generated markdown files:

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
The `_render_object` method in the `HaystackMarkdownRenderer` must be re-implemented in order to fix the generated markdown code. The original code is here:

https://github.com/NiklasRosenstein/pydoc-markdown/blob/3aa2fa94f514ee827992e4145a23e1260b5a4efd/src/pydoc_markdown/contrib/renderers/markdown.py#L353

and from skimming through the code I think we need to fix it somewhere under the `if obj.docstring:` block.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
