### PR TITLE
fix: make the crawler runnable and testable on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ env:
     --ignore=test/pipelines/test_ray.py
     --ignore=test/document_stores/test_knowledge_graph.py
     --ignore=test/nodes/test_audio.py
-    --ignore=test/nodes/test_connector.py
     --ignore=test/nodes/test_summarizer_translation.py
     --ignore=test/nodes/test_summarizer.py
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -300,7 +300,7 @@ class Crawler(BaseComponent):
             if crawler_naming_function is not None:
                 file_name_prefix = crawler_naming_function(link, text)
             else:
-                file_name_link = re.sub(r"[<>:'/\\|?*\0 ]", "_", link[:129])
+                file_name_link = re.sub("[<>:'/\\|?*\0 ]", "_", link[:129])
                 file_name_hash = hashlib.md5(f"{link}".encode("utf-8")).hexdigest()
                 file_name_prefix = f"{file_name_link}_{file_name_hash[-6:]}"
 

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -209,7 +209,7 @@ class Crawler(BaseComponent):
         if crawler_naming_function is None:
             crawler_naming_function = self.crawler_naming_function
 
-        output_dir = Path(output_dir).absolute()
+        output_dir = Path(output_dir)
         if not output_dir.exists():
             output_dir.mkdir(parents=True)
 
@@ -300,7 +300,7 @@ class Crawler(BaseComponent):
             if crawler_naming_function is not None:
                 file_name_prefix = crawler_naming_function(link, text)
             else:
-                file_name_link = re.sub("[<>:'/\\|?*\0 ]", "_", link[:129])
+                file_name_link = re.sub(r"[<>:'/\\|?*\0 ]", "_", link[:129])
                 file_name_hash = hashlib.md5(f"{link}".encode("utf-8")).hexdigest()
                 file_name_prefix = f"{file_name_link}_{file_name_hash[-6:]}"
 

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -101,7 +101,9 @@ class Crawler(BaseComponent):
 
         IN_COLAB = "google.colab" in sys.modules
         IN_AZUREML = True if os.environ.get("AZUREML_ENVIRONMENT_IMAGE", None) == "True" else False
-        IS_ROOT = True if os.geteuid() == 0 else False
+        IS_ROOT = False
+        if sys.platform not in ["win32", "cygwin"] and os.geteuid() == 0:
+            IS_ROOT = True
 
         if webdriver_options is None:
             webdriver_options = ["--headless", "--disable-gpu", "--disable-dev-shm-usage", "--single-process"]

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -100,7 +100,7 @@ class Crawler(BaseComponent):
         super().__init__()
 
         IN_COLAB = "google.colab" in sys.modules
-        IN_AZUREML = True if os.environ.get("AZUREML_ENVIRONMENT_IMAGE", None) == "True" else False
+        IN_AZUREML = os.environ.get("AZUREML_ENVIRONMENT_IMAGE", None) == "True"
         IS_ROOT = sys.platform not in ["win32", "cygwin"] and os.geteuid() == 0
 
         if webdriver_options is None:

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -209,7 +209,7 @@ class Crawler(BaseComponent):
         if crawler_naming_function is None:
             crawler_naming_function = self.crawler_naming_function
 
-        output_dir = Path(output_dir)
+        output_dir = Path(output_dir).absolute()
         if not output_dir.exists():
             output_dir.mkdir(parents=True)
 

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -101,9 +101,7 @@ class Crawler(BaseComponent):
 
         IN_COLAB = "google.colab" in sys.modules
         IN_AZUREML = True if os.environ.get("AZUREML_ENVIRONMENT_IMAGE", None) == "True" else False
-        IS_ROOT = False
-        if sys.platform not in ["win32", "cygwin"] and os.geteuid() == 0:
-            IS_ROOT = True
+        IS_ROOT = sys.platform not in ["win32", "cygwin"] and os.geteuid() == 0
 
         if webdriver_options is None:
             webdriver_options = ["--headless", "--disable-gpu", "--disable-dev-shm-usage", "--single-process"]

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -18,7 +18,7 @@ from ..conftest import SAMPLES_PATH
 
 @pytest.fixture(scope="session")
 def test_url():
-    return f"file://{SAMPLES_PATH.absolute()}/crawler"
+    return (SAMPLES_PATH / "crawler").absolute().as_uri()
 
 
 def content_match(crawler: Crawler, url: str, crawled_page: Path):


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/3832

### Proposed Changes:
https://github.com/deepset-ai/haystack/blob/5b0b338175c5eea8a237861da9812e3993b79f50/haystack/nodes/connector/crawler.py#L104

In the `__init__` method of the crawler, `os.geteuid()` is called.
It only works on Linux.
**On Windows, it raises an `AttributeError`.**

My hunch is that on Windows `IS_ROOT` can be set to `False` without affecting the proper functioning of the crawler.

### How did you test it?
- Manual verification on Windows 11
- The crawler is not tested on Windows in the CI. Let's try it and see what happens... ❌ 
**Since the tests don't properly work on Windows, I'm also changing them a bit**


### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
