### PR TITLE
ci: Fix docstring-labeler.yml workflow

### DIFF
--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get docstrings
         id: base-docstrings
         run: |
-          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ env.GITHUB_WORKSPACE }}")
+          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ github.workspace }}")
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Checkout HEAD commit
@@ -39,7 +39,7 @@ jobs:
       - name: Get docstrings
         id: head-docstrings
         run: |
-          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ env.GITHUB_WORKSPACE }}")
+          CHECKSUM=$(python "${{ runner.temp }}/docstrings_checksum.py" --root "${{ github.workspace }}")
           echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Check if we should label


### PR DESCRIPTION
### Proposed Changes:

`docstring-labeler.yml` workflow is not working correctly as the `GITHUB_WORKSPACE` variable is not stored in the `env` context.

This PR fixes that.

### How did you test it?

Can't be tested.

### Notes for the reviewer

N/A
