### PR TITLE
chore: make Mypy work when Haystack is installed

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -33,13 +33,21 @@ runs:
     with:
       python-version: ${{ inputs.pythonVersion }}
 
-  - name: Cache
+  - name: Cache Python path
     id: cache-python-env
     uses: actions/cache@v3
     with:
       path: ${{ env.pythonLocation }}
       # The cache will be rebuild every day and at every change of the dependency files
       key: ${{ inputs.prefix }}-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/pyproject.toml') }}
+
+  - name: Cache Mypy path
+    id: cache-mypy
+    uses: actions/cache@v3
+    with:
+      path: ${{ env.pythonLocation }}/.mypy_cache
+      # The cache will be rebuild every day and at every change of the dependency files
+      key: mypy-${{ inputs.prefix }}-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/pyproject.toml') }}
 
   - name: Install dependencies
     # NOTE: this action runs only on cache miss to refresh the dependencies and make sure the next Haystack install will be faster.
@@ -52,3 +60,8 @@ runs:
       python -m pip install --upgrade pip
       pip install .[all]
       pip install rest_api/
+
+  - name: Install mypy dependencies
+    shell: bash
+    if: ${{ inputs.pythonVersion }} != "3.7"
+    run: python -m mypy --install-types --non-interactive --cache-dir=${{ env.pythonLocation }}/.mypy_cache/ haystack/ rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -63,5 +63,5 @@ runs:
 
   - name: Install mypy dependencies
     shell: bash
-    if: inputs.pythonVersion != "3.7"
+    if: inputs.pythonVersion != 3.7
     run: python -m mypy --install-types --non-interactive --cache-dir=${{ env.pythonLocation }}/.mypy_cache/ haystack/ rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -63,5 +63,5 @@ runs:
 
   - name: Install mypy dependencies
     shell: bash
-    if: ${{ inputs.pythonVersion }} != "3.7"
+    if: inputs.pythonVersion != "3.7"
     run: python -m mypy --install-types --non-interactive --cache-dir=${{ env.pythonLocation }}/.mypy_cache/ haystack/ rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,9 +90,9 @@ jobs:
       run: |
         mkdir .mypy_cache/
         echo "=== haystack/ ==="
-        mypy --install-types --non-interactive --cache-dir=.mypy_cache/ haystack/
+        mypy haystack/
         echo "=== rest_api/ ==="
-        mypy --install-types --non-interactive --cache-dir=.mypy_cache/ rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/
+        mypy rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,18 +85,13 @@ jobs:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
     - name: Get changed files
-      id: complete-diff
-      run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-            echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
-        else
-            echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
-        fi
+      id: files
+      uses: tj-actions/changed-files@v34
 
     - name: Filter changed files
-      id: python-diff
+      id: python-files
       run: |
-        for file in ${{ steps.complete-diff.outputs.changed_files }}; do
+        for file in ${{ steps.files.outputs.all_changed_files }}; do
           if [[ $file == *.py ]]; then
             changed_files="$changed_files $file"
           fi
@@ -111,7 +106,7 @@ jobs:
     - name: Mypy
       run: |
         mkdir .mypy_cache/
-        mypy ${{ steps.python-diff.outputs.changed_files }}
+        mypy ${{ steps.python-files.outputs.changed_files }}
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
       run: |
         for file in ${{ steps.complete-diff.outputs.changed_files }}; do
           if [[ $file == *.py ]]; then
-            changed_files=$changed_files $file
+            changed_files="$changed_files $file"
           fi
         done
         echo "changed_files=$changed_files" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # https://stackoverflow.com/questions/74265821/get-modified-files-in-github-actions
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+    - name: Get changed files
+      id: changed-files
+      run: |
+        if ${{ github.event_name == 'pull_request' }}; then
+            echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+        else
+            echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+        fi
+    - name: List changed files
+      run: |
+        for file in ${{ steps.changed-files.outputs.changed_files }}; do
+            echo "$file was changed"
+        done
 
     - name: Setup Python
       uses: ./.github/actions/python_cache/
@@ -89,7 +106,7 @@ jobs:
     - name: Mypy
       run: |
         mkdir .mypy_cache/
-        mypy $(git --no-pager diff --name-only ${{github.event.pull_request.base.sha}} ${{ github.event.pull_request.head.sha }})
+        mypy ${{ steps.changed-files.outputs.changed_files }}
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Mypy
       run: |
         mkdir .mypy_cache/
-        mypy $(git --no-pager diff --name-only main...)
+        mypy $(git --no-pager diff --name-only ${{github.event.pull_request.base.sha}} ${{ github.event.pull_request.head.sha }})
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Install Mypy types if needed
       run: |
         mkdir .mypy_cache/
-        python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ .
+        python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ haystack/
 
     - name: Mypy
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
       run: |
         mkdir .mypy_cache/
         python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ haystack/
+        python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ rest_api/
 
     - name: Mypy
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,8 @@ jobs:
 
     - name: Setup Python
       uses: ./.github/actions/python_cache/
+      with:
+        pythonVersion: 3.8   # Literals and mypy just don't work well together.
 
     - name: Install Mypy types if needed
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,18 +85,23 @@ jobs:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
     - name: Get changed files
-      id: changed-files
+      id: complete-diff
       run: |
         if ${{ github.event_name == 'pull_request' }}; then
             echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
         else
             echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
         fi
-    - name: List changed files
+
+    - name: Filter changed files
+      id: python-diff
       run: |
         for file in ${{ steps.changed-files.outputs.changed_files }}; do
-            echo "$file was changed"
+          if [[ $file == *.py ]]; then
+            changed_files=$changed_files $file
+          fi
         done
+        echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
 
     - name: Setup Python
       uses: ./.github/actions/python_cache/
@@ -106,7 +111,7 @@ jobs:
     - name: Mypy
       run: |
         mkdir .mypy_cache/
-        mypy ${{ steps.changed-files.outputs.changed_files }}
+        mypy ${{ steps.python-diff.outputs.changed_files }}
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,9 @@ jobs:
       uses: ./.github/actions/python_cache/
 
     - name: Install Mypy types if needed
-      run: python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ .
+      run: |
+        mkdir .mypy_cache/
+        python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ .
 
     - name: Mypy
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,10 +89,7 @@ jobs:
     - name: Mypy
       run: |
         mkdir .mypy_cache/
