### PR TITLE
feat: arbitrary `crawler_depth` for `Crawler` class

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -6,7 +6,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Set
 from urllib.parse import urlparse
 
 try:
@@ -264,49 +264,18 @@ class Crawler(BaseComponent):
         documents: List[Document] = []
 
         # Start by crawling the initial list of urls
-        if filter_urls:
-            pattern = re.compile("|".join(filter_urls))
-            for url in urls:
-                if pattern.search(url):
-                    documents += self._crawl_urls(
-                        [url],
-                        extract_hidden_text=extract_hidden_text,
-                        loading_wait_time=loading_wait_time,
-                        id_hash_keys=id_hash_keys,
-                        output_dir=output_dir,
-                        overwrite_existing_files=overwrite_existing_files,
-                        file_path_meta_field_name=file_path_meta_field_name,
-                        crawler_naming_function=crawler_naming_function,
-                    )
-        else:
-            documents += self._crawl_urls(
-                urls,
-                extract_hidden_text=extract_hidden_text,
-                loading_wait_time=loading_wait_time,
-                id_hash_keys=id_hash_keys,
-                output_dir=output_dir,
-                overwrite_existing_files=overwrite_existing_files,
-                file_path_meta_field_name=file_path_meta_field_name,
-                crawler_naming_function=crawler_naming_function,
-            )
-
-        # follow one level of sublinks if requested
-        if crawler_depth == 1:
-            sub_links: Dict[str, List] = {}
-            for url_ in urls:
-                already_found_links: List = list(sum(list(sub_links.values()), []))
-                sub_links[url_] = list(
-                    self._extract_sublinks_from_url(
-                        base_url=url_,
-                        filter_urls=filter_urls,
-                        already_found_links=already_found_links,
-                        loading_wait_time=loading_wait_time,
+        uncrawled_urls = {base_url: {base_url} for base_url in urls}
+        crawled_urls = set()
+        for current_depth in range(crawler_depth + 1):
+            for base_url, uncrawled_urls_for_base in uncrawled_urls.items():
+                urls_to_crawl = list(
+                    filter(
+                        lambda u: (not filter_urls or re.search("|".join(filter_urls), u)) and u not in crawled_urls,
+                        uncrawled_urls_for_base,
                     )
                 )
-            for url, extracted_sublink in sub_links.items():
-                documents += self._crawl_urls(
-                    extracted_sublink,
-                    base_url=url,
+                crawled_documents = self._crawl_urls(
+                    urls_to_crawl,
                     extract_hidden_text=extract_hidden_text,
                     loading_wait_time=loading_wait_time,
                     id_hash_keys=id_hash_keys,
@@ -315,7 +284,19 @@ class Crawler(BaseComponent):
                     file_path_meta_field_name=file_path_meta_field_name,
                     crawler_naming_function=crawler_naming_function,
                 )
-
+                documents += crawled_documents
+                crawled_urls.update(urls_to_crawl)
+                if current_depth < crawler_depth:
+                    uncrawled_urls[base_url] = set()
+                    for url_ in urls_to_crawl:
+                        uncrawled_urls[base_url].update(
+                            self._extract_sublinks_from_url(
+                                base_url=url_,
+                                filter_urls=filter_urls,
+                                already_found_links=list(crawled_urls),
+                                loading_wait_time=loading_wait_time,
+                            )
+                        )
         return documents
 
     def _create_document(
@@ -527,7 +508,7 @@ class Crawler(BaseComponent):
         filter_urls: Optional[List] = None,
         already_found_links: Optional[List] = None,
         loading_wait_time: Optional[int] = None,
-    ) -> set:
+    ) -> Set[str]:
         self.driver.get(base_url)
         if loading_wait_time is not None:
             time.sleep(loading_wait_time)

--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -262,8 +262,6 @@ class Crawler(BaseComponent):
                 logger.info("Fetching from %s to `%s`", urls, output_dir)
 
         documents: List[Document] = []
-
-        # Start by crawling the initial list of urls
         uncrawled_urls = {base_url: {base_url} for base_url in urls}
         crawled_urls = set()
         for current_depth in range(crawler_depth + 1):

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -140,12 +140,6 @@ def test_crawler_filter_urls(test_url, tmp_path):
     assert len(documents) == 1
     assert content_match(crawler, test_url + "/index.html", documents[0].meta["file_path"])
 
-    # Note: filter_urls can exclude pages listed in `urls` as well
-    documents = crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["page1"], crawler_depth=1)
-    assert len(documents) == 1
-    assert content_match(crawler, test_url + "/page1.html", documents[0].meta["file_path"])
-    assert not crawler.crawl(urls=[test_url + "/index.html"], filter_urls=["google.com"], crawler_depth=1)
-
 
 @pytest.mark.integration
 def test_crawler_extract_hidden_text(test_url, tmp_path):
@@ -238,3 +232,32 @@ def test_crawler_custom_meta_file_path_name(test_url, tmp_path):
         urls=[test_url + "/index.html"], crawler_depth=0, output_dir=tmp_path, file_path_meta_field_name="custom"
     )
     assert documents[0].meta.get("custom", None) is not None
