### PR TITLE
ci: Add load arg to docker/bake-action before testing Docker images

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-      - 'v[0-9].[0-9]+.[0-9]+*'
+      - "v[0-9].[0-9]+.[0-9]+*"
 
 env:
   DOCKER_REPO_NAME: deepset/haystack
@@ -45,18 +45,20 @@ jobs:
         with:
           workdir: docker
           targets: base
+          load: true
           push: true
 
       - name: Test base images
         run: |
           EXPECTED_VERSION=$(cat VERSION.txt)
           function test_image {
-            local TAG=$1
-            local PLATFORM=$2
-            local VERSION=$(docker run --platform $PLATFORM --rm deepset/haystack:$TAG python -c"import haystack; print(haystack.__version__)")
+            local TAG, PLATFORM, VERSION
+            TAG=$1
+            PLATFORM=$2
+            VERSION=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" python -c"import haystack; print(haystack.__version__)")
             [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
             # Remove image after test to avoid filling the GitHub runner and prevent its failure
-            docker rmi deepset/haystack:$TAG
+            docker rmi "deepset/haystack:$TAG"
           }
           test_image base-cpu-${{ steps.meta.outputs.version }} linux/amd64
           test_image base-gpu-${{ steps.meta.outputs.version }} linux/amd64
@@ -104,6 +106,7 @@ jobs:
         with:
           workdir: docker
           targets: api-latest
+          load: true
           push: true
 
       - name: Test api image no version in tag


### PR DESCRIPTION
### Proposed Changes:

This PR sets the `load` argument to `true` for the steps that build Docker images that will be tested in the following steps. 

That will make the `docker/bake-action` call `docker buildx bake` with the `--load` flag so the built images will also be saved in the `docker images` registry and will be reused by the test steps with no need to pull them.

See the [Docker docs](https://docs.docker.com/engine/reference/commandline/buildx_build/#load) for info on `--load` flag.

### How did you test it?

I can't.

### Notes for the reviewer

Am not sure if the `load` and `push` flag will conflict with each other, I'd expect not to. 
If it will break in `main` I'll revert it right away.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
