### PR TITLE
fix: Add support for `_split_overlap` meta to Pinecone and `dict` metadata in general to Weaviate

### DIFF
--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -1,3 +1,4 @@
+import json
 from typing import Set, Union, List, Optional, Dict, Generator, Any
 
 import logging
@@ -1217,6 +1218,8 @@ class PineconeDocumentStore(BaseDocumentStore):
         for _id, meta in zip(ids, metadata):
             content = meta.pop("content")
             content_type = meta.pop("content_type")
+            if "_split_overlap" in meta:
+                meta["_split_overlap"] = json.loads(meta["_split_overlap"])
             doc = Document(id=_id, content=content, content_type=content_type, meta=meta)
             documents.append(doc)
         if return_embedding:
@@ -1366,6 +1369,8 @@ class PineconeDocumentStore(BaseDocumentStore):
                 # Replace any None values with empty strings
                 if value is None:
                     value = ""
+                if key == "_split_overlap":
+                    value = json.dumps(value)
                 # format key
                 new_key = f"{parent_key}.{key}" if parent_key else key
                 # if value is dict, expand

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -243,7 +243,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                 )
 
     def _convert_weaviate_result_to_document(
-        self, result: dict, return_embedding: bool, scale_score: bool = True
+        self, result: dict, return_embedding: bool, scale_score: bool = True, json_properties: List[str] = []
     ) -> Document:
         """
         Convert weaviate result dict into haystack document object. This is more involved because
@@ -315,6 +315,12 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                 continue
             if v is None:
                 continue
+            # Weaviate doesn't support dict as a property type. We store them as JSON strings and convert them back here.
+            if k in json_properties:
+                if isinstance(v, list):
+                    v = [json.loads(str(item)) for item in v]
+                else:
+                    v = json.loads(str(v))
             meta_data[k] = v
 
         document = Document.from_dict(
@@ -353,7 +359,10 @@ class WeaviateDocumentStore(KeywordDocumentStore):
         except weaviate.exceptions.UnexpectedStatusCodeException as usce:
             logger.debug("Weaviate could not get the document requested: %s", usce)
         if result:
-            document = self._convert_weaviate_result_to_document(result, return_embedding=True)
+            json_properties = self._get_json_properties(index=index)
+            document = self._convert_weaviate_result_to_document(
+                result, return_embedding=True, json_properties=json_properties
+            )
         return document
 
     def get_documents_by_id(
@@ -370,6 +379,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             raise NotImplementedError("WeaviateDocumentStore does not support headers.")
 
         index = self._sanitize_index_name(index) or self.index
+        json_properties = self._get_json_properties(index=index)
         documents = []
         # TODO: better implementation with multiple where filters instead of chatty call below?
         for id in ids:
@@ -380,7 +390,9 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             except weaviate.exceptions.UnexpectedStatusCodeException as usce:
                 logger.debug("Weaviate could not get the document requested: %s", usce)
             if result:
-                document = self._convert_weaviate_result_to_document(result, return_embedding=True)
+                document = self._convert_weaviate_result_to_document(
+                    result, return_embedding=True, json_properties=json_properties
+                )
                 documents.append(document)
         return documents
 
@@ -435,6 +447,22 @@ class WeaviateDocumentStore(KeywordDocumentStore):
 
         return cur_properties
 
+    def _get_json_properties(self, index: Optional[str] = None) -> List[str]:
+        """
+        Get all existing properties that store JSON strings in the schema.
+        """
+        index = self._sanitize_index_name(index) or self.index
+        cur_properties = []
+        for class_item in self.weaviate_client.schema.get()["classes"]:
+            if class_item["class"] == index:
+                cur_properties = [
+                    item["name"]
+                    for item in class_item["properties"]
+                    if item["description"].startswith("JSON dynamic property")
+                ]
+
+        return cur_properties
+
     def _update_schema(
         self, new_prop: str, property_value: Union[List, str, int, float, bool], index: Optional[str] = None
     ):
@@ -444,7 +472,13 @@ class WeaviateDocumentStore(KeywordDocumentStore):
         index = self._sanitize_index_name(index) or self.index
         data_type = self._get_weaviate_type_of_value(property_value)
 
-        property_dict = {"dataType": [data_type], "description": f"dynamic property {new_prop}", "name": new_prop}
+        description = f"dynamic property {new_prop}"
+        if data_type.startswith("dict"):
+            # Weaviate does not support dict type, so we use string or list of string instead
+            data_type = "string" + data_type[4:]
+            description = f"JSON dynamic property {new_prop}"
+
+        property_dict = {"dataType": [data_type], "description": description, "name": new_prop}
         self.weaviate_client.schema.property.create(index, property_dict)
 
     @staticmethod
@@ -472,6 +506,9 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             data_type = "number"
         elif isinstance(value, bool):
             data_type = "boolean"
+        # Weaviate doesn't support dictionaries as property types, we'll convert them to JSON strings.
+        elif isinstance(value, dict):
+            data_type = "dict"
 
         if list_of_values:
             data_type += "[]"
@@ -557,6 +594,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
         batched_documents = get_batches_from_generator(document_objects, batch_size)
         with tqdm(total=len(document_objects), disable=not self.progress_bar) as progress_bar:
             for document_batch in batched_documents:
+                json_fields = []
                 for doc in document_batch:
                     _doc = {**doc.to_dict(field_map=self._create_document_field_map())}
                     _ = _doc.pop("score", None)
@@ -569,6 +607,13 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                                 raise ValueError(
                                     f'"meta" info contains duplicate key "{k}" with the top-level document structure'
                                 )
+                            # Weaviate doesn't support dictionaries as property types, so we convert them to JSON strings
+                            if isinstance(v, dict):
+                                json_fields.append(k)
+                                v = json.dumps(v)
+                            elif isinstance(v, list) and isinstance(v[0], dict):
+                                json_fields.append(k)
+                                v = [json.dumps(item) for item in v]
                             _doc[k] = v
                         _doc.pop("meta")
 
@@ -586,7 +631,10 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                     missing_props = self._check_document(current_properties, _doc)
                     if missing_props:
                         for property in missing_props:
-                            self._update_schema(property, _doc[property], index)
+                            property_value = _doc[property]
+                            if property in json_fields:
+                                property_value = doc.meta[property]
+                            self._update_schema(property, property_value, index)
                             current_properties.append(property)
 
                     # Weaviate requires dates to be in RFC3339 format
@@ -891,8 +939,11 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             return_embedding = self.return_embedding
 
         results = self._get_all_documents_in_index(index=index, filters=filters, batch_size=batch_size)
+        json_properties = self._get_json_properties(index=index)
         for result in results:
-            document = self._convert_weaviate_result_to_document(result, return_embedding=return_embedding)
+            document = self._convert_weaviate_result_to_document(
+                result, return_embedding=return_embedding, json_properties=json_properties
+            )
             yield document
 
     def query(
@@ -1048,9 +1099,12 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             if query_output.get("data").get("Get").get(index):
                 results = query_output.get("data").get("Get").get(index)
 
+        json_properties = self._get_json_properties(index=index)
         documents = []
         for result in results:
-            doc = self._convert_weaviate_result_to_document(result, return_embedding=True, scale_score=scale_score)
+            doc = self._convert_weaviate_result_to_document(
+                result, return_embedding=True, scale_score=scale_score, json_properties=json_properties
+            )
             documents.append(doc)
 
         return documents
@@ -1312,10 +1366,11 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             if query_output.get("data").get("Get").get(index):
                 results = query_output.get("data").get("Get").get(index)
 
+        json_properties = self._get_json_properties(index=index)
         documents = []
         for result in results:
             doc = self._convert_weaviate_result_to_document(
-                result, return_embedding=return_embedding, scale_score=scale_score
+                result, return_embedding=return_embedding, scale_score=scale_score, json_properties=json_properties
             )
             documents.append(doc)
 
@@ -1383,10 +1438,12 @@ class WeaviateDocumentStore(KeywordDocumentStore):
             )
 
         result = self._get_all_documents_in_index(index=index, filters=filters, batch_size=batch_size)
+        json_properties = self._get_json_properties(index=index)
 
         for result_batch in get_batches_from_generator(result, batch_size):
             document_batch = [
-                self._convert_weaviate_result_to_document(hit, return_embedding=False) for hit in result_batch
+                self._convert_weaviate_result_to_document(hit, return_embedding=False, json_properties=json_properties)
+                for hit in result_batch
             ]
             embeddings = retriever.embed_documents(document_batch)
             self._validate_embeddings_shape(

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -243,13 +243,20 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                 )
 
     def _convert_weaviate_result_to_document(
-        self, result: dict, return_embedding: bool, scale_score: bool = True, json_properties: List[str] = []
+        self,
+        result: dict,
+        return_embedding: bool,
+        scale_score: bool = True,
+        json_properties: Optional[List[str]] = None,
     ) -> Document:
         """
         Convert weaviate result dict into haystack document object. This is more involved because
         weaviate search result dict varies between get and query interfaces.
         Weaviate get methods return the data items in properties key, whereas the query doesn't.
         """
+        if json_properties is None:
+            json_properties = []
+
         score = None
         content = ""
 

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -8,7 +8,7 @@ import numpy as np
 from haystack.document_stores.weaviate import WeaviateDocumentStore
 from haystack.schema import Document
 from haystack.testing import DocumentStoreBaseTestAbstract
-
+from haystack.document_stores import weaviate
 
 embedding_dim = 768
 
@@ -58,6 +58,23 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
             )
 
         return documents
+
+    @pytest.fixture()
+    def mocked_ds(self):
+        """
+        This fixture provides an instance of the WeaviateDocumentStore equipped with a mocked Weaviate client.
+        """
+
+        class DSMock(WeaviateDocumentStore):
+            pass
+
+        mocked_client = mock.MagicMock()
+        mocked_client.Client().is_ready.return_value = True
+        mocked_client.Client().schema.contains.return_value = False
+        weaviate.client = mocked_client
+        mocked_ds = DSMock()
+
+        return mocked_ds
 
     @pytest.mark.skip(reason="Weaviate does not support labels")
     @pytest.mark.integration
@@ -205,7 +222,7 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         ds.write_documents(documents)
         # This test verifies that deleting an object by its ID does not first require fetching all documents. This fixes
         # a bug, as described in https://github.com/deepset-ai/haystack/issues/2898
-        ds.get_all_documents = mock.MagicMock(wraps=ds.get_all_documents)
+        ds.get_all_documents = MagicMock(wraps=ds.get_all_documents)
 
         assert ds.get_document_count() == 9
 
@@ -258,12 +275,9 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         assert ds.get_embedding_count() == 9
 
     @pytest.mark.unit
-    def test__get_current_properties(self):
-        with mock.patch("haystack.document_stores.weaviate.client") as mocked_client:
-            mocked_client.Client().is_ready.return_value = True
-            mocked_client.Client().schema.contains.return_value = False
-            mocked_client.Client().schema.get.return_value = json.loads(
-                """
+    def test__get_current_properties(self, mocked_ds):
+        mocked_ds.weaviate_client.schema.get.return_value = json.loads(
+            """
 {
   "classes": [{
     "class": "Document",
@@ -279,7 +293,146 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
     ]
   }]
 } """
-            )
-            ds = WeaviateDocumentStore()
-            # Ensure we dropped the cross-reference property
-            assert ds._get_current_properties() == ["hitCounter"]
+        )
+        # Ensure we dropped the cross-reference property
+        assert mocked_ds._get_current_properties() == ["hitCounter"]
+
+    @pytest.mark.unit
+    def test_dict_metadata(self, mocked_ds):
+        """
+        Tests that metadata of type dict is converted to JSON string when writing to Weaviate and converted
+        back to dict when reading from Weaviate.
+        """
+        doc = Document(content="test", meta={"dict_field": {"key": "value"}})
+        # Test writing as JSON string
+        mocked_ds.write_documents([doc])
+        mocked_ds.weaviate_client.batch.add_data_object.assert_called_with(
+            data_object={
+                "content": json.dumps(doc.content),
+                "content_type": doc.content_type,
+                "id_hash_keys": doc.id_hash_keys,
+                "dict_field": json.dumps(doc.meta["dict_field"]),
+            },
+            class_name=mock.ANY,
+            uuid=mock.ANY,
+            vector=mock.ANY,
+        )
+
+        # Test retrieving as dict
+        mocked_ds.weaviate_client.query.get().do.return_value = json.loads(
+            """
+            {
+              "data": {
+                "Get": {
+                  "Document": [
+                    {
+                      "content": "\\"test\\"",
+                      "content_type": "text",
+                      "dict_field": "{\\"key\\": \\"value\\"}",
+                      "id_hash_keys": ["content"]
+                    }
+                  ]
+                }
+              }
+            }
+            """
+        )
+        mocked_ds.get_document_count = mock.MagicMock(return_value=1)
+        mocked_ds.weaviate_client.schema.get.return_value = json.loads(
+            """
+            {
+              "classes": [
+                {
+                  "class": "Document",
+                  "description": "Haystack index, it's a class in Weaviate",
+                  "properties": [
+                    {
+                      "dataType": ["text"],
+                      "description": "Document Content (e.g. the text)",
+                      "name": "content",
+                      "tokenization": "word"
+                    },
+                    {
+                      "dataType": ["text"],
+                      "description": "JSON dynamic property dict_field",
+                      "name": "dict_field",
+                      "tokenization": "whitespace"
+                    }
+                  ]
+                }
+              ]
+            }
+            """
+        )
+        retrieved_docs = mocked_ds.get_all_documents()
+        assert retrieved_docs[0].meta["dict_field"] == {"key": "value"}
+
+    @pytest.mark.unit
+    def test_list_of_dict_metadata(self, mocked_ds):
+        """
+        Tests that metadata of type list of dict is converted to list of JSON string when writing to Weaviate and
+        converted back to list of dict when reading from Weaviate.
+        """
+        doc = Document(content="test", meta={"list_dict_field": [{"key": "value"}, {"key": "value"}]})
+        # Test writing as list of JSON strings
+        mocked_ds.write_documents([doc])
+        mocked_ds.weaviate_client.batch.add_data_object.assert_called_with(
+            data_object={
+                "content": json.dumps(doc.content),
+                "content_type": doc.content_type,
+                "id_hash_keys": doc.id_hash_keys,
+                "list_dict_field": [json.dumps(item) for item in doc.meta["list_dict_field"]],
+            },
+            class_name=mock.ANY,
+            uuid=mock.ANY,
+            vector=mock.ANY,
+        )
+
+        # Test retrieving as list of dict
+        mocked_ds.weaviate_client.query.get().do.return_value = json.loads(
+            """
+            {
+              "data": {
+                "Get": {
+                  "Document": [
+                    {
+                      "content": "\\"test\\"",
+                      "content_type": "text",
+                      "list_dict_field": ["{\\"key\\": \\"value\\"}", "{\\"key\\": \\"value\\"}"],
+                      "id_hash_keys": ["content"]
+                    }
+                  ]
+                }
+              }
+            }
+            """
+        )
+        mocked_ds.get_document_count = mock.MagicMock(return_value=1)
+        mocked_ds.weaviate_client.schema.get.return_value = json.loads(
+            """
+            {
+              "classes": [
+                {
+                  "class": "Document",
+                  "description": "Haystack index, it's a class in Weaviate",
+                  "properties": [
+                    {
+                      "dataType": ["text"],
+                      "description": "Document Content (e.g. the text)",
+                      "name": "content",
+                      "tokenization": "word"
+                    },
+                    {
+                      "dataType": ["text[]"],
+                      "description": "JSON dynamic property dict_field",
+                      "name": "list_dict_field",
+                      "tokenization": "whitespace"
+                    }
+                  ]
+                }
+              ]
+            }
+            """
+        )
+        retrieved_docs = mocked_ds.get_all_documents()
+        assert retrieved_docs[0].meta["list_dict_field"] == [{"key": "value"}, {"key": "value"}]

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -222,7 +222,7 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         ds.write_documents(documents)
         # This test verifies that deleting an object by its ID does not first require fetching all documents. This fixes
         # a bug, as described in https://github.com/deepset-ai/haystack/issues/2898
-        ds.get_all_documents = MagicMock(wraps=ds.get_all_documents)
+        ds.get_all_documents = mock.MagicMock(wraps=ds.get_all_documents)
 
         assert ds.get_document_count() == 9
 


### PR DESCRIPTION
### Related Issues
- fixes #4629

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds support for the `_split_overlap` meta field to the `PineconeDocumentStore` and adds support for any metadata of type `dict` to `WeaviateDocumentStore`. 

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added unit tests.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
Weaviate and Pinecone don't support dict type natively, so the workaround is to convert dict metadata fields to JSON strings at index time and convert the JSON strings back to dicts at query time. I haven't found a way to support dict in general for Pinecone, so I restricted the implementation to at least support the `_split_overlap` meta field.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
