### PR TITLE
ci: Fix pylint CI check running with no files

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -53,5 +53,6 @@ jobs:
         uses: ./.github/actions/python_cache/
 
       - name: Pylint
+        if: steps.files.outputs.any_changed == 'true'
         run: |
           pylint -ry -j 0 ${{ steps.files.outputs.all_changed_files }}


### PR DESCRIPTION
### Proposed Changes:

Skip `pylint` if there are no modified files to check. This is the same approach used in the `mypy` check.

### How did you test it?

Can't test.

### Notes for the reviewer

This is a corner case that would happen in a PR that modifies a `pyproject.toml` file without editing any `*.py` files. See #4088 as an example.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue~
