### PR TITLE
chore: Revert "fix: Log 'Observation' on new line (#4704)"

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -210,7 +210,7 @@ class Agent:
             llm_prefix: Optional[str] = None,
             **kwargs: Any,
         ) -> None:
-            print_text(f"\n{observation_prefix}")  # type: ignore
+            print_text(observation_prefix)  # type: ignore
             print_text(tool_output, color=color)
             print_text(f"\n{llm_prefix}")
 


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR reverts the changes made in #4704.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
The newline character was initially added because of the way how agent observations were printed in notebooks. However, after merging #4704 we noticed that there's too many newline characters for agent observations when using the agent from a script.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
