### PR TITLE
fix: check that `answer` is not `None` before accessing it in `table.py`

### DIFF
--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -279,7 +279,8 @@ class _TapasEncoder:
         if isinstance(answers[0], list):
             answers = list(itertools.chain.from_iterable(answers))
         for ans, doc in zip(answers, table_documents):
-            ans.document_ids = [doc.id]
+            if ans is not None:
+                ans.document_ids = [doc.id]
 
         # Remove no_answers from the answers list
         answers = [ans for ans in answers if ans is not None]


### PR DESCRIPTION
Answer should be checked if it is not none before adding id to it

### Related Issues
- fixes #issue-number

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
