### PR TITLE
fix: ParsrConverter list element added

### DIFF
--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -173,7 +173,7 @@ class ParsrConverter(BaseConverter):
             headlines = []
             for page_idx, page in enumerate(parsr_output["pages"]):
                 for elem_idx, element in enumerate(page["elements"]):
-                    if element["type"] in ["paragraph", "heading", "table-of-contents"]:
+                    if element["type"] in ["paragraph", "heading", "table-of-contents", "list"]:
                         current_paragraph = self._convert_text_element(element)
                         if current_paragraph:
                             if element["type"] == "heading" and extract_headlines:
@@ -242,6 +242,10 @@ class ParsrConverter(BaseConverter):
             else:
                 current_paragraph = "\n".join([self._get_paragraph_string(elem) for elem in element["content"]])
                 return current_paragraph
+
+        if element["type"] == "list":
+            current_paragraph = "\n".join([self._get_paragraph_string(elem) for elem in element["content"]])
+            return current_paragraph
 
         current_paragraph = self._get_paragraph_string(element)
         return current_paragraph

--- a/test/nodes/test_file_converter.py
+++ b/test/nodes/test_file_converter.py
@@ -396,6 +396,19 @@ def test_parsr_converter_headline_extraction():
                 assert extracted_headline["headline"] == doc.content[start_idx : start_idx + hl_len]
 
 
+@pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Parsr not running on Windows CI")
+def test_parsr_converter_list_mapping():
+    # This exact line(without line break characters) only exists in the list object we want to make sure it's being mapped correctly
+    expected_list_line = "Maecenas tincidunt est efficitur ligula euismod, sit amet ornare est vulputate."
+
+    converter = ParsrConverter()
+
+    docs = converter.convert(file_path=str((SAMPLES_PATH / "pdf" / "sample_pdf_4.pdf").absolute()))
+    assert len(docs) == 2
+    assert docs[1].content_type == "text"
+    assert expected_list_line in docs[1].content
+
+
 @pytest.mark.unit
 def test_id_hash_keys_from_pipeline_params():
     doc_path = SAMPLES_PATH / "docs" / "doc_1.txt"


### PR DESCRIPTION
This PR tackles the following issue [https://github.com/deepset-ai/haystack/issues/4156](https://github.com/deepset-ai/haystack/issues/4156) in the context of the Community Sprint.

### Related Issues
- fixes #4156 

### Proposed Changes:
As the issuer reported, ParsrConverter is not mapping currently the elements of type "_list_" that the Parsr document holds. I've added this type to ParsrConverter's logic and, considering each member of this list seems to be of type "_paragraph_", the text of each is appended in the same style as similar paragraph content is. 

### How did you test it?
Initially I did a small test using "_sample_pdf_4.pdf_" available at _test/samples/pdf_ in the following style:
`from haystack.nodes import ParsrConverter
converter = ParsrConverter()
converter.convert("test/samples/pdf/sample_pdf_4.pdf")`
where I confirmed the bug (the 7 item bullet list was not present in the resulting Haystack documents) and later, confirmed the fix was okay.

I also added a really simple unit test using this same sample pdf where it asserts that a specific sentence appears in the resulting "_text_" document without any break line escape characters. (the same sentence is present in a paragraph later in the pdf, but it is contains a break lin escape character). Feel free to suggest a better assert strategy.

### Notes for the reviewer

### Checklist
- [x ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x ] I have updated the related issue with new insights and changes
- [x ] I added tests that demonstrate the correct behavior of the change
- [x ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
