### PR TITLE
fix: Deduplicate same Documents in isolated evaluation of Reader

### DIFF
--- a/haystack/nodes/reader/base.py
+++ b/haystack/nodes/reader/base.py
@@ -118,7 +118,8 @@ class BaseReader(BaseComponent):
 
         # run evaluation with labels as node inputs
         if add_isolated_node_eval and labels is not None:
-            relevant_documents = [label.document for label in labels.labels]
+            # This dict comprehension deduplicates same Documents in a MultiLabel based on their Document ID
+            relevant_documents = list({label.document.id: label.document for label in labels.labels}.values())
             # Filter out empty documents
             relevant_documents = [d for d in relevant_documents if d.content.strip() != ""]
             results_label_input = predict(query=query, documents=relevant_documents, top_k=top_k)

--- a/haystack/nodes/reader/base.py
+++ b/haystack/nodes/reader/base.py
@@ -118,10 +118,13 @@ class BaseReader(BaseComponent):
 
         # run evaluation with labels as node inputs
         if add_isolated_node_eval and labels is not None:
-            # This dict comprehension deduplicates same Documents in a MultiLabel based on their Document ID
-            relevant_documents = list({label.document.id: label.document for label in labels.labels}.values())
-            # Filter out empty documents
-            relevant_documents = [d for d in relevant_documents if d.content.strip() != ""]
+            # This dict comprehension deduplicates same Documents in a MultiLabel based on their Document ID and
+            # filters out empty documents
+            relevant_documents = list(
+                {
+                    label.document.id: label.document for label in labels.labels if label.document.content.strip() != ""
+                }.values()
+            )
             results_label_input = predict(query=query, documents=relevant_documents, top_k=top_k)
 
             # Add corresponding document_name and more meta data, if an answer contains the document_id
@@ -175,10 +178,15 @@ class BaseReader(BaseComponent):
         if add_isolated_node_eval and labels is not None:
             relevant_documents = []
             for labelx in labels:
-                # Filter out empty documents
-                relevant_docs_labelx = [
-                    label.document for label in labelx.labels if label.document.content.strip() != ""
-                ]
+                # This dict comprehension deduplicates same Documents in a MultiLabel based on their Document ID
+                # and filters out empty documents
+                relevant_docs_labelx = list(
+                    {
+                        label.document.id: label.document
+                        for label in labelx.labels
+                        if label.document.content.strip() != ""
+                    }.values()
+                )
                 relevant_documents.append(relevant_docs_labelx)
             results_label_input = predict_batch(queries=queries, documents=relevant_documents, top_k=top_k)
 

--- a/haystack/nodes/reader/base.py
+++ b/haystack/nodes/reader/base.py
@@ -120,11 +120,14 @@ class BaseReader(BaseComponent):
         if add_isolated_node_eval and labels is not None:
             # This dict comprehension deduplicates same Documents in a MultiLabel based on their Document ID and
             # filters out empty documents
-            relevant_documents = list(
-                {
-                    label.document.id: label.document for label in labels.labels if label.document.content.strip() != ""
-                }.values()
-            )
+            # relevant_documents = list(
+            #     {
+            #         label.document.id: label.document for label in labels.labels if label.document.content.strip() != ""
+            #     }.values()
+            # )
+            relevant_documents = [label.document for label in labels.labels]
+            # Filter out empty documents
+            relevant_documents = [d for d in relevant_documents if d.content.strip() != ""]
             results_label_input = predict(query=query, documents=relevant_documents, top_k=top_k)
 
             # Add corresponding document_name and more meta data, if an answer contains the document_id

--- a/haystack/nodes/reader/base.py
+++ b/haystack/nodes/reader/base.py
@@ -120,14 +120,11 @@ class BaseReader(BaseComponent):
         if add_isolated_node_eval and labels is not None:
             # This dict comprehension deduplicates same Documents in a MultiLabel based on their Document ID and
             # filters out empty documents
-            # relevant_documents = list(
-            #     {
-            #         label.document.id: label.document for label in labels.labels if label.document.content.strip() != ""
-            #     }.values()
-            # )
-            relevant_documents = [label.document for label in labels.labels]
-            # Filter out empty documents
-            relevant_documents = [d for d in relevant_documents if d.content.strip() != ""]
+            relevant_documents = list(
+                {
+                    label.document.id: label.document for label in labels.labels if label.document.content.strip() != ""
+                }.values()
+            )
             results_label_input = predict(query=query, documents=relevant_documents, top_k=top_k)
 
             # Add corresponding document_name and more meta data, if an answer contains the document_id

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -1775,5 +1775,3 @@ def test_empty_documents_dont_fail_pipeline(reader, retriever_with_docs):
         .iloc[0]
         == ""
     )
