### PR TITLE
docs: Fix Haystack classes docs category

### DIFF
--- a/docs/pydoc/config/answer-generator.yml
+++ b/docs/pydoc/config/answer-generator.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/answer_generator]
-    modules: ['base', 'transformers', 'openai']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "transformers", "openai"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Reads a set of documents and generates an answer to a question, word by word
-   category: 6310ca73c622850ddd3875a2
-   title: Answer Generator API
-   slug: answer-generator-api
-   order: 0
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: answer_generator_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Reads a set of documents and generates an answer to a question, word by word
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Answer Generator API
+  slug: answer-generator-api
+  order: 0
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: answer_generator_api.md

--- a/docs/pydoc/config/crawler.yml
+++ b/docs/pydoc/config/crawler.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/connector]
-    modules: ['crawler']
-    ignore_when_discovered: ['__init__']
+    modules: ["crawler"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: The Crawler scrapes the text from a website, creates a Haystack Document object out of it, and saves it to a JSON file.
-   category: 6310ca73c622850ddd3875a2
-   title: Crawler API
-   slug: crawler-api
-   order: 10
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: crawler_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: The Crawler scrapes the text from a website, creates a Haystack Document object out of it, and saves it to a JSON file.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Crawler API
+  slug: crawler-api
+  order: 10
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: crawler_api.md

--- a/docs/pydoc/config/document-classifier.yml
+++ b/docs/pydoc/config/document-classifier.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/document_classifier]
-    modules: ['base', 'transformers']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "transformers"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Used to create predictions that are attached to documents as metadata.
-   category: 6310ca73c622850ddd3875a2
-   title: Document Classifier API
-   slug: document-classifier-api
-   order: 20
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: document_classifier_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Used to create predictions that are attached to documents as metadata.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Document Classifier API
+  slug: document-classifier-api
+  order: 20
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: document_classifier_api.md

--- a/docs/pydoc/config/document-store.yml
+++ b/docs/pydoc/config/document-store.yml
@@ -1,8 +1,23 @@
 loaders:
   - type: python
     search_path: [../../../haystack/document_stores]
-    modules: ['base', 'elasticsearch', 'opensearch', 'memory', 'sql', 'faiss', 'milvus', 'weaviate', 'graphdb', 'deepsetcloud', 'pinecone', 'search_engine', 'utils']
-    ignore_when_discovered: ['__init__']
+    modules:
+      [
+        "base",
+        "elasticsearch",
+        "opensearch",
+        "memory",
+        "sql",
+        "faiss",
+        "milvus",
+        "weaviate",
+        "graphdb",
+        "deepsetcloud",
+        "pinecone",
+        "search_engine",
+        "utils",
+      ]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +27,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Stores your texts and meta data and provides them to the Retriever at query time.
-   category: 6310ca73c622850ddd3875a2
-   title: Document Store API
-   slug: document-store-api
-   order: 30
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: document_store_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Stores your texts and meta data and provides them to the Retriever at query time.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Document Store API
+  slug: document-store-api
+  order: 30
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: document_store_api.md

