### PR TITLE
refactor: Extract ToolsManager, add it to Agent by composition

### DIFF
--- a/examples/agent_multihop_qa.py
+++ b/examples/agent_multihop_qa.py
@@ -1,6 +1,7 @@
 import os
 
 from haystack.agents import Agent, Tool
+from haystack.agents.base import ToolsManager
 from haystack.nodes import PromptNode, PromptTemplate
 from haystack.nodes.retriever.web import WebRetriever
 from haystack.pipelines import WebQAPipeline
@@ -15,7 +16,7 @@ if not search_key:
 
 
 pn = PromptNode(
-    "text-davinci-003",
+    "gpt-3.5-turbo",
     api_key=openai_key,
     max_length=256,
     default_prompt_template="question-answering-with-document-scores",
@@ -84,7 +85,7 @@ Thought:
 """
 few_shot_agent_template = PromptTemplate("few-shot-react", prompt_text=few_shot_prompt)
 prompt_node = PromptNode(
-    "text-davinci-003", api_key=os.environ.get("OPENAI_API_KEY"), max_length=512, stop_words=["Observation:"]
+    "gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"), max_length=512, stop_words=["Observation:"]
 )
 
 web_qa_tool = Tool(
@@ -97,7 +98,7 @@ web_qa_tool = Tool(
 agent = Agent(
     prompt_node=prompt_node,
     prompt_template=few_shot_agent_template,
-    tools=[web_qa_tool],
+    tools_manager=ToolsManager(tools=[web_qa_tool]),
     final_answer_pattern=r"Final Answer\s*:\s*(.*)",
 )
 

--- a/examples/agent_multihop_qa.py
+++ b/examples/agent_multihop_qa.py
@@ -1,6 +1,7 @@
 import os
 
 from haystack.agents import Agent, Tool
+from haystack.agents.base import ToolsManager
 from haystack.nodes import PromptNode, PromptTemplate
 from haystack.nodes.retriever.web import WebRetriever
 from haystack.pipelines import WebQAPipeline
@@ -94,7 +95,9 @@ web_qa_tool = Tool(
     output_variable="results",
 )
 
-agent = Agent(prompt_node=prompt_node, prompt_template=few_shot_agent_template, tools=[web_qa_tool])
+agent = Agent(
+    prompt_node=prompt_node, prompt_template=few_shot_agent_template, tools_manager=ToolsManager([web_qa_tool])
+)
 
 hotpot_questions = [
     "What year was the father of the Princes in the Tower born?",

--- a/examples/agent_multihop_qa.py
+++ b/examples/agent_multihop_qa.py
@@ -11,7 +11,7 @@ if not search_key:
     raise ValueError("Please set the SERPERDEV_API_KEY environment variable")
 
 openai_key = os.environ.get("OPENAI_API_KEY")
-if not search_key:
+if not openai_key:
     raise ValueError("Please set the OPENAI_API_KEY environment variable")
 
 

--- a/examples/agent_multihop_qa.py
+++ b/examples/agent_multihop_qa.py
@@ -1,7 +1,6 @@
 import os
 
 from haystack.agents import Agent, Tool
-from haystack.agents.base import ToolsManager
 from haystack.nodes import PromptNode, PromptTemplate
 from haystack.nodes.retriever.web import WebRetriever
 from haystack.pipelines import WebQAPipeline
@@ -95,12 +94,7 @@ web_qa_tool = Tool(
     output_variable="results",
 )
 
-agent = Agent(
-    prompt_node=prompt_node,
-    prompt_template=few_shot_agent_template,
-    tools_manager=ToolsManager(tools=[web_qa_tool]),
-    final_answer_pattern=r"Final Answer\s*:\s*(.*)",
-)
+agent = Agent(prompt_node=prompt_node, prompt_template=few_shot_agent_template, tools=[web_qa_tool])
 
 hotpot_questions = [
     "What year was the father of the Princes in the Tower born?",

--- a/haystack/agents/agent_step.py
+++ b/haystack/agents/agent_step.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Optional, Dict, Tuple, Any
+from typing import Optional, Dict, Any
 
 from haystack import Answer
 from haystack.errors import AgentError
@@ -68,19 +68,6 @@ class AgentStep:
             prompt_node_response=prompt_node_response[0],
             transcript=self.transcript,
         )
-
-    def extract_tool_name_and_tool_input(self, tool_pattern: str) -> Tuple[Optional[str], Optional[str]]:
-        """
-        Parse the tool name and the tool input from the PromptNode response.
-        :param tool_pattern: The regex pattern to extract the tool name and the tool input from the PromptNode response.
-        :return: A tuple containing the tool name and the tool input.
-        """
-        tool_match = re.search(tool_pattern, self.prompt_node_response)
-        if tool_match:
-            tool_name = tool_match.group(1)
-            tool_input = tool_match.group(3)
-            return tool_name.strip('" []\n').strip(), tool_input.strip('" \n')
-        return None, None
 
     def final_answer(self, query: str) -> Dict[str, Any]:
         """

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from hashlib import md5
-from typing import List, Optional, Union, Dict, Any
+from typing import List, Optional, Union, Dict, Any, Tuple
 
 from events import Events
 
@@ -111,6 +111,108 @@ class Tool:
                 return str(result)
 
 
+class ToolsManager:
+    """
+    The ToolsManager manages tools for an Agent.
+    """
+
+    def __init__(
+        self,
+        tools: Optional[List[Tool]] = None,
+        tool_pattern: str = r'Tool:\s*(\w+)\s*Tool Input:\s*("?)([^"\n]+)\2\s*',
+    ):
+        """
+        :param tools: A list of tools to add to the ToolManager. Each tool must have a unique name.
+        :param tool_pattern: A regular expression pattern that matches the text that the Agent generates to invoke
+            a tool.
+        """
+        self.tools = {tool.name: tool for tool in tools} if tools else {}
+        self.tool_pattern = tool_pattern
+        self.callback_manager = Events(("on_tool_start", "on_tool_finish", "on_tool_error"))
+
+    def add_tool(self, tool: Tool):
+        """
+        Add a tool to the Agent. This also updates the PromptTemplate for the Agent's PromptNode with the tool name.
+
+        :param tool: The tool to add to the Agent. Any previously added tool with the same name will be overwritten.
+        Example:
+        `agent.add_tool(
+            Tool(
+                name="Calculator",
+                pipeline_or_node=calculator
+                description="Useful when you need to answer questions about math"
+            )
+        )
+        """
+        self.tools[tool.name] = tool
+
+    def get_tool_names(self):
+        return ", ".join(self.tools.keys())
+
+    def get_tools(self):
+        return self.tools.values()
+
+    def get_tool_names_with_descriptions(self):
+        return "\n".join([f"{tool.name}: {tool.description}" for tool in self.tools.values()])
+
+    def has_tools(self):
+        return len(self.tools) > 0
+
+    def has_tool(self, tool_name: str):
+        """
+        Check whether the Agent has a tool with the name you provide.
+
+        :param tool_name: The name of the tool for which you want to check whether the Agent has it.
+        """
+        return tool_name in self.tools
+
+    def run_tool(self, llm_response: str, params: Optional[Dict[str, Any]] = None) -> str:
+        tool_result: str = ""
+        if self.has_tools():
+            tool_name, tool_input = self.extract_tool_name_and_tool_input(llm_response)
+            if tool_name and tool_input:
+                tool: Tool = self.tools[tool_name]
+                try:
+                    self.callback_manager.on_tool_start(tool_input, tool=tool)
+                    tool_result = tool.run(tool_input, params)
+                    self.callback_manager.on_tool_finish(
+                        tool_result,
+                        observation_prefix="Observation: ",
+                        llm_prefix="Thought: ",
+                        color=tool.logging_color,
+                    )
+                except Exception as e:
+                    self.callback_manager.on_tool_error(e, tool=self.tools[tool_name])
+                    raise e
+        return tool_result
+
+    def extract_tool_name_and_tool_input(self, llm_response: str) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Parse the tool name and the tool input from the PromptNode response.
+        :param llm_response: The PromptNode response.
+        :return: A tuple containing the tool name and the tool input.
+        """
+        tool_match = re.search(self.tool_pattern, llm_response)
+        if tool_match:
+            tool_name = tool_match.group(1)
+            tool_input = tool_match.group(3)
+            return tool_name.strip('" []\n').strip(), tool_input.strip('" \n')
+        return None, None
+
+    def valid_tool_selected(self, llm_response: str) -> bool:
+        """
+        Verify that the tool selected by LLM is an actual registered tool.
+        :param llm_response: The PromptNode response.
+        :return: A boolean indicating whether the tool selected by LLM is valid.
+        """
+        tool_match = re.search(self.tool_pattern, llm_response)
+        if tool_match:
+            tool_name = tool_match.group(1)
+            tool_name = tool_name.strip('" []\n').strip()
+            return self.has_tools() and tool_name in self.tools
+        return False
+
+
 class Agent:
     """
     An Agent answers queries using the tools you give to it. The tools are pipelines or nodes. The Agent uses a large
@@ -131,9 +233,8 @@ class Agent:
         self,
         prompt_node: PromptNode,
         prompt_template: Union[str, PromptTemplate] = "zero-shot-react",
-        tools: Optional[List[Tool]] = None,
+        tools_manager: Optional[ToolsManager] = None,
         max_steps: int = 8,
-        tool_pattern: str = r'Tool:\s*(\w+)\s*Tool Input:\s*("?)([^"\n]+)\2\s*',
         final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
     ):
         """
@@ -153,17 +254,9 @@ class Agent:
         text the Agent generated.
         :param final_answer_pattern: A regular expression to extract the final answer from the text the Agent generated.
         """