+
+
+@pytest.mark.integration
+def test_crawler_depth_2_single_url(test_url, tmp_path):
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
+    documents = crawler.crawl(urls=[test_url + "/index.html"], crawler_depth=2)
+    assert len(documents) == 6
+    paths = [doc.meta["file_path"] for doc in documents]
+    assert content_in_results(crawler, test_url + "/index.html", paths)
+    assert content_in_results(crawler, test_url + "/page1.html", paths)
+    assert content_in_results(crawler, test_url + "/page2.html", paths)
+    assert content_in_results(crawler, test_url + "/page1_subpage1.html", paths)
+    assert content_in_results(crawler, test_url + "/page1_subpage2.html", paths)
+    assert content_in_results(crawler, test_url + "/page2_subpage1.html", paths)
+
+
+@pytest.mark.integration
+def test_crawler_depth_2_multiple_urls(test_url, tmp_path):
+    crawler = Crawler(output_dir=tmp_path, file_path_meta_field_name="file_path")
+    _urls = [test_url + "/index.html", test_url + "/page1.html"]
+    documents = crawler.crawl(urls=_urls, crawler_depth=2)
+    assert len(documents) == 6
+    paths = [doc.meta["file_path"] for doc in documents]
+    assert content_in_results(crawler, test_url + "/index.html", paths)
+    assert content_in_results(crawler, test_url + "/page1.html", paths)
+    assert content_in_results(crawler, test_url + "/page2.html", paths)
+    assert content_in_results(crawler, test_url + "/page1_subpage1.html", paths)
+    assert content_in_results(crawler, test_url + "/page1_subpage2.html", paths)
+    assert content_in_results(crawler, test_url + "/page2_subpage1.html", paths)

--- a/test/samples/crawler/page1.html
+++ b/test/samples/crawler/page1.html
@@ -7,5 +7,7 @@
     <p>page 1 content</p>
     <a href="index.html">link to home</a>
     <a href="page2.html">link to page 2</a>
+    <a href="page1_subpage1.html">link to subpage 1</a>
+    <a href="page1_subpage2.html">link to subpage 2</a>
 </body>
 </html>

--- a/test/samples/crawler/page1_subpage1.html
+++ b/test/samples/crawler/page1_subpage1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Subpage 1 of Page 1 for Crawler</title>
+</head>
+<body>
+    <p>subpage 1 of page 1 content</p>
+</body>
+</html>

--- a/test/samples/crawler/page1_subpage2.html
+++ b/test/samples/crawler/page1_subpage2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Subpage 2 of Page 1 for Crawler</title>
+</head>
+<body>
+    <p>subpage 2 of page 1 content</p>
+</body>
+</html>

--- a/test/samples/crawler/page2.html
+++ b/test/samples/crawler/page2.html
@@ -7,5 +7,6 @@
     <p>page 2 content</p>
     <a href="index.html">link to home</a>
     <a href="page1.html">link to page 1</a>
+    <a href="page2_subpage1.html">link to subpage</a>
 </body>
 </html>

--- a/test/samples/crawler/page2_subpage1.html
+++ b/test/samples/crawler/page2_subpage1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Subpage 1 of Page 2 for Crawler</title>
+</head>
+<body>
+    <p>subpage 1 of page 2 content</p>
+</body>
+</html>


### PR DESCRIPTION
### Related Issues
- fixes #3674 

### Proposed Changes:
Implements the proposed crawler depth > 1. 

### How did you test it?
Added two additional tests (along with their mock HTML files) in `test_connector.py` following the method of the existing tests.

### Notes for the reviewer
I changed one thing about the existing filter logic (and one existing test): If a URL does not match any of `filter_urls`, its page will not be searched for matching sublinks either. This seemed more straightforward because the complete link tree would have to be crawled otherwise (e.g. if you want to crawl a webpage that includes a link to Wikipedia you would not want to crawl Wikipedia for links back to your page). Let me know if that makes sense to you.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
