### PR TITLE
ci: Change docker_release.yml workflow to run after successful PyPi release

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,12 +1,13 @@
 name: Docker image release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
-    tags:
-      - "v[0-9].[0-9]+.[0-9]+*"
+  workflow_run:
+    workflows: [Project release on PyPi]
+    types:
+      - completed
 
 env:
   DOCKER_REPO_NAME: deepset/haystack
@@ -14,6 +15,8 @@ env:
 jobs:
   build-and-push:
     name: Build ${{ matrix.target }} image for ${{ matrix.platform }}
+    # We need this to run only when we're merging in main or the PyPi release was successful
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,3 +1,4 @@
+# If you change this name also do it in docker_release.yml
 name: Project release on PyPi
 
 on:


### PR DESCRIPTION
### Proposed Changes:

Make `docker_release.yml` run only on push/merges in `main` and after the `pypi_release.yml` workflow is sucessful.

### How did you test it?

`workflow_run` can't be tested. 

I verified it would run on push by triggering it in this branch just to verify it would start, I cancelled the job right after.
The run is [here](https://github.com/deepset-ai/haystack/actions/runs/4294119725).

### Notes for the reviewer

This is done in preparation to future changes in the `Dockerfile.base` that will install Haystack directly from PyPi with no need to clone the repo.
