### PR TITLE
fix: fix `EvaluationResult.load` bug

### DIFF
--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -1508,8 +1508,6 @@ class EvaluationResult:
             "gold_answers_match",
             "gold_contexts_similarity",
             "offsets_in_document",
-            "document_ids",
-            "custom_document_ids",
             "gold_document_contents",
         ]
         converters = dict.fromkeys(cols_to_convert, ast.literal_eval)

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -1910,3 +1910,79 @@ def test_load_legacy_evaluation_result(tmp_path):
     assert "custom_document_id" not in eval_result["legacy"]
     assert "gold_document_contents" not in eval_result["legacy"]
     assert "content" not in eval_result["legacy"]
+
+
+def test_load_evaluation_result_w_empty_document_ids(tmp_path):
+    eval_result_csv = Path(tmp_path) / "Reader.csv"
+    with open(eval_result_csv, "w") as eval_result_csv:
+        columns = [
+            "multilabel_id",
+            "query",
+            "filters",
+            "gold_answers",
+            "answer",
+            "context",
+            "exact_match",
+            "f1",
+            "exact_match_context_scope",
+            "f1_context_scope",
+            "exact_match_document_id_scope",
+            "f1_document_id_scope",
+            "exact_match_document_id_and_context_scope",
+            "f1_document_id_and_context_scope",
+            "gold_contexts",
+            "rank",
+            "document_ids",
+            "gold_document_ids",
+            "offsets_in_document",
+            "gold_offsets_in_documents",
+            "offsets_in_context",
+            "gold_offsets_in_contexts",
+            "gold_answers_exact_match",
+            "gold_answers_f1",
+            "gold_documents_id_match",
+            "gold_contexts_similarity",
+            "type",
+            "node",
+            "eval_mode",
+            "index",
+        ]
+        writer = DictWriter(eval_result_csv, fieldnames=columns)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "multilabel_id": "ddc1562602f2d6d895b91e53f83e4c16",
+                "query": "who is written in the book of life",
+                "filters": "b'null'",
+                "gold_answers": "['every person who is destined for Heaven or the World to Come', 'all people considered righteous before God']",
+                "answer": None,
+                "context": None,
+                "exact_match": 0.0,
+                "f1": 0.0,
+                "exact_match_context_scope": 0.0,
+                "f1_context_scope": 0.0,
+                "exact_match_document_id_scope": 0.0,
+                "f1_document_id_scope": 0.0,
+                "exact_match_document_id_and_context_scope": 0.0,
+                "f1_document_id_and_context_scope": 0.0,
+                "gold_contexts": "['Book of Life - wikipedia Book of Life Jump to: navigation, search...']",
+                "rank": 1.0,
+                "document_ids": None,
+                "gold_document_ids": "['de2fd2f109e11213af1ea189fd1488a3-0', 'de2fd2f109e11213af1ea189fd1488a3-0']",
+                "offsets_in_document": "[{'start': 0, 'end': 0}]",
+                "gold_offsets_in_documents": "[{'start': 374, 'end': 434}, {'start': 1107, 'end': 1149}]",
+                "offsets_in_context": "[{'start': 0, 'end': 0}]",
+                "gold_offsets_in_contexts": "[{'start': 374, 'end': 434}, {'start': 1107, 'end': 1149}]",
+                "gold_answers_exact_match": "[0, 0]",
+                "gold_answers_f1": "[0, 0]",
+                "gold_documents_id_match": "[0.0, 0.0]",
+                "gold_contexts_similarity": "[0.0, 0.0]",
+                "type": "answer",
+                "node": "Reader",
+                "eval_mode": "integrated",
+            }
+        )
+
+    eval_result = EvaluationResult.load(tmp_path)
+    assert "Reader" in eval_result
+    assert len(eval_result) == 1


### PR DESCRIPTION
### Related Issues
- fixes #4411
- fixes https://github.com/deepset-ai/haystack-tutorials/issues/121

### Debugging:
- Since #4062, `document_ids` have replaced `document_id` in the `Answer` object.