-        self.callback_manager = Events(
-            (
-                "on_tool_start",
-                "on_tool_finish",
-                "on_tool_error",
-                "on_agent_start",
-                "on_agent_step",
-                "on_agent_finish",
-                "on_new_token",
-            )
-        )
+        self.max_steps = max_steps
+        self.tm = tools_manager if tools_manager else ToolsManager()
+        self.callback_manager = Events(("on_agent_start", "on_agent_step", "on_agent_finish", "on_new_token"))
         self.prompt_node = prompt_node
         resolved_prompt_template = prompt_node.get_prompt_template(prompt_template)
         if not resolved_prompt_template:
@@ -171,13 +264,6 @@ class Agent:
                 f"Prompt template '{prompt_template}' not found. Please check the spelling of the template name."
             )
         self.prompt_template = resolved_prompt_template
-        self.tools = {tool.name: tool for tool in tools} if tools else {}
-        self.tool_names = ", ".join(self.tools.keys())
-        self.tool_names_with_descriptions = "\n".join(
-            [f"{tool.name}: {tool.description}" for tool in self.tools.values()]
-        )
-        self.max_steps = max_steps
-        self.tool_pattern = tool_pattern
         self.final_answer_pattern = final_answer_pattern
         # Resolve model name to check if it's a streaming model
         if isinstance(self.prompt_node.model_name_or_path, str):
