### PR TITLE
fix: make `langdetect` truly optional

### DIFF
--- a/.github/workflows/imports.yml
+++ b/.github/workflows/imports.yml
@@ -1,0 +1,41 @@
+name: Dependency checker
+
+on:
+  workflow_dispatch: # Activate this workflow manually
+  push:
+    branches:
+      - main
+      # release branches have the form v1.9.x
+      - 'v[0-9].*[0-9].x'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - "!.github/**/*.py"
+      - "!rest_api/**/*.py"
+
+env:
+  PYTHON_VERSION: "3.8"
+
+jobs:
+
+  base-install:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install Haystack with no extras
+      run: pip install .
+
+    - name: Try to import
+      run: python -c 'import haystack'

--- a/.github/workflows/imports.yml
+++ b/.github/workflows/imports.yml
@@ -1,7 +1,6 @@
 name: Dependency checker
 
 on:
-  workflow_dispatch: # Activate this workflow manually
   push:
     branches:
       - main
@@ -18,6 +17,7 @@ on:
       - "pyproject.toml"
       - "!.github/**/*.py"
       - "!rest_api/**/*.py"
+      - "!test/*"
 
 env:
   PYTHON_VERSION: "3.8"

--- a/haystack/nodes/doc_language_classifier/langdetect.py
+++ b/haystack/nodes/doc_language_classifier/langdetect.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import langdetect
-except ImportError as exc:
+except (ImportError, ModuleNotFoundError) as exc:
     logger.debug(
         "langdetect could not be imported. "
         "Run 'pip install farm-haystack[file-conversion]' or 'pip install langdetect' to fix this issue."

--- a/haystack/nodes/doc_language_classifier/langdetect.py
+++ b/haystack/nodes/doc_language_classifier/langdetect.py
@@ -13,7 +13,7 @@ try:
 except (ImportError, ModuleNotFoundError) as exc:
     logger.debug(
         "langdetect could not be imported. "
-        "Run 'pip install farm-haystack[file-conversion]' or 'pip install langdetect' to fix this issue."
+        "Run 'pip install farm-haystack[preprocessing]' or 'pip install langdetect' to fix this issue."
     )
     langdetect = None
 

--- a/haystack/nodes/file_converter/base.py
+++ b/haystack/nodes/file_converter/base.py
@@ -1,11 +1,23 @@
 from typing import List, Optional, Dict, Union, Any
 
+import logging
 from abc import abstractmethod
 from pathlib import Path
-import langdetect
+
 from tqdm.auto import tqdm
 from haystack.nodes.base import BaseComponent
 from haystack.schema import Document
+
+logger = logging.getLogger(__name__)
+
+try:
+    import langdetect
+except (ImportError, ModuleNotFoundError) as exc:
+    logger.debug(
+        "langdetect could not be imported. "
+        "Run 'pip install farm-haystack[file-conversion]' or 'pip install langdetect' to fix this issue."
+    )
+    langdetect = None
 
 
 # https://en.wikipedia.org/wiki/Ligature_(writing)
@@ -125,10 +137,14 @@ class BaseConverter(BaseComponent):
         if not valid_languages:
             return True
 
-        try:
-            lang = langdetect.detect(text)
-        except langdetect.lang_detect_exception.LangDetectException:
-            lang = None
+        lang = None
+        if not langdetect:
+            logger.debug("langdetect could not be imported. Haystack won't try to guess the document language.")
+        else:
+            try:
+                lang = langdetect.detect(text)
+            except langdetect.lang_detect_exception.LangDetectException:
+                pass
 
         return lang in valid_languages
 

--- a/haystack/nodes/file_converter/base.py
+++ b/haystack/nodes/file_converter/base.py
@@ -15,7 +15,7 @@ try:
 except (ImportError, ModuleNotFoundError) as exc:
     logger.debug(
         "langdetect could not be imported. "
-        "Run 'pip install farm-haystack[file-conversion]' or 'pip install langdetect' to fix this issue."
+        "Run 'pip install farm-haystack[preprocessing]' or 'pip install langdetect' to fix this issue."
     )
     langdetect = None
 


### PR DESCRIPTION
### Related Issues
- fixes #4684

### Proposed Changes:
- Fixes the `langdetect` import to be actually optional
- Adds a CI job to check that the minimal Haystack install is importable.

### How did you test it?
- Manually
- CI

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
