### PR TITLE
ci: Automate release on PyPi

### DIFF
--- a/.github/config/pypi-release-slack-notification.yml
+++ b/.github/config/pypi-release-slack-notification.yml
@@ -1,0 +1,32 @@
+pretext: Triggered via {{eventName}} of {{env.VERSION}} by {{actor}}
+title: "Haystack PyPi release"
+
+text: |
+  <https://pypi.org/project/farm-haystack/{{env.VERSION}}/|PyPi release {{env.VERSION}}>
+
+  {{#if (eq jobStatus "SUCCESS")}}
+    Haystack {{env.VERSION}} has been released on PyPi :rocket:
+  {{else if (eq jobStatus "FAILURE")}}
+    {{icon jobStatus}} Haystack {{env.VERSION}} PyPi release failed! {{icon jobStatus}}
+  {{else if (eq jobStatus "CANCELLED")}}
+    {{icon jobStatus}} Haystack {{env.VERSION}} PyPi release has been cancelled! {{icon jobStatus}}
+  {{/if}}
+
+fallback: |-
+  Haystack {{env.VERSION}} PyPi release status: {{jobStatus}}
+
+footer: >-
+  <{{repositoryUrl}}|{{repositoryName}}> <{{workflowRunUrl}}|{{workflow}} #{{runNumber}}>
+
+colors:
+  success: "#5DADE2"
+  failure: "#884EA0"
+  cancelled: "#A569BD"
+  default: "#7D3C98"
+
+icons:
+  success: ":white_check_mark:"
+  failure: ":x:"
+  cancelled: ":interrobang:"
+  skipped: ":interrobang:"
+  default: ":interrobang:"

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,35 @@
+name: Project release on PyPi
+
+on:
+  tags:
+    - "v[0-9].[0-9]+.[0-9]+*"
+
+jobs:
+  release-on-pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Build Haystack
+        run: hatch build
+
+      - name: Publish on PyPi
+        env:
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
+        run: hatch publish -y
+
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()
+        uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+          channel: "#haystack"
+          config: .github/config/pypi-release-slack-notification.yml


### PR DESCRIPTION
### Related Issues

Partly fixes #3116.

### Proposed Changes:

Automate the build and PyPi publish steps of the release process, the workflow will be triggered each time a `v[0-9].[0-9]+.[0-9]+*` tag is pushed.

### How did you test it?

I didn't test the whole process as that would imply making a release, also there's close to nothing to test.
Though I tested that the Slack notifications would be sent as expected by using [a separate repository](https://github.com/silvanocerza/nodenode) with a similar `act10n/slack` config file.

### Notes for the reviewer

⚠️⚠️⚠️
`PYPI_API_TOKEN` secret must be set before merging this PR.
The secret must contain an [API token](https://pypi.org/help/#apitoken) of a user authorized to publish the project.
⚠️⚠️⚠️

The notifications received on Slack will be similar to this:

<img width="424" alt="Screenshot 2023-01-31 at 12 38 52" src="https://user-images.githubusercontent.com/3314350/215750775-b57a9280-e5f2-4daf-82c3-6541dc19b5f4.png">

Ideally in the future the success of this workflow will trigger the workflow that builds and release Docker images. This way we'll be able to install Haystack in the images using `pip`.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
