### PR TITLE
docs: Update Crawler docstring for correct usage in Google colab

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -125,9 +125,38 @@ class Crawler(BaseComponent):
                 raise NodeError(
                     """
         \'chromium-driver\' needs to be installed manually when running colab. Follow the below given commands:
-                        !apt-get update
-                        !apt install chromium-driver
-                        !cp /usr/lib/chromium-browser/chromedriver /usr/bin
+                        %%shell
+                        cat > /etc/apt/sources.list.d/debian.list <<'EOF'
+                        deb [arch=amd64 signed-by=/usr/share/keyrings/debian-buster.gpg] http://deb.debian.org/debian buster main
+                        deb [arch=amd64 signed-by=/usr/share/keyrings/debian-buster-updates.gpg] http://deb.debian.org/debian buster-updates main
+                        deb [arch=amd64 signed-by=/usr/share/keyrings/debian-security-buster.gpg] http://deb.debian.org/debian-security buster/updates main
+                        EOF
+
+                        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DCC9EFBF77E11517
+                        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
+                        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 112695A0E562B32A
+                        apt-key export 77E11517 | gpg --dearmour -o /usr/share/keyrings/debian-buster.gpg
+                        apt-key export 22F3D138 | gpg --dearmour -o /usr/share/keyrings/debian-buster-updates.gpg
+                        apt-key export E562B32A | gpg --dearmour -o /usr/share/keyrings/debian-security-buster.gpg
+
+                        cat > /etc/apt/preferences.d/chromium.pref << 'EOF'
+                        Package: *
+                        Pin: release a=eoan
+                        Pin-Priority: 500
+
+
+                        Package: *
+                        Pin: origin "deb.debian.org"
+                        Pin-Priority: 300
+
+
+                        Package: chromium*
+                        Pin: origin "deb.debian.org"
+                        Pin-Priority: 700
+                        EOF
+
+                        apt-get update
+                        apt-get install chromium chromium-driver
         If it has already been installed, please check if it has been copied to the right directory i.e. to \'/usr/bin\'"""
                 ) from exc
         else:


### PR DESCRIPTION
### Related Issues

Fix #3932

### Proposed Changes:

Updates the Crawler docstring to reflect change in documentation.

### Notes for the reviewer

Documentation has already been updated.

See [this Colab notebook](https://colab.research.google.com/drive/1b05bB2-SjVtjY3mrECKL0MbZOS1jgDMa?usp=sharing) to test it out.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
