### PR TITLE
ci: Use bigger runner for Docker release

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-and-push:
     name: Build ${{ matrix.target }} images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     strategy:
       matrix:
         target:


### PR DESCRIPTION
Docker release is continuously failing because there's not enough space left in the error.
This PR changes the runner used to one with more disk space.

Example failure:
https://github.com/deepset-ai/haystack/actions/runs/4552883576
