### PR TITLE
refactor: Mark MilvusDocumentStore as deprecated

### DIFF
--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -16,7 +16,7 @@ except (ImportError, ModuleNotFoundError) as ie:
     _optional_component_not_installed(__name__, "milvus2", ie)
 
 from haystack.schema import Document, FilterType
-from haystack.document_stores.sql import SQLDocumentStore
+from haystack.document_stores import SQLDocumentStore
 from haystack.document_stores.base import get_batches_from_generator
 from haystack.nodes.retriever import DenseRetriever
 

--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -128,6 +128,11 @@ class MilvusDocumentStore(SQLDocumentStore):
             lost if you choose to recreate the index. Be aware that both the document_index and the label_index will
             be recreated.
         """
+        warnings.warn(
+            "The MilvusDocumentStore node is deprecated and will be removed in future versions.",
+            category=DeprecationWarning,
+        )
+
         super().__init__(
             url=sql_url, index=index, duplicate_documents=duplicate_documents, isolation_level=isolation_level
         )

--- a/test/document_stores/test_milvus.py
+++ b/test/document_stores/test_milvus.py
@@ -1,9 +1,12 @@
 import pytest
 import numpy as np
+from unittest.mock import patch, DEFAULT
 
 from haystack.document_stores.milvus import MilvusDocumentStore
 from haystack.schema import Document
 from haystack.testing import DocumentStoreBaseTestAbstract
+
+from ..conftest import fail_at_version
 
 
 class TestMilvusDocumentStore(DocumentStoreBaseTestAbstract):
@@ -46,6 +49,23 @@ class TestMilvusDocumentStore(DocumentStoreBaseTestAbstract):
             )
 
         return documents
+
+    @pytest.mark.unit
+    @fail_at_version(1, 17)
+    def test_deprecation_warning(self):
+        with patch.multiple(
+            "haystack.document_stores.milvus",
+            SQLDocumentStore=DEFAULT,
+            FieldSchema=DEFAULT,
+            CollectionSchema=DEFAULT,
+            Collection=DEFAULT,
+            connections=DEFAULT,
+            utility=DEFAULT,
+            QueryResult=DEFAULT,
+            DataType=DEFAULT,
+        ):
+            with pytest.warns(DeprecationWarning):
+                MilvusDocumentStore()
 
     @pytest.mark.integration
     def test_delete_index(self, ds, documents):


### PR DESCRIPTION
### Proposed Changes:

Marks `MilvusDocumentStore` as deprecated.

### How did you test it?

Ran `pytest -m "unit" test/document_stores/test_milvus.py`.

### Notes for the reviewer

N/A
