### PR TITLE
fix: shaper exception when retriever return 0 docs.

### DIFF
--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -740,7 +740,7 @@ class Shaper(BaseComponent):
         if labels and "labels" not in invocation_context.keys():
             invocation_context["labels"] = labels
 
-        if documents and "documents" not in invocation_context.keys():
+        if documents != None and "documents" not in invocation_context.keys():
             invocation_context["documents"] = documents
 
         if meta and "meta" not in invocation_context.keys():


### PR DESCRIPTION
* When retriever retrieves 0 documents from the documentStore, shaper will raise an exception.

### Related Issues
- fixes #4928 

### Proposed Changes:
don't filter the empty list [], when assign the documents to invocation_context["documents"] 

### How did you test it?
mypy, pylint, black

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
