### PR TITLE
fix: Fixing the Weaviate BM25 query builder bug

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -1028,7 +1028,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                 gql_query = (
                     gql.get.GetBuilder(class_name=index, properties=properties, connection=self.weaviate_client)
                     .with_limit(top_k)
-                    .with_bm25({"query": query, "properties": self.content_field})
+                    .with_bm25(query=query, properties=[self.content_field])
                     .with_where(filter_dict)
                     .build()
                 )
@@ -1037,7 +1037,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                 gql_query = (
                     gql.get.GetBuilder(class_name=index, properties=properties, connection=self.weaviate_client)
                     .with_limit(top_k)
-                    .with_bm25({"query": query, "properties": self.content_field})
+                    .with_bm25(query=query, properties=[self.content_field])
                     .build()
                 )
 


### PR DESCRIPTION
### Related Issues
- fixes #4702 

### Proposed Changes:
We should be calling the Weaviate client's query builder class' `with_bm25()` method with the correct params instead of a dict, see https://github.com/weaviate/weaviate-python-client/blob/27f6254bc01480ad8c1ce5e47be965bf8b19b6b6/weaviate/gql/get.py#L913

### How did you test it?
Unit tests + testing it locally.

### Notes for the reviewer
This should be a rather easy thing to approve (I hope).

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
