### PR TITLE
docs: add `DocumentLanguageClassifier` API

### DIFF
--- a/docs/pydoc/config/doc-language-classifier.yml
+++ b/docs/pydoc/config/doc-language-classifier.yml
@@ -1,0 +1,26 @@
+loaders:
+  - type: python
+    search_path: [../../../haystack/nodes/doc_language_classifier]
+    modules: ["base", "langdetect", "transformers"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: renderers.ReadmeRenderer
+  excerpt: Detects the language of the Documents
+  category_slug: haystack-classes
+  title: Document Language Classifier API
+  slug: doc-language-classifier-api
+  order: 25
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: doc_language_classifier_api.md

--- a/haystack/nodes/doc_language_classifier/langdetect.py
+++ b/haystack/nodes/doc_language_classifier/langdetect.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class LangdetectDocumentLanguageClassifier(BaseDocumentLanguageClassifier):
     """
     Node based on the lightweight and fast [langdetect library](https://github.com/Mimino666/langdetect) for document language classification.
-    This node detects the languge of Documents and adds the output to the Documents metadata.
+    This node detects the language of Documents and adds the output to the Documents metadata.
     The meta field of the Document is a dictionary with the following format:
     ``'meta': {'name': '450_Baelor.txt', 'language': 'en'}``
     - Using the document language classifier, you can directly get predictions via predict()

--- a/haystack/nodes/doc_language_classifier/transformers.py
+++ b/haystack/nodes/doc_language_classifier/transformers.py
@@ -18,7 +18,7 @@ class TransformersDocumentLanguageClassifier(BaseDocumentLanguageClassifier):
     Transformer based model for document language classification using the HuggingFace's transformers framework
     (https://github.com/huggingface/transformers).
     While the underlying model can vary (BERT, Roberta, DistilBERT ...), the interface remains the same.
-    This node detects the languge of Documents and adds the output to the Documents metadata.
+    This node detects the language of Documents and adds the output to the Documents metadata.
     The meta field of the Document is a dictionary with the following format:
     ``'meta': {'name': '450_Baelor.txt', 'language': 'en'}``
     - Using the document language classifier, you can directly get predictions via predict()


### PR DESCRIPTION
### Related Issues
- missing API docs from #2994

### Proposed Changes:
 Added an API config file.

### Notes for the reviewer
I've tried to be consistent with the [guide](https://github.com/deepset-ai/haystack/blob/main/docs/README.md), but please take a careful look.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
