### PR TITLE
Missing import for `TransformersImageToText`

### DIFF
--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -21,6 +21,7 @@ from haystack.nodes.file_converter import (
     ParsrConverter,
     CsvTextConverter,
 )
+from haystack.nodes.image_to_text import TransformersImageToText
 from haystack.nodes.label_generator import PseudoLabelGenerator
 from haystack.nodes.other import Docs2Answers, JoinDocuments, RouteDocuments, JoinAnswers, DocumentMerger
 from haystack.nodes.preprocessor import BasePreProcessor, PreProcessor


### PR DESCRIPTION
### Related Issues
n/a

### Proposed Changes:
Allow users to import `TransformersImageToText` as `fro,m haystack.nodes import TransformersImageToText`

### How did you test it?
n/a

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
