### PR TITLE
feat: add additional params to file upload endpoint

### DIFF
--- a/rest_api/rest_api/controller/file_upload.py
+++ b/rest_api/rest_api/controller/file_upload.py
@@ -46,6 +46,7 @@ def upload_file(
     files: List[UploadFile] = File(...),
     # JSON serialized string
     meta: Optional[str] = Form("null"),  # type: ignore
+    additional_params: Optional[str] = Form("null"),  # type: ignore
     fileconverter_params: FileConverterParams = Depends(FileConverterParams.as_form),  # type: ignore
     preprocessor_params: PreprocessorParams = Depends(PreprocessorParams.as_form),  # type: ignore
 ):
@@ -75,11 +76,12 @@ def upload_file(
         finally:
             file.file.close()
 
+    params = json.loads(additional_params) or {}
+
     # Find nodes names
     converters = indexing_pipeline.get_nodes_by_class(BaseConverter)
     preprocessors = indexing_pipeline.get_nodes_by_class(PreProcessor)
 
-    params = {}
     for converter in converters:
         params[converter.name] = fileconverter_params.dict()
     for preprocessor in preprocessors:

--- a/rest_api/rest_api/controller/file_upload.py
+++ b/rest_api/rest_api/controller/file_upload.py
@@ -76,7 +76,7 @@ def upload_file(
         finally:
             file.file.close()
 
-    params = json.loads(additional_params) or {}
+    params = json.loads(additional_params) or {}  # type: ignore
 
     # Find nodes names
     converters = indexing_pipeline.get_nodes_by_class(BaseConverter)


### PR DESCRIPTION
### Related Issues
- fixes #4404 

### Proposed Changes:
Allows to indicate additional params, besides the converter and preprocessor ones, in json format. For instance:
--form additional_params='{"index": "myindex"}' 

### How did you test it?
Running a local rest api and using this feature to specify the name of the elasticsearch index I wanted to use:
```
 curl --request POST \
          --url http://127.0.0.1:8000/file-upload \
          --header 'accept: application/json' \
          --header 'content-type: multipart/form-data' \
          --form files="@{}" \
 	  --form additional_params='{"index": "nvm"}' \
          --form meta=null \;
```
### Notes for the reviewer


### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
