### PR TITLE
refactor: Remove ElasticsearchRetriever and ElasticsearchFilterOnlyRetriever

### DIFF
--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -38,7 +38,6 @@ from haystack.nodes.retriever import (
     BM25Retriever,
     FilterRetriever,
     MultihopEmbeddingRetriever,
-    ElasticsearchFilterOnlyRetriever,
     TfidfRetriever,
     Text2SparqlRetriever,
     TableTextRetriever,

--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -36,7 +36,6 @@ from haystack.nodes.retriever import (
     DensePassageRetriever,
     EmbeddingRetriever,
     BM25Retriever,
-    ElasticsearchRetriever,
     FilterRetriever,
     MultihopEmbeddingRetriever,
     ElasticsearchFilterOnlyRetriever,

--- a/haystack/nodes/retriever/__init__.py
+++ b/haystack/nodes/retriever/__init__.py
@@ -10,7 +10,6 @@ from haystack.nodes.retriever.multimodal import MultiModalRetriever
 from haystack.nodes.retriever.sparse import (
     BM25Retriever,
     ElasticsearchFilterOnlyRetriever,
-    ElasticsearchRetriever,
     FilterRetriever,
     TfidfRetriever,
 )

--- a/haystack/nodes/retriever/__init__.py
+++ b/haystack/nodes/retriever/__init__.py
@@ -7,10 +7,5 @@ from haystack.nodes.retriever.dense import (
     TableTextRetriever,
 )
 from haystack.nodes.retriever.multimodal import MultiModalRetriever
-from haystack.nodes.retriever.sparse import (
-    BM25Retriever,
-    ElasticsearchFilterOnlyRetriever,
-    FilterRetriever,
-    TfidfRetriever,
-)
+from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
 from haystack.nodes.retriever.text2sparql import Text2SparqlRetriever

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -366,18 +366,6 @@ class BM25Retriever(BaseRetriever):
         return documents
 
 
-class ElasticsearchRetriever(BM25Retriever):
-    def __init__(
-        self,
-        document_store: Optional[KeywordDocumentStore] = None,
-        top_k: int = 10,
-        all_terms_must_match: bool = False,
-        custom_query: Optional[str] = None,
-    ):
-        logger.warn("This class is now deprecated. Please use the BM25Retriever instead")
-        super().__init__(document_store, top_k, all_terms_must_match, custom_query)
-
-
 class FilterRetriever(BM25Retriever):
     """
     Naive "Retriever" that returns all documents that match the given filters. No impact of query at all.

--- a/haystack/nodes/retriever/sparse.py
+++ b/haystack/nodes/retriever/sparse.py
@@ -408,18 +408,6 @@ class FilterRetriever(BM25Retriever):
         return documents
 
 
-class ElasticsearchFilterOnlyRetriever(FilterRetriever):
-    def __init__(
-        self,
-        document_store: Optional[KeywordDocumentStore] = None,
-        top_k: int = 10,
-        all_terms_must_match: bool = False,
-        custom_query: Optional[str] = None,
-    ):
-        logger.warn("This class is now deprecated. Please use the FilterRetriever instead")
-        super().__init__(document_store, top_k, all_terms_must_match, custom_query)
-
-
 # TODO make Paragraph generic for configurable units of text eg, pages, paragraphs, or split by a char_limit
 Paragraph = namedtuple("Paragraph", ["paragraph_id", "document_id", "content", "meta"])
 

--- a/haystack/pipelines/ray.py
+++ b/haystack/pipelines/ray.py
@@ -242,8 +242,8 @@ class RayPipeline(Pipeline):
                        from Python: https://docs.ray.io/en/main/serve/package-ref.html#servehandle-api.
         :param name: The name for the node. It must not contain any dots.
         :param inputs: A list of inputs to the node. If the predecessor node has a single outgoing edge, just the name
-                       of node is sufficient. For instance, a 'ElasticsearchRetriever' node would always output a single
-                       edge with a list of documents. It can be represented as ["ElasticsearchRetriever"].
+                       of node is sufficient. For instance, a 'FilterRetriever' node would always output a single
+                       edge with a list of documents. It can be represented as ["FilterRetriever"].
 
                        In cases when the predecessor node has multiple outputs, e.g., a "QueryClassifier", the output
                        must be specified explicitly as "QueryClassifier.output_2".


### PR DESCRIPTION
### Proposed Changes:

Remove deprecated `ElasticsearchRetriever` and `ElasticsearchFilterOnlyRetriever`.

### How did you test it?

Didn't.

### Notes for the reviewer

N/A
