### PR TITLE
ci: Add missing unit tests topics to coverage upload step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         topic:
+          # WARNING: When updating this list remember to also update the
+          # carryforward field in the upload-coverage job
           - document_stores
           - nodes
           - agents
@@ -232,7 +234,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: "document_stores,nodes,agents,preview,prompt,pipelines,utils"
+          carryforward: "document_stores,nodes,agents,preview,prompt,pipelines,utils,others,modeling"
 
   integration-tests-elasticsearch:
     name: Integration / Elasticsearch / ${{ matrix.os }}


### PR DESCRIPTION
### Proposed Changes:

Add all unit test topics to `upload-coverage` job `carryforward` input and add a warning to remind people to update it when adding new topics to `unit-test` matrix.

### How did you test it?

I triggered a run on this branch and the coverage upload ran fine, the workflow failed later on for unrelated reasons.
https://github.com/deepset-ai/haystack/actions/runs/4934763052 

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
