### PR TITLE
test: replace `ElasticsearchDocumentStore` with `InMemoryDocumentStore` when it makes sense

### DIFF
--- a/test/nodes/test_extractor_translation.py
+++ b/test/nodes/test_extractor_translation.py
@@ -1,22 +1,18 @@
 import pytest
 
 from haystack.pipelines import TranslationWrapperPipeline, ExtractiveQAPipeline
-from haystack.nodes import DensePassageRetriever, EmbeddingRetriever
 from .test_summarizer import SPLIT_DOCS
 
 
 # Keeping few (retriever,document_store,reader) combination to reduce test time
 @pytest.mark.integration
-@pytest.mark.elasticsearch
 @pytest.mark.summarizer
 @pytest.mark.parametrize("retriever,document_store,reader", [("embedding", "memory", "farm")], indirect=True)
 def test_extractive_qa_pipeline_with_translator(
     document_store, retriever, reader, en_to_de_translator, de_to_en_translator
 ):
     document_store.write_documents(SPLIT_DOCS)
-
-    if isinstance(retriever, EmbeddingRetriever) or isinstance(retriever, DensePassageRetriever):
-        document_store.update_embeddings(retriever=retriever)
+    document_store.update_embeddings(retriever=retriever)
 
     query = "Wo steht der Eiffelturm?"
     base_pipeline = ExtractiveQAPipeline(retriever=retriever, reader=reader)

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -161,8 +161,7 @@ def test_eval_reader(reader, document_store, use_confidence_scores):
         assert reader_eval_results["top_n_accuracy"] == 100.0
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("open_domain", [True, False])
 @pytest.mark.parametrize("retriever", ["bm25"], indirect=True)
 def test_eval_elastic_retriever(document_store, open_domain, retriever):

--- a/test/pipelines/test_pipeline_debug_and_validation.py
+++ b/test/pipelines/test_pipeline_debug_and_validation.py
@@ -21,8 +21,7 @@ class MockRetriever(BaseMockRetriever):
             raise ValueError("TEST ERROR!")
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_node_names_validation(document_store_with_docs, tmp_path):
     pipeline = Pipeline()
     pipeline.add_node(
@@ -52,28 +51,27 @@ def test_node_names_validation(document_store_with_docs, tmp_path):
     assert "top_k" not in exception_raised
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_debug_attributes_global(document_store_with_docs, tmp_path):
-    es_retriever = BM25Retriever(document_store=document_store_with_docs)
+    bm25_retriever = BM25Retriever(document_store=document_store_with_docs)
     reader = FARMReader(model_name_or_path="deepset/minilm-uncased-squad2", num_processes=0)
 
     pipeline = Pipeline()
-    pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["ESRetriever"])
+    pipeline.add_node(component=bm25_retriever, name="BM25Retriever", inputs=["Query"])
+    pipeline.add_node(component=reader, name="Reader", inputs=["BM25Retriever"])
 
     prediction = pipeline.run(
-        query="Who lives in Berlin?", params={"ESRetriever": {"top_k": 10}, "Reader": {"top_k": 3}}, debug=True
+        query="Who lives in Berlin?", params={"BM25Retriever": {"top_k": 10}, "Reader": {"top_k": 3}}, debug=True
     )
     assert "_debug" in prediction.keys()
-    assert "ESRetriever" in prediction["_debug"].keys()
+    assert "BM25Retriever" in prediction["_debug"].keys()
     assert "Reader" in prediction["_debug"].keys()
-    assert "input" in prediction["_debug"]["ESRetriever"].keys()
-    assert "output" in prediction["_debug"]["ESRetriever"].keys()
+    assert "input" in prediction["_debug"]["BM25Retriever"].keys()
+    assert "output" in prediction["_debug"]["BM25Retriever"].keys()
     assert "input" in prediction["_debug"]["Reader"].keys()
     assert "output" in prediction["_debug"]["Reader"].keys()
-    assert prediction["_debug"]["ESRetriever"]["input"]
-    assert prediction["_debug"]["ESRetriever"]["output"]
+    assert prediction["_debug"]["BM25Retriever"]["input"]
+    assert prediction["_debug"]["BM25Retriever"]["output"]
     assert prediction["_debug"]["Reader"]["input"]
     assert prediction["_debug"]["Reader"]["output"]
 
@@ -81,57 +79,55 @@ def test_debug_attributes_global(document_store_with_docs, tmp_path):
     json.dumps(prediction, default=str)
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_debug_attributes_per_node(document_store_with_docs, tmp_path):
-    es_retriever = BM25Retriever(document_store=document_store_with_docs)
+    bm25_retriever = BM25Retriever(document_store=document_store_with_docs)
     reader = FARMReader(model_name_or_path="deepset/minilm-uncased-squad2", num_processes=0)
 
     pipeline = Pipeline()