-        echo "=== haystack/ ==="
-        mypy haystack/
-        echo "=== rest_api/ ==="
-        mypy rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/
+        mypy $(git --no-pager diff --name-only main...)
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,18 +86,13 @@ jobs:
       with:
         pythonVersion: 3.8   # Literals and mypy just don't work well together.
 
-    - name: Install Mypy types if needed
-      run: |
-        mkdir .mypy_cache/
-        python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ haystack/
-        python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ rest_api/
-
     - name: Mypy
       run: |
+        mkdir .mypy_cache/
         echo "=== haystack/ ==="
-        mypy haystack
+        mypy --install-types --non-interactive --cache-dir=.mypy_cache/ haystack/
         echo "=== rest_api/ ==="
-        mypy rest_api --exclude=rest_api/build/ --exclude=rest_api/test/
+        mypy --install-types --non-interactive --cache-dir=.mypy_cache/ rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Filter changed files
       id: python-diff
       run: |
-        for file in ${{ steps.changed-files.outputs.changed_files }}; do
+        for file in ${{ steps.complete-diff.outputs.changed_files }}; do
           if [[ $file == *.py ]]; then
             changed_files=$changed_files $file
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
       uses: ./.github/actions/python_cache/
 
     - name: Install Mypy types if needed
-      run: mypy --install-types --non-interactive .
+      run: python -m mypy --install-types --non-interactive --cache-dir=.mypy_cache/ .
 
     - name: Mypy
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,26 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        # Mypy can't run properly on 3.7 as it misses support for Literal types.
-        # FIXME once we drop support for 3.7, use the cache.
-        python-version: 3.8
+      uses: ./.github/actions/python_cache/
 
-    - name: Install dependencies
-      run: |
-        # FIXME installing the packages before running mypy raises
-        # a lot of errors which were never detected before!
-        # pip install .
-        # pip install rest_api/
-        # FIXME --install-types does not work properly yet, see https://github.com/python/mypy/issues/10600
-        # Hotfixing by installing type packages explicitly.
-        # Run mypy --install-types haystack locally to ensure the list is still up to date
-        # mypy --install-types --non-interactive .
-        pip install mypy pydantic types-Markdown types-PyYAML types-requests types-setuptools types-six types-tabulate types-chardet types-emoji types-protobuf
+    - name: Install Mypy types if needed
+      run: mypy --install-types --non-interactive .
 
     - name: Mypy
       run: |
@@ -115,7 +103,6 @@ jobs:
   pylint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/haystack/document_stores/graphdb.py
+++ b/haystack/document_stores/graphdb.py
@@ -174,7 +174,7 @@ class GraphDBKnowledgeGraph(BaseKnowledgeGraph):
         # Pylint raises unsupported-membership-test and unsubscriptable-object.
         # Silenced for now, keep in mind for future debugging.
         return (
-            results["results"]["bindings"]  # pylint: disable=unsubscriptable-object
-            if "results" in results  # pylint: disable=unsupported-membership-test
-            else results["boolean"]  # pylint: disable=unsubscriptable-object
+            results["results"]["bindings"]  # type: ignore  # pylint: disable=unsubscriptable-object
+            if "results" in results  # type: ignore  # pylint: disable=unsupported-membership-test
+            else results["boolean"]  # type: ignore  # pylint: disable=unsubscriptable-object
         )

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -284,32 +284,32 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         :param query_emb: Embedding of the query (e.g. gathered from DPR)
         :param document_to_search: List of documents to compare `query_emb` against.
         """
-        query_emb = torch.tensor(query_emb, dtype=torch.float).to(self.main_device)
+        query_emb = torch.tensor(query_emb, dtype=torch.float).to(self.main_device)  # type: ignore [assignment]
         if len(query_emb.shape) == 1:
-            query_emb = query_emb.unsqueeze(dim=0)
+            query_emb = query_emb.unsqueeze(dim=0)  # type: ignore [attr-defined]
 
         doc_embeds = np.array([doc.embedding for doc in document_to_search])
-        doc_embeds = torch.as_tensor(doc_embeds, dtype=torch.float)
+        doc_embeds = torch.as_tensor(doc_embeds, dtype=torch.float)  # type: ignore [assignment]
         if len(doc_embeds.shape) == 1 and doc_embeds.shape[0] == 1:
-            doc_embeds = doc_embeds.unsqueeze(dim=0)
+            doc_embeds = doc_embeds.unsqueeze(dim=0)  # type: ignore [attr-defined]
         elif len(doc_embeds.shape) == 1 and doc_embeds.shape[0] == 0:
             return []
 
         if self.similarity == "cosine":
             # cosine similarity is just a normed dot product
             query_emb_norm = torch.norm(query_emb, dim=1)
-            query_emb = torch.div(query_emb, query_emb_norm)
+            query_emb = torch.div(query_emb, query_emb_norm)  # type: ignore [assignment,arg-type]
 
             doc_embeds_norms = torch.norm(doc_embeds, dim=1)
-            doc_embeds = torch.div(doc_embeds.T, doc_embeds_norms).T
+            doc_embeds = torch.div(doc_embeds.T, doc_embeds_norms).T  # type: ignore [assignment,arg-type]
 
         curr_pos = 0
-        scores = []
+        scores = []  # type: ignore [var-annotated]
         while curr_pos < len(doc_embeds):
             doc_embeds_slice = doc_embeds[curr_pos : curr_pos + self.scoring_batch_size]
-            doc_embeds_slice = doc_embeds_slice.to(self.main_device)
+            doc_embeds_slice = doc_embeds_slice.to(self.main_device)  # type: ignore [attr-defined]
             with torch.inference_mode():
-                slice_scores = torch.matmul(doc_embeds_slice, query_emb.T).cpu()
+                slice_scores = torch.matmul(doc_embeds_slice, query_emb.T).cpu()  # type: ignore [arg-type,arg-type]
                 slice_scores = slice_scores.squeeze(dim=1)
                 slice_scores = slice_scores.numpy().tolist()
 
@@ -330,7 +330,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
 
         doc_embeds = np.array([doc.embedding for doc in document_to_search])
         if len(doc_embeds.shape) == 1 and doc_embeds.shape[0] == 1:
-            doc_embeds = doc_embeds.unsqueeze(dim=0)
+            doc_embeds = doc_embeds.unsqueeze(dim=0)  # type: ignore [attr-defined]
         elif len(doc_embeds.shape) == 1 and doc_embeds.shape[0] == 0:
             return []
 

--- a/haystack/document_stores/memory_knowledgegraph.py
+++ b/haystack/document_stores/memory_knowledgegraph.py
@@ -24,7 +24,7 @@ class InMemoryKnowledgeGraph(BaseKnowledgeGraph):
         """
         super().__init__()
 
