### PR TITLE
fix: query filters in REST API

### DIFF
--- a/rest_api/rest_api/controller/search.py
+++ b/rest_api/rest_api/controller/search.py
@@ -1,6 +1,5 @@
 from typing import Dict, Any
 
-from collections.abc import Mapping
 import logging
 import time
 import json
@@ -65,16 +64,6 @@ def _process_request(pipeline, request) -> Dict[str, Any]:
     start_time = time.time()
 
     params = request.params or {}
-
-    # format global, top-level filters (e.g. "params": {"filters": {"name": ["some"]}})
-    if "filters" in params.keys():
-        params["filters"] = _format_filters(params["filters"])
-
-    # format targeted node filters (e.g. "params": {"Retriever": {"filters": {"value"}}})
-    for key in params.keys():
-        if isinstance(params[key], Mapping) and "filters" in params[key].keys():
-            params[key]["filters"] = _format_filters(params[key]["filters"])
-
     result = pipeline.run(query=request.query, params=params, debug=request.debug)
 
     # Ensure answers and documents exist, even if they're empty lists
@@ -87,39 +76,3 @@ def _process_request(pipeline, request) -> Dict[str, Any]:
         json.dumps({"request": request, "response": result, "time": f"{(time.time() - start_time):.2f}"}, default=str)
     )
     return result
-
-
-def _format_filters(filters):
-    """
-    Adjust filters to compliant format:
-    Put filter values into a list and remove filters with null value.
-    """
-    new_filters = {}
-    if filters is None:
-        logger.warning(
-            "Request with deprecated filter format ('\"filters\": null'). "
-            "Remove empty filters from params to be compliant with future versions"
-        )
-    else:
-        for key, values in filters.items():
-            if values is None:
-                logger.warning(
-                    "Request with deprecated filter format ('%s: null'). "
-                    "Remove null values from filters to be compliant with future versions",
-                    key,
-                )
-                continue
-
-            if not isinstance(values, list):
-                logger.warning(
-                    "Request with deprecated filter format ('%s': %s). "
-                    "Change to '%s':[%s]' to be compliant with future versions",
-                    key,
-                    values,
-                    key,
-                    values,
-                )
-                values = [values]
-
-            new_filters[key] = values
-    return new_filters

--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -358,19 +358,6 @@ def test_query_with_filter_list(client):
         mocked_pipeline.run.assert_called_with(query=TEST_QUERY, params=params, debug=False)
 
 
-def test_query_with_deprecated_filter_format(client):
-    request_params = {"TestRetriever": {"filters": {"test_key": "i_should_be_a_list"}}}
-    expected_params = {"TestRetriever": {"filters": {"test_key": ["i_should_be_a_list"]}}}
-    with mock.patch("rest_api.controller.search.query_pipeline") as mocked_pipeline:
-        # `run` must return a dictionary containing a `query` key
-        mocked_pipeline.run.return_value = {"query": TEST_QUERY}
-        response = client.post(url="/query", json={"query": TEST_QUERY, "params": request_params})
-        assert 200 == response.status_code
-        # Ensure `run` was called with the expected parameters. In this case,
-        # `_format_filters` will fix the `filters` format within the params
-        mocked_pipeline.run.assert_called_with(query=TEST_QUERY, params=expected_params, debug=False)
-
-
 def test_query_with_no_documents_and_no_answers(client):
     with mock.patch("rest_api.controller.search.query_pipeline") as mocked_pipeline:
         # `run` must return a dictionary containing a `query` key


### PR DESCRIPTION
### Issue

Query filters for date types are currently not working on the REST API. 

For instance, the query below 
```json
{
    "query": "blah",
    "params": {
        "filters": {
            "date": {
                "$gte": "2013-09-11",
                "$lt": "2015-08-31"
            }
        }
    }
}
```

gets the date filter clause typecasted as a list by `_format_filters()`:
```python
{'date': [{'$gte': '2013-09-11', '$lt': '2015-08-31'}]}
```

This breaks things downstream in the construction of the OpenSearch query with the `ComparisonOperation`.




### Proposed Changes:
This PR removes the `_format_filters()` method entirely as its legacy code. 

In addition, it would ease maintenance & documentation if we keep the Pipeline & REST API filter format consistent. 

### How did you test it?
None as I could not find an integration test suite for the REST API that could cover this case.

### Notes for the reviewer
I'm not sure if it has implications for filtering other data types.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
