### PR TITLE
bug: Exclude rdflib 6.3.2 because of license issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,11 @@ pinecone = [
 ]
 graphdb = [
   "SPARQLWrapper",
+  "rdflib!=6.3.2", # GPL-2.0-only license issue
 ]
 inmemorygraph = [
   "SPARQLWrapper",
+  "rdflib!=6.3.2", # GPL-2.0-only license issue
 ]
 opensearch = [
   "opensearch-py>=2",


### PR DESCRIPTION
### Related Issues
- fossa license check fails with `⚑ GPL-2.0-only license detected in rdflib@6.3.2` [here](https://github.com/deepset-ai/haystack/actions/runs/4526970233/jobs/7976623026)

### Proposed Changes:
- Exclude rdflib 6.3.2

### How did you test it?
CI tests on https://github.com/deepset-ai/haystack/pull/4437

### Notes for the reviewer
We will deprecate KnowledgeGraph features so let's save some time and not spend much time on investigating this issue.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