-        self.indexes: Dict[str, Graph] = defaultdict(dict)
+        self.indexes: Dict[str, Graph] = defaultdict(dict)  # type: ignore [arg-type]
         self.index: str = index
 
     def create_index(self, index: Optional[str] = None):

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -236,7 +236,7 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
         hosts = prepare_hosts(host, port)
         connection_class = Urllib3HttpConnection
         if use_system_proxy:
-            connection_class = RequestsHttpConnection
+            connection_class = RequestsHttpConnection  # type: ignore [assignment]
 
         if username:
             # standard http_auth

--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -85,12 +85,12 @@ class MetaDocumentORM(ORMBase):
 
     document_id = Column(String(100), nullable=False, index=True)
     document_index = Column(String(100), nullable=False, index=True)
-    __table_args__ = (
+    __table_args__ = (  # type: ignore
         ForeignKeyConstraint(
             [document_id, document_index], [DocumentORM.id, DocumentORM.index], ondelete="CASCADE", onupdate="CASCADE"
         ),
         {},
-    )  # type: ignore
+    )
 
 
 class LabelORM(ORMBase):
@@ -118,12 +118,12 @@ class MetaLabelORM(ORMBase):
 
     label_id = Column(String(100), nullable=False, index=True)
     label_index = Column(String(100), nullable=False, index=True)
-    __table_args__ = (
+    __table_args__ = (  # type: ignore
         ForeignKeyConstraint(
             [label_id, label_index], [LabelORM.id, LabelORM.index], ondelete="CASCADE", onupdate="CASCADE"
         ),
         {},
-    )  # type: ignore
+    )
 
 
 class SQLDocumentStore(BaseDocumentStore):

--- a/haystack/modeling/data_handler/data_silo.py
+++ b/haystack/modeling/data_handler/data_silo.py
@@ -529,20 +529,20 @@ class DataSiloForCrossVal:
         self.batch_size = origsilo.batch_size
         # should not be necessary, xval makes no sense with huge data
         # sampler_train = DistributedSampler(self.data["train"])
-        sampler_train = RandomSampler(trainset)
+        sampler_train = RandomSampler(trainset)  # type: ignore [arg-type]
 
         self.data_loader_train = NamedDataLoader(
-            dataset=trainset, sampler=sampler_train, batch_size=self.batch_size, tensor_names=self.tensor_names
+            dataset=trainset, sampler=sampler_train, batch_size=self.batch_size, tensor_names=self.tensor_names  # type: ignore [arg-type]
         )
         self.data_loader_dev = NamedDataLoader(
-            dataset=devset,
-            sampler=SequentialSampler(devset),
+            dataset=devset,  # type: ignore [arg-type]
+            sampler=SequentialSampler(devset),  # type: ignore [arg-type]
             batch_size=self.batch_size,
             tensor_names=self.tensor_names,
         )
         self.data_loader_test = NamedDataLoader(
-            dataset=testset,
-            sampler=SequentialSampler(testset),
+            dataset=testset,  # type: ignore [arg-type]
+            sampler=SequentialSampler(testset),  # type: ignore [arg-type]
             batch_size=self.batch_size,
             tensor_names=self.tensor_names,
         )
@@ -669,7 +669,7 @@ class DataSiloForCrossVal:
 
             ds_train = train_samples
             ds_test = [sample for document in test_set for sample in document]
-            silos.append(DataSiloForCrossVal(datasilo, ds_train, ds_dev, ds_test))
+            silos.append(DataSiloForCrossVal(datasilo, ds_train, ds_dev, ds_test))  # type: ignore [arg-type]
         return silos
 
     @staticmethod
@@ -690,7 +690,7 @@ class DataSiloForCrossVal:
             questions_per_doc.append(len(questions))
 
         # split documents into n_splits splits with approximately same number of questions per split
-        questions_per_doc = np.array(questions_per_doc)
+        questions_per_doc = np.array(questions_per_doc)  # type: ignore [assignment]
         accumulated_questions_per_doc = questions_per_doc.cumsum()  # type: ignore
         questions_per_fold = accumulated_questions_per_doc[-1] // n_splits
         accumulated_questions_per_fold = np.array(range(1, n_splits)) * questions_per_fold
@@ -706,7 +706,7 @@ class DataSiloForCrossVal:
 
         for idx, split in enumerate(splits):
             current_test_set = split
-            current_train_set = np.hstack(np.delete(splits, idx, axis=0))
+            current_train_set = np.hstack(np.delete(splits, idx, axis=0))  # type: ignore [call-overload]
 
             yield current_train_set, current_test_set
 

--- a/haystack/modeling/evaluation/eval.py
+++ b/haystack/modeling/evaluation/eval.py
@@ -87,7 +87,7 @@ class Evaluator:
                         output_attentions=batch.get("output_attentions", False),
                     )
                 elif isinstance(module, BiAdaptiveModel):
