### PR TITLE
fix: make the crawler more robust on Windows

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -106,9 +106,7 @@ class Crawler(BaseComponent):
 
         if webdriver_options is None:
             webdriver_options = ["--headless", "--disable-gpu", "--disable-dev-shm-usage", "--single-process"]
-        else:
-            webdriver_options.append("--headless")
-
+        webdriver_options.append("--headless")
         if IS_ROOT or IN_WINDOWS:
             webdriver_options.append("--no-sandbox")
         if IN_WINDOWS:

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -98,7 +98,7 @@ class Crawler(BaseComponent):
                  3) ["--remote-debugging-port=9222"]
                     This option enables remote debug over HTTP.
             See [Chromium Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches/) for more details on the available options.
-            If your crawler fails, rasing a `selenium.WebDriverException`, this [Stack Overflow thread] can be helpful. Contains useful suggestions for webdriver_options.
+            If your crawler fails, rasing a `selenium.WebDriverException`, this [Stack Overflow thread](https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t) can be helpful. Contains useful suggestions for webdriver_options.
         """
         super().__init__()
 

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -95,7 +95,10 @@ class Crawler(BaseComponent):
                     and spawn a single process.
                  2) ["--no-sandbox"]
                     This option disables the sandbox, which is required for running Chrome as root.
-            See [Chrome Web Driver Options](https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.chrome.options) for more details.
+                 3) ["--remote-debugging-port=9222"]
+                    This option enables remote debug over HTTP.
+            See [Chromium Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches/) for more details on the available options.
+            If your crawler fails, rasing a `selenium.WebDriverException`, this [Stack Overflow thread] can be helpful. Contains useful suggestions for webdriver_options.
         """
         super().__init__()
 
@@ -108,9 +111,7 @@ class Crawler(BaseComponent):
             webdriver_options = ["--headless", "--disable-gpu", "--disable-dev-shm-usage", "--single-process"]
         webdriver_options.append("--headless")
         if IS_ROOT or IN_WINDOWS:
-            webdriver_options.append("--no-sandbox")
-        if IN_WINDOWS:
-            webdriver_options.append("--no--remote-debugging-port=9222")
+            webdriver_options.extend(["--no-sandbox", "--remote-debugging-port=9222"])
         if IN_COLAB or IN_AZUREML:
             webdriver_options.append("--disable-dev-shm-usage")
 


### PR DESCRIPTION
### Related Issues
- fixes #4002 

### Proposed Changes:
There is no single reason for the error reported in the issue. (`WebDriverException: unknown error: DevToolsActivePort file doesn't exist while trying to initiate Chrome Browser`)
It is a generic error.
However, in the [StackOverflow thread](https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t) suggested by @sjrl, there are several strategies to solve/mitigate these errors.

- I added some reasonable `webdriver_options` when running on Windows
- Little refactoring of the options code

### How did you test it?
CI


### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
