### PR TITLE
fix: use correct count of outgoing edges in RayPipeline

### DIFF
--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -251,7 +251,7 @@ class RayPipeline(Pipeline):
             if "." in i:
                 [input_node_name, input_edge_name] = i.split(".")
                 assert "output_" in input_edge_name, f"'{input_edge_name}' is not a valid edge name."
-                outgoing_edges_input_node = self.graph.nodes[input_node_name]["component"].outgoing_edges
+                outgoing_edges_input_node = self.graph.nodes[input_node_name]["outgoing_edges"]
                 assert int(input_edge_name.split("_")[1]) <= outgoing_edges_input_node, (
                     f"Cannot connect '{input_edge_name}' from '{input_node_name}' as it only has "
                     f"{outgoing_edges_input_node} outgoing edge(s)."


### PR DESCRIPTION
### Related Issues
- fixes #4065

### Proposed Changes:
RayPipeline with a decision node fails.

Error message
```
File ~/.local/share/virtualenvs/llm_demo-hW1oTPAF/src/farm-haystack/haystack/pipelines/ray.py:255, in RayPipeline._add_ray_deployment_in_graph(self, handle, name, outgoing_edges, inputs)
    253     assert "output_" in input_edge_name, f"'{input_edge_name}' is not a valid edge name."
    254     outgoing_edges_input_node = self.graph.nodes[input_node_name]["component"].outgoing_edges
--> 255     assert int(input_edge_name.split("_")[1]) <= outgoing_edges_input_node, (
    256         f"Cannot connect '{input_edge_name}' from '{input_node_name}' as it only has "
    257         f"{outgoing_edges_input_node} outgoing edge(s)."
    258     )
    259 else:
    260     outgoing_edges_input_node = self.graph.nodes[i]["outgoing_edges"]

TypeError: '<=' not supported between instances of 'int' and 'RayServeSyncHandle'
```

This is clear by comparing the following two lines:
https://github.com/deepset-ai/haystack/blob/main/haystack/pipelines/ray.py#L260
and
https://github.com/deepset-ai/haystack/blob/main/haystack/pipelines/ray.py#L254

### How did you test it?
Running a RayPipeline with a decision node.

### Notes for the reviewer
None

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
