### PR TITLE
chore: bump pydoc-markdown version used in the CI

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pydoc-markdown==4.5.1
+          pip install pydoc-markdown==4.6.4
 
       - name: Generate API docs
         run: ./.github/utils/pydoc-markdown.sh

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -1,6 +1,7 @@
 name: Sync docs with Readme
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -44,11 +44,11 @@ class ReadmeRenderer(Renderer):
     def render(self, modules: t.List[docspec.Module]) -> None:
         if self.markdown.filename is None:
             sys.stdout.write(self._frontmatter())
-            self.markdown.render_to_stream(modules, sys.stdout)
+            self.markdown._render_to_stream(modules, sys.stdout)
         else:
             with io.open(self.markdown.filename, "w", encoding=self.markdown.encoding) as fp:
                 fp.write(self._frontmatter())
-                self.markdown.render_to_stream(modules, t.cast(t.TextIO, fp))
+                self.markdown._render_to_stream(modules, t.cast(t.TextIO, fp))
 
     def _frontmatter(self) -> str:
         return README_FRONTMATTER.format(

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -44,11 +44,11 @@ class ReadmeRenderer(Renderer):
     def render(self, modules: t.List[docspec.Module]) -> None:
         if self.markdown.filename is None:
             sys.stdout.write(self._frontmatter())
-            self.markdown._render_to_stream(modules, sys.stdout)
+            self.markdown.render_single_page(sys.stdout, modules)
         else:
             with io.open(self.markdown.filename, "w", encoding=self.markdown.encoding) as fp:
                 fp.write(self._frontmatter())
-                self.markdown._render_to_stream(modules, t.cast(t.TextIO, fp))
+                self.markdown.render_single_page(t.cast(t.TextIO, fp), modules)
 
     def _frontmatter(self) -> str:
         return README_FRONTMATTER.format(


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Bump pydoc-markdown to 4.6.4 so we pull in some improvements and fixes we need.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
The internal API has changed a bit and I had to adjust two method calls but the logic stays the same

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
