### PR TITLE
refactor: Updated rest_api schema for tables to be consistent with Document.to_dict

### DIFF
--- a/rest_api/rest_api/schema.py
+++ b/rest_api/rest_api/schema.py
@@ -16,7 +16,10 @@ from haystack.schema import Answer, Document
 
 
 BaseConfig.arbitrary_types_allowed = True
-BaseConfig.json_encoders = {np.ndarray: lambda x: x.tolist(), pd.DataFrame: lambda x: x.to_dict(orient="records")}
+BaseConfig.json_encoders = {
+    np.ndarray: lambda x: x.tolist(),
+    pd.DataFrame: lambda x: [x.columns.tolist()] + x.values.tolist(),
+}
 
 
 PrimitiveType = Union[str, int, float, bool]

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -412,10 +412,7 @@ def test_query_with_dataframe(client):
         response = client.post(url="/query", json={"query": TEST_QUERY})
         assert 200 == response.status_code
         assert len(response.json()["documents"]) == 1
-        assert response.json()["documents"][0]["content"] == [
-            {"col1": "text_1", "col2": 1},
-            {"col1": "text_2", "col2": 2},
-        ]
+        assert response.json()["documents"][0]["content"] == [["col1", "col2"], ["text_1", 1], ["text_2", 2]]
         assert response.json()["documents"][0]["content_type"] == "table"
         # Ensure `run` was called with the expected parameters
         mocked_pipeline.run.assert_called_with(query=TEST_QUERY, params={}, debug=False)


### PR DESCRIPTION
### Related Issues
- fixes #3866 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updated schema in rest_api to make returned table format consistent with how it is returned when using Haystacks' Document.to_dict().

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated existing unit test.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
Since this is changing the schema of the rest_api should this be labelled as a breaking change?

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
