### PR TITLE
chore: `mypy` should ignore files in `test/`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,9 @@ jobs:
       run: |
         for file in ${{ steps.files.outputs.all_changed_files }}; do
           if [[ $file == *.py ]]; then
-            changed_files="$changed_files $file"
+            if [[ $file != test/* ]]; then
+              changed_files="$changed_files $file"
+            fi
           fi
         done
         echo "changed_files=$changed_files" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Related Issues
- fixes CI failures like https://github.com/deepset-ai/haystack/actions/runs/3959111243/jobs/6781507712#step:6:20

### Proposed Changes:
- Make the mypy step ignore every file in the tests folder.

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
