### PR TITLE
feat: Change default save_dir for FARMReader.train

### DIFF
--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -229,7 +229,7 @@ class FARMReader(BaseReader):
         devices, n_gpu = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)  # type: ignore [arg-type]
 
         if not save_dir:
-            save_dir = f"../../saved_models/{self.inferencer.model.language_model.name}"
+            save_dir = f"./saved_models/{self.inferencer.model.language_model.name}"
             if tinybert:
                 save_dir += "_tinybert_stage_1"
 


### PR DESCRIPTION
### Related Issues
- fixes #2836

### Proposed Changes:
 <!--- In case of a feature: Describe what did you add and how it works -->
 Followed [kalki7](https://github.com/kalki7) proposal for the fix by changing save_dir path.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested the farm reader with the new changes based on this tutorial 👉 [Tutorial: Build Your First Question Answering System](https://haystack.deepset.ai/tutorials/01_basic_qa_pipeline)

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
