### PR TITLE
fix: Add model_max_length model_kwargs parameter to HF PromptNode

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -48,6 +48,8 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         all PromptModelInvocationLayer instances, this instance of HFLocalInvocationLayer might receive some unrelated
         kwargs. Only kwargs relevant to the HFLocalInvocationLayer are considered. The list of supported kwargs
         includes: trust_remote_code, revision, feature_extractor, tokenizer, config, use_fast, torch_dtype, device_map.
+        For more details about pipeline kwargs in general, see
+        Hugging Face [documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.pipeline).
 
         This layer supports two additional kwargs: generation_kwargs and model_max_length.
 
@@ -56,9 +58,6 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         for more details.
 
         The model_max_length is used to specify the custom sequence length for the underlying pipeline.
-
-        For more details about pipeline kwargs in general, see
-        Hugging Face [documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.pipeline).
         """
         super().__init__(model_name_or_path)
         self.use_auth_token = use_auth_token

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -48,7 +48,16 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         all PromptModelInvocationLayer instances, this instance of HFLocalInvocationLayer might receive some unrelated
         kwargs. Only kwargs relevant to the HFLocalInvocationLayer are considered. The list of supported kwargs
         includes: trust_remote_code, revision, feature_extractor, tokenizer, config, use_fast, torch_dtype, device_map.
-        For more details about these kwargs, see
+
+        This layer supports two additional kwargs: generation_kwargs and model_max_length.
+
+        The generation_kwargs are used to customize text generation for the underlying pipeline. See Hugging
+        Face [docs](https://huggingface.co/docs/transformers/main/en/generation_strategies#customize-text-generation)
+        for more details.
+
+        The model_max_length is used to specify the custom sequence length for the underlying pipeline.
+
+        For more details about pipeline kwargs in general, see
         Hugging Face [documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.pipeline).
         """
         super().__init__(model_name_or_path)

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -136,6 +136,14 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         # embeddings and can accept sequences of more than 512 tokens
         self.model_max_length = model_max_length or self.pipe.tokenizer.model_max_length
 
+        if self.max_length > self.model_max_length:
+            logger.warning(
+                "The max_length %s is greater than model_max_length %s. This might result in truncation of the "
+                "generated text. Please lower the max_length (number of answer tokens) parameter!",
+                self.max_length,
+                self.model_max_length,
+            )
+
     def invoke(self, *args, **kwargs):
         """
         It takes a prompt and returns a list of generated texts using the local Hugging Face transformers model

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -311,7 +311,7 @@ def test_prompt_node_model_max_length(caplog):
     # the model max length minus the length of the output
     # no warning is raised
     node = PromptNode(model_kwargs={"model_max_length": 1024})
-    assert node.prompt_model.model_invocation_layer.model_max_length == 1024
+    assert node.prompt_model.model_invocation_layer.pipe.tokenizer.model_max_length == 1024
     with caplog.at_level(logging.WARNING):
         node.prompt(prompt)
         assert len(caplog.text) <= 0
@@ -320,7 +320,7 @@ def test_prompt_node_model_max_length(caplog):
     # test that model truncates the prompt if it is longer than the max length (10 tokens)
     # a warning is raised
     node = PromptNode(model_kwargs={"model_max_length": 10})
-    assert node.prompt_model.model_invocation_layer.model_max_length == 10
+    assert node.prompt_model.model_invocation_layer.pipe.tokenizer.model_max_length == 10
     with caplog.at_level(logging.WARNING):
         node.prompt(prompt)
         assert "The prompt has been truncated from 26 tokens to 0 tokens" in caplog.text

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -304,13 +304,23 @@ def test_stop_words(prompt_model):
 
 @pytest.mark.unit
 def test_prompt_node_model_max_length(caplog):
-    """
-    Tests that PromptNode passes model_max_length to HFInvocationLayer.
-    """
+    prompt = "This is a prompt " * 5  # (26 tokens with t5 flan tokenizer)
+
+    # test that model_max_length is set to 1024
+    # test that model doesn't truncate the prompt if it is shorter than
+    # the model max length minus the length of the output
+    # no warning is raised
+    node = PromptNode(model_kwargs={"model_max_length": 1024})
+    assert node.prompt_model.model_invocation_layer.model_max_length == 1024
+    with caplog.at_level(logging.WARNING):
+        node.prompt(prompt)
+        assert len(caplog.text) <= 0
+
+    # test that model_max_length is set to 10
+    # test that model truncates the prompt if it is longer than the max length (10 tokens)
+    # a warning is raised
     node = PromptNode(model_kwargs={"model_max_length": 10})
     assert node.prompt_model.model_invocation_layer.model_max_length == 10
-
-    prompt = "This is a prompt " * 5
     with caplog.at_level(logging.WARNING):
         node.prompt(prompt)
         assert "The prompt has been truncated from 26 tokens to 0 tokens" in caplog.text

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -303,6 +303,20 @@ def test_stop_words(prompt_model):
 
 
 @pytest.mark.unit
+def test_prompt_node_model_max_length(caplog):
+    """
+    Tests that PromptNode passes model_max_length to HFInvocationLayer.
+    """
+    node = PromptNode(model_kwargs={"model_max_length": 10})
+    assert node.prompt_model.model_invocation_layer.model_max_length == 10
+
+    prompt = "This is a prompt " * 5
+    with caplog.at_level(logging.WARNING):
+        node.prompt(prompt)
+        assert "The prompt has been truncated from 26 tokens to 0 tokens" in caplog.text
+
+
+@pytest.mark.unit
 @patch("haystack.nodes.prompt.prompt_node.PromptModel")
 def test_prompt_node_streaming_handler_on_call(mock_model):
     """


### PR DESCRIPTION
### Related Issues
- fixes #4379

### Proposed Changes:
Introduces a new PromptNode HF parameter allowing users to override `model_max_length` for HF PromptNode. Until now, the maximum sequence length of HF models has been determined from the model tokenizer field. However, in some rare cases, as with T5 Flan models, the model can infer longer sequence lengths than specified by the tokenizer (512). In such cases, we want to have the ability to specify a custom maximum sequence length. Users can now do the following:

```
prompt_node = PromptNode("google/flan-t5-xxl", model_kwargs={"model_max_length" : 1024})
```

And thus override the maximum sequence length of 512 and set it to 1024, as in the example above.

### How did you test it?
Added unit test

### Notes for the reviewer
Note that this is only relevant for HF models and other invocation layers will ignore this parameter. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
