### PR TITLE
refactor: Remove `id_hash_keys` parameter in `from_dict` method

### DIFF
--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -298,10 +298,10 @@ class SpeechDocument(Document):
         return dictionary
 
     @classmethod
-    def from_dict(cls, dict, field_map=None):
+    def from_dict(cls, dict, field_map=None, id_hash_keys=None):
         if field_map is None:
             field_map = {}
-        doc = super().from_dict(dict=dict, field_map=field_map)
+        doc = super().from_dict(dict=dict, field_map=field_map, id_hash_keys=id_hash_keys)
         doc.content_audio = Path(dict["content_audio"])
         return doc
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -298,10 +298,10 @@ class SpeechDocument(Document):
         return dictionary
 
     @classmethod
-    def from_dict(cls, dict, field_map=None, id_hash_keys=None):
+    def from_dict(cls, dict, field_map=None):
         if field_map is None:
             field_map = {}
-        doc = super().from_dict(dict=dict, field_map=field_map, id_hash_keys=id_hash_keys)
+        doc = super().from_dict(dict=dict, field_map=field_map)
         doc.content_audio = Path(dict["content_audio"])
         return doc
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import csv
-import warnings
 import hashlib
 import inspect
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -178,9 +178,7 @@ class Document:
         return _doc
 
     @classmethod
-    def from_dict(
-        cls, dict: Dict[str, Any], field_map: Optional[Dict[str, Any]] = None, id_hash_keys: Optional[List[str]] = None
-    ) -> Document:
+    def from_dict(cls, dict: Dict[str, Any], field_map: Optional[Dict[str, Any]] = None) -> Document:
         """
         Create Document from dict. An optional `field_map` parameter can be supplied to adjust for custom names of the keys in the
         input dict. This way you can work with standardized Document objects in Haystack, but adjust the format that
@@ -198,15 +196,6 @@ class Document:
         """
         if not field_map:
             field_map = {}
-        if id_hash_keys:
-            warnings.warn(
-                message="Passing id_hash_keys directly is deprecated: Document objects now store such information internally.\n"
-                "Old API: Document.from_dict({'content': 'test', 'meta': {'some': 'value'}}, id_hash_keys=['meta'])\n"
-                "New API: Document.from_dict({'content': 'test', 'meta': {'some': 'value'}, 'id_hash_keys': ['meta']})\n",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            dict["id_hash_keys"] = id_hash_keys
 
         _doc = dict.copy()
         init_args = ["content", "content_type", "id", "score", "id_hash_keys", "question", "meta", "embedding"]

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -52,19 +52,6 @@ def test_document_from_dict():
     assert doc == Document.from_dict(doc.to_dict())
 
 
-@fail_at_version(1, 15)
-def test_deprecated_id_hash_keys_in_document_from_dict():
-    doc = Document(
-        content="this is the content of the document", meta={"some": "meta"}, id_hash_keys=["content", "meta"]
-    )
-    # id_hash_keys in Document.from_dict() is deprecated and should be removed.
-    with pytest.warns(DeprecationWarning):
-        assert doc == Document.from_dict(
-            {"content": "this is the content of the document", "meta": {"some": "meta"}},
-            id_hash_keys=["content", "meta"],
-        )
-
-
 def test_no_answer_label():
     labels = [
         Label(


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR removes the `id_hash_keys` parameter in the `from_dict` method of `Document`. `id_hash_keys` is deprecated since 1.13 and should be removed in 1.15 according to our deprecation policy.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
