### PR TITLE
Remove double batching in retrieve_batch

### DIFF
--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1769,9 +1769,11 @@ class EmbeddingRetriever(DenseRetriever):
         if scale_score is None:
             scale_score = self.scale_score
 
-        query_embs: List[np.ndarray] = []
-        for batch in self._get_batches(queries=queries, batch_size=batch_size):
-            query_embs.extend(self.embed_queries(queries=batch))
+        # embed_queries is already batched within by batch_size
+        query_embs: np.ndarray = self.embed_queries(queries=queries)
+        batched_query_embs: List[np.ndarray] = []
+        for index in range(0, len(query_embs), batch_size):
+            batched_query_embs.extend(query_embs[index : index + batch_size])
         documents = document_store.query_by_embedding_batch(
             query_embs=query_embs, top_k=top_k, filters=filters, index=index, headers=headers, scale_score=scale_score
         )

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1075,7 +1075,7 @@ class TableTextRetriever(DenseRetriever):
         if scale_score is None:
             scale_score = self.scale_score
 
-        # embed_queries is already batched within by batch_size
+        # embed_queries is already batched within by batch_size, so no need to batch the input here
         query_embs: np.ndarray = self.embed_queries(queries=queries)
         batched_query_embs: List[np.ndarray] = []
         for i in range(0, len(query_embs), batch_size):
@@ -1776,7 +1776,7 @@ class EmbeddingRetriever(DenseRetriever):
         if scale_score is None:
             scale_score = self.scale_score
 
-        # embed_queries is already batched within by batch_size
+        # embed_queries is already batched within by batch_size, so no need to batch the input here
         query_embs: np.ndarray = self.embed_queries(queries=queries)
         batched_query_embs: List[np.ndarray] = []
         for i in range(0, len(query_embs), batch_size):

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1078,8 +1078,8 @@ class TableTextRetriever(DenseRetriever):
         # embed_queries is already batched within by batch_size
         query_embs: np.ndarray = self.embed_queries(queries=queries)
         batched_query_embs: List[np.ndarray] = []
