### PR TITLE
fix: prevent posthog from sending errors to stderr

### DIFF
--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -31,8 +31,11 @@ user_id: Optional[str] = None
 logger = logging.getLogger(__name__)
 
 # disable posthog logging
-logging.getLogger("posthog").setLevel(CRITICAL)
-logging.getLogger("backoff").setLevel(CRITICAL)
+for module_name in ["posthog", "backoff"]:
+    logging.getLogger(module_name).setLevel(CRITICAL)
+    # Prevent module from sending errors to stderr when an exception is encountered during an emit() call
+    logging.getLogger(module_name).addHandler(logging.NullHandler())
+    logging.getLogger(module_name).propagate = False
 
 
 class TelemetryFileType(Enum):


### PR DESCRIPTION
### Related Issues
- fixes #3994

### Proposed Changes:
So far, we were just setting the log level of posthog to CRITICAL. With this PR we now also add a handler to the posthog logger that prevents it from from sending errors to stderr when an exception is encountered during an emit() call. Further, we prevent posthog from propagating any log messages to loggers higher in the chain.

### How did you test it?
I changed the url in telemetry.py that is `posthog.host = "https://tm.hs.deepset.ai"` to `"https://tm.hs.deepset.ai/services"` to trigger a 403 error (503 should work just the same).

### Notes for the reviewer
As an alternative, there is a module-wide setting that prevents any module from sending errors that happen in logging to stderr. It's documented here: https://docs.python.org/3/howto/logging.html#exceptions-raised-during-logging
```python
import logging
logging.raiseExceptions = False
```
It's recommend to set this for production use but we would expect Haystack users to set it themselves when they use Haystack and configure their logging. For example, when they run the first three lines as in our tutorials:
```python
import logging
logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
logging.getLogger("haystack").setLevel(logging.INFO)
```
The downside of the alternative of using `logging.raiseExceptions` is that it affects all other modules if Haystack is used as a library. That's the same reason why we removed any logging configuration from Haystack: https://github.com/deepset-ai/haystack/pull/2848

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
