### PR TITLE
Enhance the error logging in PromptTemplate variable resolution

### DIFF
--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -268,8 +268,8 @@ class PromptTemplate(BasePromptTemplate, ABC):
                 if param in kwargs:
                     params_dict[param] = kwargs[param]
 
-        if not set(self.prompt_params).issubset(set(params_dict.keys())):
-            available_params = set(list(params_dict.keys()) + list(set(kwargs.keys())))
+        if not set(self.prompt_params).issubset(params_dict.keys()):
+            available_params = {*params_dict.keys(), *kwargs.keys()}
             provided = set(self.prompt_params).intersection(available_params)
             message = f"only {list(provided)}" if provided else "none of these parameters"
             raise ValueError(

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -274,7 +274,7 @@ class PromptTemplate(BasePromptTemplate, ABC):
             message = f"only {list(provided)}" if provided else "none of these parameters"
             raise ValueError(
                 f"Expected prompt parameters {self.prompt_params} to be provided but got "
-                f"{message}. Please make sure to provide all template parameters."
+                f"{message}. Make sure to provide all template parameters."
             )
 
         template_dict = {"_at_least_one_prompt": True}

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -268,9 +268,14 @@ class PromptTemplate(BasePromptTemplate, ABC):
                 if param in kwargs:
                     params_dict[param] = kwargs[param]
 
-        if set(params_dict.keys()) != set(self.prompt_params):
+        if not set(self.prompt_params).issubset(set(params_dict.keys())):
             available_params = set(list(params_dict.keys()) + list(set(kwargs.keys())))
-            raise ValueError(f"Expected prompt parameters {self.prompt_params} but got {list(available_params)}.")
+            provided = set(self.prompt_params).intersection(available_params)
+            message = f"only {list(provided)}" if provided else "none of these parameters"
+            raise ValueError(
+                f"Expected prompt parameters {self.prompt_params} to be provided but got "
+                f"{message}. Please make sure to provide all template parameters."
+            )
 
         template_dict = {"_at_least_one_prompt": True}
         for id, call in self._prompt_params_functions.items():

--- a/test/prompt/test_prompt_template.py
+++ b/test/prompt/test_prompt_template.py
@@ -36,6 +36,27 @@ def test_prompt_templates():
 
 
 @pytest.mark.unit
+def test_missing_prompt_template_params():
+    p = PromptTemplate("missing_params", "Here is some fake template with variable {foo} and {bar}")
+
+    # both params provided - ok
+    p.prepare(foo="foo", bar="bar")
+
+    # missing one param
+    with pytest.raises(ValueError, match=".*parameters \['bar', 'foo'\] to be provided but got only \['foo'\].*"):
+        p.prepare(foo="foo")
+
+    # missing both params
+    with pytest.raises(
+        ValueError, match=".*parameters \['bar', 'foo'\] to be provided but got none of these parameters.*"
+    ):
+        p.prepare(lets="go")
+
+    # more than both params provided - also ok
+    p.prepare(foo="foo", bar="bar", lets="go")
+
+
+@pytest.mark.unit
 def test_prompt_template_repr():
     p = PromptTemplate("t", "Here is variable {baz}")
     desired_repr = "PromptTemplate(name=t, prompt_text=Here is variable {baz}, prompt_params=['baz'])"

--- a/test/prompt/test_prompt_template.py
+++ b/test/prompt/test_prompt_template.py
@@ -37,23 +37,23 @@ def test_prompt_templates():
 
 @pytest.mark.unit
 def test_missing_prompt_template_params():
-    p = PromptTemplate("missing_params", "Here is some fake template with variable {foo} and {bar}")
+    template = PromptTemplate("missing_params", "Here is some fake template with variable {foo} and {bar}")
 
     # both params provided - ok
-    p.prepare(foo="foo", bar="bar")
+    template.prepare(foo="foo", bar="bar")
 
     # missing one param
-    with pytest.raises(ValueError, match=".*parameters \['bar', 'foo'\] to be provided but got only \['foo'\].*"):
-        p.prepare(foo="foo")
+    with pytest.raises(ValueError, match=r".*parameters \['bar', 'foo'\] to be provided but got only \['foo'\].*"):
+        template.prepare(foo="foo")
 
     # missing both params
     with pytest.raises(
-        ValueError, match=".*parameters \['bar', 'foo'\] to be provided but got none of these parameters.*"
+        ValueError, match=r".*parameters \['bar', 'foo'\] to be provided but got none of these parameters.*"
     ):
-        p.prepare(lets="go")
+        template.prepare(lets="go")
 
     # more than both params provided - also ok
-    p.prepare(foo="foo", bar="bar", lets="go")
+    template.prepare(foo="foo", bar="bar", lets="go")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues
- fixes #4365 #4366 

### Proposed Changes:
Properly logs which prompt params are missing

### How did you test it?
Unit test, see diff

### Notes for the reviewer
N/A

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
