### PR TITLE
fix: Shaper store all outputs from function

### DIFF
--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -379,12 +379,34 @@ class Shaper(BaseComponent):
                 "and parameter types."
             ) from e
 
+        if len(self.outputs) < len(output_values):
+            logger.warning(
+                "The number of outputs from function %s is %s. However, only %s output key(s) were provided. "
+                "Only %s output(s) will be stored. "
+                "Provide %s output keys to store all outputs.",
+                self.function.__name__,
+                len(output_values),
+                len(self.outputs),
+                len(self.outputs),
+                len(output_values),
+            )
+
+        if len(self.outputs) > len(output_values):
+            logger.warning(
+                "The number of outputs from function %s is %s. However, %s output key(s) were provided. "
+                "Only the first %s output key(s) will be used.",
+                self.function.__name__,
+                len(output_values),
+                len(self.outputs),
+                len(output_values),
+            )
+
+        results = {}
         for output_key, output_value in zip(self.outputs, output_values):
             invocation_context[output_key] = output_value
-
-        results = {"invocation_context": invocation_context}
-        if output_key in ["query", "file_paths", "labels", "documents", "meta"]:
-            results[output_key] = output_value
+            if output_key in ["query", "file_paths", "labels", "documents", "meta"]:
+                results[output_key] = output_value
+        results["invocation_context"] = invocation_context
 
         return results, "output_1"
 


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Fix bug in storing multiple outputs
- Checking if output keys and output_values are the same length and if not print a warning to the user

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added two new tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] ~~I have updated the related issue with new insights and changes~~
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] ~~I documented my code~~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