- In the same PR, `document_ids` and `custom_document_ids` have been added to `cols_to_convert`.
(previously `document_id` was not in that list)
https://github.com/deepset-ai/haystack/blob/3272e2b9fec70ca769eb752b97f3ea284563fd7c/haystack/schema.py#L1511-L1518
When loading `EvaluationResult`, the columns in that list are converted using `ast.literal_eval` to fix corrupted CSVs (see #2854). 

- The reported error is raised by `ast.literal_eval` when encountering an empty string.

<details><summary> A CSV to reproduce the error (with an empty string in document_ids)</summary>"multilabel_id","query","filters","gold_answers","answer","context","exact_match","f1","exact_match_context_scope","f1_context_scope","exact_match_document_id_scope","f1_document_id_scope","exact_match_document_id_and_context_scope","f1_document_id_and_context_scope","gold_contexts","rank","document_ids","gold_document_ids","offsets_in_document","gold_offsets_in_documents","offsets_in_context","gold_offsets_in_contexts","gold_answers_exact_match","gold_answers_f1","gold_documents_id_match","gold_contexts_similarity","type","node","eval_mode","index"

"ddc1562602f2d6d895b91e53f83e4c16","who is written in the book of life","b'null'","['every person who is destined for Heaven or the World to Come', 'all people considered righteous before God']","","",0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,"['Book of Life - wikipedia Book of Life Jump to: navigation, search This article is about the book mentioned in Christian and Jewish religious teachings. For other uses, see The Book of Life. In Christianity and Judaism, the Book of Life (Hebrew: ספר החיים, transliterated Sefer HaChaim; Greek: βιβλίον τῆς ζωῆς Biblíon tēs Zōēs) is the book in which God records the names of every person who is destined for Heaven or the World to Come. According to the Talmud it is open on Rosh Hashanah, as is its analog for the wicked, the Book of the Dead. For this reason extra mention is made for the Book of Life during Amidah recitations during the Days of Awe, the ten days between Rosh Hashanah, the Jewish new year, and Yom Kippur, the day of atonement (the two High Holidays, particularly in the prayer Unetaneh Tokef). Contents (hide) 1 In the Hebrew Bible 2 Book of Jubilees 3 References in the New Testament 4 The eschatological or annual roll-call 5 Fundraising 6 See also 7 Notes 8 References In the Hebrew Bible(edit) In the Hebrew Bible the Book of Life - the book or muster-roll of God - records forever all people considered righteous before God', 'Book of Life - wikipedia Book of Life Jump to: navigation, search This article is about the book mentioned in Christian and Jewish religious teachings. For other uses, see The Book of Life. In Christianity and Judaism, the Book of Life (Hebrew: ספר החיים, transliterated Sefer HaChaim; Greek: βιβλίον τῆς ζωῆς Biblíon tēs Zōēs) is the book in which God records the names of every person who is destined for Heaven or the World to Come. According to the Talmud it is open on Rosh Hashanah, as is its analog for the wicked, the Book of the Dead. For this reason extra mention is made for the Book of Life during Amidah recitations during the Days of Awe, the ten days between Rosh Hashanah, the Jewish new year, and Yom Kippur, the day of atonement (the two High Holidays, particularly in the prayer Unetaneh Tokef). Contents (hide) 1 In the Hebrew Bible 2 Book of Jubilees 3 References in the New Testament 4 The eschatological or annual roll-call 5 Fundraising 6 See also 7 Notes 8 References In the Hebrew Bible(edit) In the Hebrew Bible the Book of Life - the book or muster-roll of God - records forever all people considered righteous before God']",1.0,"","['de2fd2f109e11213af1ea189fd1488a3-0', 'de2fd2f109e11213af1ea189fd1488a3-0']","[{'start': 0, 'end': 0}]","[{'start': 374, 'end': 434}, {'start': 1107, 'end': 1149}]","[{'start': 0, 'end': 0}]","[{'start': 374, 'end': 434}, {'start': 1107, 'end': 1149}]","[0, 0]","[0, 0]","[0.0, 0.0]","[0.0, 0.0]","answer","Reader","integrated",0</details>

### Proposed changes:
I simply removed `document_ids` and `custom_document_ids` from the converted columns,
as it was in Haystack 1.13.0, which is properly working.

### How did you test it?
- CI
- new test about loading a CSV with empty `document_ids` string

### Notes for the reviewer
The issue is a bit intricate, so maybe I missed some important points.
I think @tstadel can help shed some light on this problem.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [X] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
