### PR TITLE
feat: Expose `output_variable` in PromptNode result, adjust unit tests

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -909,9 +909,14 @@ class PromptNode(BaseComponent):
             **invocation_context,
         )
 
+        final_result: Dict[str, Any] = {}
         if self.output_variable:
             invocation_context[self.output_variable] = results
-        return {"results": results, "invocation_context": invocation_context}, "output_1"
+            final_result[self.output_variable] = results
+
+        final_result["results"] = results
+        final_result["invocation_context"] = invocation_context
+        return final_result, "output_1"
 
     def run_batch(
         self,

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -377,6 +377,7 @@ def test_complex_pipeline_yaml(tmp_path):
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert len(result["questions"]) > 0
     assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
@@ -415,6 +416,7 @@ def test_complex_pipeline_with_shared_prompt_model_yaml(tmp_path):
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert len(result["questions"]) > 0
     assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
@@ -462,6 +464,7 @@ def test_complex_pipeline_with_shared_prompt_model_and_prompt_template_yaml(tmp_
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert len(result["questions"]) > 0
     assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
@@ -541,6 +544,7 @@ def test_complex_pipeline_with_with_dummy_node_between_prompt_nodes_yaml(tmp_pat
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert len(result["questions"]) > 0
     assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0
 
 
@@ -601,4 +605,5 @@ def test_complex_pipeline_with_all_features(tmp_path):
     response = result["results"][0]
     assert any(word for word in ["berlin", "germany", "population", "city", "amazing"] if word in response.casefold())
     assert len(result["invocation_context"]) > 0
+    assert len(result["questions"]) > 0
     assert "questions" in result["invocation_context"] and len(result["invocation_context"]["questions"]) > 0


### PR DESCRIPTION
### Related Issues
- fixes #3878

### Proposed Changes:
 As noted by the author of #3878 the results of intermediate PromptNode(s) in the pipeline are stored under the invocation_context results variable thus making them a bit less accessible than having it ideally as they key under the root of the resulting dictionary returned to the Haystack pipeline user. 

The change required is relatively simple. We elevate `output_variable` value under the root output dictionary returned to the Haystack pipeline user. However, we also leave it in invocation_context so other nodes down the pipeline can use it. 

### How did you test it?
No new tests were added but the existing tests have been adjusted to check for presence of `output_variable` in the resulting dictionary. We also check the value of that variable for validity. 

### Notes for the reviewer
There is some duplication of keys and values in the resulting dictionary. The reason for that is that we need to put key/value resulting pair in the invocation_context as well. We'll remove the duplication once we refactor pipelines inner logic and clean up pipeline run signatures.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