-                    logits = model.forward(  # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]
+                    logits = model.forward(  # type: ignore [call-arg]   # type: ignore [call-arg]
                         query_input_ids=batch.get("query_input_ids", None),
                         query_segment_ids=batch.get("query_segment_ids", None),
                         query_attention_mask=batch.get("query_attention_mask", None),

--- a/haystack/modeling/evaluation/eval.py
+++ b/haystack/modeling/evaluation/eval.py
@@ -87,7 +87,7 @@ class Evaluator:
                         output_attentions=batch.get("output_attentions", False),
                     )
                 elif isinstance(module, BiAdaptiveModel):
-                    logits = model.forward(
+                    logits = model.forward(  # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]   # type: ignore [call-arg]
                         query_input_ids=batch.get("query_input_ids", None),
                         query_segment_ids=batch.get("query_segment_ids", None),
                         query_attention_mask=batch.get("query_attention_mask", None),
@@ -139,7 +139,7 @@ class Evaluator:
                     passage_start_t=passage_start_t_all[head_num],
                     ids=head_ids,
                 )
-            result = {"loss": loss_all[head_num] / len(self.data_loader.dataset), "task_name": head.task_name}
+            result = {"loss": loss_all[head_num] / len(self.data_loader.dataset), "task_name": head.task_name}  # type: ignore [arg-type]
             result.update(compute_metrics(metric=head.metric, preds=preds_all[head_num], labels=label_all[head_num]))
             # Select type of report depending on prediction head output type
             if self.report:

--- a/haystack/modeling/evaluation/metrics.py
+++ b/haystack/modeling/evaluation/metrics.py
@@ -108,7 +108,7 @@ def compute_metrics(metric: str, preds, labels):
 
 def compute_report_metrics(head: PredictionHead, preds, labels):
     if head.ph_output_type in registered_reports:
-        report_fn = registered_reports[head.ph_output_type]
+        report_fn = registered_reports[head.ph_output_type]  # type: ignore [index]
     elif head.ph_output_type == "per_token":
         report_fn = token_classification_report
     elif head.ph_output_type == "per_sequence":
@@ -130,9 +130,9 @@ def compute_report_metrics(head: PredictionHead, preds, labels):
         if head.model_type == "text_similarity":
             labels = reduce(lambda x, y: x + list(y.astype("long")), labels, [])
             preds = reduce(lambda x, y: x + [0] * y[0] + [1] + [0] * (len(y) - y[0] - 1), preds, [])  # type: ignore
-            all_possible_labels = list(range(len(head.label_list)))
+            all_possible_labels = list(range(len(head.label_list)))  # type: ignore [arg-type]
         else:
-            all_possible_labels = head.label_list
+            all_possible_labels = head.label_list  # type: ignore [assignment]
         return report_fn(labels, preds, digits=4, labels=all_possible_labels, target_names=head.label_list)
     else:
         return report_fn(labels, preds)

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -187,7 +187,7 @@ class Inferencer:
             tokenizer_args = {}
 
         devices, _ = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)  # type: ignore [assignment]
-        if len(devices) > 1:
+        if devices and len(devices) > 1:
             logger.warning("Multiple devices are not supported in Inferencer, using the first device %s.", devices[0])  # type: ignore [index]
 
         name = os.path.basename(model_name_or_path)

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -98,8 +98,8 @@ class Inferencer:
                     "Since FARM 0.4.2, you set both when initializing the Inferencer and then call inferencer.inference_from_dicts() instead of inferencer.extract_vectors()"
                 )
             self.model.prediction_heads = torch.nn.ModuleList([])
-            self.model.language_model.extraction_layer = extraction_layer
-            self.model.language_model.extraction_strategy = extraction_strategy
+            self.model.language_model.extraction_layer = extraction_layer  # type: ignore [assignment]
+            self.model.language_model.extraction_strategy = extraction_strategy  # type: ignore [assignment]
 
         # TODO add support for multiple prediction heads
 
@@ -186,9 +186,9 @@ class Inferencer:
         if tokenizer_args is None:
             tokenizer_args = {}
 
-        devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)
-        if len(devices) > 1:
-            logger.warning("Multiple devices are not supported in Inferencer, using the first device %s.", devices[0])
+        devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)  # type: ignore [assignment]
+        if len(devices) > 1:  # type: ignore [arg-type]
+            logger.warning("Multiple devices are not supported in Inferencer, using the first device %s.", devices[0])  # type: ignore [index]
 
         name = os.path.basename(model_name_or_path)
 
@@ -196,7 +196,7 @@ class Inferencer:
         farm_model_bin = os.path.join(model_name_or_path, "language_model.bin")
         onnx_model = os.path.join(model_name_or_path, "model.onnx")
         if os.path.isfile(farm_model_bin) or os.path.isfile(onnx_model):
-            model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=devices[0], strict=strict)
+            model = BaseAdaptiveModel.load(load_dir=model_name_or_path, device=devices[0], strict=strict)  # type: ignore [index]
             if task_type == "embeddings":
                 processor = InferenceProcessor.load_from_dir(model_name_or_path)
             else:
@@ -361,7 +361,7 @@ class Inferencer:
         samples = [s for b in baskets for s in b.samples]
 
         data_loader = NamedDataLoader(
-            dataset=dataset, sampler=SequentialSampler(dataset), batch_size=self.batch_size, tensor_names=tensor_names
+            dataset=dataset, sampler=SequentialSampler(dataset), batch_size=self.batch_size, tensor_names=tensor_names  # type: ignore [arg-type]
         )  # type ignore
         preds_all = []
         for i, batch in enumerate(
@@ -395,7 +395,7 @@ class Inferencer:
         :return: list of predictions
         """
         data_loader = NamedDataLoader(
-            dataset=dataset, sampler=SequentialSampler(dataset), batch_size=self.batch_size, tensor_names=tensor_names
+            dataset=dataset, sampler=SequentialSampler(dataset), batch_size=self.batch_size, tensor_names=tensor_names  # type: ignore [arg-type]
         )  # type ignore
         # TODO Sometimes this is the preds of one head, sometimes of two. We need a more advanced stacking operation
         # TODO so that preds of the right shape are passed in to formatted_preds
@@ -456,8 +456,8 @@ class Inferencer:
         """
         logger.warning("Deprecated! Please use Inferencer.inference_from_dicts() instead.")
         self.model.prediction_heads = torch.nn.ModuleList([])
-        self.model.language_model.extraction_layer = extraction_layer
-        self.model.language_model.extraction_strategy = extraction_strategy
+        self.model.language_model.extraction_layer = extraction_layer  # type: ignore [assignment]
+        self.model.language_model.extraction_strategy = extraction_strategy  # type: ignore [assignment]
 
         return self.inference_from_dicts(dicts)
 

--- a/haystack/modeling/model/adaptive_model.py
+++ b/haystack/modeling/model/adaptive_model.py
@@ -101,7 +101,7 @@ class BaseAdaptiveModel:
                 kwargs["preds"] = None
             head = self.prediction_heads[0]
             logits_for_head = logits[0]
-            preds = head.formatted_preds(logits=logits_for_head, **kwargs)
+            preds = head.formatted_preds(logits=logits_for_head, **kwargs)  # type: ignore [operator]
             # TODO This is very messy - we need better definition of what the output should look like
             if type(preds) == list:
                 preds_final += preds
@@ -361,7 +361,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
                 prediction_heads=[ph],
                 embeds_dropout_prob=0.1,
                 lm_output_types="per_token",
-                device=device,
+                device=device,  # type: ignore [arg-type]
             )
         elif task_type == "embeddings":
             adaptive_model = cls(
@@ -369,7 +369,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
                 prediction_heads=[],
                 embeds_dropout_prob=0.1,
                 lm_output_types=["per_token", "per_sequence"],
-                device=device,
+                device=device,  # type: ignore [arg-type]
             )
 
         if processor:
@@ -586,7 +586,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
         Verifies that the model fits to the tokenizer vocabulary.
         They could diverge in case of custom vocabulary added via tokenizer.add_tokens()
         """
-        model_vocab_len = self.language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+        model_vocab_len = self.language_model.model.resize_token_embeddings(new_num_tokens=None).num_embeddings  # type: ignore [union-attr,operator]
 
         msg = (
             f"Vocab size of tokenizer {vocab_size} doesn't match with model {model_vocab_len}. "
@@ -597,7 +597,7 @@ class AdaptiveModel(nn.Module, BaseAdaptiveModel):
 
         for head in self.prediction_heads:
             if head.model_type == "language_modelling":
-                ph_decoder_len = head.decoder.weight.shape[0]
+                ph_decoder_len = head.decoder.weight.shape[0]  # type: ignore [union-attr,index]
                 assert vocab_size == ph_decoder_len, msg
 
     def get_language(self):

--- a/haystack/modeling/model/biadaptive_model.py
+++ b/haystack/modeling/model/biadaptive_model.py
@@ -384,7 +384,7 @@ class BiAdaptiveModel(nn.Module):
         They could diverge in case of custom vocabulary added via tokenizer.add_tokens()
         """
 
-        model1_vocab_len = self.language_model1.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+        model1_vocab_len = self.language_model1.model.resize_token_embeddings(new_num_tokens=None).num_embeddings  # type: ignore [union-attr,operator]
 
         msg = (
             f"Vocab size of tokenizer {vocab_size1} doesn't match with model {model1_vocab_len}. "
@@ -393,7 +393,7 @@ class BiAdaptiveModel(nn.Module):
         )
         assert vocab_size1 == model1_vocab_len, msg
 
