### PR TITLE
fix: Add PromptTemplate __repr__ method

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -173,6 +173,9 @@ class PromptTemplate(BasePromptTemplate, ABC):
             prompt_prepared: str = template.substitute(template_input)
             yield prompt_prepared
 
+    def __repr__(self):
+        return f"PromptTemplate(name={self.name}, prompt_text={self.prompt_text}, prompt_params={self.prompt_params})"
+
 
 class PromptModelInvocationLayer:
     """

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -54,7 +54,7 @@ def test_prompt_templates():
 def test_prompt_template_repr():
     p = PromptTemplate("t", "Here is variable $baz")
     desired_repr = "PromptTemplate(name=t, prompt_text=Here is variable $baz, prompt_params=['baz'])"
-    assert p.__repr__() == desired_repr
+    assert repr(p) == desired_repr
     assert str(p) == desired_repr
 
 

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -51,6 +51,14 @@ def test_prompt_templates():
     assert p.prompt_text == "Here is some fake template with variable $baz"
 
 
+def test_prompt_template_repr():
+    p = PromptTemplate("t", "Here is variable $baz")
+    desired_repr = "PromptTemplate(name=t, prompt_text=Here is variable $baz, prompt_params=['baz'])"
+    assert p.__repr__() == desired_repr
+    assert p.__str__() == desired_repr
+    assert str(p) == desired_repr
+
+
 def test_create_prompt_model():
     model = PromptModel("google/flan-t5-small")
     assert model.model_name_or_path == "google/flan-t5-small"

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -55,7 +55,6 @@ def test_prompt_template_repr():
     p = PromptTemplate("t", "Here is variable $baz")
     desired_repr = "PromptTemplate(name=t, prompt_text=Here is variable $baz, prompt_params=['baz'])"
     assert p.__repr__() == desired_repr
-    assert p.__str__() == desired_repr
     assert str(p) == desired_repr
 
 


### PR DESCRIPTION
### Related Issues
- no related issue

### Proposed Changes:
 Adds __repr__ method to PromptTemplate

### How did you test it?
Added a unit test

### Notes for the reviewer
See unit test

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
