### PR TITLE
feat: OpenAI - warn users if `max_tokens` is too short

### DIFF
--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -200,11 +200,13 @@ class OpenAIAnswerGenerator(BaseGenerator):
             raise openai_error
 
         number_of_truncated_answers = sum(1 for ans in res["choices"] if ans["finish_reason"] == "length")
-        if number_of_truncated_answers>0:
+        if number_of_truncated_answers > 0:
             logger.warning(
                 "%s out of the %s answers have been truncated before reaching a natural stopping point."
                 "Consider increasing the max_tokens parameter to allow for longer answers.",
-                number_of_truncated_answers, top_k)
+                number_of_truncated_answers,
+                top_k,
+            )
 
         generated_answers = [ans["text"] for ans in res["choices"]]
         answers = self._create_answers(generated_answers, input_docs)

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -199,13 +199,12 @@ class OpenAIAnswerGenerator(BaseGenerator):
                 )
             raise openai_error
 
-        for ans in res["choices"]:
-            if ans["finish_reason"] == "length":
-                logger.warning(
-                    "At least one of the answers has been truncated before reaching a natural stopping point."
-                    "Consider increasing max_tokens parameter to produce better answers."
-                )
-                break
+        number_of_truncated_answers = sum(1 for ans in res["choices"] if ans["finish_reason"] == "length")
+        if number_of_truncated_answers>0:
+            logger.warning(
+                "%s out of the %s answers have been truncated before reaching a natural stopping point."
+                "Consider increasing the max_tokens parameter to allow for longer answers.",
+                number_of_truncated_answers, top_k)
 
         generated_answers = [ans["text"] for ans in res["choices"]]
         answers = self._create_answers(generated_answers, input_docs)

--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -69,7 +69,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         :param model: ID of the engine to use for generating the answer. You can select one of `"text-ada-001"`,
                      `"text-babbage-001"`, `"text-curie-001"`, or `"text-davinci-002"`
                      (from worst to best and from cheapest to most expensive). For more information about the models,
