### PR TITLE
ci: Fix Dockerfile.base failing cause of missing dependencies

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -9,6 +9,7 @@ ARG haystack_extras
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    build-essential \
     git
 
 # Shallow clone Haystack repo, we'll install from the local sources


### PR DESCRIPTION
### Proposed Changes:

Add missing dependencies in `Dockerfile.base` image to fix build failure.

### How did you test it?

I built the image locally from start to end.

### Notes for the reviewer

I was dumb enough to not run the build from start to finish after the fix from #4210 but only waited for the git fetch to work and then interrupted the build.
I should have caught that then. 🤦 

