### PR TITLE
test: Add others folder to unit test job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,7 @@ jobs:
           - prompt
           - pipelines
           - utils
+          - others
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Proposed Changes:

Add the `test/others` folder to `unit-tests` job, this way we'll get coverage for that too.

### How did you test it?

Can't really be tested as its a CI thing.

### Notes for the reviewer

N/A