### PR TITLE
fix: Fix pipeline config and agent tools hashing for telemetry

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -191,7 +191,8 @@ class Agent:
         See haystack/telemetry.py::send_event
         """
         try:
-            self.hash = md5(" ".join([tool.pipeline_or_node.__class__.__name__ for tool in self.tools.values()]))
+            tool_names = " ".join([tool.pipeline_or_node.__class__.__name__ for tool in self.tools.values()])
+            self.hash = md5(tool_names.encode()).hexdigest()
         except Exception as exc:
             logger.debug("Telemetry exception: %s", str(exc))
             self.hash = "[an exception occurred during hashing]"

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -438,7 +438,7 @@ class Pipeline:
             for comp in config_to_hash["components"]:
                 del comp["name"]
             config_hash = json.dumps(config_to_hash, default=str)
-            self.config_hash = md5(config_hash)
+            self.config_hash = md5(config_hash.encode()).hexdigest()
         except Exception as exc:
             logger.debug("Telemetry exception: %s", str(exc))
             self.config_hash = "[an exception occurred during hashing]"

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -2,7 +2,6 @@ import ssl
 import json
 import platform
 import sys
-import datetime
 from typing import Tuple
 from copy import deepcopy
 from unittest import mock
@@ -2048,3 +2047,31 @@ def test_fix_to_pipeline_execution_when_join_follows_join():
     res = pipeline.run(query="Alpha Beta Gamma Delta")
     documents = res["documents"]
     assert len(documents) == 4  # all four documents should be found
+
+
+@pytest.mark.unit
+def test_update_config_hash():
+    fake_configs = {
+        "version": "ignore",
+        "components": [
+            {
+                "name": "MyReader",
+                "type": "FARMReader",
+                "params": {"no_ans_boost": -10, "model_name_or_path": "deepset/roberta-base-squad2"},
+            }
+        ],
+        "pipelines": [
+            {
+                "name": "my_query_pipeline",
+                "nodes": [
+                    {"name": "MyRetriever", "inputs": ["Query"]},
+                    {"name": "MyReader", "inputs": ["MyRetriever"]},
+                ],
+            }
+        ],
+    }
+    with mock.patch("haystack.pipelines.base.Pipeline.get_config", return_value=fake_configs):
+        test_pipeline = Pipeline()
+        assert test_pipeline.config_hash == None
+        test_pipeline.update_config_hash()
+        assert test_pipeline.config_hash == "a30d3273de0d70e63e8cd91d915255b3"


### PR DESCRIPTION
### Proposed Changes:

Fix pipeline configs and agents tools hashing for telemetry. This is causing telemetry data to not be collected correctly. 

### How did you test it?

I ran `pytest test/agents/test_agent.py::test_update_hash test/pipelines/test_pipeline.py::test_update_config_hash`.

### Notes for the reviewer

Example of telemetry pushed to PostHog with failing hashing.

<img width="1414" alt="Screenshot 2023-03-27 at 22 31 21" src="https://user-images.githubusercontent.com/3314350/228060036-09398822-8b08-4df6-aad8-e4a91fd49624.png">
