### PR TITLE
fix: gpt-3.5-turbo is an agent streaming model

### DIFF
--- a/docs/pydoc/config/retriever.yml
+++ b/docs/pydoc/config/retriever.yml
@@ -24,4 +24,3 @@ renderer:
     add_method_class_prefix: true
     add_member_class_prefix: false
     filename: retriever_api.md
-

--- a/haystack/agents/utils.py
+++ b/haystack/agents/utils.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from haystack.agents.types import Color
 
-STREAMING_CAPABLE_MODELS = ["davinci", "gpt-3.5"]
+STREAMING_CAPABLE_MODELS = ["davinci", "gpt-3.5", "gpt-35-turbo", "gpt-4"]
 
 
 def print_text(text: str, end="", color: Optional[Color] = None) -> None:

--- a/haystack/agents/utils.py
+++ b/haystack/agents/utils.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from haystack.agents.types import Color
 
-STREAMING_CAPABLE_MODELS = ["davinci", "gpt-3.5", "gpt-35-turbo", "gpt-4"]
+STREAMING_CAPABLE_MODELS = ["text-davinci-003", "gpt-3.5-turbo", "gpt-35-turbo", "gpt-4"]
 
 
 def print_text(text: str, end="", color: Optional[Color] = None) -> None:

--- a/haystack/agents/utils.py
+++ b/haystack/agents/utils.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from haystack.agents.types import Color
 
-STREAMING_CAPABLE_MODELS = ["davinci"]
+STREAMING_CAPABLE_MODELS = ["davinci", "gpt-3.5"]
 
 
 def print_text(text: str, end="", color: Optional[Color] = None) -> None:


### PR DESCRIPTION
### Related Issues
- None

### Proposed Changes:
 Adds gpt-3.5-turbo to list of agents that can stream tokens

### How did you test it?
Manually

### Notes for the reviewer
N/A

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
