### PR TITLE
fix: Fix debug on PromptNode

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -420,6 +420,7 @@ class PromptNode(BaseComponent):
         devices: Optional[List[Union[str, torch.device]]] = None,
         stop_words: Optional[List[str]] = None,
         top_k: int = 1,
+        debug: Optional[bool] = False,
         model_kwargs: Optional[Dict] = None,
     ):
         """
@@ -452,6 +453,8 @@ class PromptNode(BaseComponent):
         self.prompt_model: PromptModel
         self.stop_words: Optional[List[str]] = stop_words
         self.top_k: int = top_k
+        self.debug = debug
+        
         if isinstance(self.default_prompt_template, str) and not self.is_supported_template(
             self.default_prompt_template
         ):
@@ -653,6 +656,9 @@ class PromptNode(BaseComponent):
         # prompt_collector is an empty list, it's passed to the PromptNode that will fill it with the rendered prompts,
         # so that they can be returned by `run()` as part of the pipeline's debug output.
         prompt_collector: List[str] = []
+            
+        if self.debug is None:
+            self.debug = False
 
         invocation_context = invocation_context or {}
         if query and "query" not in invocation_context.keys():
@@ -684,8 +690,11 @@ class PromptNode(BaseComponent):
         final_result: Dict[str, Any] = {
             self.output_variable: results,
             "invocation_context": invocation_context,
-            "_debug": {"prompts_used": prompt_collector},
         }
+
+        if self.debug == True:
+            final_result["_debug"] = {"prompts_used": prompt_collector}
+
         return final_result, "output_1"
 
     def run_batch(  # type: ignore

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -454,7 +454,7 @@ class PromptNode(BaseComponent):
         self.stop_words: Optional[List[str]] = stop_words
         self.top_k: int = top_k
         self.debug = debug
-        
+
         if isinstance(self.default_prompt_template, str) and not self.is_supported_template(
             self.default_prompt_template
         ):
@@ -656,9 +656,6 @@ class PromptNode(BaseComponent):
         # prompt_collector is an empty list, it's passed to the PromptNode that will fill it with the rendered prompts,
         # so that they can be returned by `run()` as part of the pipeline's debug output.
         prompt_collector: List[str] = []
-            
-        if self.debug is None:
-            self.debug = False
 
         invocation_context = invocation_context or {}
         if query and "query" not in invocation_context.keys():
@@ -687,12 +684,9 @@ class PromptNode(BaseComponent):
         results = self(prompt_collector=prompt_collector, **invocation_context)
 
         invocation_context[self.output_variable] = results
-        final_result: Dict[str, Any] = {
-            self.output_variable: results,
-            "invocation_context": invocation_context,
-        }
+        final_result: Dict[str, Any] = {self.output_variable: results, "invocation_context": invocation_context}
 
-        if self.debug == True:
+        if self.debug:
             final_result["_debug"] = {"prompts_used": prompt_collector}
 
         return final_result, "output_1"


### PR DESCRIPTION
Allow the ability to control debug output on PromptNode

### Related Issues
- fixes #4477 

### Proposed Changes:
 Debug was implicit in PromptNode.  Made it only output if you define either `debug: true` as global on the pipeline, or in `params` for the PromptNode

### How did you test it?
Made a punt at the code, then tested all the possible variations of global and specific debug settings against PromptNode and the pipeline.

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [X] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
