### PR TITLE
ci: Upload coverage only if all unit tests pass

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,8 +137,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         topic:
-          # WARNING: When updating this list remember to also update the
-          # carryforward field in the upload-coverage job
           - document_stores
           - nodes
           - agents
@@ -227,14 +225,12 @@ jobs:
 
   upload-coverage:
     needs: unit-tests
-    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: "document_stores,nodes,agents,preview,prompt,pipelines,utils,others,modeling"
 
   integration-tests-elasticsearch:
     name: Integration / Elasticsearch / ${{ matrix.os }}


### PR DESCRIPTION
### Proposed Changes:

Coverage upload is always done after the `unit-test` matrix job finishes running, even if there are failing tests.

This causes reruns to fail on upload since the `coverage-upload` job "closes" the run and it won't let it accept any more coverage reports.

Preventing the upload even if a single test fails should solve the issue. 

### How did you test it?

Can't really be tested.

### Notes for the reviewer

Example job failing on rerun after previous failure: https://github.com/deepset-ai/haystack/actions/runs/4927098118/jobs/8819249825?pr=4853