### PR TITLE
test: Add pytest fixture to block requests in unit tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1011,3 +1011,16 @@ def chatgpt_prompt_model():
 @pytest.fixture
 def azure_conf():
     return haystack_azure_conf()
+
+
+@pytest.fixture(autouse=True)
+def request_blocker(request: pytest.FixtureRequest, monkeypatch):
+    """
+    This fixture is applied automatically to all tests.
+    Those that are marked as unit will have the requests module
+    monkeypatched to avoid making HTTP requests by mistake.
+    """
+    marker = request.node.get_closest_marker("unit")
+    if marker is None:
+        return
+    monkeypatch.delattr("requests.sessions.Session")

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -56,8 +56,9 @@ def content_in_results(crawler: Crawler, url: str, results: List[Path], expected
 
 
 @pytest.mark.unit
+@patch("haystack.nodes.connector.crawler.ChromeDriverManager")
 @patch("haystack.nodes.connector.crawler.webdriver")
-def test_crawler_url_none_exception(webdriver):
+def test_crawler_url_none_exception(webdriver, manager):
     crawler = Crawler()
     with pytest.raises(ValueError):
         crawler.crawl()

--- a/test/nodes/test_sampler.py
+++ b/test/nodes/test_sampler.py
@@ -35,7 +35,7 @@ docs = [
 ]
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_top_p_sampling(top_p_sampler):
     query = "What is the most important religious learning from the Bible?"
     results = top_p_sampler.predict(query=query, documents=docs, top_p=0.98)
@@ -44,7 +44,7 @@ def test_top_p_sampling(top_p_sampler):
     assert results[1].id == "5"
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_top_p_sampling_top_p_none(top_p_sampler):
     query = "What is the most important religious learning from the Bible?"
     results = top_p_sampler.predict(query=query, documents=docs, top_p=None)
@@ -55,7 +55,7 @@ def test_top_p_sampling_top_p_none(top_p_sampler):
     assert len(results) == 5
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_top_p_sampling_at_least_one_result(top_p_sampler):
     query = "What is the most important building in King's Landing that has a religious background?"
     results = top_p_sampler.predict(query=query, documents=docs, top_p=0.9)


### PR DESCRIPTION
### Proposed Changes:

This PR adds a `pytest` fixture that is applied to all tests, those that are decorated with `@pytest.mark.unit` will have the `requests` module monkeypatched to avoid making HTTP requests by mistake.

### How did you test it?

I ran `pytest -m "unit" test` locally.

### Notes for the reviewer

N/A
