### PR TITLE
ci: Add missing env vars in rest_api CI tests

### DIFF
--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -81,11 +81,15 @@ jobs:
           pip install .
 
       - name: Run tests
+        env:
+          PYTEST_PARAMS: --maxfail=5 --durations=10 --suppress-no-test-exit-code
         run: |
           pytest ${{ env.PYTEST_PARAMS }} rest_api/
 
       - uses: act10ns/slack@v2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
           channel: "#haystack"
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        if: failure() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
### Proposed Changes:

Add missing env vars in `rest_api_tests.yml`.

### How did you test it?

Can't be tested.

### Notes for the reviewer

We moved `rest_api` from `tests.yml` with #4086 but I forgot to also move the env vars used by those tests. 

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
