### PR TITLE
ci: Use larger runner for Docker release workflow

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
-  labels: ["cml"]
+  labels: ["cml", "ubuntu-latest-4-cores"]

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Proposed Changes:

Use larger builder to fix out of space errors during Docker images builds.

### How did you test it?

We triggered a build with this branch, [this is the run](https://github.com/deepset-ai/haystack/actions/runs/4196301152/jobs/7277152867).

### Notes for the reviewer

N/A

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
