### PR TITLE
ci: Run linting only on haystack and rest_api files

### DIFF
--- a/.github/workflows/linting-skipper.yml
+++ b/.github/workflows/linting-skipper.yml
@@ -4,7 +4,8 @@ name: Linting
 on:
   pull_request:
     paths-ignore:
-      - "**.py"
+      - "haystack/**/*.py"
+      - "rest_api/**/*.py"
       - "**/pyproject.toml"
 
 jobs:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,7 +4,8 @@ name: Linting
 on:
   pull_request:
     paths:
-      - "**.py"
+      - "haystack/**/*.py"
+      - "rest_api/**/*.py"
       - "**/pyproject.toml"
 
 env:


### PR DESCRIPTION
### Proposed Changes:

`pylint` and `mypy` are currently running whenever a `.py` file is edited, this includes utilities files that run in CI only like those in `.github/` folder. 

This PR changes this behaviour so that `pylint` and `mypy` are run only when `.py` files in `haystack/` or `rest_api/` are modified.

### How did you test it?

Can't be tested.

### Notes for the reviewer

Should solve `pylint` failure in #4885.