### PR TITLE
feat: Add GenerationConfig option to PromptNode's HuggingFace invocation layer

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -2,8 +2,14 @@ from typing import Optional, Union, List, Dict
 import logging
 
 import torch
-from transformers import pipeline, StoppingCriteriaList, StoppingCriteria, PreTrainedTokenizer, PreTrainedTokenizerFast, \
-    GenerationConfig
+from transformers import (
+    pipeline,
+    StoppingCriteriaList,
+    StoppingCriteria,
+    PreTrainedTokenizer,
+    PreTrainedTokenizerFast,
+    GenerationConfig,
+)
 from transformers.pipelines import get_task
 
 from haystack.modeling.utils import initialize_device_settings

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -2,7 +2,8 @@ from typing import Optional, Union, List, Dict
 import logging
 
 import torch
-from transformers import pipeline, StoppingCriteriaList, StoppingCriteria, PreTrainedTokenizer, PreTrainedTokenizerFast
+from transformers import pipeline, StoppingCriteriaList, StoppingCriteria, PreTrainedTokenizer, PreTrainedTokenizerFast, \
+    GenerationConfig
 from transformers.pipelines import get_task
 
 from haystack.modeling.utils import initialize_device_settings
@@ -71,6 +72,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
                 "use_fast",
                 "torch_dtype",
                 "device_map",
+                "generation_kwargs",
             ]
             if key in kwargs
         }
@@ -78,6 +80,9 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         if "model_kwargs" in model_input_kwargs:
             mkwargs = model_input_kwargs.pop("model_kwargs")
             model_input_kwargs.update(mkwargs)
+
+        # save generation_kwargs for pipeline invocation
+        self.generation_kwargs = model_input_kwargs.pop("generation_kwargs", {})
 
         torch_dtype = model_input_kwargs.get("torch_dtype")
         if torch_dtype is not None:
@@ -136,9 +141,18 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
                     "return_full_text",
                     "clean_up_tokenization_spaces",
                     "truncation",
+                    "generation_kwargs",
                 ]
                 if key in kwargs
             }
+            generation_kwargs = model_input_kwargs.pop("generation_kwargs", self.generation_kwargs)
+            if isinstance(generation_kwargs, dict):
+                model_input_kwargs.update(generation_kwargs)
+            elif isinstance(generation_kwargs, GenerationConfig):
+                gen_dict = generation_kwargs.to_diff_dict()
+                gen_dict.pop("transformers_version", None)
+                model_input_kwargs.update(gen_dict)
+
             is_text_generation = "text-generation" == self.task_name
             # Prefer return_full_text is False for text-generation (unless explicitly set)
             # Thus only generated text is returned (excluding prompt)

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -228,17 +228,19 @@ def test_generation_kwargs_from_prompt_node_init():
 @pytest.mark.integration
 def test_generation_kwargs_from_prompt_node_call():
     the_question = "What does 42 mean?"
-    # test that generation_kwargs are passed to the underlying HF model
+    # default node with local HF model
     node = PromptNode()
     with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
+        # test that generation_kwargs are passed to the underlying HF model
         node(the_question, generation_kwargs={"do_sample": True})
         mock_call.assert_called_with(
             the_question, {}, {"do_sample": True, "num_return_sequences": 1, "num_beams": 1, "max_length": 100}, {}
         )
 
-    # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
+    # default node with local HF model
     node = PromptNode()
     with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
