### PR TITLE
fix: Dynamic `max_answers` for SquadProcessor (fixes IndexError when max_answers is less than the number of answers in the dataset)

### DIFF
--- a/haystack/modeling/data_handler/processor.py
+++ b/haystack/modeling/data_handler/processor.py
@@ -381,7 +381,7 @@ class SquadProcessor(Processor):
         doc_stride: int = 128,
         max_query_length: int = 64,
         proxies: Optional[dict] = None,
-        max_answers: int = None,
+        max_answers: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -633,8 +633,9 @@ class SquadProcessor(Processor):
                     for i, answer in enumerate(basket.raw["answers"]):
                         if i >= self.max_answers:
                             logger.warning(
-                                f"Found a sample with more answers ({len(basket.raw['answers'])}) than "
-                                f"max_answers ({self.max_answers}). These will be ignored."
+                                "Found a sample with more answers (%d) than "
+                                "max_answers (%d). These will be ignored."
+                                % (len(basket.raw["answers"]), self.max_answers)
                             )
                             break
                         # Calculate start and end relative to document

--- a/test/modeling/test_processor.py
+++ b/test/modeling/test_processor.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 
 import pytest
@@ -312,6 +313,11 @@ def test_dataset_from_dicts_auto_determine_max_answers(samples_path, caplog=None
     dicts = processor.file_to_dicts(samples_path / "qa" / "vanilla.json")
     dataset, tensor_names, problematic_sample_ids = processor.dataset_from_dicts(dicts, indices=[1])
     assert len(dataset[0][tensor_names.index("labels")]) == 2
+    # check that a max_answers will be adjusted when processing a different dataset with the same SquadProcessor
+    dicts_more_answers = copy.deepcopy(dicts)
+    dicts_more_answers[0]["qas"][0]["answers"] = dicts_more_answers[0]["qas"][0]["answers"] * 3
+    dataset, tensor_names, problematic_sample_ids = processor.dataset_from_dicts(dicts_more_answers, indices=[1])
+    assert len(dataset[0][tensor_names.index("labels")]) == 6
 
 
 @pytest.mark.integration

--- a/test/modeling/test_processor.py
+++ b/test/modeling/test_processor.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytest
 from transformers import AutoTokenizer
 
 from haystack.modeling.data_handler.processor import SquadProcessor
@@ -298,6 +299,7 @@ def test_dataset_from_dicts_qa_labelconversion(samples_path, caplog=None):
                     ], f"Processing labels for {model} has changed."
 
 
+@pytest.mark.integration
 def test_dataset_from_dicts_auto_determine_max_answers(samples_path, caplog=None):
     """
     Squadprocessor should determine the number of answers for the pytorch dataset by the maximum of the data.
@@ -311,6 +313,7 @@ def test_dataset_from_dicts_auto_determine_max_answers(samples_path, caplog=None
     assert len(dataset[0][tensor_names.index("labels")]) == 2
 
 
+@pytest.mark.integration
 def test_dataset_from_dicts_truncate_max_answers(samples_path, caplog=None):
     """
     Test that it is possible to manually set the number of answers, truncating the answers in the data.

--- a/test/modeling/test_processor.py
+++ b/test/modeling/test_processor.py
@@ -234,7 +234,7 @@ def test_batch_encoding_flatten_rename():
         pass
 
 
-def test_dataset_from_dicts_qa_labelconversion(samples_path, caplog=None):
+def test_dataset_from_dicts_qa_label_conversion(samples_path, caplog=None):
     if caplog:
         caplog.set_level(logging.CRITICAL)
 
@@ -249,7 +249,7 @@ def test_dataset_from_dicts_qa_labelconversion(samples_path, caplog=None):
 
     for model in models:
         tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model)
-        processor = SquadProcessor(tokenizer, max_seq_len=256, data_dir=None)
+        processor = SquadProcessor(tokenizer, max_seq_len=256, data_dir=None, max_answers=6)
 
         for sample_type in sample_types:
             dicts = processor.file_to_dicts(samples_path / "qa" / f"{sample_type}.json")
@@ -302,8 +302,9 @@ def test_dataset_from_dicts_qa_labelconversion(samples_path, caplog=None):
 @pytest.mark.integration
 def test_dataset_from_dicts_auto_determine_max_answers(samples_path, caplog=None):
     """
-    Squadprocessor should determine the number of answers for the pytorch dataset by the maximum of the data.
-    In the case of vanilla.json, there is only one question with two answers. Therefore, it should be two.
+    SquadProcessor should determine the number of answers for the pytorch dataset based on
+    the maximum number of answers for each question. Vanilla.json has one question with two answers,
+    so the number of answers should be two.
     """
     model = "deepset/roberta-base-squad2"
     tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model)

--- a/test/modeling/test_processor.py
+++ b/test/modeling/test_processor.py
@@ -296,3 +296,28 @@ def test_dataset_from_dicts_qa_labelconversion(samples_path, caplog=None):
                         12,
                         12,
                     ], f"Processing labels for {model} has changed."
+
+
+def test_dataset_from_dicts_auto_determine_max_answers(samples_path, caplog=None):
+    """
+    Squadprocessor should determine the number of answers for the pytorch dataset by the maximum of the data.
+    In the case of vanilla.json, there is only one question with two answers. Therefore, it should be two.
+    """
+    model = "deepset/roberta-base-squad2"
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model)
+    processor = SquadProcessor(tokenizer, max_seq_len=256, data_dir=None)
+    dicts = processor.file_to_dicts(samples_path / "qa" / "vanilla.json")
+    dataset, tensor_names, problematic_sample_ids = processor.dataset_from_dicts(dicts, indices=[1])
+    assert len(dataset[0][tensor_names.index("labels")]) == 2
+
+
+def test_dataset_from_dicts_truncate_max_answers(samples_path, caplog=None):
+    """
+    Test that it is possible to manually set the number of answers, truncating the answers in the data.
+    """
+    model = "deepset/roberta-base-squad2"
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model)
+    processor = SquadProcessor(tokenizer, max_seq_len=256, data_dir=None, max_answers=1)
+    dicts = processor.file_to_dicts(samples_path / "qa" / "vanilla.json")
+    dataset, tensor_names, problematic_sample_ids = processor.dataset_from_dicts(dicts, indices=[1])
+    assert len(dataset[0][tensor_names.index("labels")]) == 1


### PR DESCRIPTION
### Related Issues
- fixes #4320

### Proposed Changes:
Currently, the parameter `max_answers` is hardcoded to 6 and will throw an IndexError if the dataset contains a sample with more than 6 answers. 

This is not a nice user experience, especially when `SquadProcessor` is not used directly but is automatically instantiated (e.g. in `FARMReader`. The user would have to know about this hardcoded value, instantiate a `SquadProcessor` manually and pass it to `FARMReader`.

This PR solves this by dynamically determining `max_answers` from the data dict by default. The parameter `max_answers` can still be set manually. If max_answers is manually set to be less than the actual maximum amount of answers, the answers will be truncated and the logger will issue a warning.

### How did you test it?
Added two unit tests in test_processor.py

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
