### PR TITLE
refactor: Remove PromptNode hash and equality functions

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -877,16 +877,6 @@ class PromptNode(BaseComponent):
 
         return list(self.prompt_templates[prompt_template].prompt_params)
 
-    def __eq__(self, other):
-        if isinstance(other, PromptNode):
-            if self.default_prompt_template != other.default_prompt_template:
-                return False
-            return self.model_name_or_path == other.model_name_or_path
-        return False
-
-    def __hash__(self):
-        return hash((self.default_prompt_template, self.model_name_or_path))
-
     def run(
         self,
         query: Optional[str] = None,


### PR DESCRIPTION
### Related Issues

I stumbled on a unit test case where I wanted to use *two* exact YAML definitions of a PromptNode in the pipeline. The pipeline refused to include these two PromptNode(s), complaining that they are the same objects. I remembered that I implemented the PromptNode hashes and equality (in the early version) to prevent multiple same PromptNodes from being injected in the pipeline. That was when we didn't have the PromptModel object, only heavyweight PromptNode. However, now that we can have multiple "light" PromptNodes sharing PromptModel, this reasonable restriction can potentially become a liability. 

To prevent potential issues in the future, I believe we should remove hash and equality functions from PromptNode. This will be in line will all other components in Haystack. None of them implement these methods. 

### Proposed Changes:
Remove eq and hash functions. 

### How did you test it?
Add a unit test that inserts the same two YAML-defined PromptNodes and make sure that the pipeline can be created.

### Notes for the reviewer
NA

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
