### PR TITLE
feat: add utility method to skip tests when an endpoint is down

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,7 @@ jobs:
           - document_stores
           - nodes
           - agents
+          - testing
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/haystack/testing/utils.py
+++ b/haystack/testing/utils.py
@@ -1,0 +1,19 @@
+import pytest
+import requests
+
+
+def skip_if_down(url):
+    """
+    Usage:
+
+    @skip_if_down("https://api.openai.com/v1/models")
+    def test_foo():
+        ...
+    """
+    try:
+        r = requests.options(url, timeout=5)
+        r.raise_for_status()
+        return pytest.mark.skipif(False)
+
+    except Exception as e:
+        return pytest.mark.skipif(True, reason=f"Error accessing '{url}': {e}")

--- a/test/testing/test_utils.py
+++ b/test/testing/test_utils.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+import pytest
+from requests import Response, HTTPError
+
+from haystack.testing.utils import skip_if_down
+
+
+@pytest.mark.unit
+def test_skip_is_down_dont_skip():
+    with mock.patch("haystack.testing.utils.requests") as r:
+        r.options.return_value.status_code = 200
+
+        mark_fn = skip_if_down("https://foo")
+        assert mark_fn.args[0] == False
+        assert mark_fn.kwargs.get("reason") is None
+
+
+@pytest.mark.unit
+def test_skip_is_down_unauthorized():
+    with mock.patch("haystack.testing.utils.requests") as r:
+        r.options.return_value.raise_for_status.side_effect = HTTPError("Something went wrong")
+
+        mark_fn = skip_if_down("https://foo")
+        assert mark_fn.args[0] == True
+        assert mark_fn.kwargs.get("reason") == "Error accessing 'https://foo': Something went wrong"


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add a pytest marker that can be used to skip tests when a certain endpoint is down (Huggingface, OpenAI).

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Code has unit tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
I added this code under the `haystack/testing` package so it can be used from external packages (e.g. custom nodes).

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
