### PR TITLE
chore: add `topic:promptnode` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,6 +45,9 @@ topic:rest_api:
 topic:LLM:
 - haystack/nodes/prompt/*
 - test/nodes/test_prompt_node.py
+topic:promptnode:
+- haystack/nodes/prompt/*
+- test/nodes/test_prompt_node.py
 topic:file_converter:
 - haystack/nodes/file_converter/*
 - test/nodes/test_file_converter.py


### PR DESCRIPTION
### Proposed Changes:
Add the new `topic:promptnode` label to the workflow

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
