### PR TITLE
feat: Improve performance and add default media support in FileTypeClassifier

### DIFF
--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -22,7 +22,7 @@ except ImportError as ie:
 
 DEFAULT_TYPES = ["txt", "pdf", "md", "docx", "html", "media"]
 
-MEDIA_TYPES = ["mp3", "mp4", "mpeg", "m4a", "wav", "webm"]
+DEFAULT_MEDIA_TYPES = ["mp3", "mp4", "mpeg", "m4a", "wav", "webm"]
 
 
 class FileTypeClassifier(BaseComponent):
@@ -77,7 +77,7 @@ class FileTypeClassifier(BaseComponent):
                 extension = magic.from_buffer(buffer, mime=True)
                 real_extension = mimetypes.guess_extension(extension) or ""
                 real_extension = real_extension.lstrip(".")
-                if self._default_types and real_extension in MEDIA_TYPES:
+                if self._default_types and real_extension in DEFAULT_MEDIA_TYPES:
                     return "media"
                 return real_extension or ""
         except NameError:
@@ -99,12 +99,12 @@ class FileTypeClassifier(BaseComponent):
         """
         extension = file_paths[0].suffix.lower().lstrip(".")
 
-        if extension == "" or (self._default_types and extension in MEDIA_TYPES):
+        if extension == "" or (self._default_types and extension in DEFAULT_MEDIA_TYPES):
             extension = self._estimate_extension(file_paths[0])
 
         for path in file_paths:
             path_suffix = path.suffix.lower().lstrip(".")
-            if path_suffix == "" or (self._default_types and path_suffix in MEDIA_TYPES):
+            if path_suffix == "" or (self._default_types and path_suffix in DEFAULT_MEDIA_TYPES):
                 path_suffix = self._estimate_extension(path)
             if path_suffix != extension:
                 raise ValueError("Multiple non-default file types are not allowed at once.")

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -91,12 +91,12 @@ class FileTypeClassifier(BaseComponent):
         """
         extension = file_paths[0].suffix.lower().lstrip(".")
 
-        if extension == "" or extension in MEDIA_TYPES:
+        if extension == "" or (self._default_types and extension in MEDIA_TYPES):
             extension = self._estimate_extension(file_paths[0])
 
         for path in file_paths:
             path_suffix = path.suffix.lower().lstrip(".")
-            if path_suffix == "" or path_suffix in MEDIA_TYPES:
+            if path_suffix == "" or (self._default_types and path_suffix in MEDIA_TYPES):
                 path_suffix = self._estimate_extension(path)
             if path_suffix != extension:
                 raise ValueError("Multiple non-default file types are not allowed at once.")

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -67,8 +67,8 @@ class FileTypeClassifier(BaseComponent):
         """
         try:
             extension = magic.from_file(str(file_path), mime=True)
-            real_extension = mimetypes.guess_extension(extension)
-            if self._default_types and real_extension in MEDIA_TYPES:
+            real_extension = mimetypes.guess_extension(extension) or ""
+            if self._default_types and real_extension.lstrip(".") in MEDIA_TYPES:
                 return "media"
             return real_extension or ""
         except NameError:
@@ -89,12 +89,13 @@ class FileTypeClassifier(BaseComponent):
         :return: a set of strings with all the extensions (without duplicates), the extension will be guessed if the file has none
         """
         extension = file_paths[0].suffix.lower()
-        if extension == "":
+
+        if extension == "" or extension.lstrip(".") in MEDIA_TYPES:
             extension = self._estimate_extension(file_paths[0])
 
         for path in file_paths:
-            path_suffix = path.suffix.lower()
-            if path_suffix == "":
+            path_suffix = path.suffix.lower().lstrip(".")
+            if path_suffix == "" or path_suffix in MEDIA_TYPES:
                 path_suffix = self._estimate_extension(path)
             if path_suffix != extension:
                 raise ValueError("Multiple file types are not allowed at once.")

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -40,7 +40,9 @@ class FileTypeClassifier(BaseComponent):
               If no value is provided, the value created by default comprises: `txt`, `pdf`, `md`, `docx`, and `html`.
              Lists with duplicate elements are not allowed.
         """
+        self._default_types = False
         if supported_types is None:
+            self._default_types = True
             supported_types = DEFAULT_TYPES
         if len(set(supported_types)) != len(supported_types):
             duplicates = supported_types
@@ -66,7 +68,7 @@ class FileTypeClassifier(BaseComponent):
         try:
             extension = magic.from_file(str(file_path), mime=True)
             real_extension = mimetypes.guess_extension(extension)
-            if real_extension in MEDIA_TYPES:
+            if self._default_types and real_extension in MEDIA_TYPES:
                 return "media"
             return real_extension or ""
         except NameError:

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -20,7 +20,9 @@ except ImportError as ie:
     )
 
 
-DEFAULT_TYPES = ["txt", "pdf", "md", "docx", "html"]
+DEFAULT_TYPES = ["txt", "pdf", "md", "docx", "html", "media"]
+
+MEDIA_TYPES = ["mp3", "mp4", "mpeg", "m4a", "wav", "webm"]
 
 
 class FileTypeClassifier(BaseComponent):
@@ -63,7 +65,10 @@ class FileTypeClassifier(BaseComponent):
         """
         try:
             extension = magic.from_file(str(file_path), mime=True)