-    pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["ESRetriever"])
+    pipeline.add_node(component=bm25_retriever, name="BM25Retriever", inputs=["Query"])
+    pipeline.add_node(component=reader, name="Reader", inputs=["BM25Retriever"])
 
     prediction = pipeline.run(
-        query="Who lives in Berlin?", params={"ESRetriever": {"top_k": 10, "debug": True}, "Reader": {"top_k": 3}}
+        query="Who lives in Berlin?", params={"BM25Retriever": {"top_k": 10, "debug": True}, "Reader": {"top_k": 3}}
     )
     assert "_debug" in prediction.keys()
-    assert "ESRetriever" in prediction["_debug"].keys()
+    assert "BM25Retriever" in prediction["_debug"].keys()
     assert "Reader" not in prediction["_debug"].keys()
-    assert "input" in prediction["_debug"]["ESRetriever"].keys()
-    assert "output" in prediction["_debug"]["ESRetriever"].keys()
-    assert prediction["_debug"]["ESRetriever"]["input"]
-    assert prediction["_debug"]["ESRetriever"]["output"]
+    assert "input" in prediction["_debug"]["BM25Retriever"].keys()
+    assert "output" in prediction["_debug"]["BM25Retriever"].keys()
+    assert prediction["_debug"]["BM25Retriever"]["input"]
+    assert prediction["_debug"]["BM25Retriever"]["output"]
 
     # Avoid circular reference: easiest way to detect those is to use json.dumps
     json.dumps(prediction, default=str)
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_debug_attributes_for_join_nodes(document_store_with_docs, tmp_path):
-    es_retriever_1 = BM25Retriever(document_store=document_store_with_docs)
-    es_retriever_2 = BM25Retriever(document_store=document_store_with_docs)
+    bm25_retriever_1 = BM25Retriever(document_store=document_store_with_docs)
+    bm25_retriever_2 = BM25Retriever(document_store=document_store_with_docs)
 
     pipeline = Pipeline()
-    pipeline.add_node(component=es_retriever_1, name="ESRetriever1", inputs=["Query"])
-    pipeline.add_node(component=es_retriever_2, name="ESRetriever2", inputs=["Query"])
+    pipeline.add_node(component=bm25_retriever_1, name="BM25Retriever1", inputs=["Query"])
+    pipeline.add_node(component=bm25_retriever_2, name="BM25Retriever2", inputs=["Query"])
     pipeline.add_node(component=JoinDocuments(), name="JoinDocuments", inputs=["ESRetriever1", "ESRetriever2"])
 
     prediction = pipeline.run(query="Who lives in Berlin?", debug=True)
     assert "_debug" in prediction.keys()
-    assert "ESRetriever1" in prediction["_debug"].keys()
-    assert "ESRetriever2" in prediction["_debug"].keys()
+    assert "BM25Retriever1" in prediction["_debug"].keys()
+    assert "BM25Retriever2" in prediction["_debug"].keys()
     assert "JoinDocuments" in prediction["_debug"].keys()
-    assert "input" in prediction["_debug"]["ESRetriever1"].keys()
-    assert "output" in prediction["_debug"]["ESRetriever1"].keys()
-    assert "input" in prediction["_debug"]["ESRetriever2"].keys()
-    assert "output" in prediction["_debug"]["ESRetriever2"].keys()
+    assert "input" in prediction["_debug"]["BM25Retriever1"].keys()
+    assert "output" in prediction["_debug"]["BM25Retriever1"].keys()
+    assert "input" in prediction["_debug"]["BM25Retriever2"].keys()
+    assert "output" in prediction["_debug"]["BM25Retriever2"].keys()
     assert "input" in prediction["_debug"]["JoinDocuments"].keys()
     assert "output" in prediction["_debug"]["JoinDocuments"].keys()
-    assert prediction["_debug"]["ESRetriever1"]["input"]
-    assert prediction["_debug"]["ESRetriever1"]["output"]
-    assert prediction["_debug"]["ESRetriever2"]["input"]
-    assert prediction["_debug"]["ESRetriever2"]["output"]
+    assert prediction["_debug"]["BM25Retriever1"]["input"]
+    assert prediction["_debug"]["BM25Retriever1"]["output"]
+    assert prediction["_debug"]["BM25Retriever2"]["input"]
+    assert prediction["_debug"]["BM25Retriever2"]["output"]
     assert prediction["_debug"]["JoinDocuments"]["input"]
     assert prediction["_debug"]["JoinDocuments"]["output"]
 
