### PR TITLE
ci: Move xpdf build into separate container

### DIFF
--- a/.github/workflows/xpdf_release.yml
+++ b/.github/workflows/xpdf_release.yml
@@ -1,0 +1,39 @@
+name: Xpdf Docker image release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docker/docker-bake-xpdf.hcl
+      - docker/Dockerfile.xpdf
+
+jobs:
+  publish-xpdf-image:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REPO_NAME: deepset/xpdf
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and publish Xpdf image
+        uses: docker/bake-action@v2
+        with:
+          files: "docker-bake-xpdf.hcl"
+          workdir: docker
+          targets: xpdf
+          push: true

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -7,20 +7,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG haystack_version
 ARG haystack_extras
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential gcc git curl cmake \
-    tesseract-ocr libtesseract-dev poppler-utils
-
-# Install PDF converter
-RUN curl -O https://dl.xpdfreader.com/xpdf-4.04.tar.gz && \
-    tar -xvf xpdf-4.04.tar.gz && \
-    cd xpdf-4.04 && \
-    cmake . && \
-    make && \
-    cp xpdf/pdftotext /opt && \
-    cd .. && \
-    rm -rf xpdf-4.04
-
 # Shallow clone Haystack repo, we'll install from the local sources
 RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-ai/haystack.git /opt/haystack
 WORKDIR /opt/haystack
@@ -37,7 +23,8 @@ RUN pip install --upgrade pip && \
 FROM $base_image AS final
 
 COPY --from=build-image /opt/venv /opt/venv
-COPY --from=build-image /opt/pdftotext /usr/local/bin
+COPY --from=deepset/xpdf:latest /opt/pdftotext /usr/local/bin
+
 # pdftotext requires fontconfig runtime
 RUN apt-get update && apt-get install -y libfontconfig && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.xpdf
+++ b/docker/Dockerfile.xpdf
@@ -1,0 +1,21 @@
+FROM ubuntu:latest
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    curl \
+    gcc \
+    git \
+    libtesseract-dev \
+    poppler-utils \
+    tesseract-ocr
+
+ARG xpdf_version
+RUN curl -O https://dl.xpdfreader.com/xpdf-${xpdf_version}.tar.gz && \
+    tar -xvf xpdf-${xpdf_version}.tar.gz && \
+    cd xpdf-${xpdf_version} && \
+    cmake . && \
+    make && \
+    cp xpdf/pdftotext /opt && \
+    rm -rf ../xpdf-${xpdf_version}

--- a/docker/Dockerfile.xpdf
+++ b/docker/Dockerfile.xpdf
@@ -11,11 +11,12 @@ RUN apt-get update && \
     poppler-utils \
     tesseract-ocr
 
-ARG xpdf_version
-RUN curl -O https://dl.xpdfreader.com/xpdf-${xpdf_version}.tar.gz && \
-    tar -xvf xpdf-${xpdf_version}.tar.gz && \
-    cd xpdf-${xpdf_version} && \
+ARG XPDF_VERSION
+RUN curl -O https://dl.xpdfreader.com/xpdf-${XPDF_VERSION}.tar.gz && \
+    tar -xvf xpdf-${XPDF_VERSION}.tar.gz && \
+    cd xpdf-${XPDF_VERSION} && \
     cmake . && \
     make && \
     cp xpdf/pdftotext /opt && \
-    rm -rf ../xpdf-${xpdf_version}
+    cd .. \
+    rm -rf xpdf-${XPDF_VERSION}

--- a/docker/Dockerfile.xpdf
+++ b/docker/Dockerfile.xpdf
@@ -11,12 +11,12 @@ RUN apt-get update && \
     poppler-utils \
     tesseract-ocr
 
-ARG XPDF_VERSION
-RUN curl -O https://dl.xpdfreader.com/xpdf-${XPDF_VERSION}.tar.gz && \
-    tar -xvf xpdf-${XPDF_VERSION}.tar.gz && \
-    cd xpdf-${XPDF_VERSION} && \
+ARG xpdf_version
+RUN curl -O https://dl.xpdfreader.com/xpdf-${xpdf_version}.tar.gz && \
+    tar -xvf xpdf-${xpdf_version}.tar.gz && \
+    cd xpdf-${xpdf_version} && \
     cmake . && \
     make && \
     cp xpdf/pdftotext /opt && \
     cd .. \
-    rm -rf xpdf-${XPDF_VERSION}
+    rm -rf xpdf-${xpdf_version}

--- a/docker/docker-bake-xpdf.hcl
+++ b/docker/docker-bake-xpdf.hcl
@@ -1,0 +1,12 @@
+variable "XPDF_VERSION" {
+  default = "4.04"
+}
+
+target "xpdf" {
+  dockerfile = "Dockerfile.xpdf"
+  tags = ["deepset/xpdf:latest"]
+  args = {
+    xpdf_version = "4.04"
+  }
+  platforms = ["linux/amd64", "linux/arm64"]
+}

--- a/docker/docker-bake-xpdf.hcl
+++ b/docker/docker-bake-xpdf.hcl
@@ -6,7 +6,7 @@ target "xpdf" {
   dockerfile = "Dockerfile.xpdf"
   tags = ["deepset/xpdf:latest"]
   args = {
-    XPDF_VERSION = "4.04"
+    xpdf_version = "${XPDF_VERSION}"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/docker/docker-bake-xpdf.hcl
+++ b/docker/docker-bake-xpdf.hcl
@@ -6,7 +6,7 @@ target "xpdf" {
   dockerfile = "Dockerfile.xpdf"
   tags = ["deepset/xpdf:latest"]
   args = {
-    xpdf_version = "4.04"
+    XPDF_VERSION = "4.04"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
### Proposed Changes:

Speed up the base Docker images build process by removing the `xpdf` build and moving into a separate container, so that we'll need only to `COPY --from=deepset/xpdf:latest` to get the `pdftotext` binary in the published image.

The `deepset/xpdf` image will be built whenever `docker/docker-bake-xpdf.hcl` or `docker/Dockerfile.xpdf` are modified in `main`.

### How did you test it?

Can't be tested until it's merged. Am pretty confident it will work as the process is extremely similar to the Haystack images.

### Notes for the reviewer

I tried another approach with branch [`xpdf-build`](https://github.com/deepset-ai/haystack/tree/xpdf-build) but sadly it's not feasible.

The idea was to run the builds in CI and upload the binaries to S3, so that the Haystack base image could download it directly with no need to build it each time.

But we can't use ARM64 images in as job containers in GitHub Actions, the job won't even start as shown in [this run](https://github.com/deepset-ai/haystack/actions/runs/4212080555/jobs/7310854554).