### PR TITLE
feat: add frontmatter to meta

### DIFF
--- a/haystack/nodes/file_converter/markdown.py
+++ b/haystack/nodes/file_converter/markdown.py
@@ -85,10 +85,6 @@ class MarkdownConverter(BaseConverter):
         extract_headlines = extract_headlines if extract_headlines is not None else self.extract_headlines
         add_frontmatter_to_meta = add_frontmatter_to_meta if add_frontmatter_to_meta is not None else self.add_frontmatter_to_meta
 
-        
-        # with open(file_path, encoding=encoding, errors="ignore") as f:
-        #     markdown_text = f.read()
-
         with open(file_path, encoding=encoding, errors="ignore") as f:
             metadata, markdown_text = frontmatter.parse(f.read())
         
@@ -99,7 +95,6 @@ class MarkdownConverter(BaseConverter):
         if remove_code_snippets:
             html = re.sub(r"<pre>(.*?)</pre>", " ", html, flags=re.DOTALL)
             html = re.sub(r"<code>(.*?)</code>", " ", html, flags=re.DOTALL)
-            html = re.sub(r"<p>```(.*?)```</p>", " ", html, flags=re.DOTALL)
         soup = BeautifulSoup(html, "html.parser")
 
         if add_frontmatter_to_meta:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ crawler = [
 preprocessing = [
   "beautifulsoup4",
   "markdown",
+  "python-frontmatter",
   "python-magic; platform_system != 'Windows'",  # Depends on libmagic: https://pypi.org/project/python-magic/
   "python-magic-bin; platform_system == 'Windows'",  # Needs to be installed without python-magic, otherwise Windows CI gets stuck.
 ]


### PR DESCRIPTION
### Related Issues
- fixes #3945 

### Proposed Changes:
I propose using the `python-frontmatter` package to split the content of a markdown from it's frontmatter and providing an option for people to add the frontmatter to the `meta` 

### How did you test it?
`MarkdownConverter(add_frontmatter_to_meta=True)`
Use tutorial 1 and convert it to a Document

### Notes for the reviewer
This is something we would like to implement to enable search for tutorials

Is this an ok fix? If yes I can update the docstrings. And let me know if there is anywhere I should add tests to

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
