### PR TITLE
feat: Add AgentAnswerParser

### DIFF
--- a/haystack/agents/answer_parser.py
+++ b/haystack/agents/answer_parser.py
@@ -1,0 +1,54 @@
+import re
+from abc import abstractmethod, ABC
+from typing import Any
+
+
+class AgentAnswerParser(ABC):
+    """
+    Abstract base class for parsing agent's answer.
+    """
+
+    @abstractmethod
+    def can_parse(self, parser_input: Any) -> bool:
+        """
+        Check if the parser can parse the input.
+        :param parser_input: The input to parse.
+        :return: True if the parser can parse the input, False otherwise.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse(self, parser_input: Any) -> str:
+        """
+        Parse the input.
+        :param parser_input: The input to parse.
+        :return: The parsed input.
+        """
+        raise NotImplementedError
+
+
+class RegexAnswerParser(AgentAnswerParser):
+    """
+    Parser that uses a regex to parse the agent's answer.
+    """
+
+    def __init__(self, final_answer_pattern: str = r"^([\s\S]+)$"):
+        """
+        Initialize the regex parser.
+        :param final_answer_pattern: The regex pattern to use to parse the agent's answer with the default pattern
+        matching any non-empty string.
+        """
+        self.pattern = final_answer_pattern
+
+    def can_parse(self, parser_input: Any) -> bool:
+        if isinstance(parser_input, str):
+            return bool(re.search(self.pattern, parser_input))
+        return False
+
+    def parse(self, parser_input: Any) -> str:
+        if self.can_parse(parser_input):
+            final_answer_match = re.search(self.pattern, parser_input)
+            if final_answer_match:
+                final_answer = final_answer_match.group(1)
+                return final_answer.strip('" ')  # type: ignore
+        return ""

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -141,29 +141,6 @@ def test_format_answer():
     assert formatted_answer["answers"] == [Answer(answer="Florida", type="generative")]
 
 
-@pytest.mark.unit
-def test_final_answer_regex():
-    match_examples = [
-        "Final Answer: 42 is the answer",
-        "Final Answer:  1234",
-        "Final Answer:  Answer",
-        "Final Answer:  This list: one and two and three",
-        "Final Answer:42",
-        "Final Answer:   ",
-        "Final Answer:    The answer is 99    ",
-    ]
-
-    non_match_examples = ["Final answer: 42 is the answer", "Final Answer", "The final answer is: 100"]
-    final_answer_pattern = r"Final Answer\s*:\s*(.*)"
-    for example in match_examples:
-        match = re.match(final_answer_pattern, example)
-        assert match is not None
-
-    for example in non_match_examples:
-        match = re.match(final_answer_pattern, example)
-        assert match is None
-
-
 @pytest.mark.integration
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 @pytest.mark.parametrize("retriever_with_docs, document_store_with_docs", [("bm25", "memory")], indirect=True)

--- a/test/agents/test_answer_parser.py
+++ b/test/agents/test_answer_parser.py
@@ -4,6 +4,7 @@ from haystack.agents.answer_parser import AgentAnswerParser, RegexAnswerParser
 final_answer_pattern = r"Final Answer\s*:\s*(.*)"
 
 
+@pytest.mark.unit
 def test_agent_answer_parser_abstract_base_class():
     with pytest.raises(TypeError):
         _ = AgentAnswerParser()
@@ -13,6 +14,7 @@ def test_agent_answer_parser_abstract_base_class():
     "input_str, expected",
     [("Hello, my name is John", True), ("This is a test", True), ("", False), (" ", True), (123, False), (None, False)],
 )
+@pytest.mark.unit
 def test_basic_answer_parser_can_parse(input_str, expected):
     parser = RegexAnswerParser()
     assert parser.can_parse(input_str) == expected
@@ -29,6 +31,7 @@ def test_basic_answer_parser_can_parse(input_str, expected):
         (" ", ""),
     ],
 )
+@pytest.mark.unit
 def test_answer_parser_parse_any_string(input_str, expected):
     parser = RegexAnswerParser()
     assert parser.parse(input_str) == expected
@@ -49,6 +52,7 @@ def test_answer_parser_parse_any_string(input_str, expected):
         ("The final answer is: 100", final_answer_pattern, False),
     ],
 )
+@pytest.mark.unit
 def test_final_answer_regex_can_parse(input_str, pattern, expected):
     parser = RegexAnswerParser(pattern)
     assert parser.can_parse(input_str) == expected
@@ -69,6 +73,7 @@ def test_final_answer_regex_can_parse(input_str, pattern, expected):
         ("The final answer is: 100", final_answer_pattern, ""),
     ],
 )
+@pytest.mark.unit
 def test_final_answer_regex_parse(input_str, pattern, expected):
     parser = RegexAnswerParser(pattern)
     assert parser.parse(input_str) == expected

--- a/test/agents/test_answer_parser.py
+++ b/test/agents/test_answer_parser.py
@@ -1,0 +1,74 @@
+import pytest
+from haystack.agents.answer_parser import AgentAnswerParser, RegexAnswerParser
+
+final_answer_pattern = r"Final Answer\s*:\s*(.*)"
+
+
+def test_agent_answer_parser_abstract_base_class():
+    with pytest.raises(TypeError):
+        _ = AgentAnswerParser()
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [("Hello, my name is John", True), ("This is a test", True), ("", False), (" ", True), (123, False), (None, False)],
+)
+def test_basic_answer_parser_can_parse(input_str, expected):
+    parser = RegexAnswerParser()
+    assert parser.can_parse(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("Hello, my name is John", "Hello, my name is John"),
+        ("This is a test", "This is a test"),
+        ("", ""),
+        (123, ""),
+        (None, ""),
+        (" ", ""),
+    ],
+)
+def test_answer_parser_parse_any_string(input_str, expected):
+    parser = RegexAnswerParser()
+    assert parser.parse(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str, pattern, expected",
+    [
+        ("Final Answer: 42 is the answer", final_answer_pattern, True),
+        ("Final Answer:  1234", final_answer_pattern, True),
+        ("Final Answer:  Answer", final_answer_pattern, True),
+        ("Final Answer:  This list: one and two and three", final_answer_pattern, True),
+        ("Final Answer:42", final_answer_pattern, True),
+        ("Final Answer:   ", final_answer_pattern, True),
+        ("Final Answer:    The answer is 99    ", final_answer_pattern, True),
+        ("Final answer: 42 is the answer", final_answer_pattern, False),
+        ("Final Answer", final_answer_pattern, False),
+        ("The final answer is: 100", final_answer_pattern, False),
+    ],
+)
+def test_final_answer_regex_can_parse(input_str, pattern, expected):
+    parser = RegexAnswerParser(pattern)
+    assert parser.can_parse(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str, pattern, expected",
+    [
+        ("Final Answer: 42 is the answer", final_answer_pattern, "42 is the answer"),
+        ("Final Answer:  1234", final_answer_pattern, "1234"),
+        ("Final Answer:  Answer", final_answer_pattern, "Answer"),
+        ("Final Answer:  This list: one and two and three", final_answer_pattern, "This list: one and two and three"),
+        ("Final Answer:42", final_answer_pattern, "42"),
+        ("Final Answer:   ", final_answer_pattern, ""),
+        ("Final Answer:    The answer is 99    ", final_answer_pattern, "The answer is 99"),
+        ("Final answer: 42 is the answer", final_answer_pattern, ""),
+        ("Final Answer", final_answer_pattern, ""),
+        ("The final answer is: 100", final_answer_pattern, ""),
+    ],
+)
+def test_final_answer_regex_parse(input_str, pattern, expected):
+    parser = RegexAnswerParser(pattern)
+    assert parser.parse(input_str) == expected


### PR DESCRIPTION
### Related Issues
- part of an encompassing PR https://github.com/deepset-ai/haystack/pull/4804

### Proposed Changes:
- Adds Agent answer parsers that can check if the agent answer is parseable (i.e. `can_parse`) in addition to parsing it (`parse`)

- There are some similarities with AnswerParser classes in the prompt node, and we will potentially see how to consolidate these in the future. 

- The initial motivation for adding AgentAnswerParser comes from the need to support different kinds of Agents being introduced and specifying their answers parsing logic easily. We retain backward compatibility as RegexAnswerParser handles current regex answer matching for react agents and conversational agents with tools, while simple conversational agents use the default RegexAnswerParser - allowing any non-empty LLM answer to be considered valid answer. 

In conclusion, AgentAnswerParser hides the details of answer parsing and elevates abstractions in agent code, so the explicit regex pattern matching code is hidden behind the implementation of RegexAnswerParser. The proposed AgentAnswerParser not only simplifies the integration of new agents but also promotes modularity, maintainability, and adaptability within our agent codebase. 

### How did you test it?
Unit tests and manually as part of conversational agents

### Notes for the reviewer
See encompassing PR

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
