### PR TITLE
chore: enable `f-string-without-interpolation`

### DIFF
--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -441,28 +441,28 @@ class BaseDocumentStore(BaseComponent):
         # TODO improve support for PreProcessor when adding eval data
         if preprocessor is not None:
             assert preprocessor.split_by != "sentence", (
-                f"Split by sentence not supported.\n"
-                f"Please set 'split_by' to either 'word' or 'passage' in the supplied PreProcessor."
+                "Split by sentence not supported.\n"
+                "Please set 'split_by' to either 'word' or 'passage' in the supplied PreProcessor."
             )
             assert preprocessor.split_respect_sentence_boundary is False, (
-                f"split_respect_sentence_boundary not supported yet.\n"
-                f"Please set 'split_respect_sentence_boundary' to False in the supplied PreProcessor."
+                "split_respect_sentence_boundary not supported yet.\n"
+                "Please set 'split_respect_sentence_boundary' to False in the supplied PreProcessor."
             )
             assert preprocessor.split_overlap == 0, (
-                f"Overlapping documents are currently not supported when adding eval data.\n"
-                f"Please set 'split_overlap=0' in the supplied PreProcessor."
+                "Overlapping documents are currently not supported when adding eval data.\n"
+                "Please set 'split_overlap=0' in the supplied PreProcessor."
             )
             assert preprocessor.clean_empty_lines is False, (
-                f"clean_empty_lines currently not supported when adding eval data.\n"
-                f"Please set 'clean_empty_lines=False' in the supplied PreProcessor."
+                "clean_empty_lines currently not supported when adding eval data.\n"
+                "Please set 'clean_empty_lines=False' in the supplied PreProcessor."
             )
             assert preprocessor.clean_whitespace is False, (
-                f"clean_whitespace is currently not supported when adding eval data.\n"
-                f"Please set 'clean_whitespace=False' in the supplied PreProcessor."
+                "clean_whitespace is currently not supported when adding eval data.\n"
+                "Please set 'clean_whitespace=False' in the supplied PreProcessor."
             )
             assert preprocessor.clean_header_footer is False, (
-                f"clean_header_footer is currently not supported when adding eval data.\n"
-                f"Please set 'clean_header_footer=False' in the supplied PreProcessor."
+                "clean_header_footer is currently not supported when adding eval data.\n"
+                "Please set 'clean_header_footer=False' in the supplied PreProcessor."
             )
 
         file_path = Path(filename)

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -1181,7 +1181,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             document = Document.from_dict(doc_dict)
         except (KeyError, ValidationError) as e:
             raise DocumentStoreError(
-                f"Failed to create documents from the content of the document store. Make sure the index you specified contains documents."
+                "Failed to create documents from the content of the document store. Make sure the index you specified contains documents."
             ) from e
         return document
 

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -365,7 +365,7 @@ class Inferencer:
         )  # type ignore
         preds_all = []
         for i, batch in enumerate(
-            tqdm(data_loader, desc=f"Inferencing Samples", unit=" Batches", disable=self.disable_tqdm)
+            tqdm(data_loader, desc="Inferencing Samples", unit=" Batches", disable=self.disable_tqdm)
         ):
             batch = {key: batch[key].to(self.devices[0]) for key in batch}
             batch_samples = samples[i * self.batch_size : (i + 1) * self.batch_size]
@@ -401,7 +401,7 @@ class Inferencer:
         # TODO so that preds of the right shape are passed in to formatted_preds
         unaggregated_preds_all = []
 
-        for batch in tqdm(data_loader, desc=f"Inferencing Samples", unit=" Batches", disable=self.disable_tqdm):
+        for batch in tqdm(data_loader, desc="Inferencing Samples", unit=" Batches", disable=self.disable_tqdm):
 
             batch = {key: batch[key].to(self.devices[0]) for key in batch}
 

