### PR TITLE
feat: Add more prompting options to OpenAIAnswerGenerator

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -437,6 +437,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
     @retry_with_exponential_backoff(
         backoff_in_seconds=int(os.environ.get(HAYSTACK_REMOTE_API_BACKOFF_SEC, 5)),
         max_retries=int(os.environ.get(HAYSTACK_REMOTE_API_MAX_RETRIES, 5)),
+        errors=(OpenAIRateLimitError, OpenAIError),
     )
     def invoke(self, *args, **kwargs):
         """


### PR DESCRIPTION
### Proposed Changes:
- Add a better default prompt that conditions the answer more to the given context documents. Also the model will try to cite the source of the answer.
- Add the option to give instructions at runtime inside the query, see docstrings for format

### How did you test it?
- I only tested manually, I hope existing tests should suffice.

### Notes for the reviewer
- I also added the OpenAIError to the backoff method, since the OpenAI API is often unreachable. With the generic backoff we should be safe against the unstable API 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
