### PR TITLE
test: Pin requests-cache test dependency to <1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ dev = [
   "mkdocs",
   "jupytercontrib",
   "watchdog",
-  "requests-cache",
+  "requests-cache<1.0.0",
 ]
 
 formatting = [


### PR DESCRIPTION
### Proposed Changes:

New version of `requests-cache` released yesterday is causing segfaults in certain tests.
Here we pin it to fix the segfaults.

### How did you test it?

Run segfaulting tests locally.

### Notes for the reviewer

N/A.
