### PR TITLE
bug: disable telemetry in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ on:
       - "!rest_api/**/*.py"
 
 env:
+  HAYSTACK_TELEMETRY_VERSION: "0"  # Disables telemetry
   PYTEST_PARAMS: --maxfail=5 --durations=10 --suppress-no-test-exit-code
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   SUITES_EXCLUDED_FROM_WINDOWS:


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
- Sets an env var called `HAYSTACK_TELEMETRY_VERSION` to 0 in the test's workflow, to prevent spamming the telemetry server with useless events.

### How did you test it?
n/a

### Notes for the reviewer
Double-check whether this is the right way to set env vars in workflows.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- ~I added tests that demonstrate the correct behavior of the change~
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- ~I documented my code~
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
