### PR TITLE
refactor: Update schema objects to handle Dataframes in to_{dict,json} and from_{dict,json}

### DIFF
--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -431,7 +431,7 @@ class Answer:
         return cls(**dict)
 
     def to_json(self):
-        return json.dumps(self.to_dict(), cls=NumpyEncoder)
+        return json.dumps(self, default=pydantic_encoder)
 
     @classmethod
     def from_json(cls, data):
@@ -578,7 +578,7 @@ class Label:
         return cls(**dict)
 
     def to_json(self):
-        return json.dumps(self.to_dict(), cls=NumpyEncoder)
+        return json.dumps(self, default=pydantic_encoder)
 
     @classmethod
     def from_json(cls, data):
@@ -684,7 +684,7 @@ class MultiLabel:
         # If we do not exclude them from document_ids this would be problematic for retriever evaluation as they do not contain the answer.
         # Hence, we exclude them here as well.
         self._document_ids = [l.document.id for l in self._labels if not l.no_answer]
-        self._contexts = [l.document.content for l in self._labels if not l.no_answer]
+        self._contexts = [str(l.document.content) for l in self._labels if not l.no_answer]
 
     @staticmethod
     def _to_dict_offsets(offset: Union[Span, TableCell]) -> Dict:

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -795,6 +795,11 @@ def _pydantic_dataclass_from_dict(dict: "dict", pydantic_dataclass_type) -> Any:
 
 
 def _dict_factory(list_of_tuples):
+    """Meant to be as the dict_factory for `asdict`. This function is called within `asdict` to convert a list of tuples
+    into a dictionary object. This handles the conversion of pandas Dataframes into a list of lists.
+
+    :param list_of_tuples: list of (key, value) pairs
+    """
     res = {}
     for key, val in list_of_tuples:
         if isinstance(val, pd.DataFrame):

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -607,7 +607,7 @@ def test_multilabel_with_doc_containing_dataframes():
     )
     multilabel = MultiLabel(labels=[label])
     assert multilabel.query == "A question"
-    assert multilabel.contexts[0].equals(pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}))
+    assert multilabel.contexts == ["   col1  col2\n0     1     3\n1     2     4"]
     assert multilabel.answers == ["1"]
     assert multilabel.document_ids == ["table1"]
     assert multilabel.offsets_in_documents == [{"row": 0, "col": 0}]

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -659,52 +659,6 @@ def test_multilabel_serialization():
     assert json_deserialized_multilabel.labels[0] == label
 
 
-# TODO Fix
-# def test_table_multilabel_serialization():
-#     tabel_label_dict = {
-#         "id": "011079cf-c93f-49e6-83bb-42cd850dce12",
-#         "query": "What is the first number?",
-#         "document": {
-#             "content": [["col1", "col2"], [1, 3], [2, 4]],
-#             "content_type": "table",
-#             "id": "table1",
-#             "meta": {},
-#             "score": None,
-#             "embedding": None,
-#         },
-#         "is_correct_answer": True,
-#         "is_correct_document": True,
-#         "origin": "user-feedback",
-#         "answer": {
-#             "answer": "1",
-#             "type": "extractive",
-#             "score": None,
-#             "context": [["col1", "col2"], [1, 3], [2, 4]],
-#             "offsets_in_document": [{"row": 0, "col": 0}],
-#             "offsets_in_context": [{"row": 0, "col": 0}],
-#             "document_ids": ["table1"],
-#             "meta": {},
-#         },
-#         "no_answer": False,
-#         "pipeline_id": None,
-#         "created_at": "2022-07-22T13:29:33.699781+00:00",
-#         "updated_at": "2022-07-22T13:29:33.784895+00:00",
-#         "meta": {"answer_id": "374394", "document_id": "604995", "question_id": "345530"},
-#         "filters": None,
-#     }
-#
-#     label = Label.from_dict(tabel_label_dict)
-#     original_multilabel = MultiLabel([label])
-#
-#     deserialized_multilabel = MultiLabel.from_dict(original_multilabel.to_dict())
-#     assert deserialized_multilabel == original_multilabel
-#     assert deserialized_multilabel.labels[0] == label
-#
-#     json_deserialized_multilabel = MultiLabel.from_json(original_multilabel.to_json())
-#     assert json_deserialized_multilabel == original_multilabel
-#     assert json_deserialized_multilabel.labels[0] == label
-
-
 def test_span_in():
     assert 10 in Span(5, 15)
     assert not 20 in Span(1, 15)

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -55,6 +55,7 @@ def table_label_1():
             type="extractive",
             score=0.1,
             document_ids=["123"],
