### PR TITLE
ci: Add a simple way to skip required tests checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -642,3 +642,27 @@ jobs:
         status: ${{ job.status }}
         channel: '#haystack'
       if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+
+  catch-all:
+    name: Catch-all check
+    runs-on: ubuntu-latest
+    # This job will be executed only after all the other tests
+    # are successful.
+    # This way we'll be able to mark only this test as required
+    # and skip it accordingly.
+    needs:
+      - integration-tests-elasticsearch
+      - integration-tests-sql
+      - integration-tests-opensearch
+      - integration-tests-dc
+      - integration-tests-faiss
+      - integration-tests-weaviate
+      - integration-tests-pinecone
+      - integration-tests-milvus
+      - integration-tests-memory
+      - integration-tests-linux
+      - integration-tests-windows
+
+    steps:
+      - name: Finisher
+        run: echo "Finish him!"

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths-ignore:
+      - "**.py"
+      - "pyproject.toml"
+      - "!.github/**/*.py"
+      - "!rest_api/**/*.py"
+
+jobs:
+  catch-all:
+    name: Catch-all check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip tests
+        run: echo "Skipped!"


### PR DESCRIPTION
### Proposed Changes:

Add a new `catch-all` job in `tests.yml` that runs only after all integration tests have passed.

This also adds a `tests_skipper.yml` that runs whenever `tests.yml` doesn't, it only contains a `catch-all` job.

This way we'll be able to mark only the `catch-all` job as required instead of having to create a workflow that mirrors the `tests.yml`.

### How did you test it?

Can't be tested locally.

### Notes for the reviewer

I already added the `Catch-all check` as required in the repo settings.
