### PR TITLE
ci: Use bigger runner for integration-tests-linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -533,7 +533,7 @@ jobs:
           - "modeling"
           - "others"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Proposed Changes:

Use a bigger runner to run certain tests in CI to avoid failure cause of limited disk space.

Failure example: https://github.com/deepset-ai/haystack/actions/runs/4407823874

### How did you test it?

Can't be tested.

### Notes for the reviewer

N/A
