### PR TITLE
fix: Fix bug in prompt template check of OpenAIAnswerGenerator

### DIFF
--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -138,7 +138,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         else:
             # Check for required prompts
             required_params = ["context", "query"]
-            if all(p in prompt_template.prompt_params for p in required_params):
+            if not all(p in prompt_template.prompt_params for p in required_params):
                 raise ValueError(
                     "The OpenAIAnswerGenerator requires a PromptTemplate that has `context` and "
                     "`query` in its `prompt_params`. Supply a different `prompt_template` or "

--- a/test/nodes/test_generator.py
+++ b/test/nodes/test_generator.py
@@ -7,6 +7,7 @@ import pytest
 from haystack.schema import Document
 from haystack.nodes.answer_generator import Seq2SeqGenerator, OpenAIAnswerGenerator
 from haystack.pipelines import TranslationWrapperPipeline, GenerativeQAPipeline
+from haystack.nodes import PromptTemplate
 
 import logging
 
@@ -140,6 +141,26 @@ def test_openai_answer_generator(openai_generator, docs):
     prediction = openai_generator.predict(query="Who lives in Berlin?", documents=docs, top_k=1)
     assert len(prediction["answers"]) == 1
     assert "Carla" in prediction["answers"][0].answer
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="No OpenAI API key provided. Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
+def test_openai_answer_generator_custom_template(docs):
+    lfqa_prompt = PromptTemplate(
+        name="lfqa",
+        prompt_text="""
+        Synthesize a comprehensive answer from your knowledge and the following topk most relevant paragraphs and the given question.
+        \n===\Paragraphs: $context\n===\n$query""",
+        prompt_params=["context", "query"],
+    )
+    node = OpenAIAnswerGenerator(
+        api_key=os.environ.get("OPENAI_API_KEY", ""), model="text-babbage-001", top_k=1, prompt_template=lfqa_prompt
+    )
+    prediction = node.predict(query="Who lives in Berlin?", documents=docs, top_k=1)
+    assert len(prediction["answers"]) == 1
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues
- fixes #4211 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Fixed bug for using custom templates in OpenAIAnswerGenerator due to a bad check.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added new test using custom template.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] ~~I documented my code~~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
