### PR TITLE
refact: mark unit tests under the `test/nodes/**` path

### DIFF
--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -84,12 +84,14 @@ def test_crawler(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_crawler_url_none_exception(tmp_path):
     crawler = Crawler(tmp_path)
     with pytest.raises(ValueError):
         crawler.crawl()
 
 
+@pytest.mark.unit
 def test_crawler_depth_0_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
@@ -97,6 +99,7 @@ def test_crawler_depth_0_single_url(test_url, tmp_path):
     assert content_match(crawler, test_url + "/index.html", paths[0])
 
 
+@pytest.mark.unit
 def test_crawler_depth_0_many_urls(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     _urls = [test_url + "/index.html", test_url + "/page1.html"]
@@ -106,6 +109,7 @@ def test_crawler_depth_0_many_urls(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page1.html", paths)
 
 
+@pytest.mark.unit
 def test_crawler_depth_1_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=1)
@@ -115,6 +119,7 @@ def test_crawler_depth_1_single_url(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
+@pytest.mark.unit
 def test_crawler_output_file_structure(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
@@ -128,6 +133,7 @@ def test_crawler_output_file_structure(test_url, tmp_path):
         assert len(data["content"].split()) > 2
 
 
+@pytest.mark.unit
 def test_crawler_filter_urls(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
 
@@ -142,6 +148,7 @@ def test_crawler_filter_urls(test_url, tmp_path):
     assert not crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["google.com"], crawler_depth=1)
 
 
+@pytest.mark.unit
 def test_crawler_return_document(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     documents, _ = crawler.run(urls=[test_url + "/index.html"], crawler_depth=0, return_documents=True)
@@ -154,6 +161,7 @@ def test_crawler_return_document(test_url, tmp_path):
             assert file_content["content"] == document.content
 
 
+@pytest.mark.unit
 def test_crawler_extract_hidden_text(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     documents, _ = crawler.run(
@@ -169,6 +177,7 @@ def test_crawler_extract_hidden_text(test_url, tmp_path):
     assert "hidden text" not in crawled_content
 
 
+@pytest.mark.unit
 def test_crawler_loading_wait_time(test_url, tmp_path):
     loading_wait_time = 3
     crawler = Crawler(output_dir=tmp_path)
@@ -195,6 +204,7 @@ def test_crawler_loading_wait_time(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
+@pytest.mark.unit
 def test_crawler_default_naming_function(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
 
@@ -209,6 +219,7 @@ def test_crawler_default_naming_function(test_url, tmp_path):
     assert paths[0] == Path(expected_crawled_file_path)
 
 
+@pytest.mark.unit
 def test_crawler_naming_function(test_url, tmp_path):
     crawler = Crawler(
         output_dir=tmp_path, crawler_naming_function=lambda link, text: re.sub("[<>:'/\\|?*\0 ]", "_", link)

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -87,14 +87,12 @@ def test_crawler(tmp_path):
 #
 
 
-@pytest.mark.unit
 def test_crawler_url_none_exception(tmp_path):
     crawler = Crawler()
     with pytest.raises(ValueError):
         crawler.crawl()
 
 
-@pytest.mark.unit
 def test_crawler_depth_0_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, crawler_depth=0, file_path_meta_field_name="file_path")
     documents = crawler.crawl(urls=[test_url + "/index.html"])
@@ -102,7 +100,6 @@ def test_crawler_depth_0_single_url(test_url, tmp_path):
     assert content_match(crawler, test_url + "/index.html", documents[0].meta["file_path"])
 
 
-@pytest.mark.unit
 def test_crawler_depth_0_many_urls(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     _urls = [test_url + "/index.html", test_url + "/page1.html"]
@@ -113,7 +110,6 @@ def test_crawler_depth_0_many_urls(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page1.html", paths)
 
 
-@pytest.mark.unit
 def test_crawler_depth_1_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=1)
@@ -124,7 +120,6 @@ def test_crawler_depth_1_single_url(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
-@pytest.mark.unit
 def test_crawler_output_file_structure(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
@@ -139,7 +134,6 @@ def test_crawler_output_file_structure(test_url, tmp_path):
         assert len(data["content"].split()) > 2
 
 
-@pytest.mark.unit
 def test_crawler_filter_urls(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
 
@@ -154,7 +148,6 @@ def test_crawler_filter_urls(test_url, tmp_path):
     assert not crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["google.com"], crawler_depth=1)
 
 
-@pytest.mark.unit
 def test_crawler_extract_hidden_text(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     documents, _ = crawler.run(urls=[test_url + "/page_w_hidden_text.html"], extract_hidden_text=True, crawler_depth=0)
@@ -166,7 +159,6 @@ def test_crawler_extract_hidden_text(test_url, tmp_path):
     assert "hidden text" not in crawled_content
 
 
-@pytest.mark.unit
 def test_crawler_loading_wait_time(test_url, tmp_path):
     loading_wait_time = 3
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
@@ -197,7 +189,6 @@ def test_crawler_loading_wait_time(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
-@pytest.mark.unit
 def test_crawler_default_naming_function(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
 
@@ -213,7 +204,6 @@ def test_crawler_default_naming_function(test_url, tmp_path):
     assert path == Path(expected_crawled_file_path)
 
 
-@pytest.mark.unit
 def test_crawler_naming_function(test_url, tmp_path):
     crawler = Crawler(
         output_dir=tmp_path,
@@ -231,14 +221,12 @@ def test_crawler_naming_function(test_url, tmp_path):
     assert path == expected_crawled_file_path
 
 
-@pytest.mark.unit
 def test_crawler_not_save_file(test_url):
     crawler = Crawler()
     documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
     assert documents[0].meta.get("file_path", None) is None
 
 
-@pytest.mark.unit
 def test_crawler_custom_meta_file_path_name(test_url, tmp_path):
     crawler = Crawler()
     documents = crawler.crawl(

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -87,12 +87,14 @@ def test_crawler(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_crawler_url_none_exception(tmp_path):
     crawler = Crawler()
     with pytest.raises(ValueError):
         crawler.crawl()
 
 
+@pytest.mark.unit
 def test_crawler_depth_0_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, crawler_depth=0, file_path_meta_field_name="file_path")
     documents = crawler.crawl(urls=[test_url + "/index.html"])
@@ -100,6 +102,7 @@ def test_crawler_depth_0_single_url(test_url, tmp_path):
     assert content_match(crawler, test_url + "/index.html", documents[0].meta["file_path"])
 
 
+@pytest.mark.unit
 def test_crawler_depth_0_many_urls(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     _urls = [test_url + "/index.html", test_url + "/page1.html"]
@@ -110,6 +113,7 @@ def test_crawler_depth_0_many_urls(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page1.html", paths)
 
 
+@pytest.mark.unit
 def test_crawler_depth_1_single_url(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=1)
@@ -120,6 +124,7 @@ def test_crawler_depth_1_single_url(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
+@pytest.mark.unit
 def test_crawler_output_file_structure(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
@@ -134,6 +139,7 @@ def test_crawler_output_file_structure(test_url, tmp_path):
         assert len(data["content"].split()) > 2
 
 
+@pytest.mark.unit
 def test_crawler_filter_urls(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
 
@@ -148,6 +154,7 @@ def test_crawler_filter_urls(test_url, tmp_path):
     assert not crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["google.com"], crawler_depth=1)
 
 
+@pytest.mark.unit
 def test_crawler_extract_hidden_text(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
     documents, _ = crawler.run(urls=[test_url + "/page_w_hidden_text.html"], extract_hidden_text=True, crawler_depth=0)
@@ -159,6 +166,7 @@ def test_crawler_extract_hidden_text(test_url, tmp_path):
     assert "hidden text" not in crawled_content
 
 
+@pytest.mark.unit
 def test_crawler_loading_wait_time(test_url, tmp_path):
     loading_wait_time = 3
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
@@ -189,6 +197,7 @@ def test_crawler_loading_wait_time(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
+@pytest.mark.unit
 def test_crawler_default_naming_function(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
 
@@ -204,6 +213,7 @@ def test_crawler_default_naming_function(test_url, tmp_path):
     assert path == Path(expected_crawled_file_path)
 
 
+@pytest.mark.unit
 def test_crawler_naming_function(test_url, tmp_path):
     crawler = Crawler(
         output_dir=tmp_path,
@@ -221,12 +231,14 @@ def test_crawler_naming_function(test_url, tmp_path):
     assert path == expected_crawled_file_path
 
 
+@pytest.mark.unit
 def test_crawler_not_save_file(test_url):
     crawler = Crawler()
     documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
     assert documents[0].meta.get("file_path", None) is None
 
 
+@pytest.mark.unit
 def test_crawler_custom_meta_file_path_name(test_url, tmp_path):
     crawler = Crawler()
     documents = crawler.crawl(

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -7,10 +7,10 @@ import hashlib
 import os
 
 import pytest
+
 from selenium.webdriver.common.by import By
 
-
-from haystack.nodes.connector import Crawler
+from haystack.nodes.connector.crawler import Crawler
 from haystack.schema import Document
 
 from ..conftest import SAMPLES_PATH
@@ -64,12 +64,15 @@ def test_crawler(tmp_path):
     tmp_dir = tmp_path
     url = ["https://haystack.deepset.ai/"]
 
-    crawler = Crawler(output_dir=tmp_dir)
-    docs_path = crawler.crawl(urls=url, crawler_depth=0)
-    results, _ = crawler.run(urls=url, crawler_depth=0, return_documents=True)
-    documents = results["documents"]
+    crawler = Crawler(output_dir=tmp_dir, file_path_meta_field_name="file_path")
 
-    for json_file, document in zip(docs_path, documents):
+    documents = crawler.crawl(urls=url, crawler_depth=0)
+    docs_path = [Path(doc.meta["file_path"]) for doc in documents]
+
+    results, _ = crawler.run(urls=url, crawler_depth=0)
+    docs_result = results["documents"]
+
+    for json_file, document in zip(docs_path, docs_result):
         assert isinstance(json_file, Path)
         assert isinstance(document, Document)
 
@@ -84,48 +87,46 @@ def test_crawler(tmp_path):
 #
 
 
-@pytest.mark.unit
 def test_crawler_url_none_exception(tmp_path):
-    crawler = Crawler(tmp_path)
+    crawler = Crawler()
     with pytest.raises(ValueError):
         crawler.crawl()
 
 
-@pytest.mark.unit
 def test_crawler_depth_0_single_url(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
-    paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
-    assert len(paths) == 1
-    assert content_match(crawler, test_url + "/index.html", paths[0])
+    crawler = Crawler(output_dir=tmp_path, crawler_depth=0, file_path_meta_field_name="file_path")
+    documents = crawler.crawl(urls=[test_url + "/index.html"])
+    assert len(documents) == 1
+    assert content_match(crawler, test_url + "/index.html", documents[0].meta["file_path"])
 
 
-@pytest.mark.unit
 def test_crawler_depth_0_many_urls(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
     _urls = [test_url + "/index.html", test_url + "/page1.html"]
-    paths = crawler.crawl(urls=_urls, crawler_depth=0)
-    assert len(paths) == 2
+    documents = crawler.crawl(urls=_urls, crawler_depth=0)
+    assert len(documents) == 2
+    paths = [doc.meta["file_path"] for doc in documents]
     assert content_in_results(crawler, test_url + "/index.html", paths)
     assert content_in_results(crawler, test_url + "/page1.html", paths)
 
 
-@pytest.mark.unit
 def test_crawler_depth_1_single_url(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
-    paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=1)
-    assert len(paths) == 3
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
+    documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=1)
+    assert len(documents) == 3
+    paths = [doc.meta["file_path"] for doc in documents]
     assert content_in_results(crawler, test_url + "/index.html", paths)
     assert content_in_results(crawler, test_url + "/page1.html", paths)
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
-@pytest.mark.unit
 def test_crawler_output_file_structure(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
-    paths = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
-    assert content_match(crawler, test_url + "/index.html", paths[0])
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
+    documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
+    path = Path(documents[0].meta["file_path"])
+    assert content_match(crawler, test_url + "/index.html", path)
 
-    with open(paths[0].absolute(), "r") as doc_file:
+    with open(path.absolute(), "r") as doc_file:
         data = json.load(doc_file)
         assert "content" in data
         assert "meta" in data
@@ -133,57 +134,41 @@ def test_crawler_output_file_structure(test_url, tmp_path):
         assert len(data["content"].split()) > 2
 
 
-@pytest.mark.unit
 def test_crawler_filter_urls(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
 
-    paths = crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["index"], crawler_depth=1)
-    assert len(paths) == 1
-    assert content_match(crawler, test_url + "/index.html", paths[0])
+    documents = crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["index"], crawler_depth=1)
+    assert len(documents) == 1
+    assert content_match(crawler, test_url + "/index.html", documents[0].meta["file_path"])
 
     # Note: filter_urls can exclude pages listed in `urls` as well
-    paths = crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["page1"], crawler_depth=1)
-    assert len(paths) == 1
-    assert content_match(crawler, test_url + "/page1.html", paths[0])
+    documents = crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["page1"], crawler_depth=1)
+    assert len(documents) == 1
+    assert content_match(crawler, test_url + "/page1.html", documents[0].meta["file_path"])
     assert not crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["google.com"], crawler_depth=1)
 
 
-@pytest.mark.unit
-def test_crawler_return_document(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
-    documents, _ = crawler.run(urls=[test_url + "/index.html"], crawler_depth=0, return_documents=True)
-    paths, _ = crawler.run(urls=[test_url + "/index.html"], crawler_depth=0, return_documents=False)
-
-    for path, document in zip(paths["paths"], documents["documents"]):
-        with open(path.absolute(), "r") as doc_file:
-            file_content = json.load(doc_file)
-            assert file_content["meta"] == document.meta
-            assert file_content["content"] == document.content
-
-
-@pytest.mark.unit
 def test_crawler_extract_hidden_text(test_url, tmp_path):
     crawler = Crawler(output_dir=tmp_path)
-    documents, _ = crawler.run(
-        urls=[test_url + "/page_w_hidden_text.html"], extract_hidden_text=True, crawler_depth=0, return_documents=True
-    )
+    documents, _ = crawler.run(urls=[test_url + "/page_w_hidden_text.html"], extract_hidden_text=True, crawler_depth=0)
     crawled_content = documents["documents"][0].content
     assert "hidden text" in crawled_content
 
-    documents, _ = crawler.run(
-        urls=[test_url + "/page_w_hidden_text.html"], extract_hidden_text=False, crawler_depth=0, return_documents=True
-    )
+    documents, _ = crawler.run(urls=[test_url + "/page_w_hidden_text.html"], extract_hidden_text=False, crawler_depth=0)
     crawled_content = documents["documents"][0].content
     assert "hidden text" not in crawled_content
 
 
-@pytest.mark.unit
 def test_crawler_loading_wait_time(test_url, tmp_path):
     loading_wait_time = 3
-    crawler = Crawler(output_dir=tmp_path)
-    paths = crawler.crawl(urls=[test_url + "/page_dynamic.html"], crawler_depth=1, loading_wait_time=loading_wait_time)
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
+    documents = crawler.crawl(
+        urls=[test_url + "/page_dynamic.html"], crawler_depth=1, loading_wait_time=loading_wait_time
+    )
 
-    assert len(paths) == 4
+    assert len(documents) == 4
+
+    paths = [doc.meta["file_path"] for doc in documents]
 
     with open(f"{SAMPLES_PATH.absolute()}/crawler/page_dynamic_result.txt", "r") as dynamic_result:
         dynamic_result_text = dynamic_result.readlines()
@@ -204,32 +189,47 @@ def test_crawler_loading_wait_time(test_url, tmp_path):
     assert content_in_results(crawler, test_url + "/page2.html", paths)
 
 
-@pytest.mark.unit
 def test_crawler_default_naming_function(test_url, tmp_path):
-    crawler = Crawler(output_dir=tmp_path)
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
 
     link = f"{test_url}/page_with_a_very_long_name_to_do_some_tests_Now_let's_add_some_text_just_to_pass_the_129_chars_mark_and_trigger_the_chars_limit_of_the_default_naming_function.html"
     file_name_link = re.sub("[<>:'/\\|?*\0 ]", "_", link[:129])
     file_name_hash = hashlib.md5(f"{link}".encode("utf-8")).hexdigest()
     expected_crawled_file_path = f"{tmp_path}/{file_name_link}_{file_name_hash[-6:]}.json"
 
-    paths = crawler.crawl(urls=[link], crawler_depth=0)
+    documents = crawler.crawl(urls=[link], crawler_depth=0)
 
-    assert os.path.exists(paths[0])
-    assert paths[0] == Path(expected_crawled_file_path)
+    path = Path(documents[0].meta["file_path"])
+    assert os.path.exists(path)
+    assert path == Path(expected_crawled_file_path)
 
 
-@pytest.mark.unit
 def test_crawler_naming_function(test_url, tmp_path):
     crawler = Crawler(
-        output_dir=tmp_path, crawler_naming_function=lambda link, text: re.sub("[<>:'/\\|?*\0 ]", "_", link)
+        output_dir=tmp_path,
+        file_path_meta_field_name="file_path",
+        crawler_naming_function=lambda link, text: re.sub("[<>:'/\\|?*\0 ]", "_", link),
     )
 
     link = f"{test_url}/page_dynamic.html"
     file_name_link = re.sub("[<>:'/\\|?*\0 ]", "_", link)
     expected_crawled_file_path = tmp_path / f"{file_name_link}.json"
 
-    paths = crawler.crawl(urls=[test_url + "/page_dynamic.html"], crawler_depth=0)
+    documents = crawler.crawl(urls=[test_url + "/page_dynamic.html"], crawler_depth=0)
+    path = Path(documents[0].meta["file_path"])
+    assert os.path.exists(path)
+    assert path == expected_crawled_file_path
 
-    assert os.path.exists(paths[0])
-    assert paths[0] == expected_crawled_file_path
+
+def test_crawler_not_save_file(test_url):
+    crawler = Crawler()
+    documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=0)
+    assert documents[0].meta.get("file_path", None) is None
+
+
+def test_crawler_custom_meta_file_path_name(test_url, tmp_path):
+    crawler = Crawler()
+    documents = crawler.crawl(
+        urls=[test_url + "/index.html"], crawler_depth=0, output_dir=tmp_path, file_path_meta_field_name="custom"
+    )
+    assert documents[0].meta.get("custom", None) is not None

--- a/test/nodes/test_document_merger.py
+++ b/test/nodes/test_document_merger.py
@@ -1,73 +1,82 @@
+import pytest
+
 from haystack import Document
 from haystack.nodes.other.document_merger import DocumentMerger
 
-doc_dicts = [
-    {
-        "meta": {
-            "name": "name_1",
-            "year": "2020",
-            "month": "01",
-            "flat_field": 1,
-            "nested_field": {1: 2, "a": 5, "c": {"3": 3}, "d": "I will be dropped by the meta merge algorithm"},
-        },
-        "content": "text_1",
-    },
-    {
-        "meta": {
-            "name": "name_2",
-            "year": "2020",
-            "month": "02",
-            "flat_field": 1,
-            "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
-        },
-        "content": "text_2",
-    },
-    {
-        "meta": {
-            "name": "name_3",
-            "year": "2020",
-            "month": "03",
-            "flat_field": 1,
-            "nested_field": {1: 2, "a": 7, "c": {"3": 3}},
-        },
-        "content": "text_3",
-    },
-    {
-        "meta": {
-            "name": "name_4",
-            "year": "2021",
-            "month": "01",
-            "flat_field": 1,
-            "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
-        },
-        "content": "text_4",
-    },
-    {
-        "meta": {
-            "name": "name_5",
-            "year": "2021",
-            "month": "02",
-            "flat_field": 1,
-            "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
-        },
-        "content": "text_5",
-    },
-    {
-        "meta": {
-            "name": "name_6",
-            "year": "2021",
-            "month": "03",
-            "flat_field": 1,
-            "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
-        },
-        "content": "text_6",
-    },
-]
 
-documents = [Document.from_dict(doc) for doc in doc_dicts]
+@pytest.fixture
+def doc_dicts():
+    return [
+        {
+            "meta": {
+                "name": "name_1",
+                "year": "2020",
+                "month": "01",
+                "flat_field": 1,
+                "nested_field": {1: 2, "a": 5, "c": {"3": 3}, "d": "I will be dropped by the meta merge algorithm"},
+            },
+            "content": "text_1",
+        },
+        {
+            "meta": {
+                "name": "name_2",
+                "year": "2020",
+                "month": "02",
+                "flat_field": 1,
+                "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
+            },
+            "content": "text_2",
+        },
+        {
+            "meta": {
+                "name": "name_3",
+                "year": "2020",
+                "month": "03",
+                "flat_field": 1,
+                "nested_field": {1: 2, "a": 7, "c": {"3": 3}},
+            },
+            "content": "text_3",
+        },
+        {
+            "meta": {
+                "name": "name_4",
+                "year": "2021",
+                "month": "01",
+                "flat_field": 1,
+                "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
+            },
+            "content": "text_4",
+        },
+        {
+            "meta": {
+                "name": "name_5",
+                "year": "2021",
+                "month": "02",
+                "flat_field": 1,
+                "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
+            },
+            "content": "text_5",
+        },
+        {
+            "meta": {
+                "name": "name_6",
+                "year": "2021",
+                "month": "03",
+                "flat_field": 1,
+                "nested_field": {1: 2, "a": 5, "c": {"3": 3}},
+            },
+            "content": "text_6",
+        },
+    ]
 
 
-def test_document_merger_merge():
+@pytest.fixture
+def documents(doc_dicts):
+    return [Document.from_dict(doc) for doc in doc_dicts]
+
+
+@pytest.mark.unit
+def test_document_merger_merge(documents, doc_dicts):
     separator = "|"
     dm = DocumentMerger(separator=separator)
     merged_list = dm.merge(documents)
@@ -77,7 +86,8 @@ def test_document_merger_merge():
     assert merged_list[0].meta == {"flat_field": 1, "nested_field": {1: 2, "c": {"3": 3}}}
 
 
-def test_document_merger_run():
+@pytest.mark.unit
+def test_document_merger_run(documents, doc_dicts):
     separator = "|"
     dm = DocumentMerger(separator=separator)
     result = dm.run(documents)
@@ -87,7 +97,8 @@ def test_document_merger_run():
     assert result[0]["documents"][0].meta == {"flat_field": 1, "nested_field": {1: 2, "c": {"3": 3}}}
 
 
-def test_document_merger_run_batch():
+@pytest.mark.unit
+def test_document_merger_run_batch(documents, doc_dicts):
     separator = "|"
     dm = DocumentMerger(separator=separator)
     batch_result = dm.run_batch([documents, documents])

--- a/test/nodes/test_filetype_classifier.py
+++ b/test/nodes/test_filetype_classifier.py
@@ -65,7 +65,7 @@ def test_filetype_classifier_duplicate_custom_extensions():
 
 
 @pytest.mark.unit
-@pytest.mark.skipif(platform.system() == "Windows", reason="python-magic does not install properly on windows")
+@pytest.mark.skipif(platform.system() in ["Windows", "darwin"], reason="python-magic not available")
 def test_filetype_classifier_text_files_without_extension():
     tested_types = ["docx", "html", "odt", "pdf", "pptx", "txt"]
     node = FileTypeClassifier(supported_types=tested_types)
@@ -78,7 +78,7 @@ def test_filetype_classifier_text_files_without_extension():
 
 
 @pytest.mark.unit
-@pytest.mark.skipif(platform.system() == "Windows", reason="python-magic does not install properly on windows")
+@pytest.mark.skipif(platform.system() in ["Windows", "darwin"], reason="python-magic not available")
 def test_filetype_classifier_other_files_without_extension():
     tested_types = ["gif", "jpg", "mp3", "png", "wav", "zip"]
     node = FileTypeClassifier(supported_types=tested_types)

--- a/test/nodes/test_filetype_classifier.py
+++ b/test/nodes/test_filetype_classifier.py
@@ -9,6 +9,7 @@ from haystack.nodes.file_classifier.file_type import FileTypeClassifier, DEFAULT
 from ..conftest import SAMPLES_PATH
 
 
+@pytest.mark.unit
 def test_filetype_classifier_single_file(tmp_path):
     node = FileTypeClassifier()
     test_files = [tmp_path / f"test.{extension}" for extension in DEFAULT_TYPES]
@@ -19,6 +20,7 @@ def test_filetype_classifier_single_file(tmp_path):
         assert output == {"file_paths": [test_file]}
 
 
+@pytest.mark.unit
 def test_filetype_classifier_many_files(tmp_path):
     node = FileTypeClassifier()
 
@@ -30,6 +32,7 @@ def test_filetype_classifier_many_files(tmp_path):
         assert output == {"file_paths": test_files}
 
 
+@pytest.mark.unit
 def test_filetype_classifier_many_files_mixed_extensions(tmp_path):
     node = FileTypeClassifier()
     test_files = [tmp_path / f"test.{extension}" for extension in DEFAULT_TYPES]
@@ -38,6 +41,7 @@ def test_filetype_classifier_many_files_mixed_extensions(tmp_path):
         node.run(test_files)
 
 
+@pytest.mark.unit
 def test_filetype_classifier_unsupported_extension(tmp_path):
     node = FileTypeClassifier()
     test_file = tmp_path / f"test.really_weird_extension"
@@ -45,6 +49,7 @@ def test_filetype_classifier_unsupported_extension(tmp_path):
         node.run(test_file)
 
 
+@pytest.mark.unit
 def test_filetype_classifier_custom_extensions(tmp_path):
     node = FileTypeClassifier(supported_types=["my_extension"])
     test_file = tmp_path / f"test.my_extension"
@@ -53,11 +58,13 @@ def test_filetype_classifier_custom_extensions(tmp_path):
     assert output == {"file_paths": [test_file]}
 
 
+@pytest.mark.unit
 def test_filetype_classifier_duplicate_custom_extensions():
     with pytest.raises(ValueError):
         FileTypeClassifier(supported_types=[f"my_extension", "my_extension"])
 
 
+@pytest.mark.unit
 @pytest.mark.skipif(platform.system() == "Windows", reason="python-magic does not install properly on windows")
 def test_filetype_classifier_text_files_without_extension():
     tested_types = ["docx", "html", "odt", "pdf", "pptx", "txt"]
@@ -70,6 +77,7 @@ def test_filetype_classifier_text_files_without_extension():
         assert output == {"file_paths": [test_file]}
 
 
+@pytest.mark.unit
 @pytest.mark.skipif(platform.system() == "Windows", reason="python-magic does not install properly on windows")
 def test_filetype_classifier_other_files_without_extension():
     tested_types = ["gif", "jpg", "mp3", "png", "wav", "zip"]
@@ -82,6 +90,7 @@ def test_filetype_classifier_other_files_without_extension():
         assert output == {"file_paths": [test_file]}
 
 
+@pytest.mark.unit
 def test_filetype_classifier_text_files_without_extension_no_magic(monkeypatch, caplog):
     monkeypatch.delattr(haystack.nodes.file_classifier.file_type, "magic")
 

--- a/test/nodes/test_filetype_classifier.py
+++ b/test/nodes/test_filetype_classifier.py
@@ -92,7 +92,11 @@ def test_filetype_classifier_other_files_without_extension():
 
 @pytest.mark.unit
 def test_filetype_classifier_text_files_without_extension_no_magic(monkeypatch, caplog):
-    monkeypatch.delattr(haystack.nodes.file_classifier.file_type, "magic")
+    try:
+        monkeypatch.delattr(haystack.nodes.file_classifier.file_type, "magic")
+    except AttributeError:
+        # magic not installed, even better
+        pass
 
     node = FileTypeClassifier(supported_types=[""])
 

--- a/test/nodes/test_filetype_classifier.py
+++ b/test/nodes/test_filetype_classifier.py
@@ -65,7 +65,7 @@ def test_filetype_classifier_duplicate_custom_extensions():
 
 
 @pytest.mark.unit
-@pytest.mark.skipif(platform.system() in ["Windows", "darwin"], reason="python-magic not available")
+@pytest.mark.skipif(platform.system() in ["Windows", "Darwin"], reason="python-magic not available")
 def test_filetype_classifier_text_files_without_extension():
     tested_types = ["docx", "html", "odt", "pdf", "pptx", "txt"]
     node = FileTypeClassifier(supported_types=tested_types)
@@ -78,7 +78,7 @@ def test_filetype_classifier_text_files_without_extension():
 
 
 @pytest.mark.unit
-@pytest.mark.skipif(platform.system() in ["Windows", "darwin"], reason="python-magic not available")
+@pytest.mark.skipif(platform.system() in ["Windows", "Darwin"], reason="python-magic not available")
 def test_filetype_classifier_other_files_without_extension():
     tested_types = ["gif", "jpg", "mp3", "png", "wav", "zip"]
     node = FileTypeClassifier(supported_types=tested_types)

--- a/test/nodes/test_preprocessor.py
+++ b/test/nodes/test_preprocessor.py
@@ -196,7 +196,7 @@ def test_preprocess_passage_split(split_length_and_results):
     assert len(documents) == expected_documents_count
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="FIXME Footer not detected correctly on Windows")
 def test_clean_header_footer():
     converter = PDFToTextConverter()

--- a/test/nodes/test_preprocessor.py
+++ b/test/nodes/test_preprocessor.py
@@ -89,6 +89,7 @@ def patched_nltk_data_path(module_tmp_dir: Path, monkeypatch: MonkeyPatch, tmp_p
     return tmp_path
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("split_length_and_results", [(1, 15), (10, 2)])
 def test_preprocess_sentence_split(split_length_and_results):
     split_length, expected_documents_count = split_length_and_results
@@ -101,6 +102,7 @@ def test_preprocess_sentence_split(split_length_and_results):
     assert len(documents) == expected_documents_count
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("split_length_and_results", [(1, 15), (10, 2)])
 def test_preprocess_sentence_split_custom_models_wrong_file_format(split_length_and_results):
     split_length, expected_documents_count = split_length_and_results
@@ -118,6 +120,7 @@ def test_preprocess_sentence_split_custom_models_wrong_file_format(split_length_
     assert len(documents) == expected_documents_count
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("split_length_and_results", [(1, 15), (10, 2)])
 def test_preprocess_sentence_split_custom_models_non_default_language(split_length_and_results):
     split_length, expected_documents_count = split_length_and_results
@@ -134,6 +137,7 @@ def test_preprocess_sentence_split_custom_models_non_default_language(split_leng
     assert len(documents) == expected_documents_count
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("split_length_and_results", [(1, 8), (8, 1)])
 def test_preprocess_sentence_split_custom_models(split_length_and_results):
     split_length, expected_documents_count = split_length_and_results
@@ -151,6 +155,7 @@ def test_preprocess_sentence_split_custom_models(split_length_and_results):
     assert len(documents) == expected_documents_count
 
 
+@pytest.mark.unit
 def test_preprocess_word_split():
     document = Document(content=TEXT)
     preprocessor = PreProcessor(
@@ -178,6 +183,7 @@ def test_preprocess_word_split():
     assert len(documents) == 15
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("split_length_and_results", [(1, 3), (2, 2)])
 def test_preprocess_passage_split(split_length_and_results):
     split_length, expected_documents_count = split_length_and_results
@@ -190,6 +196,7 @@ def test_preprocess_passage_split(split_length_and_results):
     assert len(documents) == expected_documents_count
 
 
+@pytest.mark.unit
 @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="FIXME Footer not detected correctly on Windows")
 def test_clean_header_footer():
     converter = PDFToTextConverter()
@@ -206,6 +213,7 @@ def test_clean_header_footer():
     assert "footer" not in documents[0].content
 
 
+@pytest.mark.unit
 def test_remove_substrings():
     document = Document(content="This is a header. Some additional text. wiki. Some emoji ✨ 🪲 Weird whitespace\b\b\b.")
 
@@ -226,6 +234,7 @@ def test_remove_substrings():
     assert "✨" in documents[0].content
 
 
+@pytest.mark.unit
 def test_id_hash_keys_from_pipeline_params():
     document_1 = Document(content="This is a document.", meta={"key": "a"})
     document_2 = Document(content="This is a document.", meta={"key": "b"})
@@ -242,6 +251,7 @@ def test_id_hash_keys_from_pipeline_params():
 
 # test_input is a tuple consisting of the parameters for split_length, split_overlap and split_respect_sentence_boundary
 # and the expected index in the output list of Documents where the page number changes from 1 to 2
+@pytest.mark.unit
 @pytest.mark.parametrize("test_input", [(10, 0, True, 5), (10, 0, False, 4), (10, 5, True, 6), (10, 5, False, 7)])
 def test_page_number_extraction(test_input):
     split_length, overlap, resp_sent_boundary, exp_doc_index = test_input
@@ -261,6 +271,7 @@ def test_page_number_extraction(test_input):
             assert doc.meta["page"] == 2
 
 
+@pytest.mark.unit
 def test_page_number_extraction_on_empty_pages():
     """
     Often "marketing" documents contain pages without text (visuals only). When extracting page numbers, these pages should be counted as well to avoid
@@ -283,6 +294,7 @@ def test_page_number_extraction_on_empty_pages():
     assert documents[1].content.strip() == text_page_three
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_word():
     expected_headlines = [
         [{"headline": "sample sentence in paragraph_1", "start_idx": 11, "level": 0}],
@@ -313,6 +325,7 @@ def test_headline_processing_split_by_word():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_word_overlap():
     expected_headlines = [
         [{"headline": "sample sentence in paragraph_1", "start_idx": 11, "level": 0}],
@@ -347,6 +360,7 @@ def test_headline_processing_split_by_word_overlap():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_word_respect_sentence_boundary():
     expected_headlines = [
         [{"headline": "sample sentence in paragraph_1", "start_idx": 11, "level": 0}],
@@ -378,6 +392,7 @@ def test_headline_processing_split_by_word_respect_sentence_boundary():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_sentence():
     expected_headlines = [
         [
@@ -408,6 +423,7 @@ def test_headline_processing_split_by_sentence():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_sentence_overlap():
     expected_headlines = [
         [
@@ -441,6 +457,7 @@ def test_headline_processing_split_by_sentence_overlap():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_passage():
     expected_headlines = [
         [
@@ -471,6 +488,7 @@ def test_headline_processing_split_by_passage():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_headline_processing_split_by_passage_overlap():
     expected_headlines = [
         [
@@ -499,6 +517,7 @@ def test_headline_processing_split_by_passage_overlap():
         assert doc.meta["headlines"] == expected
 
 
+@pytest.mark.unit
 def test_file_exists_error_during_download(monkeypatch: MonkeyPatch, module_tmp_dir: Path):
     # Pretend the model resources were not found in the first attempt
     monkeypatch.setattr(nltk.data, "find", Mock(side_effect=[LookupError, str(module_tmp_dir)]))
@@ -510,6 +529,7 @@ def test_file_exists_error_during_download(monkeypatch: MonkeyPatch, module_tmp_
     PreProcessor(split_length=2, split_respect_sentence_boundary=False)
 
 
+@pytest.mark.unit
 def test_preprocessor_very_long_document(caplog):
     preproc = PreProcessor(
         clean_empty_lines=False, clean_header_footer=False, clean_whitespace=False, split_by=None, max_chars_check=10

--- a/test/nodes/test_shaper.py
+++ b/test/nodes/test_shaper.py
@@ -6,842 +6,176 @@ from haystack import Pipeline, Document, Answer
 from haystack.nodes.other.shaper import Shaper
 
 
-@pytest.fixture
-def mock_function(monkeypatch):
-    monkeypatch.setattr(
-        haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"test_function": lambda a, b: ([a] * len(b),)}
-    )
+@pytest.mark.unit
+class TestShaperUnit:
+    @pytest.fixture
+    def mock_function(self, monkeypatch):
+        monkeypatch.setattr(
+            haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"test_function": lambda a, b: ([a] * len(b),)}
+        )
 
+    @pytest.fixture
+    def mock_function_two_outputs(self, monkeypatch):
+        monkeypatch.setattr(
+            haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"two_output_test_function": lambda a: (a, len(a))}
+        )
 
-@pytest.fixture
-def mock_function_two_outputs(monkeypatch):
-    monkeypatch.setattr(
-        haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"two_output_test_function": lambda a: (a, len(a))}
-    )
+    def test_basic_invocation_only_inputs(self, mock_function):
+        shaper = Shaper(func="test_function", inputs={"a": "query", "b": "documents"}, outputs=["c"])
+        results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
+        assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
 
-
-def test_basic_invocation_only_inputs(mock_function):
-    shaper = Shaper(func="test_function", inputs={"a": "query", "b": "documents"}, outputs=["c"])
-    results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-    assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
-
-
-def test_multiple_outputs(mock_function_two_outputs):
-    shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c", "d"])
-    results, _ = shaper.run(query="test")
-    assert results["invocation_context"]["c"] == "test"
-    assert results["invocation_context"]["d"] == 4
-
-
-def test_multiple_outputs_error(mock_function_two_outputs, caplog):
-    shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c"])
-    with caplog.at_level(logging.WARNING):
+    def test_multiple_outputs(self, mock_function_two_outputs):
+        shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c", "d"])
         results, _ = shaper.run(query="test")
-        assert "Only 1 output(s) will be stored." in caplog.text
+        assert results["invocation_context"]["c"] == "test"
+        assert results["invocation_context"]["d"] == 4
 
+    def test_multiple_outputs_error(self, mock_function_two_outputs, caplog):
+        shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c"])
+        with caplog.at_level(logging.WARNING):
+            results, _ = shaper.run(query="test")
+            assert "Only 1 output(s) will be stored." in caplog.text
 
-def test_basic_invocation_only_params(mock_function):
-    shaper = Shaper(func="test_function", params={"a": "A", "b": list(range(3))}, outputs=["c"])
-    results, _ = shaper.run()
-    assert results["invocation_context"]["c"] == ["A", "A", "A"]
+    def test_basic_invocation_only_params(self, mock_function):
+        shaper = Shaper(func="test_function", params={"a": "A", "b": list(range(3))}, outputs=["c"])
+        results, _ = shaper.run()
+        assert results["invocation_context"]["c"] == ["A", "A", "A"]
 
+    def test_basic_invocation_inputs_and_params(self, mock_function):
+        shaper = Shaper(func="test_function", inputs={"a": "query"}, params={"b": list(range(2))}, outputs=["c"])
+        results, _ = shaper.run(query="test query")
+        assert results["invocation_context"]["c"] == ["test query", "test query"]
 
-def test_basic_invocation_inputs_and_params(mock_function):
-    shaper = Shaper(func="test_function", inputs={"a": "query"}, params={"b": list(range(2))}, outputs=["c"])
-    results, _ = shaper.run(query="test query")
-    assert results["invocation_context"]["c"] == ["test query", "test query"]
+    def test_basic_invocation_inputs_and_params_colliding(self, mock_function):
+        shaper = Shaper(
+            func="test_function",
+            inputs={"a": "query"},
+            params={"a": "default value", "b": list(range(2))},
+            outputs=["c"],
+        )
+        results, _ = shaper.run(query="test query")
+        assert results["invocation_context"]["c"] == ["test query", "test query"]
 
+    def test_basic_invocation_inputs_and_params_using_params_as_defaults(self, mock_function):
+        shaper = Shaper(
+            func="test_function", inputs={"a": "query"}, params={"a": "default", "b": list(range(2))}, outputs=["c"]
+        )
+        results, _ = shaper.run()
+        assert results["invocation_context"]["c"] == ["default", "default"]
 
-def test_basic_invocation_inputs_and_params_colliding(mock_function):
-    shaper = Shaper(
-        func="test_function", inputs={"a": "query"}, params={"a": "default value", "b": list(range(2))}, outputs=["c"]
-    )
-    results, _ = shaper.run(query="test query")
-    assert results["invocation_context"]["c"] == ["test query", "test query"]
+    def test_missing_argument(self, mock_function):
+        shaper = Shaper(func="test_function", inputs={"b": "documents"}, outputs=["c"])
+        with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
+            shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
+    def test_excess_argument(self, mock_function):
+        shaper = Shaper(
+            func="test_function", inputs={"a": "query", "b": "documents", "something_extra": "query"}, outputs=["c"]
+        )
+        with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
+            shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
-def test_basic_invocation_inputs_and_params_using_params_as_defaults(mock_function):
-    shaper = Shaper(
-        func="test_function", inputs={"a": "query"}, params={"a": "default", "b": list(range(2))}, outputs=["c"]
-    )
-    results, _ = shaper.run()
-    assert results["invocation_context"]["c"] == ["default", "default"]
+    def test_value_not_in_invocation_context(self, mock_function):
+        shaper = Shaper(
+            func="test_function", inputs={"a": "query", "b": "something_that_does_not_exist"}, outputs=["c"]
+        )
+        with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
+            shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
+    def test_value_only_in_invocation_context(self, mock_function):
+        shaper = Shaper(func="test_function", inputs={"a": "query", "b": "invocation_context_specific"}, outputs=["c"])
+        results, _s = shaper.run(
+            query="test query", invocation_context={"invocation_context_specific": ["doesn't", "really", "matter"]}
+        )
+        assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
 
-def test_missing_argument(mock_function):
-    shaper = Shaper(func="test_function", inputs={"b": "documents"}, outputs=["c"])
-    with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
-        shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-
-
-def test_excess_argument(mock_function):
-    shaper = Shaper(
-        func="test_function", inputs={"a": "query", "b": "documents", "something_extra": "query"}, outputs=["c"]
-    )
-    with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
-        shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-
-
-def test_value_not_in_invocation_context(mock_function):
-    shaper = Shaper(func="test_function", inputs={"a": "query", "b": "something_that_does_not_exist"}, outputs=["c"])
-    with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
-        shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-
-
-def test_value_only_in_invocation_context(mock_function):
-    shaper = Shaper(func="test_function", inputs={"a": "query", "b": "invocation_context_specific"}, outputs=["c"])
-    results, _s = shaper.run(
-        query="test query", invocation_context={"invocation_context_specific": ["doesn't", "really", "matter"]}
-    )
-    assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
-
-
-def test_yaml(mock_function, tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: test_function
-                inputs:
-                  a: query
+    def test_yaml(self, mock_function, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
                 params:
-                  b: [1, 1]
-                outputs:
-                  - c
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
+                  func: test_function
+                  inputs:
+                    a: query
+                  params:
+                    b: [1, 1]
+                  outputs:
+                    - c
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(
+            query="test query",
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
         )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(
-        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert result["invocation_context"]["c"] == ["test query", "test query"]
-    assert result["query"] == "test query"
-    assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
+        assert result["invocation_context"]["c"] == ["test query", "test query"]
+        assert result["query"] == "test query"
+        assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
 
+    #
+    # rename
+    #
 
-#
-# rename
-#
+    def test_rename(self):
+        shaper = Shaper(func="rename", inputs={"value": "query"}, outputs=["questions"])
+        results, _ = shaper.run(query="test query")
+        assert results["invocation_context"]["questions"] == "test query"
 
-
-def test_rename():
-    shaper = Shaper(func="rename", inputs={"value": "query"}, outputs=["questions"])
-    results, _ = shaper.run(query="test query")
-    assert results["invocation_context"]["questions"] == "test query"
-
-
-def test_rename_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: rename
-                inputs:
-                  value: query
-                outputs:
-                  - questions
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(query="test query")
-    assert result["invocation_context"]["query"] == "test query"
-    assert result["invocation_context"]["questions"] == "test query"
-
-
-#
-# value_to_list
-#
-
-
-def test_value_to_list():
-    shaper = Shaper(func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"])
-    results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-    assert results["invocation_context"]["questions"] == ["test query", "test query", "test query"]
-
-
-def test_value_to_list_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: query
-                  target_list: documents
-                outputs:
-                  - questions
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(
-        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert result["invocation_context"]["questions"] == ["test query", "test query", "test query"]
-    # Assert pipeline output is unaffected
-    assert result["query"] == "test query"
-    assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
-
-
-#
-# join_lists
-#
-
-
-def test_join_lists():
-    shaper = Shaper(func="join_lists", params={"lists": [[1, 2, 3], [4, 5]]}, outputs=["list"])
-    results, _ = shaper.run()
-    assert results["invocation_context"]["list"] == [1, 2, 3, 4, 5]
-
-
-def test_join_lists_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: join_lists
-                inputs:
-                  lists:
-                   - documents
-                   - file_paths
-                outputs:
-                  - single_list
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(documents=["first", "second", "third"], file_paths=["file1.txt", "file2.txt"])
-    assert result["invocation_context"]["single_list"] == ["first", "second", "third", "file1.txt", "file2.txt"]
-
-
-#
-# join_strings
-#
-
-
-def test_join_strings():
-    shaper = Shaper(
-        func="join_strings", params={"strings": ["first", "second"], "delimiter": " | "}, outputs=["single_string"]
-    )
-    results, _ = shaper.run()
-    assert results["invocation_context"]["single_string"] == "first | second"
-
-
-def test_join_strings_default_delimiter():
-    shaper = Shaper(func="join_strings", params={"strings": ["first", "second"]}, outputs=["single_string"])
-    results, _ = shaper.run()
-    assert results["invocation_context"]["single_string"] == "first second"
-
-
-def test_join_strings_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: join_strings
-                inputs:
-                  strings: documents
+    def test_rename_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
                 params:
-                  delimiter: ' - '
-                outputs:
-                  - single_string
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
+                  func: rename
+                  inputs:
+                    value: query
+                  outputs:
+                    - questions
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(query="test query")
+        assert result["invocation_context"]["query"] == "test query"
+        assert result["invocation_context"]["questions"] == "test query"
+
+    #
+    # value_to_list
+    #
+
+    def test_value_to_list(self):
+        shaper = Shaper(
+            func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"]
         )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(documents=["first", "second", "third"])
-    assert result["invocation_context"]["single_string"] == "first - second - third"
-
-
-def test_join_strings_default_delimiter_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: join_strings
-                inputs:
-                  strings: documents
-                outputs:
-                  - single_string
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(documents=["first", "second", "third"])
-    assert result["invocation_context"]["single_string"] == "first second third"
-
-
-#
-# join_documents
-#
-
-
-def test_join_documents():
-    shaper = Shaper(
-        func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " | "}, outputs=["documents"]
-    )
-    results, _ = shaper.run(
-        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
-
-
-def test_join_documents_default_delimiter():
-    shaper = Shaper(func="join_documents", inputs={"documents": "documents"}, outputs=["documents"])
-    results, _ = shaper.run(
-        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert results["invocation_context"]["documents"] == [Document(content="first second third")]
-
-
-def test_join_documents_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: join_documents
-                inputs:
-                  documents: documents
-                params:
-                  delimiter: ' - '
-                outputs:
-                  - documents
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(
-        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert result["invocation_context"]["documents"] == [Document(content="first - second - third")]
-    assert result["documents"] == [Document(content="first - second - third")]
-
-
-def test_join_documents_default_delimiter_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: join_documents
-                inputs:
-                  documents: documents
-                outputs:
-                  - documents
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(
-        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert result["invocation_context"]["documents"] == [Document(content="first second third")]
-
-
-#
-# strings_to_answers
-#
-
-
-def test_strings_to_answers_no_meta_no_hashkeys():
-    shaper = Shaper(func="strings_to_answers", inputs={"strings": "responses"}, outputs=["answers"])
-    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-    assert results["invocation_context"]["answers"] == [
-        Answer(answer="first", type="generative"),
-        Answer(answer="second", type="generative"),
-        Answer(answer="third", type="generative"),
-    ]
-
-
-def test_strings_to_answers_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: strings_to_answers
-                params:
-                  strings: ['a', 'b', 'c']
-                outputs:
-                  - answers
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run()
-    assert result["invocation_context"]["answers"] == [
-        Answer(answer="a", type="generative"),
-        Answer(answer="b", type="generative"),
-        Answer(answer="c", type="generative"),
-    ]
-
-
-#
-# answers_to_strings
-#
-
-
-def test_answers_to_strings():
-    shaper = Shaper(func="answers_to_strings", inputs={"answers": "documents"}, outputs=["strings"])
-    results, _ = shaper.run(documents=[Answer(answer="first"), Answer(answer="second"), Answer(answer="third")])
-    assert results["invocation_context"]["strings"] == ["first", "second", "third"]
-
-
-def test_answers_to_strings_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: answers_to_strings
-                inputs:
-                  answers: documents
-                outputs:
-                  - strings
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(documents=[Answer(answer="a"), Answer(answer="b"), Answer(answer="c")])
-    assert result["invocation_context"]["strings"] == ["a", "b", "c"]
-
-
-#
-# strings_to_documents
-#
-
-
-def test_strings_to_documents_no_meta_no_hashkeys():
-    shaper = Shaper(func="strings_to_documents", inputs={"strings": "responses"}, outputs=["documents"])
-    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-    assert results["invocation_context"]["documents"] == [
-        Document(content="first"),
-        Document(content="second"),
-        Document(content="third"),
-    ]
-
-
-def test_strings_to_documents_single_meta_no_hashkeys():
-    shaper = Shaper(
-        func="strings_to_documents", inputs={"strings": "responses"}, params={"meta": {"a": "A"}}, outputs=["documents"]
-    )
-    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-    assert results["invocation_context"]["documents"] == [
-        Document(content="first", meta={"a": "A"}),
-        Document(content="second", meta={"a": "A"}),
-        Document(content="third", meta={"a": "A"}),
-    ]
-
-
-def test_strings_to_documents_wrong_number_of_meta():
-    shaper = Shaper(
-        func="strings_to_documents",
-        inputs={"strings": "responses"},
-        params={"meta": [{"a": "A"}]},
-        outputs=["documents"],
-    )
-
-    with pytest.raises(ValueError, match="Not enough metadata dictionaries."):
-        shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-
-
-def test_strings_to_documents_many_meta_no_hashkeys():
-    shaper = Shaper(
-        func="strings_to_documents",
-        inputs={"strings": "responses"},
-        params={"meta": [{"a": i + 1} for i in range(3)]},
-        outputs=["documents"],
-    )
-    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-    assert results["invocation_context"]["documents"] == [
-        Document(content="first", meta={"a": 1}),
-        Document(content="second", meta={"a": 2}),
-        Document(content="third", meta={"a": 3}),
-    ]
-
-
-def test_strings_to_documents_single_meta_with_hashkeys():
-    shaper = Shaper(
-        func="strings_to_documents",
-        inputs={"strings": "responses"},
-        params={"meta": {"a": "A"}, "id_hash_keys": ["content", "meta"]},
-        outputs=["documents"],
-    )
-    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-    assert results["invocation_context"]["documents"] == [
-        Document(content="first", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
-        Document(content="second", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
-        Document(content="third", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
-    ]
-
-
-def test_strings_to_documents_no_meta_no_hashkeys_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: strings_to_documents
-                params:
-                  strings: ['a', 'b', 'c']
-                outputs:
-                  - documents
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run()
-    assert result["invocation_context"]["documents"] == [
-        Document(content="a"),
-        Document(content="b"),
-        Document(content="c"),
-    ]
-
-
-def test_strings_to_documents_meta_and_hashkeys_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: strings_to_documents
-                params:
-                  strings: ['first', 'second', 'third']
-                  id_hash_keys: ['content', 'meta']
-                  meta:
-                    - a: 1
-                    - a: 2
-                    - a: 3
-                outputs:
-                  - documents
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run()
-    assert result["invocation_context"]["documents"] == [
-        Document(content="first", meta={"a": 1}, id_hash_keys=["content", "meta"]),
-        Document(content="second", meta={"a": 2}, id_hash_keys=["content", "meta"]),
-        Document(content="third", meta={"a": 3}, id_hash_keys=["content", "meta"]),
-    ]
-
-
-#
-# documents_to_strings
-#
-
-
-def test_documents_to_strings():
-    shaper = Shaper(func="documents_to_strings", inputs={"documents": "documents"}, outputs=["strings"])
-    results, _ = shaper.run(
-        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-    assert results["invocation_context"]["strings"] == ["first", "second", "third"]
-
-
-def test_documents_to_strings_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: shaper
-              type: Shaper
-              params:
-                func: documents_to_strings
-                inputs:
-                  documents: documents
-                outputs:
-                  - strings
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(documents=[Document(content="a"), Document(content="b"), Document(content="c")])
-    assert result["invocation_context"]["strings"] == ["a", "b", "c"]
-
-
-#
-# Chaining and real-world usage
-#
-
-
-def test_chain_shapers():
-    shaper_1 = Shaper(
-        func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " - "}, outputs=["documents"]
-    )
-    shaper_2 = Shaper(
-        func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"]
-    )
-
-    pipe = Pipeline()
-    pipe.add_node(shaper_1, name="shaper_1", inputs=["Query"])
-    pipe.add_node(shaper_2, name="shaper_2", inputs=["shaper_1"])
-
-    results = pipe.run(
-        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-
-    assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
-    assert results["invocation_context"]["questions"] == ["test query"]
-
-
-def test_chain_shapers_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-
-            - name: shaper_1
-              type: Shaper
-              params:
-                func: join_documents
-                inputs:
-                  documents: documents
-                params:
-                  delimiter: ' - '
-                outputs:
-                  - documents
-
-            - name: shaper_2
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: query
-                  target_list: documents
-                outputs:
-                  - questions
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper_1
-                    inputs:
-                      - Query
-                  - name: shaper_2
-                    inputs:
-                      - shaper_1
-        """
-        )
-    pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-
-    results = pipe.run(
-        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-    )
-
-    assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
-    assert results["invocation_context"]["questions"] == ["test query"]
-
-
-def test_chain_shapers_yaml_2(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-
-            - name: shaper_1
-              type: Shaper
-              params:
-                func: strings_to_documents
-                params:
-                  strings:
-                    - first
-                    - second
-                    - third
-                outputs:
-                  - string_documents
-
-            - name: shaper_2
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  target_list: string_documents
-                params:
-                  value: hello
-                outputs:
-                  - greetings
-
-            - name: shaper_3
-              type: Shaper
-              params:
-                func: join_strings
-                inputs:
-                  strings: greetings
-                params:
-                  delimiter: '. '
-                outputs:
-                  - many_greetings
-
-            - name: expander
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: many_greetings
-                params:
-                  target_list: [1]
-                outputs:
-                  - many_greetings
-
-            - name: shaper_4
-              type: Shaper
-              params:
-                func: strings_to_documents
-                inputs:
-                  strings: many_greetings
-                outputs:
-                  - documents_with_greetings
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper_1
-                    inputs:
-                      - Query
-                  - name: shaper_2
-                    inputs:
-                      - shaper_1
-                  - name: shaper_3
-                    inputs:
-                      - shaper_2
-                  - name: expander
-                    inputs:
-                      - shaper_3
-                  - name: shaper_4
-                    inputs:
-                      - expander
-        """
-        )
-    pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    results = pipe.run()
-    assert results["invocation_context"]["documents_with_greetings"] == [Document(content="hello. hello. hello")]
-
-
-def test_with_prompt_node(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-              - name: prompt_model
-                type: PromptModel
-
+        results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
+        assert results["invocation_context"]["questions"] == ["test query", "test query", "test query"]
+
+    def test_value_to_list_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
               - name: shaper
                 type: Shaper
                 params:
@@ -851,24 +185,812 @@ def test_with_prompt_node(tmp_path):
                     target_list: documents
                   outputs:
                     - questions
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(
+            query="test query",
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
+        )
+        assert result["invocation_context"]["questions"] == ["test query", "test query", "test query"]
+        # Assert pipeline output is unaffected
+        assert result["query"] == "test query"
+        assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
 
-              - name: prompt_node
-                type: PromptNode
+    #
+    # join_lists
+    #
+
+    def test_join_lists(self):
+        shaper = Shaper(func="join_lists", params={"lists": [[1, 2, 3], [4, 5]]}, outputs=["list"])
+        results, _ = shaper.run()
+        assert results["invocation_context"]["list"] == [1, 2, 3, 4, 5]
+
+    def test_join_lists_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
                 params:
-                  output_variable: answers
-                  model_name_or_path: prompt_model
-                  default_prompt_template: question-answering
+                  func: join_lists
+                  inputs:
+                    lists:
+                    - documents
+                    - file_paths
+                  outputs:
+                    - single_list
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(documents=["first", "second", "third"], file_paths=["file1.txt", "file2.txt"])
+        assert result["invocation_context"]["single_list"] == ["first", "second", "third", "file1.txt", "file2.txt"]
 
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-                  - name: prompt_node
-                    inputs:
-                      - shaper
-            """
+    #
+    # join_strings
+    #
+
+    def test_join_strings(self):
+        shaper = Shaper(
+            func="join_strings", params={"strings": ["first", "second"], "delimiter": " | "}, outputs=["single_string"]
+        )
+        results, _ = shaper.run()
+        assert results["invocation_context"]["single_string"] == "first | second"
+
+    def test_join_strings_default_delimiter(self):
+        shaper = Shaper(func="join_strings", params={"strings": ["first", "second"]}, outputs=["single_string"])
+        results, _ = shaper.run()
+        assert results["invocation_context"]["single_string"] == "first second"
+
+    def test_join_strings_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: join_strings
+                  inputs:
+                    strings: documents
+                  params:
+                    delimiter: ' - '
+                  outputs:
+                    - single_string
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(documents=["first", "second", "third"])
+        assert result["invocation_context"]["single_string"] == "first - second - third"
+
+    def test_join_strings_default_delimiter_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: join_strings
+                  inputs:
+                    strings: documents
+                  outputs:
+                    - single_string
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(documents=["first", "second", "third"])
+        assert result["invocation_context"]["single_string"] == "first second third"
+
+    #
+    # join_documents
+    #
+
+    def test_join_documents(self):
+        shaper = Shaper(
+            func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " | "}, outputs=["documents"]
+        )
+        results, _ = shaper.run(
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+        )
+        assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
+
+    def test_join_documents_default_delimiter(self):
+        shaper = Shaper(func="join_documents", inputs={"documents": "documents"}, outputs=["documents"])
+        results, _ = shaper.run(
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+        )
+        assert results["invocation_context"]["documents"] == [Document(content="first second third")]
+
+    def test_join_documents_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: join_documents
+                  inputs:
+                    documents: documents
+                  params:
+                    delimiter: ' - '
+                  outputs:
+                    - documents
+
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(
+            query="test query",
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
+        )
+        assert result["invocation_context"]["documents"] == [Document(content="first - second - third")]
+        assert result["documents"] == [Document(content="first - second - third")]
+
+    def test_join_documents_default_delimiter_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: join_documents
+                  inputs:
+                    documents: documents
+                  outputs:
+                    - documents
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(
+            query="test query",
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
+        )
+        assert result["invocation_context"]["documents"] == [Document(content="first second third")]
+
+    #
+    # strings_to_answers
+    #
+
+    def test_strings_to_answers_no_meta_no_hashkeys(self):
+        shaper = Shaper(func="strings_to_answers", inputs={"strings": "responses"}, outputs=["answers"])
+        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+        assert results["invocation_context"]["answers"] == [
+            Answer(answer="first", type="generative"),
+            Answer(answer="second", type="generative"),
+            Answer(answer="third", type="generative"),
+        ]
+
+    def test_strings_to_answers_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: strings_to_answers
+                  params:
+                    strings: ['a', 'b', 'c']
+                  outputs:
+                    - answers
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run()
+        assert result["invocation_context"]["answers"] == [
+            Answer(answer="a", type="generative"),
+            Answer(answer="b", type="generative"),
+            Answer(answer="c", type="generative"),
+        ]
+
+    #
+    # answers_to_strings
+    #
+
+    def test_answers_to_strings(self):
+        shaper = Shaper(func="answers_to_strings", inputs={"answers": "documents"}, outputs=["strings"])
+        results, _ = shaper.run(documents=[Answer(answer="first"), Answer(answer="second"), Answer(answer="third")])
+        assert results["invocation_context"]["strings"] == ["first", "second", "third"]
+
+    def test_answers_to_strings_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: answers_to_strings
+                  inputs:
+                    answers: documents
+                  outputs:
+                    - strings
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(documents=[Answer(answer="a"), Answer(answer="b"), Answer(answer="c")])
+        assert result["invocation_context"]["strings"] == ["a", "b", "c"]
+
+    #
+    # strings_to_documents
+    #
+
+    def test_strings_to_documents_no_meta_no_hashkeys(self):
+        shaper = Shaper(func="strings_to_documents", inputs={"strings": "responses"}, outputs=["documents"])
+        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+        assert results["invocation_context"]["documents"] == [
+            Document(content="first"),
+            Document(content="second"),
+            Document(content="third"),
+        ]
+
+    def test_strings_to_documents_single_meta_no_hashkeys(self):
+        shaper = Shaper(
+            func="strings_to_documents",
+            inputs={"strings": "responses"},
+            params={"meta": {"a": "A"}},
+            outputs=["documents"],
+        )
+        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+        assert results["invocation_context"]["documents"] == [
+            Document(content="first", meta={"a": "A"}),
+            Document(content="second", meta={"a": "A"}),
+            Document(content="third", meta={"a": "A"}),
+        ]
+
+    def test_strings_to_documents_wrong_number_of_meta(self):
+        shaper = Shaper(
+            func="strings_to_documents",
+            inputs={"strings": "responses"},
+            params={"meta": [{"a": "A"}]},
+            outputs=["documents"],
+        )
+
+        with pytest.raises(ValueError, match="Not enough metadata dictionaries."):
+            shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+
+    def test_strings_to_documents_many_meta_no_hashkeys(self):
+        shaper = Shaper(
+            func="strings_to_documents",
+            inputs={"strings": "responses"},
+            params={"meta": [{"a": i + 1} for i in range(3)]},
+            outputs=["documents"],
+        )
+        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+        assert results["invocation_context"]["documents"] == [
+            Document(content="first", meta={"a": 1}),
+            Document(content="second", meta={"a": 2}),
+            Document(content="third", meta={"a": 3}),
+        ]
+
+    def test_strings_to_documents_single_meta_with_hashkeys(self):
+        shaper = Shaper(
+            func="strings_to_documents",
+            inputs={"strings": "responses"},
+            params={"meta": {"a": "A"}, "id_hash_keys": ["content", "meta"]},
+            outputs=["documents"],
+        )
+        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+        assert results["invocation_context"]["documents"] == [
+            Document(content="first", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
+            Document(content="second", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
+            Document(content="third", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
+        ]
+
+    def test_strings_to_documents_no_meta_no_hashkeys_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: strings_to_documents
+                  params:
+                    strings: ['a', 'b', 'c']
+                  outputs:
+                    - documents
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run()
+        assert result["invocation_context"]["documents"] == [
+            Document(content="a"),
+            Document(content="b"),
+            Document(content="c"),
+        ]
+
+    def test_strings_to_documents_meta_and_hashkeys_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: strings_to_documents
+                  params:
+                    strings: ['first', 'second', 'third']
+                    id_hash_keys: ['content', 'meta']
+                    meta:
+                      - a: 1
+                      - a: 2
+                      - a: 3
+                  outputs:
+                    - documents
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run()
+        assert result["invocation_context"]["documents"] == [
+            Document(content="first", meta={"a": 1}, id_hash_keys=["content", "meta"]),
+            Document(content="second", meta={"a": 2}, id_hash_keys=["content", "meta"]),
+            Document(content="third", meta={"a": 3}, id_hash_keys=["content", "meta"]),
+        ]
+
+    #
+    # documents_to_strings
+    #
+
+    def test_documents_to_strings(self):
+        shaper = Shaper(func="documents_to_strings", inputs={"documents": "documents"}, outputs=["strings"])
+        results, _ = shaper.run(
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+        )
+        assert results["invocation_context"]["strings"] == ["first", "second", "third"]
+
+    def test_documents_to_strings_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: shaper
+                type: Shaper
+                params:
+                  func: documents_to_strings
+                  inputs:
+                    documents: documents
+                  outputs:
+                    - strings
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper
+                      inputs:
+                        - Query
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(documents=[Document(content="a"), Document(content="b"), Document(content="c")])
+        assert result["invocation_context"]["strings"] == ["a", "b", "c"]
+
+    #
+    # Chaining and real-world usage
+    #
+
+    def test_chain_shapers(self):
+        shaper_1 = Shaper(
+            func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " - "}, outputs=["documents"]
+        )
+        shaper_2 = Shaper(
+            func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"]
+        )
+
+        pipe = Pipeline()
+        pipe.add_node(shaper_1, name="shaper_1", inputs=["Query"])
+        pipe.add_node(shaper_2, name="shaper_2", inputs=["shaper_1"])
+
+        results = pipe.run(
+            query="test query",
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
+        )
+
+        assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
+        assert results["invocation_context"]["questions"] == ["test query"]
+
+    def test_chain_shapers_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+
+              - name: shaper_1
+                type: Shaper
+                params:
+                  func: join_documents
+                  inputs:
+                    documents: documents
+                  params:
+                    delimiter: ' - '
+                  outputs:
+                    - documents
+
+              - name: shaper_2
+                type: Shaper
+                params:
+                  func: value_to_list
+                  inputs:
+                    value: query
+                    target_list: documents
+                  outputs:
+                    - questions
+
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper_1
+                      inputs:
+                        - Query
+                    - name: shaper_2
+                      inputs:
+                        - shaper_1
+          """
+            )
+        pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+
+        results = pipe.run(
+            query="test query",
+            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
+        )
+
+        assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
+        assert results["invocation_context"]["questions"] == ["test query"]
+
+    def test_chain_shapers_yaml_2(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+
+              - name: shaper_1
+                type: Shaper
+                params:
+                  func: strings_to_documents
+                  params:
+                    strings:
+                      - first
+                      - second
+                      - third
+                  outputs:
+                    - string_documents
+
+              - name: shaper_2
+                type: Shaper
+                params:
+                  func: value_to_list
+                  inputs:
+                    target_list: string_documents
+                  params:
+                    value: hello
+                  outputs:
+                    - greetings
+
+              - name: shaper_3
+                type: Shaper
+                params:
+                  func: join_strings
+                  inputs:
+                    strings: greetings
+                  params:
+                    delimiter: '. '
+                  outputs:
+                    - many_greetings
+
+              - name: expander
+                type: Shaper
+                params:
+                  func: value_to_list
+                  inputs:
+                    value: many_greetings
+                  params:
+                    target_list: [1]
+                  outputs:
+                    - many_greetings
+
+              - name: shaper_4
+                type: Shaper
+                params:
+                  func: strings_to_documents
+                  inputs:
+                    strings: many_greetings
+                  outputs:
+                    - documents_with_greetings
+
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: shaper_1
+                      inputs:
+                        - Query
+                    - name: shaper_2
+                      inputs:
+                        - shaper_1
+                    - name: shaper_3
+                      inputs:
+                        - shaper_2
+                    - name: expander
+                      inputs:
+                        - shaper_3
+                    - name: shaper_4
+                      inputs:
+                        - expander
+          """
+            )
+        pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        results = pipe.run()
+        assert results["invocation_context"]["documents_with_greetings"] == [Document(content="hello. hello. hello")]
+
+    def test_join_query_and_documents_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+
+              components:
+              - name: expander
+                type: Shaper
+                params:
+                  func: value_to_list
+                  inputs:
+                    value: query
+                  params:
+                    target_list: [1]
+                  outputs:
+                    - query
+
+              - name: joiner
+                type: Shaper
+                params:
+                  func: join_lists
+                  inputs:
+                    lists:
+                    - documents
+                    - query
+                  outputs:
+                    - query
+
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: expander
+                      inputs:
+                        - Query
+                    - name: joiner
+                      inputs:
+                        - expander
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
+        assert result["query"] == ["first", "second", "third", "What is going on here?"]
+
+    def test_join_query_and_documents_into_single_string_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: expander
+                type: Shaper
+                params:
+                  func: value_to_list
+                  inputs:
+                    value: query
+                  params:
+                    target_list: [1]
+                  outputs:
+                    - query
+
+              - name: joiner
+                type: Shaper
+                params:
+                  func: join_lists
+                  inputs:
+                    lists:
+                    - documents
+                    - query
+                  outputs:
+                    - query
+
+              - name: concatenator
+                type: Shaper
+                params:
+                  func: join_strings
+                  inputs:
+                    strings: query
+                  outputs:
+                    - query
+
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: expander
+                      inputs:
+                        - Query
+                    - name: joiner
+                      inputs:
+                        - expander
+                    - name: concatenator
+                      inputs:
+                        - joiner
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
+        assert result["query"] == "first second third What is going on here?"
+
+    def test_join_query_and_documents_convert_into_documents_yaml(self, tmp_path):
+        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+            tmp_file.write(
+                f"""
+              version: ignore
+              components:
+              - name: expander
+                type: Shaper
+                params:
+                  func: value_to_list
+                  inputs:
+                    value: query
+                  params:
+                    target_list: [1]
+                  outputs:
+                    - query
+
+              - name: joiner
+                type: Shaper
+                params:
+                  func: join_lists
+                  inputs:
+                    lists:
+                    - documents
+                    - query
+                  outputs:
+                    - query_and_docs
+
+              - name: converter
+                type: Shaper
+                params:
+                  func: strings_to_documents
+                  inputs:
+                    strings: query_and_docs
+                  outputs:
+                    - query_and_docs
+
+              pipelines:
+                - name: query
+                  nodes:
+                    - name: expander
+                      inputs:
+                        - Query
+                    - name: joiner
+                      inputs:
+                        - expander
+                    - name: converter
+                      inputs:
+                        - joiner
+          """
+            )
+        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+        result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
+        assert result["invocation_context"]["query_and_docs"]
+        assert len(result["invocation_context"]["query_and_docs"]) == 4
+        assert isinstance(result["invocation_context"]["query_and_docs"][0], Document)
+
+
+@pytest.mark.integration
+def test_with_prompt_node(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+          version: ignore
+          components:
+            - name: prompt_model
+              type: PromptModel
+
+            - name: shaper
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: query
+                  target_list: documents
+                outputs:
+                  - questions
+
+            - name: prompt_node
+              type: PromptNode
+              params:
+                output_variable: answers
+                model_name_or_path: prompt_model
+                default_prompt_template: question-answering
+
+          pipelines:
+            - name: query
+              nodes:
+                - name: shaper
+                  inputs:
+                    - Query
+                - name: prompt_node
+                  inputs:
+                    - shaper
+          """
         )
     pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
     result = pipeline.run(
@@ -882,72 +1004,73 @@ def test_with_prompt_node(tmp_path):
     assert len(result["invocation_context"]["questions"]) == 2
 
 
+@pytest.mark.integration
 def test_with_multiple_prompt_nodes(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
             f"""
-            version: ignore
-            components:
-              - name: prompt_model
-                type: PromptModel
+          version: ignore
+          components:
+            - name: prompt_model
+              type: PromptModel
 
-              - name: shaper
-                type: Shaper
-                params:
-                  func: value_to_list
+            - name: shaper
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: query
+                  target_list: documents
+                outputs: [questions]
+
+            - name: renamer
+              type: Shaper
+              params:
+                func: rename
+                inputs:
+                  value: new-questions
+                outputs:
+                  - questions
+
+            - name: prompt_node
+              type: PromptNode
+              params:
+                model_name_or_path: prompt_model
+                default_prompt_template: question-answering
+
+            - name: prompt_node_second
+              type: PromptNode
+              params:
+                model_name_or_path: prompt_model
+                default_prompt_template: question-generation
+                output_variable: new-questions
+
+            - name: prompt_node_third
+              type: PromptNode
+              params:
+                output_variable: answers
+                model_name_or_path: google/flan-t5-small
+                default_prompt_template: question-answering
+
+          pipelines:
+            - name: query
+              nodes:
+                - name: shaper
                   inputs:
-                    value: query
-                    target_list: documents
-                  outputs: [questions]
-
-              - name: renamer
-                type: Shaper
-                params:
-                  func: rename
+                    - Query
+                - name: prompt_node
                   inputs:
-                    value: new-questions
-                  outputs:
-                    - questions
-
-              - name: prompt_node
-                type: PromptNode
-                params:
-                  model_name_or_path: prompt_model
-                  default_prompt_template: question-answering
-
-              - name: prompt_node_second
-                type: PromptNode
-                params:
-                  model_name_or_path: prompt_model
-                  default_prompt_template: question-generation
-                  output_variable: new-questions
-
-              - name: prompt_node_third
-                type: PromptNode
-                params:
-                  output_variable: answers
-                  model_name_or_path: google/flan-t5-small
-                  default_prompt_template: question-answering
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: shaper
-                    inputs:
-                      - Query
-                  - name: prompt_node
-                    inputs:
-                      - shaper
-                  - name: prompt_node_second
-                    inputs:
-                      - prompt_node
-                  - name: renamer
-                    inputs:
-                      - prompt_node_second
-                  - name: prompt_node_third
-                    inputs:
-                      - renamer
-            """
+                    - shaper
+                - name: prompt_node_second
+                  inputs:
+                    - prompt_node
+                - name: renamer
+                  inputs:
+                    - prompt_node_second
+                - name: prompt_node_third
+                  inputs:
+                    - renamer
+          """
         )
     pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
     result = pipeline.run(
@@ -957,162 +1080,3 @@ def test_with_multiple_prompt_nodes(tmp_path):
     results = result["answers"]
     assert len(results) == 2
     assert any([True for r in results if "Berlin" in r])
-
-
-def test_join_query_and_documents_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-
-            components:
-            - name: expander
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: query
-                params:
-                  target_list: [1]
-                outputs:
-                  - query
-
-            - name: joiner
-              type: Shaper
-              params:
-                func: join_lists
-                inputs:
-                  lists:
-                   - documents
-                   - query
-                outputs:
-                  - query
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: expander
-                    inputs:
-                      - Query
-                  - name: joiner
-                    inputs:
-                      - expander
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
-    assert result["query"] == ["first", "second", "third", "What is going on here?"]
-
-
-def test_join_query_and_documents_into_single_string_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: expander
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: query
-                params:
-                  target_list: [1]
-                outputs:
-                  - query
-
-            - name: joiner
-              type: Shaper
-              params:
-                func: join_lists
-                inputs:
-                  lists:
-                   - documents
-                   - query
-                outputs:
-                  - query
-
-            - name: concatenator
-              type: Shaper
-              params:
-                func: join_strings
-                inputs:
-                  strings: query
-                outputs:
-                  - query
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: expander
-                    inputs:
-                      - Query
-                  - name: joiner
-                    inputs:
-                      - expander
-                  - name: concatenator
-                    inputs:
-                      - joiner
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
-    assert result["query"] == "first second third What is going on here?"
-
-
-def test_join_query_and_documents_convert_into_documents_yaml(tmp_path):
-    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-        tmp_file.write(
-            f"""
-            version: ignore
-            components:
-            - name: expander
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: query
-                params:
-                  target_list: [1]
-                outputs:
-                  - query
-
-            - name: joiner
-              type: Shaper
-              params:
-                func: join_lists
-                inputs:
-                  lists:
-                   - documents
-                   - query
-                outputs:
-                  - query_and_docs
-
-            - name: converter
-              type: Shaper
-              params:
-                func: strings_to_documents
-                inputs:
-                  strings: query_and_docs
-                outputs:
-                  - query_and_docs
-
-            pipelines:
-              - name: query
-                nodes:
-                  - name: expander
-                    inputs:
-                      - Query
-                  - name: joiner
-                    inputs:
-                      - expander
-                  - name: converter
-                    inputs:
-                      - joiner
-        """
-        )
-    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-    result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
-    assert result["invocation_context"]["query_and_docs"]
-    assert len(result["invocation_context"]["query_and_docs"]) == 4
-    assert isinstance(result["invocation_context"]["query_and_docs"][0], Document)

--- a/test/nodes/test_shaper.py
+++ b/test/nodes/test_shaper.py
@@ -20,12 +20,14 @@ def mock_function_two_outputs(monkeypatch):
     )
 
 
+@pytest.mark.unit
 def test_basic_invocation_only_inputs(mock_function):
     shaper = Shaper(func="test_function", inputs={"a": "query", "b": "documents"}, outputs=["c"])
     results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
     assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
 
 
+@pytest.mark.unit
 def test_multiple_outputs(mock_function_two_outputs):
     shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c", "d"])
     results, _ = shaper.run(query="test")
@@ -33,6 +35,7 @@ def test_multiple_outputs(mock_function_two_outputs):
     assert results["invocation_context"]["d"] == 4
 
 
+@pytest.mark.unit
 def test_multiple_outputs_error(mock_function_two_outputs, caplog):
     shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c"])
     with caplog.at_level(logging.WARNING):
@@ -40,18 +43,21 @@ def test_multiple_outputs_error(mock_function_two_outputs, caplog):
         assert "Only 1 output(s) will be stored." in caplog.text
 
 
+@pytest.mark.unit
 def test_basic_invocation_only_params(mock_function):
     shaper = Shaper(func="test_function", params={"a": "A", "b": list(range(3))}, outputs=["c"])
     results, _ = shaper.run()
     assert results["invocation_context"]["c"] == ["A", "A", "A"]
 
 
+@pytest.mark.unit
 def test_basic_invocation_inputs_and_params(mock_function):
     shaper = Shaper(func="test_function", inputs={"a": "query"}, params={"b": list(range(2))}, outputs=["c"])
     results, _ = shaper.run(query="test query")
     assert results["invocation_context"]["c"] == ["test query", "test query"]
 
 
+@pytest.mark.unit
 def test_basic_invocation_inputs_and_params_colliding(mock_function):
     shaper = Shaper(
         func="test_function", inputs={"a": "query"}, params={"a": "default value", "b": list(range(2))}, outputs=["c"]
@@ -60,6 +66,7 @@ def test_basic_invocation_inputs_and_params_colliding(mock_function):
     assert results["invocation_context"]["c"] == ["test query", "test query"]
 
 
+@pytest.mark.unit
 def test_basic_invocation_inputs_and_params_using_params_as_defaults(mock_function):
     shaper = Shaper(
         func="test_function", inputs={"a": "query"}, params={"a": "default", "b": list(range(2))}, outputs=["c"]
@@ -68,12 +75,14 @@ def test_basic_invocation_inputs_and_params_using_params_as_defaults(mock_functi
     assert results["invocation_context"]["c"] == ["default", "default"]
 
 
+@pytest.mark.unit
 def test_missing_argument(mock_function):
     shaper = Shaper(func="test_function", inputs={"b": "documents"}, outputs=["c"])
     with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
         shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
 
+@pytest.mark.unit
 def test_excess_argument(mock_function):
     shaper = Shaper(
         func="test_function", inputs={"a": "query", "b": "documents", "something_extra": "query"}, outputs=["c"]
@@ -82,12 +91,14 @@ def test_excess_argument(mock_function):
         shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
 
+@pytest.mark.unit
 def test_value_not_in_invocation_context(mock_function):
     shaper = Shaper(func="test_function", inputs={"a": "query", "b": "something_that_does_not_exist"}, outputs=["c"])
     with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
         shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
 
+@pytest.mark.unit
 def test_value_only_in_invocation_context(mock_function):
     shaper = Shaper(func="test_function", inputs={"a": "query", "b": "invocation_context_specific"}, outputs=["c"])
     results, _s = shaper.run(
@@ -96,6 +107,7 @@ def test_value_only_in_invocation_context(mock_function):
     assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
 
 
+@pytest.mark.unit
 def test_yaml(mock_function, tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -134,12 +146,14 @@ def test_yaml(mock_function, tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_rename():
     shaper = Shaper(func="rename", inputs={"value": "query"}, outputs=["questions"])
     results, _ = shaper.run(query="test query")
     assert results["invocation_context"]["questions"] == "test query"
 
 
+@pytest.mark.unit
 def test_rename_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -173,12 +187,14 @@ def test_rename_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_value_to_list():
     shaper = Shaper(func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"])
     results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
     assert results["invocation_context"]["questions"] == ["test query", "test query", "test query"]
 
 
+@pytest.mark.unit
 def test_value_to_list_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -217,12 +233,14 @@ def test_value_to_list_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_join_lists():
     shaper = Shaper(func="join_lists", params={"lists": [[1, 2, 3], [4, 5]]}, outputs=["list"])
     results, _ = shaper.run()
     assert results["invocation_context"]["list"] == [1, 2, 3, 4, 5]
 
 
+@pytest.mark.unit
 def test_join_lists_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -257,6 +275,7 @@ def test_join_lists_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_join_strings():
     shaper = Shaper(
         func="join_strings", params={"strings": ["first", "second"], "delimiter": " | "}, outputs=["single_string"]
@@ -265,12 +284,14 @@ def test_join_strings():
     assert results["invocation_context"]["single_string"] == "first | second"
 
 
+@pytest.mark.unit
 def test_join_strings_default_delimiter():
     shaper = Shaper(func="join_strings", params={"strings": ["first", "second"]}, outputs=["single_string"])
     results, _ = shaper.run()
     assert results["invocation_context"]["single_string"] == "first second"
 
 
+@pytest.mark.unit
 def test_join_strings_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -300,6 +321,7 @@ def test_join_strings_yaml(tmp_path):
     assert result["invocation_context"]["single_string"] == "first - second - third"
 
 
+@pytest.mark.unit
 def test_join_strings_default_delimiter_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -332,6 +354,7 @@ def test_join_strings_default_delimiter_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_join_documents():
     shaper = Shaper(
         func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " | "}, outputs=["documents"]
@@ -342,6 +365,7 @@ def test_join_documents():
     assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
 
 
+@pytest.mark.unit
 def test_join_documents_default_delimiter():
     shaper = Shaper(func="join_documents", inputs={"documents": "documents"}, outputs=["documents"])
     results, _ = shaper.run(
@@ -350,6 +374,7 @@ def test_join_documents_default_delimiter():
     assert results["invocation_context"]["documents"] == [Document(content="first second third")]
 
 
+@pytest.mark.unit
 def test_join_documents_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -384,6 +409,7 @@ def test_join_documents_yaml(tmp_path):
     assert result["documents"] == [Document(content="first - second - third")]
 
 
+@pytest.mark.unit
 def test_join_documents_default_delimiter_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -418,6 +444,7 @@ def test_join_documents_default_delimiter_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_strings_to_answers_no_meta_no_hashkeys():
     shaper = Shaper(func="strings_to_answers", inputs={"strings": "responses"}, outputs=["answers"])
     results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
@@ -428,6 +455,7 @@ def test_strings_to_answers_no_meta_no_hashkeys():
     ]
 
 
+@pytest.mark.unit
 def test_strings_to_answers_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -464,12 +492,14 @@ def test_strings_to_answers_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_answers_to_strings():
     shaper = Shaper(func="answers_to_strings", inputs={"answers": "documents"}, outputs=["strings"])
     results, _ = shaper.run(documents=[Answer(answer="first"), Answer(answer="second"), Answer(answer="third")])
     assert results["invocation_context"]["strings"] == ["first", "second", "third"]
 
 
+@pytest.mark.unit
 def test_answers_to_strings_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -502,6 +532,7 @@ def test_answers_to_strings_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_strings_to_documents_no_meta_no_hashkeys():
     shaper = Shaper(func="strings_to_documents", inputs={"strings": "responses"}, outputs=["documents"])
     results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
@@ -512,6 +543,7 @@ def test_strings_to_documents_no_meta_no_hashkeys():
     ]
 
 
+@pytest.mark.unit
 def test_strings_to_documents_single_meta_no_hashkeys():
     shaper = Shaper(
         func="strings_to_documents", inputs={"strings": "responses"}, params={"meta": {"a": "A"}}, outputs=["documents"]
@@ -524,6 +556,7 @@ def test_strings_to_documents_single_meta_no_hashkeys():
     ]
 
 
+@pytest.mark.unit
 def test_strings_to_documents_wrong_number_of_meta():
     shaper = Shaper(
         func="strings_to_documents",
@@ -536,6 +569,7 @@ def test_strings_to_documents_wrong_number_of_meta():
         shaper.run(invocation_context={"responses": ["first", "second", "third"]})
 
 
+@pytest.mark.unit
 def test_strings_to_documents_many_meta_no_hashkeys():
     shaper = Shaper(
         func="strings_to_documents",
@@ -551,6 +585,7 @@ def test_strings_to_documents_many_meta_no_hashkeys():
     ]
 
 
+@pytest.mark.unit
 def test_strings_to_documents_single_meta_with_hashkeys():
     shaper = Shaper(
         func="strings_to_documents",
@@ -566,6 +601,7 @@ def test_strings_to_documents_single_meta_with_hashkeys():
     ]
 
 
+@pytest.mark.unit
 def test_strings_to_documents_no_meta_no_hashkeys_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -597,6 +633,7 @@ def test_strings_to_documents_no_meta_no_hashkeys_yaml(tmp_path):
     ]
 
 
+@pytest.mark.unit
 def test_strings_to_documents_meta_and_hashkeys_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -638,6 +675,7 @@ def test_strings_to_documents_meta_and_hashkeys_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_documents_to_strings():
     shaper = Shaper(func="documents_to_strings", inputs={"documents": "documents"}, outputs=["strings"])
     results, _ = shaper.run(
@@ -646,6 +684,7 @@ def test_documents_to_strings():
     assert results["invocation_context"]["strings"] == ["first", "second", "third"]
 
 
+@pytest.mark.unit
 def test_documents_to_strings_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -678,6 +717,7 @@ def test_documents_to_strings_yaml(tmp_path):
 #
 
 
+@pytest.mark.unit
 def test_chain_shapers():
     shaper_1 = Shaper(
         func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " - "}, outputs=["documents"]
@@ -698,6 +738,7 @@ def test_chain_shapers():
     assert results["invocation_context"]["questions"] == ["test query"]
 
 
+@pytest.mark.unit
 def test_chain_shapers_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -747,6 +788,7 @@ def test_chain_shapers_yaml(tmp_path):
     assert results["invocation_context"]["questions"] == ["test query"]
 
 
+@pytest.mark.unit
 def test_chain_shapers_yaml_2(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -833,6 +875,7 @@ def test_chain_shapers_yaml_2(tmp_path):
     assert results["invocation_context"]["documents_with_greetings"] == [Document(content="hello. hello. hello")]
 
 
+@pytest.mark.integration
 def test_with_prompt_node(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -882,6 +925,7 @@ def test_with_prompt_node(tmp_path):
     assert len(result["invocation_context"]["questions"]) == 2
 
 
+@pytest.mark.integration
 def test_with_multiple_prompt_nodes(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -959,6 +1003,7 @@ def test_with_multiple_prompt_nodes(tmp_path):
     assert any([True for r in results if "Berlin" in r])
 
 
+@pytest.mark.unit
 def test_join_query_and_documents_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -1004,6 +1049,7 @@ def test_join_query_and_documents_yaml(tmp_path):
     assert result["query"] == ["first", "second", "third", "What is going on here?"]
 
 
+@pytest.mark.unit
 def test_join_query_and_documents_into_single_string_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -1060,6 +1106,7 @@ def test_join_query_and_documents_into_single_string_yaml(tmp_path):
     assert result["query"] == "first second third What is going on here?"
 
 
+@pytest.mark.unit
 def test_join_query_and_documents_convert_into_documents_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(

--- a/test/nodes/test_shaper.py
+++ b/test/nodes/test_shaper.py
@@ -6,964 +6,185 @@ from haystack import Pipeline, Document, Answer
 from haystack.nodes.other.shaper import Shaper
 
 
-@pytest.mark.unit
-class TestShaperUnit:
-    @pytest.fixture
-    def mock_function(self, monkeypatch):
-        monkeypatch.setattr(
-            haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"test_function": lambda a, b: ([a] * len(b),)}
-        )
+@pytest.fixture
+def mock_function(monkeypatch):
+    monkeypatch.setattr(
+        haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"test_function": lambda a, b: ([a] * len(b),)}
+    )
 
-    @pytest.fixture
-    def mock_function_two_outputs(self, monkeypatch):
-        monkeypatch.setattr(
-            haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"two_output_test_function": lambda a: (a, len(a))}
-        )
 
-    def test_basic_invocation_only_inputs(self, mock_function):
-        shaper = Shaper(func="test_function", inputs={"a": "query", "b": "documents"}, outputs=["c"])
-        results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-        assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
+@pytest.fixture
+def mock_function_two_outputs(monkeypatch):
+    monkeypatch.setattr(
+        haystack.nodes.other.shaper, "REGISTERED_FUNCTIONS", {"two_output_test_function": lambda a: (a, len(a))}
+    )
 
-    def test_multiple_outputs(self, mock_function_two_outputs):
-        shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c", "d"])
+
+def test_basic_invocation_only_inputs(mock_function):
+    shaper = Shaper(func="test_function", inputs={"a": "query", "b": "documents"}, outputs=["c"])
+    results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
+    assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
+
+
+def test_multiple_outputs(mock_function_two_outputs):
+    shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c", "d"])
+    results, _ = shaper.run(query="test")
+    assert results["invocation_context"]["c"] == "test"
+    assert results["invocation_context"]["d"] == 4
+
+
+def test_multiple_outputs_error(mock_function_two_outputs, caplog):
+    shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c"])
+    with caplog.at_level(logging.WARNING):
         results, _ = shaper.run(query="test")
-        assert results["invocation_context"]["c"] == "test"
-        assert results["invocation_context"]["d"] == 4
+        assert "Only 1 output(s) will be stored." in caplog.text
 
-    def test_multiple_outputs_error(self, mock_function_two_outputs, caplog):
-        shaper = Shaper(func="two_output_test_function", inputs={"a": "query"}, outputs=["c"])
-        with caplog.at_level(logging.WARNING):
-            results, _ = shaper.run(query="test")
-            assert "Only 1 output(s) will be stored." in caplog.text
 
-    def test_basic_invocation_only_params(self, mock_function):
-        shaper = Shaper(func="test_function", params={"a": "A", "b": list(range(3))}, outputs=["c"])
-        results, _ = shaper.run()
-        assert results["invocation_context"]["c"] == ["A", "A", "A"]
+def test_basic_invocation_only_params(mock_function):
+    shaper = Shaper(func="test_function", params={"a": "A", "b": list(range(3))}, outputs=["c"])
+    results, _ = shaper.run()
+    assert results["invocation_context"]["c"] == ["A", "A", "A"]
 
-    def test_basic_invocation_inputs_and_params(self, mock_function):
-        shaper = Shaper(func="test_function", inputs={"a": "query"}, params={"b": list(range(2))}, outputs=["c"])
-        results, _ = shaper.run(query="test query")
-        assert results["invocation_context"]["c"] == ["test query", "test query"]
 
-    def test_basic_invocation_inputs_and_params_colliding(self, mock_function):
-        shaper = Shaper(
-            func="test_function",
-            inputs={"a": "query"},
-            params={"a": "default value", "b": list(range(2))},
-            outputs=["c"],
-        )
-        results, _ = shaper.run(query="test query")
-        assert results["invocation_context"]["c"] == ["test query", "test query"]
+def test_basic_invocation_inputs_and_params(mock_function):
+    shaper = Shaper(func="test_function", inputs={"a": "query"}, params={"b": list(range(2))}, outputs=["c"])
+    results, _ = shaper.run(query="test query")
+    assert results["invocation_context"]["c"] == ["test query", "test query"]
 
-    def test_basic_invocation_inputs_and_params_using_params_as_defaults(self, mock_function):
-        shaper = Shaper(
-            func="test_function", inputs={"a": "query"}, params={"a": "default", "b": list(range(2))}, outputs=["c"]
-        )
-        results, _ = shaper.run()
-        assert results["invocation_context"]["c"] == ["default", "default"]
 
-    def test_missing_argument(self, mock_function):
-        shaper = Shaper(func="test_function", inputs={"b": "documents"}, outputs=["c"])
-        with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
-            shaper.run(query="test query", documents=["doesn't", "really", "matter"])
+def test_basic_invocation_inputs_and_params_colliding(mock_function):
+    shaper = Shaper(
+        func="test_function", inputs={"a": "query"}, params={"a": "default value", "b": list(range(2))}, outputs=["c"]
+    )
+    results, _ = shaper.run(query="test query")
+    assert results["invocation_context"]["c"] == ["test query", "test query"]
 
-    def test_excess_argument(self, mock_function):
-        shaper = Shaper(
-            func="test_function", inputs={"a": "query", "b": "documents", "something_extra": "query"}, outputs=["c"]
-        )
-        with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
-            shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
-    def test_value_not_in_invocation_context(self, mock_function):
-        shaper = Shaper(
-            func="test_function", inputs={"a": "query", "b": "something_that_does_not_exist"}, outputs=["c"]
-        )
-        with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
-            shaper.run(query="test query", documents=["doesn't", "really", "matter"])
+def test_basic_invocation_inputs_and_params_using_params_as_defaults(mock_function):
+    shaper = Shaper(
+        func="test_function", inputs={"a": "query"}, params={"a": "default", "b": list(range(2))}, outputs=["c"]
+    )
+    results, _ = shaper.run()
+    assert results["invocation_context"]["c"] == ["default", "default"]
 
-    def test_value_only_in_invocation_context(self, mock_function):
-        shaper = Shaper(func="test_function", inputs={"a": "query", "b": "invocation_context_specific"}, outputs=["c"])
-        results, _s = shaper.run(
-            query="test query", invocation_context={"invocation_context_specific": ["doesn't", "really", "matter"]}
-        )
-        assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
 
-    def test_yaml(self, mock_function, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: test_function
-                  inputs:
-                    a: query
-                  params:
-                    b: [1, 1]
-                  outputs:
-                    - c
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(
-            query="test query",
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
-        )
-        assert result["invocation_context"]["c"] == ["test query", "test query"]
-        assert result["query"] == "test query"
-        assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
+def test_missing_argument(mock_function):
+    shaper = Shaper(func="test_function", inputs={"b": "documents"}, outputs=["c"])
+    with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
+        shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
-    #
-    # rename
-    #
 
-    def test_rename(self):
-        shaper = Shaper(func="rename", inputs={"value": "query"}, outputs=["questions"])
-        results, _ = shaper.run(query="test query")
-        assert results["invocation_context"]["questions"] == "test query"
+def test_excess_argument(mock_function):
+    shaper = Shaper(
+        func="test_function", inputs={"a": "query", "b": "documents", "something_extra": "query"}, outputs=["c"]
+    )
+    with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
+        shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
-    def test_rename_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: rename
-                  inputs:
-                    value: query
-                  outputs:
-                    - questions
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(query="test query")
-        assert result["invocation_context"]["query"] == "test query"
-        assert result["invocation_context"]["questions"] == "test query"
 
-    #
-    # value_to_list
-    #
+def test_value_not_in_invocation_context(mock_function):
+    shaper = Shaper(func="test_function", inputs={"a": "query", "b": "something_that_does_not_exist"}, outputs=["c"])
+    with pytest.raises(ValueError, match="Shaper couldn't apply the function to your inputs and parameters."):
+        shaper.run(query="test query", documents=["doesn't", "really", "matter"])
 
-    def test_value_to_list(self):
-        shaper = Shaper(
-            func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"]
-        )
-        results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
-        assert results["invocation_context"]["questions"] == ["test query", "test query", "test query"]
 
-    def test_value_to_list_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    value: query
-                    target_list: documents
-                  outputs:
-                    - questions
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(
-            query="test query",
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
-        )
-        assert result["invocation_context"]["questions"] == ["test query", "test query", "test query"]
-        # Assert pipeline output is unaffected
-        assert result["query"] == "test query"
-        assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
+def test_value_only_in_invocation_context(mock_function):
+    shaper = Shaper(func="test_function", inputs={"a": "query", "b": "invocation_context_specific"}, outputs=["c"])
+    results, _s = shaper.run(
+        query="test query", invocation_context={"invocation_context_specific": ["doesn't", "really", "matter"]}
+    )
+    assert results["invocation_context"]["c"] == ["test query", "test query", "test query"]
 
-    #
-    # join_lists
-    #
 
-    def test_join_lists(self):
-        shaper = Shaper(func="join_lists", params={"lists": [[1, 2, 3], [4, 5]]}, outputs=["list"])
-        results, _ = shaper.run()
-        assert results["invocation_context"]["list"] == [1, 2, 3, 4, 5]
-
-    def test_join_lists_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: join_lists
-                  inputs:
-                    lists:
-                    - documents
-                    - file_paths
-                  outputs:
-                    - single_list
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(documents=["first", "second", "third"], file_paths=["file1.txt", "file2.txt"])
-        assert result["invocation_context"]["single_list"] == ["first", "second", "third", "file1.txt", "file2.txt"]
-
-    #
-    # join_strings
-    #
-
-    def test_join_strings(self):
-        shaper = Shaper(
-            func="join_strings", params={"strings": ["first", "second"], "delimiter": " | "}, outputs=["single_string"]
-        )
-        results, _ = shaper.run()
-        assert results["invocation_context"]["single_string"] == "first | second"
-
-    def test_join_strings_default_delimiter(self):
-        shaper = Shaper(func="join_strings", params={"strings": ["first", "second"]}, outputs=["single_string"])
-        results, _ = shaper.run()
-        assert results["invocation_context"]["single_string"] == "first second"
-
-    def test_join_strings_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: join_strings
-                  inputs:
-                    strings: documents
-                  params:
-                    delimiter: ' - '
-                  outputs:
-                    - single_string
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(documents=["first", "second", "third"])
-        assert result["invocation_context"]["single_string"] == "first - second - third"
-
-    def test_join_strings_default_delimiter_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: join_strings
-                  inputs:
-                    strings: documents
-                  outputs:
-                    - single_string
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(documents=["first", "second", "third"])
-        assert result["invocation_context"]["single_string"] == "first second third"
-
-    #
-    # join_documents
-    #
-
-    def test_join_documents(self):
-        shaper = Shaper(
-            func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " | "}, outputs=["documents"]
-        )
-        results, _ = shaper.run(
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-        )
-        assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
-
-    def test_join_documents_default_delimiter(self):
-        shaper = Shaper(func="join_documents", inputs={"documents": "documents"}, outputs=["documents"])
-        results, _ = shaper.run(
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-        )
-        assert results["invocation_context"]["documents"] == [Document(content="first second third")]
-
-    def test_join_documents_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: join_documents
-                  inputs:
-                    documents: documents
-                  params:
-                    delimiter: ' - '
-                  outputs:
-                    - documents
-
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(
-            query="test query",
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
-        )
-        assert result["invocation_context"]["documents"] == [Document(content="first - second - third")]
-        assert result["documents"] == [Document(content="first - second - third")]
-
-    def test_join_documents_default_delimiter_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: join_documents
-                  inputs:
-                    documents: documents
-                  outputs:
-                    - documents
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(
-            query="test query",
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
-        )
-        assert result["invocation_context"]["documents"] == [Document(content="first second third")]
-
-    #
-    # strings_to_answers
-    #
-
-    def test_strings_to_answers_no_meta_no_hashkeys(self):
-        shaper = Shaper(func="strings_to_answers", inputs={"strings": "responses"}, outputs=["answers"])
-        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-        assert results["invocation_context"]["answers"] == [
-            Answer(answer="first", type="generative"),
-            Answer(answer="second", type="generative"),
-            Answer(answer="third", type="generative"),
-        ]
-
-    def test_strings_to_answers_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: strings_to_answers
-                  params:
-                    strings: ['a', 'b', 'c']
-                  outputs:
-                    - answers
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run()
-        assert result["invocation_context"]["answers"] == [
-            Answer(answer="a", type="generative"),
-            Answer(answer="b", type="generative"),
-            Answer(answer="c", type="generative"),
-        ]
-
-    #
-    # answers_to_strings
-    #
-
-    def test_answers_to_strings(self):
-        shaper = Shaper(func="answers_to_strings", inputs={"answers": "documents"}, outputs=["strings"])
-        results, _ = shaper.run(documents=[Answer(answer="first"), Answer(answer="second"), Answer(answer="third")])
-        assert results["invocation_context"]["strings"] == ["first", "second", "third"]
-
-    def test_answers_to_strings_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: answers_to_strings
-                  inputs:
-                    answers: documents
-                  outputs:
-                    - strings
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(documents=[Answer(answer="a"), Answer(answer="b"), Answer(answer="c")])
-        assert result["invocation_context"]["strings"] == ["a", "b", "c"]
-
-    #
-    # strings_to_documents
-    #
-
-    def test_strings_to_documents_no_meta_no_hashkeys(self):
-        shaper = Shaper(func="strings_to_documents", inputs={"strings": "responses"}, outputs=["documents"])
-        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-        assert results["invocation_context"]["documents"] == [
-            Document(content="first"),
-            Document(content="second"),
-            Document(content="third"),
-        ]
-
-    def test_strings_to_documents_single_meta_no_hashkeys(self):
-        shaper = Shaper(
-            func="strings_to_documents",
-            inputs={"strings": "responses"},
-            params={"meta": {"a": "A"}},
-            outputs=["documents"],
-        )
-        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-        assert results["invocation_context"]["documents"] == [
-            Document(content="first", meta={"a": "A"}),
-            Document(content="second", meta={"a": "A"}),
-            Document(content="third", meta={"a": "A"}),
-        ]
-
-    def test_strings_to_documents_wrong_number_of_meta(self):
-        shaper = Shaper(
-            func="strings_to_documents",
-            inputs={"strings": "responses"},
-            params={"meta": [{"a": "A"}]},
-            outputs=["documents"],
-        )
-
-        with pytest.raises(ValueError, match="Not enough metadata dictionaries."):
-            shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-
-    def test_strings_to_documents_many_meta_no_hashkeys(self):
-        shaper = Shaper(
-            func="strings_to_documents",
-            inputs={"strings": "responses"},
-            params={"meta": [{"a": i + 1} for i in range(3)]},
-            outputs=["documents"],
-        )
-        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-        assert results["invocation_context"]["documents"] == [
-            Document(content="first", meta={"a": 1}),
-            Document(content="second", meta={"a": 2}),
-            Document(content="third", meta={"a": 3}),
-        ]
-
-    def test_strings_to_documents_single_meta_with_hashkeys(self):
-        shaper = Shaper(
-            func="strings_to_documents",
-            inputs={"strings": "responses"},
-            params={"meta": {"a": "A"}, "id_hash_keys": ["content", "meta"]},
-            outputs=["documents"],
-        )
-        results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
-        assert results["invocation_context"]["documents"] == [
-            Document(content="first", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
-            Document(content="second", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
-            Document(content="third", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
-        ]
-
-    def test_strings_to_documents_no_meta_no_hashkeys_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: strings_to_documents
-                  params:
-                    strings: ['a', 'b', 'c']
-                  outputs:
-                    - documents
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run()
-        assert result["invocation_context"]["documents"] == [
-            Document(content="a"),
-            Document(content="b"),
-            Document(content="c"),
-        ]
-
-    def test_strings_to_documents_meta_and_hashkeys_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: strings_to_documents
-                  params:
-                    strings: ['first', 'second', 'third']
-                    id_hash_keys: ['content', 'meta']
-                    meta:
-                      - a: 1
-                      - a: 2
-                      - a: 3
-                  outputs:
-                    - documents
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run()
-        assert result["invocation_context"]["documents"] == [
-            Document(content="first", meta={"a": 1}, id_hash_keys=["content", "meta"]),
-            Document(content="second", meta={"a": 2}, id_hash_keys=["content", "meta"]),
-            Document(content="third", meta={"a": 3}, id_hash_keys=["content", "meta"]),
-        ]
-
-    #
-    # documents_to_strings
-    #
-
-    def test_documents_to_strings(self):
-        shaper = Shaper(func="documents_to_strings", inputs={"documents": "documents"}, outputs=["strings"])
-        results, _ = shaper.run(
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")]
-        )
-        assert results["invocation_context"]["strings"] == ["first", "second", "third"]
-
-    def test_documents_to_strings_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: shaper
-                type: Shaper
-                params:
-                  func: documents_to_strings
-                  inputs:
-                    documents: documents
-                  outputs:
-                    - strings
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper
-                      inputs:
-                        - Query
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(documents=[Document(content="a"), Document(content="b"), Document(content="c")])
-        assert result["invocation_context"]["strings"] == ["a", "b", "c"]
-
-    #
-    # Chaining and real-world usage
-    #
-
-    def test_chain_shapers(self):
-        shaper_1 = Shaper(
-            func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " - "}, outputs=["documents"]
-        )
-        shaper_2 = Shaper(
-            func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"]
-        )
-
-        pipe = Pipeline()
-        pipe.add_node(shaper_1, name="shaper_1", inputs=["Query"])
-        pipe.add_node(shaper_2, name="shaper_2", inputs=["shaper_1"])
-
-        results = pipe.run(
-            query="test query",
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
-        )
-
-        assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
-        assert results["invocation_context"]["questions"] == ["test query"]
-
-    def test_chain_shapers_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-
-              - name: shaper_1
-                type: Shaper
-                params:
-                  func: join_documents
-                  inputs:
-                    documents: documents
-                  params:
-                    delimiter: ' - '
-                  outputs:
-                    - documents
-
-              - name: shaper_2
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    value: query
-                    target_list: documents
-                  outputs:
-                    - questions
-
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper_1
-                      inputs:
-                        - Query
-                    - name: shaper_2
-                      inputs:
-                        - shaper_1
-          """
-            )
-        pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-
-        results = pipe.run(
-            query="test query",
-            documents=[Document(content="first"), Document(content="second"), Document(content="third")],
-        )
-
-        assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
-        assert results["invocation_context"]["questions"] == ["test query"]
-
-    def test_chain_shapers_yaml_2(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-
-              - name: shaper_1
-                type: Shaper
-                params:
-                  func: strings_to_documents
-                  params:
-                    strings:
-                      - first
-                      - second
-                      - third
-                  outputs:
-                    - string_documents
-
-              - name: shaper_2
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    target_list: string_documents
-                  params:
-                    value: hello
-                  outputs:
-                    - greetings
-
-              - name: shaper_3
-                type: Shaper
-                params:
-                  func: join_strings
-                  inputs:
-                    strings: greetings
-                  params:
-                    delimiter: '. '
-                  outputs:
-                    - many_greetings
-
-              - name: expander
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    value: many_greetings
-                  params:
-                    target_list: [1]
-                  outputs:
-                    - many_greetings
-
-              - name: shaper_4
-                type: Shaper
-                params:
-                  func: strings_to_documents
-                  inputs:
-                    strings: many_greetings
-                  outputs:
-                    - documents_with_greetings
-
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: shaper_1
-                      inputs:
-                        - Query
-                    - name: shaper_2
-                      inputs:
-                        - shaper_1
-                    - name: shaper_3
-                      inputs:
-                        - shaper_2
-                    - name: expander
-                      inputs:
-                        - shaper_3
-                    - name: shaper_4
-                      inputs:
-                        - expander
-          """
-            )
-        pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        results = pipe.run()
-        assert results["invocation_context"]["documents_with_greetings"] == [Document(content="hello. hello. hello")]
-
-    def test_join_query_and_documents_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-
-              components:
-              - name: expander
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    value: query
-                  params:
-                    target_list: [1]
-                  outputs:
-                    - query
-
-              - name: joiner
-                type: Shaper
-                params:
-                  func: join_lists
-                  inputs:
-                    lists:
-                    - documents
-                    - query
-                  outputs:
-                    - query
-
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: expander
-                      inputs:
-                        - Query
-                    - name: joiner
-                      inputs:
-                        - expander
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
-        assert result["query"] == ["first", "second", "third", "What is going on here?"]
-
-    def test_join_query_and_documents_into_single_string_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: expander
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    value: query
-                  params:
-                    target_list: [1]
-                  outputs:
-                    - query
-
-              - name: joiner
-                type: Shaper
-                params:
-                  func: join_lists
-                  inputs:
-                    lists:
-                    - documents
-                    - query
-                  outputs:
-                    - query
-
-              - name: concatenator
-                type: Shaper
-                params:
-                  func: join_strings
-                  inputs:
-                    strings: query
-                  outputs:
-                    - query
-
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: expander
-                      inputs:
-                        - Query
-                    - name: joiner
-                      inputs:
-                        - expander
-                    - name: concatenator
-                      inputs:
-                        - joiner
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
-        assert result["query"] == "first second third What is going on here?"
-
-    def test_join_query_and_documents_convert_into_documents_yaml(self, tmp_path):
-        with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
-            tmp_file.write(
-                f"""
-              version: ignore
-              components:
-              - name: expander
-                type: Shaper
-                params:
-                  func: value_to_list
-                  inputs:
-                    value: query
-                  params:
-                    target_list: [1]
-                  outputs:
-                    - query
-
-              - name: joiner
-                type: Shaper
-                params:
-                  func: join_lists
-                  inputs:
-                    lists:
-                    - documents
-                    - query
-                  outputs:
-                    - query_and_docs
-
-              - name: converter
-                type: Shaper
-                params:
-                  func: strings_to_documents
-                  inputs:
-                    strings: query_and_docs
-                  outputs:
-                    - query_and_docs
-
-              pipelines:
-                - name: query
-                  nodes:
-                    - name: expander
-                      inputs:
-                        - Query
-                    - name: joiner
-                      inputs:
-                        - expander
-                    - name: converter
-                      inputs:
-                        - joiner
-          """
-            )
-        pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
-        result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
-        assert result["invocation_context"]["query_and_docs"]
-        assert len(result["invocation_context"]["query_and_docs"]) == 4
-        assert isinstance(result["invocation_context"]["query_and_docs"][0], Document)
-
-
-@pytest.mark.integration
-def test_with_prompt_node(tmp_path):
+def test_yaml(mock_function, tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
             f"""
-          version: ignore
-          components:
-            - name: prompt_model
-              type: PromptModel
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: test_function
+                inputs:
+                  a: query
+                params:
+                  b: [1, 1]
+                outputs:
+                  - c
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(
+        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert result["invocation_context"]["c"] == ["test query", "test query"]
+    assert result["query"] == "test query"
+    assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
 
+
+#
+# rename
+#
+
+
+def test_rename():
+    shaper = Shaper(func="rename", inputs={"value": "query"}, outputs=["questions"])
+    results, _ = shaper.run(query="test query")
+    assert results["invocation_context"]["questions"] == "test query"
+
+
+def test_rename_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: rename
+                inputs:
+                  value: query
+                outputs:
+                  - questions
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(query="test query")
+    assert result["invocation_context"]["query"] == "test query"
+    assert result["invocation_context"]["questions"] == "test query"
+
+
+#
+# value_to_list
+#
+
+
+def test_value_to_list():
+    shaper = Shaper(func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"])
+    results, _ = shaper.run(query="test query", documents=["doesn't", "really", "matter"])
+    assert results["invocation_context"]["questions"] == ["test query", "test query", "test query"]
+
+
+def test_value_to_list_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
             - name: shaper
               type: Shaper
               params:
@@ -973,24 +194,681 @@ def test_with_prompt_node(tmp_path):
                   target_list: documents
                 outputs:
                   - questions
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(
+        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert result["invocation_context"]["questions"] == ["test query", "test query", "test query"]
+    # Assert pipeline output is unaffected
+    assert result["query"] == "test query"
+    assert result["documents"] == [Document(content="first"), Document(content="second"), Document(content="third")]
 
-            - name: prompt_node
-              type: PromptNode
+
+#
+# join_lists
+#
+
+
+def test_join_lists():
+    shaper = Shaper(func="join_lists", params={"lists": [[1, 2, 3], [4, 5]]}, outputs=["list"])
+    results, _ = shaper.run()
+    assert results["invocation_context"]["list"] == [1, 2, 3, 4, 5]
+
+
+def test_join_lists_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
               params:
-                output_variable: answers
-                model_name_or_path: prompt_model
-                default_prompt_template: question-answering
+                func: join_lists
+                inputs:
+                  lists:
+                   - documents
+                   - file_paths
+                outputs:
+                  - single_list
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(documents=["first", "second", "third"], file_paths=["file1.txt", "file2.txt"])
+    assert result["invocation_context"]["single_list"] == ["first", "second", "third", "file1.txt", "file2.txt"]
 
-          pipelines:
-            - name: query
-              nodes:
-                - name: shaper
+
+#
+# join_strings
+#
+
+
+def test_join_strings():
+    shaper = Shaper(
+        func="join_strings", params={"strings": ["first", "second"], "delimiter": " | "}, outputs=["single_string"]
+    )
+    results, _ = shaper.run()
+    assert results["invocation_context"]["single_string"] == "first | second"
+
+
+def test_join_strings_default_delimiter():
+    shaper = Shaper(func="join_strings", params={"strings": ["first", "second"]}, outputs=["single_string"])
+    results, _ = shaper.run()
+    assert results["invocation_context"]["single_string"] == "first second"
+
+
+def test_join_strings_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: join_strings
+                inputs:
+                  strings: documents
+                params:
+                  delimiter: ' - '
+                outputs:
+                  - single_string
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(documents=["first", "second", "third"])
+    assert result["invocation_context"]["single_string"] == "first - second - third"
+
+
+def test_join_strings_default_delimiter_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: join_strings
+                inputs:
+                  strings: documents
+                outputs:
+                  - single_string
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(documents=["first", "second", "third"])
+    assert result["invocation_context"]["single_string"] == "first second third"
+
+
+#
+# join_documents
+#
+
+
+def test_join_documents():
+    shaper = Shaper(
+        func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " | "}, outputs=["documents"]
+    )
+    results, _ = shaper.run(
+        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
+
+
+def test_join_documents_default_delimiter():
+    shaper = Shaper(func="join_documents", inputs={"documents": "documents"}, outputs=["documents"])
+    results, _ = shaper.run(
+        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert results["invocation_context"]["documents"] == [Document(content="first second third")]
+
+
+def test_join_documents_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: join_documents
+                inputs:
+                  documents: documents
+                params:
+                  delimiter: ' - '
+                outputs:
+                  - documents
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(
+        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert result["invocation_context"]["documents"] == [Document(content="first - second - third")]
+    assert result["documents"] == [Document(content="first - second - third")]
+
+
+def test_join_documents_default_delimiter_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: join_documents
+                inputs:
+                  documents: documents
+                outputs:
+                  - documents
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(
+        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert result["invocation_context"]["documents"] == [Document(content="first second third")]
+
+
+#
+# strings_to_answers
+#
+
+
+def test_strings_to_answers_no_meta_no_hashkeys():
+    shaper = Shaper(func="strings_to_answers", inputs={"strings": "responses"}, outputs=["answers"])
+    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+    assert results["invocation_context"]["answers"] == [
+        Answer(answer="first", type="generative"),
+        Answer(answer="second", type="generative"),
+        Answer(answer="third", type="generative"),
+    ]
+
+
+def test_strings_to_answers_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: strings_to_answers
+                params:
+                  strings: ['a', 'b', 'c']
+                outputs:
+                  - answers
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run()
+    assert result["invocation_context"]["answers"] == [
+        Answer(answer="a", type="generative"),
+        Answer(answer="b", type="generative"),
+        Answer(answer="c", type="generative"),
+    ]
+
+
+#
+# answers_to_strings
+#
+
+
+def test_answers_to_strings():
+    shaper = Shaper(func="answers_to_strings", inputs={"answers": "documents"}, outputs=["strings"])
+    results, _ = shaper.run(documents=[Answer(answer="first"), Answer(answer="second"), Answer(answer="third")])
+    assert results["invocation_context"]["strings"] == ["first", "second", "third"]
+
+
+def test_answers_to_strings_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: answers_to_strings
+                inputs:
+                  answers: documents
+                outputs:
+                  - strings
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(documents=[Answer(answer="a"), Answer(answer="b"), Answer(answer="c")])
+    assert result["invocation_context"]["strings"] == ["a", "b", "c"]
+
+
+#
+# strings_to_documents
+#
+
+
+def test_strings_to_documents_no_meta_no_hashkeys():
+    shaper = Shaper(func="strings_to_documents", inputs={"strings": "responses"}, outputs=["documents"])
+    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+    assert results["invocation_context"]["documents"] == [
+        Document(content="first"),
+        Document(content="second"),
+        Document(content="third"),
+    ]
+
+
+def test_strings_to_documents_single_meta_no_hashkeys():
+    shaper = Shaper(
+        func="strings_to_documents", inputs={"strings": "responses"}, params={"meta": {"a": "A"}}, outputs=["documents"]
+    )
+    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+    assert results["invocation_context"]["documents"] == [
+        Document(content="first", meta={"a": "A"}),
+        Document(content="second", meta={"a": "A"}),
+        Document(content="third", meta={"a": "A"}),
+    ]
+
+
+def test_strings_to_documents_wrong_number_of_meta():
+    shaper = Shaper(
+        func="strings_to_documents",
+        inputs={"strings": "responses"},
+        params={"meta": [{"a": "A"}]},
+        outputs=["documents"],
+    )
+
+    with pytest.raises(ValueError, match="Not enough metadata dictionaries."):
+        shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+
+
+def test_strings_to_documents_many_meta_no_hashkeys():
+    shaper = Shaper(
+        func="strings_to_documents",
+        inputs={"strings": "responses"},
+        params={"meta": [{"a": i + 1} for i in range(3)]},
+        outputs=["documents"],
+    )
+    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+    assert results["invocation_context"]["documents"] == [
+        Document(content="first", meta={"a": 1}),
+        Document(content="second", meta={"a": 2}),
+        Document(content="third", meta={"a": 3}),
+    ]
+
+
+def test_strings_to_documents_single_meta_with_hashkeys():
+    shaper = Shaper(
+        func="strings_to_documents",
+        inputs={"strings": "responses"},
+        params={"meta": {"a": "A"}, "id_hash_keys": ["content", "meta"]},
+        outputs=["documents"],
+    )
+    results, _ = shaper.run(invocation_context={"responses": ["first", "second", "third"]})
+    assert results["invocation_context"]["documents"] == [
+        Document(content="first", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
+        Document(content="second", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
+        Document(content="third", meta={"a": "A"}, id_hash_keys=["content", "meta"]),
+    ]
+
+
+def test_strings_to_documents_no_meta_no_hashkeys_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: strings_to_documents
+                params:
+                  strings: ['a', 'b', 'c']
+                outputs:
+                  - documents
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run()
+    assert result["invocation_context"]["documents"] == [
+        Document(content="a"),
+        Document(content="b"),
+        Document(content="c"),
+    ]
+
+
+def test_strings_to_documents_meta_and_hashkeys_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: strings_to_documents
+                params:
+                  strings: ['first', 'second', 'third']
+                  id_hash_keys: ['content', 'meta']
+                  meta:
+                    - a: 1
+                    - a: 2
+                    - a: 3
+                outputs:
+                  - documents
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run()
+    assert result["invocation_context"]["documents"] == [
+        Document(content="first", meta={"a": 1}, id_hash_keys=["content", "meta"]),
+        Document(content="second", meta={"a": 2}, id_hash_keys=["content", "meta"]),
+        Document(content="third", meta={"a": 3}, id_hash_keys=["content", "meta"]),
+    ]
+
+
+#
+# documents_to_strings
+#
+
+
+def test_documents_to_strings():
+    shaper = Shaper(func="documents_to_strings", inputs={"documents": "documents"}, outputs=["strings"])
+    results, _ = shaper.run(
+        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert results["invocation_context"]["strings"] == ["first", "second", "third"]
+
+
+def test_documents_to_strings_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: documents_to_strings
+                inputs:
+                  documents: documents
+                outputs:
+                  - strings
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(documents=[Document(content="a"), Document(content="b"), Document(content="c")])
+    assert result["invocation_context"]["strings"] == ["a", "b", "c"]
+
+
+#
+# Chaining and real-world usage
+#
+
+
+def test_chain_shapers():
+    shaper_1 = Shaper(
+        func="join_documents", inputs={"documents": "documents"}, params={"delimiter": " - "}, outputs=["documents"]
+    )
+    shaper_2 = Shaper(
+        func="value_to_list", inputs={"value": "query", "target_list": "documents"}, outputs=["questions"]
+    )
+
+    pipe = Pipeline()
+    pipe.add_node(shaper_1, name="shaper_1", inputs=["Query"])
+    pipe.add_node(shaper_2, name="shaper_2", inputs=["shaper_1"])
+
+    results = pipe.run(
+        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+
+    assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
+    assert results["invocation_context"]["questions"] == ["test query"]
+
+
+def test_chain_shapers_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+
+            - name: shaper_1
+              type: Shaper
+              params:
+                func: join_documents
+                inputs:
+                  documents: documents
+                params:
+                  delimiter: ' - '
+                outputs:
+                  - documents
+
+            - name: shaper_2
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: query
+                  target_list: documents
+                outputs:
+                  - questions
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper_1
+                    inputs:
+                      - Query
+                  - name: shaper_2
+                    inputs:
+                      - shaper_1
+        """
+        )
+    pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+
+    results = pipe.run(
+        query="test query", documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+
+    assert results["invocation_context"]["documents"] == [Document(content="first - second - third")]
+    assert results["invocation_context"]["questions"] == ["test query"]
+
+
+def test_chain_shapers_yaml_2(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+
+            - name: shaper_1
+              type: Shaper
+              params:
+                func: strings_to_documents
+                params:
+                  strings:
+                    - first
+                    - second
+                    - third
+                outputs:
+                  - string_documents
+
+            - name: shaper_2
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  target_list: string_documents
+                params:
+                  value: hello
+                outputs:
+                  - greetings
+
+            - name: shaper_3
+              type: Shaper
+              params:
+                func: join_strings
+                inputs:
+                  strings: greetings
+                params:
+                  delimiter: '. '
+                outputs:
+                  - many_greetings
+
+            - name: expander
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: many_greetings
+                params:
+                  target_list: [1]
+                outputs:
+                  - many_greetings
+
+            - name: shaper_4
+              type: Shaper
+              params:
+                func: strings_to_documents
+                inputs:
+                  strings: many_greetings
+                outputs:
+                  - documents_with_greetings
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper_1
+                    inputs:
+                      - Query
+                  - name: shaper_2
+                    inputs:
+                      - shaper_1
+                  - name: shaper_3
+                    inputs:
+                      - shaper_2
+                  - name: expander
+                    inputs:
+                      - shaper_3
+                  - name: shaper_4
+                    inputs:
+                      - expander
+        """
+        )
+    pipe = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    results = pipe.run()
+    assert results["invocation_context"]["documents_with_greetings"] == [Document(content="hello. hello. hello")]
+
+
+def test_with_prompt_node(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+              - name: prompt_model
+                type: PromptModel
+
+              - name: shaper
+                type: Shaper
+                params:
+                  func: value_to_list
                   inputs:
-                    - Query
-                - name: prompt_node
-                  inputs:
-                    - shaper
-          """
+                    value: query
+                    target_list: documents
+                  outputs:
+                    - questions
+
+              - name: prompt_node
+                type: PromptNode
+                params:
+                  output_variable: answers
+                  model_name_or_path: prompt_model
+                  default_prompt_template: question-answering
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+                  - name: prompt_node
+                    inputs:
+                      - shaper
+            """
         )
     pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
     result = pipeline.run(
@@ -1004,73 +882,72 @@ def test_with_prompt_node(tmp_path):
     assert len(result["invocation_context"]["questions"]) == 2
 
 
-@pytest.mark.integration
 def test_with_multiple_prompt_nodes(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
             f"""
-          version: ignore
-          components:
-            - name: prompt_model
-              type: PromptModel
+            version: ignore
+            components:
+              - name: prompt_model
+                type: PromptModel
 
-            - name: shaper
-              type: Shaper
-              params:
-                func: value_to_list
-                inputs:
-                  value: query
-                  target_list: documents
-                outputs: [questions]
-
-            - name: renamer
-              type: Shaper
-              params:
-                func: rename
-                inputs:
-                  value: new-questions
-                outputs:
-                  - questions
-
-            - name: prompt_node
-              type: PromptNode
-              params:
-                model_name_or_path: prompt_model
-                default_prompt_template: question-answering
-
-            - name: prompt_node_second
-              type: PromptNode
-              params:
-                model_name_or_path: prompt_model
-                default_prompt_template: question-generation
-                output_variable: new-questions
-
-            - name: prompt_node_third
-              type: PromptNode
-              params:
-                output_variable: answers
-                model_name_or_path: google/flan-t5-small
-                default_prompt_template: question-answering
-
-          pipelines:
-            - name: query
-              nodes:
-                - name: shaper
+              - name: shaper
+                type: Shaper
+                params:
+                  func: value_to_list
                   inputs:
-                    - Query
-                - name: prompt_node
+                    value: query
+                    target_list: documents
+                  outputs: [questions]
+
+              - name: renamer
+                type: Shaper
+                params:
+                  func: rename
                   inputs:
-                    - shaper
-                - name: prompt_node_second
-                  inputs:
-                    - prompt_node
-                - name: renamer
-                  inputs:
-                    - prompt_node_second
-                - name: prompt_node_third
-                  inputs:
-                    - renamer
-          """
+                    value: new-questions
+                  outputs:
+                    - questions
+
+              - name: prompt_node
+                type: PromptNode
+                params:
+                  model_name_or_path: prompt_model
+                  default_prompt_template: question-answering
+
+              - name: prompt_node_second
+                type: PromptNode
+                params:
+                  model_name_or_path: prompt_model
+                  default_prompt_template: question-generation
+                  output_variable: new-questions
+
+              - name: prompt_node_third
+                type: PromptNode
+                params:
+                  output_variable: answers
+                  model_name_or_path: google/flan-t5-small
+                  default_prompt_template: question-answering
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+                  - name: prompt_node
+                    inputs:
+                      - shaper
+                  - name: prompt_node_second
+                    inputs:
+                      - prompt_node
+                  - name: renamer
+                    inputs:
+                      - prompt_node_second
+                  - name: prompt_node_third
+                    inputs:
+                      - renamer
+            """
         )
     pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
     result = pipeline.run(
@@ -1080,3 +957,162 @@ def test_with_multiple_prompt_nodes(tmp_path):
     results = result["answers"]
     assert len(results) == 2
     assert any([True for r in results if "Berlin" in r])
+
+
+def test_join_query_and_documents_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+
+            components:
+            - name: expander
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: query
+                params:
+                  target_list: [1]
+                outputs:
+                  - query
+
+            - name: joiner
+              type: Shaper
+              params:
+                func: join_lists
+                inputs:
+                  lists:
+                   - documents
+                   - query
+                outputs:
+                  - query
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: expander
+                    inputs:
+                      - Query
+                  - name: joiner
+                    inputs:
+                      - expander
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
+    assert result["query"] == ["first", "second", "third", "What is going on here?"]
+
+
+def test_join_query_and_documents_into_single_string_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: expander
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: query
+                params:
+                  target_list: [1]
+                outputs:
+                  - query
+
+            - name: joiner
+              type: Shaper
+              params:
+                func: join_lists
+                inputs:
+                  lists:
+                   - documents
+                   - query
+                outputs:
+                  - query
+
+            - name: concatenator
+              type: Shaper
+              params:
+                func: join_strings
+                inputs:
+                  strings: query
+                outputs:
+                  - query
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: expander
+                    inputs:
+                      - Query
+                  - name: joiner
+                    inputs:
+                      - expander
+                  - name: concatenator
+                    inputs:
+                      - joiner
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
+    assert result["query"] == "first second third What is going on here?"
+
+
+def test_join_query_and_documents_convert_into_documents_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: expander
+              type: Shaper
+              params:
+                func: value_to_list
+                inputs:
+                  value: query
+                params:
+                  target_list: [1]
+                outputs:
+                  - query
+
+            - name: joiner
+              type: Shaper
+              params:
+                func: join_lists
+                inputs:
+                  lists:
+                   - documents
+                   - query
+                outputs:
+                  - query_and_docs
+
+            - name: converter
+              type: Shaper
+              params:
+                func: strings_to_documents
+                inputs:
+                  strings: query_and_docs
+                outputs:
+                  - query_and_docs
+
+            pipelines:
+              - name: query
+                nodes:
+                  - name: expander
+                    inputs:
+                      - Query
+                  - name: joiner
+                    inputs:
+                      - expander
+                  - name: converter
+                    inputs:
+                      - joiner
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run(query="What is going on here?", documents=["first", "second", "third"])
+    assert result["invocation_context"]["query_and_docs"]
+    assert len(result["invocation_context"]["query_and_docs"]) == 4
+    assert isinstance(result["invocation_context"]["query_and_docs"][0], Document)


### PR DESCRIPTION
### Related Issues
- part of https://github.com/deepset-ai/haystack/issues/3157

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
