### PR TITLE
ci: Fix docker images testing

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Test base image
         run: |
           EXPECTED_VERSION=$(cat VERSION.txt)
+          if [[ $EXPECTED_VERSION == *"-"* ]]; then
+            EXPECTED_VERSION=$(cut -d '-' -f 1 < VERSION.txt)$(cut -d '-' -f 2 < VERSION.txt)
+          fi
           TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
 
           PLATFORM="linux/amd64"


### PR DESCRIPTION
### Proposed Changes:

Change how the testing of the base Docker images is done to handle RCs.

### How did you test it?

I ran the changed snippet locally.

### Notes for the reviewer

We recently changed the format of the version stored in `VERSION.txt` to be semver compliant, though the one returned from `import haystack; haystack.__version__` is formatted differently cause that's set using the `importlib` package.

This is a temporary fix to unlock `1.15.0` release process, in the future I plan to change how the version is retrieved so that it's set directly in `__version__` and scrap the `VERSION.txt` file.


