### PR TITLE
docs: add web retriever to api docs

### DIFF
--- a/docs/pydoc/config/retriever.yml
+++ b/docs/pydoc/config/retriever.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/retriever]
-    modules: ["base", "sparse", "dense", "text2sparql", "multimodal/retriever"]
+    modules: ["base", "sparse", "dense", "text2sparql", "multimodal/retriever", "web"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter


### PR DESCRIPTION
### Related Issues


### Proposed Changes:
adding `web` to retriever API docs

### How did you test it?

### Notes for the reviewer

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
