### PR TITLE
Docs: Hide the promptnode modules from 1.13 docs

### DIFF
--- a/docs/_src/api/pydoc/prompt-node.yml
+++ b/docs/_src/api/pydoc/prompt-node.yml
@@ -9,6 +9,8 @@ processors:
     documented_only: true
     do_not_filter_modules: false
     skip_empty_modules: true
+  - type: filter
+    expression: "name not in ['PromptModelInvocationLayer', 'StopWordsCriteria', 'HFLocalInvocationLayer', 'OpenAIInvocationLayer']"
   - type: smart
   - type: crossref
 renderer:


### PR DESCRIPTION
### Related Issues
- fixes #[4246](https://github.com/deepset-ai/haystack/issues/4246)

### Proposed Changes:
Add a filter to the YAML to hide the modules from being generated into docs.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
