### PR TITLE
test: Remove unnecessary imports in conftest.py

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -62,12 +62,6 @@ from haystack.nodes.prompt import PromptNode, PromptModel
 from haystack.schema import Document, FilterType
 from haystack.utils.import_utils import _optional_component_not_installed
 
-try:
-    from elasticsearch import Elasticsearch
-    import weaviate
-except (ImportError, ModuleNotFoundError) as ie:
-    _optional_component_not_installed("test", "test", ie)
-
 from .mocks import pinecone as pinecone_mock
 
 


### PR DESCRIPTION
### Proposed Changes:

The main `conftest.py` has an unnecessary import and related `ImportError` that returns a error that is not clear.

```
   ImportError: Failed to import 'test', which is an optional component in Haystack.
   Run 'pip install 'farm-haystack[test]'' to install the required dependencies and make this component available.
   (Original error: No module named 'weaviate')
```

The `test` extra doesn't exist.

### How did you test it?

I ran `pytest -m "unit" test` locally and it passed. Am not sure about other tests.

### Notes for the reviewer

This should fix some CI errors in #4429.