### PR TITLE
Pouyanpi/feat/search engine/providers/google api

### DIFF
--- a/haystack/nodes/search_engine/providers.py
+++ b/haystack/nodes/search_engine/providers.py
@@ -274,3 +274,78 @@ class BingAPI(SearchEngine):
 
         logger.debug("Bing API returned %s documents for the query '%s'", len(documents), query)
         return documents[:top_k]
+
+
+class GoogleAPI(SearchEngine):
+    """Search engine using the Google API. See [Google Search API](https://developers.google.com/custom-search/v1/overview) for more details."""
+
+    def __init__(
+        self,
+        top_k: Optional[int] = 10,
+        api_key: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        search_engine_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        :param top_k: Number of documents to return.
+        :param api_key: API key for the Google API.
+        :param engine_id: Engine ID for the Google API.
+        :param search_engine_kwargs: Additional parameters passed to the Google API. As an example, you can pass the hl parameter to specify the language to use for the query: 'hl':'en'.
+        """
+        super().__init__()
+        self.api_key = api_key
+        self.engine_id = engine_id
+        self.top_k = top_k
+        self.kwargs = search_engine_kwargs if search_engine_kwargs else {}
+
+    def _validate_environment(self):
+        """
+        Validate if the environment variables are set.
+        """
+        if not self.api_key:
+            raise ValueError(
+                "You need to provide an API key for the Google API. See https://developers.google.com/custom-search/v1/overview"
+            )
+        if not self.engine_id:
+            raise ValueError(
+                "You need to provide an engine ID for the Google API. See https://developers.google.com/custom-search/v1/overview"
+            )
+
+        # check if google api is installed
+        try:
+            from googleapiclient.discovery import build
+        except ImportError:
+            raise ImportError(
+                "You need to install the Google API client. You can do so by running 'pip install google-api-python-client'."
+            )
+        # create a custom search service
+        self.service = build("customsearch", "v1", developerKey=self.api_key)
+
+    def search(self, query: str, **kwargs) -> List[Document]:
+        """
+        :param query: Query string.
+        :param kwargs: Additional parameters passed to the Google API.
+                       As an example, you can pass the hl parameter to specify the language to use for the query: 'hl':'en'.
+                       If you don't specify the hl parameter, the default language for the user's location is used.
+                       For a complete list of the language codes, see [Language Codes](https://developers.google.com/custom-search/docs/xml_results#languageCollections).
+                       You can also pass the num parameter to specify the number of results to return: 'num':10.
+                       You can find a full list of parameters at [Query Parameters](https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list).
+        :return: List[Document]
+        """
+        kwargs = {**self.kwargs, **kwargs}
+        self.engine_id = kwargs.pop("engine_id", self.engine_id)
+
+        self._validate_environment()
+
+        top_k = kwargs.pop("top_k", self.top_k)
+        params: Dict[str, Union[str, int, float]] = {"num": 10, **kwargs}
+        res = self.service.cse().list(q=query, cx=self.engine_id, **params).execute()
+        documents: List[Document] = []
+        for i, result in enumerate(res["items"]):
+            documents.append(
+                Document.from_dict(
+                    {"title": result["title"], "content": result["snippet"], "position": i, "link": result["link"]}
+                )
+            )
+        logger.debug("Google API returned %s documents for the query '%s'", len(documents), query)
+        return documents[:top_k]

--- a/test/nodes/test_web_search.py
+++ b/test/nodes/test_web_search.py
@@ -33,3 +33,21 @@ def test_web_search_with_site_keyword():
     assert all(
         ["nasa" in doc.meta["link"] or "lifewire" in doc.meta["link"] for doc in result["documents"]]
     ), "Some documents are not from the specified sites lifewire.com or nasa.gov."
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GOOGLE_API_KEY", None),
+    reason="Please export an env var called GOOGLE_API_KEY containing the serper.dev API key to run this test.",
+)
+@pytest.mark.skipif(
+    not os.enviorn.get("SEARCH_ENGINE_ID", None),
+    reason="Please export an env var called SEARCH_ENGINE_ID containing your search engine id to run this test.",
+)
+@pytest.mark.integration
+def test_web_search_with_google_api():
+    ws = WebSearch(api_key=G_API_KEY, search_engine_provider="GoogleAPI", search_engine_kwargs={"engine_id": s_id})
+
+    result, _ = ws.run(query="The founder of Python")
+    assert len(result["documents"]) > 1
+    assert "guido" in result["docker"][0].content.lower()
+    assert isinstance(result["documents"][0], Document)


### PR DESCRIPTION
### Related Issues
- implements #4721

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This feature allows the user to benefit from the google api search engine. Using the google cloud console the user can send queries to the google search api and it is much more cost effective comparing to serp for search. (free,e tc.)

https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
integeration tests are available. 

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
You need to obtain the relevant credentials and set the search engine id by following this procedure:
1. create a custom search engine service at:
    https://programmablesearchengine.google.com/
**you can allow the search engine to access all websites**

3. create an api key from https://console.cloud.google.com/apis/
 go to
 - credentials ->create a credential -> api key
    - copy the api key
    - 
![image](https://user-images.githubusercontent.com/13303554/233609333-d4c264a2-3e78-42b1-bbae-9746fbbe1a25.png)

The test are skipped if the environ variables are not set.

`SEARCH_ENGINE_ID` and `GOOGLE_API_KEY` must be set.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
