### PR TITLE
fix: ignore non-serializable params when hashing pipeline objects

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -2288,7 +2288,8 @@ class Pipeline:
         return datetime.datetime.now(datetime.timezone.utc) - self.init_time
 
     def send_pipeline_event(self, is_indexing: bool = False):
-        fingerprint = sha1(json.dumps(self.get_config(), sort_keys=True).encode()).hexdigest()
+        json_repr = json.dumps(self.get_config(), sort_keys=True, default=lambda o: "<not serializable>")
+        fingerprint = sha1(json_repr.encode()).hexdigest()
         send_custom_event(
             "pipeline",
             payload={

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -1,19 +1,17 @@
-from copy import deepcopy
-from pathlib import Path
-import os
 import ssl
 import json
 import platform
 import sys
+import datetime
 from typing import Tuple
+from copy import deepcopy
+from unittest import mock
 
 import pytest
 from requests import PreparedRequest
 import responses
 import logging
-from transformers import pipeline
 import yaml
-import pandas as pd
 
 from haystack import __version__
 from haystack.document_stores.deepsetcloud import DeepsetCloudDocumentStore
@@ -36,16 +34,13 @@ from haystack.pipelines import (
     DocumentSearchPipeline,
     QuestionGenerationPipeline,
     MostSimilarDocumentsPipeline,
-    BaseStandardPipeline,
 )
 from haystack.pipelines.config import validate_config_strings, get_component_definitions
 from haystack.pipelines.utils import generate_code
 from haystack.errors import PipelineConfigError
-from haystack.nodes import PreProcessor, TextConverter, QuestionGenerator
+from haystack.nodes import PreProcessor, TextConverter
 from haystack.utils.deepsetcloud import DeepsetCloudError
-from haystack import Document, Answer
-from haystack.nodes.other.route_documents import RouteDocuments
-from haystack.nodes.other.join_answers import JoinAnswers
+from haystack import Answer
 
 from ..conftest import (
     MOCK_DC,
@@ -2158,3 +2153,35 @@ def test_fix_to_pipeline_execution_when_join_follows_join():
     res = pipeline.run(query="Alpha Beta Gamma Delta")
     documents = res["documents"]
     assert len(documents) == 4  # all four documents should be found
+
+
+def test_send_pipeline_event():
+    class CustomNode(MockNode):
+        def __init__(self, param):
+            self.param = param
+
+    pipeline = Pipeline()
+    pipeline.add_node(CustomNode(param="foo"), name="custom_node", inputs=["Query"])
+
+    with mock.patch("haystack.pipelines.base.send_custom_event") as mocked_send:
+        today_at_midnight = datetime.datetime.combine(datetime.datetime.now(), datetime.time.min, datetime.timezone.utc)
+        pipeline.send_pipeline_event()
+        mocked_send.assert_called_once()
+        assert pipeline.time_of_last_sent_event == today_at_midnight
+        assert pipeline.last_window_run_total == 0
+
+
+def test_send_pipeline_event_unserializable_param():
+    class CustomNode(MockNode):
+        def __init__(self, param):
+            self.param = param
+
+    pipeline = Pipeline()
+    pipeline.add_node(CustomNode(param=set()), name="custom_node", inputs=["Query"])
+
+    with mock.patch("haystack.pipelines.base.send_custom_event") as mocked_send:
+        today_at_midnight = datetime.datetime.combine(datetime.datetime.now(), datetime.time.min, datetime.timezone.utc)
+        pipeline.send_pipeline_event()
+        mocked_send.assert_called_once()
+        assert pipeline.time_of_last_sent_event == today_at_midnight
+        assert pipeline.last_window_run_total == 0

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -2156,12 +2156,11 @@ def test_fix_to_pipeline_execution_when_join_follows_join():
 
 
 def test_send_pipeline_event():
-    class CustomNode(MockNode):
-        def __init__(self, param):
-            self.param = param
-
+    """
+    Test the event can be sent and the internal fields are correctly set
+    """
     pipeline = Pipeline()
-    pipeline.add_node(CustomNode(param="foo"), name="custom_node", inputs=["Query"])
+    pipeline.add_node(MockNode(), name="mock_node", inputs=["Query"])
 
     with mock.patch("haystack.pipelines.base.send_custom_event") as mocked_send:
         today_at_midnight = datetime.datetime.combine(datetime.datetime.now(), datetime.time.min, datetime.timezone.utc)
@@ -2172,12 +2171,22 @@ def test_send_pipeline_event():
 
 
 def test_send_pipeline_event_unserializable_param():
+    """
+    Test the event can be sent even when a certain component was initialized with a
+    non-serializable parameter, see https://github.com/deepset-ai/haystack/issues/3833
+    """
+
     class CustomNode(MockNode):
+        """A mock node that can be inited passing a param"""
+
         def __init__(self, param):
             self.param = param
 
+    # create a custom node passing a parameter that can't be serialized (an empty set)
+    custom_node = CustomNode(param=set())
+
     pipeline = Pipeline()
-    pipeline.add_node(CustomNode(param=set()), name="custom_node", inputs=["Query"])
+    pipeline.add_node(custom_node, name="custom_node", inputs=["Query"])
 
     with mock.patch("haystack.pipelines.base.send_custom_event") as mocked_send:
         today_at_midnight = datetime.datetime.combine(datetime.datetime.now(), datetime.time.min, datetime.timezone.utc)


### PR DESCRIPTION
### Related Issues
- fixes #3833

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
If a pipeline component was initialised passing a non-serializable param, just ignore it when computing the hash of the pipeline object.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
I cleaned up the unused imports from the test module

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
