### PR TITLE
chore: make the benchmark workflow run only manually

### DIFF
--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -2,11 +2,9 @@ name: benchmarks
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [labeled]
+
 jobs:
   deploy-cloud-runner:
-    if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'benchmark') || github.event.action == 'workflow_dispatch' }}
     runs-on: [ubuntu-latest]
     container: docker://dvcorg/cml
     steps:
@@ -65,7 +63,6 @@ jobs:
           sleep 20 && echo "Deployed $MACHINE"
           ) || (echo "Shut down machine" && docker-machine rm -y -f $MACHINE && exit 1)
   run-benchmark:
-    if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'benchmark') || github.event.action == 'workflow_dispatch' }}
     needs: deploy-cloud-runner
     runs-on: [self-hosted,cml]
     steps:


### PR DESCRIPTION
### Related Issues
- n/a

Benchmarks are supposed to run only manually or when a PR is labelled in a certain way. This means that the jobs are almost always skipped, cluttering the list of checks you see in a PR.

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Run benchmarks manually, removing the PR event trigger

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
