### PR TITLE
ci: Exclude .github folder from triggering tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "**.py"
       - "pyproject.toml"
+      - "!.github/**/*.py"
       - "!rest_api/**/*.py"
 
 env:


### PR DESCRIPTION
### Proposed Changes:

Disable the `tests.yml` workflow from running if `*.py` files in `.github/` are modified. 

### How did you test it?

Can't be tested.

### Notes for the reviewer

Not essential but avoids running tests when not necessary.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
