### PR TITLE
feat: Add `use_prefiltering` parameter to `DeepsetCloudDocumentStore`

### DIFF
--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -46,6 +46,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         return_embedding: bool = False,
         label_index: str = "default",
         embedding_dim: int = 768,
+        use_prefiltering: bool = False,
     ):
         """
         A DocumentStore facade enabling you to interact with the documents stored in deepset Cloud.
@@ -86,6 +87,8 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param label_index: index for the evaluation set interface
         :param return_embedding: To return document embedding.
         :param embedding_dim: Specifies the dimensionality of the embedding vector (only needed when using a dense retriever, for example, DensePassageRetriever pr EmbeddingRetriever, on top).
+        :param use_prefiltering: DeepsetCloudDocumentStore uses post-filtering by default when querying with filters.
+                                 If you want to use pre-filtering instead at the cost of higher latency, set this to True.
         """
         self.index = index
         self.label_index = label_index
@@ -93,6 +96,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         self.similarity = similarity
         self.return_embedding = return_embedding
         self.embedding_dim = embedding_dim
+        self.use_prefiltering = use_prefiltering
         self.client = DeepsetCloud.get_index_client(
             api_key=api_key, api_endpoint=api_endpoint, workspace=workspace, index=index
         )


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds the option to use pre-filtering in `DeepsetCloudDocumentStore`. Previously, when `DeepsetCloudDocumentStore` was queried using filters, only post-filtering was available.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
