### PR TITLE
feat: Add HF local runtime token streaming support

### DIFF
--- a/haystack/agents/types.py
+++ b/haystack/agents/types.py
@@ -1,5 +1,8 @@
 from enum import Enum
 
+from events import Events
+from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler
+
 
 class Color(Enum):
     BLACK = "\033[30m"
@@ -11,3 +14,12 @@ class Color(Enum):
     CYAN = "\033[36m"
     WHITE = "\033[37m"
     RESET = "\x1b[0m"
+
+
+class AgentTokenStreamingHandler(TokenStreamingHandler):
+    def __init__(self, events: Events):
+        self.events = events
+
+    def __call__(self, token_received, **kwargs) -> str:
+        self.events.on_new_token(token_received, **kwargs)
+        return token_received

--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -1,4 +1,7 @@
 from abc import abstractmethod, ABC
+from typing import Union
+
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, TextStreamer
 
 
 class TokenStreamingHandler(ABC):
@@ -31,3 +34,15 @@ class DefaultTokenStreamingHandler(TokenStreamingHandler):
         """
         print(token_received, flush=True, end="")
         return token_received
+
+
+class HFTokenStreamingHandler(TextStreamer):
+    def __init__(
+        self, tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], stream_handler: TokenStreamingHandler
+    ):
+        super().__init__(tokenizer=tokenizer)
+        self.token_handler = stream_handler
+
+    def on_finalized_text(self, token: str, stream_end: bool = False):
+        token_to_send = token + "\n" if stream_end else token
+        self.token_handler(token_received=token_to_send, **{})

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -90,6 +90,8 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
                 "device_map",
                 "generation_kwargs",
                 "model_max_length",
+                "stream",
+                "stream_handler",
             ]
             if key in kwargs
         }
@@ -97,6 +99,10 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         if "model_kwargs" in model_input_kwargs:
             mkwargs = model_input_kwargs.pop("model_kwargs")
             model_input_kwargs.update(mkwargs)
+
+        # save stream settings and stream_handler for pipeline invocation
+        self.stream_handler = model_input_kwargs.pop("stream_handler", None)
+        self.stream = model_input_kwargs.pop("stream", False)
 
         # save generation_kwargs for pipeline invocation
         self.generation_kwargs = model_input_kwargs.pop("generation_kwargs", {})
@@ -165,7 +171,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         stop_words = kwargs.pop("stop_words", None)
         top_k = kwargs.pop("top_k", None)
         # either stream is True (will use default handler) or stream_handler is provided for custom handler
-        stream = kwargs.get("stream", False) or kwargs.get("stream_handler", None) is not None
+        stream = kwargs.get("stream", self.stream) or kwargs.get("stream_handler", self.stream_handler) is not None
         if kwargs and "prompt" in kwargs:
             prompt = kwargs.pop("prompt")
 

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -2,7 +2,6 @@ from typing import Optional, Union, List, Dict
 import logging
 
 import torch
-from haystack.nodes.prompt.invocation_layer.handlers import DefaultTokenStreamingHandler, HFTokenStreamingHandler
 
 from transformers import (
     pipeline,
@@ -16,6 +15,7 @@ from transformers.pipelines import get_task
 
 from haystack.modeling.utils import initialize_device_settings
 from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer, TokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer.handlers import DefaultTokenStreamingHandler, HFTokenStreamingHandler
 
 logger = logging.getLogger(__name__)
 

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -4,12 +4,11 @@ from typing import Optional, Union, List, Dict, Any, Tuple
 from unittest.mock import patch, Mock, MagicMock
 
 import pytest
-from transformers import AutoTokenizer, GenerationConfig
+from transformers import GenerationConfig, TextStreamer
 
 from haystack import Document, Pipeline, BaseComponent, MultiLabel
 from haystack.nodes.prompt import PromptTemplate, PromptNode, PromptModel
-from haystack.nodes.prompt.invocation_layer import HFLocalInvocationLayer
-from haystack.nodes.prompt.invocation_layer.handlers import HFTokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer import HFLocalInvocationLayer, DefaultTokenStreamingHandler
 
 
 def skip_test_for_invalid_key(prompt_model):
@@ -336,21 +335,23 @@ def test_prompt_node_streaming_handler_on_call(mock_model):
     mock_handler = Mock()
     node = PromptNode()
     node.prompt_model = mock_model
-    node("What are some of the best cities in the world to live and why?", stream=True, stream_handler=mock_handler)
+    node("Irrelevant prompt", stream=True, stream_handler=mock_handler)
     # Verify model has been constructed with expected model_kwargs
     mock_model.invoke.assert_called_once()
     assert mock_model.invoke.call_args_list[0].kwargs["stream_handler"] == mock_handler
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_prompt_node_hf_model_streaming():
-    # tests that the streaming handler is passed to the model as "streamer" kwarg with the expected type
-    pn = PromptNode(model_kwargs={"stream_handler": Mock()})
+    # tests that HF streaming handler is passed to the HF pipeline run_single method as "streamer" kwarg with
+    # the required HF type transformers.generation.streamers.TextStreamer
+
+    pn = PromptNode(model_kwargs={"stream_handler": DefaultTokenStreamingHandler()})
     with patch.object(pn.prompt_model.model_invocation_layer.pipe, "run_single", MagicMock()) as mock_call:
         pn("Irrelevant prompt")
         args, kwargs = mock_call.call_args
         assert "streamer" in args[2]
-        assert isinstance(args[2]["streamer"], HFTokenStreamingHandler)
+        assert isinstance(args[2]["streamer"], TextStreamer)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues
- Adds local HF model streaming

### Proposed Changes:
Adds streaming token support released in HF transformers 4.28.0

This PR introduces `HFTokenStreamingHandler`, Haystack internal class, which hooks into transformers streaming and bridges to our customer-facing `TokenStreamingHandler` higher-level abstraction. Therefore our clients who implement `TokenStreamingHandler` can use any underlying invocation layer supporting streaming via that interface.  One of these implementations of TokenStreamingHandler is our own `AgentTokenStreamingHandler` that we currently use for both HF and OpenAI models. Tomorrow we'll add support for Anthropic and Cohere. And for them, we'll implement internal streaming hooks and expose them via already familiar `TokenStreamingHandler` abstraction as well, thus enabling a single customer implementation of `TokenStreamingHandler` to be used across all the above-mentioned invocation layers. 

### How did you test it?
Manually, and added HF transformers specific test

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
