### PR TITLE
test: Enhance some prompt tests

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -267,4 +267,5 @@ class StopWordsCriteria(StoppingCriteria):
         self.stop_words = tokenizer(stop_words, add_special_tokens=False, return_tensors="pt").to(device)
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        # TODO: Update relative test in test_hugging_face.py when this is fixed
         return any(torch.isin(input_ids[-1], self.stop_words["input_ids"]))

--- a/test/prompt/invocation_layer/test_chatgpt.py
+++ b/test/prompt/invocation_layer/test_chatgpt.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+import pytest
+
+from haystack.nodes.prompt.invocation_layer import ChatGPTInvocationLayer
+
+
+@pytest.mark.unit
+def test_chatgpt_invoke_with_messages_as_prompt():
+    with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer"):
+        layer = ChatGPTInvocationLayer(api_key="fake_key")
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Who won the world series in 2020?"},
+        {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
+        {"role": "user", "content": "Where was it played?"},
+    ]
+
+    with patch("haystack.nodes.prompt.invocation_layer.chatgpt.openai_request") as mock_request:
+        layer.invoke(prompt=messages)
+        calls = mock_request.call_args_list
+        assert len(calls) == 1
+        assert calls[0].kwargs["payload"]["messages"] == messages

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch, Mock
+
+import pytest
+from torch import Tensor
+
+
+from haystack.nodes.prompt.invocation_layer import HFLocalInvocationLayer
+from haystack.nodes.prompt.invocation_layer.hugging_face import StopWordsCriteria
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task")
+def test_supports_text2text_generation_task(mock_get_task):
+    mock_get_task.return_value = "text2text-generation"
+    assert HFLocalInvocationLayer.supports("supported_model")
+
+    assert not HFLocalInvocationLayer.supports("supported_model", api_key="some_key")
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task")
+def test_supports_text_generation_task(mock_get_task):
+    mock_get_task.return_value = "text-generation"
+    assert HFLocalInvocationLayer.supports("supported_model")
+
+    assert not HFLocalInvocationLayer.supports("supported_model", api_key="some_key")
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task")
+def test_supports_with_unsupported_task(mock_get_task):
+    mock_get_task.return_value = "some-unsupported-task"
+    assert not HFLocalInvocationLayer.supports("supported_model")
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task")
+def test_supports_with_unsupported_model(mock_get_task):
+    mock_get_task.side_effect = RuntimeError
+    assert not HFLocalInvocationLayer.supports("unsupported_model")
+
+
+@pytest.mark.unit
+def test_stop_words_criteria_init():
+    mock_batch_encoding = Mock()
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = mock_batch_encoding
+
+    StopWordsCriteria(tokenizer=mock_tokenizer, stop_words=[], device="gpu")
+    mock_tokenizer.assert_called_once_with([], add_special_tokens=False, return_tensors="pt")
+    mock_batch_encoding.to.assert_called_once_with("gpu")
+
+
+@pytest.mark.unit
+@pytest.mark.skip("Update this test after StopWordsCriteria is fixed")
+def test_stop_words_criteria_call():
+    mock_batch_encoding = Mock()
+    mock_batch_encoding.to.return_value = {"input_ids": Tensor([[1190]]), "attention_mask": Tensor([[1]])}
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = mock_batch_encoding
+
+    criteria = StopWordsCriteria(tokenizer=mock_tokenizer, stop_words=[], device="gpu")


### PR DESCRIPTION
### Related Issues

Fixes #4561

### Proposed Changes:

Removed some duplicate code from `PromptNode.prompt()`.

Rewrite some integration tests to unit test of other components, mostly invocation layers.

Mark most remaining integration tests as skipped as it's not clear whether they're testing the `prompt` module or some other component or 3rd party.

### How did you test it?

I ran `pytest -u unit test/prompt` locally and it was green.

### Notes for the reviewer

N/A