### PR TITLE
build: Use `uvicorn` instead of `gunicorn` as server in REST API's Dockerfile

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -3,8 +3,10 @@ ARG base_image
 
 FROM ${base_image}:${base_image_tag}
 
-ENV SERVICE_NAME="uvicorn-service"
+ENV SERVICE_NAME="haystackd"
 
+# Ensuring that Haystack pipelines run with a specific user "haystackd".
+# This makes the process & log management neat.
 RUN addgroup --gid 1001 $SERVICE_NAME && \
     adduser --gid 1001 --uid 1001 --shell /bin/false --disabled-password $SERVICE_NAME && \
     mkdir -p /var/log/$SERVICE_NAME && \
@@ -19,6 +21,7 @@ ENV FILE_UPLOAD_PATH="/opt/file-upload"
 
 ENV TIKA_LOG_PATH="/var/log/$SERVICE_NAME/"
 
+# uvicorn server runs on port 8000, which needs to be accessible from outside the container.
 EXPOSE 8000
 
 USER $SERVICE_NAME

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -5,8 +5,8 @@ FROM ${base_image}:${base_image_tag}
 
 ENV SERVICE_NAME="haystackd"
 
-# Ensuring that Haystack pipelines run with a specific user "haystackd".
-# This makes the process & log management neat.
+# Haystack pipelines are run by the "haystackd" user.
+# This helps keep the process and log management organized.
 RUN addgroup --gid 1001 $SERVICE_NAME && \
     adduser --gid 1001 --uid 1001 --shell /bin/false --disabled-password $SERVICE_NAME && \
     mkdir -p /var/log/$SERVICE_NAME && \
@@ -21,7 +21,7 @@ ENV FILE_UPLOAD_PATH="/opt/file-upload"
 
 ENV TIKA_LOG_PATH="/var/log/$SERVICE_NAME/"
 
-# uvicorn server runs on port 8000, which needs to be accessible from outside the container.
+# The uvicorn server runs on port 8000, and it needs to be accessible from outside the container.
 EXPOSE 8000
 
 USER $SERVICE_NAME

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -3,7 +3,7 @@ ARG base_image
 
 FROM ${base_image}:${base_image_tag}
 
-ENV SERVICE_NAME="gunicorn-service"
+ENV SERVICE_NAME="uvicorn-service"
 
 RUN addgroup --gid 1001 $SERVICE_NAME && \
     adduser --gid 1001 --uid 1001 --shell /bin/false --disabled-password $SERVICE_NAME && \
@@ -22,4 +22,4 @@ ENV TIKA_LOG_PATH="/var/log/$SERVICE_NAME/"
 EXPOSE 8000
 
 USER $SERVICE_NAME
-CMD ["gunicorn", "rest_api.application:app",  "-b", "0.0.0.0", "-k", "uvicorn.workers.UvicornWorker", "--workers", "1", "--timeout", "1000"]
+CMD ["uvicorn", "rest_api.application:app",  "--host", "0.0.0.0"]

--- a/rest_api/pyproject.toml
+++ b/rest_api/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "farm-haystack",
     "fastapi<1",
     "uvicorn<1",
-    "gunicorn<21",
     "python-multipart<1",  # optional FastAPI dependency for form data
     "pynvml",
     "psutil"


### PR DESCRIPTION
### Related Issues
- fixes #3913 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR changes the Dockerfile of our REST API to use `uvicorn` as a server instead of using `gunicorn` with a single uvicorn worker.
cc: @mayankjobanputra 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I built and ran the Docker image locally.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
