### PR TITLE
ci: add a job to vet license of direct dependencies only

### DIFF
--- a/.github/utils/pyproject_to_requirements.py
+++ b/.github/utils/pyproject_to_requirements.py
@@ -13,7 +13,7 @@ parser.add_argument("pyproject_path")
 parser.add_argument("--extra", default="")
 
 
-def resolve(target: str, extras: dict, results: set) -> set:
+def resolve(target: str, extras: dict, results: set):
     if target not in extras:
         results.add(target)
         return

--- a/.github/utils/pyproject_to_requirements.py
+++ b/.github/utils/pyproject_to_requirements.py
@@ -1,9 +1,9 @@
 import argparse
 import re
 import sys
-import toml
 from pathlib import Path
 
+import toml
 
 matcher = re.compile(r"farm-haystack\[(.+)\]")
 parser = argparse.ArgumentParser(
@@ -13,10 +13,10 @@ parser.add_argument("pyproject_path")
 parser.add_argument("--extra", default="")
 
 
-def resolve(target: str, extras: dict, results: set):
+def resolve(target: str, extras: dict, results: set) -> set:
     if target not in extras:
         results.add(target)
-        return results
+        return
 
     for t in extras[target]:
         m = matcher.match(t)

--- a/.github/utils/pyproject_to_requirements.py
+++ b/.github/utils/pyproject_to_requirements.py
@@ -1,0 +1,47 @@
+import argparse
+import re
+import sys
+import toml
+from pathlib import Path
+
+
+matcher = re.compile(r"farm-haystack\[(.+)\]")
+parser = argparse.ArgumentParser(
+    prog="pyproject_to_requirements.py", description="Convert pyproject.toml to requirements.txt"
+)
+parser.add_argument("pyproject_path")
+parser.add_argument("--extra", default="")
+
+
+def resolve(target: str, extras: dict, results: set):
+    if target not in extras:
+        results.add(target)
+        return results
+
+    for t in extras[target]:
+        m = matcher.match(t)
+        if m:
+            for i in m.group(1).split(","):
+                resolve(i, extras, results)
+        else:
+            resolve(t, extras, results)
+
+
+def main(pyproject_path: Path, extra: str = ""):
+    content = toml.load(pyproject_path)
+    # basic set of dependencies
+    deps = set(content["project"]["dependencies"])
+
+    if extra:
+        extras = content["project"]["optional-dependencies"]
+        resolve(extra, extras, deps)
+
+    sys.stdout.write("\n".join(sorted(deps)))
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    pyproject_path = Path(args.pyproject_path).absolute()
+
+    main(pyproject_path, args.extra)

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Get direct dependencies, all extras
       run: |
-        .github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
+        python .github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
 
     - name: Check Licenses
       id: license_check_report

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -43,8 +43,9 @@ jobs:
         #
         # - tqdm is MLP but there are no better alternatives
         # - PyMuPDF is optional
-        # - pinecone-client is
-        exclude: '(?i)^(PyMuPDF|tqdm|pinecone-client).*'
+        # - pinecone-client is optional
+        # - psycopg2 is optional
+        exclude: '(?i)^(PyMuPDF|tqdm|pinecone-client|psycopg2).*'
 
     # We keep the license inventory on FOSSA
     - name: Send license report to Fossa

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -42,7 +42,9 @@ jobs:
         # Exclusions in the vanilla distribution must be explicitly motivated
         #
         # - tqdm is MLP but there are no better alternatives
-        exclude: '(?i)^(tqdm).*'
+        # - PyMuPDF is optional
+        # - pinecone-client is
+        exclude: '(?i)^(PyMuPDF|tqdm|pinecone-client).*'
 
     # We keep the license inventory on FOSSA
     - name: Send license report to Fossa

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -29,6 +29,7 @@ jobs:
 
     - name: Get direct dependencies, all extras
       run: |
+        pip install toml
         python .github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
 
     - name: Check Licenses

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -8,9 +8,6 @@ on:
   # merge on `main`. Let's use a cron job instead.
   schedule:
     - cron: "0 0 * * *" # every day at midnight
-  push:
-    branches:
-      - "massi/project-converter"
 
 jobs:
   license_check_direct:

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -8,11 +8,108 @@ on:
   # merge on `main`. Let's use a cron job instead.
   schedule:
     - cron: "0 0 * * *" # every day at midnight
-
+  push:
+    branches:
+      - "massi/project-converter"
 
 jobs:
+  license_check_direct:
+    name: Direct dependencies only
+    env:
+      REQUIREMENTS_FILE: requirements_direct.txt
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v3
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Get direct dependencies, all extras
+      run: |
+        ./github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
+
+    - name: Check Licenses
+      id: license_check_report
+      uses: pilosus/action-pip-license-checker@v2
+      with:
+        github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+        requirements: ${{ env.REQUIREMENTS_FILE }}
+        fail: 'Copyleft,Other,Error'
+        # Exclusions in the vanilla distribution must be explicitly motivated
+        #
+        # - tqdm is MLP but there are no better alternatives
+        exclude: '(?i)^(tqdm).*'
+
+    # We keep the license inventory on FOSSA
+    - name: Send license report to Fossa
+      uses: fossas/fossa-action@v1.3.1
+      continue-on-error: true  # not critical
+      with:
+        api-key: ${{ secrets.FOSSA_LICENSE_SCAN_TOKEN }}
+
+    - name: Print report
+      if: ${{ always() }}
+      run: echo "${{ steps.license_check_report.outputs.report }}"
+
+    - uses: slackapi/slack-github-action@v1.23.0
+      if: failure() && github.ref == 'refs/heads/main'
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "https://avatars.githubusercontent.com/u/${{ github.actor_id }}?v=4",
+                    "alt_text": "Actor"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*<https://github.com/${{ github.actor }}|${{ github.actor }}>*"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Job ${{ github.job }} in workflow <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/workflow/|${{ github.workflow }}>"
+                }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "Triggered by ${{ github.event_name }} for ${{ github.ref_type }} `${{ github.ref_name }}`"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "image",
+                    "image_url": "https://github.githubassets.com/favicons/favicon.png",
+                    "alt_text": "Github logo"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/${{ github.repository }}/|${{ github.repository }}> Run <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/|#${{ github.run_number }} | Attempt #${{ github.run_attempt }}>"
+                  }
+                ]
+              }
+            ]
+          }
+
+
   license_check_vanilla:
-    name: Core dependencies
+    name: Core dependencies, no extras
     env:
       REQUIREMENTS_FILE: requirements_vanilla.txt
     runs-on: ubuntu-latest
@@ -105,7 +202,7 @@ jobs:
 
 
   license_check_all:
-    name: All dependencies
+    name: All extras
     env:
       REQUIREMENTS_FILE: requirements_all.txt
     runs-on: ubuntu-latest
@@ -197,7 +294,7 @@ jobs:
 
 
   license_check_all_GPU:
-    name: All dependencies - GPU
+    name: All extras, GPU version
     env:
       REQUIREMENTS_FILE: requirements_all_gpu.txt
     runs-on: ubuntu-latest
@@ -229,13 +326,6 @@ jobs:
         # - pyzmq is flagged because dual-licensed, but we assume using BSD
         # - tqdm is MLP but there are no better alternatives
         exclude: '(?i)^(astroid|certifi|chardet|num2words|nvidia-|pathspec|pinecone-client|psycopg2|pylint|PyMuPDF|pyzmq|tqdm).*'
-
-    # We keep the license inventory on FOSSA
-    - name: Send license report to Fossa
-      uses: fossas/fossa-action@v1.3.1
-      continue-on-error: true  # not critical
-      with:
-        api-key: ${{ secrets.FOSSA_LICENSE_SCAN_TOKEN }}
 
     - name: Print report
       if: ${{ always() }}

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Get direct dependencies, all extras
       run: |
-        ./github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
+        .github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
 
     - name: Check Licenses
       id: license_check_report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,7 @@ dev = [
   "mkdocs",
   "jupytercontrib",
   "watchdog",
+  "toml",
 ]
 
 formatting = [


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add a job that checks only dependencies explicitly listed in `pyproject.toml` (so called "direct dependencies")

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
I added a script that extracts the list of dependencies included the optional ones from `pyproject.toml`

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