-
-    # test

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import sys
+from copy import deepcopy
 from haystack.document_stores.memory import InMemoryDocumentStore
 from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.nodes.preprocessor import PreProcessor
@@ -1267,7 +1268,7 @@ def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriev
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
-    labels = EVAL_LABELS.copy()
+    labels = deepcopy(EVAL_LABELS)
     labels[0].labels.append(
         Label(
             query="Who lives in Berlin?",

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -299,17 +299,7 @@ EVAL_LABELS = [
                 is_correct_answer=True,
                 is_correct_document=True,
                 origin="gold-label",
-            ),
-            Label(
-                query="Who lives in Munich?",
-                answer=Answer(answer="Carl", offsets_in_context=[Span(11, 15)]),
-                document=Document(
-                    id="something_else", content_type="text", content="My name is Carla and I live in Munich"
-                ),
-                is_correct_answer=True,
-                is_correct_document=True,
-                origin="gold-label",
-            ),
+            )
         ]
     ),
 ]
@@ -1277,9 +1267,24 @@ def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriev
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
+    labels = EVAL_LABELS.copy()
+    labels[0].labels.append(
+        Label(
+            query="Who lives in Berlin?",
+            answer=Answer(answer="I", offsets_in_context=[Span(21, 22)]),
+            document=Document(
+                id="a0747b83aea0b60c4b114b15476dd32d",
+                content_type="text",
+                content="My name is Carla and I live in Berlin",
+            ),
+            is_correct_answer=True,
+            is_correct_document=True,
+            origin="gold-label",
+        )
+    )
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval(
-        labels=EVAL_LABELS,
+        labels=labels,
         sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
         add_isolated_node_eval=True,
     )
@@ -1305,7 +1310,7 @@ def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
     # Check if same Document in MultiLabel got deduplicated
     reader_eval_df = eval_result.node_results["Reader"]
     isolated_reader_eval_df = reader_eval_df[reader_eval_df["eval_mode"] == "isolated"]
-    assert len(isolated_reader_eval_df) == len(EVAL_LABELS) * reader.top_k_per_candidate
+    assert len(isolated_reader_eval_df) == len(labels) * reader.top_k_per_candidate
 
 
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -285,19 +285,7 @@ EVAL_LABELS = [
                 is_correct_answer=True,
                 is_correct_document=True,
                 origin="gold-label",
-            ),
-            Label(
-                query="Who lives in Berlin?",
-                answer=Answer(answer="I", offsets_in_context=[Span(21, 22)]),
-                document=Document(
-                    id="a0747b83aea0b60c4b114b15476dd32d",
-                    content_type="text",
-                    content="My name is Carla and I live in Berlin",
-                ),
-                is_correct_answer=True,
-                is_correct_document=True,
-                origin="gold-label",
-            ),
+            )
         ]
     ),
     MultiLabel(
@@ -311,7 +299,17 @@ EVAL_LABELS = [
                 is_correct_answer=True,
                 is_correct_document=True,
                 origin="gold-label",
-            )
+            ),
+            Label(
+                query="Who lives in Munich?",
+                answer=Answer(answer="Carl", offsets_in_context=[Span(11, 15)]),
+                document=Document(
+                    id="something_else", content_type="text", content="My name is Carla and I live in Munich"
+                ),
+                is_correct_answer=True,
+                is_correct_document=True,
+                origin="gold-label",
+            ),
         ]
     ),
 ]

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -1775,3 +1775,5 @@ def test_empty_documents_dont_fail_pipeline(reader, retriever_with_docs):
         .iloc[0]
         == ""
     )
