### PR TITLE
chore: skip flaky test

### DIFF
--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -205,6 +205,7 @@ def test_tool_result_extraction(reader, retriever_with_docs):
     assert "Christelle" in result
 
 
+@pytest.mark.skip("FIXME")
 @pytest.mark.integration
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 @pytest.mark.parametrize("retriever_with_docs, document_store_with_docs", [("bm25", "memory")], indirect=True)


### PR DESCRIPTION
### Related Issues
- fixes flaky test

### Proposed Changes:
- Skips `test/agents/test_agent.py::test_agent_run` due to increasing flakyness

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
