### PR TITLE
refactor: Simplify agent and tool interaction

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import re
 from typing import List, Optional, Union, Dict, Tuple
-from collections.abc import Container
 
 from haystack import Pipeline, BaseComponent, Answer, Document
 from haystack.errors import AgentError
@@ -77,7 +76,7 @@ class Tool:
     def _process_result(self, result: Union[Tuple, Dict]) -> str:
         # Base case: string or an empty container
         if not result or isinstance(result, str):
-            return result
+            return str(result)
         # Recursive case: process the result based on its type and return the result
         else:
             if isinstance(result, (tuple, list)):
@@ -93,6 +92,8 @@ class Tool:
                 return self._process_result(result.answer)
             elif isinstance(result, Document):
                 return self._process_result(result.content)
+            else:
+                return str(result)
 
 
 class Agent:

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import List, Optional, Union, Dict, Tuple, Any
+from typing import List, Optional, Union, Dict, Tuple
 
-from haystack import Pipeline, BaseComponent, Answer
+from haystack import Pipeline, BaseComponent, Answer, Document
 from haystack.errors import AgentError
 from haystack.nodes import PromptNode, BaseRetriever, PromptTemplate
 from haystack.pipelines import (
@@ -52,6 +52,7 @@ class Tool:
             RetrieverQuestionGenerationPipeline,
         ],
         description: str,