-        for index in range(0, len(query_embs), batch_size):
-            batched_query_embs.extend(query_embs[index : index + batch_size])
+        for i in range(0, len(query_embs), batch_size):
+            batched_query_embs.extend(query_embs[i : i + batch_size])
         documents = document_store.query_by_embedding_batch(
             query_embs=batched_query_embs,
             top_k=top_k,
@@ -1779,8 +1779,8 @@ class EmbeddingRetriever(DenseRetriever):
         # embed_queries is already batched within by batch_size
         query_embs: np.ndarray = self.embed_queries(queries=queries)
         batched_query_embs: List[np.ndarray] = []
-        for index in range(0, len(query_embs), batch_size):
-            batched_query_embs.extend(query_embs[index : index + batch_size])
+        for i in range(0, len(query_embs), batch_size):
+            batched_query_embs.extend(query_embs[i : i + batch_size])
         documents = document_store.query_by_embedding_batch(
             query_embs=batched_query_embs,
             top_k=top_k,

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1075,11 +1075,18 @@ class TableTextRetriever(DenseRetriever):
         if scale_score is None:
             scale_score = self.scale_score
 
-        query_embs: List[np.ndarray] = []
-        for batch in self._get_batches(queries=queries, batch_size=batch_size):
-            query_embs.extend(self.embed_queries(queries=batch))
+        # embed_queries is already batched within by batch_size
+        query_embs: np.ndarray = self.embed_queries(queries=queries)
+        batched_query_embs: List[np.ndarray] = []
+        for index in range(0, len(query_embs), batch_size):
+            batched_query_embs.extend(query_embs[index : index + batch_size])
         documents = document_store.query_by_embedding_batch(
-            query_embs=query_embs, top_k=top_k, filters=filters, index=index, headers=headers, scale_score=scale_score
+            query_embs=batched_query_embs,
+            top_k=top_k,
+            filters=filters,
+            index=index,
+            headers=headers,
+            scale_score=scale_score,
         )
 
         return documents
@@ -1775,7 +1782,12 @@ class EmbeddingRetriever(DenseRetriever):
         for index in range(0, len(query_embs), batch_size):
             batched_query_embs.extend(query_embs[index : index + batch_size])
         documents = document_store.query_by_embedding_batch(
-            query_embs=query_embs, top_k=top_k, filters=filters, index=index, headers=headers, scale_score=scale_score
+            query_embs=batched_query_embs,
+            top_k=top_k,
+            filters=filters,
+            index=index,
+            headers=headers,
+            scale_score=scale_score,
         )
 
         return documents

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -195,7 +195,10 @@ def test_batch_retrieval_multiple_queries(retriever_with_docs, document_store_wi
     if not isinstance(retriever_with_docs, (BM25Retriever, FilterRetriever, TfidfRetriever)):
         document_store_with_docs.update_embeddings(retriever_with_docs)
 
+    orig_batch_size = retriever_with_docs.batch_size
+    retriever_with_docs.batch_size = 1
     res = retriever_with_docs.retrieve_batch(queries=["Who lives in Berlin?", "Who lives in New York?"])
+    retriever_with_docs.batch_size = orig_batch_size
 
     # Expected return type: list of lists of Documents
     assert isinstance(res, list)

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -172,6 +172,7 @@ def test_retrieval_empty_query(document_store: BaseDocumentStore):
     assert result[0]["documents"][0][0] == mock_document
 
 
+@pytest.mark.parametrize("retriever_with_docs", ["embedding", "dpr", "tfidf"], indirect=True)
 def test_batch_retrieval_single_query(retriever_with_docs, document_store_with_docs):
     if not isinstance(retriever_with_docs, (BM25Retriever, FilterRetriever, TfidfRetriever)):
         document_store_with_docs.update_embeddings(retriever_with_docs)
@@ -189,6 +190,7 @@ def test_batch_retrieval_single_query(retriever_with_docs, document_store_with_d
     assert res[0][0].meta["name"] == "filename1"
 
 
+@pytest.mark.parametrize("retriever_with_docs", ["embedding", "dpr", "tfidf"], indirect=True)
 def test_batch_retrieval_multiple_queries(retriever_with_docs, document_store_with_docs):
     if not isinstance(retriever_with_docs, (BM25Retriever, FilterRetriever, TfidfRetriever)):
         document_store_with_docs.update_embeddings(retriever_with_docs)

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -195,10 +195,7 @@ def test_batch_retrieval_multiple_queries(retriever_with_docs, document_store_wi
     if not isinstance(retriever_with_docs, (BM25Retriever, FilterRetriever, TfidfRetriever)):
         document_store_with_docs.update_embeddings(retriever_with_docs)
 
-    orig_batch_size = retriever_with_docs.batch_size
-    retriever_with_docs.batch_size = 1
     res = retriever_with_docs.retrieve_batch(queries=["Who lives in Berlin?", "Who lives in New York?"])
-    retriever_with_docs.batch_size = orig_batch_size
 
     # Expected return type: list of lists of Documents
     assert isinstance(res, list)


### PR DESCRIPTION
### Related Issues
- fixes #4012

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Following the suggestion laid out in issue #4012 I removed the extra loop and just call `embed_queries` directly since `embed_queries` already batches the queries inside the function. This removes the excessive tqdm printing and removes unnecessary double batching. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Reactivated existing unit tests for the embedding retriever. Reran the colab notebook provided in the issue and checked the printing is now a single tqdm bar. 
<img width="804" alt="Screenshot 2023-01-31 at 11 47 58" src="https://user-images.githubusercontent.com/10526848/215756342-e159bf9a-3513-4f0b-bb62-9c678a9c16a6.png">


### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
