### PR TITLE
ci: Use new Slack action to send failure messages

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -3,14 +3,14 @@ name: License Compliance Checks
 on:
   pull_request:
     paths:
-      - '**/pyproject.toml'
+      - "**/pyproject.toml"
   schedule:
-    - cron: '0 0 * * *'  # every day at midnight
+    - cron: "0 0 * * *" # every day at midnight
 
 env:
-  GH_ACCESS_TOKEN:  ${{ secrets.GH_ACCESS_TOKEN }}
+  GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  SLACK_ALERT_CHANNEL: "#haystack"
+  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 jobs:
   check-license-compliance-cpu:
@@ -49,12 +49,30 @@ jobs:
           api-key: ${{ secrets.FOSSA_LICENSE_SCAN_TOKEN }}
           run-tests: true
 
-      - name: Send Slack notification if license check failed
-        uses: act10ns/slack@v2
-        if: failure() && github.ref == 'refs/heads/master'
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: ${{ env.SLACK_ALERT_CHANNEL }}
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   check-license-compliance-gpu:
     if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -91,9 +109,27 @@ jobs:
           api-key: ${{ secrets.FOSSA_LICENSE_SCAN_TOKEN }}
           run-tests: true
 
-      - name: Send Slack notification if license check failed
-        uses: act10ns/slack@v2
-        if: failure() && github.ref == 'refs/heads/master'
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: ${{ env.SLACK_ALERT_CHANNEL }}
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/examples-tests.yml
+++ b/.github/workflows/examples-tests.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   PYTHON_VERSION: "3.8"
 
 jobs:
@@ -44,8 +45,27 @@ jobs:
         - name: Run
           run: pytest examples/
 
-        - uses: act10ns/slack@v2
+        - uses: slackapi/slack-github-action@v1.23.0
+          if: failure() && github.ref == 'refs/heads/main'
           with:
-            status: ${{ job.status }}
-            channel: '#haystack'
-          if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+            payload: |
+              {
+                "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                    }
+                  }
+                ]
+              }

--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -18,6 +18,8 @@ on:
       - "rest_api/pyproject.toml"
 
 env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   PYTHON_VERSION: "3.8"
 
 jobs:
@@ -61,11 +63,30 @@ jobs:
             exit 1
           fi
 
-      - uses: act10ns/slack@v2
-        with:
-          status: ${{ job.status }}
-          channel: "#haystack"
+      - uses: slackapi/slack-github-action@v1.23.0
         if: failure() && github.ref == 'refs/heads/main'
+        with:
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   rest_api:
     needs: black
@@ -94,10 +115,27 @@ jobs:
         run: |
           pytest ${{ env.PYTEST_PARAMS }} rest_api/
 
-      - uses: act10ns/slack@v2
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          channel: "#haystack"
+      - uses: slackapi/slack-github-action@v1.23.0
         if: failure() && github.ref == 'refs/heads/main'
+        with:
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ env:
   HAYSTACK_TELEMETRY_VERSION: "0"  # Disables telemetry
   PYTEST_PARAMS: --maxfail=5 --durations=10 --suppress-no-test-exit-code
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   SUITES_EXCLUDED_FROM_WINDOWS:
     --ignore=test/pipelines/test_ray.py
     --ignore=test/document_stores/test_knowledge_graph.py
@@ -77,11 +78,30 @@ jobs:
           exit 1
         fi
 
-    - uses: act10ns/slack@v2
-      with:
-        status: ${{ job.status }}
-        channel: '#haystack'
+    - uses: slackapi/slack-github-action@v1.23.0
       if: failure() && github.ref == 'refs/heads/main'
+      with:
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   unit-tests:
     name: Unit / ${{ matrix.topic }} / ${{ matrix.os }}
@@ -112,11 +132,30 @@ jobs:
       - name: Run
         run: pytest -m "unit" test/${{ matrix.topic }}
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-elasticsearch:
     name: Integration / Elasticsearch / ${{ matrix.os }}
@@ -149,11 +188,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_elasticsearch.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-sql:
     name: Integration / SQL / ${{ matrix.os }}