--- a/haystack/nodes/_json_schema.py
+++ b/haystack/nodes/_json_schema.py
@@ -432,7 +432,7 @@ def update_json_schema(destination_path: Path = JSON_SCHEMAS_PATH, main_only: bo
     """
     # `main` schema is always updated and will contain the same data as the latest
     # commit from `main` or a release branch
-    filename = f"haystack-pipeline-main.schema.json"
+    filename = "haystack-pipeline-main.schema.json"
 
     os.makedirs(destination_path, exist_ok=True)
     with open(destination_path / filename, "w") as json_file:

--- a/haystack/nodes/audio/_text_to_speech.py
+++ b/haystack/nodes/audio/_text_to_speech.py
@@ -130,7 +130,7 @@ class TextToSpeech:
         prediction = self.model(text)
         if not prediction:
             raise AudioNodeError(
-                f"The model returned no predictions. Make sure you selected a valid text-to-speech model."
+                "The model returned no predictions. Make sure you selected a valid text-to-speech model."
             )
         output = prediction.get(_models_output_key, None)
         if output is None:

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -87,7 +87,7 @@ class FileTypeClassifier(BaseComponent):
             if path_suffix == "":
                 path_suffix = self._estimate_extension(path)
             if path_suffix != extension:
-                raise ValueError(f"Multiple file types are not allowed at once.")
+                raise ValueError("Multiple file types are not allowed at once.")
 
         return extension.lstrip(".")
 

--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -461,7 +461,7 @@ class PreProcessor(BasePreProcessor):
 
             if word_count_sen > split_length:
                 long_sentence_message = (
-                    f"We found one or more sentences whose word count is higher than the split length."
+                    "We found one or more sentences whose word count is higher than the split length."
                 )
                 if long_sentence_message not in self.print_log:
                     self.print_log.add(long_sentence_message)
@@ -763,11 +763,10 @@ class PreProcessor(BasePreProcessor):
                 sentence_tokenizer = nltk.data.load(f"file:{str(tokenizer_model_path)}", format="pickle")
             except (LookupError, UnpicklingError, ValueError) as e:
                 if isinstance(e, LookupError):
-                    logger.exception(f"PreProcessor couldn't load sentence tokenizer from %s", tokenizer_model_path)
+                    logger.exception("PreProcessor couldn't load sentence tokenizer from %s", tokenizer_model_path)
                 else:
                     logger.exception(
-                        f"PreProcessor couldn't determine model format of sentence tokenizer at %s",
-                        tokenizer_model_path,
+                        "PreProcessor couldn't determine model format of sentence tokenizer at %s", tokenizer_model_path
                     )
 
                 # NLTK failed to load custom SentenceTokenizer, fallback to the default model or to English
@@ -784,7 +783,7 @@ class PreProcessor(BasePreProcessor):
                         "Using English instead.",
                         self.language,
                     )
-                    sentence_tokenizer = nltk.data.load(f"tokenizers/punkt/english.pickle")
+                    sentence_tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
 
         # Use a default NLTK model
         elif language_name is not None:
@@ -795,7 +794,7 @@ class PreProcessor(BasePreProcessor):
                 " Using English instead. You may train your own model and use the 'tokenizer_model_folder' parameter.",
                 self.language,
             )
-            sentence_tokenizer = nltk.data.load(f"tokenizers/punkt/english.pickle")
+            sentence_tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
 
         return sentence_tokenizer
 

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -730,7 +730,7 @@ class PromptNode(BaseComponent):
         elif isinstance(model_name_or_path, PromptModel):
             self.prompt_model = model_name_or_path
         else:
-            raise ValueError(f"model_name_or_path must be either a string or a PromptModel object")
+            raise ValueError("model_name_or_path must be either a string or a PromptModel object")
 
     def __call__(self, *args, **kwargs) -> List[str]:
         """

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -306,7 +306,7 @@ class _RetribertEmbeddingEncoder(_BaseEmbeddingEncoder):
         embeddings: List[np.ndarray] = []
         disable_tqdm = True if len(dataloader) == 1 else not self.progress_bar
 
-        for batch in tqdm(dataloader, desc=f"Creating Embeddings", unit=" Batches", disable=disable_tqdm):
+        for batch in tqdm(dataloader, desc="Creating Embeddings", unit=" Batches", disable=disable_tqdm):
             batch = {key: batch[key].to(self.embedding_model.device) for key in batch}
             with torch.inference_mode():
                 q_reps = (
@@ -333,7 +333,7 @@ class _RetribertEmbeddingEncoder(_BaseEmbeddingEncoder):
         embeddings: List[np.ndarray] = []
         disable_tqdm = True if len(dataloader) == 1 else not self.progress_bar
 
-        for batch in tqdm(dataloader, desc=f"Creating Embeddings", unit=" Batches", disable=disable_tqdm):
+        for batch in tqdm(dataloader, desc="Creating Embeddings", unit=" Batches", disable=disable_tqdm):
             batch = {key: batch[key].to(self.embedding_model.device) for key in batch}
             with torch.inference_mode():
                 q_reps = (

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -500,7 +500,7 @@ class DensePassageRetriever(DenseRetriever):
         with tqdm(
             total=len(data_loader) * self.batch_size,
             unit=" Docs",
-            desc=f"Create embeddings",
+            desc="Create embeddings",
             position=1,
             leave=False,
             disable=disable_tqdm,
@@ -1119,7 +1119,7 @@ class TableTextRetriever(DenseRetriever):
         with tqdm(
             total=len(data_loader) * self.batch_size,
             unit=" Docs",
-            desc=f"Create embeddings",
+            desc="Create embeddings",
             position=1,
             leave=False,
             disable=disable_tqdm,

--- a/haystack/nodes/retriever/multimodal/embedder.py
+++ b/haystack/nodes/retriever/multimodal/embedder.py
@@ -136,7 +136,7 @@ class MultiModalEmbedder:
         for batch_index in tqdm(
             iterable=range(0, len(documents), batch_size),
             unit=" Docs",
-            desc=f"Create embeddings",
+            desc="Create embeddings",
             position=1,
             leave=False,
             disable=not self.progress_bar,

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1004,7 +1004,7 @@ class Pipeline:
                     f"Please specify a valid experiment_tracking_tool. Possible values are: {TRACKING_TOOL_TO_HEAD.keys()}"
                 )
             if experiment_tracking_uri is None:
-                raise HaystackError(f"experiment_tracking_uri must be specified if experiment_tracking_tool is set.")
+                raise HaystackError("experiment_tracking_uri must be specified if experiment_tracking_tool is set.")
             tracking_head = tracking_head_cls(tracking_uri=experiment_tracking_uri)
             tracker.set_tracking_head(tracking_head)
 
@@ -1037,7 +1037,7 @@ class Pipeline:
             # check index before eval
             document_store = index_pipeline.get_document_store()
             if document_store is None:
-                raise HaystackError(f"Document store not found. Please provide pipelines with proper document store.")
+                raise HaystackError("Document store not found. Please provide pipelines with proper document store.")
             document_count = document_store.get_document_count()
 
             if document_count > 0:
@@ -1846,9 +1846,9 @@ class Pipeline:
             import pygraphviz  # pylint: disable=unused-import
         except ImportError:
             raise ImportError(
-                f"Could not import `pygraphviz`. Please install via: \n"
-                f"pip install pygraphviz\n"
-                f"(You might need to run this first: apt install libgraphviz-dev graphviz )"
+                "Could not import `pygraphviz`. Please install via: \n"
+                "pip install pygraphviz\n"
+                "(You might need to run this first: apt install libgraphviz-dev graphviz )"
             )
 
         graphviz = to_agraph(self.graph)
@@ -2001,7 +2001,7 @@ class Pipeline:
 
             component_params = definitions[name].get("params", {})
             component_type = definitions[name]["type"]
-            logger.debug(f"Loading component '%s' of type '%s'", name, definitions[name]["type"])
+            logger.debug("Loading component '%s' of type '%s'", name, definitions[name]["type"])
 
             for key, value in component_params.items():
                 # Component params can reference to other components. For instance, a Retriever can reference a

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -90,7 +90,7 @@ class Document:
         """
 
         if content is None:
-            raise ValueError(f"Can't create 'Document': Mandatory 'content' field is None")
+            raise ValueError("Can't create 'Document': Mandatory 'content' field is None")
 
         self.content = content
         self.content_type = content_type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,8 +248,6 @@ disable = [
   # To keep
   "fixme",
   "c-extension-no-member",
-  "wrong-spelling-in-comment",
-  "wrong-spelling-in-docstring",
 
   # To review:
   "missing-docstring",
@@ -269,10 +267,9 @@ disable = [
   "attribute-defined-outside-init",
   "too-many-instance-attributes",
   "super-with-arguments",
-  "anomalous-backslash-in-string",
   "redefined-builtin",
   "logging-format-interpolation",
-  "f-string-without-interpolation",
+  #"f-string-without-interpolation",
   "abstract-method",
   "too-many-branches",
   "unspecified-encoding",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,7 +269,6 @@ disable = [
   "super-with-arguments",
   "redefined-builtin",
   "logging-format-interpolation",
-  #"f-string-without-interpolation",
   "abstract-method",
   "too-many-branches",
   "unspecified-encoding",


### PR DESCRIPTION
### Related Issues
n/a

### Proposed Changes:
- re-enables PyLint's `f-string-without-interpolation`
- removes a few other warnings that were silencing no issues:
  -  `wrong-spelling-in-docstring`
  -  `wrong-spelling-in-comment`
  - `anomalous-backlash-in-string`

### How did you test it?
- CI

### Notes for the reviewer
Don't worry for the diff: this PR only removes `f` prefixes from strings that are doing no interpolation.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
~I added tests that demonstrate the correct behavior of the change~
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
~I documented my code~
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
