### PR TITLE
Report execution time for pipeline components in `_debug`

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -7,6 +7,7 @@ import itertools
 from datetime import timedelta
 from functools import partial
 from hashlib import sha1
+from time import time
 from typing import Dict, List, Optional, Any, Set, Tuple, Union
 
 try:
@@ -527,7 +528,10 @@ class Pipeline:
             if predecessors.isdisjoint(set(queue.keys())):  # only execute if predecessor nodes are executed
                 try:
                     logger.debug("Running node '%s` with input: %s", node_id, node_input)
+                    start = time()
                     node_output, stream_id = self._run_node(node_id, node_input)
+                    if "_debug" in node_output and node_id in node_output["_debug"]:
+                        node_output["_debug"][node_id]["exec_time_ms"] = round((time() - start) * 1000, 2)
                 except Exception as e:
                     # The input might be a really large object with thousands of embeddings.
                     # If you really want to see it, raise the log level.

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 from pathlib import Path
 import networkx as nx
+from time import time
 
 try:
     from ray import serve
@@ -355,7 +356,10 @@ class RayPipeline(Pipeline):
             if predecessors.isdisjoint(set(queue.keys())):  # only execute if predecessor nodes are executed
                 try:
                     logger.debug("Running node '%s` with input: %s", node_id, node_input)
+                    start = time()
                     node_output, stream_id = await self._run_node_async(node_id, node_input)
+                    if "_debug" in node_output and node_id in node_output["_debug"]:
+                        node_output["_debug"][node_id]["exec_time_ms"] = round((time() - start) * 1000, 2)
                 except Exception as e:
                     # The input might be a really large object with thousands of embeddings.
                     # If you really want to see it, raise the log level.

--- a/test/pipelines/test_pipeline_debug_and_validation.py
+++ b/test/pipelines/test_pipeline_debug_and_validation.py
@@ -70,12 +70,16 @@ def test_debug_attributes_global(document_store_with_docs, tmp_path):
     assert "Reader" in prediction["_debug"].keys()
     assert "input" in prediction["_debug"]["ESRetriever"].keys()
     assert "output" in prediction["_debug"]["ESRetriever"].keys()
+    assert "exec_time_ms" in prediction["_debug"]["ESRetriever"].keys()
     assert "input" in prediction["_debug"]["Reader"].keys()
     assert "output" in prediction["_debug"]["Reader"].keys()
+    assert "exec_time_ms" in prediction["_debug"]["Reader"].keys()
     assert prediction["_debug"]["ESRetriever"]["input"]
     assert prediction["_debug"]["ESRetriever"]["output"]
+    assert prediction["_debug"]["ESRetriever"]["exec_time_ms"]
     assert prediction["_debug"]["Reader"]["input"]
     assert prediction["_debug"]["Reader"]["output"]
+    assert prediction["_debug"]["Reader"]["exec_time_ms"]
 
     # Avoid circular reference: easiest way to detect those is to use json.dumps
     json.dumps(prediction, default=str)

--- a/test/pipelines/test_ray.py
+++ b/test/pipelines/test_ray.py
@@ -83,6 +83,7 @@ async def test_load_advanced_pipeline_async(document_store_with_docs):
     prediction = await pipeline.run_async(
         query="Who lives in Berlin?",
         params={"ESRetriever1": {"top_k": 1}, "ESRetriever2": {"top_k": 2}, "Reader": {"top_k": 3}},
+        debug=True,
     )
 
     assert pipeline._serve_controller_client._detached is True
@@ -96,3 +97,5 @@ async def test_load_advanced_pipeline_async(document_store_with_docs):
     assert prediction["query"] == "Who lives in Berlin?"
     assert prediction["answers"][0].answer == "Carla"
     assert len(prediction["answers"]) > 1
+    assert "exec_time_ms" in prediction["_debug"]["ESRetriever1"].keys()
+    assert prediction["_debug"]["ESRetriever1"]["exec_time_ms"]


### PR DESCRIPTION
### Related Issues
- fixes #4196 

### Proposed Changes:
As Haystack pipelines are getting more and more complicated and they contain larger and large ML models, optimizing for pipeline latency (how long it takes for the pipeline to return its results) becoming more and more of a challenge in operations.
When you have a complicated pipeline and you are trying to optimize its latency, the first thing you would want to know that which component of the pipeline was contributing how much to the total pipeline execution time.

For this reason, I adding a new _debug parameter to be added to the pipeline, which reports the execution time (wall time) of each pipeline component.

The new `exec_time_ms` parameter of the `_debug` of each pipeline component now reports the execution time (wall time) of that component in milliseconds rounded to 2 decimals.

### How did you test it?
The unit tests were extended to check for the `exec_time_ms`.

### Notes for the reviewer
Nothing special, I believe this is a rather simple.
Obviously arguments could be made on which level of the debug output to include this, what parameter name to use like `exec_time_ms` or something else. Let me know if you want anything changed.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
