### PR TITLE
chore: pin `canals`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "jsonschema",
 
   # Preview
-  "canals",
+  "canals==0.1.2",
 
   # Agent events
   "events"


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/4852

### Proposed Changes:
- pin `canals==0.1.2` to shield against breaking changes

### How did you test it?
n/a

### Notes for the reviewer
n/a
