### PR TITLE
test: disable posthog in rest api tests

### DIFF
--- a/rest_api/test/test_rest_api.py
+++ b/rest_api/test/test_rest_api.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 import pytest
 from fastapi.testclient import TestClient
+import posthog
 from haystack import Document, Answer, Pipeline
 import haystack
 from haystack.nodes import BaseReader, BaseRetriever
@@ -23,6 +24,8 @@ from haystack.nodes.file_converter import BaseConverter
 from rest_api.pipeline import _load_pipeline
 from rest_api.utils import get_app
 
+# Disable telemetry reports when running tests
+posthog.disabled = True
 
 TEST_QUERY = "Who made the PDF specification?"
 


### PR DESCRIPTION
### Proposed Changes:
- disables telemetry in rest api tests

### How did you test it?
- ci & posthog dashboard

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
