### PR TITLE
ci: Add missing dependencies in openapi upload workflow

### DIFF
--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/python_cache/
 
+      - name: Install dependencies
+        run: sudo apt update && sudo apt-get install libsndfile1 ffmpeg
+
       - name: Install Haystack
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
### Proposed Changes:

Add missing dependencies installation in `openapi_sync.yml` workflow.

### How did you test it?

Can't be tested.

### Notes for the reviewer

Will fix [this failure](https://github.com/deepset-ai/haystack/actions/runs/4245094590/jobs/7380143850).

