### PR TITLE
fix: update ImportError for 'metrics' dependency

### DIFF
--- a/haystack/modeling/evaluation/metrics.py
+++ b/haystack/modeling/evaluation/metrics.py
@@ -30,7 +30,7 @@ except ImportError as exc:
 try:
     from seqeval.metrics import classification_report as token_classification_report
 except ImportError as exc:
-    logger.debug("seqeval could not be imported. Run 'pip install farm-haystack[eval]' to fix this issue.")
+    logger.debug("seqeval could not be imported. Run 'pip install farm-haystack[metrics]' to fix this issue.")
     token_classification_report = None
 
 
@@ -150,7 +150,9 @@ def compute_report_metrics(head: PredictionHead, preds, labels):
         report_fn = registered_reports[head.ph_output_type]  # type: ignore [index]
     elif head.ph_output_type == "per_token":
         if not token_classification_report:
-            raise ImportError("seqeval could not be imported. Run 'pip install farm-haystack[eval]' to fix this issue.")
+            raise ImportError(
+                "seqeval could not be imported. Run 'pip install farm-haystack[metrics]' to fix this issue."
+            )
         report_fn = token_classification_report
     elif head.ph_output_type == "per_sequence":
         if not classification_report:

--- a/haystack/utils/context_matching.py
+++ b/haystack/utils/context_matching.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__file__)
 try:
     from rapidfuzz import fuzz
 except ImportError as exc:
-    logger.debug("rapidfuzz could not be imported. Run 'pip install farm-haystack[eval]' to fix this issue.")
+    logger.debug("rapidfuzz could not be imported. Run 'pip install farm-haystack[metrics]' to fix this issue.")
     fuzz = None  # type: ignore
 
 
@@ -56,7 +56,9 @@ def calculate_context_similarity(
                                  Thus [AB] <-> [BC] (score ~50) gets recalculated with B <-> B (score ~100) scoring ~75 in total.
     """
     if not fuzz:
-        raise ImportError("rapidfuzz could not be imported. Run 'pip install farm-haystack[eval]' to fix this issue.")
+        raise ImportError(
+            "rapidfuzz could not be imported. Run 'pip install farm-haystack[metrics]' to fix this issue."
+        )
     # we need to handle short contexts/contents (e.g single word)
     # as they produce high scores by matching if the chars of the word are contained in the other one
     # this has to be done after normalizing

--- a/haystack/utils/experiment_tracking.py
+++ b/haystack/utils/experiment_tracking.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 try:
     import mlflow
 except ImportError as exc:
-    logger.debug("mlflow could not be imported. Run 'pip install farm-haystack[eval]' to fix this issue.")
+    logger.debug("mlflow could not be imported. Run 'pip install farm-haystack[metrics]' to fix this issue.")
     mlflow = None
 
 
@@ -165,7 +165,9 @@ class MLflowTrackingHead(BaseTrackingHead):
         Experiment tracking head for MLflow.
         """
         if not mlflow:
-            raise ImportError("mlflow could not be imported. Run 'pip install farm-haystack[eval]' to fix this issue.")
+            raise ImportError(
+                "mlflow could not be imported. Run 'pip install farm-haystack[metrics]' to fix this issue."
+            )
         super().__init__()
         self.tracking_uri = tracking_uri
         self.auto_track_environment = auto_track_environment


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
Update the `ImportError` messages according to the new `metrics` dependency

### How did you test it?
Tested runing [Evaluation Tutorial](https://colab.research.google.com/github/deepset-ai/haystack-tutorials/blob/main/tutorials/05_Evaluation.ipynb)

### Notes for the reviewer
n/a

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
