### PR TITLE
refactor: Adjust WhisperTranscriber to pipeline run methods

### DIFF
--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -201,4 +201,9 @@ class WhisperTranscriber(BaseComponent):
         :param params: Ignored
         :param debug: Ignored
         """
+        if isinstance(file_paths[0], list):
+            all_files = []
+            for files_list in file_paths:
+                all_files += files_list
+            return self.run(file_paths=all_files)
         return self.run(file_paths=file_paths)

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -170,14 +170,14 @@ class WhisperTranscriber(BaseComponent):
         :param documents: Ignored
         :param meta: Ignored
         """
-        documents: List[Document] = []
+        transcribed_documents: List[Document] = []
         if file_paths:
             for file_path in file_paths:
                 transcription = self.transcribe(file_path)
                 d = Document.from_dict(transcription, field_map={"text": "content"})
-                documents.append(d)
+                transcribed_documents.append(d)
 
-        output = {"documents": documents}
+        output = {"documents": transcribed_documents}
         return output, "output_1"
 
     def run_batch(
@@ -201,7 +201,7 @@ class WhisperTranscriber(BaseComponent):
         :param params: Ignored
         :param debug: Ignored
         """
-        if isinstance(file_paths[0], list):
+        if file_paths and isinstance(file_paths[0], list):
             all_files = []
             for files_list in file_paths:
                 all_files += files_list


### PR DESCRIPTION
### Related Issues
- no related issue, discovered this usability flow during documentation writing

### Proposed Changes:
 Adjust WhisperTranscriber to run method signature. Use file_paths as input parameter

### How did you test it?
Made a [colab](https://colab.research.google.com/drive/1FEy0fhRzMAaHWJ5famSF2S9chkzglkvU?usp=sharing)
Added a unit test

### Notes for the reviewer
What should we do with other params?

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
