### PR TITLE
docs: Add deprecation information to doc string of `MilvusDocumentStore`

### DIFF
--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 class MilvusDocumentStore(SQLDocumentStore):
     """
+    MilvusDocumentStore is deprecated and will be removed from Haystack starting with version 1.17!
+
     Limitations:
     Milvus 2.0 so far doesn't support the deletion of documents (https://github.com/milvus-io/milvus/issues/7130).
     Therefore, delete_documents() and update_embeddings() won't work yet.


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds a note to the docstrings of `MilvusDocumentStore` that it is deprecated.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
