### PR TITLE
refactor: Add 503 as status code that triggers retry in request_with_retry

### DIFF
--- a/haystack/utils/requests.py
+++ b/haystack/utils/requests.py
@@ -55,13 +55,13 @@ def request_with_retry(attempts: int = 3, status_codes: Optional[List[int]] = No
     res = request_with_retry(method="GET", url="https://example.com", status_codes=list(range(500, 600)))
 
     :param attempts: Maximum number of attempts to retry the request, defaults to 3
-    :param status_codes: List of HTTP status codes that will trigger a retry, defaults to [408, 418, 429]
+    :param status_codes: List of HTTP status codes that will trigger a retry, defaults to [408, 418, 429, 503]
     :param **kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     """
 
     if status_codes is None:
-        status_codes = [408, 418, 429]
+        status_codes = [408, 418, 429, 503]
 
     @retry(
         reraise=True,


### PR DESCRIPTION
### Proposed Changes:

Add the `503` status code in the list of status codes that would trigger a retry on failure in `request_with_retry` as per @julian-risch [comment](https://github.com/deepset-ai/haystack/pull/4627#discussion_r1162479325). 

### How did you test it?

I ran `pytest test/utils/test_requests.py` and everything was green.

### Notes for the reviewer

N/A