### PR TITLE
refactor: remove dummy vectors in weaviate

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -50,14 +50,16 @@ jobs:
       - name: Test base images
         run: |
           EXPECTED_VERSION=$(cat VERSION.txt)
-          VERSION=$(docker run --rm deepset/haystack:base-cpu-${{ steps.meta.outputs.version }} --platform linux/amd64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
-          VERSION=$(docker run --rm deepset/haystack:base-gpu-${{ steps.meta.outputs.version }} --platform linux/amd64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
-          VERSION=$(docker run --rm deepset/haystack:base-cpu-${{ steps.meta.outputs.version }} --platform linux/arm64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
-          VERSION=$(docker run --rm deepset/haystack:base-gpu-${{ steps.meta.outputs.version }} --platform linux/arm64 python -c"import haystack; print(haystack.__version__)")
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
+          function test_image {
+            local TAG=$1
+            local PLATFORM=$2
+            local VERSION=$(docker run --platform $PLATFORM --rm deepset/haystack:$TAG python -c"import haystack; print(haystack.__version__)")
+            [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
+          }
+          test_image base-cpu-${{ steps.meta.outputs.version }} linux/amd64
+          test_image base-gpu-${{ steps.meta.outputs.version }} linux/amd64
+          test_image base-cpu-${{ steps.meta.outputs.version }} linux/arm64
+          test_image base-gpu-${{ steps.meta.outputs.version }} linux/arm64
 
       - name: Build api images
         uses: docker/bake-action@v2
@@ -110,4 +112,4 @@ jobs:
           sleep 15s
           EXPECTED_VERSION=$(cat VERSION.txt)
           VERSION=$(curl http://localhost:8000/hs_version | jq .hs_version)
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]]
+          [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in REST API image is different from expected'"

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -466,7 +466,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
         """
         Add new documents to the DocumentStore.
 
-        :param documents: List of `Dicts` or List of `Documents`. A dummy embedding vector for each document is automatically generated if it is not provided. The document id needs to be in uuid format. Otherwise a correctly formatted uuid will be automatically generated based on the provided id.
+        :param documents: List of `Dicts` or List of `Documents`. The document id needs to be in uuid format. Otherwise a correctly formatted uuid will be automatically generated based on the provided id.
         :param index: index name for storing the docs and metadata
         :param batch_size: When working with large number of documents, batching can help reduce memory footprint.
         :param duplicate_documents: Handle duplicates document based on parameter options.

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -510,21 +510,6 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             documents=document_objects, index=index, duplicate_documents=duplicate_documents
         )
 
-        # Weaviate requires that documents contain a vector in order to be indexed. These lines add a
-        # dummy vector so that indexing can still happen
-        dummy_embed_warning_raised = False
-        for do in document_objects:
-            if do.embedding is None:
-                dummy_embedding = np.random.rand(self.embedding_dim).astype(np.float32)
-                do.embedding = dummy_embedding
-                if not dummy_embed_warning_raised:
-                    logger.warning(
-                        "No embedding found in Document object being written into Weaviate. A dummy "
-                        "embedding is being supplied so that indexing can still take place. This "
-                        "embedding should be overwritten in order to perform vector similarity searches."
-                    )
-                    dummy_embed_warning_raised = True
-
         batched_documents = get_batches_from_generator(document_objects, batch_size)
         with tqdm(total=len(document_objects), disable=not self.progress_bar) as progress_bar:
             for document_batch in batched_documents:

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -531,7 +531,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                     doc_id = str(_doc.pop("id"))
                     vector = _doc.pop(self.embedding_field)
 
-                    if self.similarity == "cosine":
+                    if self.similarity == "cosine" and vector is not None:
                         self.normalize_embedding(vector)
 
                     # Converting content to JSON-string as Weaviate doesn't allow other nested list for tables

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -55,9 +55,8 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
             documents.append(
                 Document(
                     id=get_uuid(),
-                    content=f"A Baz Document {i}",
-                    meta={"name": f"name_{i}", "month": "03"},
-                    embedding=np.random.rand(768).astype(np.float32),
+                    content=f"A Baz Document {i} without embeddings",
+                    meta={"name": f"name_{i}", "month": "03", "no_embedding": "True"}
                 )
             )
 

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -56,7 +56,7 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
                 Document(
                     id=get_uuid(),
                     content=f"A Baz Document {i} without embeddings",
-                    meta={"name": f"name_{i}", "month": "03", "no_embedding": "True"}
+                    meta={"name": f"name_{i}", "month": "03", "no_embedding": "True"},
                 )
             )
 

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -260,4 +260,4 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         embeddings.
         """
         ds.write_documents(documents)
-        assert ds.get_embedding_count() == 9
+        assert ds.get_embedding_count() == 6

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -161,14 +161,16 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
     def test_query_by_embedding(self, ds, documents):
         ds.write_documents(documents)
 
+        documents_with_embeddings = [doc for doc in documents if not doc.meta.get("no_embedding")]
+
         docs = ds.query_by_embedding(np.random.rand(embedding_dim).astype(np.float32))
-        assert len(docs) == 9
+        assert len(docs) == len(documents_with_embeddings)
 
         docs = ds.query_by_embedding(np.random.rand(embedding_dim).astype(np.float32), top_k=1)
         assert len(docs) == 1
 
         docs = ds.query_by_embedding(np.random.rand(embedding_dim).astype(np.float32), filters={"name": ["name_1"]})
-        assert len(docs) == 3
+        assert len(docs) == len([doc for doc in documents_with_embeddings if doc.meta["name"] == "name_1"])
 
     @pytest.mark.integration
     def test_query(self, ds, documents):


### PR DESCRIPTION
### Related Issues
- fixes #4007

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Removed the dummy vector logic because weaviate can index documents without a vector

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated the document fixture to include a document without an embedding

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
