### PR TITLE
ci: Add workflow to push CI metrics to Datadog

### DIFF
--- a/.github/workflows/ci_metrics.yml
+++ b/.github/workflows/ci_metrics.yml
@@ -1,0 +1,24 @@
+name: CI Metrics
+
+on:
+  workflow_run:
+    workflows:
+      - "end-to-end"
+      - "Linting"
+      - "Tests"
+      - "REST API Tests"
+    types:
+      - completed
+  pull_request:
+    types:
+      - opened
+      - closed
+jobs:
+  send:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: int128/datadog-actions-metrics@v1
+        with:
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+          datadog-site: "datadoghq.eu"
+          collect-job-metrics: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,3 +1,4 @@
+# If you change this name also do it in ci_metrics.yml
 name: end-to-end
 
 on:

--- a/.github/workflows/linting-skipper.yml
+++ b/.github/workflows/linting-skipper.yml
@@ -1,4 +1,4 @@
-# If you change this name also do it in linting.yml
+# If you change this name also do it in linting.yml and ci_metrics.yml
 name: Linting
 
 on:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-# If you change this name also do it in linting-skipper.yml
+# If you change this name also do it in linting-skipper.yml and ci_metrics.yml
 name: Linting
 
 on:

--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -1,3 +1,4 @@
+# If you change this name also do it in ci_metrics.yml
 name: REST API Tests
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+# If you change this name also do it in tests_skipper.yml and ci_metrics.yml
 name: Tests
 
 on:

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -1,3 +1,4 @@
+# If you change this name also do it in tests.yml and ci_metrics.yml
 name: Tests
 
 on:


### PR DESCRIPTION
### Proposed Changes:

Add a `ci_metrics.yml` workflow that, as the name implies, will send CI metrics to Datadog. This way we'll be able to better track trends in the CI, notice when tests are taking longer than usual, number of failures, contributors, PRs and what not.

We'll send metrics after a PR is opened or closed and when the following workflows finish running:
* `e2e.yml`
* `linting.yml` and `linting-skipper.yml`
* `rest_api_tests.yml`
* `tests.yml` and `tests_skipper.yml`

### How did you test it?

Can't be tested.

### Notes for the reviewer

Before merging we need to add `DATADOG_API_KEY` as a repo secret.

There's an option to also collect steps metrics using the `collect-step-metrics`, I decided not to enable it as I feel it might create too much noise right now. Maybe we'll enable it in the future.
