### PR TITLE
feat: Add Cohere PromptNode layer

### DIFF
--- a/haystack/nodes/prompt/providers.py
+++ b/haystack/nodes/prompt/providers.py
@@ -77,8 +77,9 @@ class TokenLimitEnforcer:
     """
     TokenLimitEnforcer enforces the prompt and the model response to be within the token limit.
 
-    Although for some models can very precisely estimate this number of tokens (we have access to their tokenizer) for
-    others we can't. In this case we use one of the HuggingFace tokenizers to estimate the number of tokens (e.g gpt2).
+    Although for some models, we can very precisely estimate this number of tokens (we have access to their tokenizer)
+    for others - we can't. In this case we use one of the HuggingFace tokenizers to estimate the number of
+    tokens (e.g gpt2).
 
     """
 

--- a/haystack/utils/http_client.py
+++ b/haystack/utils/http_client.py
@@ -1,0 +1,171 @@
+import os
+from typing import Optional, Callable, Any, Set, Dict, Type
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError
+from urllib3.util.retry import Retry
+
+from haystack.environment import HAYSTACK_REMOTE_API_TIMEOUT_SEC, HAYSTACK_REMOTE_API_MAX_RETRIES
+
+HTTP_TIMEOUT = int(os.environ.get(HAYSTACK_REMOTE_API_TIMEOUT_SEC, 30))
+HTTP_MAX_RETRIES = int(os.environ.get(HAYSTACK_REMOTE_API_MAX_RETRIES, 5))
+
+
+class HTTPClient:
+    """
+    HTTPClient provides a simplified interface for sending HTTP requests to a specified URL with the ability to set
+    custom request headers, timeouts, retries for specific status codes and error handling.
+
+    Example Usage:
+    --------------
+
+    # Creating an instance of HTTPClient
+    from haystack.utils.http_client import HTTPClient
+    client = HTTPClient(url="http://localhost:8080/test", method="GET", headers={"Authorization": "Bearer my_token"},
+                        retries=3, timeout=10)
+
+    # Sending an HTTP request with retries
+    response = client.request(json={"param1": "value1", "param2": "value2"})
+    print(response.status_code)
+
+    # Handling a custom error with a custom exception
+     from haystack.errors import OpenAIUnauthorizedError
+     client = HTTPClient(url="http://localhost:8080/test", method="GET", error_codes_map={401: OpenAIUnauthorizedError})
+     try:
+         client.request(json={"test": "test"})
+     except OpenAIUnauthorizedError as e:
+         print(e)
+
+    # Handling of custom retry status codes and using a custom error class for 429 status code
+    from haystack.utils.http_client import HTTPClient
+    from haystack.errors import OpenAIRateLimitError
+    retry_status_list = {429, 503}
+
+    # Create an instance of the HTTPClient with custom retry status codes
+    client = HTTPClient(
+        url="https://api.openai.com/v1/completions",
+        method="GET",
+        retries=3,
+        retry_status_list=retry_status_list,
+        error_codes_map={429: OpenAIRateLimitError}
+    )
+
+    # Make a request using the HTTPClient instance
+    try:
+        response = client.request(json={"test": "test"})
+        print(response.status_code)
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+    # Handling a custom error with the default exception
+     from requests import HTTPError
+     client = HTTPClient(url="http://localhost:8080/test", method="GET")
+     try:
+         client.request(json={"test": "test"})
+     except HTTPError as e:
+         print(e)
+
+    # Handling a timeout error
+     client = HTTPClient(url="http://localhost:8080/test", method="GET", timeout=1)
+     try:
+         client.request(json={"test": "test"})
+     except TimeoutError as e:
+         print(e)
+
+    """
+
+    def __init__(
+        self,
+        url: str,
+        method: Optional[str] = "GET",
+        headers: Optional[dict] = None,
+        timeout: Optional[int] = HTTP_TIMEOUT,
+        retries: Optional[int] = HTTP_MAX_RETRIES,
+        backoff_factor: Optional[float] = 2.0,
+        retry_status_list: Optional[Set[int]] = None,
+        response_handler: Optional[Callable[[requests.Response], Any]] = None,
+        error_codes_map: Optional[Dict[int, Type]] = None,
+        default_error_class: Optional[Type] = HTTPError,
+        pool_connections: Optional[int] = 2,
+        pool_maxsize: Optional[int] = 2,
+    ):
+        """
+        Create a new HTTPClient with a requests Session preconfigured with retry and timeout functionality.
+
+        :param method: HTTP method to use for the request.
+        :param url: URL to send the request to.
+        :param headers: Dictionary of HTTP Headers to send with the :class:`Request`.
+        :param timeout: The timeout length of the request. The default is 30s.
+        :param retries: The number of retries to attempt. The default is 5.
+        :param backoff_factor: The backoff factor to use when retrying. The default is 2 (a.k.a. exponential backoff).
+        :param retry_status_list: The list of status codes to retry on. The default is [500, 502, 503, 504, 413, 429].
+        :param response_handler: A function to handle the response. The default is to return the response as JSON.
+        :param error_codes_map: A dictionary of error codes to exception classes. The default is to raise an HTTPError.
+        :param default_error_class: The default exception class to raise. The default is HTTPError.
+        :param pool_connections: The number of connections to keep in the pool. The default is 2.
+        :param pool_maxsize: The maximum number of connections to save in the pool. The default is 2.
+        """
+        self.session = requests.Session()
+        self.method = method
+        self.url = url
+        self.retry_status_list = retry_status_list or {500, 502, 503, 504, 413, 429}
+        retry_strategy = Retry(
+            total=retries, backoff_factor=backoff_factor, status_forcelist=self.retry_status_list, raise_on_status=False  # type: ignore
+        )
+        adapter = HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize, max_retries=retry_strategy)  # type: ignore
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+        self.timeout = timeout
+        self.error_codes_map = error_codes_map or {}
+        self.default_error_class = default_error_class
+        self.response_handler = response_handler if response_handler else lambda response: response.json()
+        self.headers = headers or {}
+
+    def request(
+        self,
+        method: Optional[str] = None,
+        url: Optional[str] = None,
+        headers: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Any] = None,
+        json: Optional[Any] = None,
+        stream: Optional[bool] = False,
+        response_handler: Optional[Callable[[requests.Response], Any]] = None,
+    ) -> Any:
+        """
+        Send a request using the configured session with an option to override the method, url, headers, and response handler.
+
+        :param method: HTTP method to use for the request.
+        :param url: URL to send the request to.
+        :param headers: Dictionary of HTTP Headers to send with the :class:`Request`.
+        :param params: Dictionary or bytes to be sent in the query string for the :class:`Request`.
+        :param data: Dictionary, bytes, or file-like object to send in the body of the :class:`Request`.
+        :param json: JSON serializable Python object to send in the body of the :class:`Request`.
+        :param stream: Whether to immediately download the response content. The default is False.
+        :param response_handler: A function to handle the response. The default is to return the response as JSON.
+        :return: The response from the request.
+        """
+        try:
+            res = self.session.request(
+                method or self.method,  # type: ignore
+                url or self.url,
+                params=params,
+                data=data,
+                json=json,
+                headers=headers or self.headers,
+                timeout=self.timeout,
+                stream=stream,
+            )
+            handler = response_handler or self.response_handler
+            if res.status_code != 200:
+                exc_class = self.error_codes_map.get(res.status_code, self.default_error_class)
+                if exc_class:
+                    raise exc_class(f"Request failed with status code {res.status_code}")
+
+                res.raise_for_status()
+
+            return handler(res)
+        except requests.exceptions.RequestException as e:
+            raise self.default_error_class(f"Request failed {e}") if self.default_error_class else e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,7 @@ dev = [
   "jupytercontrib",
   "watchdog",
   "requests-cache<1.0.0",
+  "pytest-localserver"
 ]
 
 formatting = [

--- a/test/others/test_http_client.py
+++ b/test/others/test_http_client.py
@@ -1,0 +1,73 @@
+import time
+
+import pytest
+import requests
+from requests import RequestException, HTTPError
+
+from haystack.errors import OpenAIUnauthorizedError, OpenAIRateLimitError
+from haystack.utils.http_client import HTTPClient
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status_code", [413, 429])
+def test_retry(httpserver, status_code):
+    backoff_factor = 2  # exponential backoff, default value for HTTPClient
+    num_retries = 2  # let's make it smaller than default to speed up the test
+
+    httpserver.serve_content(f"{status_code}", status_code)
+    c = HTTPClient(url=httpserver.url, method="GET", retries=num_retries)
+    start = time.time()
+    try:
+        c.request(json={"test": "test"})
+    except requests.RequestException as e:
+        assert isinstance(e, c.default_error_class)
+    end = time.time()
+
+    # Check that the retry is working, all retries should take slightly above the total time
+    total_time = backoff_factor * (2 ** (num_retries - 1))
+
+    if end - start < total_time:
+        pytest.fail("Retries are not working")
+
+
+@pytest.mark.unit
+def test_custom_exception(httpserver):
+    httpserver.serve_content("Raise custom OpenAIUnauthorizedError", 401)
+
+    c = HTTPClient(url=httpserver.url, error_codes_map={401: OpenAIUnauthorizedError})
+    with pytest.raises(OpenAIUnauthorizedError):
+        c.request(json={"test": "test"})
+
+
+@pytest.mark.unit
+def test_default_error_class(httpserver):
+    # test that default_error_class works as expected
+    # the default HTTPError should be raised
+
+    httpserver.serve_content("NA", 429)
+
+    c = HTTPClient(url=httpserver.url, retries=1)
+    with pytest.raises(HTTPError):
+        c.request(json={"test": "test"})
+
+
+@pytest.mark.unit
+def test_custom_default_exception(httpserver):
+    # test we can raise specific exceptions for specific status codes (after retries)
+    httpserver.serve_content("Raise custom OpenAIError", 429)
+
+    c = HTTPClient(url=httpserver.url, retries=2, error_codes_map={429: OpenAIRateLimitError})
+    with pytest.raises(OpenAIRateLimitError):
+        c.request(json={"test": "test"})
+
+
+@pytest.mark.unit
+def test_default_error_class_none(httpserver):
+    # test that default_error_class=None works as expected
+    # the default RequestException should be raised
+
+    httpserver.serve_content("NA", 429)
+
+    c = HTTPClient(url=httpserver.url, default_error_class=None, retries=1)
+    with pytest.raises(RequestException):
+        c.request(json={"test": "test"})

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -11,7 +11,7 @@ from haystack.errors import OpenAIError
 from haystack.nodes.prompt import PromptTemplate, PromptNode, PromptModel
 from haystack.nodes.prompt import PromptModelInvocationLayer
 from haystack.nodes.prompt.prompt_node import PromptTemplateValidationError
-from haystack.nodes.prompt.providers import HFLocalInvocationLayer, TokenStreamingHandler, TokenLimitEnforcer
+from haystack.nodes.prompt.providers import HFLocalInvocationLayer, TokenStreamingHandler, HFTokenLimitEnforcer
 from haystack.schema import Answer
 
 
@@ -147,11 +147,13 @@ def test_create_prompt_model_dtype():
 @pytest.mark.unit
 def test_token_enforcer():
     prompt = "This is a prompt text"
-    e = TokenLimitEnforcer(tokenizer=AutoTokenizer.from_pretrained("gpt2"), answer_max_length=10, model_max_length=100)
+    e = HFTokenLimitEnforcer(
+        tokenizer=AutoTokenizer.from_pretrained("gpt2"), answer_max_length=10, model_max_length=100
+    )
     result = e.process_prompt(prompt)
     assert result == prompt
 
-    e = TokenLimitEnforcer(tokenizer=AutoTokenizer.from_pretrained("gpt2"), answer_max_length=10, model_max_length=20)
+    e = HFTokenLimitEnforcer(tokenizer=AutoTokenizer.from_pretrained("gpt2"), answer_max_length=10, model_max_length=20)
     prompt = "This prompt is too long and will be truncated, because it is too long"
     result = e.process_prompt(prompt)
     assert result == "This prompt is too long and will be truncated"


### PR DESCRIPTION
### Related Issues
- fixes #3863 

### Proposed Changes:
 Adds CohereInvocationLayer as PromptModelInvocationLayer implementation for the support of [Cohere](https://docs.cohere.ai/docs/command-beta) command model

### How did you test it?
Added unit tests for components and ran the tests personally but did not add parametrization of prompt node tests for Cohere as we don't have an API key for it yet

### Notes for the reviewer
Disregard missing prompt node integration tests; working on obtaining Cohere API key

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
