### PR TITLE
feat: adding secure loading of models by default for haystack

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -20,6 +20,8 @@ import pandas as pd
 from haystack.schema import Document, Answer, Label, MultiLabel, Span, EvaluationResult
 from haystack.nodes.base import BaseComponent
 from haystack.pipelines.base import Pipeline
+from haystack.environment import set_pytorch_secure_model_loading
 
 
 pd.options.display.max_colwidth = 80
+set_pytorch_secure_model_loading()

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -19,10 +19,9 @@ env_meta_data: Dict[str, Any] = {}
 
 
 def set_pytorch_secure_model_loading(flag_val="1"):
-    if flag_val in ["1", "y", "yes", "true"]:
-        os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
-    else:
-        os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = "0"
+    # To load secure only model pytorch requires value of
+    # TORCH_FORCE_WEIGHTS_ONLY_LOAD to be ["1", "y", "yes", "true"]
+    os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
 
 
 def get_or_create_env_meta_data() -> Dict[str, Any]:

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import platform
 import sys
@@ -17,11 +18,19 @@ HAYSTACK_REMOTE_API_MAX_RETRIES = "HAYSTACK_REMOTE_API_MAX_RETRIES"
 
 env_meta_data: Dict[str, Any] = {}
 
+logger = logging.getLogger(__name__)
+
 
 def set_pytorch_secure_model_loading(flag_val="1"):
     # To load secure only model pytorch requires value of
     # TORCH_FORCE_WEIGHTS_ONLY_LOAD to be ["1", "y", "yes", "true"]
-    os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
+    os_flag_val = os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD")
+    if os_flag_val is None:
+        os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
+    else:
+        logger.info(
+            "TORCH_FORCE_WEIGHTS_ONLY_LOAD is already set to {}, " "Haystack will use the same.".format(os_flag_val)
+        )
 
 
 def get_or_create_env_meta_data() -> Dict[str, Any]:

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -18,6 +18,13 @@ HAYSTACK_REMOTE_API_MAX_RETRIES = "HAYSTACK_REMOTE_API_MAX_RETRIES"
 env_meta_data: Dict[str, Any] = {}
 
 
+def set_pytorch_secure_model_loading(flag_val="1"):
+    if flag_val in ["1", "y", "yes", "true"]:
+        os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
+    else:
+        os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = "0"
+
+
 def get_or_create_env_meta_data() -> Dict[str, Any]:
     """
     Collects meta data about the setup that is used with Haystack, such as: operating system, python version, Haystack version, transformers version, pytorch version, number of GPUs, execution environment, and the value stored in the env variable HAYSTACK_EXECUTION_CONTEXT.

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -29,7 +29,6 @@ def set_pytorch_secure_model_loading(flag_val="1"):
         os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
     else:
         logger.info("TORCH_FORCE_WEIGHTS_ONLY_LOAD is already set to %s, Haystack will use the same.", os_flag_val)
-        )
 
 
 def get_or_create_env_meta_data() -> Dict[str, Any]:

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -28,8 +28,7 @@ def set_pytorch_secure_model_loading(flag_val="1"):
     if os_flag_val is None:
         os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = flag_val
     else:
-        logger.info(
-            "TORCH_FORCE_WEIGHTS_ONLY_LOAD is already set to {}, " "Haystack will use the same.".format(os_flag_val)
+        logger.info("TORCH_FORCE_WEIGHTS_ONLY_LOAD is already set to %s, Haystack will use the same.", os_flag_val)
         )
 
 

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -1247,15 +1247,18 @@ def test_exponential_backoff():
 
 
 def test_secure_model_loading():
-    # just importing haystack should be enough to enable secure loading of pytorch models
-    import haystack
-
-    env_val = os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD", "0")
-    assert env_val == "1"
-    haystack.environment.set_pytorch_secure_model_loading("0")
+    # setting the flag explicitly to zero
+    os.environ["TORCH_FORCE_WEIGHTS_ONLY_LOAD"] = "0"
     env_val = os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD")
     assert env_val == "0"
-    haystack.environment.set_pytorch_secure_model_loading()
+
+    # now testing if just importing haystack is enough to enable secure loading of pytorch models
+    import importlib
+    import haystack
+
+    importlib.reload(haystack)
+    env_val = os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD", "0")
+    assert env_val == "1"
 
 
 class TestAggregateLabels:

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from random import random
 from typing import List
 
@@ -1243,6 +1244,18 @@ def test_exponential_backoff():
         return f"Hello {name}"
 
     assert greet2("John") == "Hello John"
+
+
+def test_secure_model_loading():
+    # just importing haystack should be enough to enable secure loading of pytorch models
+    import haystack
+
+    env_val = os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD", "0")
+    assert env_val == "1"
+    haystack.environment.set_pytorch_secure_model_loading("0")
+    env_val = os.getenv("TORCH_FORCE_WEIGHTS_ONLY_LOAD")
+    assert env_val == "0"
+    haystack.environment.set_pytorch_secure_model_loading()
 
 
 class TestAggregateLabels:


### PR DESCRIPTION
### Related Issues
- fixes #3521

### Proposed Changes:
setting TORCH_FORCE_WEIGHTS_ONLY_LOAD to 1 by default

### How did you test it?
added unit test

### Notes for the reviewer
To load secure-only model pytorch requires the value of TORCH_FORCE_WEIGHTS_ONLY_LOAD to be ["1", "y", "yes", "true"]
For more details please refer to pytorch PR https://github.com/pytorch/pytorch/pull/87443.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