@@ -178,11 +236,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_sql.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-opensearch:
     name: Integration / Opensearch / ${{ matrix.os }}
@@ -215,11 +292,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_opensearch.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-dc:
     name: Integration / dC / ${{ matrix.os }}
@@ -244,11 +340,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_deepsetcloud.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-faiss:
     name: Integration / faiss / ${{ matrix.os }}
@@ -273,11 +388,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_faiss.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-weaviate:
     name: Integration / Weaviate / ${{ matrix.os }}
@@ -312,11 +446,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_weaviate.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-pinecone:
     name: Integration / pinecone / ${{ matrix.os }}
@@ -343,11 +496,30 @@ jobs:
       run: |
         pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_pinecone.py
 
-    - uses: act10ns/slack@v2
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
       with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   integration-tests-milvus:
     name: Integration / Milvus / ${{ matrix.os }}
@@ -383,11 +555,30 @@ jobs:
       run: |
         pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_milvus.py
 
-    - uses: act10ns/slack@v2
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
       with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   integration-tests-memory:
     name: Integration / memory / ${{ matrix.os }}
@@ -412,11 +603,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_memory.py
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-promptnode:
     name: Integration / PromptNode / ${{ matrix.os }}
@@ -441,11 +651,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "integration" test/prompt
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
   integration-tests-agents:
     name: Integration / Agents / ${{ matrix.os }}
@@ -470,11 +699,30 @@ jobs:
         run: |
           pytest --maxfail=5 -m "integration" test/agents
 
-      - uses: act10ns/slack@v2
+      - uses: slackapi/slack-github-action@v1.23.0
+        if: failure() && github.ref == 'refs/heads/main'
         with:
-          status: ${{ job.status }}
-          channel: '#haystack'
-        if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+          payload: |
+            {
+              "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                  }
+                }
+              ]
+            }
 
 
 #
@@ -519,11 +767,30 @@ jobs:
       run: |
         pytest ${{ env.PYTEST_PARAMS }} -m "not elasticsearch and not faiss and not milvus and not weaviate and not pinecone and not integration and not unit" test/${{ matrix.folder }} --document_store_type=memory
 
-    - uses: act10ns/slack@v2
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
       with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   unit-tests-windows:
     needs: black
@@ -559,11 +826,30 @@ jobs:
       run: |
         pytest ${{ env.PYTEST_PARAMS }} -m "not elasticsearch and not faiss and not milvus and not weaviate and not pinecone and not integration and not unit" ${{ env.SUITES_EXCLUDED_FROM_WINDOWS }} test/${{ matrix.folder }} --document_store_type=memory
 
-    - uses: act10ns/slack@v2
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
       with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   integration-tests-linux:
     needs:
@@ -651,11 +937,30 @@ jobs:
       if: failure()
       uses: jwalton/gh-docker-logs@v1
 
-    - uses: act10ns/slack@v2
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
       with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   integration-tests-windows:
     needs:
@@ -705,11 +1010,30 @@ jobs:
       run: |
         pytest ${{ env.PYTEST_PARAMS }} -m "integration and not tika and not graphdb" ${{ env.SUITES_EXCLUDED_FROM_WINDOWS }} test/${{ matrix.folder }} --document_store_type=memory,faiss,elasticsearch
 
-    - uses: act10ns/slack@v2
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
       with:
-        status: ${{ job.status }}
-        channel: '#haystack'
-      if: failure() && github.repository_owner == 'deepset-ai' && github.ref == 'refs/heads/main'
+        payload: |
+          {
+            "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: Job ${{ env.GITHUB_JOB }} failed for ${{ github.ref_type }} ${{ github.ref_name }}",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Click *<https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|here>* for more details "
+                }
+              }
+            ]
+          }
 
   catch-all:
     name: Catch-all check


### PR DESCRIPTION
### Proposed Changes:

Use official Slack action to post job failures messages to Slack instead of previous one.

### How did you test it?

Can't be tested.

### Notes for the reviewer

I decided to remove the `pypi_release.yml` Slack notification since it's not easy to customize as of now. 
I might write a script to generate a dynamic one.

Also it would be great if first we could test it in `main`.