### PR TITLE
ci: remove telemetry env var

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ on:
       - "!rest_api/**/*.py"
 
 env:
-  HAYSTACK_TELEMETRY_VERSION: "0"  # Disables telemetry
   PYTEST_PARAMS: --maxfail=5 --durations=10 --suppress-no-test-exit-code
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   SUITES_EXCLUDED_FROM_WINDOWS:


### PR DESCRIPTION
### Related Issues
- fixes #issue-number

### Proposed Changes:
- removes `HAYSTACK_TELEMETRY_VERSION` from CI, is not needed anymore. PostHog is disabled anyway in `test/conftest.py` (https://github.com/deepset-ai/haystack/blob/45ce87bb482e33b9b6cf07159b4f85afc94bb34e/test/conftest.py#L91)

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
