### PR TITLE
chore: add discord badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@
         <img alt="Jobs" src="https://img.shields.io/badge/Jobs-We're%20hiring-blue">
     </a>
         <a href="https://twitter.com/intent/follow?screen_name=deepset_ai">
-        <img alt="Twitter" src="https://img.shields.io/badge/follow-%40deepset_ai-1DA1F2?logo=twitter&style=social">
+        <img alt="Twitter" src="https://img.shields.io/badge/follow-%40deepset_ai-1DA1F2?logo=twitter">
+    </a>
+    <a href="https://discord.com/invite/qZxjM4bAHU">
+        <img alt="chat on Discord" src="https://img.shields.io/discord/993534733298450452?logo=discord">
     </a>
 </p>
 


### PR DESCRIPTION
### Related Issues
- No issue. Many badges could be added (YouTube channel etc.) but it shouldn't become a wall of badges. Discord invite link definitely makes sense in my opinion.

### Proposed Changes:
- add discord badge with invite link showing number of active users
- changed the style of the Twitter badge. I can also change it back if you want @TuanaCelik I changed it so that it's consistent with the style of all the other badges.

### How did you test it?
Tried it manually. Server id extracted from the desktop app.

<img width="1118" alt="image" src="https://user-images.githubusercontent.com/4181769/216082909-9d1e4d6f-e90b-437d-b25f-5c5fe1760018.png">

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
