### PR TITLE
refactor: Remove retry_with_exponential_backoff in favor of tenacity

### DIFF
--- a/haystack/utils/reflection.py
+++ b/haystack/utils/reflection.py
@@ -1,10 +1,6 @@
 import inspect
 import logging
-import time
-from random import random
 from typing import Any, Dict, Tuple, Callable
-
-from haystack.errors import OpenAIRateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -17,54 +13,3 @@ def args_to_kwargs(args: Tuple, func: Callable) -> Dict[str, Any]:
         arg_names = arg_names[1 : 1 + len(args)]
     args_as_kwargs = {arg_name: arg for arg, arg_name in zip(args, arg_names)}
     return args_as_kwargs
-
-
-def retry_with_exponential_backoff(
-    backoff_in_seconds: float = 1, max_retries: int = 10, errors: tuple = (OpenAIRateLimitError,)
-):
-    """
-    Decorator to retry a function with exponential backoff.
-    :param backoff_in_seconds: The initial backoff in seconds.
-    :param max_retries: The maximum number of retries.
-    :param errors: The errors to catch retry on.
-    """
-
-    def decorator(function):
-        def wrapper(*args, **kwargs):
-            # Initialize variables
-            num_retries = 0
-
-            # Loop until a successful response or max_retries is hit or an exception is raised
-            while True:
-                try:
-                    return function(*args, **kwargs)
-
-                # Retry on specified errors
-                except errors as e:
-                    # Check if max retries has been reached
-                    if num_retries > max_retries:
-                        raise Exception(f"Maximum number of retries ({max_retries}) exceeded.")
-
-                    # Increment the delay
-                    sleep_time = backoff_in_seconds * 2**num_retries + random()
-
-                    # Sleep for the delay
-                    logger.warning(
-                        "%s - %s, retry %s in %s seconds...",
-                        e.__class__.__name__,
-                        e,
-                        function.__name__,
-                        "{0:.2f}".format(sleep_time),
-                    )
-                    time.sleep(sleep_time)
-
-                    # Increment retries
-                    num_retries += 1
-
-                # Raise exceptions for any errors not specified
-                except Exception as e:
-                    raise e
-
-        return wrapper
-
-    return decorator

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -20,7 +20,6 @@ from haystack.utils.deepsetcloud import DeepsetCloud, DeepsetCloudExperiments
 from haystack.utils.labels import aggregate_labels
 from haystack.utils.preprocessing import convert_files_to_docs, tika_convert_files_to_docs
 from haystack.utils.cleaning import clean_wiki_text
-from haystack.utils.reflection import retry_with_exponential_backoff
 from haystack.utils.context_matching import calculate_context_similarity, match_context, match_contexts
 
 from .. import conftest
@@ -1274,27 +1273,6 @@ def test_get_eval_run_results():
     first_result = node_results.iloc[0]
     assert first_result["exact_match"] == True
     assert first_result["answer"] == "This"
-
-
-def test_exponential_backoff():
-    # Test that the exponential backoff works as expected
-    # should raise exception, check the exception contains the correct message
-    with pytest.raises(Exception, match="retries \(2\)"):
-
-        @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=2)
-        def greet(name: str):
-            if random() < 1.1:
-                raise OpenAIRateLimitError("Too many requests")
-            return f"Hello {name}"
-
-        greet("John")
-
-    # this should not raise exception and should print "Hello John"
-    @retry_with_exponential_backoff(backoff_in_seconds=1, max_retries=1)
-    def greet2(name: str):
-        return f"Hello {name}"
-
-    assert greet2("John") == "Hello John"
 
 
 def test_secure_model_loading(monkeypatch, caplog):


### PR DESCRIPTION
### Related Issues
- fixes #4316

### Proposed Changes:

Remove all references to `retry_with_exponential_backoff` function and use `tenacity` library instead.

### How did you test it?

I didn't as I don't have API keys to run the tests that use exponential backoff. Also it's kinda hard to trigger it.

### Notes for the reviewer

N/A