-            return mimetypes.guess_extension(extension) or ""
+            real_extension = mimetypes.guess_extension(extension)
+            if real_extension in MEDIA_TYPES:
+                return "media"
+            return real_extension or ""
         except NameError:
             logger.error(
                 "The type of '%s' could not be guessed, probably because 'python-magic' is not installed. Ignoring this error."

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -37,8 +37,10 @@ class FileTypeClassifier(BaseComponent):
         Node that sends out files on a different output edge depending on their extension.
 
         :param supported_types: The file types that this node can distinguish between.
-              If no value is provided, the value created by default comprises: `txt`, `pdf`, `md`, `docx`, and `html`.
-             Lists with duplicate elements are not allowed.
+            If no value is provided, the value created by default comprises: `txt`, `pdf`, `md`, `docx`, and `html`.
+            Lists with duplicate elements are not allowed.
+        :param full_analysis: If True, the whole file is analyzed to determine the file type.
+            If False, only the first 2049 bytes are analyzed.
         """
         self.full_analysis = full_analysis
         self._default_types = False

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -68,7 +68,8 @@ class FileTypeClassifier(BaseComponent):
         try:
             extension = magic.from_file(str(file_path), mime=True)
             real_extension = mimetypes.guess_extension(extension) or ""
-            if self._default_types and real_extension.lstrip(".") in MEDIA_TYPES:
+            real_extension = real_extension.lstrip(".")
+            if self._default_types and real_extension in MEDIA_TYPES:
                 return "media"
             return real_extension or ""
         except NameError:
@@ -88,9 +89,9 @@ class FileTypeClassifier(BaseComponent):
         :param file_paths: the paths to extract the extension from
         :return: a set of strings with all the extensions (without duplicates), the extension will be guessed if the file has none
         """
-        extension = file_paths[0].suffix.lower()
+        extension = file_paths[0].suffix.lower().lstrip(".")
 
-        if extension == "" or extension.lstrip(".") in MEDIA_TYPES:
+        if extension == "" or extension in MEDIA_TYPES:
             extension = self._estimate_extension(file_paths[0])
 
         for path in file_paths:
@@ -98,9 +99,9 @@ class FileTypeClassifier(BaseComponent):
             if path_suffix == "" or path_suffix in MEDIA_TYPES:
                 path_suffix = self._estimate_extension(path)
             if path_suffix != extension:
-                raise ValueError("Multiple file types are not allowed at once.")
+                raise ValueError("Multiple non-default file types are not allowed at once.")
 
-        return extension.lstrip(".")
+        return extension
 
     def run(self, file_paths: Union[Path, List[Path], str, List[str], List[Union[Path, str]]]):  # type: ignore
         """

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -32,7 +32,7 @@ class FileTypeClassifier(BaseComponent):
 
     outgoing_edges = len(DEFAULT_TYPES)
 
-    def __init__(self, supported_types: Optional[List[str]] = None):
+    def __init__(self, supported_types: Optional[List[str]] = None, full_analysis: bool = False):
         """
         Node that sends out files on a different output edge depending on their extension.
 
@@ -40,6 +40,7 @@ class FileTypeClassifier(BaseComponent):
               If no value is provided, the value created by default comprises: `txt`, `pdf`, `md`, `docx`, and `html`.
              Lists with duplicate elements are not allowed.
         """
+        self.full_analysis = full_analysis
         self._default_types = False
         if supported_types is None:
             self._default_types = True
@@ -67,7 +68,10 @@ class FileTypeClassifier(BaseComponent):
         """
         try:
             with open(file_path, "rb") as f:
-                buffer = f.read(2049)
+                if self.full_analysis:
+                    buffer = f.read()
+                else:
+                    buffer = f.read(2049)
                 extension = magic.from_buffer(buffer, mime=True)
                 real_extension = mimetypes.guess_extension(extension) or ""
                 real_extension = real_extension.lstrip(".")

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -66,12 +66,14 @@ class FileTypeClassifier(BaseComponent):
         :param file_path: the path to extract the extension from
         """
         try:
-            extension = magic.from_file(str(file_path), mime=True)
-            real_extension = mimetypes.guess_extension(extension) or ""
-            real_extension = real_extension.lstrip(".")
-            if self._default_types and real_extension in MEDIA_TYPES:
-                return "media"
-            return real_extension or ""
+            with open(file_path, "rb") as f:
+                buffer = f.read(2049)
+                extension = magic.from_buffer(buffer, mime=True)
+                real_extension = mimetypes.guess_extension(extension) or ""
+                real_extension = real_extension.lstrip(".")
+                if self._default_types and real_extension in MEDIA_TYPES:
+                    return "media"
+                return real_extension or ""
         except NameError:
             logger.error(
                 "The type of '%s' could not be guessed, probably because 'python-magic' is not installed. Ignoring this error."


### PR DESCRIPTION
### Related Issues
- #4393 

### Proposed Changes:
- Add a default setup which allows users to direct any Whisper supported media file to our recently added WhisperTranscriber. This change allows multiple media extensions to be routed at once. 

- Increase FileTypeClassifier performance by reading only the first 2049 bytes. They (2048 bytes) are the most relevant, above this value it usually only increases the certainty about a file type, being it already known. There is no need to send the full file for analysis. This will decrease memory consumption and processing time. This is particularly stronger in our default supported files.

### How did you test it?


### Notes for the reviewer
- Users will be able to route per custom types like today. The only difference is the ability to route all WhisperTranscriber media types to the correct node without being locked by the current implementation that asks for one file type per time.
- A similar approach can be used in the future to route all PyMuPDF supported files to the PDFToTextConverter (e-books, XPS and so on)
- I would like to remind the main FileTypeClassifier function, using its documentation:

>     """
>     Route files in an Indexing Pipeline to corresponding file converters.
>     """

As so, being able to, without any special node configuration, redirect the correct files to the `WhisperTranscriber` will be compliant with the node functionality.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
