### PR TITLE
CI: skip fossa check from forks

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   check-license-compliance-cpu:
+    if: github.repository_owner == 'deepset-ai'
     name: Check CPU dependencies
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +58,7 @@ jobs:
           channel: ${{ env.SLACK_ALERT_CHANNEL }}
 
   check-license-compliance-gpu:
+    if: github.repository_owner == 'deepset-ai'
     name: Check GPU dependencies
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Related Issues
- unblocks  https://github.com/deepset-ai/haystack/pull/3764#issuecomment-1374098898

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Do not run the FOSSA check from forks, because the check would always fail not being able to access the secret containing the api-key we use to push and check

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