-                     refer to the [OpenAI Documentation](https://beta.openai.com/docs/models/gpt-3).
+                     refer to the [OpenAI Documentation](https://platform.openai.com/docs/models/gpt-3).
         :param max_tokens: The maximum number of tokens allowed for the generated Answer.
         :param top_k: Number of generated Answers.
         :param temperature: What sampling temperature to use. Higher values mean the model will take more risks and
@@ -199,6 +199,14 @@ class OpenAIAnswerGenerator(BaseGenerator):
                 )
             raise openai_error
 
+        for ans in res["choices"]:
+            if ans["finish_reason"] == "length":
+                logger.warning(
+                    "At least one of the answers has been truncated before reaching a natural stopping point."
+                    "Consider increasing max_tokens parameter to produce better answers."
+                )
+                break
+
         generated_answers = [ans["text"] for ans in res["choices"]]
         answers = self._create_answers(generated_answers, input_docs)
         result = {"query": query, "answers": answers}
@@ -222,7 +230,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         n_docs_tokens = [self._count_tokens(doc.content) for doc in documents]
         logger.debug("Number of tokens in documents: %s", n_docs_tokens)
 
-        # for length restrictions of prompt see: https://beta.openai.com/docs/api-reference/completions/create#completions/create-max_tokens
+        # for length restrictions of prompt see: https://platform.openai.com/docs/api-reference/completions/create#completions/create-max_tokens
         leftover_token_len = self.MAX_TOKENS_LIMIT - n_instruction_tokens - self.max_tokens
 
         # Add as many Documents as context as fit into the model

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -379,7 +379,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
 class OpenAIInvocationLayer(PromptModelInvocationLayer):
     """
     PromptModelInvocationLayer implementation for OpenAI's GPT-3 InstructGPT models. Invocations are made using REST API.
-    See [OpenAI GPT-3](https://beta.openai.com/docs/models/gpt-3) for more details.
+    See [OpenAI GPT-3](https://platform.openai.com/docs/models/gpt-3) for more details.
 
     Note: kwargs other than init parameter names are ignored to enable reflective construction of the class
     as many variants of PromptModelInvocationLayer are possible and they may have different parameters.
@@ -399,13 +399,13 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
         kwargs. Only the kwargs relevant to OpenAIInvocationLayer are considered. The list of OpenAI-relevant
         kwargs includes: suffix, temperature, top_p, presence_penalty, frequency_penalty, best_of, n, max_tokens,
         logit_bias, stop, echo, and logprobs. For more details about these kwargs, see OpenAI
-        [documentation](https://beta.openai.com/docs/api-reference/completions/create).
+        [documentation](https://platform.openai.com/docs/api-reference/completions/create).
 
         """
         super().__init__(model_name_or_path, max_length)
         if not isinstance(api_key, str) or len(api_key) == 0:
             raise OpenAIError(
-                f"api_key {api_key} must be a valid OpenAI key. Visit https://beta.openai.com/ to get one."
+                f"api_key {api_key} must be a valid OpenAI key. Visit https://openai.com/api/ to get one."
             )
         self.api_key = api_key
         self.url = "https://api.openai.com/v1/completions"
@@ -443,7 +443,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
         :return: The responses are being returned.
 
         Note: Only kwargs relevant to OpenAI are passed to OpenAI rest API. Others kwargs are ignored.
-        For more details, see OpenAI [documentation](https://beta.openai.com/docs/api-reference/completions/create).
+        For more details, see OpenAI [documentation](https://platform.openai.com/docs/api-reference/completions/create).
         """
         prompt = kwargs.get("prompt")
         if not prompt:
@@ -491,6 +491,14 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
                     status_code=response.status_code,
                 )
             raise openai_error
+
+        for ans in res["choices"]:
+            if ans["finish_reason"] == "length":
+                logger.warning(
+                    "At least one of the completions has been truncated before reaching a natural stopping point."
+                    "Consider increasing max_tokens parameter to produce better completions."
+                )
+                break
 
         responses = [ans["text"].strip() for ans in res["choices"]]
         return responses

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -492,13 +492,12 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
                 )
             raise openai_error
 
-        for ans in res["choices"]:
-            if ans["finish_reason"] == "length":
-                logger.warning(
-                    "At least one of the completions has been truncated before reaching a natural stopping point."
-                    "Consider increasing max_tokens parameter to produce better completions."
-                )
-                break
+        number_of_truncated_completions = sum(1 for ans in res["choices"] if ans["finish_reason"] == "length")
+        if number_of_truncated_completions>0:
+            logger.warning(
+                "%s out of the %s completions have been truncated before reaching a natural stopping point."
+                "Consider increasing the max_tokens parameter to allow for longer completions.",
+                number_of_truncated_completions, payload["n"])            
 
         responses = [ans["text"].strip() for ans in res["choices"]]
         return responses

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -493,11 +493,13 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
             raise openai_error
 
         number_of_truncated_completions = sum(1 for ans in res["choices"] if ans["finish_reason"] == "length")
-        if number_of_truncated_completions>0:
+        if number_of_truncated_completions > 0:
             logger.warning(
                 "%s out of the %s completions have been truncated before reaching a natural stopping point."
                 "Consider increasing the max_tokens parameter to allow for longer completions.",
-                number_of_truncated_completions, payload["n"])            
+                number_of_truncated_completions,
+                payload["n"],
+            )
 
         responses = [ans["text"].strip() for ans in res["choices"]]
         return responses

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -260,7 +260,7 @@ def test_open_ai_warn_if_max_tokens_is_too_short(caplog):
     optional_davinci_params = {"temperature": 0.5, "max_tokens": 2, "top_p": 1, "frequency_penalty": 0.5}
     with caplog.at_level(logging.WARNING):
         _ = pn.prompt("question-generation", documents=["Berlin is the capital of Germany."], **optional_davinci_params)
-        assert "Consider increasing max_tokens parameter to produce better completions." in caplog.text
+        assert "Consider increasing the max_tokens parameter to allow for longer completions." in caplog.text
 
 
 @pytest.mark.integration

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -249,6 +249,11 @@ def test_open_ai_prompt_with_params():
     assert len(r) == 1 and len(r[0]) > 0
 
 
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
 def test_open_ai_warn_if_max_tokens_is_too_short(caplog):
     pm = PromptModel("text-davinci-003", api_key=os.environ["OPENAI_API_KEY"])
     pn = PromptNode(pm)

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Optional, Union, List, Dict, Any, Tuple
 
 import pytest
@@ -246,6 +247,15 @@ def test_open_ai_prompt_with_params():
     optional_davinci_params = {"temperature": 0.5, "max_tokens": 10, "top_p": 1, "frequency_penalty": 0.5}
     r = pn.prompt("question-generation", documents=["Berlin is the capital of Germany."], **optional_davinci_params)
     assert len(r) == 1 and len(r[0]) > 0
+
+
+def test_open_ai_warn_if_max_tokens_is_too_short(caplog):
+    pm = PromptModel("text-davinci-003", api_key=os.environ["OPENAI_API_KEY"])
+    pn = PromptNode(pm)
+    optional_davinci_params = {"temperature": 0.5, "max_tokens": 2, "top_p": 1, "frequency_penalty": 0.5}
+    with caplog.at_level(logging.WARNING):
+        _ = pn.prompt("question-generation", documents=["Berlin is the capital of Germany."], **optional_davinci_params)
+        assert "Consider increasing max_tokens parameter to produce better completions." in caplog.text
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues
- fixes #4069

### Proposed Changes:
As specified in #4069, if the `finish_reason` in the OpenAI response is `"length"`,
the completion is probably truncated.
We want to print a warning that suggests increasing the `max_tokens` parameter.

### How did you test it?
Added a new test.
(I didn't verify it locally, because I don't have OpenAI credits :smiley:) 

### Notes for the reviewer
Also updated some old URLs

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [X] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
