### PR TITLE
docs: Add PDFToTextOCRConverter to API Docs

### DIFF
--- a/docs/pydoc/config/file-converters.yml
+++ b/docs/pydoc/config/file-converters.yml
@@ -9,6 +9,7 @@ loaders:
         "image",
         "markdown",
         "pdf",
+        "pdf_ocr",
         "parsr",
         "azure",
         "tika",
@@ -36,4 +37,3 @@ renderer:
     add_method_class_prefix: true
     add_member_class_prefix: false
     filename: file_converters_api.md
-


### PR DESCRIPTION
### Related Issues
- fixes #4569

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adapts `docs/pydoc/config/file-converters.yml` such that the API reference for the `PDFToTextOCRConverter` is shown again on the documentation website.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
