### PR TITLE
ci: Remove unnecessary operations in minor_version_release.yml

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash
         # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
         run: |
-          echo "current_release_minor=$(cat VERSION.txt | cut -d "." -f 1,2)" >> $GITHUB_OUTPUT
+          echo "current_release_minor=$(cut -d "." -f 1,2 < VERSION.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Create new version branch
         run: |
@@ -33,15 +33,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout main
-          cat VERSION.txt | awk -F. '/[0-9]+\./{$2++;print}' OFS=. | tee VERSION.txt
+          NEW_VERSION=$(awk -F. '/[0-9]+\./{$2++;print}' OFS=. < VERSION.txt)
+          echo "$NEW_VERSION" > VERSION.txt
           cat VERSION.txt
-          pip install --upgrade pip
-          pip install .[all]
-          pip install ./rest_api
-          python .github/utils/generate_openapi_specs.py
           git checkout -b bump-version
           git add .
-          git commit -m "Update unstable version and openapi schema"
+          git commit -m "Update unstable version"
           git push -u origin bump-version
           gh pr create -B main -H bump-version --title 'Bump unstable version' --body 'Part of the release process' --label 'ignore-for-release-notes'
 


### PR DESCRIPTION
### Proposed Changes:

Remove generation of OpenAPI specs when running `minor_version_release.yml` since they're not necessary anymore.

OpenAPI specs are now generate and uploaded by `openapi_sync.yml` only when necessary.

### How did you test it?

Can't be tested.

### Notes for the reviewer

There are some styling changes in the PR too to fix `actionlint` complaints.
