### PR TITLE
ci: Add linting of workflow and related pre-commit hook

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels: ["cml"]

--- a/.github/actions/python_cache/action.yml
+++ b/.github/actions/python_cache/action.yml
@@ -6,9 +6,6 @@ inputs:
     description: 'prefix for the cache (to distinguish OS)'
     required: true
     default: 'linux'
-  pythonPath:
-    description: 'Python path to cache/restore'
-    required: true
   pythonVersion:
     description: 'Python version to use'
     required: true

--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -7,7 +7,6 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout this repo
         uses: actions/checkout@v3
 
@@ -19,7 +18,7 @@ jobs:
         shell: bash
         # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
         run: |
-          echo "::set-output name=current_release_minor::$(cat VERSION.txt | cut -d "." -f 1,2)"
+          echo "current_release_minor=$(cat VERSION.txt | cut -d "." -f 1,2)" >> $GITHUB_OUTPUT
 
       - name: Create new version branch
         run: |
@@ -31,7 +30,7 @@ jobs:
       - name: Bump version on main
         shell: bash
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout main
           cat VERSION.txt | awk -F. '/[0-9]+\./{$2++;print}' OFS=. | tee VERSION.txt

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -6,21 +6,19 @@ on:
     branches:
       - main
       # release branches have the form v1.9.x
-      - 'v[0-9].*[0-9].x'
-
+      - "v[0-9].*[0-9].x"
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout this repo
         uses: actions/checkout@v3
 
       - name: Set up Python 3.8.10
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -34,7 +32,7 @@ jobs:
         id: current-version
         shell: bash
         # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
-        run: echo "::set-output name=minor::$(cat VERSION.txt | cut -d "." -f 1,2)"
+        run: echo "minor=$(cat VERSION.txt | cut -d "." -f 1,2)" >> $GITHUB_OUTPUT
 
       - name: Sync docs with unstable release
         # Instead of putting more logic into the previous step, let's just assume that commits on `main`

--- a/.github/workflows/workflows_linting.yml
+++ b/.github/workflows/workflows_linting.yml
@@ -1,0 +1,19 @@
+name: Github workflows linter
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows"
+
+jobs:
+  lint-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+      - name: Run actionlint
+        run: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,9 @@ repos:
   hooks:
   - id: black-jupyter
 
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.6.23
+  hooks:
+  - id: actionlint
 
 # TODO we can make mypy and pylint run at this stage too, once their execution gets normalized


### PR DESCRIPTION
### Proposed Changes:

Add a pre-commit hook and a related workflow to run [`actionlint`](https://github.com/rhysd/actionlint), a static linter for Github Workflows .yaml files.

The hook will only run if any workflow file is edited, and only on those files.

The workflow will run only when a PR that edits a file in `.github/workflows` is edited, it will lint all workflow files.

### How did you test it?

I ran the hook locally.

### Notes for the reviewer

N/A

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
