### PR TITLE
[feat] Support Cloud FAAS

### DIFF
--- a/haystack/document_stores/elasticsearch.py
+++ b/haystack/document_stores/elasticsearch.py
@@ -28,6 +28,7 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
         port: Union[int, List[int]] = 9200,
         username: str = "",
         password: str = "",
+        cloud_id: Optional[str] = None,
         api_key_id: Optional[str] = None,
         api_key: Optional[str] = None,
         aws4auth=None,
@@ -68,6 +69,7 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
         :param port: port(s) of elasticsearch nodes
         :param username: username (standard authentication via http_auth)
         :param password: password (standard authentication via http_auth)
+        :param cloud_id: ID of cloud services (cloud FAAS authentication)
         :param api_key_id: ID of the API key (altenative authentication mode to the above http_auth)
         :param api_key: Secret value of the API key (altenative authentication mode to the above http_auth)
         :param aws4auth: Authentication for usage with aws elasticsearch (can be generated with the requests-aws4auth package)
@@ -135,6 +137,7 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
             port=port,
             username=username,
             password=password,
+            cloud_id=cloud_id,
             api_key=api_key,
             api_key_id=api_key_id,
             aws4auth=aws4auth,
@@ -187,6 +190,7 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
         port: Union[int, List[int]],
         username: str,
         password: str,
+        cloud_id: Optional[str],
         api_key_id: Optional[str],
         api_key: Optional[str],
         aws4auth,
@@ -198,14 +202,20 @@ class ElasticsearchDocumentStore(SearchEngineDocumentStore):
     ) -> Elasticsearch:
         hosts = prepare_hosts(host, port)
 
-        if (api_key or api_key_id) and not (api_key and api_key_id):
-            raise ValueError("You must provide either both or none of `api_key_id` and `api_key`")
+        if (api_key or api_key_id or cloud_id) and not (api_key and (api_key_id or cloud_id)):
+            raise ValueError(
+                "You must provide either both or none of `api_key_id` and `api_key` or `cloud_id` and `api_key`"
+            )
 
         connection_class: Type[Connection] = Urllib3HttpConnection
         if use_system_proxy:
             connection_class = RequestsHttpConnection
 
-        if api_key:
+        if cloud_id:
+            # cloud FAAS:
+            # see https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html#connecting-faas
+            client = Elasticsearch(cloud_id=cloud_id, api_key=api_key)
+        elif api_key_id:
             # api key authentication
             client = Elasticsearch(
                 hosts=hosts,

--- a/haystack/document_stores/es_converter.py
+++ b/haystack/document_stores/es_converter.py
@@ -25,6 +25,7 @@ def open_search_index_to_document_store(
     port: Union[int, List[int]] = 9200,
     username: str = "admin",
     password: str = "admin",
+    cloud_id: Optional[str] = None,
     api_key_id: Optional[str] = None,
     api_key: Optional[str] = None,
     aws4auth=None,
@@ -69,6 +70,7 @@ def open_search_index_to_document_store(
     :param port: Ports(s) of OpenSearch nodes.
     :param username: Username (standard authentication via http_auth).
     :param password: Password (standard authentication via http_auth).
+    :param cloud_id: ID of the cloud service (FAAS authentication).
     :param api_key_id: ID of the API key (altenative authentication mode to the above http_auth).
     :param api_key: Secret value of the API key (altenative authentication mode to the above http_auth).
     :param aws4auth: Authentication for usage with AWS OpenSearch
@@ -97,6 +99,7 @@ def open_search_index_to_document_store(
         port=port,
         username=username,
         password=password,
+        cloud_id=cloud_id,
         api_key_id=api_key_id,
         api_key=api_key,
         aws4auth=aws4auth,
@@ -124,6 +127,7 @@ def elasticsearch_index_to_document_store(
     port: Union[int, List[int]] = 9200,
     username: str = "",
     password: str = "",
+    cloud_id: Optional[str] = None,
     api_key_id: Optional[str] = None,
     api_key: Optional[str] = None,
     aws4auth=None,
@@ -168,6 +172,7 @@ def elasticsearch_index_to_document_store(
     :param port: Ports(s) of Elasticsearch nodes.
     :param username: Username (standard authentication via http_auth).
     :param password: Password (standard authentication via http_auth).
+    :param cloud_id: ID of the cloud service (FAAS authentication).
     :param api_key_id: ID of the API key (altenative authentication mode to the above http_auth).
     :param api_key: Secret value of the API key (altenative authentication mode to the above http_auth).
     :param aws4auth: Authentication for usage with AWS Elasticsearch
@@ -188,6 +193,7 @@ def elasticsearch_index_to_document_store(
         port=port,
         username=username,
         password=password,
+        cloud_id=cloud_id,
         api_key=api_key,
         api_key_id=api_key_id,
         aws4auth=aws4auth,

--- a/test/document_stores/test_elasticsearch.py
+++ b/test/document_stores/test_elasticsearch.py
@@ -301,6 +301,7 @@ class TestElasticsearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngine
             "host": "host",
             "port": 443,
             "password": "pass",
+            "cloud_id": None,
             "api_key_id": None,
             "api_key": None,
             "scheme": "https",


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Current Elastic Search in Haystack does not support Cloud FAAS. This PR support FAAS by introducing the `cloud_id` variable for `ElasticSearchDocumentStore` and checking if `cloud_id` and `api_key` coexists. For details please kindly refer to [here](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html#connecting-faas)

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manual verification, provide `cloud_id` and `api_key`, when both exists, it will connect to `ElasticSearch` via FAAS.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