+            context=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
             offsets_in_document=[TableCell(row=1, col=0)],
         ),
         document=Document(
@@ -76,6 +77,7 @@ def table_label_2():
             type="extractive",
             score=0.1,
             document_ids=["123"],
+            context=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
             offsets_in_document=[TableCell(row=0, col=0)],
         ),
         document=Document(
@@ -237,7 +239,6 @@ def test_answer_to_dict(text_answer):
     assert a_new == a
 
 
-# TODO Fix
 def test_table_answer_to_json(table_answer):
     json_ans = table_answer.to_json()
     assert isinstance(json_ans, str)
@@ -246,7 +247,6 @@ def test_table_answer_to_json(table_answer):
     assert a_new == table_answer
 
 
-# TODO Fix
 def test_table_answer_to_dict(table_answer):
     dict_ans = table_answer.to_dict()
     assert isinstance(dict_ans, dict)
@@ -606,7 +606,7 @@ def test_multilabel_with_doc_containing_dataframes():
     )
     multilabel = MultiLabel(labels=[label])
     assert multilabel.query == "A question"
-    assert multilabel.contexts == ["   col1  col2\n0     1     3\n1     2     4"]
+    assert multilabel.contexts[0].equals(pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}))
     assert multilabel.answers == ["1"]
     assert multilabel.document_ids == ["table1"]
     assert multilabel.offsets_in_documents == [{"row": 0, "col": 0}]
@@ -656,6 +656,52 @@ def test_multilabel_serialization():
     json_deserialized_multilabel = MultiLabel.from_json(original_multilabel.to_json())
     assert json_deserialized_multilabel == original_multilabel
     assert json_deserialized_multilabel.labels[0] == label
+
+
+# TODO Fix
+# def test_table_multilabel_serialization():
+#     tabel_label_dict = {
+#         "id": "011079cf-c93f-49e6-83bb-42cd850dce12",
+#         "query": "What is the first number?",
+#         "document": {
+#             "content": [["col1", "col2"], [1, 3], [2, 4]],
+#             "content_type": "table",
+#             "id": "table1",
+#             "meta": {},
+#             "score": None,
+#             "embedding": None,
+#         },
+#         "is_correct_answer": True,
+#         "is_correct_document": True,
+#         "origin": "user-feedback",
+#         "answer": {
+#             "answer": "1",
+#             "type": "extractive",
+#             "score": None,
+#             "context": [["col1", "col2"], [1, 3], [2, 4]],
+#             "offsets_in_document": [{"row": 0, "col": 0}],
+#             "offsets_in_context": [{"row": 0, "col": 0}],
+#             "document_ids": ["table1"],
+#             "meta": {},
+#         },
+#         "no_answer": False,
+#         "pipeline_id": None,
+#         "created_at": "2022-07-22T13:29:33.699781+00:00",
+#         "updated_at": "2022-07-22T13:29:33.784895+00:00",
+#         "meta": {"answer_id": "374394", "document_id": "604995", "question_id": "345530"},
+#         "filters": None,
+#     }
+#
+#     label = Label.from_dict(tabel_label_dict)
+#     original_multilabel = MultiLabel([label])
+#
+#     deserialized_multilabel = MultiLabel.from_dict(original_multilabel.to_dict())
+#     assert deserialized_multilabel == original_multilabel
+#     assert deserialized_multilabel.labels[0] == label
+#
+#     json_deserialized_multilabel = MultiLabel.from_json(original_multilabel.to_json())
+#     assert json_deserialized_multilabel == original_multilabel
+#     assert json_deserialized_multilabel.labels[0] == label
 
 
 def test_span_in():

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -47,60 +47,45 @@ def text_labels():
 
 
 @pytest.fixture
