### PR TITLE
docs: Update Annotation Tool README.md

### DIFF
--- a/annotation_tool/README.md
+++ b/annotation_tool/README.md
@@ -2,7 +2,7 @@
 
 - Create labels with different techniques: Come up with questions (+ answers) while reading passages (SQuAD style) or have a set of predefined questions and look for answers in the document (~ Natural Questions).
 - Structure your work via organizations, projects, users
-- Upload your documents or import labels from an existing SQuAD-style dataset
+- Upload your documents or import a predefined list of questions
 - Export your labels in SQuAD Format
 
 ![image](../docs/img/annotation_tool.png)


### PR DESCRIPTION
### Related Issues
- related to #3958

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR removes the statement that we can import labels from an existing SQuAD-style dataset from the Annotation Tool README and instead adds that we can import a list of predefined questions.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
