### PR TITLE
ci: latest version of pylint is failing, ignore new errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,6 +298,7 @@ disable = [
   "unexpected-keyword-arg",
   "simplifiable-if-expression",
   "use-list-literal",
+  "broad-exception-raised",
 
   # To review later
   "cyclic-import",


### PR DESCRIPTION
### Related Issues
- CI is red on `main`

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Quick and dirty fix, let's just ignore the error (along with the many we already have 😢)

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