-def table_labels():
-    return [
-        Label(
-            query="some",
-            answer=Answer(
-                answer="text_2",
-                type="extractive",
-                score=0.1,
-                document_ids=["123"],
-                offsets_in_document=[TableCell(row=1, col=0)],
-            ),
-            document=Document(
-                content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
-                content_type="table",
-            ),
-            is_correct_answer=True,
-            is_correct_document=True,
-            origin="user-feedback",
+def table_label_1():
+    return Label(
+        query="some",
+        answer=Answer(
+            answer="text_2",
+            type="extractive",
+            score=0.1,
+            document_ids=["123"],
+            offsets_in_document=[TableCell(row=1, col=0)],
         ),
-        Label(
-            query="some",
-            answer=Answer(
-                answer="text_1",
-                type="extractive",
-                score=0.1,
-                document_ids=["123"],
-                offsets_in_document=[TableCell(row=0, col=0)],
-            ),
-            document=Document(
-                content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
-                content_type="table",
-            ),
-            is_correct_answer=True,
-            is_correct_document=True,
-            origin="user-feedback",
+        document=Document(
+            content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
+            content_type="table",
         ),
-        Label(
-            query="some",
-            answer=Answer(
-                answer="1",
-                type="extractive",
-                score=0.1,
-                document_ids=["123"],
-                offsets_in_document=[TableCell(row=0, col=1)],
-            ),
-            document=Document(
-                content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
-                content_type="table",
-            ),
-            is_correct_answer=True,
-            is_correct_document=True,
-            origin="user-feedback",
+        is_correct_answer=True,
+        is_correct_document=True,
+        origin="user-feedback",
+    )
+
+
+@pytest.fixture
+def table_label_2():
+    return Label(
+        query="some",
+        answer=Answer(
+            answer="text_1",
+            type="extractive",
+            score=0.1,
+            document_ids=["123"],
+            offsets_in_document=[TableCell(row=0, col=0)],
         ),
-    ]
+        document=Document(
+            content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
+            content_type="table",
+        ),
+        is_correct_answer=True,
+        is_correct_document=True,
+        origin="user-feedback",
+    )
 
 
 @pytest.fixture
@@ -201,23 +186,22 @@ def test_label_to_dict(text_labels):
     assert l_new.answer.offsets_in_document[0].start == 1
 
 
-# TODO Fix
-# def test_equal_table_label(table_labels):
-#     assert table_labels[2] == table_labels[0]
-#     assert table_labels[1] != table_labels[0]
+def test_equal_table_label(table_label_1, table_label_2):
+    assert table_label_1 == table_label_1
+    assert table_label_1 != table_label_2
 
 
-def test_table_label_to_json(table_labels):
-    j0 = table_labels[0].to_json()
+def test_table_label_to_json(table_label_1):
+    j0 = table_label_1.to_json()
     l_new = Label.from_json(j0)
-    assert l_new == table_labels[0]
+    assert l_new == table_label_1
     assert l_new.answer.offsets_in_document[0].row == 1
 
 
-def test_table_label_to_dict(table_labels):
-    j0 = table_labels[0].to_dict()
+def test_table_label_to_dict(table_label_1):
+    j0 = table_label_1.to_dict()
     l_new = Label.from_dict(j0)
-    assert l_new == table_labels[0]
+    assert l_new == table_label_1
     assert l_new.answer.offsets_in_document[0].row == 1
 
 

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -250,6 +250,7 @@ def test_table_answer_to_json(table_answer):
 def test_table_answer_to_dict(table_answer):
     dict_ans = table_answer.to_dict()
     assert isinstance(dict_ans, dict)
+    assert isinstance(dict_ans["context"], list)
     a_new = Answer.from_dict(dict_ans)
     assert isinstance(a_new.offsets_in_document[0], TableCell)
     assert a_new == table_answer

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -240,6 +240,9 @@ def test_answer_to_dict(text_answer):
     assert a_new == a
 
 
+# TODO Test table answer to dict and to json
+
+
 def test_document_from_dict():
     doc = Document(
         content="this is the content of the document", meta={"some": "meta"}, id_hash_keys=["content", "meta"]

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -47,6 +47,63 @@ def text_labels():
 
 
 @pytest.fixture
+def table_labels():
+    return [
+        Label(
+            query="some",
+            answer=Answer(
+                answer="text_2",
+                type="extractive",
+                score=0.1,
+                document_ids=["123"],
+                offsets_in_document=[TableCell(row=1, col=0)],
+            ),
+            document=Document(
+                content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
+                content_type="table",
+            ),
+            is_correct_answer=True,
+            is_correct_document=True,
+            origin="user-feedback",
+        ),
+        Label(
+            query="some",
+            answer=Answer(
+                answer="text_1",
+                type="extractive",
+                score=0.1,
+                document_ids=["123"],
+                offsets_in_document=[TableCell(row=0, col=0)],
+            ),
+            document=Document(
+                content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
+                content_type="table",
+            ),
+            is_correct_answer=True,
+            is_correct_document=True,
+            origin="user-feedback",
+        ),
+        Label(
+            query="some",
+            answer=Answer(
+                answer="1",
+                type="extractive",
+                score=0.1,
+                document_ids=["123"],
+                offsets_in_document=[TableCell(row=0, col=1)],
+            ),
+            document=Document(
+                content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
+                content_type="table",
+            ),
+            is_correct_answer=True,
+            is_correct_document=True,
+            origin="user-feedback",
+        ),
+    ]
+
+
+@pytest.fixture
 def text_answer():
     return Answer(
         answer="an answer",
@@ -142,6 +199,26 @@ def test_label_to_dict(text_labels):
     l_new = Label.from_dict(j0)
     assert l_new == text_labels[0]
     assert l_new.answer.offsets_in_document[0].start == 1
+
+
+# TODO Fix
+# def test_equal_table_label(table_labels):
+#     assert table_labels[2] == table_labels[0]
+#     assert table_labels[1] != table_labels[0]
+
+
+def test_table_label_to_json(table_labels):
+    j0 = table_labels[0].to_json()
+    l_new = Label.from_json(j0)
+    assert l_new == table_labels[0]
+    assert l_new.answer.offsets_in_document[0].row == 1
+
+
+def test_table_label_to_dict(table_labels):
+    j0 = table_labels[0].to_dict()
+    l_new = Label.from_dict(j0)
+    assert l_new == table_labels[0]
+    assert l_new.answer.offsets_in_document[0].row == 1
 
 
 def test_answer_to_json(text_answer):

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -102,6 +102,19 @@ def text_answer():
 
 
 @pytest.fixture
+def table_answer():
+    return Answer(
+        answer="text_2",
+        type="extractive",
+        score=0.1,
+        context=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
+        offsets_in_document=[TableCell(row=1, col=0)],
+        offsets_in_context=[TableCell(row=1, col=0)],
+        document_ids=["123"],
+    )
+
+
+@pytest.fixture
 def table_doc():
     data = {
         "actors": ["brad pitt", "leonardo di caprio", "george clooney"],
@@ -224,7 +237,22 @@ def test_answer_to_dict(text_answer):
     assert a_new == a
 
 
-# TODO Test table answer to dict and to json
+# TODO Fix
+def test_table_answer_to_json(table_answer):
+    json_ans = table_answer.to_json()
+    assert isinstance(json_ans, str)
+    a_new = Answer.from_json(json_ans)
+    assert isinstance(a_new.offsets_in_document[0], TableCell)
+    assert a_new == table_answer
+
+
+# TODO Fix
+def test_table_answer_to_dict(table_answer):
+    dict_ans = table_answer.to_dict()
+    assert isinstance(dict_ans, dict)
+    a_new = Answer.from_dict(dict_ans)
+    assert isinstance(a_new.offsets_in_document[0], TableCell)
+    assert a_new == table_answer
 
 
 def test_document_from_dict():


### PR DESCRIPTION
### Related Issues
- fixes N/A

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Updated the `to_*` and `from_*` methods of schema objects `Answer`, and `Label` to properly load and export Table Documents and Table Answers
- Updated the `Answer.__eq__` function to work with `contexts` that are of type `pd.DataFrame` (relevant for Table Answers). This previously raised an error.
- Reduce code duplication by creating the convenience functions `dataframe_to_list` and `dataframe_from_list` to handle the conversion of Dataframes to and from a list of lists

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing unit tests and added new unit tests in `test_schema.py`

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
This does change the behavior of `Answer.to_dict()`. Previously the `context` of a Table Answer would still be of type `pd.DataFrame` after calling `to_dict`. For example,
```python
from haystack import Answer, TableCell
import pandas as pd
ans = Answer(
  answer="text_2",
  type="extractive",
  score=0.1,
  context=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
  offsets_in_document=[TableCell(row=1, col=0)],
  offsets_in_context=[TableCell(row=1, col=0)],
  document_ids=["123"],
)
type(ans.to_dict()["context"]) == pd.DataFrame  # True
```
However, this is inconsistent with how we treat `Documents`. When we call `Documents.to_dict()` on table Documents we convert the the `pd.DataFrame` to a list of lists.  For example,
```python
from haystack import Document
import pandas as pd
doc = Document(
  content=pd.DataFrame.from_records([{"col1": "text_1", "col2": 1}, {"col1": "text_2", "col2": 2}]),
  content_type="table"
)
type(doc.to_dict()["content"]) == list  # True
```
I think it makes sense to consistently convert `pd.DataFrame`s to a list of lists like we do for `Document.to_dict()`, which is what I have implemented in this PR. 


### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
