### PR TITLE
fix: gracefully handle `FileExistsError` during `Preprocessor` resource download

### DIFF
--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -103,8 +103,11 @@ class PreProcessor(BasePreProcessor):
         try:
             nltk.data.find("tokenizers/punkt")
         except LookupError:
-            nltk.download("punkt")
-
+            try:
+                nltk.download("punkt")
+            except FileExistsError as error:
+                logger.debug(f"NLTK punkt tokenizer seems to be already downloaded. Error message: {error}")
+                pass
         self.clean_whitespace = clean_whitespace
         self.clean_header_footer = clean_header_footer
         self.clean_empty_lines = clean_empty_lines

--- a/test/nodes/test_preprocessor.py
+++ b/test/nodes/test_preprocessor.py
@@ -497,3 +497,14 @@ def test_headline_processing_split_by_passage_overlap():
 
     for doc, expected in zip(documents, expected_headlines):
         assert doc.meta["headlines"] == expected
+
+
+def test_file_exists_error_during_download(monkeypatch: MonkeyPatch, module_tmp_dir: Path):
+    # Pretend the model resources were not found in the first attempt
+    monkeypatch.setattr(nltk.data, "find", Mock(side_effect=[LookupError, str(module_tmp_dir)]))
+
+    # Pretend download throws a `FileExistsError` exception as a different process already downloaded it
+    monkeypatch.setattr(nltk, "download", Mock(side_effect=FileExistsError))
+
+    # This shouldn't raise an exception as the `FileExistsError` is ignored
+    PreProcessor(split_length=2, split_respect_sentence_boundary=False)


### PR DESCRIPTION


### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/3514

### Proposed Changes:
- fix: use temp path for downloading punkt resources
- fix: gracefully handle file exists error during download

### How did you test it?
- unit test

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
