### PR TITLE
feat: Enable PromptNode to use text-generation models

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -9,7 +9,8 @@ import torch
 
 from haystack import MultiLabel
 from haystack.nodes.base import BaseComponent
-from haystack.nodes.prompt.providers import PromptModelInvocationLayer
+from haystack.nodes.prompt.providers import PromptModelInvocationLayer, instruction_following_models
+
 from haystack.schema import Document
 from haystack.telemetry_2 import send_event
 
@@ -215,6 +216,14 @@ class PromptModel(BaseComponent):
 
         self.model_kwargs = model_kwargs if model_kwargs else {}
         self.model_invocation_layer = self.create_invocation_layer(invocation_layer_class=invocation_layer_class)
+        is_instruction_following: bool = any(m in model_name_or_path for m in instruction_following_models())
+        if not is_instruction_following:
+            logger.warning(
+                "PromptNode has been potentially initialized with a language model not fine-tuned on instruction following tasks. "
+                "Many of the default prompts and PromptTemplates will likely not work as intended. "
+                "Use custom prompts and PromptTemplates specific to the %s model",
+                model_name_or_path,
+            )
 
     def create_invocation_layer(
         self, invocation_layer_class: Optional[Type[PromptModelInvocationLayer]]

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -165,7 +165,7 @@ class PromptModel(BaseComponent):
     """
     The PromptModel class is a component that uses a pre-trained model to perform tasks based on a prompt. Out of
     the box, it supports model invocation layers for:
-    - Hugging Face transformers (all text2text-generation models)
+    - Hugging Face transformers (all text2text-generation and text-generation models)
     - OpenAI InstructGPT models
     - Azure OpenAI InstructGPT models
 
@@ -400,7 +400,8 @@ class PromptNode(BaseComponent):
     additional custom model invocation layers.
 
     We recommend using LLMs fine-tuned on a collection of datasets phrased as instructions, otherwise we find that the
-    LLM does not "follow" prompt instructions well. This is why we recommend using T5 flan or OpenAI InstructGPT models.
+    LLM does not "follow" prompt instructions well. The list of instructions following models increases every month,
+    and the current list includes: Flan, OpenAI InstructGPT, opt-iml, bloomz, and mt0 models.
 
     For more details, see  [PromptNode](https://docs.haystack.deepset.ai/docs/prompt_node).
     """

--- a/haystack/nodes/prompt/providers.py
+++ b/haystack/nodes/prompt/providers.py
@@ -265,6 +265,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
             # Thus only generated text is returned (excluding prompt)
             if "text-generation" == self.task_name and "return_full_text" not in model_input_kwargs:
                 model_input_kwargs["return_full_text"] = False
+                model_input_kwargs["max_new_tokens"] = self.max_length
             if stop_words:
                 sw = StopWordsCriteria(tokenizer=self.pipe.tokenizer, stop_words=stop_words)
                 model_input_kwargs["stopping_criteria"] = StoppingCriteriaList([sw])

--- a/haystack/nodes/prompt/providers.py
+++ b/haystack/nodes/prompt/providers.py
@@ -116,6 +116,10 @@ class PromptModelInvocationLayer:
         pass
 
 
+def instruction_following_models() -> List[str]:
+    return ["flan", "mt0", "bloomz", "davinci"]
+
+
 class StopWordsCriteria(StoppingCriteria):
     """
     Stops text generation if any one of the stop words is generated.
@@ -300,16 +304,9 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         try:
             task_name = get_task(model_name_or_path)
         except RuntimeError:
-            # This is needed so OpenAI models are skipped over
+            # This will fail for all non-HF models
             return False
 
-        if not any(m in model_name_or_path for m in ["flan", "mt0", "bloomz"]):
-            logger.warning(
-                "PromptNode has been potentially initialized with a language model not fine-tuned on instruction following tasks. "
-                "Many of the default prompts and PromptTemplates will likely not work as intended. "
-                "Use custom prompts and PromptTemplates specific to the %s model",
-                model_name_or_path,
-            )
         return task_name in ["text2text-generation", "text-generation"]
 
 

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -409,9 +409,18 @@ def test_streaming_prompt_node():
 
 
 def test_prompt_node_with_text_generation_model():
+    # test simple prompting with text generation model
+    # by default, we force the model not return prompt text
+    # Thus text-generation models can be used with PromptNode
+    # just like text2text-generation models
     node = PromptNode("bigscience/bigscience-small-testing")
     r = node("Hello big science!")
     assert len(r[0]) > 0
+
+    # test prompting with parameter to return prompt text as well
+    # users can use this param to get the prompt text and the generated text
+    r = node("Hello big science!", return_full_text=True)
+    assert len(r[0]) > 0 and r[0].startswith("Hello big science!")
 
 
 @pytest.mark.integration

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -408,6 +408,12 @@ def test_streaming_prompt_node():
     assert ttsh.stream_handler_invoked, "Stream handler should have been invoked"
 
 
+def test_prompt_node_with_text_generation_model():
+    node = PromptNode("bigscience/bigscience-small-testing")
+    r = node("Hello big science!")
+    assert len(r[0]) > 0
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize("prompt_model", ["hf", "openai", "azure"], indirect=True)
 def test_simple_pipeline(prompt_model):


### PR DESCRIPTION
### Related Issues
- fixes #4322

### Proposed Changes:
Enables PromptNode to run [text-generation](https://huggingface.co/models?pipeline_tag=text-generation) models 
There has been a surge of requests to run bloomz and bloom models. People have contacted me personally about specialized LLMs they need to use and yet they can't.  
 
### How did you test it?
Add a unit test using a small text-generation model to test loading and simple invocation
Will add more tests, currently looking for immediate regression issues and potential roadblocks 

### Notes for the reviewer
This PR is not ready for review; let's consult which other unit tests to add. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
