### PR TITLE
feat: Add Azure OpenAI embeddings support

### DIFF
--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -91,6 +91,11 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         return decoded_string
 
     def embed(self, model: str, text: List[str]) -> np.ndarray:
+        if self.api_key is None:
+            raise ValueError(
+                f"{'Azure ' if self.using_azure else ''}OpenAI API key is not set. You can set it via the `api_key` parameter of the EmbeddingRetriever."
+            )
+
         generated_embeddings = []
 
         headers = {"Content-Type": "application/json"}

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -23,7 +23,8 @@ OPENAI_TIMEOUT = float(os.environ.get(HAYSTACK_REMOTE_API_TIMEOUT_SEC, 30))
 
 class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
     def __init__(self, retriever: "EmbeddingRetriever"):
-        # See https://beta.openai.com/docs/guides/embeddings for more details
+        # See https://platform.openai.com/docs/guides/embeddings and
+        # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/embeddings?tabs=console for more details
         self.using_azure = (
             retriever.azure_deployment_name is not None
             and retriever.azure_base_url is not None

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -98,7 +98,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
                 f"{'Azure ' if self.using_azure else ''}OpenAI API key is not set. You can set it via the `api_key` parameter of the EmbeddingRetriever."
             )
 
-        generated_embeddings = []
+        generated_embeddings: List[Any] = []
 
         headers: Dict[str, str] = {"Content-Type": "application/json"}
 

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -98,17 +98,17 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
 
         generated_embeddings = []
 
-        headers = {"Content-Type": "application/json"}
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
 
         if self.using_azure:
             headers["api-key"] = self.api_key
 
             for input in text:
-                payload = {"input": input}
-                res = openai_request(url=self.url, headers=headers, payload=payload, timeout=OPENAI_TIMEOUT)
+                azure_payload: Dict[str, str] = {"input": input}
+                res = openai_request(url=self.url, headers=headers, payload=azure_payload, timeout=OPENAI_TIMEOUT)
                 generated_embeddings.append(res["data"][0]["embedding"])
         else:
-            payload = {"model": model, "input": text}
+            payload: Dict[str, Union[List[str], str]] = {"model": model, "input": text}
             headers["Authorization"] = f"Bearer {self.api_key}"
 
             res = openai_request(url=self.url, headers=headers, payload=payload, timeout=OPENAI_TIMEOUT)

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1465,6 +1465,9 @@ class EmbeddingRetriever(DenseRetriever):
         scale_score: bool = True,
         embed_meta_fields: Optional[List[str]] = None,
         api_key: Optional[str] = None,
+        azure_api_version: str = "2022-12-01",
+        azure_base_url: Optional[str] = None,
+        azure_deployment_name: Optional[str] = None,
     ):
         """
         :param document_store: An instance of DocumentStore from which to retrieve documents.
@@ -1519,7 +1522,11 @@ class EmbeddingRetriever(DenseRetriever):
                                   If no value is provided, a default empty list will be created.
         :param api_key: The OpenAI API key or the Cohere API key. Required if one wants to use OpenAI/Cohere embeddings.
                         For more details see https://beta.openai.com/account/api-keys and https://dashboard.cohere.ai/api-keys
-
+        :param api_version: The version of the Azure OpenAI API to use. The default is `2022-12-01` version.
+        :param azure_base_url: The base URL for the Azure OpenAI API. If not supplied, Azure OpenAI API will not be used.
+                               This parameter is an OpenAI Azure endpoint, usually in the form `https://<your-endpoint>.openai.azure.com'
+        :param azure_deployment_name: The name of the Azure OpenAI API deployment. If not supplied, Azure OpenAI API
+                                     will not be used.
         """
         if embed_meta_fields is None:
             embed_meta_fields = []
@@ -1543,6 +1550,9 @@ class EmbeddingRetriever(DenseRetriever):
         self.use_auth_token = use_auth_token
         self.scale_score = scale_score
         self.api_key = api_key
