### PR TITLE
ci: Fix Dockerfile.base failing cause of missing git

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -7,6 +7,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG haystack_version
 ARG haystack_extras
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git
+
 # Shallow clone Haystack repo, we'll install from the local sources
 RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-ai/haystack.git /opt/haystack
 WORKDIR /opt/haystack


### PR DESCRIPTION
### Proposed Changes:

Docker release is failing cause of missing `git` in the base image, add a step to install it and fix the issue.

### How did you test it?

Built the image locally.

### Notes for the reviewer

N/A
