### PR TITLE
feat: PromptNode - implement stop words

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -346,7 +346,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         if stop_words:
             # Although HF generates text until stop words are encountered unfortunately it includes the stop word
             # We want to exclude it to be consistent with other invocation layers
-            for idx in range(len(generated_texts)):
+            for idx, gen_text in enumerate(generated_texts):
                 for stop_word in stop_words:
                     generated_texts[idx] = generated_texts[idx].replace(stop_word, "").strip()
         return generated_texts

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -346,7 +346,9 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         if stop_words:
             # Although HF generates text until stop words are encountered unfortunately it includes the stop word
             # We want to exclude it to be consistent with other invocation layers
-            generated_texts = [gt.replace(stop, "").strip() for gt in generated_texts for stop in stop_words]
+            for idx in range(len(generated_texts)):
+                for stop_word in stop_words:
+                    generated_texts[idx] = generated_texts[idx].replace(stop_word, "").strip()
         return generated_texts
 
     @classmethod
@@ -769,7 +771,9 @@ class PromptNode(BaseComponent):
 
             # prompt template used, yield prompts from inputs args
             for prompt in template_to_fill.fill(*args, **kwargs):
-                # and pass the prepared prompt to the model
+                # merge any additional model kwargs
+                kwargs = {**kwargs, **self._prepare_model_kwargs()}
+                # and pass the prepared prompt and kwargs to the model
                 output = self.prompt_model.invoke(prompt, **kwargs)
                 results.extend(output)
         else:

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -214,10 +214,10 @@ class StopWordsCriteria(StoppingCriteria):
     def __init__(self, model_name_or_path: str, stops_words: List[str]):
         super().__init__()
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
-        self.stop_tokens = tokenizer.encode(stops_words, add_special_tokens=False, return_tensors="pt")
+        self.stop_words = tokenizer.encode(stops_words, add_special_tokens=False, return_tensors="pt")
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-        return any(torch.isin(input_ids[-1], self.stop_tokens[-1]))
+        return any(torch.isin(input_ids[-1], self.stop_words[-1]))
 
 
 class HFLocalInvocationLayer(PromptModelInvocationLayer):

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -346,7 +346,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         if stop_words:
             # Although HF generates text until stop words are encountered unfortunately it includes the stop word
             # We want to exclude it to be consistent with other invocation layers
-            for idx, gen_text in enumerate(generated_texts):
+            for idx, _ in enumerate(generated_texts):
                 for stop_word in stop_words:
                     generated_texts[idx] = generated_texts[idx].replace(stop_word, "").strip()
         return generated_texts

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -344,6 +344,8 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         generated_texts = [o["generated_text"] for o in output if "generated_text" in o]
 
         if stop_words:
+            # Although HF generates text until stop words are encountered unfortunately it includes the stop word
+            # We want to exclude it to be consistent with other invocation layers
             generated_texts = [gt.replace(stop, "").strip() for gt in generated_texts for stop in stop_words]
         return generated_texts
 

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -211,10 +211,10 @@ class StopWordsCriteria(StoppingCriteria):
     Stops text generation if any one of the stop words is generated.
     """
 
-    def __init__(self, model_name_or_path: str, stops_words: List[str]):
+    def __init__(self, model_name_or_path: str, stop_words: List[str]):
         super().__init__()
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
-        self.stop_words = tokenizer.encode(stops_words, add_special_tokens=False, return_tensors="pt")
+        self.stop_words = tokenizer.encode(stop_words, add_special_tokens=False, return_tensors="pt")
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
         return any(torch.isin(input_ids[-1], self.stop_words[-1]))
@@ -338,7 +338,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
                 if key in kwargs
             }
             if stop_words:
-                sw = StopWordsCriteria(model_name_or_path=self.model_name_or_path, stops_words=stop_words)
+                sw = StopWordsCriteria(model_name_or_path=self.model_name_or_path, stop_words=stop_words)
                 model_input_kwargs["stopping_criteria"] = StoppingCriteriaList([sw])
             output = self.pipe(prompt, max_length=self.max_length, **model_input_kwargs)
         generated_texts = [o["generated_text"] for o in output if "generated_text" in o]

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union, Any, Type, Iterator
 
 import requests
 import torch
-from transformers import pipeline, AutoModelForSeq2SeqLM
+from transformers import pipeline, AutoModelForSeq2SeqLM, StoppingCriteria, StoppingCriteriaList, AutoTokenizer
 
 from haystack import MultiLabel
 from haystack.errors import OpenAIError, OpenAIRateLimitError
@@ -206,6 +206,20 @@ class PromptModelInvocationLayer:
         return False
 
 
+class StopWordsCriteria(StoppingCriteria):
+    """
+    Stops text generation if any one of the stop words is generated.
+    """
+
+    def __init__(self, model_name_or_path: str, stops_words: List[str]):
+        super().__init__()
+        tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.stop_tokens = tokenizer.encode(stops_words, add_special_tokens=False, return_tensors="pt")
+
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        return any(torch.isin(input_ids[-1], self.stop_tokens[-1]))
+
+
 class HFLocalInvocationLayer(PromptModelInvocationLayer):
     """
     A subclass of the PromptModelInvocationLayer class. It loads a pre-trained model from Hugging Face and
