### PR TITLE
refactor: remove variadic parameters in `WebSearch` initialization; make new nodes directly importable

### DIFF
--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -49,11 +49,17 @@ from haystack.nodes.retriever import (
     Text2SparqlRetriever,
     TableTextRetriever,
     MultiModalRetriever,
+    WebRetriever,
 )
 
 from haystack.nodes.sampler import BaseSampler, TopPSampler
+from haystack.nodes.search_engine import SearchEngine, WebSearch
 from haystack.nodes.summarizer import BaseSummarizer, TransformersSummarizer
 from haystack.nodes.translator import BaseTranslator, TransformersTranslator
+from haystack.nodes.doc_language_classifier import (
+    LangdetectDocumentLanguageClassifier,
+    TransformersDocumentLanguageClassifier,
+)
 
 from haystack.nodes.audio import WhisperTranscriber, WhisperModel
 

--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -53,7 +53,7 @@ from haystack.nodes.retriever import (
 )
 
 from haystack.nodes.sampler import BaseSampler, TopPSampler
-from haystack.nodes.search_engine import SearchEngine, WebSearch
+from haystack.nodes.search_engine import WebSearch
 from haystack.nodes.summarizer import BaseSummarizer, TransformersSummarizer
 from haystack.nodes.translator import BaseTranslator, TransformersTranslator
 from haystack.nodes.doc_language_classifier import (

--- a/haystack/nodes/retriever/__init__.py
+++ b/haystack/nodes/retriever/__init__.py
@@ -9,3 +9,4 @@ from haystack.nodes.retriever.dense import (
 from haystack.nodes.retriever.multimodal import MultiModalRetriever
 from haystack.nodes.retriever.sparse import BM25Retriever, FilterRetriever, TfidfRetriever
 from haystack.nodes.retriever.text2sparql import Text2SparqlRetriever
+from haystack.nodes.retriever.web import WebRetriever

--- a/haystack/nodes/search_engine/providers.py
+++ b/haystack/nodes/search_engine/providers.py
@@ -28,7 +28,7 @@ class SerpAPI(SearchEngine):
         :param top_k: Number of results to return.
         :param engine: Search engine to use, for example google, bing, baidu, duckduckgo, yahoo, yandex.
         See the [SerpAPI documentation](https://serpapi.com/search-api) for the full list of supported engines.
-        :param kwargs: Additional parameters passed to the SerperDev API. For example, you can set 'lr' to 'lang_en'
+        :param search_engine_kwargs: Additional parameters passed to the SerperDev API. For example, you can set 'lr' to 'lang_en'
         to limit the search to English.
         See the [SerpAPI documentation](https://serpapi.com/search-api) for the full list of supported parameters.
         """
@@ -128,7 +128,7 @@ class SerperDev(SearchEngine):
         """
         :param api_key: API key for the SerperDev API.
         :param top_k: Number of documents to return.
-        :param kwargs: Additional parameters passed to the SerperDev API.
+        :param search_engine_kwargs: Additional parameters passed to the SerperDev API.
         For example, you can set 'num' to 20 to increase the number of search results.
         """
         super().__init__()

--- a/haystack/nodes/search_engine/providers.py
+++ b/haystack/nodes/search_engine/providers.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, Any
 
 import requests
 

--- a/haystack/nodes/search_engine/providers.py
+++ b/haystack/nodes/search_engine/providers.py
@@ -16,7 +16,13 @@ class SerpAPI(SearchEngine):
     Amazon, and similar. See the [SerpAPI website](https://serpapi.com/) for more details.
     """
 
-    def __init__(self, api_key: str, top_k: Optional[int] = 10, engine: Optional[str] = "google", **kwargs):
+    def __init__(
+        self,
+        api_key: str,
+        top_k: Optional[int] = 10,
+        engine: Optional[str] = "google",
+        search_engine_kwargs: Optional[Dict[str, Any]] = None,
+    ):
         """
         :param api_key: API key for SerpAPI.
         :param top_k: Number of results to return.
@@ -29,7 +35,7 @@ class SerpAPI(SearchEngine):
         super().__init__()
         self.params_dict: Dict[str, Union[str, int, float]] = {}
         self.api_key = api_key
-        self.kwargs = kwargs
+        self.kwargs = search_engine_kwargs if search_engine_kwargs else {}
         self.engine = engine
         self.top_k = top_k
 
@@ -118,7 +124,7 @@ class SerperDev(SearchEngine):
     Search engine using SerperDev API. See the [Serper Dev website](https://serper.dev/) for more details.
     """
 
-    def __init__(self, api_key: str, top_k: Optional[int] = 10, **kwargs):
+    def __init__(self, api_key: str, top_k: Optional[int] = 10, search_engine_kwargs: Optional[Dict[str, Any]] = None):
         """
         :param api_key: API key for the SerperDev API.
         :param top_k: Number of documents to return.
@@ -128,7 +134,7 @@ class SerperDev(SearchEngine):
         super().__init__()
         self.api_key = api_key
         self.top_k = top_k
-        self.kwargs = kwargs
+        self.kwargs = search_engine_kwargs if search_engine_kwargs else {}
 
     def search(self, query: str, **kwargs) -> List[Document]:
         """
@@ -205,16 +211,16 @@ class BingAPI(SearchEngine):
     Search engine using the Bing API. See [Bing Web Search API](https://learn.microsoft.com/en-us/bing/search-apis/bing-web-search/overview) for more details.
     """
 
-    def __init__(self, api_key: str, top_k: Optional[int] = 10, **kwargs):
+    def __init__(self, api_key: str, top_k: Optional[int] = 10, search_engine_kwargs: Optional[Dict[str, Any]] = None):
         """
         :param api_key: API key for the Bing API.
         :param top_k: Number of documents to return.
-        :param kwargs: Additional parameters passed to the SerperDev API. As an example, you can pass the market parameter to specify the market to use for the query: 'mkt':'en-US'.
+        :param search_engine_kwargs: Additional parameters passed to the SerperDev API. As an example, you can pass the market parameter to specify the market to use for the query: 'mkt':'en-US'.
         """
         super().__init__()
         self.api_key = api_key
         self.top_k = top_k
-        self.kwargs = kwargs
+        self.kwargs = search_engine_kwargs if search_engine_kwargs else {}
 
     def search(self, query: str, **kwargs) -> List[Document]:
         """

--- a/haystack/nodes/search_engine/web.py
+++ b/haystack/nodes/search_engine/web.py
@@ -1,7 +1,8 @@
 import pydoc
 from typing import List, Dict, Any, Optional, Union, Tuple, Type
 
-from haystack import BaseComponent, MultiLabel, Document
+from haystack.nodes.base import BaseComponent
+from haystack import MultiLabel, Document
 from haystack.nodes.search_engine.base import SearchEngine
 
 

--- a/haystack/nodes/search_engine/web.py
+++ b/haystack/nodes/search_engine/web.py
@@ -26,13 +26,13 @@ class WebSearch(BaseComponent):
         api_key: str,
         top_k: Optional[int] = 10,
         search_engine_provider: Union[str, SearchEngine] = "SerperDev",
-        **kwargs,
+        search_engine_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         :param api_key: API key for the search engine provider.
         :param search_engine_provider: Name of the search engine provider class, see `providers.py` for a list of
         supported providers.
-        :param kwargs: Additional parameters to pass to the search engine provider.
+        :param search_engine_kwargs: Additional parameters to pass to the search engine provider.
         """
         super().__init__()
         if isinstance(search_engine_provider, str):
@@ -47,7 +47,7 @@ class WebSearch(BaseComponent):
                 )
             if not issubclass(klass, SearchEngine):
                 raise ValueError(f"Class {search_engine_provider} is not a subclass of SearchEngine.")
-            self.search_engine = klass(api_key=api_key, top_k=top_k, **kwargs)  # type: ignore
+            self.search_engine = klass(api_key=api_key, top_k=top_k, search_engine_kwargs=search_engine_kwargs)  # type: ignore
         elif isinstance(search_engine_provider, SearchEngine):
             self.search_engine = search_engine_provider
         else:


### PR DESCRIPTION
Some direct imports of new nodes raise errors.
(eg `from haystack.nodes import WebRetriever`)

### Proposed Changes:
Add imports to `__init__`

### How did you test it?
CI

### Notes for the reviewer
Just a draft, feel free to correct me. 

Should abstract base classes (`SearchEngine`) also be directly importable?
In the `__init__` there are conflicting examples...

### Checklist
- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
