### PR TITLE
fix: `EvaluationResult` serialization changes dataframes

### DIFF
--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -932,7 +932,7 @@ class EvaluationResult:
     def append(self, key: str, value: DataFrame):
         if value is not None and len(value) > 0:
             if key in self.node_results:
-                self.node_results[key] = pd.concat([self.node_results[key], value]).reset_index()
+                self.node_results[key] = pd.concat([self.node_results[key], value]).reset_index(drop=True)
             else:
                 self.node_results[key] = value
 

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -932,7 +932,7 @@ class EvaluationResult:
     def append(self, key: str, value: DataFrame):
         if value is not None and len(value) > 0:
             if key in self.node_results:
-                self.node_results[key] = pd.concat([self.node_results[key], value])
+                self.node_results[key] = pd.concat([self.node_results[key], value]).reset_index()
             else:
                 self.node_results[key] = value
 
@@ -1620,6 +1620,7 @@ class EvaluationResult:
         node_results = {file.stem: pd.read_csv(file, **read_csv_kwargs) for file in csv_files}
         # backward compatibility mappings
         for df in node_results.values():
+            df.replace(to_replace=np.nan, value=None, inplace=True)
             df.rename(columns={"gold_document_contents": "gold_contexts", "content": "context"}, inplace=True)
             # convert single document_id to list
             if "answer" in df.columns and "document_id" in df.columns and not "document_ids" in df.columns:

--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -1,6 +1,6 @@
 import json
 
-from haystack.schema import Document, Label, Answer, Span, MultiLabel, TableCell, _dict_factory
+from haystack.schema import Document, EvaluationResult, Label, Answer, Span, MultiLabel, TableCell, _dict_factory
 import pytest
 import numpy as np
 import pandas as pd
@@ -1062,3 +1062,19 @@ def test_dict_factory():
     assert result["key1"] == "some_value"
     assert result["key2"] == ["val1", "val2"]
     assert result["key3"] == [["col1", "col2"], [1, 3], [2, 4]]
+
+
+@pytest.mark.unit
+def test_evaluation_result_append():
+    df1 = pd.DataFrame({"col1": [1, 2], "index": [3, 4]})
+    df2 = pd.DataFrame({"col1": [5, 6], "index": [7, 8]})
+    df_expected = pd.DataFrame({"col1": [1, 2, 5, 6], "index": [3, 4, 7, 8]})
+
+    eval_result = EvaluationResult()
+    eval_result.append("test", df1)
+    pd.testing.assert_frame_equal(eval_result["test"], df1)
+    assert isinstance(eval_result["test"].index, pd.RangeIndex)
+
+    eval_result.append("test", df2)
+    pd.testing.assert_frame_equal(eval_result["test"], df_expected)
+    assert isinstance(eval_result["test"].index, pd.RangeIndex)

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -2100,7 +2100,7 @@ def test_load_legacy_evaluation_result(tmp_path):
     assert "content" not in eval_result["legacy"]
 
 
-def test_load_evaluation_result_w_empty_document_ids(tmp_path):
+def test_load_evaluation_result_w_none_values(tmp_path):
     eval_result_csv = Path(tmp_path) / "Reader.csv"
     with open(eval_result_csv, "w") as eval_result_csv:
         columns = [
@@ -2174,3 +2174,6 @@ def test_load_evaluation_result_w_empty_document_ids(tmp_path):
     eval_result = EvaluationResult.load(tmp_path)
     assert "Reader" in eval_result
     assert len(eval_result) == 1
+    assert eval_result["Reader"].iloc[0].answer is None
+    assert eval_result["Reader"].iloc[0].context is None
+    assert eval_result["Reader"].iloc[0].document_ids is None

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -598,6 +598,10 @@ def test_extractive_qa_eval(reader, retriever_with_docs, tmp_path):
 
     eval_result.save(tmp_path)
     saved_eval_result = EvaluationResult.load(tmp_path)
+
+    for key, df in eval_result.node_results.items():
+        pd.testing.assert_frame_equal(df, saved_eval_result[key])
+
     metrics = saved_eval_result.calculate_metrics(document_scope="document_id")
 
     assert (
@@ -718,6 +722,10 @@ def test_generative_qa_eval(retriever_with_docs, tmp_path):
 
     eval_result.save(tmp_path)
     saved_eval_result = EvaluationResult.load(tmp_path)
+
+    for key, df in eval_result.node_results.items():
+        pd.testing.assert_frame_equal(df, saved_eval_result[key])
+
     loaded_metrics = saved_eval_result.calculate_metrics(document_scope="document_id")
     assert metrics == loaded_metrics
 
@@ -815,6 +823,10 @@ def test_generative_qa_w_promptnode_eval(retriever_with_docs, tmp_path):
 
     eval_result.save(tmp_path)
     saved_eval_result = EvaluationResult.load(tmp_path)
+
+    for key, df in eval_result.node_results.items():
+        pd.testing.assert_frame_equal(df, saved_eval_result[key])
+
     loaded_metrics = saved_eval_result.calculate_metrics(document_scope="document_id")
     assert metrics == loaded_metrics
 
@@ -864,6 +876,10 @@ def test_extractive_qa_eval_multiple_queries(reader, retriever_with_docs, tmp_pa
 
     eval_result.save(tmp_path)
     saved_eval_result = EvaluationResult.load(tmp_path)
+
+    for key, df in eval_result.node_results.items():
+        pd.testing.assert_frame_equal(df, saved_eval_result[key])
+
     metrics = saved_eval_result.calculate_metrics(document_scope="document_id")
 
     assert (


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/4905

### Proposed Changes:
- ensure None values stay the same
- ensure index is set correctly

### How did you test it?
- extended existing tests

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