@@ -195,7 +281,7 @@ class Agent:
         See haystack/telemetry.py::send_event
         """
         try:
-            tool_names = " ".join([tool.pipeline_or_node.__class__.__name__ for tool in self.tools.values()])
+            tool_names = " ".join([tool.pipeline_or_node.__class__.__name__ for tool in self.tm.get_tools()])
             self.hash = md5(tool_names.encode()).hexdigest()
         except Exception as exc:
             logger.debug("Telemetry exception: %s", str(exc))
@@ -217,7 +303,7 @@ class Agent:
             agent_name = kwargs.pop("name", "react")
             print_text(f"\nAgent {agent_name} started with {kwargs}\n")
 
-        self.callback_manager.on_tool_finish += on_tool_finish
+        self.tm.callback_manager.on_tool_finish += on_tool_finish
         self.callback_manager.on_agent_start += on_agent_start
 
         if streaming:
@@ -241,11 +327,7 @@ class Agent:
             )
         )
         """
-        self.tools[tool.name] = tool
-        self.tool_names = ", ".join(self.tools.keys())
-        self.tool_names_with_descriptions = "\n".join(
-            [f"{tool.name}: {tool.description}" for tool in self.tools.values()]
-        )
+        self.tm.add_tool(tool)
 
     def has_tool(self, tool_name: str):
         """
@@ -253,7 +335,7 @@ class Agent:
 
         :param tool_name: The name of the tool for which you want to check whether the Agent has it.
         """