+        # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
         node(the_question, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
         mock_call.assert_called_with(
             the_question,

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -1,9 +1,10 @@
 import os
 import logging
 from typing import Optional, Union, List, Dict, Any, Tuple
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, MagicMock
 
 import pytest
+from transformers import AutoTokenizer, GenerationConfig
 
 from haystack import Document, Pipeline, BaseComponent, MultiLabel
 from haystack.nodes.prompt import PromptTemplate, PromptNode, PromptModel
@@ -199,6 +200,50 @@ def test_invalid_template_params():
     node = PromptNode("google/flan-t5-small", devices=["cpu"])
     with pytest.raises(ValueError, match="Expected prompt parameters"):
         node.prompt("question-answering-per-document", {"some_crazy_key": "Berlin is the capital of Germany."})
+
+
+@pytest.mark.integration
+def test_generation_kwargs_from_prompt_node_init():
+    the_question = "What does 42 mean?"
+    # test that generation_kwargs are passed to the underlying HF model
+    node = PromptNode(model_kwargs={"generation_kwargs": {"do_sample": True}})
+    with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
+        node(the_question)
+        mock_call.assert_called_with(the_question, {}, {"do_sample": True,
+                                                        "num_return_sequences": 1, "num_beams": 1,
+                                                        "max_length": 100},
+                                     {})
+
+    # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
+    node = PromptNode(model_kwargs={"generation_kwargs": GenerationConfig(do_sample=True, top_p=0.9)})
+    with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
+        node(the_question)
+        mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9,
+                                                        "num_return_sequences": 1, "num_beams": 1,
+                                                        "max_length": 100},
+                                     {})
+
+
+@pytest.mark.integration
+def test_generation_kwargs_from_prompt_node_call():
+    the_question = "What does 42 mean?"
+    # test that generation_kwargs are passed to the underlying HF model
+    node = PromptNode()
+    with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
+        node(the_question, generation_kwargs={"do_sample": True})
+        mock_call.assert_called_with(the_question, {}, {"do_sample": True,
+                                                        "num_return_sequences": 1, "num_beams": 1,
+                                                        "max_length": 100},
+                                     {})
+
+    # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
+    node = PromptNode()
+    with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
+        node(the_question, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
+        mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9,
+                                                        "num_return_sequences": 1, "num_beams": 1,
+                                                        "max_length": 100},
+                                     {})
 
 
 @pytest.mark.integration

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -209,19 +209,20 @@ def test_generation_kwargs_from_prompt_node_init():
     node = PromptNode(model_kwargs={"generation_kwargs": {"do_sample": True}})
     with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
         node(the_question)
-        mock_call.assert_called_with(the_question, {}, {"do_sample": True,
-                                                        "num_return_sequences": 1, "num_beams": 1,
-                                                        "max_length": 100},
-                                     {})
+        mock_call.assert_called_with(
+            the_question, {}, {"do_sample": True, "num_return_sequences": 1, "num_beams": 1, "max_length": 100}, {}
+        )
 
     # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
     node = PromptNode(model_kwargs={"generation_kwargs": GenerationConfig(do_sample=True, top_p=0.9)})
     with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
         node(the_question)
-        mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9,
-                                                        "num_return_sequences": 1, "num_beams": 1,
-                                                        "max_length": 100},
-                                     {})
+        mock_call.assert_called_with(
+            the_question,
+            {},
+            {"do_sample": True, "top_p": 0.9, "num_return_sequences": 1, "num_beams": 1, "max_length": 100},
+            {},
+        )
 
 
 @pytest.mark.integration
@@ -231,19 +232,20 @@ def test_generation_kwargs_from_prompt_node_call():
     node = PromptNode()
     with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
         node(the_question, generation_kwargs={"do_sample": True})
-        mock_call.assert_called_with(the_question, {}, {"do_sample": True,
-                                                        "num_return_sequences": 1, "num_beams": 1,
-                                                        "max_length": 100},
-                                     {})
+        mock_call.assert_called_with(
+            the_question, {}, {"do_sample": True, "num_return_sequences": 1, "num_beams": 1, "max_length": 100}, {}
+        )
 
     # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
     node = PromptNode()
     with patch.object(node.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
         node(the_question, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
-        mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9,
-                                                        "num_return_sequences": 1, "num_beams": 1,
-                                                        "max_length": 100},
-                                     {})
+        mock_call.assert_called_with(
+            the_question,
+            {},
+            {"do_sample": True, "top_p": 0.9, "num_return_sequences": 1, "num_beams": 1, "max_length": 100},
+            {},
+        )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues
- fixes #4647

### Proposed Changes:
Adds support for generation kwargs (and GenerationConfig) to PromptNode's HuggingFace invocation layer
This feature will enable users to finely adjust generation params for text generation using local runtime HuggingFace models

### How did you test it?
Added mocked tests to ensure that these params are pushed down to the underlying pipeline in HFLocalInvocationLayer

### Notes for the reviewer
Please review my mock usage and the implementation logic of course :-)
The mocked method checking params is this [one](https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/base.py#L1114)
### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
