### PR TITLE
ci: do not run `launch_es` in the CI

### DIFF
--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -21,6 +21,15 @@ jobs:
   tests:
       name: Examples
       runs-on: ubuntu-latest
+      services:
+        elasticsearch:
+          image: elasticsearch:7.17.6
+          env:
+            discovery.type: "single-node"
+            ES_JAVA_OPTS: "-Xms128m -Xmx256m"
+          ports:
+            - 9200:9200
+
       steps:
         - uses: actions/checkout@v3
 

--- a/examples/basic_faq_pipeline.py
+++ b/examples/basic_faq_pipeline.py
@@ -13,8 +13,6 @@ from haystack.pipelines import Pipeline
 
 
 def basic_faq_pipeline():
-
-    launch_es()
     document_store = ElasticsearchDocumentStore(
         host="localhost",
         username="",
@@ -68,4 +66,5 @@ def basic_faq_pipeline():
 
 
 if __name__ == "__main__":
+    launch_es()
     basic_faq_pipeline()

--- a/examples/basic_qa_pipeline.py
+++ b/examples/basic_qa_pipeline.py
@@ -14,9 +14,6 @@ from haystack.pipelines import Pipeline
 
 
 def basic_qa_pipeline():
-    # launch and create DocumentStore
-    launch_es()
-
     # Initialize a DocumentStore
     document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="document")
 
@@ -73,4 +70,5 @@ def basic_qa_pipeline():
 
 
 if __name__ == "__main__":
+    launch_es()
     basic_qa_pipeline()


### PR DESCRIPTION
### Related Issues
- fixes flakyness in example tests

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
move the call to `launch_es` in the `main` function of the script, so that it won't be called from the tests.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
