### PR TITLE
fix: Fix missing error in openai_request retry strategy

### DIFF
--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -128,7 +128,8 @@ def _openai_text_completion_tokenization_details(model_name: str):
 
 
 @tenacity.retry(
-    retry=tenacity.retry_if_exception_type(OpenAIRateLimitError),
+    reraise=True,
+    retry=tenacity.retry_if_exception_type((OpenAIRateLimitError, OpenAIError)),
     wait=tenacity.wait_exponential(multiplier=OPENAI_BACKOFF),
     stop=tenacity.stop_after_attempt(OPENAI_MAX_RETRIES),
 )

--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -129,7 +129,8 @@ def _openai_text_completion_tokenization_details(model_name: str):
 
 @tenacity.retry(
     reraise=True,
-    retry=tenacity.retry_if_exception_type((OpenAIRateLimitError, OpenAIError)),
+    retry=tenacity.retry_if_exception_type(OpenAIError)
+    and tenacity.retry_if_not_exception_type(OpenAIUnauthorizedError),
     wait=tenacity.wait_exponential(multiplier=OPENAI_BACKOFF),
     stop=tenacity.stop_after_attempt(OPENAI_MAX_RETRIES),
 )

--- a/test/utils/test_openai_utils.py
+++ b/test/utils/test_openai_utils.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+import pytest
+from tenacity import wait_none
+
+from haystack.errors import OpenAIError, OpenAIRateLimitError, OpenAIUnauthorizedError
+from haystack.utils.openai_utils import openai_request
+
+
+@pytest.mark.unit
+@patch("haystack.utils.openai_utils.requests")
+def test_openai_request_retries_generic_error(mock_requests):
+    mock_requests.request.return_value.status_code = 418
+
+    with pytest.raises(OpenAIError):
+        # We need to use a custom wait amount otherwise the test would take forever to run
+        # as the original wait time is exponential
+        openai_request.retry_with(wait=wait_none())(url="some_url", headers={}, payload={}, read_response=False)
+
+    assert mock_requests.request.call_count == 5
+
+
+@pytest.mark.unit
+@patch("haystack.utils.openai_utils.requests")
+def test_openai_request_retries_on_rate_limit_error(mock_requests):
+    mock_requests.request.return_value.status_code = 429
+
+    with pytest.raises(OpenAIRateLimitError):
+        # We need to use a custom wait amount otherwise the test would take forever to run
+        # as the original wait time is exponential
+        openai_request.retry_with(wait=wait_none())(url="some_url", headers={}, payload={}, read_response=False)
+
+    assert mock_requests.request.call_count == 5
+
+
+@pytest.mark.unit
+@patch("haystack.utils.openai_utils.requests")
+def test_openai_request_does_not_retry_on_unauthorized_error(mock_requests):
+    mock_requests.request.return_value.status_code = 401
+
+    with pytest.raises(OpenAIUnauthorizedError):
+        # We need to use a custom wait amount otherwise the test would take forever to run
+        # as the original wait time is exponential
+        openai_request.retry_with(wait=wait_none())(url="some_url", headers={}, payload={}, read_response=False)
+
+    assert mock_requests.request.call_count == 5
+
+
+@pytest.mark.unit
+@patch("haystack.utils.openai_utils.requests")
+def test_openai_request_does_not_retry_on_success(mock_requests):
+    mock_requests.request.return_value.status_code = 200
+    # We need to use a custom wait amount otherwise the test would take forever to run
+    # as the original wait time is exponential
+    openai_request.retry_with(wait=wait_none())(url="some_url", headers={}, payload={}, read_response=False)
+
+    assert mock_requests.request.call_count == 1

--- a/test/utils/test_openai_utils.py
+++ b/test/utils/test_openai_utils.py
@@ -43,7 +43,7 @@ def test_openai_request_does_not_retry_on_unauthorized_error(mock_requests):
         # as the original wait time is exponential
         openai_request.retry_with(wait=wait_none())(url="some_url", headers={}, payload={}, read_response=False)
 
-    assert mock_requests.request.call_count == 5
+    assert mock_requests.request.call_count == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues
- fixes #4799

### Proposed Changes:

When migrating to `tenacity` with PR #4460 I missed an error handling in `openai_request` function, this PR adds it back.

### How did you test it?

Added unit tests to verify failing and success cases.

### Notes for the reviewer

N/A