--- a/docs/pydoc/config/extractor.yml
+++ b/docs/pydoc/config/extractor.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/extractor]
-    modules: ['entity']
-    ignore_when_discovered: ['__init__']
+    modules: ["entity"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -14,15 +14,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Extracts predefined entities out of a piece of text.
-   category: 6310ca73c622850ddd3875a2
-   title: Entity Extractor API
-   slug: entity-extractor-api
-   order: 50
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: entity_extractor_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Extracts predefined entities out of a piece of text.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Entity Extractor API
+  slug: entity-extractor-api
+  order: 50
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: entity_extractor_api.md

--- a/docs/pydoc/config/file-classifier.yml
+++ b/docs/pydoc/config/file-classifier.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/file_classifier]
-    modules: ['file_type']
-    ignore_when_discovered: ['__init__']
+    modules: ["file_type"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Distinguishes between text, PDF, Markdown, Docx and HTML files and routes them to the appropriate File Converter in an indexing pipeline.
-   category: 6310ca73c622850ddd3875a2
-   title: File Classifier API
-   slug: file-classifier-api
-   order: 60
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: file_classifier_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Distinguishes between text, PDF, Markdown, Docx and HTML files and routes them to the appropriate File Converter in an indexing pipeline.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: File Classifier API
+  slug: file-classifier-api
+  order: 60
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: file_classifier_api.md

--- a/docs/pydoc/config/file-converters.yml
+++ b/docs/pydoc/config/file-converters.yml
@@ -1,8 +1,20 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/file_converter]
-    modules: ['base', 'csv', 'docx', 'image', 'markdown', 'pdf', 'parsr', 'azure', 'tika', 'txt']
-    ignore_when_discovered: ['__init__']
+    modules:
+      [
+        "base",
+        "csv",
+        "docx",
+        "image",
+        "markdown",
+        "pdf",
+        "parsr",
+        "azure",
+        "tika",
+        "txt",
+      ]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +24,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Extracts text from files in different formats and cast it into the unified Document format.
-   category: 6310ca73c622850ddd3875a2
-   title: File Converters API
-   slug: file-converters-api
-   order: 70
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: file_converters_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Extracts text from files in different formats and cast it into the unified Document format.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: File Converters API
+  slug: file-converters-api
+  order: 70
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: file_converters_api.md

--- a/docs/pydoc/config/other.yml
+++ b/docs/pydoc/config/other.yml
@@ -1,8 +1,16 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/other]
-    modules: ['docs2answers', 'join_docs', 'join_answers', 'route_documents', 'document_merger', 'shaper']
-    ignore_when_discovered: ['__init__']
+    modules:
+      [
+        "docs2answers",
+        "join_docs",
+        "join_answers",
+        "route_documents",
+        "document_merger",
+        "shaper",
+      ]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +20,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: The utility classes of Haystack.
-   category: 6310ca73c622850ddd3875a2
-   title: Other API
-   slug: other-api
-   order: 80
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: other_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: The utility classes of Haystack.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Other API
+  slug: other-api
+  order: 80
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: other_api.md

--- a/docs/pydoc/config/pipelines.yml
+++ b/docs/pydoc/config/pipelines.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/pipelines]
-    modules: ['base', 'ray', 'standard_pipelines']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "ray", "standard_pipelines"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Arranges nodes in a predefined flow.
-   category: 6310ca73c622850ddd3875a2
-   title: Pipelines API
-   slug: pipelines-api
-   order: 90
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: pipelines_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Arranges nodes in a predefined flow.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Pipelines API
+  slug: pipelines-api
+  order: 90
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: pipelines_api.md

--- a/docs/pydoc/config/preprocessor.yml
+++ b/docs/pydoc/config/preprocessor.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/preprocessor]
-    modules: ['base', 'preprocessor']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "preprocessor"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Normalize white spaces, gets rid of headers and footers, cleans empty lines in your Documents, or splits them into smaller pieces.
-   category: 6310ca73c622850ddd3875a2
-   title: PreProcessor API
-   slug: preprocessor-api
-   order: 100
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: preprocessor_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Normalize white spaces, gets rid of headers and footers, cleans empty lines in your Documents, or splits them into smaller pieces.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: PreProcessor API
+  slug: preprocessor-api
+  order: 100
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: preprocessor_api.md

