### PR TITLE
fix: load the local finetuning model from pipeline yaml (#4729)

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union, List, Dict
 import logging
+import os
 
 import torch
 from transformers import (
@@ -252,6 +253,9 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
         task_name: Optional[str] = None
+        if os.path.exists(model_name_or_path):
+            return True
+
         try:
             task_name = get_task(model_name_or_path, use_auth_token=kwargs.get("use_auth_token", None))
         except RuntimeError:


### PR DESCRIPTION
### Related Issues
- fixes #4729 

### Proposed Changes:
Specify which InvocationLayer and task to use in the promptModel of the YAML file.

### How did you test it?
pytest prompt/
=============== 71 passed, 46 skipped, 9 warnings in 44.37s =======================


### Notes for the reviewer
PromptModel

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
