### PR TITLE
ci: Fix OpenAPI spec sync

### DIFF
--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -29,13 +29,10 @@ jobs:
       - name: Update OpenAPI specs
         run: python .github/utils/generate_openapi_specs.py
 
-      - name: Check if specs are there
-        run: cat openapi.json
-
-      # - name: Sync OpenAPI specs
-      #   uses: readmeio/rdme@8.3.1
-      #   env:
-      #     README_API_KEY: ${{ secrets.README_API_KEY }}
-      #     README_API_DEFINITION_ID: ${{ secrets.README_API_DEFINITION_ID }}
-      #   with:
-      #     rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID"
+      - name: Sync OpenAPI specs
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+          README_API_DEFINITION_ID: ${{ secrets.README_API_DEFINITION_ID }}
+        with:
+          rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID" --dryRun

--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -3,6 +3,7 @@ name: Sync OpenAPI Schema with Readme
 on:
   push:
     branches:
+      - fix-openapi-sync
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
@@ -28,10 +29,13 @@ jobs:
       - name: Update OpenAPI specs
         run: python .github/utils/generate_openapi_specs.py
 
-      - name: Sync OpenAPI specs
-        uses: readmeio/rdme@8.3.1
-        env:
-          README_API_KEY: ${{ secrets.README_API_KEY }}
-          README_API_DEFINITION_ID: ${{ secrets.README_API_DEFINITION_ID }}
-        with:
-          rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID"
+      - name: Check if specs are there
+        run: cat openapi.json
+
+      # - name: Sync OpenAPI specs
+      #   uses: readmeio/rdme@8.3.1
+      #   env:
+      #     README_API_KEY: ${{ secrets.README_API_KEY }}
+      #     README_API_DEFINITION_ID: ${{ secrets.README_API_DEFINITION_ID }}
+      #   with:
+      #     rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID"

--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -29,10 +29,25 @@ jobs:
       - name: Update OpenAPI specs
         run: python .github/utils/generate_openapi_specs.py
 
+      - name: Get OpenAPI specs id
+        id: openapi-specs
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        run: |
+          VERSION="$(cut -d "." -f 1,2 < VERSION.txt)"
+          if [[ "$(cat VERSION.txt)" == *"rc0" ]]; then
+            VERSION="$VERSION-unstable"
+          fi
+          SPECS_ID=$(curl https://dash.readme.com/api/v1/api-specification \
+            -u "$README_API_KEY:" \
+            --header "x-readme-version: $VERSION" \
+            | jq -r ".[0].version")
+          echo "id=$SPECS_ID" >> "$GITHUB_OUTPUT"
+
       - name: Sync OpenAPI specs
         uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
-          README_API_DEFINITION_ID: ${{ secrets.README_API_DEFINITION_ID }}
+          README_API_DEFINITION_ID: ${{ steps.openapi-specs.outputs.id }}
         with:
           rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID" --dryRun

--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -3,7 +3,6 @@ name: Sync OpenAPI Schema with Readme
 on:
   push:
     branches:
-      - fix-openapi-sync
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
@@ -50,4 +49,4 @@ jobs:
           README_API_KEY: ${{ secrets.README_API_KEY }}
           README_API_DEFINITION_ID: ${{ steps.openapi-specs.outputs.id }}
         with:
-          rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID" --dryRun
+          rdme: openapi openapi.json --key="$README_API_KEY" --id="$README_API_DEFINITION_ID"


### PR DESCRIPTION
### Proposed Changes:

Add a step to retrieve specs ID for the version that triggered the workflow and use that ID to upload the updated specs. 

### How did you test it?

I ran the workflow on this branch using dry run to avoid uploading the specs.
The workflow run: https://github.com/deepset-ai/haystack/actions/runs/4253725575/jobs/7398971419

### Notes for the reviewer

This is safe as long as we keep creating new versions in Readme.io using the previous version as base.

The call to Readme.io API returns a list of specs like the one below, the `version` field is the spec id we need and it's always identical for every item. Yes, the ID is not the `id` field for some reason. 🤷 


```
$ curl https://dash.readme.com/api/v1/api-specification -u "$README_API_KEY:" --header 'x-readme-version: v1.14' | jq
[
  {
    "title": "Haystack REST API",
    "source": "file",
    "_id": "63f374c0c2ecdc004a43cd0e",
    "version": "63f374c0c2ecdc004a43cd79",
    "lastSynced": "2022-08-16T12:53:33.278Z",
    "category": null,
    "type": "oas",
    "id": "63f374c0c2ecdc004a43cd0e"
  },
  {
    "title": "Haystack REST API",
    "source": "cli",
    "_id": "63f374c0c2ecdc004a43cd0f",
    "version": "63f374c0c2ecdc004a43cd79",
    "lastSynced": "2023-02-22T09:29:20.007Z",
    "category": {
      "title": "Haystack REST API",
      "slug": "haystack-rest-api",
      "order": 8,
      "_id": "63f374c0c2ecdc004a43cd0d",
      "type": "guide",
      "id": "63f374c0c2ecdc004a43cd0d"
    },
    "type": "oas",
    "id": "63f374c0c2ecdc004a43cd0f"
  }
]
```