### PR TITLE
feat: Send pipeline config hash every 100 runs

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -73,6 +73,7 @@ class Pipeline:
         self.graph = DiGraph()
         self.config_hash = None
         self.last_config_hash = None
+        self.last_run = None
 
     @property
     def root_node(self) -> Optional[str]:

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -72,6 +72,7 @@ class Pipeline:
     def __init__(self):
         self.graph = DiGraph()
         self.config_hash = None
+        self.last_config_hash = None
         self.runs = 0
 
     @property

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -72,7 +72,7 @@ class Pipeline:
     def __init__(self):
         self.graph = DiGraph()
         self.config_hash = None
-        self.last_config_hash = None
+        self.runs = 0
 
     @property
     def root_node(self) -> Optional[str]:
@@ -492,6 +492,8 @@ class Pipeline:
                       about their execution. By default, this information includes the input parameters
                       the Nodes received and the output they generated. You can then find all debug information in the dictionary returned by this method under the key `_debug`.
         """
+        self.runs += 1
+
         send_pipeline_event(
             pipeline=self,
             query=query,
@@ -640,6 +642,8 @@ class Pipeline:
                       about their execution. By default, this information includes the input parameters
                       the Nodes received and the output they generated. You can then find all debug information in the dictionary returned by this method under the key `_debug`.
         """
+        self.runs += 1
+
         send_pipeline_event(
             pipeline=self,
             queries=queries,

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -73,7 +73,6 @@ class Pipeline:
         self.graph = DiGraph()
         self.config_hash = None
         self.last_config_hash = None
-        self.last_run = None
 
     @property
     def root_node(self) -> Optional[str]:

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -147,7 +147,8 @@ def send_pipeline_event(  # type: ignore
                 return
 
             # If pipeline config has not changed, send an event every 100 runs
-            if pipeline.last_config_hash == pipeline.config_hash and pipeline.runs % 100 == 0:
+            SEND_EVENT_EVERY_N_RUNS = 100
+            if pipeline.last_config_hash == pipeline.config_hash and pipeline.runs % SEND_EVENT_EVERY_N_RUNS == 0:
                 event_properties = {"pipeline.config_hash": pipeline.config_hash, "pipeline.runs": pipeline.runs}
                 telemetry.send_event(event_name="Pipeline", event_properties=event_properties)
                 return

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -146,8 +146,10 @@ def send_pipeline_event(  # type: ignore
                 telemetry.send_event(event_name="Public Demo", event_properties=event_properties)
                 return
 
-            # Send this event only if the pipeline config has changed
+            # If pipeline config has not changed, send only config hash
             if pipeline.last_config_hash == pipeline.config_hash:
+                event_properties = {"pipeline.config_hash": pipeline.config_hash}
+                telemetry.send_event(event_name="Pipeline", event_properties=event_properties)
                 return
             pipeline.last_config_hash = pipeline.config_hash
 

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -146,16 +146,18 @@ def send_pipeline_event(  # type: ignore
                 telemetry.send_event(event_name="Public Demo", event_properties=event_properties)
                 return
 
-            # If pipeline config has not changed, send only config hash
-            if pipeline.last_config_hash == pipeline.config_hash:
-                event_properties = {"pipeline.config_hash": pipeline.config_hash}
+            # If pipeline config has not changed, send an event every 100 runs
+            if pipeline.last_config_hash == pipeline.config_hash and pipeline.runs % 100 == 0:
+                event_properties = {"pipeline.config_hash": pipeline.config_hash, "pipeline.runs": pipeline.runs}
                 telemetry.send_event(event_name="Pipeline", event_properties=event_properties)
                 return
             pipeline.last_config_hash = pipeline.config_hash
+            pipeline.runs = 1
 
             event_properties = {
                 "pipeline.classname": pipeline.__class__.__name__,
                 "pipeline.config_hash": pipeline.config_hash,
+                "pipeline.runs": pipeline.runs,
             }
 
             # Add document store

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 from typing import Any, Dict, Optional, List, Union
 import uuid
 import logging
@@ -160,6 +161,14 @@ def send_pipeline_event(  # type: ignore
             docstore = pipeline.get_document_store()
             if docstore:
                 event_properties["pipeline.document_store"] = docstore.__class__.__name__
+
+            # Track how much time has passed since the last run
+            now = datetime.datetime.now()
+            if pipeline.last_run:
+                event_properties["pipeline.since_last_run"] = (now - pipeline.last_run).total_seconds()
+            else:
+                event_properties["pipeline.since_last_run"] = 0
+            pipeline.last_run = now
 
             # Add an entry for each node class and classify the pipeline by its root node
             for node in pipeline.graph.nodes:

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -1,5 +1,4 @@
 import os
-import datetime
 from typing import Any, Dict, Optional, List, Union
 import uuid
 import logging
@@ -161,14 +160,6 @@ def send_pipeline_event(  # type: ignore
             docstore = pipeline.get_document_store()
             if docstore:
                 event_properties["pipeline.document_store"] = docstore.__class__.__name__
-
-            # Track how much time has passed since the last run
-            now = datetime.datetime.now()
-            if pipeline.last_run:
-                event_properties["pipeline.since_last_run"] = (now - pipeline.last_run).total_seconds()
-            else:
-                event_properties["pipeline.since_last_run"] = 0
-            pipeline.last_run = now
 
             # Add an entry for each node class and classify the pipeline by its root node
             for node in pipeline.graph.nodes:

--- a/haystack/telemetry.py
+++ b/haystack/telemetry.py
@@ -14,6 +14,7 @@ HAYSTACK_TELEMETRY_ENABLED = "HAYSTACK_TELEMETRY_ENABLED"
 HAYSTACK_EXECUTION_CONTEXT = "HAYSTACK_EXECUTION_CONTEXT"
 HAYSTACK_DOCKER_CONTAINER = "HAYSTACK_DOCKER_CONTAINER"
 CONFIG_PATH = Path("~/.haystack/config.yaml").expanduser()
+SEND_EVENT_EVERY_N_RUNS = 100
 
 
 logger = logging.getLogger(__name__)
@@ -146,8 +147,7 @@ def send_pipeline_event(  # type: ignore
                 telemetry.send_event(event_name="Public Demo", event_properties=event_properties)
                 return
 
-            # If pipeline config has not changed, send an event every 100 runs
-            SEND_EVENT_EVERY_N_RUNS = 100
+            # If pipeline config has not changed, send an event every SEND_EVENT_EVERY_N_RUNS runs
             if pipeline.last_config_hash == pipeline.config_hash and pipeline.runs % SEND_EVENT_EVERY_N_RUNS == 0:
                 event_properties = {"pipeline.config_hash": pipeline.config_hash, "pipeline.runs": pipeline.runs}
                 telemetry.send_event(event_name="Pipeline", event_properties=event_properties)


### PR DESCRIPTION
### Related Issues
- fixes #4871

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR send an event to our telemetry for every 100 pipeline runs. If a pipeline configuration has not changed, we only send the config hash instead of the whole configuration.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