+        self.api_version = azure_api_version
+        self.azure_base_url = azure_base_url
+        self.azure_deployment_name = azure_deployment_name
         self.model_format = (
             self._infer_model_format(model_name_or_path=embedding_model, use_auth_token=use_auth_token)
             if model_format is None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -695,9 +695,18 @@ def get_retriever(retriever_type, document_store):
     elif retriever_type == "openai":
         retriever = EmbeddingRetriever(
             document_store=document_store,
-            embedding_model="ada",
+            embedding_model="text-embedding-ada-002",
             use_gpu=False,
-            api_key=os.environ.get("OPENAI_API_KEY", ""),
+            api_key=os.getenv("OPENAI_API_KEY"),
+        )
+    elif retriever_type == "azure":
+        retriever = EmbeddingRetriever(
+            document_store=document_store,
+            embedding_model="text-embedding-ada-002",
+            use_gpu=False,
+            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+            azure_base_url=os.getenv("AZURE_OPENAI_BASE_URL"),
+            azure_deployment_name=os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
         )
     elif retriever_type == "cohere":
         retriever = EmbeddingRetriever(
@@ -973,7 +982,12 @@ def haystack_azure_conf():
     azure_base_url = os.environ.get("AZURE_OPENAI_BASE_URL", None)
     azure_deployment_name = os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME", None)
     if api_key and azure_base_url and azure_deployment_name:
-        return {"api_key": api_key, "azure_base_url": azure_base_url, "azure_deployment_name": azure_deployment_name}
+        return {
+            "api_key": api_key,
+            "embedding_model": "text-embedding-ada-002",
+            "azure_base_url": azure_base_url,
+            "azure_deployment_name": azure_deployment_name,
+        }
     else:
         return {}
 
@@ -985,9 +999,11 @@ def haystack_openai_config(request):
         if not api_key:
             return {}
         else:
-            return {"api_key": api_key}
+            return {"api_key": api_key, "embedding_model": "text-embedding-ada-002"}
     elif request.param == "azure":
         return haystack_azure_conf()
+
+    return {}
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -706,7 +706,7 @@ def get_retriever(retriever_type, document_store):
             use_gpu=False,
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),
             azure_base_url=os.getenv("AZURE_OPENAI_BASE_URL"),
-            azure_deployment_name=os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
+            azure_deployment_name=os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME_EMBED"),
         )
     elif retriever_type == "cohere":
         retriever = EmbeddingRetriever(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -982,12 +982,7 @@ def haystack_azure_conf():
     azure_base_url = os.environ.get("AZURE_OPENAI_BASE_URL", None)
     azure_deployment_name = os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME", None)
     if api_key and azure_base_url and azure_deployment_name:
-        return {
-            "api_key": api_key,
-            "embedding_model": "text-embedding-ada-002",
-            "azure_base_url": azure_base_url,
-            "azure_deployment_name": azure_deployment_name,
-        }
+        return {"api_key": api_key, "azure_base_url": azure_base_url, "azure_deployment_name": azure_deployment_name}
     else:
         return {}
 

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -378,14 +378,13 @@ def test_openai_embedding_retriever_selection():
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
-@pytest.mark.parametrize("retriever", ["openai", "cohere"], indirect=True)
+@pytest.mark.parametrize("retriever", ["cohere"], indirect=True)
 @pytest.mark.embedding_dim(1024)
 @pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY", None) and not os.environ.get("COHERE_API_KEY", None),
-    reason="Please export an env var called OPENAI_API_KEY/COHERE_API_KEY containing "
-    "the OpenAI/Cohere API key to run this test.",
+    not os.environ.get("COHERE_API_KEY", None),
+    reason="Please export an env var called COHERE_API_KEY containing " "the Cohere API key to run this test.",
 )
