### PR TITLE
fix: Add a verbose option to PromptNode to let users understand the prompts being used #2

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -789,7 +789,7 @@ class PromptNode(BaseComponent):
                 kwargs_copy = copy.copy(kwargs)
                 # and pass the prepared prompt and kwargs copy to the model
                 prompt_collector.append(prompt)
-                logger.debug(f'Prompt being sent to LLM with prompt "{prompt}" and kwargs "{kwargs_copy}"')
+                logger.debug("Prompt being sent to LLM with prompt %s and kwargs %s", prompt, kwargs_copy)
                 output = self.prompt_model.invoke(prompt, **kwargs_copy)
                 results.extend(output)
         else:
@@ -797,7 +797,7 @@ class PromptNode(BaseComponent):
             for prompt in list(args):
                 kwargs_copy = copy.copy(kwargs)
                 prompt_collector.append(prompt)
-                logger.debug(f'Prompt being sent to LLM with prompt "{prompt}" and kwargs "{kwargs_copy}"')
+                logger.debug("Prompt being sent to LLM with prompt %s and kwargs %s ", prompt, kwargs_copy)
                 output = self.prompt_model.invoke(prompt, **kwargs_copy)
                 results.extend(output)
         return results

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -911,9 +911,8 @@ class PromptNode(BaseComponent):
         # to pass results from a pipeline node to any other downstream pipeline node.
         invocation_context = invocation_context or {}
 
-        # prompt_collector is a list that is passed to the prompt node to collect the constructed prompts,
-        # so that can be returned as part of the pipeline's debug output
-        # TODO we'll revisit this approach in the near future and see if we can find a better way collect the prompts
+        # prompt_collector is an empty list, it's passed to the PromptNode that will fill it with the rendered prompts,
+        # so that they can be returned by `run()` as part of the pipeline's debug output.
         prompt_collector: List[str] = []
 
         results = self(

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -765,6 +765,7 @@ class PromptNode(BaseComponent):
         :return: A list of strings as model responses.
         """
         results = []
+        # we pop the prompt_collector kwarg to avoid passing it to the model
         prompt_collector: List[str] = kwargs.pop("prompt_collector", [])
         if isinstance(prompt_template, str) and not self.is_supported_template(prompt_template):
             raise ValueError(
@@ -912,6 +913,7 @@ class PromptNode(BaseComponent):
 
         # prompt_collector is a list that is passed to the prompt node to collect the constructed prompts,
         # so that can be returned as part of the pipeline's debug output
+        # TODO we'll revisit this approach in the near future and see if we can find a better way collect the prompts
         prompt_collector: List[str] = []
 
         results = self(

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -340,10 +340,18 @@ def test_complex_pipeline_with_qa(prompt_model):
             Document("My name is Carla and I live in Berlin"),
             Document("My name is Christelle and I live in Paris"),
         ],
+        debug=True,  # so we can verify that the constructed prompt is returned in debug
     )
 
     assert len(result["results"]) == 1
     assert "carla" in result["results"][0].casefold()
+
+    # also verify that the PromptNode has included its constructed prompt LLM model input in the returned debug
+    assert (
+        result["_debug"]["prompt_node"]["runtime"]["prompts_used"][0]
+        == "Given the context please answer the question. Context: My name is Carla and I live in Berlin; "
+        "Question: Who lives in Berlin?; Answer:"
+    )
 
 
 def test_complex_pipeline_with_shared_model():


### PR DESCRIPTION
This is the second PR to fix #3817.

Earlier attempt for this was at https://github.com/deepset-ai/haystack/pull/3827 . At the comments of that PR we agreed with @vblagoje  that I will make a new attempt to fix this issue.

### Related Issues
- fixes #3817 

### Proposed Changes:
- add the prompt used by the `PromptNode` to the debug log
- add the prompt(s) used by the `PromtNode` to the "standard" debug output of the pipeline ([see](https://github.com/deepset-ai/haystack/blob/main/haystack/pipelines/base.py#L481) and [see](https://github.com/deepset-ai/haystack/blob/ad8fbe56eef1cbc68a741db7772b07c89e1c1c78/haystack/nodes/base.py#L256) ). As the constructed prompt is NOT an input or an output to the PromptNode, the prompt ended up being included in the debug as a `runtime` debug info, [see ](https://github.com/deepset-ai/haystack/blob/ad8fbe56eef1cbc68a741db7772b07c89e1c1c78/haystack/nodes/base.py#L259) - this makes it compatible with other nodes reporting important debug information.

### How did you test it?
I was thinking whether to create a new unit test for it, but in the end I have just included the testing of this new functionality within another existing unit test (being a debug option after all).
But if needed, I can make it into a standalone unit test.


### Notes for the reviewer
@vblagoje, this is based on what we have discussed [here](https://github.com/deepset-ai/haystack/pull/3827#issuecomment-1396485603)

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
