### PR TITLE
test: Skip flaky prompt node integration test

### DIFF
--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -532,6 +532,7 @@ def test_pipeline_with_prompt_text_at_query_time(prompt_model):
     )
 
 
+@pytest.mark.skip
 @pytest.mark.integration
 @pytest.mark.parametrize("prompt_model", ["openai", "azure"], indirect=True)
 def test_pipeline_with_prompt_template_at_query_time(prompt_model):


### PR DESCRIPTION
### Proposed Changes:

Skip `test_pipeline_with_prompt_template_at_query_time` for the time being as it's failing a TON in CI. 

This is meant to be temporary as I plan to change most of those integration tests into unit ones.

### How did you test it?

Nothing to test really.

### Notes for the reviewer

Related to #4561