### PR TITLE
refactor: `InMemoryDocumentStore` - manage documents without embedding & fix mypy errors

### DIFF
--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -309,13 +309,16 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         :param documents_to_search: List of documents to compare `query_emb` against.
         """
         query_emb_tensor = torch.tensor(query_emb, dtype=torch.float).to(self.main_device)
-        if len(query_emb_tensor.shape) == 1:
+        if query_emb_tensor.ndim == 1:
             query_emb_tensor = query_emb_tensor.unsqueeze(dim=0)
 
         doc_embeds = np.array([doc.embedding for doc in documents_to_search])
         doc_embeds_tensor = torch.as_tensor(doc_embeds, dtype=torch.float)
-        if len(doc_embeds_tensor.shape) == 1 and doc_embeds_tensor.shape[0] == 0:
-            return []
+        if doc_embeds_tensor.ndim == 1:
+            # if there are no embeddings, return an empty list
+            if doc_embeds_tensor.shape[0] == 0:
+                return []
+            doc_embeds_tensor = doc_embeds_tensor.unsqueeze(dim=0)
 
         if self.similarity == "cosine":
             # cosine similarity is just a normed dot product
@@ -347,12 +350,15 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         :param query_emb: Embedding of the query (e.g. gathered from DPR)
         :param documents_to_search: List of documents to compare `query_emb` against.
         """
-        if len(query_emb.shape) == 1:
-            query_emb = np.expand_dims(query_emb, 0)
+        if query_emb.ndim == 1:
+            query_emb = np.expand_dims(a=query_emb, axis=0)
 
         doc_embeds = np.array([doc.embedding for doc in documents_to_search])
-        if len(doc_embeds.shape) == 1 and doc_embeds.shape[0] == 0:
-            return []
+        if doc_embeds.ndim == 1:
+            # if there are no embeddings, return an empty list
+            if doc_embeds.shape[0] == 0:
+                return []
+            doc_embeds = np.expand_dims(a=doc_embeds, axis=0)
 
         if self.similarity == "cosine":
             # cosine similarity is just a normed dot product

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -285,7 +285,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self,
         ids: List[str],
         index: Optional[str] = None,
-        batch_size: int = 10_000,
+        batch_size: Optional[int] = None,
         headers: Optional[Dict[str, str]] = None,
     ) -> List[Document]:
         """
@@ -293,8 +293,10 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         """
         if headers:
             raise NotImplementedError("InMemoryDocumentStore does not support headers.")
-        if batch_size != 10_000:
-            raise ValueError("InMemoryDocumentStore does not support batching.")
+        if batch_size:
+            logger.warning(
+                "InMemoryDocumentStore does not support batching in `get_documents_by_id` method. This parameter is ignored."
+            )
         index = index or self.index
         documents = [self.indexes[index][id] for id in ids]
         return documents

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -301,7 +301,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         documents = [self.indexes[index][id] for id in ids]
         return documents
 
-    def get_scores_torch(self, query_emb: np.ndarray, documents_to_search: List[Document]) -> List[float]:
+    def _get_scores_torch(self, query_emb: np.ndarray, documents_to_search: List[Document]) -> List[float]:
         """
         Calculate similarity scores between query embedding and a list of documents using torch.
 
@@ -343,7 +343,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
 
         return scores
 
-    def get_scores_numpy(self, query_emb: np.ndarray, documents_to_search: List[Document]) -> List[float]:
+    def _get_scores_numpy(self, query_emb: np.ndarray, documents_to_search: List[Document]) -> List[float]:
         """
         Calculate similarity scores between query embedding and a list of documents using numpy.
 
@@ -374,11 +374,11 @@ class InMemoryDocumentStore(KeywordDocumentStore):
 
         return scores
 
-    def get_scores(self, query_emb: np.ndarray, documents_to_search: List[Document]) -> List[float]:
+    def _get_scores(self, query_emb: np.ndarray, documents_to_search: List[Document]) -> List[float]:
         if self.main_device.type == "cuda":
-            scores = self.get_scores_torch(query_emb, documents_to_search)
+            scores = self._get_scores_torch(query_emb, documents_to_search)
         else:
-            scores = self.get_scores_numpy(query_emb, documents_to_search)
+            scores = self._get_scores_numpy(query_emb, documents_to_search)
 
         return scores
 
@@ -481,7 +481,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
                 "Skipping some of your documents that don't have embeddings. "
                 "To generate embeddings, run the document store's update_embeddings() method."
             )
-        scores = self.get_scores(query_emb, documents_with_embeddings)
+        scores = self._get_scores(query_emb, documents_with_embeddings)
 
         candidate_docs = []
         for doc, score in zip(documents_with_embeddings, scores):

--- a/test/document_stores/test_memory.py
+++ b/test/document_stores/test_memory.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from rank_bm25 import BM25
+import numpy as np
 
 from haystack.document_stores.memory import InMemoryDocumentStore
 from haystack.schema import Document
@@ -102,3 +103,15 @@ class TestInMemoryDocumentStore(DocumentStoreBaseTestAbstract):
         for docs, query_emb in zip(docs_batch, query_embs):
             assert len(docs) == 5
             assert (docs[0].embedding == query_emb).all()
+
+    @pytest.mark.integration
+    def test_memory_query_by_embedding_docs_wo_embeddings(self, ds, caplog):
+        # write document but don't update embeddings
+        ds.write_documents([Document(content="test Document")])
+
+        query_embedding = np.random.rand(768).astype(np.float32)
+
+        with caplog.at_level(logging.WARNING):
+            docs = ds.query_by_embedding(query_emb=query_embedding, top_k=1)
+            assert "Skipping some of your documents that don't have embeddings" in caplog.text
+        assert len(docs) == 0


### PR DESCRIPTION
### Related Issues
- fixes #4080

### Proposed Changes:
- implement @bogdankostic's proposal: 
> ignoring the Documents without embeddings during retrieval. (We should probably print a warning message for this case.) 
- remove mypy ignore comments and fix the errors
- fix `get_scores_numpy `and `get_scores_torch` methods (there were some errors also pointed out by mypy)

### How did you test it?
- CI
- added new test for documents without embeddings

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [X] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
