### PR TITLE
ci: Checkout correct ref in docstring-labeler.yml

### DIFF
--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Checkout HEAD commit
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Get docstrings
         id: head-docstrings


### PR DESCRIPTION
### Proposed Changes:

 Fix `docstring-labeler.yml` not checking out expected ref.

### How did you test it?

I tested in a separate repository that the expected refs are returned.
Example run: https://github.com/silvanocerza/nodenode/actions/runs/4566569246/jobs/8059255308

### Notes for the reviewer

N/A