-        model2_vocab_len = self.language_model2.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+        model2_vocab_len = self.language_model2.model.resize_token_embeddings(new_num_tokens=None).num_embeddings  # type: ignore [union-attr,operator]
 
         msg = (
             f"Vocab size of tokenizer {vocab_size1} doesn't match with model {model2_vocab_len}. "

--- a/haystack/modeling/model/feature_extraction.py
+++ b/haystack/modeling/model/feature_extraction.py
@@ -331,7 +331,7 @@ def tokenize_with_metadata(text: str, tokenizer: PreTrainedTokenizer) -> Dict[st
     words = text.split(" ")
     cumulated = 0
     for word in words:
-        word_offsets.append(cumulated)
+        word_offsets.append(cumulated)  # type: ignore [union-attr]
         cumulated += len(word) + 1  # 1 because we so far have whitespace tokenizer
 
     # split "words" into "subword tokens"

--- a/haystack/modeling/model/language_model.py
+++ b/haystack/modeling/model/language_model.py
@@ -124,10 +124,10 @@ class LanguageModel(nn.Module, ABC):
         Save the configuration of the language model in Haystack format.
         """
         save_filename = Path(save_dir) / "language_model_config.json"
-        setattr(self.model.config, "name", self.name)
-        setattr(self.model.config, "language", self.language)
+        setattr(self.model.config, "name", self.name)  # type: ignore [union-attr]
+        setattr(self.model.config, "language", self.language)  # type: ignore [union-attr]
 
-        string = self.model.config.to_json_string()
+        string = self.model.config.to_json_string()  # type: ignore [union-attr,operator]
         with open(save_filename, "w") as file:
             file.write(string)
 
@@ -143,7 +143,7 @@ class LanguageModel(nn.Module, ABC):
         model_to_save = self.model.module if hasattr(self.model, "module") else self.model  # Only save the model itself
 
         if not state_dict:
-            state_dict = model_to_save.state_dict()
+            state_dict = model_to_save.state_dict()  # type: ignore [union-attr]
         torch.save(state_dict, save_name)
         self.save_config(save_dir)
 
@@ -191,11 +191,11 @@ class LanguageModel(nn.Module, ABC):
 
         elif self.extraction_strategy == "reduce_mean":
             vecs = self._pool_tokens(
-                sequence_output, padding_mask, self.extraction_strategy, ignore_first_token=ignore_first_token
+                sequence_output, padding_mask, self.extraction_strategy, ignore_first_token=ignore_first_token  # type: ignore [arg-type]   # type: ignore [arg-type]
             )
         elif self.extraction_strategy == "reduce_max":
             vecs = self._pool_tokens(
-                sequence_output, padding_mask, self.extraction_strategy, ignore_first_token=ignore_first_token
+                sequence_output, padding_mask, self.extraction_strategy, ignore_first_token=ignore_first_token  # type: ignore [arg-type]   # type: ignore [arg-type]
             )
         elif self.extraction_strategy == "cls_token":
             vecs = sequence_output[:, 0, :].cpu().numpy()
@@ -300,7 +300,7 @@ class HFLanguageModel(LanguageModel):
             model_emb_size = self.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
             assert vocab_size == model_emb_size
 
-    def forward(
+    def forward(  # type: ignore [override]
         self,
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
@@ -337,9 +337,9 @@ class HFLanguageModel(LanguageModel):
         if attention_mask is not None:
             params["attention_mask"] = attention_mask
         if output_hidden_states:
-            params["output_hidden_states"] = output_hidden_states
+            params["output_hidden_states"] = output_hidden_states  # type: ignore [assignment]
         if output_attentions:
-            params["output_attentions"] = output_attentions
+            params["output_attentions"] = output_attentions  # type: ignore [assignment]
 
         return self.model(**params, return_dict=return_dict)
 
@@ -424,7 +424,7 @@ class HFLanguageModelWithPooler(HFLanguageModel):
         """
         output_tuple = super().forward(
             input_ids=input_ids,
-            segment_ids=segment_ids,
+            segment_ids=segment_ids,  # type: ignore [arg-type]
             attention_mask=attention_mask,
             output_hidden_states=output_hidden_states,
             output_attentions=output_attentions,

--- a/haystack/modeling/model/multimodal/__init__.py
+++ b/haystack/modeling/model/multimodal/__init__.py
@@ -160,7 +160,7 @@ def _is_sentence_transformers_model(pretrained_model_name_or_path: Union[Path, s
 
     # Check if sentence transformers config file is in model hub
     try:
-        hf_hub_download(
+        hf_hub_download(  # type: ignore [call-arg]
             repo_id=str(pretrained_model_name_or_path),
             filename="config_sentence_transformers.json",
             use_auth_token=use_auth_token,

--- a/haystack/modeling/model/optimization.py
+++ b/haystack/modeling/model/optimization.py
@@ -299,10 +299,10 @@ def optimize_model(
     if distributed:
         # for some models DistributedDataParallel might complain about parameters
         # not contributing to loss. find_used_parameters remedies that.
-        model = WrappedDDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=True)
+        model = WrappedDDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=True)  # type: ignore [assignment]
 
     elif torch.cuda.device_count() > 1 and device.type == "cuda":
-        model = WrappedDataParallel(model) if not isinstance(model, DataParallel) else WrappedDataParallel(model.module)
+        model = WrappedDataParallel(model) if not isinstance(model, DataParallel) else WrappedDataParallel(model.module)  # type: ignore [assignment]
         logger.info("Multi-GPU Training via DataParallel")
 
     return model, optimizer

--- a/haystack/modeling/model/triadaptive_model.py
+++ b/haystack/modeling/model/triadaptive_model.py
@@ -178,7 +178,7 @@ class TriAdaptiveModel(nn.Module):
             language_model3 = get_language_model(load_dir)
 
         # Prediction heads
-        ph_config_files = cls._get_prediction_head_files(load_dir)
+        ph_config_files = cls._get_prediction_head_files(load_dir)  # type: ignore [attr-defined]
         prediction_heads = []
         ph_output_type = []
         for config_file in ph_config_files:
@@ -415,7 +415,7 @@ class TriAdaptiveModel(nn.Module):
         """Verifies that the model fits to the tokenizer vocabulary.
         They could diverge in case of custom vocabulary added via tokenizer.add_tokens()"""
 
-        model1_vocab_len = self.language_model1.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+        model1_vocab_len = self.language_model1.model.resize_token_embeddings(new_num_tokens=None).num_embeddings  # type: ignore [union-attr,operator]
 
         msg = (
             f"Vocab size of tokenizer {vocab_size1} doesn't match with model {model1_vocab_len}. "
@@ -424,7 +424,7 @@ class TriAdaptiveModel(nn.Module):
         )
         assert vocab_size1 == model1_vocab_len, msg
 
-        model2_vocab_len = self.language_model2.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+        model2_vocab_len = self.language_model2.model.resize_token_embeddings(new_num_tokens=None).num_embeddings  # type: ignore [union-attr,operator]
 
         msg = (
             f"Vocab size of tokenizer {vocab_size1} doesn't match with model {model2_vocab_len}. "
@@ -433,7 +433,7 @@ class TriAdaptiveModel(nn.Module):
         )
         assert vocab_size2 == model2_vocab_len, msg
 
-        model3_vocab_len = self.language_model3.model.resize_token_embeddings(new_num_tokens=None).num_embeddings
+        model3_vocab_len = self.language_model3.model.resize_token_embeddings(new_num_tokens=None).num_embeddings  # type: ignore [union-attr,operator]
 
         msg = (
             f"Vocab size of tokenizer {vocab_size3} doesn't match with model {model3_vocab_len}. "

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -704,7 +704,7 @@ class DistillationTrainer(Trainer):
         if distillation_loss == "mse":
             self.distillation_loss_fn = MSELoss()
         elif distillation_loss == "kl_div":
-            self.distillation_loss_fn = self._kl_div
+            self.distillation_loss_fn = self._kl_div  # type: ignore [assignment]
         self.temperature = temperature
 
     def _kl_div(self, student_logits, teacher_logits):
@@ -855,7 +855,7 @@ class TinyBERTDistillationTrainer(Trainer):
 
         self.loss = DistillationLoss(model, teacher_model, device)
         if torch.cuda.device_count() > 1 and device.type == "cuda":
-            self.loss = DataParallel(self.loss).to(device)
+            self.loss = DataParallel(self.loss).to(device)  # type: ignore [assignment]
 
     def compute_loss(self, batch: dict, step: int) -> torch.Tensor:
         with torch.cuda.amp.autocast(enabled=self.use_amp):
@@ -881,16 +881,16 @@ class DistillationLoss(Module):
         self.teacher_model = teacher_model.to(device)
 
         # creating dummy inputs to get the shapes of hidden states and attention of teacher and student model
-        dummy_inputs = teacher_model.language_model.model.dummy_inputs
-        dummy_inputs["input_ids"] = dummy_inputs["input_ids"].to(device)
-        dummy_inputs["padding_mask"] = torch.ones_like(dummy_inputs["input_ids"], device=device)
-        dummy_inputs["segment_ids"] = torch.zeros_like(dummy_inputs["input_ids"], device=device)
+        dummy_inputs = teacher_model.language_model.model.dummy_inputs  # type: ignore [union-attr]
+        dummy_inputs["input_ids"] = dummy_inputs["input_ids"].to(device)  # type: ignore [operator,index]
+        dummy_inputs["padding_mask"] = torch.ones_like(dummy_inputs["input_ids"], device=device)  # type: ignore [operator,index]
+        dummy_inputs["segment_ids"] = torch.zeros_like(dummy_inputs["input_ids"], device=device)  # type: ignore [operator,index]
 
         with torch.no_grad():
-            _, teacher_hidden_states, teacher_attentions = self.teacher_model.forward(
+            _, teacher_hidden_states, teacher_attentions = self.teacher_model.forward(  # type: ignore [arg-type]
                 **dummy_inputs, output_attentions=True, output_hidden_states=True
             )
-            _, hidden_states, attentions = self.model.forward(
+            _, hidden_states, attentions = self.model.forward(  # type: ignore [arg-type]
                 **dummy_inputs, output_attentions=True, output_hidden_states=True
             )
 
@@ -905,7 +905,7 @@ class DistillationLoss(Module):
         student_dims = [hidden_state.shape[-1] for hidden_state in hidden_states]
 
         # creating linear mappings in case the teacher and student model have different hidden state dimensions
-        self.dim_mappings: List[Optional[Linear]] = ModuleList([])
+        self.dim_mappings: List[Optional[Linear]] = ModuleList([])  # type: ignore [assignment]
 
         for teacher_dim, student_dim in zip(teacher_dims, student_dims):
             if teacher_dim != student_dim:

--- a/haystack/modeling/utils.py
+++ b/haystack/modeling/utils.py
@@ -103,7 +103,7 @@ def initialize_device_settings(
             torch_devices: List[torch.device] = [torch.device(device) for device in devices]
             devices_to_use = torch_devices
         else:
-            devices_to_use = devices
+            devices_to_use = devices  # type: ignore [assignment]
         n_gpu = sum(1 for device in devices_to_use if "cpu" not in device.type)
     elif local_rank == -1:
         if torch.cuda.is_available():

--- a/haystack/nodes/audio/_text_to_speech.py
+++ b/haystack/nodes/audio/_text_to_speech.py
@@ -119,7 +119,7 @@ class TextToSpeech:
 
         return file_path
 
-    def text_to_audio_data(self, text: str, _models_output_key: str = "wav") -> np.array:
+    def text_to_audio_data(self, text: str, _models_output_key: str = "wav") -> np.array:  # type: ignore [valid-type]
         """
         Convert an input string into a numpy array representing the audio.
 
@@ -141,7 +141,7 @@ class TextToSpeech:
 
     def compress_audio(
         self,
-        data: np.array,
+        data: np.array,  # type: ignore [valid-type]
         path: Path,
         format: str,
         sample_rate: int,

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -151,7 +151,7 @@ class FARMReader(BaseReader):
             proxies=proxies,
             local_files_only=local_files_only,
             force_download=force_download,
-            devices=self.devices,
+            devices=self.devices,  # type: ignore [arg-type]
             use_auth_token=use_auth_token,
             max_query_length=max_query_length,
         )
@@ -224,7 +224,7 @@ class FARMReader(BaseReader):
         if max_query_length is None:
             max_query_length = self.max_query_length
 
-        devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
+        devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)  # type: ignore [arg-type]
 
         if not save_dir:
             save_dir = f"../../saved_models/{self.inferencer.model.language_model.name}"

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -265,7 +265,7 @@ class _SentenceTransformersEmbeddingEncoder(_BaseEmbeddingEncoder):
                 train_examples.append(InputExample(texts=texts))
 
         logger.info("Training/adapting %s with %s examples", self.embedding_model, len(train_examples))
-        train_dataloader = DataLoader(train_examples, batch_size=batch_size, drop_last=True, shuffle=True)
+        train_dataloader = DataLoader(train_examples, batch_size=batch_size, drop_last=True, shuffle=True)  # type: ignore [var-annotated,arg-type]
         train_loss = st_loss.loss(self.embedding_model)
 
         # Tune the model

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -237,7 +237,7 @@ class DensePassageRetriever(DenseRetriever):
         self.model.connect_heads_with_processor(self.processor.tasks, require_labels=False)
 
         if len(self.devices) > 1:
-            self.model = DataParallel(self.model, device_ids=self.devices)
+            self.model = DataParallel(self.model, device_ids=self.devices)  # type: ignore [assignment]
 
     def retrieve(
         self,
@@ -660,7 +660,7 @@ class DensePassageRetriever(DenseRetriever):
         self.processor.num_positives = num_positives
 
         if isinstance(self.model, DataParallel):
-            self.model.module.connect_heads_with_processor(self.processor.tasks, require_labels=True)
+            self.model.module.connect_heads_with_processor(self.processor.tasks, require_labels=True)  # type: ignore [operator]
         else:
             self.model.connect_heads_with_processor(self.processor.tasks, require_labels=True)
 
@@ -674,7 +674,7 @@ class DensePassageRetriever(DenseRetriever):
 
         # 5. Create an optimizer
         self.model, optimizer, lr_schedule = initialize_optimizer(
-            model=self.model,
+            model=self.model,  # type: ignore [arg-type]
             learning_rate=learning_rate,
             optimizer_opts={
                 "name": optimizer_name,
@@ -714,7 +714,7 @@ class DensePassageRetriever(DenseRetriever):
         self.passage_tokenizer.save_pretrained(f"{save_dir}/{passage_encoder_save_dir}")
 
         if len(self.devices) > 1 and not isinstance(self.model, DataParallel):
-            self.model = DataParallel(self.model, device_ids=self.devices)
+            self.model = DataParallel(self.model, device_ids=self.devices)  # type: ignore [assignment]
 
     def save(
         self,
@@ -932,7 +932,7 @@ class TableTextRetriever(DenseRetriever):
         self.model.connect_heads_with_processor(self.processor.tasks, require_labels=False)
 
         if len(self.devices) > 1:
-            self.model = DataParallel(self.model, device_ids=self.devices)
+            self.model = DataParallel(self.model, device_ids=self.devices)  # type: ignore [assignment]
 
     def retrieve(
         self,
@@ -1302,7 +1302,7 @@ class TableTextRetriever(DenseRetriever):
         self.processor.num_positives = num_positives
 
         if isinstance(self.model, DataParallel):
-            self.model.module.connect_heads_with_processor(self.processor.tasks, require_labels=True)
+            self.model.module.connect_heads_with_processor(self.processor.tasks, require_labels=True)  # type: ignore [operator]
         else:
             self.model.connect_heads_with_processor(self.processor.tasks, require_labels=True)
 
@@ -1312,7 +1312,7 @@ class TableTextRetriever(DenseRetriever):
 
         # 5. Create an optimizer
         self.model, optimizer, lr_schedule = initialize_optimizer(
-            model=self.model,
+            model=self.model,  # type: ignore [arg-type]
             learning_rate=learning_rate,
             optimizer_opts={
                 "name": optimizer_name,
@@ -1358,7 +1358,7 @@ class TableTextRetriever(DenseRetriever):
         self.table_tokenizer.save_pretrained(f"{save_dir}/{table_encoder_save_dir}")
 
         if len(self.devices) > 1:
-            self.model = DataParallel(self.model, device_ids=self.devices)
+            self.model = DataParallel(self.model, device_ids=self.devices)  # type: ignore [assignment]
 
     def save(
         self,
@@ -1826,7 +1826,7 @@ class EmbeddingRetriever(DenseRetriever):
         # Check if sentence transformers config file in model hub
         else:
             try:
-                hf_hub_download(
+                hf_hub_download(  # type: ignore [call-arg]
                     repo_id=model_name_or_path,
                     filename="config_sentence_transformers.json",
                     use_auth_token=use_auth_token,

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -686,7 +686,7 @@ class MostSimilarDocumentsPipeline(BaseStandardPipeline):
         documents = self.document_store.get_documents_by_id(ids=document_ids, index=index)
         query_embs = [doc.embedding for doc in documents]
         similar_documents = self.document_store.query_by_embedding_batch(
-            query_embs=query_embs, filters=filters, return_embedding=False, top_k=top_k, index=index
+            query_embs=query_embs, filters=filters, return_embedding=False, top_k=top_k, index=index  # type: ignore [arg-type]
         )
 
         self.document_store.return_embedding = False  # type: ignore

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -6,7 +6,7 @@ import inspect
 from typing import Any, Optional, Dict, List, Union
 
 try:
-    from typing import Literal  # type: ignore
+    from typing import Literal
 except ImportError:
     from typing_extensions import Literal  # type: ignore
 

--- a/haystack/utils/augment_squad.py
+++ b/haystack/utils/augment_squad.py
@@ -166,7 +166,7 @@ def get_replacements(
             word_id = glove_word_id_mapping[word]
             glove_vector = glove_vectors[word_id]
             with torch.inference_mode():
-                word_similarities = torch.mm(glove_vectors, glove_vector.unsqueeze(1)).squeeze(1)
+                word_similarities = torch.mm(glove_vectors, glove_vector.unsqueeze(1)).squeeze(1)  # type: ignore [arg-type]   # type: ignore [arg-type]
                 ranking = torch.argsort(word_similarities, descending=True)[: word_possibilities + 1]
                 possible_words.append([glove_id_word_mapping[int(id_)] for id_ in ranking.cpu()])
         else:  # word was not in glove either so we can't find any replacements
@@ -253,7 +253,7 @@ def augment_squad(
             contexts = augment(
                 word_id_mapping=word_id_mapping,
                 id_word_mapping=id_word_mapping,
-                vectors=vectors,
+                vectors=vectors,  # type: ignore [arg-type]   # type: ignore [arg-type]
                 model=transformers_model,
                 tokenizer=transformers_tokenizer,
                 text=context,

--- a/haystack/utils/augment_squad.py
+++ b/haystack/utils/augment_squad.py
@@ -166,7 +166,7 @@ def get_replacements(
             word_id = glove_word_id_mapping[word]
             glove_vector = glove_vectors[word_id]
             with torch.inference_mode():
-                word_similarities = torch.mm(glove_vectors, glove_vector.unsqueeze(1)).squeeze(1)  # type: ignore [arg-type]   # type: ignore [arg-type]
+                word_similarities = torch.mm(glove_vectors, glove_vector.unsqueeze(1)).squeeze(1)  # type: ignore [arg-type]
                 ranking = torch.argsort(word_similarities, descending=True)[: word_possibilities + 1]
                 possible_words.append([glove_id_word_mapping[int(id_)] for id_ in ranking.cpu()])
         else:  # word was not in glove either so we can't find any replacements
@@ -253,7 +253,7 @@ def augment_squad(
             contexts = augment(
                 word_id_mapping=word_id_mapping,
                 id_word_mapping=id_word_mapping,
-                vectors=vectors,  # type: ignore [arg-type]   # type: ignore [arg-type]
+                vectors=vectors,  # type: ignore [arg-type]
                 model=transformers_model,
                 tokenizer=transformers_tokenizer,
                 text=context,

--- a/haystack/utils/context_matching.py
+++ b/haystack/utils/context_matching.py
@@ -68,15 +68,15 @@ def calculate_context_similarity(
         longer_len = context_len
 
     score_alignment = fuzz.partial_ratio_alignment(shorter, longer, processor=_no_processor)
-    score = score_alignment.score
+    score = score_alignment.score  # type: ignore [union-attr]
 
     # Special handling for split overlaps (e.g. [AB] <-> [BC]):
     # If we detect that the score is near a half match and the best fitting part of longer is at its boundaries
     # we cut the shorter on the same side, recalculate the score and take the mean of both.
     # Thus [AB] <-> [BC] (score ~50) gets recalculated with B <-> B (score ~100) scoring ~75 in total
     if boost_split_overlaps and 40 <= score < 65:
-        cut_shorter_left = score_alignment.dest_start == 0
-        cut_shorter_right = score_alignment.dest_end == longer_len
+        cut_shorter_left = score_alignment.dest_start == 0  # type: ignore [union-attr]
+        cut_shorter_right = score_alignment.dest_end == longer_len  # type: ignore [union-attr]
         cut_len = shorter_len // 2
 
         if cut_shorter_left:


### PR DESCRIPTION
### Related Issues
- fixes #2149
- fixes #2351

### Proposed Changes:
- Adds `# type: ignore [<specific error>]` or every line that was failing mypy after haystack is installed
- Simplify the CI to make use of this

### How did you test it?
- CI

### Notes for the reviewer
- This PR is only adding `# type: ignore` to several lines, hence the huge diff. None of these lines was actually fixed.
- The only important changes to review are in the GitHub workflow.

~:warning:  **HOWEVER**~
~Mypy used to be the fastest check in the CI at about 37 seconds. With these changes, the runtime goes up to about 7 minutes, way more than PyLint at 2 mins :disappointed: I'd argue this is the right price to pay for actual type checking, but up for discussion on this point.~
Solved, see comment below. Execution time now depends on the size of the PR, but for a PR with 26 Python files like this it takes about 3-4 mins, which I find acceptable. On smaller PRs it should run faster.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
