### PR TITLE
fix: `OpenSearchDocumentStore.delete_index` doesn't raise

### DIFF
--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -745,10 +745,11 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
         :return: None
         """
         # Check if index uses an IVF model and delete it
-        index_mapping = self.client.indices.get(index)[index]["mappings"]["properties"]
-        if self.embedding_field in index_mapping and "model_id" in index_mapping[self.embedding_field]:
-            model_id = index_mapping[self.embedding_field]["model_id"]
-            self.client.transport.perform_request("DELETE", f"/_plugins/_knn/models/{model_id}")
+        if self._index_exists(index):
+            index_mapping = self.client.indices.get(index)[index]["mappings"]["properties"]
+            if self.embedding_field in index_mapping and "model_id" in index_mapping[self.embedding_field]:
+                model_id = index_mapping[self.embedding_field]["model_id"]
+                self.client.transport.perform_request("DELETE", f"/_plugins/_knn/models/{model_id}")
 
         super().delete_index(index)
 

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -479,6 +479,10 @@ class DocumentStoreBaseTestAbstract:
             ds.get_document_count(index="custom_index")
 
     @pytest.mark.integration
+    def test_delete_index_does_not_raise_if_not_exists(self, ds):
+        ds.delete_index(index="unknown_index")
+
+    @pytest.mark.integration
     def test_update_meta(self, ds, documents):
         ds.write_documents(documents)
         doc = documents[0]


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/4292

### Proposed Changes:
- check if index exists before IVF cleanup

### How did you test it?
- added test

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
