### PR TITLE
fix: Add a verbose option to PromptNode to let users understand the prompts being used

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -744,6 +744,7 @@ class PromptNode(BaseComponent):
             # prompt template used, yield prompts from inputs args
             for prompt in template_to_fill.fill(*args, **kwargs):
                 # and pass the prepared prompt to the model
+                logger.debug("Prompt being sent to LLM. prompt=%s, kwargs=%s", prompt, kwargs)
                 output = self.prompt_model.invoke(prompt, **kwargs)
                 results.extend(output)
         else:


### PR DESCRIPTION
### Related Issues
- fixes #3817

### Proposed Changes:
Added a log listener to log the prompt requests to the log file.  

### How did you test it?
Manual test

### Notes for the reviewer
This is just a proposal PR. We might not go in this direction, but it could be helpful if we need to log these requests or add more events in the future.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
