### PR TITLE
fix: loads local HF Models in PromptNode pipeline

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -127,7 +127,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
             self.task_name = get_task(model_name_or_path, use_auth_token=use_auth_token)
 
         self.pipe = pipeline(
-            task=self.task_name, # task_name is used to determine the pipeline type
+            task=self.task_name,  # task_name is used to determine the pipeline type
             model=model_name_or_path,
             device=self.devices[0] if "device_map" not in model_input_kwargs else None,
             use_auth_token=self.use_auth_token,

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -47,7 +47,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         :param kwargs: Additional keyword arguments passed to the underlying model. Due to reflective construction of
         all PromptModelInvocationLayer instances, this instance of HFLocalInvocationLayer might receive some unrelated
         kwargs. Only kwargs relevant to the HFLocalInvocationLayer are considered. The list of supported kwargs
-        includes: trust_remote_code, revision, feature_extractor, tokenizer, config, use_fast, torch_dtype, device_map.
+        includes: task_name, trust_remote_code, revision, feature_extractor, tokenizer, config, use_fast, torch_dtype, device_map.
         For more details about pipeline kwargs in general, see
         Hugging Face [documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.pipeline).
 
@@ -122,7 +122,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
 
         # If task_name is not provided, get the task name from the model name or path (uses HFApi)
         if "task_name" in kwargs:
-            self.task_name = kwargs.pop("task_name")
+            self.task_name = kwargs.get("task_name")
         else:
             self.task_name = get_task(model_name_or_path, use_auth_token=use_auth_token)
 

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -126,14 +126,6 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         else:
             self.task_name = get_task(model_name_or_path, use_auth_token=use_auth_token)
 
-        # validate task_name
-        if self.supports(model_name_or_path, **kwargs):
-            logger.info("Using task %s for model %s", self.task_name, model_name_or_path)
-        else:
-            raise ValueError(
-                f"Task {self.task_name} is not supported for {self.__class__.__name__}."
-            )
-
         self.pipe = pipeline(
             task=self.task_name, # task_name is used to determine the pipeline type
             model=model_name_or_path,
@@ -256,8 +248,6 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        if 'task_name' in kwargs:
-            return kwargs['task_name'] in ["text2text-generation", "text-generation"]
         task_name: Optional[str] = None
         try:
             task_name = get_task(model_name_or_path, use_auth_token=kwargs.get("use_auth_token", None))

--- a/test/prompt/test_prompt_model.py
+++ b/test/prompt/test_prompt_model.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, Mock
 import pytest
 
 from haystack.nodes.prompt.prompt_model import PromptModel
-from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
+from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer, HFLocalInvocationLayer
 
 from .conftest import create_mock_layer_that_supports
 
@@ -36,3 +36,28 @@ def test_construtor_with_custom_model():
 def test_constructor_with_no_supported_model():
     with pytest.raises(ValueError, match="Model some-random-model is not supported"):
         PromptModel("some-random-model")
+
+
+def create_mock_pipeline(model_name_or_path=None, max_length=100):
+    return Mock(
+        **{"model_name_or_path": model_name_or_path},
+        return_value=Mock(**{"model_name_or_path": model_name_or_path, "tokenizer.model_max_length": max_length}),
+    )
+
+
+@pytest.mark.unit
+def test_hf_local_invocation_layer_with_task_name():
+    mock_pipeline = create_mock_pipeline()
+    mock_get_task = Mock(return_value="dummy_task")
+
+    with patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task", mock_get_task):
+        with patch("haystack.nodes.prompt.invocation_layer.hugging_face.pipeline", mock_pipeline):
+            PromptModel(
+                model_name_or_path="local_model",
+                max_length=100,
+                model_kwargs={"task_name": "dummy_task"},
+                invocation_layer_class=HFLocalInvocationLayer,
+            )
+            # checking if get_task is called when task_name is passed to HFLocalInvocationLayer constructor
+            mock_get_task.assert_not_called()
+            mock_pipeline.assert_called_once()


### PR DESCRIPTION
### Related Issues
- fixes #4669 Loading local HF models using PromptModel 
- 
### Proposed Changes:
In [HFLocalInvocationLayer]( https://github.com/deepset-ai/haystack/blob/main/haystack/nodes/prompt/invocation_layer/hugging_face.py#L112) while trying to use a local model, one should be able to pass task_type as an argument as well. if it exists in kwargs use that instead. 


### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested it Manually to see, if i can load a local HD model using PromptModel (in combination with [HFLocalInvocationLayer](https://github.com/deepset-ai/haystack/blob/main/haystack/nodes/prompt/invocation_layer/hugging_face.py)
### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
