### PR TITLE
test: move summarizer tests under e2e

### DIFF
--- a/e2e/nodes/test_summarizer.py
+++ b/e2e/nodes/test_summarizer.py
@@ -2,7 +2,7 @@ import pytest
 
 from haystack.schema import Document
 from haystack.pipelines import SearchSummarizationPipeline
-from haystack.nodes import DensePassageRetriever, EmbeddingRetriever, TransformersSummarizer, BM25Retriever
+from haystack.nodes import EmbeddingRetriever, TransformersSummarizer, BM25Retriever
 from haystack.nodes.other.document_merger import DocumentMerger
 from haystack.document_stores import ElasticsearchDocumentStore, InMemoryDocumentStore
 
@@ -83,7 +83,7 @@ def test_summarization_batch_multiple_doc_lists(summarizer):
 def test_summarization_pipeline(retriever, summarizer):
     retriever.document_store.write_documents(DOCS)
 
-    if isinstance(retriever, EmbeddingRetriever) or isinstance(retriever, DensePassageRetriever):
+    if isinstance(retriever, EmbeddingRetriever):
         retriever.document_store.update_embeddings(retriever=retriever)
 
     query = "Where is Eiffel Tower?"

--- a/test/nodes/test_extractor_translation.py
+++ b/test/nodes/test_extractor_translation.py
@@ -2,7 +2,17 @@ import pytest
 
 from haystack.pipelines import TranslationWrapperPipeline, ExtractiveQAPipeline
 from haystack.nodes import DensePassageRetriever, EmbeddingRetriever
-from .test_summarizer import SPLIT_DOCS
+from haystack.schema import Document
+
+
+SPLIT_DOCS = [
+    Document(
+        content="""The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower surpassed the Washington Monument to become the tallest man-made structure in the world, a title it held for 41 years until the Chrysler Building in New York City was finished in 1930."""
+    ),
+    Document(
+        content="""It was the first structure to reach a height of 300 metres. Due to the addition of a broadcasting aerial at the top of the tower in 1957, it is now taller than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel Tower is the second tallest free-standing structure in France after the Millau Viaduct."""
+    ),
+]
 
 
 # Keeping few (retriever,document_store,reader) combination to reduce test time


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/4243

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Move summarizer tests under e2e and eventually run on a powerful enough custom node

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manually tested locally with `pytest e2e/nodes/test_summarizer.py `

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
