### PR TITLE
fix: add `unit` markers to several v2 tests

### DIFF
--- a/test/preview/dataclasses/test_dataclasses.py
+++ b/test/preview/dataclasses/test_dataclasses.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import hashlib
+import pytest
 import pandas as pd
 import numpy as np
 
@@ -7,6 +7,7 @@ from haystack.preview import Document
 from haystack.preview.dataclasses.document import _create_id
 
 
+@pytest.mark.unit
 def test_default_text_document_to_dict():
     assert Document(content="test content").to_dict() == {
         "id": _create_id(classname=Document.__name__, content="test content"),
@@ -19,6 +20,7 @@ def test_default_text_document_to_dict():
     }
 
 
+@pytest.mark.unit
 def test_default_text_document_from_dict():
     assert Document.from_dict(
         {
@@ -33,6 +35,7 @@ def test_default_text_document_from_dict():
     ) == Document(content="test content")
 
 
+@pytest.mark.unit
 def test_default_table_document_to_dict():
     df = pd.DataFrame([1, 2])
     dictionary = Document(content=df, content_type="table").to_dict()
@@ -50,6 +53,7 @@ def test_default_table_document_to_dict():
     }
 
 
+@pytest.mark.unit
 def test_default_table_document_from_dict():
     df = pd.DataFrame([1, 2])
     assert Document.from_dict(
@@ -65,6 +69,7 @@ def test_default_table_document_from_dict():
     ) == Document(content=df, content_type="table")
 
 
+@pytest.mark.unit
 def test_default_image_document_to_dict():
     path = Path(__file__).parent / "test_files" / "apple.jpg"
     assert Document(content=path, content_type="image").to_dict() == {
@@ -78,6 +83,7 @@ def test_default_image_document_to_dict():
     }
 
 
+@pytest.mark.unit
 def test_default_image_document_from_dict():
     path = Path(__file__).parent / "test_files" / "apple.jpg"
     assert Document.from_dict(
@@ -93,6 +99,7 @@ def test_default_image_document_from_dict():
     ) == Document(content=path, content_type="image")
 
 
+@pytest.mark.unit
 def test_document_with_most_attributes_to_dict():
     """
     This tests also id_hash_keys
@@ -125,6 +132,7 @@ def test_document_with_most_attributes_to_dict():
     }
 
 
+@pytest.mark.unit
 def test_document_with_most_attributes_from_dict():
     embedding = np.zeros([10, 10])
     assert Document.from_dict(

--- a/test/preview/document_stores/_base.py
+++ b/test/preview/document_stores/_base.py
@@ -47,7 +47,6 @@ class DocumentStoreBaseTests:
 
         return documents
 
-    @pytest.mark.unit
     def contains_same_docs(self, first_list: List[Document], second_list: List[Document]) -> bool:
         """
         Utility to compare two lists of documents for equality regardless of the order od the documents.

--- a/test/preview/document_stores/_base.py
+++ b/test/preview/document_stores/_base.py
@@ -47,41 +47,49 @@ class DocumentStoreBaseTests:
 
         return documents
 
+    @pytest.mark.unit
     def contains_same_docs(self, first_list: List[Document], second_list: List[Document]) -> bool:
         """
         Utility to compare two lists of documents for equality regardless of the order od the documents.
         """
         return first_list.sort(key=lambda d: d.id) == second_list.sort(key=lambda d: d.id)
 
+    @pytest.mark.unit
     def test_count_empty(self, docstore):
         assert docstore.count_documents() == 0
 
