### PR TITLE
fix: Use `AutoTokenizer` instead of DPR specific tokenizer

### DIFF
--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -867,12 +867,8 @@ class TableTextRetriever(DenseRetriever):
         self.embed_meta_fields = embed_meta_fields
         self.scale_score = scale_score
 
-        query_tokenizer_class = DPRQuestionEncoderTokenizerFast if use_fast else DPRQuestionEncoderTokenizer
-        passage_tokenizer_class = DPRContextEncoderTokenizerFast if use_fast else DPRContextEncoderTokenizer
-        table_tokenizer_class = DPRContextEncoderTokenizerFast if use_fast else DPRContextEncoderTokenizer
-
         # Init & Load Encoders
-        self.query_tokenizer = query_tokenizer_class.from_pretrained(
+        self.query_tokenizer = AutoTokenizer.from_pretrained(
             query_embedding_model,
             revision=model_version,
             do_lower_case=True,
@@ -882,7 +878,7 @@ class TableTextRetriever(DenseRetriever):
         self.query_encoder = get_language_model(
             pretrained_model_name_or_path=query_embedding_model, revision=model_version, use_auth_token=use_auth_token
         )
-        self.passage_tokenizer = passage_tokenizer_class.from_pretrained(
+        self.passage_tokenizer = AutoTokenizer.from_pretrained(
             passage_embedding_model,
             revision=model_version,
             do_lower_case=True,
@@ -892,7 +888,7 @@ class TableTextRetriever(DenseRetriever):
         self.passage_encoder = get_language_model(
             pretrained_model_name_or_path=passage_embedding_model, revision=model_version, use_auth_token=use_auth_token
         )
-        self.table_tokenizer = table_tokenizer_class.from_pretrained(
+        self.table_tokenizer = AutoTokenizer.from_pretrained(
             table_embedding_model,
             revision=model_version,
             do_lower_case=True,

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -19,13 +19,7 @@ from torch.nn import DataParallel
 from torch.utils.data.sampler import SequentialSampler
 import pandas as pd
 from huggingface_hub import hf_hub_download
-from transformers import (
-    AutoConfig,
-    DPRContextEncoderTokenizerFast,
-    DPRQuestionEncoderTokenizerFast,
-    DPRContextEncoderTokenizer,
-    DPRQuestionEncoderTokenizer,
-)
+from transformers import AutoConfig, AutoTokenizer
 
 from haystack.errors import HaystackError
 from haystack.schema import Document, FilterType
@@ -191,7 +185,7 @@ class DensePassageRetriever(DenseRetriever):
             )
 
         # Init & Load Encoders
-        self.query_tokenizer = DPRQuestionEncoderTokenizerFast.from_pretrained(
+        self.query_tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path=query_embedding_model,
             revision=model_version,
             do_lower_case=True,
@@ -203,7 +197,7 @@ class DensePassageRetriever(DenseRetriever):
             model_type="DPRQuestionEncoder",
             use_auth_token=use_auth_token,
         )
-        self.passage_tokenizer = DPRContextEncoderTokenizerFast.from_pretrained(
+        self.passage_tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path=passage_embedding_model,
             revision=model_version,
             do_lower_case=True,

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 from boilerpy3.extractors import ArticleExtractor
 from pandas.testing import assert_frame_equal
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizerFast
 
 
 try:
@@ -578,8 +578,8 @@ def test_dpr_saving_and_loading(tmp_path, retriever, document_store):
     assert loaded_retriever.processor.max_seq_len_query == 64
 
     # Tokenizer
-    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizer)
-    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizer)
+    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizerFast)
+    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizerFast)
     assert loaded_retriever.passage_tokenizer.do_lower_case == True
     assert loaded_retriever.query_tokenizer.do_lower_case == True
     assert loaded_retriever.passage_tokenizer.vocab_size == 30522
@@ -621,9 +621,9 @@ def test_table_text_retriever_saving_and_loading(tmp_path, retriever, document_s
     assert loaded_retriever.processor.max_seq_len_query == 64
 
     # Tokenizer
-    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizer)
-    assert isinstance(loaded_retriever.table_tokenizer, PreTrainedTokenizer)
-    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizer)
+    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizerFast)
+    assert isinstance(loaded_retriever.table_tokenizer, PreTrainedTokenizerFast)
+    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizerFast)
     assert loaded_retriever.passage_tokenizer.do_lower_case == True
     assert loaded_retriever.table_tokenizer.do_lower_case == True
     assert loaded_retriever.query_tokenizer.do_lower_case == True

--- a/test/nodes/test_retriever.py
+++ b/test/nodes/test_retriever.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 from boilerpy3.extractors import ArticleExtractor
 from pandas.testing import assert_frame_equal
-from transformers import DPRContextEncoderTokenizerFast, DPRQuestionEncoderTokenizerFast
+from transformers import PreTrainedTokenizer
 
 
 try:
@@ -578,8 +578,8 @@ def test_dpr_saving_and_loading(tmp_path, retriever, document_store):
     assert loaded_retriever.processor.max_seq_len_query == 64
 
     # Tokenizer
-    assert isinstance(loaded_retriever.passage_tokenizer, DPRContextEncoderTokenizerFast)
-    assert isinstance(loaded_retriever.query_tokenizer, DPRQuestionEncoderTokenizerFast)
+    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizer)
+    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizer)
     assert loaded_retriever.passage_tokenizer.do_lower_case == True
     assert loaded_retriever.query_tokenizer.do_lower_case == True
     assert loaded_retriever.passage_tokenizer.vocab_size == 30522
@@ -621,9 +621,9 @@ def test_table_text_retriever_saving_and_loading(tmp_path, retriever, document_s
     assert loaded_retriever.processor.max_seq_len_query == 64
 
     # Tokenizer
-    assert isinstance(loaded_retriever.passage_tokenizer, DPRContextEncoderTokenizerFast)
-    assert isinstance(loaded_retriever.table_tokenizer, DPRContextEncoderTokenizerFast)
-    assert isinstance(loaded_retriever.query_tokenizer, DPRQuestionEncoderTokenizerFast)
+    assert isinstance(loaded_retriever.passage_tokenizer, PreTrainedTokenizer)
+    assert isinstance(loaded_retriever.table_tokenizer, PreTrainedTokenizer)
+    assert isinstance(loaded_retriever.query_tokenizer, PreTrainedTokenizer)
     assert loaded_retriever.passage_tokenizer.do_lower_case == True
     assert loaded_retriever.table_tokenizer.do_lower_case == True
     assert loaded_retriever.query_tokenizer.do_lower_case == True


### PR DESCRIPTION
### Related Issues
- fixes #4897 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR changes the tokenizer in `DensePassageRetriever` from `DPRQuestionEncoderTokenizerFast`/`DPRContextEncoderTokenizerFast` to `AutoTokenizer`.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I manually loaded `etalab-ia/dpr-question_encoder-fr_qa-camembert` and `etalab-ia/dpr-ctx_encoder-fr_qa-camembert` which was previously failing.

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
