### PR TITLE
fix: Remove double super class init from ParsrConverter init

### DIFF
--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -99,7 +99,6 @@ class ParsrConverter(BaseConverter):
         self.remove_table_of_contents = remove_table_of_contents
         self.add_page_number = add_page_number
         self.extract_headlines = extract_headlines
-        super().__init__(valid_languages=valid_languages)
 
     def convert(
         self,


### PR DESCRIPTION
### Proposed Changes:

Remove a duplicated `super().__init__()` call in `ParsrConverter.__init__()`.

### How did you test it?

Didn't test it.

### Notes for the reviewer

None.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
