### PR TITLE
chore: make the docs generator runnable without an API key

### DIFF
--- a/.github/utils/pydoc-markdown.sh
+++ b/.github/utils/pydoc-markdown.sh
@@ -6,5 +6,6 @@ cd docs/pydoc
 rm -rf temp && mkdir temp
 cd temp
 for file in ../config/* ; do
+    echo "Converting $file..."
     pydoc-markdown "$file"
 done

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -4,6 +4,7 @@ import io
 import dataclasses
 import typing as t
 import base64
+import warnings
 from pathlib import Path
 
 import requests
@@ -68,7 +69,8 @@ class ReadmeRenderer(Renderer):
         """
         README_API_KEY = os.getenv("README_API_KEY")
         if not README_API_KEY:
-            sys.exit("README_API_KEY env var is not set")
+            warnings.warn("README_API_KEY env var is not set, using a placeholder category ID")
+            return {"haystack-classes": "ID"}
 
         token = base64.b64encode(f"{README_API_KEY}:".encode()).decode()
         headers = {"authorization": f"Basic {token}", "x-readme-version": version}

--- a/docs/pydoc/requirements.txt
+++ b/docs/pydoc/requirements.txt
@@ -1,2 +1,4 @@
 pydoc-markdown==4.6.4
+# pin docspec while waiting for https://github.com/NiklasRosenstein/docspec/issues/91 to be fixed
+docspec-python<2.1.0
 requests==2.28.2


### PR DESCRIPTION
### Related Issues
- fixes n/a

The conversion script fails when run locally because the reaadme.io api key is missing. This is problematic when you want to test the markdown generation locally.

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Use a fake ID and spit a warning instead of `sys.exit`ing the program

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Locally tested

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
I pinned `docspec` as a temporary fix for the current failure of the readme sync workflow.

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
