### PR TITLE
fix: TransformerTranslator.max_sequence_length cuts off documents

### DIFF
--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -144,6 +144,16 @@ class TransformersTranslator(BaseTranslator):
         else:
             text_for_translator: List[str] = [query]  # type: ignore
 
+        # avoid silent truncation if max_seq_len is not passed (or longer than model's max_len)
+        if self.max_seq_len is None or self.max_seq_len > self.tokenizer.model_max_length:
+            for text in text_for_translator:
+                token_ids = self.tokenizer.encode(text)
+                if len(token_ids) > self.tokenizer.model_max_length:
+                    logger.warning(f"The text passed for translation is longer than the model's max length. "
+                                   f"Model's limit: {self.tokenizer.model_max_length} tokens. "
+                                   f"Input's length: {len(token_ids) + 2} tokens.")
+                    break
+
         batch = self.tokenizer(
             text=text_for_translator,
             return_tensors="pt",

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -144,56 +144,29 @@ class TransformersTranslator(BaseTranslator):
         else:
             text_for_translator: List[str] = [query]  # type: ignore
 
+        # avoid silent truncation if max_seq_len is not passed (or longer than model's max_len)
+        if self.max_seq_len is None or self.max_seq_len > self.tokenizer.model_max_length:
+            for text in text_for_translator:
+                token_ids = self.tokenizer.encode(text)
+                if len(token_ids) > self.tokenizer.model_max_length:
+                    logger.warning(
+                        f"The text passed for translation is longer than the model's max length. "
+                        f"Consider using a Pipeline to pre-process your documents"
+                    )
+                    break
+
         batch = self.tokenizer(
-            text=text_for_translator, return_tensors="pt", max_length=self.max_seq_len, padding="longest"
+            text=text_for_translator,
+            return_tensors="pt",
+            max_length=self.max_seq_len,
+            padding="longest",
+            truncation=True,
         ).to(self.devices[0])
 
-        translated_texts = []
-        input_len = len(batch["input_ids"][0])
-        if input_len > self.tokenizer.model_max_length:
-            logger.warning(
-                f"The text passed for translation is longer than the model's max length. "
-                f"Model's limit: {self.tokenizer.model_max_length} tokens. "
-                f"Input's length: {input_len} tokens. "
-                f"The long text(s) will be cut in pieces and translated separately (it might affect "
-                f"the quality and the speed)"
-            )
-            for i in range(0, len(batch)):
-                ones = (batch["attention_mask"][i] == 1.0).sum(dim=0).item()
-                if ones <= self.tokenizer.model_max_length:
-                    generated_output = self.model.generate(
-                        input_ids=batch["input_ids"][i], attention_mask=batch["attention_mask"][i]
-                    )
-                    translated_text = self.tokenizer.batch_decode(
-                        generated_output,
-                        skip_special_tokens=True,
-                        clean_up_tokenization_spaces=self.clean_up_tokenization_spaces,
-                    )
-                    translated_texts.append(translated_text)
-                else:
-                    # todo: check? better? apply attention mask - multiply?
-                    input_ids = batch["input_ids"][i][:ones][:-1]  # assume only right padding is used
-                    split_input = input_ids.split(self.tokenizer.model_max_length - 2)
-
-                    # todo: batch at least the split part
-                    for sp in split_input:
-                        sp = torch.cat((sp, torch.tensor([self.tokenizer.eos_token_id], dtype=torch.int64)), dim=0)
-
-                        generated_output = self.model.generate(sp)
-
-                        translated_text = self.tokenizer.batch_decode(
-                            generated_output,
-                            skip_special_tokens=True,
-                            clean_up_tokenization_spaces=self.clean_up_tokenization_spaces,
-                        )
-                        translated_texts.append(translated_text)
-        else:
-            generated_output = self.model.generate(**batch)
-            translated_texts = self.tokenizer.batch_decode(
-                generated_output,
-                skip_special_tokens=True,
-                clean_up_tokenization_spaces=self.clean_up_tokenization_spaces,
-            )
+        generated_output = self.model.generate(**batch)
+        translated_texts = self.tokenizer.batch_decode(
+            generated_output, skip_special_tokens=True, clean_up_tokenization_spaces=self.clean_up_tokenization_spaces
+        )
 
         if queries_for_translator is not None and answers_for_translator is not None:
             return translated_texts


### PR DESCRIPTION
### Related Issues
- fixes #3471 

### Proposed Changes:
Adds a warning in case there is no max_seq_len passed but one of the texts for translation is longer than the model's limit

### How did you test it?
Manual verification 

### Notes for the reviewer
It currently involves calling the tokenizer twice: to check the number of sentencepiece tokens and later to encode the batch adding special tokens and padding. I could make batches by hand to avoid calling tokenizer twice but wasn't sure a warning is worth so much code (and potential bugs). For chopping encoded tokens, I'd do it.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