+
+    # test

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -285,7 +285,19 @@ EVAL_LABELS = [
                 is_correct_answer=True,
                 is_correct_document=True,
                 origin="gold-label",
-            )
+            ),
+            Label(
+                query="Who lives in Berlin?",
+                answer=Answer(answer="I", offsets_in_context=[Span(21, 22)]),
+                document=Document(
+                    id="a0747b83aea0b60c4b114b15476dd32d",
+                    content_type="text",
+                    content="My name is Carla and I live in Berlin",
+                ),
+                is_correct_answer=True,
+                is_correct_document=True,
+                origin="gold-label",
+            ),
         ]
     ),
     MultiLabel(
@@ -1291,6 +1303,11 @@ def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
     assert metrics_top_1["Reader"]["exact_match"] == 1.0
     assert metrics_top_1["Reader"]["f1"] == 1.0
     assert metrics_top_1["Reader"]["sas"] == pytest.approx(1.0, abs=1e-4)
+
+    # Check if same Document in MultiLabel got deduplicated
+    reader_eval_df = eval_result.node_results["Reader"]
+    isolated_reader_eval_df = reader_eval_df[reader_eval_df["eval_mode"] == "isolated"]
+    assert len(isolated_reader_eval_df) == len(EVAL_LABELS) * reader.top_k_per_candidate
 
 
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -607,9 +607,24 @@ def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriev
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
+    labels = EVAL_LABELS.copy()
+    labels[0].labels.append(
+        Label(
+            query="Who lives in Berlin?",
+            answer=Answer(answer="I", offsets_in_context=[Span(21, 22)]),
+            document=Document(
+                id="a0747b83aea0b60c4b114b15476dd32d",
+                content_type="text",
+                content="My name is Carla and I live in Berlin",
+            ),
+            is_correct_answer=True,
+            is_correct_document=True,
+            origin="gold-label",
+        )
+    )
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval_batch(
-        labels=EVAL_LABELS,
+        labels=labels,
         sas_model_name_or_path="sentence-transformers/paraphrase-MiniLM-L3-v2",
         add_isolated_node_eval=True,
     )
@@ -635,7 +650,7 @@ def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
     # Check if same Document in MultiLabel got deduplicated
     reader_eval_df = eval_result.node_results["Reader"]
     isolated_reader_eval_df = reader_eval_df[reader_eval_df["eval_mode"] == "isolated"]
-    assert len(isolated_reader_eval_df) == len(EVAL_LABELS) * reader.top_k_per_candidate
+    assert len(isolated_reader_eval_df) == len(labels) * reader.top_k_per_candidate
 
 
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -632,6 +632,11 @@ def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
     assert metrics_top_1["Reader"]["f1"] == 1.0
     assert metrics_top_1["Reader"]["sas"] == pytest.approx(1.0, abs=1e-4)
 
+    # Check if same Document in MultiLabel got deduplicated
+    reader_eval_df = eval_result.node_results["Reader"]
+    isolated_reader_eval_df = reader_eval_df[reader_eval_df["eval_mode"] == "isolated"]
+    assert len(isolated_reader_eval_df) == len(EVAL_LABELS) * reader.top_k_per_candidate
+
 
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 import sys
+from copy import deepcopy
 from haystack.document_stores.memory import InMemoryDocumentStore
 from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.nodes.preprocessor import PreProcessor
@@ -607,7 +608,7 @@ def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriev
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
-    labels = EVAL_LABELS.copy()
+    labels = deepcopy(EVAL_LABELS)
     labels[0].labels.append(
         Label(
             query="Who lives in Berlin?",

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -609,20 +609,10 @@ def test_extractive_qa_eval_simulated_top_k_reader_and_retriever(reader, retriev
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
     labels = deepcopy(EVAL_LABELS)
-    labels[0].labels.append(
-        Label(
-            query="Who lives in Berlin?",
-            answer=Answer(answer="I", offsets_in_context=[Span(21, 22)]),
-            document=Document(
-                id="a0747b83aea0b60c4b114b15476dd32d",
-                content_type="text",
-                content="My name is Carla and I live in Berlin",
-            ),
-            is_correct_answer=True,
-            is_correct_document=True,
-            origin="gold-label",
-        )
-    )
+    # Copy one of the labels and change only the answer have a label with a different answer but same Document
+    label_copy = deepcopy(labels[0].labels[0])
+    label_copy.answer = Answer(answer="I", offsets_in_context=[Span(21, 22)])
+    labels[0].labels.append(label_copy)
     pipeline = ExtractiveQAPipeline(reader=reader, retriever=retriever_with_docs)
     eval_result: EvaluationResult = pipeline.eval_batch(
         labels=labels,
@@ -649,6 +639,7 @@ def test_extractive_qa_eval_isolated(reader, retriever_with_docs):
     assert metrics_top_1["Reader"]["sas"] == pytest.approx(1.0, abs=1e-4)
 
     # Check if same Document in MultiLabel got deduplicated
+    assert labels[0].labels[0].id == labels[0].labels[1].id
     reader_eval_df = eval_result.node_results["Reader"]
     isolated_reader_eval_df = reader_eval_df[reader_eval_df["eval_mode"] == "isolated"]
     assert len(isolated_reader_eval_df) == len(labels) * reader.top_k_per_candidate


### PR DESCRIPTION
### Related Issues
- fixes #4092

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR reverts a change introduced in #3773. In this PR, we make sure to deduplicate same Documents in a MultiLabel based on their Document ID when doing isolated evaluation of Reader nodes.

Also, we were missing deduplication in `ran_batch`, so added it there as well.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I adapted `EVAL_LABELS` by adding a second `Label` using the same Document but a different Answer span. I added a check to `test_extractive_qa_eval_isolated` to check that the number of produced predictions does not exceed top_k_per_candidate.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
