### PR TITLE
refactor: Deprecate BaseKnowledgeGraph and InMemoryKnowledgeGraph

### DIFF
--- a/haystack/document_stores/base.py
+++ b/haystack/document_stores/base.py
@@ -2,6 +2,7 @@
 
 from typing import Generator, Optional, Dict, List, Set, Union, Any
 
+import warnings
 import logging
 import collections
 from pathlib import Path
@@ -39,6 +40,13 @@ class BaseKnowledgeGraph(BaseComponent):
     """
     Base class for implementing Knowledge Graphs.
     """
+
+    def __init__(self):
+        warnings.warn(
+            "The BaseKnowledgeGraph component is deprecated and will be removed in future versions.",
+            category=DeprecationWarning,
+        )
+        super().__init__()
 
     outgoing_edges = 1
 

--- a/haystack/document_stores/memory_knowledgegraph.py
+++ b/haystack/document_stores/memory_knowledgegraph.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional
 
+import warnings
 import logging
 from collections import defaultdict
 from pathlib import Path
@@ -22,6 +23,10 @@ class InMemoryKnowledgeGraph(BaseKnowledgeGraph):
 
         :param index: name of the index
         """
+        warnings.warn(
+            "The InMemoryKnowledgeGraph component is deprecated and will be removed in future versions.",
+            category=DeprecationWarning,
+        )
         super().__init__()
 
         self.indexes: Dict[str, Graph] = defaultdict(dict)  # type: ignore [arg-type]

--- a/test/document_stores/test_graphdb.py
+++ b/test/document_stores/test_graphdb.py
@@ -1,0 +1,18 @@
+import pytest
+
+from haystack.document_stores.graphdb import GraphDBKnowledgeGraph
+
+from ..conftest import fail_at_version
+
+
+@pytest.mark.unit
+@fail_at_version(1, 17)
+def test_graphdb_knowledge_graph_deprecation_warning():
+    with pytest.warns(DeprecationWarning) as w:
+        GraphDBKnowledgeGraph()
+
+        assert len(w) == 1
+        assert (
+            w[0].message.args[0]
+            == "The BaseKnowledgeGraph component is deprecated and will be removed in future versions."
+        )

--- a/test/document_stores/test_memory_knowledgegraph.py
+++ b/test/document_stores/test_memory_knowledgegraph.py
@@ -1,0 +1,22 @@
+import pytest
+
+from haystack.document_stores.memory_knowledgegraph import InMemoryKnowledgeGraph
+
+from ..conftest import fail_at_version
+
+
+@pytest.mark.unit
+@fail_at_version(1, 17)
+def test_in_memory_knowledge_graph_deprecation_warning():
+    with pytest.warns(DeprecationWarning) as w:
+        InMemoryKnowledgeGraph()
+
+        assert len(w) == 2
+        assert (
+            w[0].message.args[0]
+            == "The InMemoryKnowledgeGraph component is deprecated and will be removed in future versions."
+        )
+        assert (
+            w[1].message.args[0]
+            == "The BaseKnowledgeGraph component is deprecated and will be removed in future versions."
+        )


### PR DESCRIPTION
### Proposed Changes:

Marks for deprecation `BaseKnowledgeGraph` and `InMemoryKnowledgeGraph`.

### How did you test it?

Ran `pytest test/document_stores/test_graphdb.py  test/document_stores/test_memory_knowledgegraph.py`.

### Notes for the reviewer

I didn't mark `GraphDBKnowledgeGraph` as deprecated even if it inheriths from `BaseKnowledgeGraph` since we didn't talk about deprecating that too.

`Text2SparqlRetriever` takes a `BaseKnowledgeGraph` as init argument, we should that into consideration.