### PR TITLE
docs: Add repo name to install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ You might need to install additional dependencies, depending on what exactly you
 Now fork and clone the repo. From the terminal, run:
 
 ```bash
-git clone https://github.com/<your-gh-username>/haystack.git
+git clone https://github.com/deepset-ai/haystack.git
 ```
 
 or use your favourite Git(Hub) client.


### PR DESCRIPTION
### Related Issues
None

### Proposed Changes:
The instructions for installing Haystack from GitHub didn't use the repo name but just a placeholder. This PR replaces the placeholder with the actual repo name

### How did you test it?
No tests

### Notes for the reviewer
@dfokina is working on the README file and has a related PR open here: https://github.com/deepset-ai/haystack/pull/4741

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
