### PR TITLE
test: Added integration test for using EntityExtractor in query pipeline

### DIFF
--- a/test/nodes/test_extractor.py
+++ b/test/nodes/test_extractor.py
@@ -4,22 +4,32 @@ from haystack.nodes import TextConverter
 from haystack.nodes.retriever.sparse import BM25Retriever
 from haystack.nodes.reader import FARMReader
 from haystack.pipelines import Pipeline
+from haystack import Document
 
 from haystack.nodes.extractor import EntityExtractor, simplify_ner_for_qa
 
 from ..conftest import SAMPLES_PATH
 
 
+@pytest.fixture
+def tiny_reader():
+    return FARMReader(model_name_or_path="deepset/tinyroberta-squad2", num_processes=0)
+
+
+@pytest.fixture
+def ner_node():
+    return EntityExtractor(model_name_or_path="elastic/distilbert-base-cased-finetuned-conll03-english")
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_extractor(document_store_with_docs):
+def test_extractor(document_store_with_docs, tiny_reader, ner_node):
     es_retriever = BM25Retriever(document_store=document_store_with_docs)
-    ner = EntityExtractor(model_name_or_path="elastic/distilbert-base-cased-finetuned-conll03-english")
-    reader = FARMReader(model_name_or_path="deepset/tinyroberta-squad2", num_processes=0)
 
     pipeline = Pipeline()
     pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=ner, name="NER", inputs=["ESRetriever"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["NER"])
+    pipeline.add_node(component=ner_node, name="NER", inputs=["ESRetriever"])
+    pipeline.add_node(component=tiny_reader, name="Reader", inputs=["NER"])
 
     prediction = pipeline.run(
         query="Who lives in Berlin?", params={"ESRetriever": {"top_k": 1}, "Reader": {"top_k": 1}}
@@ -29,16 +39,15 @@ def test_extractor(document_store_with_docs):
     assert "Berlin" in entities
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_extractor_batch_single_query(document_store_with_docs):
+def test_extractor_batch_single_query(document_store_with_docs, tiny_reader, ner_node):
     es_retriever = BM25Retriever(document_store=document_store_with_docs)
-    ner = EntityExtractor(model_name_or_path="elastic/distilbert-base-cased-finetuned-conll03-english")
-    reader = FARMReader(model_name_or_path="deepset/tinyroberta-squad2", num_processes=0)
 
     pipeline = Pipeline()
     pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=ner, name="NER", inputs=["ESRetriever"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["NER"])
+    pipeline.add_node(component=ner_node, name="NER", inputs=["ESRetriever"])
+    pipeline.add_node(component=tiny_reader, name="Reader", inputs=["NER"])
 
     prediction = pipeline.run_batch(
         queries=["Who lives in Berlin?"], params={"ESRetriever": {"top_k": 1}, "Reader": {"top_k": 1}}
@@ -48,16 +57,15 @@ def test_extractor_batch_single_query(document_store_with_docs):
     assert "Berlin" in entities
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_extractor_batch_multiple_queries(document_store_with_docs):
+def test_extractor_batch_multiple_queries(document_store_with_docs, tiny_reader, ner_node):
     es_retriever = BM25Retriever(document_store=document_store_with_docs)
-    ner = EntityExtractor(model_name_or_path="elastic/distilbert-base-cased-finetuned-conll03-english")
-    reader = FARMReader(model_name_or_path="deepset/tinyroberta-squad2", num_processes=0)
 
     pipeline = Pipeline()
     pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=ner, name="NER", inputs=["ESRetriever"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["NER"])
+    pipeline.add_node(component=ner_node, name="NER", inputs=["ESRetriever"])
+    pipeline.add_node(component=tiny_reader, name="Reader", inputs=["NER"])
 
     prediction = pipeline.run_batch(
         queries=["Who lives in Berlin?", "Who lives in New York?"],
@@ -71,16 +79,15 @@ def test_extractor_batch_multiple_queries(document_store_with_docs):
     assert "New York" in entities_paul
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
-def test_extractor_output_simplifier(document_store_with_docs):
+def test_extractor_output_simplifier(document_store_with_docs, tiny_reader, ner_node):
     es_retriever = BM25Retriever(document_store=document_store_with_docs)
-    ner = EntityExtractor(model_name_or_path="elastic/distilbert-base-cased-finetuned-conll03-english")
-    reader = FARMReader(model_name_or_path="deepset/tinyroberta-squad2", num_processes=0)
 
     pipeline = Pipeline()
     pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=ner, name="NER", inputs=["ESRetriever"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["NER"])
+    pipeline.add_node(component=ner_node, name="NER", inputs=["ESRetriever"])
+    pipeline.add_node(component=tiny_reader, name="Reader", inputs=["NER"])
 
     prediction = pipeline.run(
         query="Who lives in Berlin?", params={"ESRetriever": {"top_k": 1}, "Reader": {"top_k": 1}}
@@ -89,6 +96,7 @@ def test_extractor_output_simplifier(document_store_with_docs):
     assert simplified[0] == {"answer": "Carla and I", "entities": ["Carla"]}
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
 def test_extractor_indexing(document_store):
     doc_path = SAMPLES_PATH / "docs" / "doc_2.txt"
@@ -107,6 +115,21 @@ def test_extractor_indexing(document_store):
     meta = docs[0].meta
     assert "ORG" in meta["entity_groups"]
     assert "Haystack" in meta["entity_words"]
+
+
+@pytest.mark.integration
+def test_extractor_doc_query():
+    ner = EntityExtractor(
+        model_name_or_path="elastic/distilbert-base-cased-finetuned-conll03-english", flatten_entities_in_meta_data=True
+    )
+
+    pipeline = Pipeline()
+    pipeline.add_node(component=ner, name="NER", inputs=["Query"])
+
+    prediction = pipeline.run(query=None, documents=[Document(content="Carla lives in Berlin", content_type="text")])
+    entities = prediction["documents"][0].meta["entity_words"]
+    assert "Carla" in entities
+    assert "Berlin" in entities
 
 
 def test_extract_method():


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Added integration test for using EntityExtractor in query pipeline and added fixtures to reduce code duplication.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added new test.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This came up because @ju-gu asked if it was possible to use the EntityExtractor in a querying pipeline for just documents. So, send a document to the pipeline, add detected entities to the metadata and then return the document. This already works out of the box, but I thought it would be good to add a small (and fast) integration test to check the behavior. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~~I have updated the related issue with new insights and changes~~
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~~I documented my code~~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
