### PR TITLE
ci: Remove mypy deps install step in python_cache action

### DIFF
--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -41,14 +41,6 @@ runs:
       # The cache will be rebuild every day and at every change of the dependency files
       key: ${{ inputs.prefix }}-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/pyproject.toml') }}
 
-  - name: Cache Mypy path
-    id: cache-mypy
-    uses: actions/cache@v3
-    with:
-      path: ${{ env.pythonLocation }}/.mypy_cache
-      # The cache will be rebuild every day and at every change of the dependency files
-      key: mypy-${{ inputs.prefix }}-py${{ inputs.pythonVersion }}-${{ env.date }}-${{ hashFiles('**/pyproject.toml') }}
-
   - name: Install dependencies
     # NOTE: this action runs only on cache miss to refresh the dependencies and make sure the next Haystack install will be faster.
     # Do not rely on this step to install Haystack itself!

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -60,8 +60,3 @@ runs:
       python -m pip install --upgrade pip
       pip install .[all]
       pip install rest_api/
-
-  - name: Install mypy dependencies
-    shell: bash
-    if: inputs.pythonVersion != 3.7
-    run: python -m mypy --install-types --non-interactive --cache-dir=${{ env.pythonLocation }}/.mypy_cache/ haystack/ rest_api/ --exclude=rest_api/build/ --exclude=rest_api/test/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,18 +87,9 @@ jobs:
     - name: Get changed files
       id: files
       uses: tj-actions/changed-files@v34
-
-    - name: Filter changed files
-      id: python-files
-      run: |
-        for file in ${{ steps.files.outputs.all_changed_files }}; do
-          if [[ $file == *.py ]]; then
-            if [[ $file != test/* ]]; then
-              changed_files="$changed_files $file"
-            fi
-          fi
-        done
-        echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
+      with:
+        files: |
+          *.py
 
     - name: Setup Python
       uses: ./.github/actions/python_cache/
@@ -109,7 +100,7 @@ jobs:
       if: steps.python-files.outputs.changed_files
       run: |
         mkdir .mypy_cache/
-        mypy ${{ steps.python-files.outputs.changed_files }}
+        mypy --install-types --non-interactive ${{ steps.python-files.outputs.changed_files }} --exclude=rest_api/build/ --exclude=rest_api/test/
 
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,9 @@ jobs:
       with:
         files: |
           *.py
+        files_ignore: |
+          test/**
+          rest_api/test/**
 
     - name: Setup Python
       uses: ./.github/actions/python_cache/


### PR DESCRIPTION
### Related Issues

https://github.com/deepset-ai/haystack/actions/runs/4014088908/jobs/6894191362

### Proposed Changes:

Remove the step that install `mypy` deps in the `python_cache` action.

`mypy` deps installation is now done directly when invoked on modified `*.py` files, this should also make it faster since it only installs depedencies necessary to test those files.

This PR also removes the `mypy` caching step in `python_cache` action as there would be nothing to cache.

### How did you test it?

I didn't, it's CI stuff. I just tested that the commands are correct by running them locally first.

### Notes for the reviewer

The step that install `mypy` deps in `python_cache` was called with both `--install-types` and `--non-interactive` flags, as documented [here](https://mypy.readthedocs.io/en/stable/running_mypy.html#library-stubs-not-installed) those two flags used in combination forces type checking the code.

> Use `--install-types` with `--non-interactive` to install all suggested stub packages without asking for confirmation, _and_ type check your code

For more info about the individual flags see [`--install-types`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-install-types) and [`--non-interactive`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-non-interactive) documentation.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~~I have updated the related issue with new insights and changes~~
- [ ] ~~I added tests that demonstrate the correct behavior of the change~~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~~I documented my code~~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
