### PR TITLE
feat: Add BM25 support for tables in InMemoryDocumentStore

### DIFF
--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -972,7 +972,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         docs_scores = self.bm25[index].get_scores(tokenized_query)
         top_docs_positions = np.argsort(docs_scores)[::-1][:top_k]
 
-        textual_docs_list = [doc for doc in self.indexes[index].values() if doc.content_type == "text"]
+        textual_docs_list = [doc for doc in self.indexes[index].values() if doc.content_type in ["text", "table"]]
         top_docs = []
         for i in top_docs_positions:
             doc = textual_docs_list[i]

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional, Union, Generator
 
-import pandas as pd
-
 try:
     from typing import Literal
 except ImportError:
@@ -17,6 +15,7 @@ import numpy as np
 import torch
 from tqdm.auto import tqdm
 import rank_bm25
+import pandas as pd
 
 from haystack.schema import Document, FilterType, Label
 from haystack.errors import DuplicateDocumentError, DocumentStoreError

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -213,7 +213,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
                 textual_documents.append(doc.content.lower())
             elif doc.content_type == "table":
                 if isinstance(doc.content, pd.DataFrame):
-                    textual_documents.append(doc.content.to_csv(index=False).lower())
+                    textual_documents.append(doc.content.astype(str).to_csv(index=False).lower())
                 else:
                     raise DocumentStoreError("Documents of type 'table' need to have a pd.DataFrame as content field")
         if len(textual_documents) < len(all_documents):

--- a/test/document_stores/test_memory.py
+++ b/test/document_stores/test_memory.py
@@ -1,5 +1,6 @@
 import logging
 
+import pandas as pd
 import pytest
 from rank_bm25 import BM25
 
@@ -68,6 +69,19 @@ class TestInMemoryDocumentStore(DocumentStoreBaseTestAbstract):
     def test_update_bm25(self, documents):
         ds = InMemoryDocumentStore(use_bm25=False)
         ds.write_documents(documents)
+        ds.update_bm25()
+        bm25_representation = ds.bm25[ds.index]
+        assert isinstance(bm25_representation, BM25)
+        assert bm25_representation.corpus_size == ds.get_document_count()
+
+    @pytest.mark.integration
+    def test_update_bm25_table(self):
+        table_doc = Document(
+            content=pd.DataFrame(columns=["id", "text"], data=[["1", "This is a test"], ["2", "This is another test"]]),
+            content_type="table",
+        )
+        ds = InMemoryDocumentStore(use_bm25=False)
+        ds.write_documents([table_doc])
         ds.update_bm25()
         bm25_representation = ds.bm25[ds.index]
         assert isinstance(bm25_representation, BM25)

--- a/test/document_stores/test_memory.py
+++ b/test/document_stores/test_memory.py
@@ -66,23 +66,19 @@ class TestInMemoryDocumentStore(DocumentStoreBaseTestAbstract):
         assert set(ids) == result
 
     @pytest.mark.integration
-    def test_update_bm25(self, documents):
-        ds = InMemoryDocumentStore(use_bm25=False)
+    def test_update_bm25(self, ds, documents):
         ds.write_documents(documents)
-        ds.update_bm25()
         bm25_representation = ds.bm25[ds.index]
         assert isinstance(bm25_representation, BM25)
         assert bm25_representation.corpus_size == ds.get_document_count()
 
     @pytest.mark.integration
-    def test_update_bm25_table(self):
+    def test_update_bm25_table(self, ds):
         table_doc = Document(
-            content=pd.DataFrame(columns=["id", "text"], data=[["1", "This is a test"], ["2", "This is another test"]]),
+            content=pd.DataFrame(columns=["id", "text"], data=[[0, "This is a test"], ["2", "This is another test"]]),
             content_type="table",
         )
-        ds = InMemoryDocumentStore(use_bm25=False)
         ds.write_documents([table_doc])
-        ds.update_bm25()
         bm25_representation = ds.bm25[ds.index]
         assert isinstance(bm25_representation, BM25)
         assert bm25_representation.corpus_size == ds.get_document_count()


### PR DESCRIPTION
### Related Issues
- A test in #4048 is failing due to missing BM25 support for tables in `InMemoryDocumentStore`.

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds BM25 support for tables in `InMemoryDocumentStore` by converting them to strings using pandas' `to_csv` method.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added an integration test.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
