### PR TITLE
docs: Fix search path for Shaper API docs

### DIFF
--- a/docs/pydoc/config/shaper.yml
+++ b/docs/pydoc/config/shaper.yml
@@ -1,6 +1,6 @@
 loaders:
   - type: python
-    search_path: [../../../haystack/nodes/other/shaper]
+    search_path: [../../../haystack/nodes/other]
     modules: ['shaper']
     ignore_when_discovered: ['__init__']
 processors:


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR fixes the search path for creating API docs for Shaper.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I tested this manually.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
