### PR TITLE
bug: (rest_api) remove logging of overwritten env variables

### DIFF
--- a/haystack/pipelines/config.py
+++ b/haystack/pipelines/config.py
@@ -87,7 +87,7 @@ def get_component_definitions(
                         param_name,
                         name,
                         key,
-                        value,
+                        f"{value[:5]}...",
                     )
     return component_definitions
 

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -1682,7 +1682,7 @@ def test_pipeline_nodes_can_have_uncopiable_objects_as_args():
     get_component_definitions(pipeline.get_config())
 
 
-def test_pipeline_env_vars_do_not_modify__component_config(monkeypatch):
+def test_pipeline_env_vars_do_not_modify__component_config(caplog, monkeypatch):
     class DummyNode(MockNode):
         def __init__(self, replaceable: str):
             self.replaceable = replaceable
@@ -1697,7 +1697,10 @@ def test_pipeline_env_vars_do_not_modify__component_config(monkeypatch):
     original_pipeline_config = deepcopy(pipeline.get_config())
 
     no_env_defs = get_component_definitions(pipeline.get_config(), overwrite_with_env_variables=False)
-    env_defs = get_component_definitions(pipeline.get_config(), overwrite_with_env_variables=True)
+
+    with caplog.at_level(logging.INFO):
+        env_defs = get_component_definitions(pipeline.get_config(), overwrite_with_env_variables=True)
+        assert "overwritten with environment variable 'NODE_PARAMS_REPLACEABLE' value 'env v...'." in caplog.text
 
     new_component_config = deepcopy(node._component_config)
     new_pipeline_config = deepcopy(pipeline.get_config())


### PR DESCRIPTION
### Related Issues
- fixes #4677 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Per #4677, the REST API outputs the full value of a secret if provided by as an environment variable to overwrite the pipeline YAML configuration. The full value of the secret should not be output in logs.

This change only logs the first 5 characters of the value and `...` for the remaining characters.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Added a test.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

n/a

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
