### PR TITLE
chore: Add Datadog in Who Uses Haystack README.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Here's a list of organizations that we know about from our community. Don't hesi
 -   [Apple](https://www.apple.com/)
 -   [BetterUp](https://www.betterup.com/)
 -   [Databricks](https://www.databricks.com/)
+-   [Datadog](https://www.datadoghq.com/)
 -   [Deepset](https://deepset.ai/)
 -   [Etalab](https://www.etalab.gouv.fr/)
 -   [Infineon](https://www.infineon.com/)


### PR DESCRIPTION
As discussed internally this PR adds Datadog to list of organizations that we know are using Haystack.