### PR TITLE
fix: linefeeds in custom_query

### DIFF
--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -1064,7 +1064,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         elif custom_query:  # substitute placeholder for query and filters for the custom_query template string
             template = Template(custom_query)
             # replace all "${query}" placeholder(s) with query
-            substitutions = {"query": f'"{query}"'}
+            substitutions = {"query": json.dumps(query)}
             # For each filter we got passed, we'll try to find & replace the corresponding placeholder in the template
             # Example: filters={"years":[2018]} => replaces {$years} in custom_query with '[2018]'
             if filters:

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -272,6 +272,10 @@ def test_elasticsearch_custom_query():
     results = retriever.retrieve(query="test", filters={"years": ["2020", "2021"]})
     assert len(results) == 4
 
+    # test linefeeds in query
+    results = retriever.retrieve(query="test\n", filters={"years": ["2020", "2021"]})
+    assert len(results) == 3
+
     # test custom "term" query
     retriever = BM25Retriever(
         document_store=document_store,

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -276,6 +276,10 @@ def test_elasticsearch_custom_query():
     results = retriever.retrieve(query="test\n", filters={"years": ["2020", "2021"]})
     assert len(results) == 3
 
+    # test double quote in query
+    results = retriever.retrieve(query='test"', filters={"years": ["2020", "2021"]})
+    assert len(results) == 3
+
     # test custom "term" query
     retriever = BM25Retriever(
         document_store=document_store,


### PR DESCRIPTION
### Related Issues
- fixes #3812
- fixes #3737 

### Proposed Changes:
- escape query using `json.dumps`

### How did you test it?
- extended custom_query test

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
