### PR TITLE
feat: update the docker image for haystack-api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
 
   haystack-api:
-    # Pull Haystack's latest commit
-    image: "deepset/haystack:cpu-main"
+    image: "deepset/haystack:cpu"
     volumes:
       - ./rest_api/rest_api/pipeline:/opt/pipelines
     ports:


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
* Change the image to `deepset/haystack:cpu`, this is a more stable image

### How did you test it?
- n/a

### Notes for the reviewer
- n/a

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I've used the [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
