### PR TITLE
Simplifies and fix docker images tests on release

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -50,14 +50,16 @@ jobs:
       - name: Test base images
         run: |
           EXPECTED_VERSION=$(cat VERSION.txt)
-          VERSION=$(docker run --rm deepset/haystack:base-cpu-${{ steps.meta.outputs.version }} --platform linux/amd64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
-          VERSION=$(docker run --rm deepset/haystack:base-gpu-${{ steps.meta.outputs.version }} --platform linux/amd64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
-          VERSION=$(docker run --rm deepset/haystack:base-cpu-${{ steps.meta.outputs.version }} --platform linux/arm64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
-          VERSION=$(docker run --rm deepset/haystack:base-gpu-${{ steps.meta.outputs.version }} --platform linux/arm64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
+          function test_image {
+            local TAG=$1
+            local PLATFORM=$2
+            local VERSION=$(docker run --platform $PLATFORM --rm deepset/haystack:$TAG python -c"import haystack; print(haystack.__version__)")
+            [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
+          }
+          test_image base-cpu-${{ steps.meta.outputs.version }} linux/amd64
+          test_image base-gpu-${{ steps.meta.outputs.version }} linux/amd64
+          test_image base-cpu-${{ steps.meta.outputs.version }} linux/arm64
+          test_image base-gpu-${{ steps.meta.outputs.version }} linux/arm64
 
       - name: Build api images
         uses: docker/bake-action@v2
@@ -110,4 +112,4 @@ jobs:
           sleep 15s
           EXPECTED_VERSION=$(cat VERSION.txt)
           VERSION=$(curl http://localhost:8000/hs_version | jq .hs_version)
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
+          [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in REST API image is different from expected'"


### PR DESCRIPTION
### Proposed Changes:

Simplifies the docker images testing using a bash function and making it clearer what's the cause of the failure.

Also fixes an issue that was causing tests to always fail. 
The `--platform` flag of the `docker run` command was set after the image name making it part of the command to run in the image instead of an option of the `docker run` command. 

### How did you test it?

I ran the bash script locally, final test will be running in CI.

### Notes for the reviewer

This will fix `docker_release.yml` failures in `main` like [this one](https://github.com/deepset-ai/haystack/actions/runs/4025115208/jobs/6917929038).

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
