### PR TITLE
chore: show warning on old prompt syntax

### DIFF
--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -1400,6 +1400,21 @@ class TestPromptTemplateSyntax:
         prompts = [prompt for prompt in prompt_template.fill(documents=documents, query=query)]
         assert prompts == expected_prompts
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "prompt_text, expected",
+        [
+            ("Please answer the question. Context: $documents; Question: $question; Answer:", True),
+            ("Please answer the question. Context: {documents}; Question: {question}; Answer:", False),
+            (
+                "Please answer the question. Context: {join(documents, pattern='$idx $content')}; Question: {question}; Answer:",
+                False,
+            ),
+        ],
+    )
+    def test_prompt_template_old_syntax_detection(self, prompt_text: str, expected: bool):
+        assert PromptTemplate._detect_old_syntax(prompt_text=prompt_text) == expected
+
 
 @pytest.mark.integration
 def test_chatgpt_direct_prompting(chatgpt_prompt_model):


### PR DESCRIPTION
### Related Issues
- fixes #issue-number

### Proposed Changes:
- show warning if we detect that old PromptTemplate syntax is being used and point the user to the migration guide.

### How did you test it?
- added unit test

### Notes for the reviewer
- the logic is not perfect, e.g. using any `{` would prevent us from showing the warning. We should still tackle most of the cases with this. And writing a proper detection logic is expensive due to the `{`-nesting.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
