### PR TITLE
ci: Update workflow to add labels in PR editing docstrings safe to run from forks

### DIFF
--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -1,17 +1,77 @@
 name: Add label on docstrings edit
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "haystack/**/*.py"
       - "rest_api/**/*.py"
 
-permissions:
-  pull-requests: write
-
 jobs:
+  verify-integrity:
+    #
+    # This job is really important!
+    #
+    # It's meant to verify that the python script run in the
+    # label job has not been modified in the PR that triggered
+    # this workflow.
+    #
+    # This must be done because we're using the pull_request_target
+    # event instead of pull_request. That event gives us a GITHUB_TOKEN
+    # with permissions to edit PRs necessary to add labels, but also
+    # do more dangerous operations.
+    #
+    # pull_request runs the HEAD version of the workflow, while
+    # pull_request_target runs the base version. This makes it safe
+    # to also run on PRs from forks, unless the workflow checks out
+    # the PR's HEAD and runs checked out code.
+    # This is exactly what we need to docstrings_checksum.py.
+    #
+    # If we'd run the script with no checks anyone would be
+    # able to use GitHub API tokens with elevated permissions
+    # on this repo and potentially do harmful stuff.
+    #
+    # For more detailed information read this post in GitHub's blog:
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: read
+
+    steps:
+      - name: Checkout base commit
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Base script checksum
+        id: base-script
+        run: |
+          CHECKSUM=$(md5 .github/utils/docstrings_checksum.py)
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout head commit
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Head script checksum
+        id: head-script
+        run: |
+          CHECKSUM=$(md5 .github/utils/docstrings_checksum.py)
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+
+      - name: Check script has been modified
+        run: |
+          [[ "${{ steps.base-script.outputs.checksum == steps.head-script.outputs.checksum }}" = "true" ]] || \
+          echo "::error 'Script has been modified, this might be an attempt to run malicious code.'"
+
   label:
     runs-on: ubuntu-latest
+    needs: verify-integrity
+
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout base commit
@@ -32,6 +92,8 @@ jobs:
 
       - name: Checkout HEAD commit
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Get docstrings
         id: head-docstrings


### PR DESCRIPTION
### Proposed Changes:

This changes the event that triggers the `docstring-labeler.yml` workflow from [`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) to [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

It also adds a new job to prevent running malicious code.

### How did you test it?

Can't be tested.

### Notes for the reviewer

This PR has some security implications that we might need to discuss.

This is only one of the possible approaches to label PRs from forks. Other approaches might be:

* Use `pull_request` event and a different token with elevated privilege
* Use `pull_request_target` event and embed the Python code in the workflow file
* Use `pull_request_target` event, checkout base, copy the Python script outside the repo and run that (This might be good 🤔 ), see #4146

I recommend reading [this blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) to gain a clear view on the security issues.

Am open to different solutions.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
