### PR TITLE
test: Remove duplicate whisper test

### DIFF
--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -82,7 +82,8 @@ class WhisperTranscriber(BaseComponent):
 
         :param audio_file: Path to audio file or a binary file-like object.
         :param language: Language of the audio file. If None, the language is automatically detected.
-        :param return_segments: If True, returns the transcription for each segment of the audio file.
+        :param return_segments: If True, returns the transcription for each segment of the audio file. Supported with
+        local installation of whisper only.
         :param translate: If True, translates the transcription to English.
 
         """

--- a/test/nodes/test_whisper.py
+++ b/test/nodes/test_whisper.py
@@ -16,14 +16,6 @@ def test_whisper_api_transcribe():
     assert "segments" not in audio_object_transcript and "segments" not in audio_path_transcript
 
 
-@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OpenAI API key not found")
-@pytest.mark.integration
-def test_whisper_api_transcribe_with_params():
-    w = WhisperTranscriber(api_key=os.environ.get("OPENAI_API_KEY"))
-    audio_object_transcript, audio_path_transcript = transcribe_test_helper(w)
-    assert "segments" not in audio_object_transcript and "segments" not in audio_path_transcript
-
-
 @pytest.mark.skip("Fails on CI cause it fills up memory")
 @pytest.mark.integration
 @pytest.mark.skipif(not is_whisper_available(), reason="Whisper is not installed")


### PR DESCRIPTION
### Related Issues
- fixes #4540 

### Proposed Changes:
- Removed duplicate test
- Mentioned in docstring that local installation of whisper supports a parameter that the API doesn't support

### How did you test it?
-

### Notes for the reviewer
The local installation of whisper and and the API do not support the same parameters. That's why the tests for both are also not the exact same.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue