### PR TITLE
ci: Update docstring-labeler.yml workflow to safely run in PRs from forks

### DIFF
--- a/.github/utils/docstrings_checksum.py
+++ b/.github/utils/docstrings_checksum.py
@@ -30,8 +30,14 @@ def docstrings_checksum(python_files: Iterator[Path]):
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", help="Haystack root folder", required=True, type=Path)
+    args = parser.parse_args()
+
     # Get all Haystack and rest_api python files
-    root = Path(__file__).parent.parent.parent
+    root: Path = args.root.absolute()
     haystack_files = root.glob("haystack/**/*.py")
     rest_api_files = root.glob("rest_api/**/*.py")
 

--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -1,13 +1,10 @@
 name: Add label on docstrings edit
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "haystack/**/*.py"
       - "rest_api/**/*.py"
-
-permissions:
-  pull-requests: write
 
 jobs:
   label:
@@ -19,6 +16,12 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
 
+      - name: Copy file
+        # We copy our script after base ref checkout so we keep executing
+        # the same version even after checking out the HEAD ref.
+        # This is done to prevent executing malicious code in forks' PRs.
+        run: cp .github/utils/docstrings_checksum.py "${{ runner.temp }}/docstrings_checksum.py"
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -27,7 +30,7 @@ jobs:
       - name: Get docstrings
         id: base-docstrings
         run: |
-          CHECKSUM=$(python .github/utils/docstrings_checksum.py)
+          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ env.GITHUB_WORKSPACE }}")
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Checkout HEAD commit
@@ -36,7 +39,7 @@ jobs:
       - name: Get docstrings
         id: head-docstrings
         run: |
-          CHECKSUM=$(python .github/utils/docstrings_checksum.py)
+          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ env.GITHUB_WORKSPACE }}")
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Check if we should label


### PR DESCRIPTION
### Proposed Changes:

This changes the event that triggers the docstring-labeler.yml workflow from [pull_request](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) to [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

The job has been changed a bit too.

Instead of executing the `docstrings_checksum.py` directly after checkout we first copy it to a temp directory after checking out base ref. This way we prevent executing code in forks' PRs since the version of the script will always be the one from the PR's base.

A malicious user would have to manage to merge in `main` a modified version of the script before being able to exploit it.

### How did you test it?

Can't be tested.

### Notes for the reviewer

This is probably a better and simpler solution than the one implemented in #4145.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~I have updated the related issue with new insights and changes~
- [ ] ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
