### PR TITLE
ci: Add workflow to update social readmes on release

### DIFF
--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -1,6 +1,9 @@
 name: Update Haystack version in social cards
 
 on:
+  push:
+    branches:
+      - readmes-updater
   release:
     types: [released]
 
@@ -11,7 +14,7 @@ jobs:
     steps:
       - name: Trigger update in GitHub Org Readme
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: "test-version"
           GITHUB_TOKEN: ${{ secrets.HAYSTACK_BOT_TOKEN }}
         run: |
           gh workflow run -R deepset-ai/.github update_haystack_version.yml -f "version=$VERSION"
@@ -34,7 +37,7 @@ jobs:
 
       - name: Update README.md
         env:
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: "test-version"
         run: |
           sed -i -r "s/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on $VERSION/g" profile/README.md
 

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           VERSION: "test-version"
         run: |
-          sed -i -r "s/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on $VERSION/g" profile/README.md
+          sed -i -r "s/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on $VERSION/g" README.md
 
       - name: Commit and push
         run: |

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -1,0 +1,46 @@
+name: Update Haystack version in social cards
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update-gh-org-readme:
+    name: Update GitHub Organization Readme
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger update in GitHub Org Readme
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+          GITHUB_TOKEN: ${{ secrets.HAYSTACK_BOT_TOKEN }}
+        run: |
+          gh workflow run -R deepset-ai/.github update_haystack_version.yml -f "version=$VERSION"
+
+  update-hf-org-card:
+    name: Update Hugging Face Organization Card
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Hugging Face credentials
+        env:
+          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+          HUGGING_FACE_URL: https://huggingface.co
+        run: |
+          printf "url=%s\nusername=hf_user\npassword=%s\n\n" "$HUGGING_FACE_URL" "$HUGGING_FACE_HUB_TOKEN" \
+          | git credential approve
+
+      - name: Checkout README repository
+        run: |
+          GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/spaces/deepset/README .
+
+      - name: Update README.md
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          sed -i -r "s/Haystack is on v[0-9]+\.[0-9]+\.[0-9]+/Haystack is on $VERSION/g" profile/README.md
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --all -m "Update Haystack version"
+          git push


### PR DESCRIPTION
### Proposed Changes:

Add a workflow that automatically updates or triggers an update of social README.md. 
As of now it only updates Hugging Face deepset's Organization Card and GitHub Org Readme.

### How did you test it?

Can't be tested.

### Notes for the reviewer

I used `HAYSTACK_BOT_TOKEN` as the `GITHUB_TOKEN` to trigger the update workflow in [deepset-ai/.github](https://github.com/deepset-ai/.github/pull/6) but am not sure whether it has the right permissions to do it or not.

`HUGGING_FACE_HUB_TOKEN` has already been added as secret.

This PR depends on deepset-ai/.github#6