### PR TITLE
fix: add option to not override results by `Shaper`

### DIFF
--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -246,7 +246,7 @@ class Shaper(BaseComponent):
         outputs: List[str],
         inputs: Optional[Dict[str, Union[List[str], str]]] = None,
         params: Optional[Dict[str, Any]] = None,
-        publish_outputs: bool = True,
+        publish_outputs: Union[bool, List[str]] = True,
     ):
         """
         Initializes the Shaper component.
@@ -320,9 +320,10 @@ class Shaper(BaseComponent):
             You can use params to provide fallback values for arguments of `run` that you're not sure exist.
             So if you need `query` to exist, you can provide a fallback value in the params, which will be used only if `query`
             is not passed to this node by the pipeline.
-        :param outputs: THe key to store the outputs in the invocation context. The length of the outputs must match
+        :param outputs: The key to store the outputs in the invocation context. The length of the outputs must match
             the number of outputs produced by the function invoked.
-        :param publish_outputs: Whether to publish the outputs to the pipeline's output. Defaults to True.
+        :param publish_outputs: Controls whether to publish the outputs to the pipeline's output.
+            Set `True` (default value) to publishes all outputs or `False` to publish None.
             E.g. if `outputs = ["documents"]` result for `publish_outputs = True` looks like
             ```python
                 {
@@ -340,14 +341,17 @@ class Shaper(BaseComponent):
                     },
                 }
             ```
-            Note that only outputs ["query", "file_paths", "labels", "documents", "meta", "answers"] can be published.
+            If you want to have finer-grained control, pass a list of the outputs you want to publish.
         """
         super().__init__()
         self.function = REGISTERED_FUNCTIONS[func]
         self.outputs = outputs
-        self.publish_outputs = publish_outputs
         self.inputs = inputs or {}
         self.params = params or {}
+        if isinstance(publish_outputs, bool):
+            self.publish_outputs = self.outputs if publish_outputs else []
+        else:
+            self.publish_outputs = publish_outputs
 
     def run(  # type: ignore
         self,
@@ -425,7 +429,7 @@ class Shaper(BaseComponent):
         results = {}
         for output_key, output_value in zip(self.outputs, output_values):
             invocation_context[output_key] = output_value
-            if self.publish_outputs:
+            if output_key in self.publish_outputs:
                 results[output_key] = output_value
         results["invocation_context"] = invocation_context
 

--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -425,7 +425,7 @@ class Shaper(BaseComponent):
         results = {}
         for output_key, output_value in zip(self.outputs, output_values):
             invocation_context[output_key] = output_value
-            if self.publish_outputs and output_key in ["query", "file_paths", "labels", "documents", "meta", "answers"]:
+            if self.publish_outputs:
                 results[output_key] = output_value
         results["invocation_context"] = invocation_context
 

--- a/test/nodes/test_shaper.py
+++ b/test/nodes/test_shaper.py
@@ -360,6 +360,21 @@ def test_join_documents_without_publish_outputs():
     assert "documents" not in results
 
 
+def test_join_documents_with_publish_outputs_as_list():
+    shaper = Shaper(
+        func="join_documents",
+        inputs={"documents": "documents"},
+        params={"delimiter": " | "},
+        outputs=["documents"],
+        publish_outputs=["documents"],
+    )
+    results, _ = shaper.run(
+        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
+    assert results["documents"] == [Document(content="first | second | third")]
+
+
 def test_join_documents_default_delimiter():
     shaper = Shaper(func="join_documents", inputs={"documents": "documents"}, outputs=["documents"])
     results, _ = shaper.run(

--- a/test/nodes/test_shaper.py
+++ b/test/nodes/test_shaper.py
@@ -340,6 +340,22 @@ def test_join_documents():
         documents=[Document(content="first"), Document(content="second"), Document(content="third")]
     )
     assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
+    assert results["documents"] == [Document(content="first | second | third")]
+
+
+def test_join_documents_without_publish_outputs():
+    shaper = Shaper(
+        func="join_documents",
+        inputs={"documents": "documents"},
+        params={"delimiter": " | "},
+        outputs=["documents"],
+        publish_outputs=False,
+    )
+    results, _ = shaper.run(
+        documents=[Document(content="first"), Document(content="second"), Document(content="third")]
+    )
+    assert results["invocation_context"]["documents"] == [Document(content="first | second | third")]
+    assert "documents" not in results
 
 
 def test_join_documents_default_delimiter():
@@ -453,6 +469,11 @@ def test_strings_to_answers_yaml(tmp_path):
     pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
     result = pipeline.run()
     assert result["invocation_context"]["answers"] == [
+        Answer(answer="a", type="generative"),
+        Answer(answer="b", type="generative"),
+        Answer(answer="c", type="generative"),
+    ]
+    assert result["answers"] == [
         Answer(answer="a", type="generative"),
         Answer(answer="b", type="generative"),
         Answer(answer="c", type="generative"),


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/4230

### Proposed Changes:
- add `publish_outputs` option, defaults to `True` (same behavior as before)
- when `False` `outputs` won't be published to the pipeline result
- add `answers` to the eligible outputs that can be published

### How did you test it?
- added tests

### Notes for the reviewer
- This will save us two additional `Shapers` in a QA pipeline using `PromptNode`. See the issue above for more information.
- The yaml of the issue pipeline would then look like this:
```yaml
version: '1.13.2'
components:
  - name: DocumentStore
    type: InMemoryDocumentStore
  - name: Retriever
    type: BM25Retriever
    params:
      document_store: DocumentStore
      top_k: 3
  - name: PromptModel
    type: PromptModel
    params:
      model_name_or_path: google/flan-t5-large
      model_kwargs:
        model_kwargs:
          num_return_sequences: 3
          num_beams: 3
  - name: PromptNode 
    type: PromptNode
    params:
      default_prompt_template: question-answering
      model_name_or_path: PromptModel
  - name: InputDocumentShaper
    type: Shaper
    params:
      func: join_documents
      inputs:
        documents: documents
      outputs:
        - documents
      publish_outputs: false # this line can save two shapers
      params:
        delimiter: " - "
  - name: InputQuestionsShaper
    type: Shaper
    params:
      func: value_to_list
      inputs:
        value: query
      outputs:
        - questions
      params:
        target_list: [1]
  - name: OutputAnswerShaper
    type: Shaper
    params:
      func: strings_to_answers
      inputs:
        strings: results
      outputs:
        - answers
pipelines:
  - name: query
    nodes:
      - name: Retriever
        inputs: [Query]
      - name: InputDocumentShaper
        inputs: [Retriever]
      - name: InputQuestionsShaper
        inputs: [InputDocumentShaper]
      - name: PromptNode
        inputs: [InputQuestionsShaper]
      - name: OutputAnswerShaper
        inputs: [PromptNode]
```

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
