### PR TITLE
ci: Delete Docker images after testing to prevent workflow failure

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -55,6 +55,8 @@ jobs:
             local PLATFORM=$2
             local VERSION=$(docker run --platform $PLATFORM --rm deepset/haystack:$TAG python -c"import haystack; print(haystack.__version__)")
             [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
+            # Remove image after test to avoid filling the GitHub runner and prevent its failure
+            docker rmi deepset/haystack:$TAG
           }
           test_image base-cpu-${{ steps.meta.outputs.version }} linux/amd64
           test_image base-gpu-${{ steps.meta.outputs.version }} linux/amd64


### PR DESCRIPTION
### Related Issues

N/A 

### Proposed Changes:

Remove Haystack Docker image after testing it to prevent GtiHub runner to fail because there is no space left.
See [this workflow run](https://github.com/deepset-ai/haystack/actions/runs/4044500130) as an example.

### How did you test it?

Can't test it.

### Notes for the reviewer

N/A

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
