### PR TITLE
ci: Fix OpenAPI specs upload

### DIFF
--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -40,7 +40,7 @@ jobs:
           SPECS_ID=$(curl https://dash.readme.com/api/v1/api-specification \
             -u "$README_API_KEY:" \
             --header "x-readme-version: $VERSION" \
-            | jq -r ".[0].version")
+            | jq -r ".[0].id")
           echo "id=$SPECS_ID" >> "$GITHUB_OUTPUT"
 
       - name: Sync OpenAPI specs


### PR DESCRIPTION
### Proposed Changes:

Change the property retrieved from `api-specification` endpoint.

### How did you test it?

I ran the commands locally.

### Notes for the reviewer

I cleaned up some files on Readme.io so now we can be sure that `/api/v1/api-specification` endpoint will always return only a single item list.
