### PR TITLE
bug: fix default search_param in milvus.py

### DIFF
--- a/haystack/document_stores/milvus.py
+++ b/haystack/document_stores/milvus.py
@@ -112,7 +112,7 @@ class MilvusDocumentStore(SQLDocumentStore):
                             For example: {"nlist": 16384} as the number of cluster units to create for index_type IVF_FLAT.
                             See https://milvus.io/docs/v2.0.x/index.md
         :param search_param: Configuration parameters for the chose index_type needed at query time
-                             For example: {"nprobe": 10} as the number of cluster units to query for index_type IVF_FLAT.
+                             For example: {"params": {"nprobe": 10}} as the number of cluster units to query for index_type IVF_FLAT.
                              See https://milvus.io/docs/v2.0.x/index.md
         :param return_embedding: To return document embedding.
         :param embedding_field: Name of field containing an embedding vector.
@@ -171,7 +171,7 @@ class MilvusDocumentStore(SQLDocumentStore):
 
         self.index_type = index_type
         self.index_param = index_param or {"nlist": 16384}
-        self.search_param = search_param or {"nprobe": 10}
+        self.search_param = search_param or {"params": {"nprobe": 10}}
         self.index = index
         self.embedding_field = embedding_field
         self.id_field = id_field


### PR DESCRIPTION
Describe the bug
A bug in haystack/blob/main/haystack/document_stores/milvus.py.
In MilvusDocumentStore, search_param, line 167:
        self.search_param = search_param or {"nprobe": 10}
And in line 433:
            param={"metric_type": self.metric_type, **self.search_param},
query with milvus2 will give an error due to this incorrect parameter passing

Error message
ERROR:pymilvus.decorators:RPC error: [search], <MilvusException: (code=1, message=fail to search on all shard leaders, err=All attempts results:
attempt https://github.com/deepset-ai/haystack/pull/1:code: UnexpectedError, error: fail to Search, QueryNode ID=14, reason=Search 14 failed, reason [UnexpectedError] Error in virtual knowhere::DatasetPtr knowhere::IVF_NM::Query(const DatasetPtr&, const Config&, faiss::BitsetView) at IndexIVF_NM.cpp:216: [json.exception.out_of_range. 403] key 'nprobe' not found err %!w()
attempt https://github.com/deepset-ai/haystack/issues/2:context canceled
)>, <Time:{'RPC start': '2023-04-17 10:19:17.569321', 'RPC error': '2023-04-17 10:19:17.987552'}>

Error Reason
According to https://milvus.io/docs/search.md , search_params = {"metric_type": "L2", "params": {"nprobe": 10}, "offset": 5}
But in line 433, it will be search_params = {"metric_type": "L2", "nprobe": 10}, if user uses default self.search_param

Method of correction
change line 433 into:
            param={"metric_type": self.metric_type, "params": self.search_param},
or change line167 and related describe:
        self.search_param = search_param or {"params":{"nprobe": 10}}