### PR TITLE
ci: Fix docker release process after PyPi release

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,13 +1,12 @@
 name: Docker image release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_run:
-    workflows: [Project release on PyPi]
-    types:
-      - completed
+    tags:
+      - "v[0-9].[0-9]+.[0-9]+*"
 
 env:
   DOCKER_REPO_NAME: deepset/haystack
@@ -15,8 +14,6 @@ env:
 jobs:
   build-and-push:
     name: Build ${{ matrix.target }} image for ${{ matrix.platform }}
-    # We need this to run only when we're merging in main or the PyPi release was successful
-    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,4 +1,3 @@
-# If you change this name also do it in docker_release.yml
 name: Project release on PyPi
 
 on:


### PR DESCRIPTION
### Proposed Changes:

Revert the changes from #4293.

The release process is broken as of now since the `docker/metadata-action` can't pick up the version from the tag ref since we're triggering the release process with a `workflow_run`. If we use that trigger the ref will always be `main`.

This is a quick fix, in the future we should find a better solution to keep using `workflow_run`.

### How did you test it?

Can't be tested.

### Notes for the reviewer

This must be included in `1.15.0` otherwise we won't be able to release version tagged images.