@@ -310,7 +324,8 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         Note: Only kwargs relevant to Text2TextGenerationPipeline are passed to Hugging Face as model_input_kwargs.
         Other kwargs are ignored.
         """
-        output = []
+        output: List[Dict[str, str]] = []
+        stop_words = kwargs.pop("stop", None)
         if kwargs and "prompt" in kwargs:
             prompt = kwargs.pop("prompt")
 
@@ -322,8 +337,15 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
                 for key in ["return_tensors", "return_text", "clean_up_tokenization_spaces", "truncation"]
                 if key in kwargs
             }
+            if stop_words:
+                sw = StopWordsCriteria(model_name_or_path=self.model_name_or_path, stops_words=stop_words)
+                model_input_kwargs["stopping_criteria"] = StoppingCriteriaList([sw])
             output = self.pipe(prompt, max_length=self.max_length, **model_input_kwargs)
-        return [o["generated_text"] for o in output]
+        generated_texts = [o["generated_text"] for o in output if "generated_text" in o]
+
+        if stop_words:
+            generated_texts = [gt.replace(stop, "").strip() for gt in generated_texts for stop in stop_words]
+        return generated_texts
 
     @classmethod
     def supports(cls, model_name_or_path: str) -> bool:
@@ -655,6 +677,7 @@ class PromptNode(BaseComponent):
         use_auth_token: Optional[Union[str, bool]] = None,
         use_gpu: Optional[bool] = None,
         devices: Optional[List[Union[str, torch.device]]] = None,
+        stop_words: Optional[List[str]] = None,
     ):
         """
         Creates a PromptNode instance.
@@ -674,6 +697,7 @@ class PromptNode(BaseComponent):
         self.output_variable: Optional[str] = output_variable
         self.model_name_or_path: Union[str, PromptModel] = model_name_or_path
         self.prompt_model: PromptModel
+        self.stop_words: Optional[List[str]] = stop_words
         if isinstance(self.default_prompt_template, str) and not self.is_supported_template(
             self.default_prompt_template
         ):
@@ -894,3 +918,6 @@ class PromptNode(BaseComponent):
         debug: Optional[bool] = None,
     ):
         pass
+
+    def _prepare_model_kwargs(self):
+        return {"stop": self.stop_words}

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -241,6 +241,16 @@ def test_open_ai_prompt_with_params():
 
 
 @pytest.mark.parametrize("prompt_model", ["hf", "openai"], indirect=True)
+def test_stop_words(prompt_model):
+    if prompt_model.api_key is not None and not is_openai_api_key_set(prompt_model.api_key):
+        pytest.skip("No API key found for OpenAI, skipping test")
+
+    node = PromptNode(prompt_model, stop_words=["capital", "Germany"])
+    r = node.prompt("question-generation", documents=["Berlin is the capital of Germany."])
+    assert r[0] == "What is the"
+
+
+@pytest.mark.parametrize("prompt_model", ["hf", "openai"], indirect=True)
 def test_simple_pipeline(prompt_model):
     if prompt_model.api_key is not None and not is_openai_api_key_set(prompt_model.api_key):
         pytest.skip("No API key found for OpenAI, skipping test")


### PR DESCRIPTION
### Related Issues
- fixes #3862

### Proposed Changes:
Implements stop_words on the level of the PromptNode (for all models). Users can specify `stop_words` parameter in the `__init()__` of the PromptNode or from a YAML file. When one of the generated tokens is one of the specified stop words, the text generation will abort. The stop word is not included in the generated text.

### How did you test it?
Added a unit test (tests stop words for all models)

### Notes for the reviewer
We debated whether to implement the stop words on the PromptNode abstraction level or PromptTemplate. As for our immediate needs having stop words on the level of PromptNode is satisfactory - hence this PR. If we find use cases where having stop words on the level of PromptTemplate abstraction is necessary, we'll also implement it at that level. In that case, the stop words from PromptTemplate will precede those from PromptNode. 
 
### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
