### PR TITLE
ci: Fix pylint version to prevent crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,7 @@ dev = [
   "python-multipart",
   "psutil",
   # Linting
-  "pylint",
+  "pylint==2.15.10",
   # Code formatting
   "black[jupyter]==22.6.0",
   # Documentation


### PR DESCRIPTION
### Proposed Changes:

`pylint` version `2.16.0` crashes and is causing CI to fail repeatdly, PyCQA/pylint#8163 fixes the issue but has not been released yet.
So we fix `pylint` to `2.15.10` for the time being to keep CI from failing, we'll unfix it as soon as a new version that includes the fix is released. 