### PR TITLE
fix: allowing file-upload api to write files to disk

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -12,7 +12,7 @@ RUN addgroup --gid 1001 $SERVICE_NAME && \
 
 
 # Create a folder for the /file-upload API endpoint with write permissions for the service user only
-RUN mkdir -p /opt/file-upload && chown $SERVICE_NAME:$SERVICE_NAME /opt/file-upload && chmod 600 /opt/file-upload
+RUN mkdir -p /opt/file-upload && chown $SERVICE_NAME:$SERVICE_NAME /opt/file-upload && chmod 700 /opt/file-upload
 
 # Tell rest_api which folder to use for uploads
 ENV FILE_UPLOAD_PATH="/opt/file-upload"


### PR DESCRIPTION
### Related Issues
- No issues

### Proposed Changes:
Corrected `chmod` permissions

### How did you test it?
checked manually by building the image locally


### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
