### PR TITLE
fix: Allowing InMemStore and FAISSDocStore for indexing using single worker

### DIFF
--- a/rest_api/rest_api/pipeline/__init__.py
+++ b/rest_api/rest_api/pipeline/__init__.py
@@ -27,8 +27,9 @@ def _load_pipeline(pipeline_yaml_path, indexing_pipeline_name):
         document_store = _get_pipeline_doc_store(pipeline)
     except PipelineConfigError as e:
         pipeline, document_store = None, None
-        logger.error(f"Error loading {indexing_pipeline_name} pipeline from {pipeline_yaml_path}. \n {e.message}\n")
-
+        logger.error(
+            "Error loading %s pipeline from %s. \n %s\n", indexing_pipeline_name, pipeline_yaml_path, e.message
+        )
     return pipeline, document_store
 
 
@@ -59,7 +60,7 @@ def setup_pipelines() -> Dict[str, Any]:
     # Load indexing pipeline
     index_pipeline, _ = _load_pipeline(config.PIPELINE_YAML_PATH, config.INDEXING_PIPELINE_NAME)
     if not index_pipeline:
-        logger.warning("%s\nIndexing Pipeline is not setup. File Upload API will not be available.")
+        logger.warning("Indexing Pipeline is not setup. File Upload API will not be available.")
     pipelines["indexing_pipeline"] = index_pipeline
 
     # Create directory for uploaded files

--- a/rest_api/rest_api/pipeline/__init__.py
+++ b/rest_api/rest_api/pipeline/__init__.py
@@ -19,19 +19,25 @@ logger = logging.getLogger(__name__)
 SINGLE_PROCESS_DOC_STORES = (FAISSDocumentStore, InMemoryDocumentStore)
 
 
-def _setup_indexing_pipeline(pipeline_yaml_path, indexing_pipeline_name):
-    # Load indexing pipeline (if available)
+def _load_pipeline(pipeline_yaml_path, indexing_pipeline_name):
+    # Load pipeline (if available)
     try:
-        indexing_pipeline = Pipeline.load_from_yaml(Path(pipeline_yaml_path), pipeline_name=indexing_pipeline_name)
-        docstore = indexing_pipeline.get_document_store()
-        if isinstance(docstore, SINGLE_PROCESS_DOC_STORES):
-            logger.warning("FAISSDocumentStore or InMemoryDocumentStore should only be used with 1 worker.")
-
+        pipeline = Pipeline.load_from_yaml(Path(pipeline_yaml_path), pipeline_name=indexing_pipeline_name)
+        logging.info("Loaded pipeline nodes: %s", pipeline.graph.nodes.keys())
+        document_store = _get_pipeline_doc_store(pipeline)
     except PipelineConfigError as e:
-        indexing_pipeline = None
-        logger.error("%s\nFile Upload API will not be available.", e.message)
+        pipeline, document_store = None, None
+        logger.error(f"Error loading {indexing_pipeline_name} pipeline from {pipeline_yaml_path}. \n {e.message}\n")
 
-    return indexing_pipeline
+    return pipeline, document_store
+
+
+def _get_pipeline_doc_store(pipeline):
+    document_store = pipeline.get_document_store()
+    logging.info("Loaded docstore: %s", document_store)
+    if isinstance(document_store, SINGLE_PROCESS_DOC_STORES):
+        logger.warning("FAISSDocumentStore or InMemoryDocumentStore should only be used with 1 worker.")
+    return document_store
 
 
 def setup_pipelines() -> Dict[str, Any]:
@@ -40,14 +46,9 @@ def setup_pipelines() -> Dict[str, Any]:
 
     pipelines = {}
 
-    # Load query pipeline
-    query_pipeline = Pipeline.load_from_yaml(Path(config.PIPELINE_YAML_PATH), pipeline_name=config.QUERY_PIPELINE_NAME)
-    logging.info("Loaded pipeline nodes: %s", query_pipeline.graph.nodes.keys())
+    # Load query pipeline & document store
+    query_pipeline, document_store = _load_pipeline(config.PIPELINE_YAML_PATH, config.QUERY_PIPELINE_NAME)
     pipelines["query_pipeline"] = query_pipeline
-
-    # Find document store
-    document_store = query_pipeline.get_document_store()
-    logging.info("Loaded docstore: %s", document_store)
     pipelines["document_store"] = document_store
 
     # Setup concurrency limiter
@@ -55,7 +56,11 @@ def setup_pipelines() -> Dict[str, Any]:
     logging.info("Concurrent requests per worker: %s", config.CONCURRENT_REQUEST_PER_WORKER)
     pipelines["concurrency_limiter"] = concurrency_limiter
 
-    pipelines["indexing_pipeline"] = _setup_indexing_pipeline(config.PIPELINE_YAML_PATH, config.INDEXING_PIPELINE_NAME)
+    # Load indexing pipeline
+    index_pipeline, _ = _load_pipeline(config.PIPELINE_YAML_PATH, config.INDEXING_PIPELINE_NAME)
+    if not index_pipeline:
+        logger.warning("%s\nIndexing Pipeline is not setup. File Upload API will not be available.")
+    pipelines["indexing_pipeline"] = index_pipeline
 
     # Create directory for uploaded files
     os.makedirs(config.FILE_UPLOAD_PATH, exist_ok=True)

