### PR TITLE
feat: expose prompts to Answer and EvaluationResult

### DIFF
--- a/haystack/nodes/answer_generator/base.py
+++ b/haystack/nodes/answer_generator/base.py
@@ -64,7 +64,9 @@ class BaseGenerator(BaseComponent):
                 flat_docs_dict[k].append(v)
         return flat_docs_dict
 
-    def _create_answers(self, generated_answers: List[str], documents: List[Document]) -> List[Answer]:
+    def _create_answers(
+        self, generated_answers: List[str], documents: List[Document], prompt: Optional[str] = None
+    ) -> List[Answer]:
         flat_docs_dict = self._flatten_docs(documents)
         answers: List[Any] = []
         for generated_answer in generated_answers:
@@ -78,6 +80,7 @@ class BaseGenerator(BaseComponent):
                         "content": flat_docs_dict.get("content"),
                         "titles": [d.get("name", "") for d in flat_docs_dict.get("meta", [])],
                         "doc_metas": flat_docs_dict.get("meta"),
+                        "prompt": prompt,
                     },
                 )
             )

--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -88,7 +88,7 @@ def join_documents(documents: List[Document], delimiter: str = " ") -> Tuple[Lis
     return ([Document(content=delimiter.join([d.content for d in documents]))],)
 
 
-def strings_to_answers(strings: List[str]) -> Tuple[List[Answer]]:
+def strings_to_answers(strings: List[str], prompts_used: Optional[List[Optional[str]]] = None) -> Tuple[List[Answer]]:
     """
     Transforms a list of strings into a list of Answers.
 
@@ -102,7 +102,23 @@ def strings_to_answers(strings: List[str]) -> Tuple[List[Answer]]:
         ], )
     ```
     """
-    return ([Answer(answer=string, type="generative") for string in strings],)
+    if prompts_used:
+        if len(prompts_used) > 1:
+            if len(prompts_used) != len(strings):
+                raise ValueError(
+                    f"Not enough prompts. strings_to_answers received {len(strings)} and {len(prompts_used)} prompts."
+                )
+        else:
+            prompts_used = prompts_used * len(strings)
+    else:
+        prompts_used = [None] * len(strings)
+
+    return (
+        [
+            Answer(answer=string, type="generative", meta={"prompt": prompt})
+            for string, prompt in zip(strings, prompts_used)
+        ],
+    )
 
 
 def answers_to_strings(answers: List[Answer]) -> Tuple[List[str]]:

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -1134,6 +1134,7 @@ class PromptNode(BaseComponent):
         results = self(prompt_collector=prompt_collector, **invocation_context)
 
         invocation_context[self.output_variable] = results
+        invocation_context["prompts_used"] = prompt_collector
         final_result: Dict[str, Any] = {
             self.output_variable: results,
             "invocation_context": invocation_context,

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1525,6 +1525,7 @@ class Pipeline:
             "type",  # generic
             "node",  # generic
             "eval_mode",  # generic
+            "prompt",  # answer-specific
         ]
         for key, df in eval_result.node_results.items():
             eval_result.node_results[key] = self._reorder_columns(df, desired_col_order)
@@ -1626,6 +1627,8 @@ class Pipeline:
                     df_answers["gold_offsets_in_contexts"] = [gold_offsets_in_contexts] * len(df_answers)
                     df_answers["gold_document_ids"] = [gold_document_ids] * len(df_answers)
                     df_answers["gold_contexts"] = [gold_contexts] * len(df_answers)
+                    if any(answer for answer in answers if answer.type == "generative"):
+                        df_answers["prompt"] = [(answer.meta or {}).get("prompt") for answer in answers]
                     df_answers["gold_answers_exact_match"] = df_answers.map_rows(
                         lambda row: [calculate_em_str(gold_answer, row["answer"]) for gold_answer in gold_answers]
                     )


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/4338

### Proposed Changes:
- store prompt for `PromptNode` and `OpenAIAnswerGenerator` in `Answer` objects (e.g. meta or dedicated field)
- store prompt to `EvaluationResult` dataframes

### How did you test it?
- added / extended tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
