### PR TITLE
Adding filtering support for Weaviate when used for BM25 querying

### DIFF
--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -83,8 +83,7 @@ def test_retrieval_without_filters(retriever_with_docs: BaseRetriever, document_
         ("embedding", "elasticsearch"),
         ("embedding", "memory"),
         ("bm25", "elasticsearch"),
-        # TODO - add once Weaviate starts supporting filters with BM25 in Weaviate v1.18+
-        # ("bm25", "weaviate"),
+        ("bm25", "weaviate"),
         ("es_filter_only", "elasticsearch"),
     ],
     indirect=True,


### PR DESCRIPTION
### Related Issues
- fixes #4384 

### Proposed Changes:
We were waiting for Weaviate v1.18.0 to close a gap of functionality - lack of support for using filters with BM25 searching.
Version v1.18.0 just has been released and now it has this missing functionality, so I was uncommenting all the places where I left code in for the time when Weaviate starts supporting this.

### How did you test it?
I have some local tests with some live data in Weaviate, plus there is also a unit test which was activated for the Weaviate BM25 search with filter scenario.

### Notes for the reviewer
None

### Checklist
- [x I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
