### PR TITLE
ci: Parallellize Docker build job

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -13,7 +13,16 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest-4-cores
+    name: Build ${{ matrix.target }} image for ${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - "cpu"
+          - "gpu"
+        platform:
+          - "linux/amd64"
+          - "linux/arm64"
 
     steps:
       - name: Checkout
@@ -37,50 +46,46 @@ jobs:
         with:
           images: $DOCKER_REPO_NAME
 
-      - name: Build base images
+      - name: Build base image
         uses: docker/bake-action@v2
         env:
           IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
           HAYSTACK_VERSION: ${{ steps.meta.outputs.version }}
         with:
           workdir: docker
-          targets: base
+          targets: base-${{ matrix.target }}
           push: true
 
-      - name: Test base images
+      - name: Test base image
         run: |
           EXPECTED_VERSION=$(cat VERSION.txt)
-          function test_image {
-            local TAG PLATFORM VERSION
-            TAG=$1
-            PLATFORM=$2
-            VERSION=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" python -c"import haystack; print(haystack.__version__)")
-            [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
-            # Remove image after test to avoid filling the GitHub runner and prevent its failure
-            docker rmi "deepset/haystack:$TAG"
-          }
-          test_image base-cpu-${{ steps.meta.outputs.version }} linux/amd64
-          test_image base-gpu-${{ steps.meta.outputs.version }} linux/amd64
-          test_image base-cpu-${{ steps.meta.outputs.version }} linux/arm64
-          test_image base-gpu-${{ steps.meta.outputs.version }} linux/arm64
+          TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
+          PLATFORM="${{ matrix.platform }}"
 
-      - name: Build api images
+          VERSION=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" python -c"import haystack; print(haystack.__version__)")
+          [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in deepset/haystack:$TAG image for $PLATFORM is different from expected'"
+          # Remove image after test to avoid filling the GitHub runner and prevent its failure
+          docker rmi "deepset/haystack:$TAG"
+
+      - name: Build api image
         uses: docker/bake-action@v2
         env:
           IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
           BASE_IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
         with:
           workdir: docker
-          targets: api
+          targets: ${{ matrix.target }}
           push: true
+          set: "*.platform=${{ matrix.platform }}"
 
       - name: Get latest version of Haystack
         id: latest-version
-        uses: pozetroninc/github-action-get-latest-release@master
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          repository: ${{ github.repository }}
-          excludes: prerelease, draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(gh api repos/${{ github.repository }}/releases/latest --jq ".tag_name")
+          echo "release=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Compare current version with latest
         uses: madhead/semver-utils@latest
@@ -104,15 +109,6 @@ jobs:
           BASE_IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
         with:
           workdir: docker
-          targets: api-latest
+          targets: ${{ matrix.target }}-latest
           push: true
-
-      - name: Test api image no version in tag
-        if: steps.version.outputs.comparison-result == '>'
-        run: |
-          docker compose up -d
-          # Waits for containers to come up
-          sleep 15s
-          EXPECTED_VERSION=$(cat VERSION.txt)
-          VERSION=$(curl http://localhost:8000/hs_version | jq .hs_version)
-          [[ "$VERSION" = "$EXPECTED_VERSION" ]] || echo "::error 'Haystack version in REST API image is different from expected'"
+          set: "*.platform=${{ matrix.platform }}"


### PR DESCRIPTION
### Proposed Changes:

Split build process of Docker images using `matrix` strategy, this way we'll have a single job for each target and platform combination.

### How did you test it?

Triggered a workflow in this branch.
https://github.com/deepset-ai/haystack/actions/runs/4263932762

### Notes for the reviewer

I removed the last step that was testing the `api-latest` target using the `docker-compose.yml` in the root as I didn't find it that useful, and neither it was easy to integrate with the new matrix strategy.

Also I changed `ubuntu-latest-4-cores` back to `ubuntu-latest`.