+        output_variable: Optional[str] = "results",
     ):
         if re.search(r"\W", name):
             raise ValueError(
@@ -60,6 +61,35 @@ class Tool:
         self.name = name
         self.pipeline_or_node = pipeline_or_node
         self.description = description
+        self.output_variable = output_variable
+
+    def run(self, tool_input: str, params: Optional[dict] = None) -> str:
+        # We can only pass params to pipelines but not to nodes
+        if isinstance(self.pipeline_or_node, (Pipeline, BaseStandardPipeline)):
+            result = self.pipeline_or_node.run(query=tool_input, params=params)
+        elif isinstance(self.pipeline_or_node, BaseRetriever):
+            result = self.pipeline_or_node.run(query=tool_input, root_node="Query")
+        else:
+            result = self.pipeline_or_node.run(query=tool_input)
+
+        # if result was returned by a node it is of type tuple. We use only the output but not the name of the output.
+        # if result was returned by a pipeline it is of type dict that we can use directly.
+        if isinstance(result, tuple):
+            result = result[0]
+        if isinstance(result, dict):
+            if result and self.output_variable not in result:
+                raise ValueError(
+                    f"Tool {self.name} returned result {result} but "
+                    f"output variable '{self.output_variable}' not found in."
+                )
+            result = result.get(self.output_variable)
+        if isinstance(result, list):
+            result = result[0] if result else []
+        if isinstance(result, Answer):
+            result = result.answer
+        if isinstance(result, Document):
+            result = result.content
+        return result
 
 
 class Agent:
@@ -168,17 +198,8 @@ class Agent:
                 transcript += preds[0]
                 return self._format_answer(query=query, transcript=transcript, answer=final_answer)
             tool_name, tool_input = self._extract_tool_name_and_tool_input(pred=preds[0])
-            if tool_name is None or tool_input is None:
-                raise AgentError(
-                    f"Could not identify the next tool or input for that tool from Agent's output. Adjust the Agent's param 'tool_pattern' or 'prompt_template'. \n"
-                    f"# Agent's output: {preds[0]} \n"
-                    f"# 'tool_pattern' to identify next tool: {self.tool_pattern} \n"
-                    f"# Transcript:\n{transcript}"
-                )
-
-            result = self._run_tool(tool_name=tool_name, tool_input=tool_input, transcript=transcript, params=params)
-            observation = self._extract_observation(result)
-            transcript += f"{preds[0]}\nObservation: {observation}\nThought: Now that I know that {observation} is the answer to {tool_name} {tool_input}, I "
+            observation = self._run_tool(tool_name, tool_input, transcript + preds[0], params)
+            transcript += f"{preds[0]}\nObservation: {observation}\nThought:"
 
         logger.warning(
             "Maximum number of iterations (%s) reached for query (%s). Increase max_iterations "
@@ -213,41 +234,22 @@ class Agent:
         return results
 
     def _run_tool(
-        self, tool_name: str, tool_input: str, transcript: str, params: Optional[dict] = None
-    ) -> Union[Tuple[Dict[str, Any], str], Dict[str, Any]]:
+        self, tool_name: Optional[str], tool_input: Optional[str], transcript: str, params: Optional[dict] = None
+    ) -> str:
+        if tool_name is None or tool_input is None:
+            raise AgentError(
+                f"Could not identify the next tool or input for that tool from Agent's output. "
+                f"Adjust the Agent's param 'tool_pattern' or 'prompt_template'. \n"
+                f"# 'tool_pattern' to identify next tool: {self.tool_pattern} \n"
+                f"# Transcript:\n{transcript}"
+            )
         if not self.has_tool(tool_name):
             raise AgentError(
                 f"Cannot use the tool {tool_name} because it is not in the list of added tools {self.tools.keys()}."
                 "Add the tool using `add_tool()` or include it in the parameter `tools` when initializing the Agent."
                 f"Transcript:\n{transcript}"
             )
-
-        pipeline_or_node = self.tools[tool_name].pipeline_or_node
-        # We can only pass params to pipelines but not to nodes
-        if isinstance(pipeline_or_node, (Pipeline, BaseStandardPipeline)):
-            result = pipeline_or_node.run(query=tool_input, params=params)
-        elif isinstance(pipeline_or_node, BaseRetriever):
-            result = pipeline_or_node.run(query=tool_input, root_node="Query")
-        else:
-            result = pipeline_or_node.run(query=tool_input)
-        return result
-
-    def _extract_observation(self, result: Union[Tuple[Dict[str, Any], str], Dict[str, Any]]) -> str:
-        observation = ""
-        # if result was returned by a node it is of type tuple. We use only the output but not the name of the output.
-        # if result was returned by a pipeline it is of type dict that we can use directly.
-        if isinstance(result, tuple):
-            result = result[0]
-        if isinstance(result, dict):
-            if result.get("results", None):
-                observation = result["results"][0]
-            elif result.get("answers", None):
-                observation = result["answers"][0].answer
-            elif result.get("documents", None):
-                observation = result["documents"][0].content
-
-        # observation remains "" if no result/answer/document was returned
-        return observation
+        return self.tools[tool_name].run(tool_input, params)
 
     def _extract_tool_name_and_tool_input(self, pred: str) -> Tuple[Optional[str], Optional[str]]:
         """

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import List, Optional, Union, Dict, Tuple
+from typing import List, Optional, Union, Dict, Tuple, Any
 
 from haystack import Pipeline, BaseComponent, Answer, Document
 from haystack.errors import AgentError
@@ -73,7 +73,7 @@ class Tool:
             result = self.pipeline_or_node.run(query=tool_input)
         return self._process_result(result)
 
-    def _process_result(self, result: Union[Tuple, Dict]) -> str:
+    def _process_result(self, result: Any) -> str:
         # Base case: string or an empty container
         if not result or isinstance(result, str):
             return str(result)

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -71,11 +71,15 @@ class Tool:
             result = self.pipeline_or_node.run(query=tool_input, root_node="Query")
         else:
             result = self.pipeline_or_node.run(query=tool_input)
+        return self._process_result(result)
 
+    def _process_result(self, result: Union[Tuple, Dict]) -> str:
+        # Process the result returned by the tool. The result can be a tuple or dict, however we
+        # have to dig into the result to get the actual str output of the tool.
         # if result was returned by a node it is of type tuple. We use only the output but not the name of the output.
         # if result was returned by a pipeline it is of type dict that we can use directly.
         if isinstance(result, tuple):
-            result = result[0]
+            result = result[0] if result else []
         if isinstance(result, dict):
             if result and self.output_variable not in result:
                 raise ValueError(

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -87,6 +87,8 @@ class Tool:
                     f"output variable '{self.output_variable}' not found in."
                 )
             result = result.get(self.output_variable)
+        # we keep these if statements (in this order and without else) as the result can be a list, str, Answer
+        # or Document; we want to return the result as str in all cases.
         if isinstance(result, list):
             result = result[0] if result else []
         if isinstance(result, Answer):

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -116,7 +116,7 @@ def test_run_tool():
         )
     )
     result = agent._run_tool(tool_name="Retriever", tool_input="", transcript="")
-    assert result == []
+    assert result == "[]"  # empty list of documents
 
 
 @pytest.mark.unit

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -80,6 +80,7 @@ def test_max_iterations(caplog, monkeypatch):
             name="Retriever",
             pipeline_or_node=retriever,
             description="useful for when you need to retrieve documents from your index",
+            output_variable="documents",
         )
     )
 
@@ -111,24 +112,11 @@ def test_run_tool():
             name="Retriever",
             pipeline_or_node=retriever,
             description="useful for when you need to retrieve documents from your index",
+            output_variable="documents",
         )
     )
     result = agent._run_tool(tool_name="Retriever", tool_input="", transcript="")
-    assert result[0]["documents"] == []
-
-
-@pytest.mark.unit
-def test_extract_observation():
-    agent = Agent(prompt_node=MockPromptNode())
-    observation = agent._extract_observation(
-        result={
-            "answers": [
-                Answer(answer="first answer", type="generative"),
-                Answer(answer="second answer", type="generative"),
-            ]
-        }
-    )
-    assert observation == "first answer"
+    assert result == []
 
 
 @pytest.mark.unit
@@ -190,6 +178,7 @@ def test_agent_run(reader, retriever_with_docs, document_store_with_docs):
             description="useful for when you need to answer "
             "questions about where people live. You "
             "should ask targeted questions",
+            output_variable="answers",
         )
     )
     agent.add_tool(
@@ -240,6 +229,7 @@ def test_agent_run_batch(reader, retriever_with_docs, document_store_with_docs):
             description="useful for when you need to answer "
             "questions about where people live. You "
             "should ask targeted questions",
+            output_variable="answers",
         )
     )
     agent.add_tool(

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import pytest
 
-from haystack import BaseComponent, Answer
+from haystack import BaseComponent, Answer, Document
 from haystack.agents import Agent
 from haystack.agents.base import Tool
 from haystack.errors import AgentError
@@ -144,6 +144,47 @@ def test_format_answer():
     assert formatted_answer["query"] == "query"
     assert formatted_answer["answers"] == [Answer(answer="answer", type="generative")]
     assert formatted_answer["transcript"] == "transcript"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("reader", ["farm"], indirect=True)
+@pytest.mark.parametrize("retriever_with_docs, document_store_with_docs", [("bm25", "memory")], indirect=True)
+def test_tool_result_extraction(reader, retriever_with_docs):
+    # Test that the result of a Tool is correctly extracted as a string
+
+    # Pipeline as a Tool
+    search = ExtractiveQAPipeline(reader, retriever_with_docs)
+    t = Tool(
+        name="Search",
+        pipeline_or_node=search,
+        description="useful for when you need to answer "
+        "questions about where people live. You "
+        "should ask targeted questions",
+        output_variable="answers",
+    )
+    result = t.run("Where does Christelle live?")
+    assert isinstance(result, str)
+    assert result == "Paris" or result == "Madrid"
+
+    # PromptNode as a Tool
+    pt = PromptTemplate("test", "Here is a question: $query, Answer:")
+    pn = PromptNode(default_prompt_template=pt)
+
+    t = Tool(name="Search", pipeline_or_node=pn, description="N/A", output_variable="results")
+    result = t.run(tool_input="What is the capital of Germany?")
+    assert isinstance(result, str)
+    assert "berlin" in result.lower()
+
+    # Retriever as a Tool
+    t = Tool(
+        name="Retriever",
+        pipeline_or_node=retriever_with_docs,
+        description="useful for when you need to retrieve documents from your index",
+        output_variable="documents",
+    )
+    result = t.run(tool_input="Where does Christelle live?")
+    assert isinstance(result, str)
+    assert "Christelle" in result
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues
- Not an issue, small refactor to simplify agent tool interaction
- I discovered the need for this change when I added my tool with an output variable "output"

### Proposed Changes:
This refactoring inverts responsibilities (in a good sense) between the agent and the tool. Currently, we attempt to retrieve tool results from an agent code and guess the variable's name where the result is stored (if dictionary)! However, this approach will always be insufficient as the tool should extract its own result and return it to the agent, not vice-versa. 

### How did you test it?
Slightly adjusted unit tests and simplified code significantly. 

### Notes for the reviewer
The diff should be enough to see this change. There is also a slight change regarding the agent transcript (line 202). We shouldn't hardcode the agent trace as custom agent prompts might not assume this format. I can elaborate more privately.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