@@ -139,37 +135,36 @@ def test_debug_attributes_for_join_nodes(document_store_with_docs, tmp_path):
     json.dumps(prediction, default=str)
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_global_debug_attributes_override_node_ones(document_store_with_docs, tmp_path):
-    es_retriever = BM25Retriever(document_store=document_store_with_docs)
+    bm25_retriever = BM25Retriever(document_store=document_store_with_docs)
     reader = FARMReader(model_name_or_path="deepset/minilm-uncased-squad2", num_processes=0)
 
     pipeline = Pipeline()
-    pipeline.add_node(component=es_retriever, name="ESRetriever", inputs=["Query"])
-    pipeline.add_node(component=reader, name="Reader", inputs=["ESRetriever"])
+    pipeline.add_node(component=bm25_retriever, name="BM25Retriever", inputs=["Query"])
+    pipeline.add_node(component=reader, name="Reader", inputs=["BM25Retriever"])
 
     prediction = pipeline.run(
         query="Who lives in Berlin?",
-        params={"ESRetriever": {"top_k": 10, "debug": True}, "Reader": {"top_k": 3, "debug": True}},
+        params={"BM25Retriever": {"top_k": 10, "debug": True}, "Reader": {"top_k": 3, "debug": True}},
         debug=False,
     )
     assert "_debug" not in prediction.keys()
 
     prediction = pipeline.run(
         query="Who lives in Berlin?",
-        params={"ESRetriever": {"top_k": 10, "debug": False}, "Reader": {"top_k": 3, "debug": False}},
+        params={"BM25Retriever": {"top_k": 10, "debug": False}, "Reader": {"top_k": 3, "debug": False}},
         debug=True,
     )
     assert "_debug" in prediction.keys()
-    assert "ESRetriever" in prediction["_debug"].keys()
+    assert "BM25Retriever" in prediction["_debug"].keys()
     assert "Reader" in prediction["_debug"].keys()
-    assert "input" in prediction["_debug"]["ESRetriever"].keys()
-    assert "output" in prediction["_debug"]["ESRetriever"].keys()
+    assert "input" in prediction["_debug"]["BM25Retriever"].keys()
+    assert "output" in prediction["_debug"]["BM25Retriever"].keys()
     assert "input" in prediction["_debug"]["Reader"].keys()
     assert "output" in prediction["_debug"]["Reader"].keys()
-    assert prediction["_debug"]["ESRetriever"]["input"]
-    assert prediction["_debug"]["ESRetriever"]["output"]
+    assert prediction["_debug"]["BM25Retriever"]["input"]
+    assert prediction["_debug"]["BM25Retriever"]["output"]
     assert prediction["_debug"]["Reader"]["input"]
     assert prediction["_debug"]["Reader"]["output"]
 