--- a/docs/pydoc/config/primitives.yml
+++ b/docs/pydoc/config/primitives.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack]
-    modules: ['schema']
-    ignore_when_discovered: ['__init__']
+    modules: ["schema"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: These are the core classes that carry data through the system.
-   category: 6310ca73c622850ddd3875a2
-   title: Primitives API
-   slug: primitives-api
-   order: 110
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: primitives_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: These are the core classes that carry data through the system.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Primitives API
+  slug: primitives-api
+  order: 110
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: primitives_api.md

--- a/docs/pydoc/config/prompt-node.yml
+++ b/docs/pydoc/config/prompt-node.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/prompt]
-    modules: ['prompt_node']
-    ignore_when_discovered: ['__init__']
+    modules: ["prompt_node"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -14,15 +14,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Uses Large Language Models directly in your pipelines.
-   category: 6310ca73c622850ddd3875a2
-   title: PromptNode API
-   slug: prompt-node-api
-   order: 115
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: prompt_node_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Uses Large Language Models directly in your pipelines.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: PromptNode API
+  slug: prompt-node-api
+  order: 115
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: prompt_node_api.md

--- a/docs/pydoc/config/pseudo-label-generator.yml
+++ b/docs/pydoc/config/pseudo-label-generator.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/label_generator]
-    modules: ['pseudo_label_generator']
-    ignore_when_discovered: ['__init__']
+    modules: ["pseudo_label_generator"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Creates training data for dense retrievers without human annotation.
-   category: 6310ca73c622850ddd3875a2
-   title: Pseudo Label Generator API
-   slug: pseudo-label-generator-api
-   order: 120
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: pseudo_label_generator_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Creates training data for dense retrievers without human annotation.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Pseudo Label Generator API
+  slug: pseudo-label-generator-api
+  order: 120
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: pseudo_label_generator_api.md

--- a/docs/pydoc/config/query-classifier.yml
+++ b/docs/pydoc/config/query-classifier.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/query_classifier]
-    modules: ['base', 'sklearn', 'transformers']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "sklearn", "transformers"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Distinguishes between keyword, question and statements queries.
-   category: 6310ca73c622850ddd3875a2
-   title: Query Classifier API
-   slug: query-classifier-api
-   order: 130
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: query_classifier_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Distinguishes between keyword, question and statements queries.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Query Classifier API
+  slug: query-classifier-api
+  order: 130
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: query_classifier_api.md

--- a/docs/pydoc/config/question-generator.yml
+++ b/docs/pydoc/config/question-generator.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/question_generator]
-    modules: ['question_generator']
-    ignore_when_discovered: ['__init__']
+    modules: ["question_generator"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Takes a Document as input and generates questions which it believes the Document can answer.
-   category: 6310ca73c622850ddd3875a2
-   title: Question Generator API
-   slug: question-generator-api
-   order: 140
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: question_generator_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Takes a Document as input and generates questions which it believes the Document can answer.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Question Generator API
+  slug: question-generator-api
+  order: 140
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: question_generator_api.md

--- a/docs/pydoc/config/ranker.yml
+++ b/docs/pydoc/config/ranker.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/ranker]
-    modules: ['base', 'sentence_transformers']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "sentence_transformers"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Reorders a set of Documents based on their relevance to the Query.
-   category: 6310ca73c622850ddd3875a2
-   title: Ranker API
-   slug: ranker-api
-   order: 150
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: ranker_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Reorders a set of Documents based on their relevance to the Query.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Ranker API
+  slug: ranker-api
+  order: 150
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: ranker_api.md

--- a/docs/pydoc/config/reader.yml
+++ b/docs/pydoc/config/reader.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/reader]
-    modules: ['base', 'farm', 'transformers', 'table']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "farm", "transformers", "table"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Takes a question and a set of Documents as input and returns an Answer by selecting a text span within the Documents.
-   category: 6310ca73c622850ddd3875a2
-   title: Reader API
-   slug: reader-api
-   order: 160
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: reader_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Takes a question and a set of Documents as input and returns an Answer by selecting a text span within the Documents.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Reader API
+  slug: reader-api
+  order: 160
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: reader_api.md

--- a/docs/pydoc/config/retriever.yml
+++ b/docs/pydoc/config/retriever.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/retriever]
-    modules: ['base', 'sparse', 'dense', 'text2sparql', 'multimodal/retriever']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "sparse", "dense", "text2sparql", "multimodal/retriever"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Sweeps through a document store and returns a set of candidate documents that are relevant to the query.
-   category: 6310ca73c622850ddd3875a2
-   title: Retriever API
-   slug: retriever-api
-   order: 170
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: retriever_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Sweeps through a document store and returns a set of candidate documents that are relevant to the query.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Retriever API
+  slug: retriever-api
+  order: 170
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: retriever_api.md