+    @pytest.mark.unit
     def test_count_not_empty(self, docstore):
         self.direct_write(
             docstore, [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
         )
         assert docstore.count_documents() == 3
 
+    @pytest.mark.unit
     def test_no_filter_empty(self, docstore):
         assert docstore.filter_documents() == []
         assert docstore.filter_documents(filters={}) == []
 
+    @pytest.mark.unit
     def test_no_filter_not_empty(self, docstore):
         docs = [Document(content="test doc")]
         self.direct_write(docstore, docs)
         assert docstore.filter_documents() == docs
         assert docstore.filter_documents(filters={}) == docs
 
+    @pytest.mark.unit
     def test_filter_simple_value(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": "2020"})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("year") == "2020"])
 
+    @pytest.mark.unit
     def test_filter_simple_list_single_element(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": ["2020"]})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("year") == "2020"])
 
+    @pytest.mark.unit
     def test_filter_simple_list(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": ["2020", "2021"]})
@@ -89,41 +97,49 @@ class DocumentStoreBaseTests:
             result, [doc for doc in filterable_docs if doc.metadata.get("year") in ["2020", "2021"]]
         )
 
+    @pytest.mark.unit
     def test_incorrect_filter_name(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"non_existing_meta_field": ["whatever"]})
         assert len(result) == 0
 
+    @pytest.mark.unit
     def test_incorrect_filter_type(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         with pytest.raises(ValueError, match="dictionaries or lists"):
             docstore.filter_documents(filters="something odd")
 
+    @pytest.mark.unit
     def test_incorrect_filter_value(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": ["nope"]})
         assert len(result) == 0
 
+    @pytest.mark.unit
     def test_incorrect_filter_nesting(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         with pytest.raises(ValueError, match="malformed"):
             docstore.filter_documents(filters={"number": {"year": "2020"}})
 
+    @pytest.mark.unit
     def test_deeper_incorrect_filter_nesting(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         with pytest.raises(ValueError, match="malformed"):
             docstore.filter_documents(filters={"number": {"year": {"month": "01"}}})
 
+    @pytest.mark.unit
     def test_eq_filter_explicit(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": {"$eq": "2020"}})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("year") == "2020"])
 
+    @pytest.mark.unit
     def test_eq_filter_implicit(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": "2020"})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("year") == "2020"])
 
+    @pytest.mark.unit
     def test_in_filter_explicit(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": {"$in": ["2020", "2021", "n.a."]}})
@@ -131,6 +147,7 @@ class DocumentStoreBaseTests:
             result, [doc for doc in filterable_docs if doc.metadata.get("year") in ["2020", "2021"]]
         )
 
+    @pytest.mark.unit
     def test_in_filter_implicit(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": ["2020", "2021", "n.a."]})
@@ -138,11 +155,13 @@ class DocumentStoreBaseTests:
             result, [doc for doc in filterable_docs if doc.metadata.get("year") in ["2020", "2021"]]
         )
 
+    @pytest.mark.unit
     def test_ne_filter(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": {"$ne": "2020"}})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("year") != "2020"])
 
+    @pytest.mark.unit
     def test_nin_filter(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"year": {"$nin": ["2020", "2021", "n.a."]}})
@@ -150,6 +169,7 @@ class DocumentStoreBaseTests:
             result, [doc for doc in filterable_docs if doc.metadata.get("year") not in ["2020", "2021"]]
         )
 
+    @pytest.mark.unit
     def test_gt_filter(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$gt": 0.0}})
@@ -157,6 +177,7 @@ class DocumentStoreBaseTests:
             result, [doc for doc in filterable_docs if "number" in doc.metadata.keys() and doc.metadata["number"] > 0]
         )
 
+    @pytest.mark.unit
     def test_gte_filter(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$gte": -2.0}})
@@ -165,6 +186,7 @@ class DocumentStoreBaseTests:
             [doc for doc in filterable_docs if "number" in doc.metadata.keys() and doc.metadata["number"] >= -2.0],
         )
 
+    @pytest.mark.unit
     def test_lt_filter(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$lt": 0.0}})
@@ -172,6 +194,7 @@ class DocumentStoreBaseTests:
             result, [doc for doc in filterable_docs if "number" in doc.metadata.keys() and doc.metadata["number"] < 0]
         )
 
+    @pytest.mark.unit
     def test_lte_filter(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$lte": 2.0}})
@@ -180,6 +203,7 @@ class DocumentStoreBaseTests:
             [doc for doc in filterable_docs if "number" in doc.metadata.keys() and doc.metadata["number"] <= 2.0],
         )
 
+    @pytest.mark.unit
     def test_filter_simple_explicit_and_with_multikey_dict(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$and": {"$lte": 1, "$gte": -1}}})
@@ -192,6 +216,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_simple_explicit_and_with_list(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$and": [{"$lte": 1}, {"$gte": -1}]}})
@@ -204,6 +229,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_simple_implicit_and(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$lte": 1, "$gte": -1}})
@@ -216,6 +242,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_explicit_and(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters = {"$and": {"number": {"$and": {"$lte": 1, "$gte": -1}}, "name": {"$in": ["name_0", "name_1"]}}}
@@ -234,6 +261,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_implicit_and(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters_simplified = {"number": {"$lte": 1, "$gte": -1}, "name": ["name_0", "name_1"]}
@@ -252,6 +280,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_simple_or(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters = {"$or": {"name": {"$in": ["name_0", "name_1"]}, "number": {"$lt": 1.0}}}
@@ -268,6 +297,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_or(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters = {"$or": {"name": {"$or": [{"$eq": "name_0"}, {"$eq": "name_1"}]}, "number": {"$lt": 1.0}}}
@@ -284,6 +314,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_and_or_explicit(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters_simplified = {
@@ -305,6 +336,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_and_or_implicit(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters_simplified = {
@@ -327,6 +359,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_or_and(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters_simplified = {
@@ -351,6 +384,7 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_filter_nested_multiple_identical_operators_same_level(self, docstore, filterable_docs):
         self.direct_write(docstore, filterable_docs)
         filters = {
@@ -372,11 +406,13 @@ class DocumentStoreBaseTests:
             ],
         )
 
+    @pytest.mark.unit
     def test_write(self, docstore):
         doc = Document(content="test doc")
         docstore.write_documents(documents=[doc])
         assert self.direct_access(docstore, doc_id=doc.id) == doc
 
+    @pytest.mark.unit
     def test_write_duplicate_fail(self, docstore):
         doc = Document(content="test doc")
         self.direct_write(docstore, [doc])
@@ -384,12 +420,14 @@ class DocumentStoreBaseTests:
             docstore.write_documents(documents=[doc])
         assert self.direct_access(docstore, doc_id=doc.id) == doc
 
+    @pytest.mark.unit
     def test_write_duplicate_skip(self, docstore):
         doc = Document(content="test doc")
         self.direct_write(docstore, [doc])
         docstore.write_documents(documents=[doc], duplicates="skip")
         assert self.direct_access(docstore, doc_id=doc.id) == doc
 
+    @pytest.mark.unit
     def test_write_duplicate_overwrite(self, docstore):
         doc1 = Document(content="test doc 1")
         doc2 = Document(content="test doc 2")
@@ -400,18 +438,22 @@ class DocumentStoreBaseTests:
         docstore.write_documents(documents=[doc1], duplicates="overwrite")
         assert self.direct_access(docstore, doc_id=doc1.id) == doc1
 
+    @pytest.mark.unit
     def test_write_not_docs(self, docstore):
         with pytest.raises(ValueError, match="Please provide a list of Documents"):
             docstore.write_documents(["not a document for sure"])
 
+    @pytest.mark.unit
     def test_write_not_list(self, docstore):
         with pytest.raises(ValueError, match="Please provide a list of Documents"):
             docstore.write_documents("not a list actually")
 
+    @pytest.mark.unit
     def test_delete_empty(self, docstore):
         with pytest.raises(MissingDocumentError):
             docstore.delete_documents(["test"])
 
+    @pytest.mark.unit
     def test_delete_not_empty(self, docstore):
         doc = Document(content="test doc")
         self.direct_write(docstore, [doc])
@@ -421,6 +463,7 @@ class DocumentStoreBaseTests:
         with pytest.raises(Exception):
             assert self.direct_access(docstore, doc_id=doc.id)
 
+    @pytest.mark.unit
     def test_delete_not_empty_nonexisting(self, docstore):
         doc = Document(content="test doc")
         self.direct_write(docstore, [doc])


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
- Add `pytest.mark.unit` to all tests in `haystack/preview` that did not have it.

### How did you test it?
- CI

### Notes for the reviewer
Needed for the coverage to show up on Coveralls

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
