### PR TITLE
ci: Fix docstring-labeler.yml not working in PR from forks

### DIFF
--- a/.github/workflows/docstring-labeler.yml
+++ b/.github/workflows/docstring-labeler.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          # This must be set to correctly checkout a fork
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Get docstrings
         id: head-docstrings


### PR DESCRIPTION
### Proposed Changes:

Change the `docstring-labeler.yml` work to checkout the correct repository when trigger in PRs from forks.

See example failure [here](https://github.com/deepset-ai/haystack/actions/runs/4678099751/jobs/8286417917?pr=4512).

### How did you test it?

Can't really be tested easily.

### Notes for the reviewer

N/A