--- a/docs/pydoc/config/summarizer.yml
+++ b/docs/pydoc/config/summarizer.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/summarizer]
-    modules: ['base', 'transformers']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "transformers"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: The Summarizer gives a short overview of a long Document.
-   category: 6310ca73c622850ddd3875a2
-   title: Summarizer API
-   slug: summarizer-api
-   order: 180
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: summarizer_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: The Summarizer gives a short overview of a long Document.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Summarizer API
+  slug: summarizer-api
+  order: 180
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: summarizer_api.md

--- a/docs/pydoc/config/transformers-img-to-text.yml
+++ b/docs/pydoc/config/transformers-img-to-text.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/image_to_text]
-    modules: ['base', 'transformers']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "transformers"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Generates captions for images.
-   category: 6310ca73c622850ddd3875a2
-   title: TransformersImageToText API
-   slug: transformers-image-to-text-api
-   order: 185
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: transformers-image-to-text.md
+  type: renderers.ReadmeRenderer
+  excerpt: Generates captions for images.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: TransformersImageToText API
+  slug: transformers-image-to-text-api
+  order: 185
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: transformers-image-to-text.md

--- a/docs/pydoc/config/translator.yml
+++ b/docs/pydoc/config/translator.yml
@@ -1,8 +1,8 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/translator]
-    modules: ['base', 'transformers']
-    ignore_when_discovered: ['__init__']
+    modules: ["base", "transformers"]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +12,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Does what it says on the tin - it translates text from one language into another.
-   category: 6310ca73c622850ddd3875a2
-   title: Translator API
-   slug: translator-api
-   order: 190
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: translator_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Does what it says on the tin - it translates text from one language into another.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Translator API
+  slug: translator-api
+  order: 190
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: translator_api.md

--- a/docs/pydoc/config/utils.yml
+++ b/docs/pydoc/config/utils.yml
@@ -1,8 +1,19 @@
 loaders:
   - type: python
     search_path: [../../../haystack/utils]
-    modules: ['doc_store', 'export_utils', 'preprocessing', 'squad_data', 'early_stopping', 'cleaning', 'context_matching', 'deepsetcloud', 'docker']
-    ignore_when_discovered: ['__init__']
+    modules:
+      [
+        "doc_store",
+        "export_utils",
+        "preprocessing",
+        "squad_data",
+        "early_stopping",
+        "cleaning",
+        "context_matching",
+        "deepsetcloud",
+        "docker",
+      ]
+    ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
     expression:
@@ -12,15 +23,15 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-   type: renderers.ReadmeRenderer
-   excerpt: Utility functions for Haystack.
-   category: 6310ca73c622850ddd3875a2
-   title: Utils API
-   slug: utils-api
-   order: 200
-   markdown:
-     descriptive_class_title: false
-     descriptive_module_title: true
-     add_method_class_prefix: true
-     add_member_class_prefix: false
-     filename: utils_api.md
+  type: renderers.ReadmeRenderer
+  excerpt: Utility functions for Haystack.
+  category: 63f374c0c2ecdc004a43cd0a
+  title: Utils API
+  slug: utils-api
+  order: 200
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: utils_api.md


### PR DESCRIPTION
### Proposed Changes:

Category id of `Haystack classes` in Readme.io changed for some reason recently so docs upload is failing.
This updates the docs' category id so the upload won't fail anymore.

See [this run](https://github.com/deepset-ai/haystack/actions/runs/4243401036/jobs/7376706597) as an example failure.

### How did you test it?

Can't be tested.

### Notes for the reviewer

This must be cherry picked in `v1.14.x` release branch, I'll do it after this is merged.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
