### PR TITLE
fix: preserve `root_node` in `JoinNode`'s output

### DIFF
--- a/haystack/nodes/other/join.py
+++ b/haystack/nodes/other/join.py
@@ -22,7 +22,8 @@ class JoinNode(BaseComponent):
     ) -> Tuple[Dict, str]:
         if inputs:
             results = self.run_accumulated(inputs, top_k_join=top_k_join)
-            results[0]["root_node"] = inputs[0]["root_node"]
+            if "root_node" in inputs[0]:
+                results[0]["root_node"] = inputs[0]["root_node"]
             return results
         warnings.warn("You are using a JoinNode with only one input. This is usually equivalent to a no-op.")
         return self.run_accumulated(
@@ -58,7 +59,8 @@ class JoinNode(BaseComponent):
     ) -> Tuple[Dict, str]:
         if inputs:
             results = self.run_batch_accumulated(inputs=inputs, top_k_join=top_k_join)
-            results[0]["root_node"] = inputs[0]["root_node"]
+            if "root_node" in inputs[0]:
+                results[0]["root_node"] = inputs[0]["root_node"]
             return results
         warnings.warn("You are using a JoinNode with only one input. This is usually equivalent to a no-op.")
         return self.run_batch_accumulated(

--- a/haystack/nodes/other/join.py
+++ b/haystack/nodes/other/join.py
@@ -21,7 +21,9 @@ class JoinNode(BaseComponent):
         top_k_join: Optional[int] = None,
     ) -> Tuple[Dict, str]:
         if inputs:
-            return self.run_accumulated(inputs, top_k_join=top_k_join)
+            results = self.run_accumulated(inputs, top_k_join=top_k_join)
+            results[0]["root_node"] = inputs[0]["root_node"]
+            return results
         warnings.warn("You are using a JoinNode with only one input. This is usually equivalent to a no-op.")
         return self.run_accumulated(
             inputs=[
@@ -55,7 +57,9 @@ class JoinNode(BaseComponent):
         top_k_join: Optional[int] = None,
     ) -> Tuple[Dict, str]:
         if inputs:
-            return self.run_batch_accumulated(inputs=inputs, top_k_join=top_k_join)
+            results = self.run_batch_accumulated(inputs=inputs, top_k_join=top_k_join)
+            results[0]["root_node"] = inputs[0]["root_node"]
+            return results
         warnings.warn("You are using a JoinNode with only one input. This is usually equivalent to a no-op.")
         return self.run_batch_accumulated(
             inputs=[

--- a/test/nodes/test_join_answers.py
+++ b/test/nodes/test_join_answers.py
@@ -17,3 +17,15 @@ def test_joinanswers(join_mode):
     result, _ = join_answers.run(inputs, top_k_join=1)
     assert len(result["answers"]) == 1
     assert result["answers"][0].answer == "answer 2"
+
+
+@pytest.mark.unit
+def test_joinanswers_preserves_root_node():
+    # https://github.com/deepset-ai/haystack-private/issues/51
+    inputs = [
+        {"answers": [Answer(answer="answer 1", score=0.7)], "root_node": "Query"},
+        {"answers": [Answer(answer="answer 2", score=0.8)], "root_node": "Query"},
+    ]
+    join_docs = JoinAnswers()
+    result, _ = join_docs.run(inputs)
+    assert result["root_node"] == "Query"

--- a/test/nodes/test_join_documents.py
+++ b/test/nodes/test_join_documents.py
@@ -42,3 +42,15 @@ def test_joindocuments_score_none(join_mode, sort_by_score):
 
     result, _ = join_docs.run(inputs, top_k_join=1)
     assert len(result["documents"]) == 1
+
+
+@pytest.mark.unit
+def test_joindocuments_preserves_root_node():
+    # https://github.com/deepset-ai/haystack-private/issues/51
+    inputs = [
+        {"documents": [Document(content="text document 1", content_type="text", score=0.2)], "root_node": "File"},
+        {"documents": [Document(content="text document 2", content_type="text", score=None)], "root_node": "File"},
+    ]
+    join_docs = JoinDocuments()
+    result, _ = join_docs.run(inputs)
+    assert result["root_node"] == "File"


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack-private/issues/51

### Proposed Changes:
- `JoinNode` subclasses are dropping several parameters that they are not merging, but some, namely `root_node`, should be preserved for other nodes like `Retriever`s to work when placed downstream.
- This PR forces `JoinNode`s to retain `root_node` in their output and adds tests.

### How did you test it?
- Added tests

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
