### PR TITLE
test: Skip flaky test_multimodal_retriever_query

### DIFF
--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -1101,6 +1101,7 @@ def test_multimodal_table_retrieval(table_docs: List[Document]):
     )
 
 
+@pytest.mark.skip("Must be reworked as it fails randomly")
 @pytest.mark.integration
 def test_multimodal_retriever_query():
     retriever = MultiModalRetriever(


### PR DESCRIPTION
Test is failing randomly with no clear reason, fixing takes time and lots of investigation.

We'll skip it for the time being and then rework it.