-def test_basic_embedding(document_store, retriever, docs_with_ids):
+def test_basic_cohere_embedding(document_store, retriever, docs_with_ids):
     document_store.return_embedding = True
     document_store.write_documents(docs_with_ids)
     document_store.update_embeddings(retriever=retriever)
@@ -395,6 +394,53 @@ def test_basic_embedding(document_store, retriever, docs_with_ids):
 
     for doc in docs:
         assert len(doc.embedding) == 1024
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("retriever", ["openai"], indirect=True)
+@pytest.mark.embedding_dim(1536)
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason=("Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test."),
+)
+def test_basic_openai_embedding(document_store, retriever, docs_with_ids):
+    document_store.return_embedding = True
+    document_store.write_documents(docs_with_ids)
+    document_store.update_embeddings(retriever=retriever)
+
+    docs = document_store.get_all_documents()
+    docs = sorted(docs, key=lambda d: d.id)
+
+    for doc in docs:
+        assert len(doc.embedding) == 1536
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("retriever", ["azure"], indirect=True)
+@pytest.mark.embedding_dim(1536)
+@pytest.mark.skipif(
+    not os.environ.get("AZURE_OPENAI_API_KEY", None)
+    and not os.environ.get("AZURE_OPENAI_BASE_URL", None)
+    and not os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME", None),
+    reason=(
+        "Please export env variables called AZURE_OPENAI_API_KEY containing "
+        "the Azure OpenAI key, AZURE_OPENAI_BASE_URL containing "
+        "the Azure OpenAI base URL, and AZURE_OPENAI_DEPLOYMENT_NAME containing "
+        "the Azure OpenAI deployment name to run this test."
+    ),
+)
+def test_basic_azure_embedding(document_store, retriever, docs_with_ids):
+    document_store.return_embedding = True
+    document_store.write_documents(docs_with_ids)
+    document_store.update_embeddings(retriever=retriever)
+
+    docs = document_store.get_all_documents()
+    docs = sorted(docs, key=lambda d: d.id)
+
+    for doc in docs:
+        assert len(doc.embedding) == 1536
 
 
 @pytest.mark.integration

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -423,11 +423,11 @@ def test_basic_openai_embedding(document_store, retriever, docs_with_ids):
 @pytest.mark.skipif(
     not os.environ.get("AZURE_OPENAI_API_KEY", None)
     and not os.environ.get("AZURE_OPENAI_BASE_URL", None)
-    and not os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME", None),
+    and not os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME_EMBED", None),
     reason=(
         "Please export env variables called AZURE_OPENAI_API_KEY containing "
         "the Azure OpenAI key, AZURE_OPENAI_BASE_URL containing "
-        "the Azure OpenAI base URL, and AZURE_OPENAI_DEPLOYMENT_NAME containing "
+        "the Azure OpenAI base URL, and AZURE_OPENAI_DEPLOYMENT_NAME_EMBED containing "
         "the Azure OpenAI deployment name to run this test."
     ),
 )
@@ -445,14 +445,58 @@ def test_basic_azure_embedding(document_store, retriever, docs_with_ids):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
-@pytest.mark.parametrize("retriever", ["openai", "cohere"], indirect=True)
+@pytest.mark.parametrize("retriever", ["cohere"], indirect=True)
 @pytest.mark.embedding_dim(1024)
 @pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY", None) and not os.environ.get("COHERE_API_KEY", None),
-    reason="Please export an env var called OPENAI_API_KEY/COHERE_API_KEY containing "
-    "the OpenAI/Cohere API key to run this test.",
+    not os.environ.get("COHERE_API_KEY", None),
+    reason="Please export an env var called COHERE_API_KEY containing " "the Cohere API key to run this test.",
 )
