### PR TITLE
chore: wire up `AnswerParser`

### DIFF
--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -25,7 +25,14 @@ from haystack.nodes.image_to_text import TransformersImageToText
 from haystack.nodes.label_generator import PseudoLabelGenerator
 from haystack.nodes.other import Docs2Answers, JoinDocuments, RouteDocuments, JoinAnswers, DocumentMerger, Shaper
 from haystack.nodes.preprocessor import BasePreProcessor, PreProcessor
-from haystack.nodes.prompt import PromptNode, PromptTemplate, PromptModel, PromptModelInvocationLayer
+from haystack.nodes.prompt import (
+    PromptNode,
+    PromptTemplate,
+    PromptModel,
+    PromptModelInvocationLayer,
+    BaseOutputParser,
+    AnswerParser,
+)
 from haystack.nodes.query_classifier import SklearnQueryClassifier, TransformersQueryClassifier
 from haystack.nodes.question_generator import QuestionGenerator
 from haystack.nodes.ranker import BaseRanker, SentenceTransformersRanker

--- a/haystack/nodes/prompt/__init__.py
+++ b/haystack/nodes/prompt/__init__.py
@@ -1,2 +1,2 @@
-from haystack.nodes.prompt.prompt_node import PromptNode, PromptTemplate, PromptModel
+from haystack.nodes.prompt.prompt_node import PromptNode, PromptTemplate, PromptModel, BaseOutputParser, AnswerParser
 from haystack.nodes.prompt.providers import PromptModelInvocationLayer


### PR DESCRIPTION
### Related Issues
- fixes `from haystack.nodes import AnswerParser` raises
- fixes `from haystack.nodes.prompt import AnswerParser` raises

### Proposed Changes:
- correct imports wiring up `AnswerParser`

### How did you test it?
- run `from haystack.nodes import AnswerParser`

### Notes for the reviewer
- it was already possible to load `AnswerParser` via `from haystack.nodes.prompt.prompt_node import AnswerParser` 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
