### PR TITLE
ci: Add workflow to label PRs that edit docstrings

### DIFF
--- a/.github/utils/docstrings_checksum.py
+++ b/.github/utils/docstrings_checksum.py
@@ -31,8 +31,13 @@ def docstrings_checksum(python_files: Generator[Path, None, None]):
 
 if __name__ == "__main__":
     # Get all Haystack and rest_api python files
-    root = Path(".").absolute().parent.parent
-    python_files = root.glob("+(haystack|rest_api)/**/*.py")
+    root = Path(__file__).parent.parent.parent
+    haystack_files = root.glob("haystack/**/*.py")
+    rest_api_files = root.glob("rest_api/**/*.py")
+
+    import itertools
+
+    python_files = itertools.chain(haystack_files, rest_api_files)
 
     md5 = docstrings_checksum(python_files)
     print(md5)

--- a/.github/utils/docstrings_checksum.py
+++ b/.github/utils/docstrings_checksum.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-from typing import Generator
+from typing import Iterator
 
 import ast
 import hashlib
 
 
-def docstrings_checksum(python_files: Generator[Path, None, None]):
+def docstrings_checksum(python_files: Iterator[Path]):
     files_content = (f.read_text() for f in python_files)
     trees = (ast.parse(c) for c in files_content)
 

--- a/.github/utils/docstrings_checksum.py
+++ b/.github/utils/docstrings_checksum.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Generator
+
+import ast
+import hashlib
+
+
+def docstrings_checksum(python_files: Generator[Path, None, None]):
+    files_content = (f.read_text() for f in python_files)
+    trees = (ast.parse(c) for c in files_content)
+
+    # Get all docstrings from async functions, functions,
+    # classes and modules definitions
+    docstrings = []
+    for tree in trees:
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.ClassDef, ast.Module)):
+                # Skip all node types that can't have docstrings to prevent failures
+                continue
+            docstring = ast.get_docstring(node)
+            if docstring:
+                docstrings.append(docstring)
+
+    # Sort them to be safe, since ast.walk() returns
+    # nodes in no specified order.
+    # See https://docs.python.org/3/library/ast.html#ast.walk
+    docstrings.sort()
+
+    return hashlib.md5(str(docstrings).encode("utf-8")).hexdigest()
+
+
+if __name__ == "__main__":
+    # Get all Haystack and rest_api python files
+    root = Path(".").absolute().parent.parent
+    python_files = root.glob("+(haystack|rest_api)/**/*.py")
+
+    md5 = docstrings_checksum(python_files)
+    print(md5)

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -3,7 +3,8 @@ name: Add label on docstrings edit
 on:
   pull_request:
     paths:
-      - "**.py"
+      - "haystack/**/*.py"
+      - "rest_api/**/*.py"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -65,4 +65,4 @@ jobs:
         if: ${{ steps.run-check.outputs.should_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit --add-label "type:documentation"
+        run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "type:documentation"

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -1,0 +1,63 @@
+name: Add label on docstrings edit
+
+on:
+  pull_request:
+    paths:
+      - "**.py"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  base-docstrings:
+    runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.docstrings.outputs.checksum }}
+
+    steps:
+      - name: Checkout base commit
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+
+      - name: Get docstrings
+        id: docstrings
+        run: |
+          CHECKSUM=$(python .github/utils/docstrings_checksum.py)
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+
+  head-docstrings:
+    runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.docstrings.outputs.checksum }}
+
+    steps:
+      - name: Checkout HEAD commit
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+
+      - name: Get docstrings
+        id: docstrings
+        run: |
+          CHECKSUM=$(python .github/utils/docstrings_checksum.py)
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+
+  label:
+    runs-on: ubuntu-latest
+    needs: [base-docstrings, head-docstrings]
+
+    steps:
+      - name: Check if we should label
+        id: run-check
+        run: echo "should_run=${{ needs.base-docstrings.outputs.checksum != needs.head-docstrings.outputs.checksum }}" >> "$GITHUB_OUTPUT"
+
+      - name: Add label
+        if: ${{ steps.run-check.outputs.should_run }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit --add-label "type:documentation"

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -10,10 +10,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  base-docstrings:
+  label:
     runs-on: ubuntu-latest
-    outputs:
-      checksum: ${{ steps.docstrings.outputs.checksum }}
 
     steps:
       - name: Checkout base commit
@@ -27,39 +25,23 @@ jobs:
           python-version: "3.11"
 
       - name: Get docstrings
-        id: docstrings
+        id: base-docstrings
         run: |
           CHECKSUM=$(python .github/utils/docstrings_checksum.py)
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
-  head-docstrings:
-    runs-on: ubuntu-latest
-    outputs:
-      checksum: ${{ steps.docstrings.outputs.checksum }}
-
-    steps:
       - name: Checkout HEAD commit
         uses: actions/checkout@v3
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
       - name: Get docstrings
-        id: docstrings
+        id: head-docstrings
         run: |
           CHECKSUM=$(python .github/utils/docstrings_checksum.py)
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
-  label:
-    runs-on: ubuntu-latest
-    needs: [base-docstrings, head-docstrings]
-
-    steps:
       - name: Check if we should label
         id: run-check
-        run: echo "should_run=${{ needs.base-docstrings.outputs.checksum != needs.head-docstrings.outputs.checksum }}" >> "$GITHUB_OUTPUT"
+        run: echo "should_run=${{ steps.base-docstrings.outputs.checksum != steps.head-docstrings.outputs.checksum }}" >> "$GITHUB_OUTPUT"
 
       - name: Add label
         if: ${{ steps.run-check.outputs.should_run == 'true' }}

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -62,7 +62,7 @@ jobs:
         run: echo "should_run=${{ needs.base-docstrings.outputs.checksum != needs.head-docstrings.outputs.checksum }}" >> "$GITHUB_OUTPUT"
 
       - name: Add label
-        if: ${{ steps.run-check.outputs.should_run }}
+        if: ${{ steps.run-check.outputs.should_run == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit ${{ github.event.pull_request.html_url }} --add-label "type:documentation"

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: Get docstrings
         id: docstrings
@@ -40,6 +42,8 @@ jobs:
 
       - name: Setup Python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: Get docstrings
         id: docstrings


### PR DESCRIPTION
### Related Issues

- fixes #3967

### Proposed Changes:

This PR introduces a new workflow that will run for every PR and labels them if there's been any docstrings edit.

### How did you test it?

I ran the `docstrings_checksum.py` script locally. We'll test the workflow later.

### Notes for the reviewer

I'll probably create a follow-up PR that edits a random docstring and use this as base to verify the workflow behaviour.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