-def test_retriever_basic_search(document_store, retriever, docs_with_ids):
+def test_retriever_basic_cohere_search(document_store, retriever, docs_with_ids):
+    document_store.return_embedding = True
+    document_store.write_documents(docs_with_ids)
+    document_store.update_embeddings(retriever=retriever)
+
+    p_retrieval = DocumentSearchPipeline(retriever)
+    res = p_retrieval.run(query="Madrid", params={"Retriever": {"top_k": 1}})
+    assert len(res["documents"]) == 1
+    assert "Madrid" in res["documents"][0].content
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("retriever", ["openai"], indirect=True)
+@pytest.mark.embedding_dim(1536)
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Please export env called OPENAI_API_KEY containing " "the OpenAI API key to run this test.",
+)
+def test_retriever_basic_openai_search(document_store, retriever, docs_with_ids):
+    document_store.return_embedding = True
+    document_store.write_documents(docs_with_ids)
+    document_store.update_embeddings(retriever=retriever)
+
+    p_retrieval = DocumentSearchPipeline(retriever)
+    res = p_retrieval.run(query="Madrid", params={"Retriever": {"top_k": 1}})
+    assert len(res["documents"]) == 1
+    assert "Madrid" in res["documents"][0].content
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("retriever", ["azure"], indirect=True)
+@pytest.mark.embedding_dim(1536)
+@pytest.mark.skipif(
+    not os.environ.get("AZURE_OPENAI_API_KEY", None)
+    and not os.environ.get("AZURE_OPENAI_BASE_URL", None)
+    and not os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME_EMBED", None),
+    reason=(
+        "Please export env variables called AZURE_OPENAI_API_KEY containing "
+        "the Azure OpenAI key, AZURE_OPENAI_BASE_URL containing "
+        "the Azure OpenAI base URL, and AZURE_OPENAI_DEPLOYMENT_NAME_EMBED containing "
+        "the Azure OpenAI deployment name to run this test."
+    ),
+)
+def test_retriever_basic_azure_search(document_store, retriever, docs_with_ids):
     document_store.return_embedding = True
     document_store.write_documents(docs_with_ids)
     document_store.update_embeddings(retriever=retriever)

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -449,7 +449,7 @@ def test_basic_azure_embedding(document_store, retriever, docs_with_ids):
 @pytest.mark.embedding_dim(1024)
 @pytest.mark.skipif(
     not os.environ.get("COHERE_API_KEY", None),
-    reason="Please export an env var called COHERE_API_KEY containing " "the Cohere API key to run this test.",
+    reason="Please export an env var called COHERE_API_KEY containing the Cohere API key to run this test.",
 )
 def test_retriever_basic_cohere_search(document_store, retriever, docs_with_ids):
     document_store.return_embedding = True
@@ -468,7 +468,7 @@ def test_retriever_basic_cohere_search(document_store, retriever, docs_with_ids)
 @pytest.mark.embedding_dim(1536)
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY", None),
-    reason="Please export env called OPENAI_API_KEY containing " "the OpenAI API key to run this test.",
+    reason="Please export env called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
 def test_retriever_basic_openai_search(document_store, retriever, docs_with_ids):
     document_store.return_embedding = True


### PR DESCRIPTION
### Related Issues
- fixes #3890

### Proposed Changes:
- Azure OpenAI endpoints can be enabled on the EmbeddingRetriever
- To avoid turning on/off all third-party tests if only one env is not set up, separate tests should be run.

### How did you test it?
Current tests, new tests and local tests using Azure OpenAI API

### Notes for the reviewer
- Same pattern used by @vblagoje on the AnswerGenerator and related code/tests were adopted with minor changes
- Azure OpenAI embedding endpoint doesn't accept multiple _inputs_; so we are doing one query per input
- Azure OpenAI only supports the latest ada-002 model and similarity ones, none of the search are supported
- AZURE_OPENAI_DEPLOYMENT_NAME_EMBED has been used because Azure demands a unique name for deployments, and AZURE_OPENAI_DEPLOYMENT_NAME is being used for the davinci-003 deployment.
### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
