### PR TITLE
fix: PineconeDocumentStore error when delete_documents right after initialization

### DIFF
--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -997,6 +997,8 @@ class PineconeDocumentStore(BaseDocumentStore):
 
         pinecone_syntax_filter = LogicalFilterClause.parse(filters).convert_to_pinecone() if filters else None
 
+        if index not in self.all_ids:
+            self.all_ids[index] = set()
         if ids is None and pinecone_syntax_filter is None:
             # If no filters or IDs we delete everything
             self.pinecone_indexes[index].delete(delete_all=True, namespace=namespace)


### PR DESCRIPTION
### Related Issues
- fixes #3107 

### Proposed Changes:
As @jamescalam mentioned in the issue, if `delete_documents` is called right after PineconeDocumentStore initialization, an error is raised due to the fact that the code attempts to access `self.all_ids`'s (a temporary/helper/local dictionary which is completely empty after initializing the store) value for that particular index.
Thus, adding the index to the dict with an empty set() avoids this error being thrown and does not affect the `delete_documents` flows from my analysis.
Also, this seems to be a avoidable user experience point of attrition at this time, considering that [https://docs.haystack.deepset.ai/docs/faq](https://docs.haystack.deepset.ai/docs/faq) question related with seeing duplicate answers (although it does not mention Pinecone directly) incentivizes users to call `delete_documents` right after initializing a DocumentStore.

### How did you test it?
Essentially tested this manually using the snippet used in the issue report.

```
from haystack.document_stores.pinecone import PineconeDocumentStore

ENV ='us-west1-gcp'
KEY = '<<API_KEY>>'

document_store = PineconeDocumentStore(
    api_key=KEY, environment=ENV,
    index="haystack",
    similarity="dot_product"
)

document_store.delete_all_documents()
document_store.delete_documents()
```

### Notes for the reviewer

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
