### PR TITLE
fix: Log 'Observation on new line

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -210,7 +210,7 @@ class Agent:
             llm_prefix: Optional[str] = None,
             **kwargs: Any,
         ) -> None:
-            print_text(observation_prefix)  # type: ignore
+            print_text(f"\n{observation_prefix}")  # type: ignore
             print_text(tool_output, color=color)
             print_text(f"\n{llm_prefix}")
 


### PR DESCRIPTION
Without this fix observation is logged on the same line as the previous step as in the image below.

![image](https://user-images.githubusercontent.com/15802862/232918617-e79eb46c-8eac-4fb3-a767-db0f334eb457.png)

I've made a small change to the code to make it so that Observation gets logged in the line below. 

PS: It's easy to not notice this because often in notebooks a ipython widget (for things like 'Calculating embeddings' gets added before, meaning it looks like observation is on the next line..) 