### PR TITLE
fix: Add inner query for mysql compatibility

### DIFF
--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -24,7 +24,7 @@ try:
         TypeDecorator,
     )
     from sqlalchemy.ext.declarative import declarative_base
-    from sqlalchemy.orm import relationship, sessionmaker
+    from sqlalchemy.orm import relationship, sessionmaker, aliased
     from sqlalchemy.sql import case, null
 except (ImportError, ModuleNotFoundError) as ie:
     from haystack.utils.import_utils import _optional_component_not_installed
@@ -688,7 +688,8 @@ class SQLDocumentStore(BaseDocumentStore):
             if ids:
                 document_ids_to_delete = document_ids_to_delete.filter(DocumentORM.id.in_(ids))
 
-            self.session.query(DocumentORM).filter(DocumentORM.id.in_(document_ids_to_delete)).delete(
+            inner_query = document_ids_to_delete.subquery()
+            self.session.query(DocumentORM).filter(DocumentORM.id.in_(aliased(inner_query))).delete(
                 synchronize_session=False
             )
 
@@ -736,7 +737,8 @@ class SQLDocumentStore(BaseDocumentStore):
             if ids:
                 label_ids_to_delete = label_ids_to_delete.filter(LabelORM.id.in_(ids))
 
-            self.session.query(LabelORM).filter(LabelORM.id.in_(label_ids_to_delete)).delete(synchronize_session=False)
+            inner_query = label_ids_to_delete.subquery()
+            self.session.query(LabelORM).filter(LabelORM.id.in_(aliased(inner_query))).delete(synchronize_session=False)
 
         self.session.commit()
 


### PR DESCRIPTION
### Related Issues
- fixes #3834

### Proposed Changes:
When we delete documents or labels in SQLDocumentStore, the inner SQL query is aliased now.
MYSQL doesn't allow queries where changes are made to a table that is referenced in an inner table [(stackoverflow)](https://stackoverflow.com/questions/4429319/you-cant-specify-target-table-for-update-in-from-clause).

Therefore, we now use an alias for the table in the inner query.

Before (simplified):
```sql
DELETE FROM document WHERE document.id IN (SELECT document.id 
FROM document 
WHERE document.`index` = %(index_1)s AND document.id IN (%(id_1_1)s))
```

After (simplified:
```sql
DELETE FROM document WHERE document.id IN 
	(SELECT document_inner_table.id FROM (SELECT * FROM document) AS document_inner_table
WHERE document_inner_table.`index` = %(index_1)s AND document_inner_table.id IN (%(id_1_1)s))
```

### How did you test it?
I manually changed the tests to use mysql and then ran `test_delete_documents_by_id` and `test_delete_labels_by_id` with milvus. Here are the commands that I used:

```
docker pull mysql
docker run --name mysql_for_milvus -p 3306:3306 -e MYSQL_ROOT_PASSWORD=123456 -d mysql:latest
docker ps -aqf "name=^mysql_for_milvus$"
docker exec -it 8466419a6757 bash
mysql -uroot -p'123456'
create database milvus;
```

and a small change needed in `TestMilvusDocumentStore`:

```python
class TestMilvusDocumentStore(DocumentStoreBaseTestAbstract):
    @pytest.fixture
    def ds(self, tmp_path):
        # db_url = f"sqlite:///{tmp_path}/haystack_test_milvus.db"
        db_url = "mysql+pymysql://root:123456@localhost:3306/milvus"
        return MilvusDocumentStore(sql_url=db_url, return_embedding=True)
```

In addition I used logging to inspect the generated SQL queries:
```python
import logging
logging.basicConfig()
logging.getLogger("sqlalchemy.engine").setLevel(logging.DEBUG)
```

### Notes for the reviewer
The linked issue only concerns the deletion of documents from MilvusDocumentStore with mysql but I found that also the deletion of labels is a problem and that any SQL-based DocumentStore would face the same problem with mysql.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
