### PR TITLE
test: Block requests_cache in unit tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -823,3 +823,4 @@ def request_blocker(request: pytest.FixtureRequest, monkeypatch):
     if marker is None:
         return
     monkeypatch.delattr("requests.sessions.Session")
+    monkeypatch.delattr("requests_cache.session.CachedSession")


### PR DESCRIPTION
### Proposed Changes:

Block HTTP calls made by `requests_cache` in unit tests.

### How did you test it?

`pytest -u "unit" test`, everything was green.

### Notes for the reviewer

N/A