### PR TITLE
docs: Adapt Shaper docstrings regarding dropping metadata

### DIFF
--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -100,7 +100,7 @@ def join_documents(
     - $id: The ID of the document.
     - $META_FIELD: The value of the metadata field called 'META_FIELD'.
 
-    All metadata is dropped. (TODO: fix)
+    All metadata is dropped.
 
     Example:
 
@@ -124,7 +124,7 @@ def join_documents_and_scores(documents: List[Document]) -> Tuple[List[Document]
     """
     Transforms a list of documents with scores in their metadata into a list containing a single document.
     The resulting document contains the scores and the contents of all the original documents.
-    All metadata is dropped. (TODO: fix)
+    All metadata is dropped.
     Example:
     ```python
     assert join_documents_and_scores(


### PR DESCRIPTION
### Related Issues
- fixes #4478

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR removes the `(TODO: fix)` message from the `join_documents` method in shapers. We found that there's no obvious way on how to keep differing metadata, so we decided that we'll keep dropping the metadata. Also, `Shaper` is not needed anymore with `PromptNode` and the new way of joining Documents doesn't drop metadata.


### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
