### PR TITLE
ci: Add ca-certificates installation to xpdf container

### DIFF
--- a/docker/Dockerfile.xpdf
+++ b/docker/Dockerfile.xpdf
@@ -3,6 +3,7 @@ FROM ubuntu:latest
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
     cmake \
     curl \
     gcc \


### PR DESCRIPTION
### Proposed Changes:

Fix [`publish-xpdf-image`](https://github.com/deepset-ai/haystack/actions/runs/4224096355/jobs/7334623717) workflow failing.

`curl` is failing in the image cause of missing certificates, installing `ca-certificates` will solve the issue.

### How did you test it?

Built image locally.

### Notes for the reviewer

I didn't notice the issue in the PR that introduced the building of the container as I was hotspotting in the airport and didn't want to waste data downloading Docker images. <3

