### PR TITLE
chore: Fixing PromptNode .prompt() docstring to include the PromptTemplate object as an option

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -773,13 +773,11 @@ class PromptNode(BaseComponent):
     def prompt(self, prompt_template: Optional[Union[str, PromptTemplate]], *args, **kwargs) -> List[str]:
         """
         Prompts the model and represents the central API for the PromptNode. It takes a prompt template,
-        a list of non-keyword and keyword arguments, and returns a list of strings - the responses from
-        the underlying model.
+        a list of non-keyword and keyword arguments, and returns a list of strings - the responses from the underlying model.
 
-        If you specify the optional prompt_template parameter, it takes precedence over the default prompt
-        template for this PromptNode.
+        If you specify the optional prompt_template parameter, it takes precedence over the default PromptTemplate for this PromptNode.
 
-        :param prompt_template: The name of the optional prompt template to use.
+        :param prompt_template: The name or object of the optional PromptTemplate to use.
         :return: A list of strings as model responses.
         """
         results = []


### PR DESCRIPTION
This is a super small PR based on a problem I noticed in the `PromptNode` API reference. The `prompt_template` argument for the `.prompt()` function doesn't only have to be the name, it can also be the object as far as I see.. 