### PR TITLE
fix: add back `tutorial_running()`

### DIFF
--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -101,6 +101,14 @@ class Telemetry:
             logger.debug("Telemetry couldn't make a POST request to PostHog.", exc_info=e)
 
 
+def tutorial_running(tutorial_id: int):
+    """
+    Can be called when a tutorial is executed so that the tutorial_id is used to identify the tutorial and send an event.
+    :param tutorial_id: ID number of the tutorial
+    """
+    send_event(event_name="Tutorial", event_properties={"tutorial.id": tutorial_id})
+
+
 def send_pipeline_event(  # type: ignore
     pipeline: "Pipeline",  # type: ignore
     query: Optional[str] = None,


### PR DESCRIPTION
### Proposed Changes:
- This function got accidentally removed with the telemetry changes. This PR adds it back.
- Original PR https://github.com/deepset-ai/haystack/pull/4155

### How did you test it?
n/a

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
