### PR TITLE
feat: Add Hugging Face inferencing PromptNode layer

### DIFF
--- a/haystack/nodes/prompt/providers.py
+++ b/haystack/nodes/prompt/providers.py
@@ -556,7 +556,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
     Hugging Face Inference Endpoints [documentation](https://huggingface.co/inference-endpoints)
     """
 
-    def __init__(self, api_key: str, model_name_or_path: str = None, max_length: Optional[int] = 100, **kwargs):
+    def __init__(self, api_key: str, model_name_or_path: str, max_length: Optional[int] = 500, **kwargs):
         """
          Creates an instance of HFInferenceEndpointInvocationLayer
 
@@ -631,7 +631,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
             "num_return_sequences": kwargs_with_defaults.get("top_k", 1),
         }
         json_data = {"inputs": prompt, "parameters": params}
-        response = requests.post(self.url, headers=self.headers, json=json_data)
+        response = requests.post(self.url, headers=self.headers, json=json_data, timeout=60)
         if response.status_code != 200:
             raise RuntimeError(
                 f"Error while HF inference endpoint {self.model_name_or_path} with prompt {prompt}. "
@@ -646,4 +646,4 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        return model_name_or_path and model_name_or_path.startswith("https://")
+        return model_name_or_path is not None and model_name_or_path.startswith("https://")


### PR DESCRIPTION
### Related Issues
- no issue

### Proposed Changes:
Adds HFInferenceEndpointInvocationLayer as PromptModelInvocationLayer implementation for the support of [HF Inferencing](https://huggingface.co/inference-endpoints) deployed models (all text2text-generation and text-generation models)

### How did you test it?
No tests have been added yet; unit tests and documentation are coming soon
To test this model you need to invoke the HF inferencing deployed model. I'll provide you with all the necessary details and a remote test endpoint for T5-Flan deployed model


### Notes for the reviewer
This is a draft proposal, do not yet integrate.


### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
