### PR TITLE
fix: FARMReader produces Answers with negative start and end position

### DIFF
--- a/haystack/modeling/model/feature_extraction.py
+++ b/haystack/modeling/model/feature_extraction.py
@@ -180,7 +180,7 @@ def tokenize_batch_question_answering(
     tokenids_batch = tokenized_docs_batch["input_ids"]
     offsets_batch = []
     for o in tokenized_docs_batch["offset_mapping"]:
-        offsets_batch.append(np.asarray([x[0] for x in o], dtype="int16"))
+        offsets_batch.append(np.asarray([x[0] for x in o], dtype=np.int32))
     start_of_words_batch = []
     for e in tokenized_docs_batch.encodings:
         start_of_words_batch.append(_get_start_of_word_QA(e.word_ids))
@@ -222,7 +222,7 @@ def tokenize_batch_question_answering(
 
 
 def _get_start_of_word_QA(word_ids):
-    return [1] + list(np.ediff1d(np.asarray(word_ids, dtype="int16")))
+    return [1] + list(np.ediff1d(np.asarray(word_ids, dtype=np.int32)))
 
 
 def truncate_sequences(

--- a/test/nodes/test_reader.py
+++ b/test/nodes/test_reader.py
@@ -435,3 +435,12 @@ def test_reader_training(tmp_path):
         max_seq_len=max_seq_len,
         max_query_length=max_query_length,
     )
+
+
+@pytest.mark.integration
+def test_reader_long_document(reader):
+    # Check that long documents with >2^16 characters do not result in negative offsets
+    docs = [Document(content=("abbreviation " * 2550) + "Christelle lives in Madrid.")]
+    res = reader.predict(query="Where does Christelle live?", documents=docs)
+    assert res["answers"][0].offsets_in_document[0].start >= 0
+    assert res["answers"][0].offsets_in_document[0].end >= 0


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack-private/issues/48

### Proposed Changes:
- Changed int16 to int32
- Added test case that failed before and now passes

### How did you test it?
- Added integration test

### Notes for the reviewer
I think int32 is sufficient because Documents with more than 2^32 ~4 billion characters are unlikely and would also be problematic in number of tokens and the time it takes to tokenize. 2^16 was just ~65000 characters so not a surprise that we hit that limit now.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
