### PR TITLE
ci: Fix pylint workflow check running on tests files

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           files: |
             **/*.py
+          files_ignore: |
+            test/**
+            rest_api/test/**
 
       - name: Setup Python
         uses: ./.github/actions/python_cache/


### PR DESCRIPTION
### Proposed Changes:

Ignore tests files in `pylint` workflow check.

### How did you test it?

Can't be tested.

### Notes for the reviewer

Fixes linting in PRs like [this failure here](https://github.com/deepset-ai/haystack/actions/runs/4105464145/jobs/7082357140).

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