--- a/rest_api/test/samples/test.bogus_pipeline.yml
+++ b/rest_api/test/samples/test.bogus_pipeline.yml
@@ -1,0 +1,17 @@
+version: 'ignore'
+
+components:
+  - name: InMemoryDocumentStore
+    params: {}
+    # Wrong DocumentStore Type
+    type: MyOwnDocumentStore
+  - name: tfidf_ret
+    params:
+      document_store: InMemoryDocumentStore
+    type: TfidfRetriever
+pipelines:
+  - name: query
+    nodes:
+      - inputs:
+          - Query
+        name: tfidf_ret

--- a/rest_api/test/samples/test.in-memory-haystack-pipeline.yml
+++ b/rest_api/test/samples/test.in-memory-haystack-pipeline.yml
@@ -1,0 +1,16 @@
+version: 'ignore'
+
+components:
+  - name: InMemoryDocumentStore
+    params: {}
+    type: InMemoryDocumentStore
+  - name: tfidf_ret
+    params:
+      document_store: InMemoryDocumentStore
+    type: TfidfRetriever
+pipelines:
+  - name: query
+    nodes:
+      - inputs:
+          - Query
+        name: tfidf_ret

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -25,23 +25,27 @@ from rest_api.utils import get_app
 TEST_QUERY = "Who made the PDF specification?"
 
 
-def test_check_single_worker_warning_for_indexing_pipelines(caplog):
+def test_single_worker_warning_for_indexing_pipelines(caplog):
     yaml_pipeline_path = Path(__file__).parent.resolve() / "samples" / "test.in-memory-haystack-pipeline.yml"
     p, _ = _load_pipeline(yaml_pipeline_path, None)
 
     assert isinstance(p, Pipeline)
     assert "used with 1 worker" in caplog.text
 
+
+def test_check_error_for_pipeline_not_found(caplog):
+
     yaml_pipeline_path = Path(__file__).parent.resolve() / "samples" / "test.in-memory-haystack-pipeline.yml"
-    p, _ = _load_pipeline(yaml_pipeline_path, "BogusPipeline")
+    p, _ = _load_pipeline(yaml_pipeline_path, "ThisPipelineDoesntExist")
     assert p is None
 
+
+def test_bad_yaml_pipeline_configuration_error():
+
     yaml_pipeline_path = Path(__file__).parent.resolve() / "samples" / "test.bogus_pipeline.yml"
-    try:
-        _, _ = _load_pipeline(yaml_pipeline_path, None)
-        assert False
-    except PipelineSchemaError:
-        assert True
+    with pytest.raises(PipelineSchemaError) as excinfo:
+        _load_pipeline(yaml_pipeline_path, None)
+    assert "MyOwnDocumentStore" in str(excinfo.value)
 
 
 class MockReader(BaseReader):

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -14,7 +14,7 @@ from haystack import Document, Answer, Pipeline
 import haystack
 from haystack.nodes import BaseReader, BaseRetriever
 from haystack.document_stores import BaseDocumentStore
-from haystack.errors import PipelineSchemaError, PipelineConfigError
+from haystack.errors import PipelineSchemaError
 from haystack.schema import Label, FilterType
 from haystack.nodes.file_converter import BaseConverter
 

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -5,23 +5,31 @@ from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 from unittest.mock import MagicMock, Mock
-import functools
 import numpy as np
 import pandas as pd
 
 import pytest
 from fastapi.testclient import TestClient
-from haystack import Document, Answer
+from haystack import Document, Answer, Pipeline
 import haystack
 from haystack.nodes import BaseReader, BaseRetriever
 from haystack.document_stores import BaseDocumentStore
 from haystack.schema import Label, FilterType
 from haystack.nodes.file_converter import BaseConverter
 
+from rest_api.pipeline import _setup_indexing_pipeline
 from rest_api.utils import get_app
 
 
 TEST_QUERY = "Who made the PDF specification?"
+
+
+def test_check_single_worker_warning_for_indexing_pipelines(caplog):
+    yaml_pipeline_path = Path(__file__).parent.resolve() / "samples" / "test.in-memory-haystack-pipeline.yml"
+    p = _setup_indexing_pipeline(yaml_pipeline_path, None)
+
+    assert isinstance(p, Pipeline)
+    assert "used with 1 worker" in caplog.text
 
 
 class MockReader(BaseReader):

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -33,7 +33,7 @@ def test_single_worker_warning_for_indexing_pipelines(caplog):
     assert "used with 1 worker" in caplog.text
 
 
-def test_check_error_for_pipeline_not_found(caplog):
+def test_check_error_for_pipeline_not_found():
 
     yaml_pipeline_path = Path(__file__).parent.resolve() / "samples" / "test.in-memory-haystack-pipeline.yml"
     p, _ = _load_pipeline(yaml_pipeline_path, "ThisPipelineDoesntExist")


### PR DESCRIPTION

### Related Issues
- Unblocks #3618 for simple InMemPipelines

### Proposed Changes:
Currently, Haystack REST-API is launched with a single worker. With a single worker, it's okay to allow indexing FAISSDocumentStore & InMemoryDocumentStore as there will not be multiple in-memory copies and no race-conditions.

### How did you test it?
Added a unit-test to capture the warning and make sure a Pipeline instance is returned instead of None.


### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
