### PR TITLE
feat: implementation of loading local model of huggingface (#4729)

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/base.py
+++ b/haystack/nodes/prompt/invocation_layer/base.py
@@ -10,7 +10,7 @@ class PromptModelInvocationLayer:
     could be even remote, for example, a call to a remote API endpoint.
     """
 
-    invocation_layer_providers: List[Type["PromptModelInvocationLayer"]] = []
+    invocation_layer_providers: dict = {}
 
     def __init__(self, model_name_or_path: str, **kwargs):
         """
@@ -31,7 +31,8 @@ class PromptModelInvocationLayer:
         Called when a subclass of PromptModelInvocationLayer is imported.
         """
         super().__init_subclass__(**kwargs)
-        cls.invocation_layer_providers.append(cls)
+        #cls.invocation_layer_providers.append(cls)
+        cls.invocation_layer_providers[cls.__name__] = cls
 
     @abstractmethod
     def invoke(self, *args, **kwargs):
@@ -40,6 +41,18 @@ class PromptModelInvocationLayer:
         :return: A list of generated text.
         """
         pass
+
+    @classmethod
+    def get_subclass(cls, layer_name: str) :
+        if layer_name not in cls.invocation_layer_providers.keys():
+            raise ValueError(
+                f"Haystack component with the name '{layer_name}' not found. "
+                "Check the class name of your component for spelling mistakes and make sure you installed "
+                "Haystack with the proper extras: https://docs.haystack.deepset.ai/docs/installation#custom-installation"
+            )
+
+        subclass = cls.invocation_layer_providers[layer_name]
+        return subclass
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:


### PR DESCRIPTION
*Compatible with original usage

*Local model usage:
  1. add the invocation_layer_class parameters to select existing invocation layer;
  2. add the task parameter in model_kwargs for local model. for example text-generation or text2text-generation.

- name: PModel type: PromptModel params: invocation_layer_class: HFLocalInvocationLayer model_name_or_path: /local_path/llama-7b-hf model_kwargs: task: text-generation
- name: Prompter params: model_name_or_path: PModel default_prompt_template: question-answering type: PromptNode

### Related Issues
- fixes #4729 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
