### PR TITLE
docs: Remove some classes regarding PromptNode from API reference docs

### DIFF
--- a/docs/pydoc/config/prompt-node.yml
+++ b/docs/pydoc/config/prompt-node.yml
@@ -9,6 +9,8 @@ processors:
     documented_only: true
     do_not_filter_modules: false
     skip_empty_modules: true
+  - type: filter
+    expression: "name not in ['PromptModelInvocationLayer', 'StopWordsCriteria', 'HFLocalInvocationLayer', 'OpenAIInvocationLayer']"
   - type: smart
   - type: crossref
 renderer:


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adapts the configuration of PromptNode API documentation to exclude `PromptModelInvocationLayer`, `StopWordsCriteria`, `HFLocalInvocationLayer`, and `OpenAIInvocationLayer` from the API reference of Haystack documentation.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I ran `pydoc-markdown` locally.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