--- a/test/pipelines/test_standard_pipelines.py
+++ b/test/pipelines/test_standard_pipelines.py
@@ -293,10 +293,9 @@ def test_most_similar_documents_pipeline_with_filters_batch(retriever, document_
             assert document.meta["source"] in ["wiki3", "wiki4", "wiki5"]
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_dot_product_with_docs", ["memory"], indirect=True)
 def test_join_merge_no_weights(document_store_dot_product_with_docs):
-    es = BM25Retriever(document_store=document_store_dot_product_with_docs)
+    bm25 = BM25Retriever(document_store=document_store_dot_product_with_docs)
     dpr = DensePassageRetriever(
         document_store=document_store_dot_product_with_docs,
         query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -309,17 +308,16 @@ def test_join_merge_no_weights(document_store_dot_product_with_docs):
 
     join_node = JoinDocuments(join_mode="merge")
     p = Pipeline()
-    p.add_node(component=es, name="R1", inputs=["Query"])
+    p.add_node(component=bm25, name="R1", inputs=["Query"])
     p.add_node(component=dpr, name="R2", inputs=["Query"])
     p.add_node(component=join_node, name="Join", inputs=["R1", "R2"])
     results = p.run(query=query)
     assert len(results["documents"]) == 5
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_dot_product_with_docs", ["memory"], indirect=True)
 def test_join_merge_with_weights(document_store_dot_product_with_docs):
-    es = BM25Retriever(document_store=document_store_dot_product_with_docs)
+    bm25 = BM25Retriever(document_store=document_store_dot_product_with_docs)
     dpr = DensePassageRetriever(
         document_store=document_store_dot_product_with_docs,
         query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -332,7 +330,7 @@ def test_join_merge_with_weights(document_store_dot_product_with_docs):
 
     join_node = JoinDocuments(join_mode="merge", weights=[1000, 1], top_k_join=2)
     p = Pipeline()
-    p.add_node(component=es, name="R1", inputs=["Query"])
+    p.add_node(component=bm25, name="R1", inputs=["Query"])
     p.add_node(component=dpr, name="R2", inputs=["Query"])
     p.add_node(component=join_node, name="Join", inputs=["R1", "R2"])
     results = p.run(query=query)
@@ -340,10 +338,9 @@ def test_join_merge_with_weights(document_store_dot_product_with_docs):
     assert len(results["documents"]) == 2
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_dot_product_with_docs", ["memory"], indirect=True)
 def test_join_concatenate(document_store_dot_product_with_docs):
-    es = BM25Retriever(document_store=document_store_dot_product_with_docs)
+    bm25 = BM25Retriever(document_store=document_store_dot_product_with_docs)
     dpr = DensePassageRetriever(
         document_store=document_store_dot_product_with_docs,
         query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -356,17 +353,16 @@ def test_join_concatenate(document_store_dot_product_with_docs):
 
     join_node = JoinDocuments(join_mode="concatenate")
     p = Pipeline()
-    p.add_node(component=es, name="R1", inputs=["Query"])
+    p.add_node(component=bm25, name="R1", inputs=["Query"])
     p.add_node(component=dpr, name="R2", inputs=["Query"])
     p.add_node(component=join_node, name="Join", inputs=["R1", "R2"])
     results = p.run(query=query)
     assert len(results["documents"]) == 5
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_dot_product_with_docs", ["memory"], indirect=True)
 def test_join_concatenate_with_topk(document_store_dot_product_with_docs):
-    es = BM25Retriever(document_store=document_store_dot_product_with_docs)
+    bm25 = BM25Retriever(document_store=document_store_dot_product_with_docs)
     dpr = DensePassageRetriever(
         document_store=document_store_dot_product_with_docs,
         query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -388,11 +384,10 @@ def test_join_concatenate_with_topk(document_store_dot_product_with_docs):
     assert len(two_results["documents"]) == 2
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_dot_product_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 def test_join_with_reader(document_store_dot_product_with_docs, reader):
-    es = BM25Retriever(document_store=document_store_dot_product_with_docs)
+    bm25 = BM25Retriever(document_store=document_store_dot_product_with_docs)
     dpr = DensePassageRetriever(
         document_store=document_store_dot_product_with_docs,
         query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -405,7 +400,7 @@ def test_join_with_reader(document_store_dot_product_with_docs, reader):
 
     join_node = JoinDocuments()
     p = Pipeline()
-    p.add_node(component=es, name="R1", inputs=["Query"])
+    p.add_node(component=bm25, name="R1", inputs=["Query"])
     p.add_node(component=dpr, name="R2", inputs=["Query"])
     p.add_node(component=join_node, name="Join", inputs=["R1", "R2"])
     p.add_node(component=reader, name="Reader", inputs=["Join"])
@@ -414,10 +409,9 @@ def test_join_with_reader(document_store_dot_product_with_docs, reader):
     assert results["answers"][0].answer == "Berlin" or results["answers"][1].answer == "Berlin"
 
 
-@pytest.mark.elasticsearch
-@pytest.mark.parametrize("document_store_dot_product_with_docs", ["elasticsearch"], indirect=True)
+@pytest.mark.parametrize("document_store_dot_product_with_docs", ["memory"], indirect=True)
 def test_join_with_rrf(document_store_dot_product_with_docs):
-    es = BM25Retriever(document_store=document_store_dot_product_with_docs)
+    bm25 = BM25Retriever(document_store=document_store_dot_product_with_docs)
     dpr = DensePassageRetriever(
         document_store=document_store_dot_product_with_docs,
         query_embedding_model="facebook/dpr-question_encoder-single-nq-base",
@@ -430,7 +424,7 @@ def test_join_with_rrf(document_store_dot_product_with_docs):
 
     join_node = JoinDocuments(join_mode="reciprocal_rank_fusion")
     p = Pipeline()
-    p.add_node(component=es, name="R1", inputs=["Query"])
+    p.add_node(component=bm25, name="R1", inputs=["Query"])
     p.add_node(component=dpr, name="R2", inputs=["Query"])
     p.add_node(component=join_node, name="Join", inputs=["R1", "R2"])
     results = p.run(query=query)


### PR DESCRIPTION
### Related Issues
- fixes #4282

### Proposed Changes:
I noticed that several tests use `ElasticsearchDocumentStore` only to test BM25 retrieval.
I modified them, introducing `InMemoryDocumentStore` (since it supports BM25), to make them lighter.

### How did you test it?
CI

### Notes for the reviewer
Only a first draft

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
