### PR TITLE
fix: increase `MetaDocumentORM` value length in `SQLDocumentStore`

### DIFF
--- a/haystack/document_stores/sql.py
+++ b/haystack/document_stores/sql.py
@@ -79,7 +79,7 @@ class MetaDocumentORM(ORMBase):
     __tablename__ = "meta_document"
 
     name = Column(String(100), index=True)
-    value = Column(ArrayType(100), index=True)
+    value = Column(ArrayType(1000), index=True)
     documents = relationship("DocumentORM", back_populates="meta")
 
     document_id = Column(String(100), nullable=False, index=True)


### PR DESCRIPTION
### Related Issues
- fixes #4285

### Proposed Changes:
Since limiting the length of this value to 100 is too restrictive, I increased it to 1000.

### How did you test it?
CI.
_(The original issue went unnoticed also because we don't test `SQLDocumentStore `using PostgreSQL, and SQLlite doesn't enforce these constraints)_

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