-        return tool_name in self.tools
+        return self.tm.has_tool(tool_name)
 
     def run(
         self, query: str, max_steps: Optional[int] = None, params: Optional[dict] = None
@@ -279,11 +361,6 @@ class Agent:
         except Exception as exc:
             logger.debug("Telemetry exception: %s", exc)
 
-        if not self.tools:
-            raise AgentError(
-                "An Agent needs tools to run. Add at least one tool using `add_tool()` or set the parameter `tools` "
-                "when initializing the Agent."
-            )
         if max_steps is None:
             max_steps = self.max_steps
         if max_steps < 2:
@@ -321,71 +398,11 @@ class Agent:
         self.callback_manager.on_agent_step(next_step)
 
         # run the tool selected by the LLM
-        observation = self._run_tool(next_step, params) if not next_step.is_last() else None
+        observation = self.tm.run_tool(next_step.prompt_node_response, params) if not next_step.is_last() else None
 
         # update the next step with the observation
         next_step.completed(observation)
         return next_step
-
-    def run_batch(
-        self, queries: List[str], max_steps: Optional[int] = None, params: Optional[dict] = None
-    ) -> Dict[str, str]:
-        """
-        Runs the Agent in a batch mode.
-
-        :param queries: List of search queries.
-        :param max_steps: The number of times the Agent can run a tool +1 to infer it knows the final answer.
-            If you want to set it, make it at least 2 so that the Agent can run a tool once and then infer it knows
-            the final answer.
-        :param params: A dictionary of parameters you want to pass to the tools that are pipelines.
-                       To pass a parameter to all nodes in those pipelines, use the format: `{"top_k": 10}`.
-                       To pass a parameter to targeted nodes in those pipelines, use the format:
-                        `{"Retriever": {"top_k": 10}, "Reader": {"top_k": 3}}`.
-                        You can only pass parameters to tools that are pipelines but not nodes.
-        """
-        try:
-            if not self.hash == self.last_hash:
-                self.last_hash = self.hash
-                send_event(event_name="Agent", event_properties={"llm.agent_hash": self.hash})
-        except Exception as exc:
-            logger.debug("Telemetry exception: %s", exc)
-
-        results: Dict = {"queries": [], "answers": [], "transcripts": []}
-        for query in queries:
-            result = self.run(query=query, max_steps=max_steps, params=params)
-            results["queries"].append(result["query"])
-            results["answers"].append(result["answers"])
-            results["transcripts"].append(result["transcript"])
-
-        return results
-
-    def _run_tool(self, next_step: AgentStep, params: Optional[Dict[str, Any]] = None) -> str:
-        tool_name, tool_input = next_step.extract_tool_name_and_tool_input(self.tool_pattern)
-        if tool_name is None or tool_input is None:
-            raise AgentError(
-                f"Could not identify the next tool or input for that tool from Agent's output. "
-                f"Adjust the Agent's param 'tool_pattern' or 'prompt_template'. \n"
-                f"# 'tool_pattern' to identify next tool: {self.tool_pattern} \n"
-                f"# Agent Step:\n{next_step}"
-            )
-        if not self.has_tool(tool_name):
-            raise AgentError(
-                f"The tool {tool_name} wasn't added to the Agent tools: {self.tools.keys()}."
-                "Add the tool using `add_tool()` or include it in the parameter `tools` when initializing the Agent."
-                f"Agent Step::\n{next_step}"
-            )
-        tool_result: str = ""
-        tool: Tool = self.tools[tool_name]
-        try:
-            self.callback_manager.on_tool_start(tool_input, tool=tool)
-            tool_result = tool.run(tool_input, params)
-            self.callback_manager.on_tool_finish(
-                tool_result, observation_prefix="Observation: ", llm_prefix="Thought: ", color=tool.logging_color
-            )
-        except Exception as e:
-            self.callback_manager.on_tool_error(e, tool=self.tools[tool_name])
-            raise e
-        return tool_result
 
     def _get_initial_transcript(self, query: str):
         """
@@ -395,7 +412,9 @@ class Agent:
         """
         return next(
             self.prompt_template.fill(
-                query=query, tool_names=self.tool_names, tool_names_with_descriptions=self.tool_names_with_descriptions
+                query=query,
+                tool_names=self.tm.get_tool_names(),
+                tool_names_with_descriptions=self.tm.get_tool_names_with_descriptions(),
             ),
             "",
         )

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -222,10 +222,9 @@ class Agent:
         self,
         prompt_node: PromptNode,
         prompt_template: Union[str, PromptTemplate] = "zero-shot-react",
-        tools: Optional[List[Tool]] = None,
+        tools_manager: Optional[ToolsManager] = None,
         max_steps: int = 8,
         final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
-        tool_pattern: Optional[str] = None,
     ):
         """
          Creates an Agent instance.
@@ -245,10 +244,7 @@ class Agent:
         :param final_answer_pattern: A regular expression to extract the final answer from the text the Agent generated.
         """
         self.max_steps = max_steps
