### PR TITLE
feat: Add max_tokens to BaseGenerator params

### DIFF
--- a/haystack/nodes/answer_generator/base.py
+++ b/haystack/nodes/answer_generator/base.py
@@ -32,7 +32,7 @@ class BaseGenerator(BaseComponent):
         """
         pass
 
-    def run(
+    def run(  # type: ignore
         self,
         query: str,
         documents: List[Document],

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -193,6 +193,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         documents: List[Document],
         top_k: Optional[int] = None,
         timeout: Union[float, Tuple[float, float]] = OPENAI_TIMEOUT,
+        max_tokens: Optional[int] = None,
     ):
         """
         Use the loaded QA model to generate Answers for a query based on the Documents it receives.
@@ -218,6 +219,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         :param timeout: How many seconds to wait for the server to send data before giving up,
             as a float, or a :ref:`(connect timeout, read timeout) <timeouts>` tuple.
             Defaults to 10 seconds.
+        :param max_tokens: The maximum number of tokens allowed for the generated Answer.
         :return: Dictionary containing query and Answers.
         """
         if top_k is None:
@@ -233,7 +235,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         payload = {
             "model": self.model,
             "prompt": prompt,
-            "max_tokens": self.max_tokens,
+            "max_tokens": max_tokens or self.max_tokens,
             "stop": self.stop_words,
             "n": top_k,
             "temperature": self.temperature,

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -206,7 +206,9 @@ class RAGenerator(BaseGenerator):
 
         return embeddings_in_tensor.to(self.devices[0])
 
-    def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None) -> Dict:
+    def predict(
+        self, query: str, documents: List[Document], top_k: Optional[int] = None, max_tokens: Optional[int] = None
+    ) -> Dict:
         """
         Generate the answer to the input query. The generation will be conditioned on the supplied documents.
         These documents can for example be retrieved via the Retriever.
@@ -214,6 +216,7 @@ class RAGenerator(BaseGenerator):
         :param query: Query
         :param documents: Related documents (e.g. coming from a retriever) that the answer shall be conditioned on.
         :param top_k: Number of returned answers
+        :param max_tokens: Maximum number of tokens to generate
         :return: Generated answers plus additional infos in a dict like this:
 
         ```python
@@ -271,7 +274,7 @@ class RAGenerator(BaseGenerator):
             doc_scores=doc_scores,
             num_return_sequences=top_k,
             num_beams=self.num_beams,
-            max_length=self.max_length,
+            max_length=max_tokens or self.max_length,
             min_length=self.min_length,
             n_docs=len(flat_docs_dict["content"]),
         )
@@ -415,7 +418,9 @@ class Seq2SeqGenerator(BaseGenerator):
     def _get_converter(cls, model_name_or_path: str) -> Optional[Callable]:
         return cls._model_input_converters.get(model_name_or_path)
 
-    def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None) -> Dict:
+    def predict(
+        self, query: str, documents: List[Document], top_k: Optional[int] = None, max_tokens: Optional[int] = None
+    ) -> Dict:
         """
         Generate the answer to the input query. The generation will be conditioned on the supplied documents.
         These document can be retrieved via the Retriever or supplied directly via predict method.
@@ -423,6 +428,7 @@ class Seq2SeqGenerator(BaseGenerator):
         :param query: Query
         :param documents: Related documents (e.g. coming from a retriever) that the answer shall be conditioned on.
         :param top_k: Number of returned answers
+        :param max_tokens: Maximum number of tokens in the generated answer
         :return: Generated answers
 
         """
@@ -459,7 +465,7 @@ class Seq2SeqGenerator(BaseGenerator):
             input_ids=query_and_docs_encoded["input_ids"],
             attention_mask=query_and_docs_encoded["attention_mask"],
             min_length=self.min_length,
-            max_length=self.max_length,
+            max_length=max_tokens or self.max_length,
             do_sample=True if self.num_beams == 1 else False,
             early_stopping=True,
             num_beams=self.num_beams,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -287,7 +287,7 @@ class MockRetriever(BaseRetriever):
 
 
 class MockSeq2SegGenerator(BaseGenerator):
-    def predict(self, query: str, documents: List[Document], top_k: Optional[int]) -> Dict:
+    def predict(self, query: str, documents: List[Document], top_k: Optional[int], max_tokens: Optional[int]) -> Dict:
         pass
 
 


### PR DESCRIPTION
### Related Issues
- fixes #3797 

### Proposed Changes:
Allow per pipeline run invocation max_tokens parameter to be set. Currently, we only allow per-component max_tokens setting. Add max_tokens implementation for OpenAIAnswerGenerator, RagGenerator, and Seq2SeqGenerator.

### How did you test it?
Unit tests added for the bare component and the pipeline usage

### Notes for the reviewer
Ready for review

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
