### PR TITLE
feat: Add model_kwargs option to PromptNode

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -711,6 +711,7 @@ class PromptNode(BaseComponent):
         use_gpu: Optional[bool] = None,
         devices: Optional[List[Union[str, torch.device]]] = None,
         stop_words: Optional[List[str]] = None,
+        model_kwargs: Optional[Dict] = None,
     ):
         """
         Creates a PromptNode instance.
@@ -723,6 +724,8 @@ class PromptNode(BaseComponent):
         :param use_auth_token: The authentication token to use for the model.
         :param use_gpu: Whether to use GPU or not.
         :param devices: The devices to use for the model.
+        :param stop_words: Stops text generation if any one of the stop words is generated.
+        :param model_kwargs: Additional keyword arguments passed when loading the model specified by `model_name_or_path`.
         """
         super().__init__()
         self.prompt_templates: Dict[str, PromptTemplate] = {pt.name: pt for pt in get_predefined_prompt_templates()}  # type: ignore
@@ -748,6 +751,7 @@ class PromptNode(BaseComponent):
                 use_auth_token=use_auth_token,
                 use_gpu=use_gpu,
                 devices=devices,
+                model_kwargs=model_kwargs,
             )
         elif isinstance(model_name_or_path, PromptModel):
             self.prompt_model = model_name_or_path

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -245,6 +245,21 @@ def test_open_ai_prompt_with_params():
     not os.environ.get("OPENAI_API_KEY", None),
     reason="Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
+def test_open_ai_prompt_with_default_params():
+    pn = PromptNode(
+        model_name_or_path="text-davinci-003",
+        api_key=os.environ["OPENAI_API_KEY"],
+        model_kwargs={"temperature": 0.5, "max_tokens": 2, "top_p": 1, "frequency_penalty": 0.5},
+    )
+    result = pn.prompt("question-generation", documents=["Berlin is the capital of Germany."])
+    assert len(result) == 1 and len(result[0]) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
 def test_open_ai_warn_if_max_tokens_is_too_short(caplog):
     pm = PromptModel("text-davinci-003", api_key=os.environ["OPENAI_API_KEY"])
     pn = PromptNode(pm)

--- a/test/nodes/test_prompt_node.py
+++ b/test/nodes/test_prompt_node.py
@@ -420,6 +420,33 @@ def test_simple_pipeline_yaml(tmp_path):
     assert result["results"][0] == "positive"
 
 
+def test_simple_pipeline_yaml_with_default_params(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: p1
+              type: PromptNode
+              params:
+                default_prompt_template: sentiment-analysis
+                model_kwargs:
+                  torch_dtype: torch.bfloat16
+            pipelines:
+            - name: query
+              nodes:
+              - name: p1
+                inputs:
+                - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    assert pipeline.graph.nodes["p1"]["component"].prompt_model.model_kwargs == {"torch_dtype": "torch.bfloat16"}
+
+    result = pipeline.run(query=None, documents=[Document("Berlin is an amazing city.")])
+    assert result["results"][0] == "positive"
+
+
 def test_complex_pipeline_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I believe adding the `model_kwargs` parameter to the `__init__` function for `PromptNode` would allow users to easily set the default values of the underlying model without being required to pass a `PromptModel`. We already pass these parameters`model_name_or_path, max_length, api_key, use_auth_token, use_gpu, devices` from `PromptNode.__init__` to the loading of the underlying `PromptModel` so I think adding `model_kwargs` here also makes sense.

This also would simplify the yaml file (example added in tests) to be able to set the default model parameters from the initialization of the `PromptNode`. It would not require creating a separate `PromptModel` to be able to set default parameters, which I think streamlines the yaml file. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added two new unit tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~~I have updated the related issue with new insights and changes~~
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
