### PR TITLE
refactor: Move invocation_context from meta to own pipeline variable

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -851,6 +851,7 @@ class PromptNode(BaseComponent):
         labels: Optional[MultiLabel] = None,
         documents: Optional[List[Document]] = None,
         meta: Optional[dict] = None,
+        invocation_context: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Dict, str]:
         """
         Runs the PromptNode on these inputs parameters. Returns the output of the prompt model.
@@ -864,25 +865,23 @@ class PromptNode(BaseComponent):
         prompt template.
         :param documents: The documents to be used for the prompt.
         :param meta: The meta to be used for the prompt. Usually not used.
+        :param invocation_context: The invocation context to be used for the prompt.
         """
 
-        if not meta:
-            meta = {}
         # invocation_context is a dictionary that is passed from a pipeline node to a pipeline node and can be used
         # to pass results from a pipeline node to any other downstream pipeline node.
-        if "invocation_context" not in meta:
-            meta["invocation_context"] = {}
+        invocation_context = invocation_context or {}
 
         results = self(
             query=query,
             labels=labels,
             documents=[doc.content for doc in documents if isinstance(doc.content, str)] if documents else [],
-            **meta["invocation_context"],
+            **invocation_context,
         )
 
         if self.output_variable:
-            meta["invocation_context"][self.output_variable] = results
-        return {"results": results, "meta": {**meta}}, "output_1"
+            invocation_context[self.output_variable] = results
+        return {"results": results, "invocation_context": invocation_context}, "output_1"
 
     def run_batch(
         self,

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -367,6 +367,7 @@ def test_complex_pipeline_yaml(tmp_path):
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
 def test_complex_pipeline_with_shared_prompt_model_yaml(tmp_path):
@@ -404,6 +405,7 @@ def test_complex_pipeline_with_shared_prompt_model_yaml(tmp_path):
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
 def test_complex_pipeline_with_shared_prompt_model_and_prompt_template_yaml(tmp_path):
@@ -450,6 +452,7 @@ def test_complex_pipeline_with_shared_prompt_model_and_prompt_template_yaml(tmp_
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
 def test_complex_pipeline_with_with_dummy_node_between_prompt_nodes_yaml(tmp_path):
@@ -528,6 +531,7 @@ def test_complex_pipeline_with_with_dummy_node_between_prompt_nodes_yaml(tmp_pat
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
 @pytest.mark.skipif(
@@ -587,3 +591,4 @@ def test_complex_pipeline_with_all_features(tmp_path):
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -365,7 +365,7 @@ def test_complex_pipeline_yaml(tmp_path):
     result = pipeline.run(query="not relevant", documents=[Document("Berlin is an amazing city.")])
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
-    assert len(result["meta"]["invocation_context"]) > 0
+    assert len(result["invocation_context"]) > 0
 
 
 def test_complex_pipeline_with_shared_prompt_model_yaml(tmp_path):
@@ -402,7 +402,7 @@ def test_complex_pipeline_with_shared_prompt_model_yaml(tmp_path):
     result = pipeline.run(query="not relevant", documents=[Document("Berlin is an amazing city.")])
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
-    assert len(result["meta"]["invocation_context"]) > 0
+    assert len(result["invocation_context"]) > 0
 
 
 def test_complex_pipeline_with_shared_prompt_model_and_prompt_template_yaml(tmp_path):
@@ -448,7 +448,7 @@ def test_complex_pipeline_with_shared_prompt_model_and_prompt_template_yaml(tmp_
     result = pipeline.run(query="not relevant", documents=[Document("Berlin is an amazing city.")])
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
-    assert len(result["meta"]["invocation_context"]) > 0
+    assert len(result["invocation_context"]) > 0
 
 
 @pytest.mark.skipif(
@@ -507,4 +507,4 @@ def test_complex_pipeline_with_all_features(tmp_path):
     result = pipeline.run(query="not relevant", documents=[Document("Berlin is a city in Germany.")])
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
-    assert len(result["meta"]["invocation_context"]) > 0
+    assert len(result["invocation_context"]) > 0


### PR DESCRIPTION
### Related Issues
No related issue. This is a refactoring of the existing codebase. This PR introduces a small change where we stop using the pipeline meta field to store PromptNode invocation context and use the custom pipeline parameter `invocation_context` dictionary to store all invocation context payload. Any potential conflict with other meta payloads is avoided, and invocation context will not end up in some document store. 

### Proposed Changes:
Simplifies and cleans up suboptimal usage of meta pipeline variable to store invocation context dictionary. We migrate the invocation context to a separate pipeline variable called `invocation_context` of type `Dict[str, Any]`

### How did you test it?
No tests have been added, but all unit tests that test for the presence of a particular state in the invocation context have been updated.

### Notes for the reviewer
N/A

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
