### PR TITLE
fix: Adjust HF stop words (single stop word)

### DIFF
--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -237,6 +237,14 @@ def test_open_ai_warn_if_max_tokens_is_too_short(prompt_model, caplog):
 def test_stop_words(prompt_model):
     skip_test_for_invalid_key(prompt_model)
 
+    # test single stop word for both HF and OpenAI
+    # set stop words in PromptNode
+    node = PromptNode(prompt_model, stop_words=["capital"])
+
+    # with default prompt template and stop words set in PN
+    r = node.prompt("question-generation", documents=["Berlin is the capital of Germany."])
+    assert r[0] == "What is the" or r[0] == "What city is the"
+
     # test stop words for both HF and OpenAI
     # set stop words in PromptNode
     node = PromptNode(prompt_model, stop_words=["capital", "Germany"])


### PR DESCRIPTION
### Related Issues
- https://github.com/deepset-ai/haystack/issues/4587 

Confirmed independently during HF agent streaming experiments. 

### Proposed Changes:
Slightly adjusts stop words algorithm for HF. We must also place tokens on the appropriate device before doing torch ops. 

### How did you test it?
Added a unit test for a single-stop word. We now test single and two words stop words scenarios. The previous test should have included both scenarios (one and two stop words). 

### Notes for the reviewer
See changes

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