-        if tool_pattern:
-            self.tm = ToolsManager(tools, tool_pattern=tool_pattern)
-        else:
-            self.tm = ToolsManager(tools)
+        self.tm = tools_manager or ToolsManager()
         self.callback_manager = Events(("on_agent_start", "on_agent_step", "on_agent_finish", "on_new_token"))
         self.prompt_node = prompt_node
         resolved_prompt_template = prompt_node.get_prompt_template(prompt_template)

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -140,7 +140,7 @@ class ToolsManager:
             Tool(
                 name="Calculator",
                 pipeline_or_node=calculator
-                description="Useful when you need to answer questions about math"
+                description="Useful when you need to answer questions about math."
             )
         )
         """
@@ -148,19 +148,19 @@ class ToolsManager:
 
     def get_tool_names(self) -> str:
         """
-        Returns a string with the names of all tools registered
+        Returns a string with the names of all registered tools.
         """
         return ", ".join(self.tools.keys())
 
     def get_tools(self) -> List[Tool]:
         """
-        Returns a list of all tool instances registered
+        Returns a list of all registered tool instances.
         """
         return list(self.tools.values())
 
     def get_tool_names_with_descriptions(self) -> str:
         """
-        Returns a string with the names and descriptions of all tools registered
+        Returns a string with the names and descriptions of all registered tools.
         """
         return "\n".join([f"{tool.name}: {tool.description}" for tool in self.tools.values()])
 

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -70,7 +70,7 @@ def test_max_steps(caplog, monkeypatch):
     def mock_extract_tool_name_and_tool_input(self, pred: str) -> Tuple[str, str]:
         return "Retriever", ""
 
-    monkeypatch.setattr(AgentStep, "extract_tool_name_and_tool_input", mock_extract_tool_name_and_tool_input)
+    monkeypatch.setattr(ToolsManager, "extract_tool_name_and_tool_input", mock_extract_tool_name_and_tool_input)
 
     # Using max_steps as specified in the Agent's init method
     with caplog.at_level(logging.WARN, logger="haystack.agents"):

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -10,7 +10,6 @@ import pytest
 from haystack import BaseComponent, Answer
 from haystack.agents import Agent, AgentStep
 from haystack.agents.base import Tool
-from haystack.errors import AgentError
 from haystack.nodes import PromptModel, PromptNode, PromptTemplate
 from haystack.pipelines import ExtractiveQAPipeline, DocumentSearchPipeline, BaseStandardPipeline
 
@@ -27,10 +26,9 @@ def test_add_and_overwrite_tool():
             description="useful for when you need to " "retrieve documents from your index",
         )
     )
-    assert len(agent.tools) == 1
-    assert "Retriever" in agent.tools
+    assert len(agent.tm.tools) == 1
     assert agent.has_tool(tool_name="Retriever")
-    assert isinstance(agent.tools["Retriever"].pipeline_or_node, BaseComponent)
+    assert isinstance(agent.tm.tools["Retriever"].pipeline_or_node, BaseComponent)
 
     agent.add_tool(
         Tool(
@@ -49,27 +47,9 @@ def test_add_and_overwrite_tool():
             description="useful for when you need to retrieve documents from your index",
         )
     )
-    assert len(agent.tools) == 1
-    assert "Retriever" in agent.tools
+    assert len(agent.tm.tools) == 1
     assert agent.has_tool(tool_name="Retriever")
-    assert isinstance(agent.tools["Retriever"].pipeline_or_node, BaseStandardPipeline)
-
-
-@pytest.mark.unit
-def test_agent_chooses_no_action():
-    agent = Agent(prompt_node=MockPromptNode())
-    retriever = MockRetriever()
-    agent.add_tool(
-        Tool(
-            name="Retriever",
-            pipeline_or_node=retriever,
-            description="useful for when you need to retrieve documents from your index",
-        )
-    )
-    with pytest.raises(
-        AgentError, match=r"Could not identify the next tool or input for that tool from Agent's output.*"
-    ):
-        agent.run("How many letters does the name of the town where Christelle lives have?")
+    assert isinstance(agent.tm.tools["Retriever"].pipeline_or_node, BaseStandardPipeline)
 
 
 @pytest.mark.unit
@@ -120,7 +100,7 @@ def test_run_tool():
     pn_response = "need to find out what city he was born.\nTool: Retriever\nTool Input: Where was Jeremy McKinnon born"
 
     step = AgentStep(prompt_node_response=pn_response)
-    result = agent._run_tool(step)
+    result = agent.tm.run_tool(step.prompt_node_response)
     assert result == "[]"  # empty list of documents
 
 
@@ -284,53 +264,6 @@ def test_agent_run(reader, retriever_with_docs, document_store_with_docs):
     result = agent.run("In which country is the city where Christelle lives?")
     country = result["answers"][0].answer
     assert "france" in country.lower()
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("reader", ["farm"], indirect=True)
-@pytest.mark.parametrize("retriever_with_docs, document_store_with_docs", [("bm25", "memory")], indirect=True)
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY", None),
-    reason="Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
-)
-def test_agent_run_batch(reader, retriever_with_docs, document_store_with_docs):
-    search = ExtractiveQAPipeline(reader, retriever_with_docs)
-    prompt_model = PromptModel(model_name_or_path="gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"))
-    prompt_node = PromptNode(model_name_or_path=prompt_model, stop_words=["Observation:"])
-    country_finder = PromptNode(
-        model_name_or_path=prompt_model,
-        default_prompt_template=PromptTemplate(
-            name="country_finder",
-            prompt_text="When I give you a name of the city, respond with the country where the city is located.\n"
-            "City: Rome\nCountry: Italy\n"
-            "City: Berlin\nCountry: Germany\n"
-            "City: Belgrade\nCountry: Serbia\n"
-            "City: {query}?\nCountry: ",
-        ),
-    )
-
-    agent = Agent(prompt_node=prompt_node)
-    agent.add_tool(
-        Tool(
-            name="Search",
-            pipeline_or_node=search,
-            description="useful for when you need to answer "
-            "questions about where people live. You "
-            "should ask targeted questions",
-            output_variable="answers",
-        )
-    )
-    agent.add_tool(
-        Tool(
-            name="CountryFinder",
-            pipeline_or_node=country_finder,
-            description="useful for when you need to find the country where a city is located",
-        )
-    )
-
-    results = agent.run_batch(queries=["Where is Madrid?", "In which country is the city where Christelle lives?"])
-    assert "spain" in results["answers"][0][0].answer.lower()
-    assert "france" in results["answers"][1][0].answer.lower()
 
 
 @pytest.mark.unit

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -9,7 +9,7 @@ import pytest
 
 from haystack import BaseComponent, Answer
 from haystack.agents import Agent, AgentStep
-from haystack.agents.base import Tool
+from haystack.agents.base import Tool, ToolsManager
 from haystack.nodes import PromptModel, PromptNode, PromptTemplate
 from haystack.pipelines import ExtractiveQAPipeline, DocumentSearchPipeline, BaseStandardPipeline
 
@@ -109,8 +109,8 @@ def test_extract_tool_name_and_tool_input():
     tool_pattern: str = r'Tool:\s*(\w+)\s*Tool Input:\s*("?)([^"\n]+)\2\s*'
     pn_response = "need to find out what city he was born.\nTool: Search\nTool Input: Where was Jeremy McKinnon born"
 
-    step = AgentStep(prompt_node_response=pn_response)
-    tool_name, tool_input = step.extract_tool_name_and_tool_input(tool_pattern=tool_pattern)
+    tm = ToolsManager(tool_pattern=tool_pattern)
+    tool_name, tool_input = tm.extract_tool_name_and_tool_input(pn_response)
     assert tool_name == "Search" and tool_input == "Where was Jeremy McKinnon born"
 
 

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -105,16 +105,6 @@ def test_run_tool():
 
 
 @pytest.mark.unit
-def test_extract_tool_name_and_tool_input():
-    tool_pattern: str = r'Tool:\s*(\w+)\s*Tool Input:\s*("?)([^"\n]+)\2\s*'
-    pn_response = "need to find out what city he was born.\nTool: Search\nTool Input: Where was Jeremy McKinnon born"
-
-    tm = ToolsManager(tool_pattern=tool_pattern)
-    tool_name, tool_input = tm.extract_tool_name_and_tool_input(pn_response)
-    assert tool_name == "Search" and tool_input == "Where was Jeremy McKinnon born"
-
-
-@pytest.mark.unit
 def test_extract_final_answer():
     match_examples = [
         "have the final answer to the question.\nFinal Answer: Florida",

--- a/test/agents/test_tools_manager.py
+++ b/test/agents/test_tools_manager.py
@@ -1,0 +1,52 @@
+from unittest import mock
+
+import pytest
+from haystack.agents.base import ToolsManager, Tool
+
+
+@pytest.fixture
+def tools_manager():
+    tools = [
+        Tool(name="ToolA", pipeline_or_node=mock.Mock(), description="Tool A Description"),
+        Tool(name="ToolB", pipeline_or_node=mock.Mock(), description="Tool B Description"),
+    ]
+    return ToolsManager(tools=tools)
+
+
+@pytest.mark.unit
+def test_add_tool(tools_manager):
+    new_tool = Tool(name="ToolC", pipeline_or_node=mock.Mock(), description="Tool C Description")
+    tools_manager.add_tool(new_tool)
+    assert "ToolC" in tools_manager.tools
+    assert tools_manager.tools["ToolC"] == new_tool
+
+
+@pytest.mark.unit
+def test_get_tool_names(tools_manager):
+    assert tools_manager.get_tool_names() == "ToolA, ToolB"
+
+
+@pytest.mark.unit
+def test_get_tools(tools_manager):
+    tools = tools_manager.get_tools()
+    assert len(tools) == 2
+    assert tools[0].name == "ToolA"
+    assert tools[1].name == "ToolB"
+
+
+@pytest.mark.unit
+def test_get_tool_names_with_descriptions(tools_manager):
+    expected_output = "ToolA: Tool A Description\n" "ToolB: Tool B Description"
+    assert tools_manager.get_tool_names_with_descriptions() == expected_output
+
+
+@pytest.mark.unit
+def test_extract_tool_name_and_tool_input(tools_manager):
+    examples = [
+        "need to find out what city he was born.\nTool: Search\nTool Input: Where was Jeremy McKinnon born",
+        "need to find out what city he was born.\n\nTool: Search\n\nTool Input: Where was Jeremy McKinnon born",
+        "need to find out what city he was born. Tool: Search Tool Input: Where was Jeremy McKinnon born",
+    ]
+    for example in examples:
+        tool_name, tool_input = tools_manager.extract_tool_name_and_tool_input(example)
+        assert tool_name == "Search" and tool_input == "Where was Jeremy McKinnon born"

--- a/test/agents/test_tools_manager.py
+++ b/test/agents/test_tools_manager.py
@@ -50,3 +50,14 @@ def test_extract_tool_name_and_tool_input(tools_manager):
     for example in examples:
         tool_name, tool_input = tools_manager.extract_tool_name_and_tool_input(example)
         assert tool_name == "Search" and tool_input == "Where was Jeremy McKinnon born"
+
+    negative_examples = [
+        "need to find out what city he was born.",
+        "Tool: Search",
+        "Tool Input: Where was Jeremy McKinnon born",
+        "need to find out what city he was born. Tool: Search",
+        "Tool Input: Where was Jeremy McKinnon born",
+    ]
+    for example in negative_examples:
+        tool_name, tool_input = tools_manager.extract_tool_name_and_tool_input(example)
+        assert tool_name is None and tool_input is None


### PR DESCRIPTION
### Related Issues
- NA
- Note: this is the first PR in a series of PRs related to adding conversational agents, memory, and self-reflection. 

### Proposed Changes:
Converts previously monolithic Agent containing tools management by default to a less assuming Agent that:

- Might not have tools at all (e.g. conversational agent)
- Extracts all tools logic into a new class `ToolsManager` responsible for management and invocation of tools

In addition, this refactoring opportunity was used to remove `run_batch` Agent method. We concluded internally it was not needed except in some very specific circumstances. 

### How did you test it?
No additional unit tests were added
Manual test of `examples/agent_multihop_qa.py` performed to test for regressions
A unit test `test_agent_chooses_no_action` has been removed as we now allow Agents without tools
run batch unit test has also been removed

### Notes for the reviewer
Please run the manual test as well, e.g  `examples/agent_multihop_qa.py`

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
