### PR TITLE
refactor: Improve stop_words handling, add unit test cases

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -328,7 +329,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         Other kwargs are ignored.
         """
         output: List[Dict[str, str]] = []
-        stop_words = kwargs.pop("stop", None)
+        stop_words = kwargs.pop("stop_words", None)
         if kwargs and "prompt" in kwargs:
             prompt = kwargs.pop("prompt")
 
@@ -445,6 +446,9 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
 
         kwargs_with_defaults = self.model_input_kwargs
         if kwargs:
+            # we use keyword stop_words but OpenAI uses stop
+            if "stop_words" in kwargs:
+                kwargs["stop"] = kwargs.pop("stop_words")
             kwargs_with_defaults.update(kwargs)
         payload = {
             "model": self.model_name_or_path,
@@ -767,6 +771,8 @@ class PromptNode(BaseComponent):
                 f"or pass a PromptTemplate instance for prompting."
             )
 
+        # kwargs override model kwargs
+        kwargs = {**self._prepare_model_kwargs(), **kwargs}
         prompt_template_used = prompt_template or self.default_prompt_template
         if prompt_template_used:
             if isinstance(prompt_template_used, PromptTemplate):
@@ -778,15 +784,15 @@ class PromptNode(BaseComponent):
 
             # prompt template used, yield prompts from inputs args
             for prompt in template_to_fill.fill(*args, **kwargs):
-                # merge any additional model kwargs
-                kwargs = {**kwargs, **self._prepare_model_kwargs()}
-                # and pass the prepared prompt and kwargs to the model
-                output = self.prompt_model.invoke(prompt, **kwargs)
+                kwargs_copy = copy.copy(kwargs)
+                # and pass the prepared prompt and kwargs copy to the model
+                output = self.prompt_model.invoke(prompt, **kwargs_copy)
                 results.extend(output)
         else:
             # straightforward prompt, no templates used
             for prompt in list(args):
-                output = self.prompt_model.invoke(prompt)
+                kwargs_copy = copy.copy(kwargs)
+                output = self.prompt_model.invoke(prompt, **kwargs_copy)
                 results.extend(output)
         return results
 
@@ -933,4 +939,6 @@ class PromptNode(BaseComponent):
         pass
 
     def _prepare_model_kwargs(self):
-        return {"stop": self.stop_words}
+        # these are the parameters from PromptNode level
+        # that are passed to the prompt model invocation layer
+        return {"stop_words": self.stop_words}

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -259,7 +259,9 @@ def test_stop_words(prompt_model):
 
     # simple prompting
     r = node("Given the context please generate a question. Context: Berlin is the capital of Germany.; Question:")
-    assert len(r[0]) > 0 and "capital" not in r[0] and "Germany" not in r[0]
+    assert len(r[0]) > 0
+    assert "capital" not in r[0]
+    assert "Germany" not in r[0]
 
     # simple prompting with stop words set in kwargs (overrides PN stop words)
     r = node(

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -245,9 +245,40 @@ def test_stop_words(prompt_model):
     if prompt_model.api_key is not None and not is_openai_api_key_set(prompt_model.api_key):
         pytest.skip("No API key found for OpenAI, skipping test")
 
+    # test stop words for both HF and OpenAI
+    # set stop words in PromptNode
     node = PromptNode(prompt_model, stop_words=["capital", "Germany"])
+
+    # with default prompt template and stop words set in PN
     r = node.prompt("question-generation", documents=["Berlin is the capital of Germany."])
-    assert r[0] == "What is the"
+    assert r[0] == "What is the" or r[0] == "What city is the"
+
+    # with default prompt template and stop words set in kwargs (overrides PN stop words)
+    r = node.prompt("question-generation", documents=["Berlin is the capital of Germany."], stop_words=None)
+    assert "capital" in r[0] or "Germany" in r[0]
+
+    # simple prompting
+    r = node("Given the context please generate a question. Context: Berlin is the capital of Germany.; Question:")
+    assert len(r[0]) > 0 and "capital" not in r[0] and "Germany" not in r[0]
+
+    # simple prompting with stop words set in kwargs (overrides PN stop words)
+    r = node(
+        "Given the context please generate a question. Context: Berlin is the capital of Germany.; Question:",
+        stop_words=None,
+    )
+    assert "capital" in r[0] or "Germany" in r[0]
+
+    tt = PromptTemplate(
+        name="question-generation-copy",
+        prompt_text="Given the context please generate a question. Context: $documents; Question:",
+    )
+    # with custom prompt template
+    r = node.prompt(tt, documents=["Berlin is the capital of Germany."])
+    assert r[0] == "What is the" or r[0] == "What city is the"
+
+    # with custom prompt template and stop words set in kwargs (overrides PN stop words)
+    r = node.prompt(tt, documents=["Berlin is the capital of Germany."], stop_words=None)
+    assert "capital" in r[0] or "Germany" in r[0]
 
 
 @pytest.mark.parametrize("prompt_model", ["hf", "openai"], indirect=True)


### PR DESCRIPTION
### Related Issues
- minor additional fixes for #3884 
- I created an inconsistency where simple prompts i.e. `node("What is the capital of Germany?")` do not pass the stop words to the underlying model invocation
- I corrected this inconsistency (all prompts are equal) and added more stop words unit tests variants
### Proposed Changes:
- Implement stop words consistently for all prompts (simple, with default installed template, and new prompt template)
- Allow kwargs stop_words to override the default stop words set in PN init
- Add more unit tests

### How did you test it?
Added more variants of `test_stop_words` unit tests

### Notes for the reviewer
Ping me if anything not clear

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
