### PR TITLE
feat: Add conversational agent

### DIFF
--- a/examples/agent_multihop_qa.py
+++ b/examples/agent_multihop_qa.py
@@ -82,6 +82,7 @@ Final Answer: Gainsville, Florida
 ##
 Question: {query}
 Thought:
+{transcript}
 """
 few_shot_agent_template = PromptTemplate("few-shot-react", prompt_text=few_shot_prompt)
 prompt_node = PromptNode(

--- a/examples/conversational_agent.py
+++ b/examples/conversational_agent.py
@@ -7,7 +7,7 @@ pn = PromptNode("gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"), max_l
 agent = ConversationalAgent(pn)
 
 while True:
-    user_input = input("Human (type 'exit' or 'quit' to quit): ")
+    user_input = input("Human (type 'exit' or 'quit' to quit, 'memory' for agent's memory): ")
     if user_input.lower() == "exit" or user_input.lower() == "quit":
         break
     if user_input.lower() == "memory":

--- a/examples/conversational_agent.py
+++ b/examples/conversational_agent.py
@@ -1,0 +1,17 @@
+import os
+
+from haystack.agents.conversational import ConversationalAgent
+from haystack.nodes import PromptNode
+
+pn = PromptNode("gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"), max_length=256)
+agent = ConversationalAgent(pn)
+
+while True:
+    user_input = input("Human (type 'exit' or 'quit' to quit): ")
+    if user_input.lower() == "exit" or user_input.lower() == "quit":
+        break
+    if user_input.lower() == "memory":
+        print("\nMemory:\n", agent.memory.load())
+    else:
+        assistant_response = agent.run(user_input)
+        print("\nAssistant:", assistant_response)

--- a/haystack/agents/agent_step.py
+++ b/haystack/agents/agent_step.py
@@ -20,49 +20,38 @@ class AgentStep:
         self,
         current_step: int = 1,
         max_steps: int = 10,
-        final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
+        final_answer_pattern: Optional[str] = None,
         prompt_node_response: str = "",
         transcript: str = "",
     ):
         """
         :param current_step: The current step in the execution of the agent.
         :param max_steps: The maximum number of steps the agent can execute.
-        :param final_answer_pattern: The regex pattern to extract the final answer from the PromptNode response.
+        :param final_answer_pattern: The regex pattern to extract the final answer from the PromptNode response. If no
+        pattern is provided, entire prompt node response is considered the final answer.
         :param prompt_node_response: The PromptNode response received.
-        :param transcript: The full Agent execution transcript based on the Agent's initial prompt template and the
         text it generated during execution up to this step. The transcript is used to generate the next prompt.
         """
         self.current_step = current_step
         self.max_steps = max_steps
-        self.final_answer_pattern = final_answer_pattern
+        self.final_answer_pattern = final_answer_pattern or r"^([\s\S]+)$"
         self.prompt_node_response = prompt_node_response
         self.transcript = transcript
 
-    def prepare_prompt(self):
-        """
-        Prepares the prompt for the next step.
-        """
-        return self.transcript
-
-    def create_next_step(self, prompt_node_response: Any) -> AgentStep:
+    def create_next_step(self, prompt_node_response: Any, current_step: Optional[int] = None) -> AgentStep:
         """
         Creates the next agent step based on the current step and the PromptNode response.
         :param prompt_node_response: The PromptNode response received.
+        :param current_step: The current step in the execution of the agent.
         """
-        if not isinstance(prompt_node_response, list):
+        if not isinstance(prompt_node_response, list) or not prompt_node_response:
             raise AgentError(
-                f"Agent output must be a list of str, but {prompt_node_response} received. "
+                f"Agent output must be a non-empty list of str, but {prompt_node_response} received. "
                 f"Transcript:\n{self.transcript}"
             )
-
-        if not prompt_node_response:
-            raise AgentError(
-                f"Agent output must be a non empty list of str, but {prompt_node_response} received. "
-                f"Transcript:\n{self.transcript}"
-            )
-
-        return AgentStep(
-            current_step=self.current_step + 1,
+        cls = type(self)
+        return cls(
+            current_step=current_step if current_step else self.current_step + 1,
             max_steps=self.max_steps,
             final_answer_pattern=self.final_answer_pattern,
             prompt_node_response=prompt_node_response[0],
@@ -81,7 +70,7 @@ class AgentStep:
             "answers": [Answer(answer="", type="generative")],
             "transcript": self.transcript,
         }
-        if self.current_step >= self.max_steps:
+        if self.current_step > self.max_steps:
             logger.warning(
                 "Maximum number of iterations (%s) reached for query (%s). Increase max_steps "
                 "or no answer can be provided for this query.",
@@ -89,10 +78,10 @@ class AgentStep:
                 query,
             )
         else:
-            final_answer = self.extract_final_answer()
+            final_answer = self.parse_final_answer()
             if not final_answer:
                 logger.warning(
-                    "Final answer pattern (%s) not found in PromptNode response (%s).",
+                    "Final answer parser (%s) could not parse PromptNode response (%s).",
                     self.final_answer_pattern,
                     self.prompt_node_response,
                 )
@@ -104,35 +93,14 @@ class AgentStep:
                 }
         return answer
 
-    def extract_final_answer(self) -> Optional[str]:
-        """
-        Parse the final answer from the PromptNode response.
-        :return: The final answer.
-        """
-        if not self.is_last():
-            raise AgentError("Cannot extract final answer from non terminal step.")
-
-        final_answer_match = re.search(self.final_answer_pattern, self.prompt_node_response)
-        if final_answer_match:
-            final_answer = final_answer_match.group(1)
-            return final_answer.strip('" ')
-        return None
-
-    def is_final_answer_pattern_found(self) -> bool:
-        """
-        Check if the final answer pattern was found in PromptNode response.
-        :return: True if the final answer pattern was found in PromptNode response, False otherwise.
-        """
-        return bool(re.search(self.final_answer_pattern, self.prompt_node_response))
-
     def is_last(self) -> bool:
         """
         Check if this is the last step of the Agent.
         :return: True if this is the last step of the Agent, False otherwise.
         """
-        return self.is_final_answer_pattern_found() or self.current_step >= self.max_steps
+        return bool(self.parse_final_answer()) or self.current_step > self.max_steps
 
-    def completed(self, observation: Optional[str]):
+    def completed(self, observation: Optional[str]) -> None:
         """
         Update the transcript with the observation
         :param observation: received observation from the Agent environment.
@@ -142,3 +110,39 @@ class AgentStep:
             if observation
             else self.prompt_node_response
         )
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the AgentStep object.
+
+        :return: A string that represents the AgentStep object.
+        """
+        return (
+            f"AgentStep(current_step={self.current_step}, max_steps={self.max_steps}, "
+            f"prompt_node_response={self.prompt_node_response}, final_answer_pattern={self.final_answer_pattern}, "
+            f"transcript={self.transcript})"
+        )
+
+    def parse_final_answer(self) -> Optional[str]:
+        """
+        Parse the final answer from the response of the prompt node.
+
+        This function searches the prompt node's response for a match with the
+        pre-defined final answer pattern. If a match is found, it's returned as the
+        final answer after removing leading/trailing quotes and whitespaces.
+        If no match is found, it returns None.
+
+        :return: The final answer as a string if a match is found, otherwise None.
+        """
+        # Search for a match with the final answer pattern in the prompt node response
+        final_answer_match = re.search(self.final_answer_pattern, self.prompt_node_response)
+
+        if final_answer_match:
+            # If a match is found, get the first group (i.e., the content inside the parentheses of the regex pattern)
+            final_answer = final_answer_match.group(1)
+
+            # Remove leading/trailing quotes and whitespaces, then return the final answer
+            return final_answer.strip('" ')  # type: ignore
+        else:
+            # If no match is found, return None
+            return None

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable, Callable
 from hashlib import md5
 from typing import List, Optional, Union, Dict, Any, Tuple
 
 from events import Events
 
 from haystack import Pipeline, BaseComponent, Answer, Document
+from haystack.agents.memory import Memory, NoMemory
 from haystack.telemetry import send_event
 from haystack.agents.agent_step import AgentStep
-from haystack.agents.types import Color, AgentTokenStreamingHandler
+from haystack.agents.types import Color, AgentTokenStreamingHandler, PromptParametersResolver
 from haystack.agents.utils import print_text, STREAMING_CAPABLE_MODELS
-from haystack.errors import AgentError
 from haystack.nodes import PromptNode, BaseRetriever, PromptTemplate
 from haystack.pipelines import (
     BaseStandardPipeline,
@@ -202,6 +203,14 @@ class ToolsManager:
         return None, None
 
 
+class CallablePromptParametersResolver(PromptParametersResolver):
+    def __init__(self, prompt_callable: Callable[..., Dict[str, Any]]):
+        self.callable = prompt_callable
+
+    def resolve(self, query: str, **kwargs) -> Dict[str, Any]:
+        return self.callable(query, **kwargs)
+
+
 class Agent:
     """
     An Agent answers queries using the tools you give to it. The tools are pipelines or nodes. The Agent uses a large
@@ -221,8 +230,10 @@ class Agent:
     def __init__(
         self,
         prompt_node: PromptNode,
-        prompt_template: Union[str, PromptTemplate] = "zero-shot-react",
+        prompt_template: Optional[Union[str, PromptTemplate]] = None,
         tools_manager: Optional[ToolsManager] = None,
+        memory: Optional[Memory] = None,
+        prompt_parameters_resolver: Optional[Union[PromptParametersResolver, Callable]] = None,
         max_steps: int = 8,
         final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
     ):
@@ -245,14 +256,31 @@ class Agent:
         """
         self.max_steps = max_steps
         self.tm = tools_manager or ToolsManager()
+        self.memory = memory or NoMemory()
         self.callback_manager = Events(("on_agent_start", "on_agent_step", "on_agent_finish", "on_new_token"))
         self.prompt_node = prompt_node
+        prompt_template = prompt_template or "zero-shot-react"
         resolved_prompt_template = prompt_node.get_prompt_template(prompt_template)
         if not resolved_prompt_template:
             raise ValueError(
                 f"Prompt template '{prompt_template}' not found. Please check the spelling of the template name."
             )
         self.prompt_template = resolved_prompt_template
+        react_parameter_resolver: Callable[[str, Any], Dict[str, Any]] = lambda query, **kwargs: {
+            "query": query,
+            "tool_names": kwargs["agent"].tm.get_tool_names(),
+            "tool_names_with_descriptions": kwargs["agent"].tm.get_tool_names_with_descriptions(),
+            "transcript": kwargs["agent_step"].transcript,
+        }
+        self.prompt_parameters_resolver = (
+            CallablePromptParametersResolver(prompt_parameters_resolver)
+            if callable(prompt_parameters_resolver)
+            else (
+                prompt_parameters_resolver
+                if prompt_parameters_resolver
+                else CallablePromptParametersResolver(react_parameter_resolver)
+            )
+        )
         self.final_answer_pattern = final_answer_pattern
         # Resolve model name to check if it's a streaming model
         if isinstance(self.prompt_node.model_name_or_path, str):
@@ -350,37 +378,18 @@ class Agent:
         except Exception as exc:
             logger.debug("Telemetry exception: %s", exc)
 
-        if max_steps is None:
-            max_steps = self.max_steps
-        if max_steps < 2:
-            raise AgentError(
-                f"max_steps must be at least 2 to let the Agent use a tool once and then infer it knows the final "
-                f"answer. It was set to {max_steps}."
-            )
         self.callback_manager.on_agent_start(name=self.prompt_template.name, query=query, params=params)
-        agent_step = self._create_first_step(query, max_steps)
+        agent_step = self.create_agent_step(max_steps)
         try:
             while not agent_step.is_last():
-                agent_step = self._step(agent_step, params)
+                agent_step = self._step(query, agent_step, params)
         finally:
             self.callback_manager.on_agent_finish(agent_step)
         return agent_step.final_answer(query=query)
 
-    def _create_first_step(self, query: str, max_steps: int = 10):
-        transcript = self._get_initial_transcript(query=query)
-        return AgentStep(
-            current_step=1,
-            max_steps=max_steps,
-            final_answer_pattern=self.final_answer_pattern,
-            prompt_node_response="",  # no LLM response for the first step
-            transcript=transcript,
-        )
-
-    def _step(self, current_step: AgentStep, params: Optional[dict] = None):
+    def _step(self, query: str, current_step: AgentStep, params: Optional[dict] = None):
         # plan next step using the LLM
-        prompt_node_response = self.prompt_node(
-            current_step.prepare_prompt(), stream_handler=AgentTokenStreamingHandler(self.callback_manager)
-        )
+        prompt_node_response = self._plan(query, current_step)
 
         # from the LLM response, create the next step
         next_step = current_step.create_next_step(prompt_node_response)
@@ -389,21 +398,41 @@ class Agent:
         # run the tool selected by the LLM
         observation = self.tm.run_tool(next_step.prompt_node_response, params) if not next_step.is_last() else None
 
+        # save the input, output and observation to memory (if memory is enabled)
+        memory_data = self.prepare_data_for_memory(input=query, output=prompt_node_response, observation=observation)
+        self.memory.save(data=memory_data)
+
         # update the next step with the observation
         next_step.completed(observation)
         return next_step
 
-    def _get_initial_transcript(self, query: str):
-        """
-        Fills the Agent's PromptTemplate with the query, tool names, and descriptions.
+    def _plan(self, query, current_step):
+        # first resolve prompt template params
+        template_params = self.prompt_parameters_resolver.resolve(query=query, agent=self, agent_step=current_step)
 
-        :param query: The search query.
+        # if prompt node has no default prompt template, use agent's prompt template
+        if self.prompt_node.default_prompt_template is None:
+            prepared_prompt = next(self.prompt_template.fill(**template_params))
+            prompt_node_response = self.prompt_node(
+                prepared_prompt, stream_handler=AgentTokenStreamingHandler(self.callback_manager)
+            )
+        # otherwise, if prompt node has default prompt template, use it
+        else:
+            prompt_node_response = self.prompt_node(
+                stream_handler=AgentTokenStreamingHandler(self.callback_manager), **template_params
+            )
+        return prompt_node_response
+
+    def create_agent_step(self, max_steps: Optional[int] = None) -> AgentStep:
         """
-        return next(
-            self.prompt_template.fill(
-                query=query,
-                tool_names=self.tm.get_tool_names(),
-                tool_names_with_descriptions=self.tm.get_tool_names_with_descriptions(),
-            ),
-            "",
-        )
+        Create an AgentStep object. Override this method to customize the AgentStep class used by the Agent.
+        """
+        return AgentStep(max_steps=max_steps or self.max_steps, final_answer_pattern=self.final_answer_pattern)
+
+    def prepare_data_for_memory(self, **kwargs) -> dict:
+        """
+        Prepare data for saving to the Agent's memory. Override this method to customize the data saved to the memory.
+        """
+        return {
+            k: v if isinstance(v, str) else next(iter(v)) for k, v in kwargs.items() if isinstance(v, (str, Iterable))
+        }

--- a/haystack/agents/conversational.py
+++ b/haystack/agents/conversational.py
@@ -1,8 +1,7 @@
-from typing import Union, Optional, Callable
+from typing import Optional, Callable
 
 from haystack.agents import Agent
 from haystack.agents.memory import Memory, ConversationMemory
-from haystack.agents.types import PromptParametersResolver
 from haystack.nodes import PromptNode
 
 
@@ -38,7 +37,7 @@ class ConversationalAgent(Agent):
         self,
         prompt_node: PromptNode,
         memory: Optional[Memory] = None,
-        prompt_parameters_resolver: Optional[Union[PromptParametersResolver, Callable]] = None,
+        prompt_parameters_resolver: Optional[Callable] = None,
     ):
         """
         Creates a new ConversationalAgent instance
@@ -46,8 +45,8 @@ class ConversationalAgent(Agent):
         :param prompt_node: A PromptNode used to communicate with LLM.
         :param memory: A memory instance for storing conversation history and other relevant data, defaults to
         ConversationMemory.
-        :param prompt_parameters_resolver: An optional resolver or callable for resolving prompt template parameters,
-        defaults to CallablePromptParametersResolver that simply returns the query and the conversation history.
+        :param prompt_parameters_resolver: An optional callable for resolving prompt template parameters,
+        defaults to a callable that returns a dictionary with the query and the conversation history.
         """
         super().__init__(
             prompt_node=prompt_node,

--- a/haystack/agents/conversational.py
+++ b/haystack/agents/conversational.py
@@ -1,0 +1,63 @@
+from typing import Union, Optional, Callable
+
+from haystack.agents import Agent
+from haystack.agents.memory import Memory, ConversationMemory
+from haystack.agents.types import PromptParametersResolver
+from haystack.nodes import PromptNode
+
+
+class ConversationalAgent(Agent):
+    """
+    A conversational agent that can be used to build a conversational chat applications.
+
+    Here is an example of how you can create a simple chat application:
+    ```
+    import os
+
+    from haystack.agents.base import ConversationalAgent
+    from haystack.agents.memory import ConversationSummaryMemory
+    from haystack.nodes import PromptNode
+
+    pn = PromptNode("gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"), max_length=256)
+    agent = ConversationalAgent(pn, memory=ConversationSummaryMemory(pn))
+
+    while True:
+        user_input = input("Human (type 'exit' or 'quit' to quit): ")
+        if user_input.lower() == "exit" or user_input.lower() == "quit":
+            break
+        elif user_input.lower() == "memory":
+            print("\nMemory:\n", agent.memory.load())
+        else:
+            assistant_response = agent.run(user_input)
+            print("\nAssistant:", assistant_response)
+
+    ```
+    """
+
+    def __init__(
+        self,
+        prompt_node: PromptNode,
+        memory: Optional[Memory] = None,
+        prompt_parameters_resolver: Optional[Union[PromptParametersResolver, Callable]] = None,
+    ):
+        """
+        Creates a new ConversationalAgent instance
+
+        :param prompt_node: A PromptNode used to communicate with LLM.
+        :param memory: A memory instance for storing conversation history and other relevant data, defaults to
+        ConversationMemory.
+        :param prompt_parameters_resolver: An optional resolver or callable for resolving prompt template parameters,
+        defaults to CallablePromptParametersResolver that simply returns the query and the conversation history.
+        """
+        super().__init__(
+            prompt_node=prompt_node,
+            prompt_template=prompt_node.default_prompt_template
+            if prompt_node.default_prompt_template is not None
+            else "conversational-agent",
+            max_steps=2,
+            memory=memory if memory else ConversationMemory(),
+            prompt_parameters_resolver=prompt_parameters_resolver
+            if prompt_parameters_resolver
+            else lambda query, agent, **kwargs: {"query": query, "history": agent.memory.load()},
+            final_answer_pattern=r"^([\s\S]+)$",
+        )

--- a/haystack/agents/types.py
+++ b/haystack/agents/types.py
@@ -1,4 +1,6 @@
+from abc import ABC, abstractmethod
 from enum import Enum
+from typing import Dict, Any
 
 from events import Events
 from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler
@@ -23,3 +25,23 @@ class AgentTokenStreamingHandler(TokenStreamingHandler):
     def __call__(self, token_received, **kwargs) -> str:
         self.events.on_new_token(token_received, **kwargs)
         return token_received
+
+
+class PromptParametersResolver(ABC):
+    """
+    Abstract base class for resolving parameters of Agent's PromptTemplate. During Agent's step planning stage, Agent
+    invokes implementations of this class to resolve parameters of its PromptTemplate. In addition to query parameter,
+    the resolver is given access to Agent runtime via **kwargs.
+
+    See various implementations for more details and examples.
+    """
+
+    @abstractmethod
+    def resolve(self, query: str, **kwargs) -> Dict[str, Any]:
+        """
+        Resolve parameters of PromptTemplate.
+        :param query: The query to resolve parameters for.
+        :param kwargs: Additional parameters to resolve parameters for.
+        :return: A dictionary containing resolved parameters.
+        """
+        raise NotImplementedError

--- a/haystack/agents/types.py
+++ b/haystack/agents/types.py
@@ -1,6 +1,4 @@
-from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Dict, Any
 
 from events import Events
 from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler
@@ -25,23 +23,3 @@ class AgentTokenStreamingHandler(TokenStreamingHandler):
     def __call__(self, token_received, **kwargs) -> str:
         self.events.on_new_token(token_received, **kwargs)
         return token_received
-
-
-class PromptParametersResolver(ABC):
-    """
-    Abstract base class for resolving parameters of Agent's PromptTemplate. During Agent's step planning stage, Agent
-    invokes implementations of this class to resolve parameters of its PromptTemplate. In addition to query parameter,
-    the resolver is given access to Agent runtime via **kwargs.
-
-    See various implementations for more details and examples.
-    """
-
-    @abstractmethod
-    def resolve(self, query: str, **kwargs) -> Dict[str, Any]:
-        """
-        Resolve parameters of PromptTemplate.
-        :param query: The query to resolve parameters for.
-        :param kwargs: Additional parameters to resolve parameters for.
-        :return: A dictionary containing resolved parameters.
-        """
-        raise NotImplementedError

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -432,7 +432,11 @@ def get_predefined_prompt_templates() -> List[PromptTemplate]:
             "Thought, Tool, Tool Input, and Observation steps can be repeated multiple times, but sometimes we can find an answer in the first pass\n"
             "---\n\n"
             "Question: {query}\n"
-            "Thought: Let's think step-by-step, I first need to ",
+            "Thought: Let's think step-by-step, I first need to {transcript}",
+        ),
+        PromptTemplate(
+            name="conversational-agent",
+            prompt_text="The following is a conversation between a human and an AI.\n{history}\nHuman: {query}\nAI:",
         ),
         PromptTemplate(
             name="conversational-summary",

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -274,3 +274,14 @@ def test_update_hash():
     assert agent.hash == "d41d8cd98f00b204e9800998ecf8427e"
     agent.update_hash()
     assert agent.hash == "5ac8eca2f92c9545adcce3682b80d4c5"
+
+
+def test_invalid_agent_template():
+    pn = PromptNode()
+    with pytest.raises(ValueError, match="some_non_existing_template not supported"):
+        Agent(prompt_node=pn, prompt_template="some_non_existing_template")
+
+    # if prompt_template is None, then we'll use zero-shot-react
+    a = Agent(prompt_node=pn, prompt_template=None)
+    assert isinstance(a.prompt_template, PromptTemplate)
+    assert a.prompt_template.name == "zero-shot-react"

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -128,17 +128,9 @@ def test_extract_final_answer():
     ]
 
     for example, expected_answer in zip(match_examples, expected_answers):
-        agent_step = AgentStep(prompt_node_response=example)
-        final_answer = agent_step.extract_final_answer()
-        assert final_answer == expected_answer
-
-
-@pytest.mark.unit
-def test_format_answer():
-    step = AgentStep(prompt_node_response="have the final answer to the question.\nFinal Answer: Florida")
-    formatted_answer = step.final_answer(query="query")
-    assert formatted_answer["query"] == "query"
-    assert formatted_answer["answers"] == [Answer(answer="Florida", type="generative")]
+        agent_step = AgentStep(prompt_node_response=example, final_answer_pattern=r"Final Answer\s*:\s*(.*)")
+        final_answer = agent_step.final_answer(query="irrelevant")
+        assert final_answer["answers"][0].answer == expected_answer
 
 
 @pytest.mark.unit
@@ -229,7 +221,7 @@ def test_agent_run(reader, retriever_with_docs, document_store_with_docs):
         ),
     )
 
-    agent = Agent(prompt_node=prompt_node)
+    agent = Agent(prompt_node=prompt_node, max_steps=12)
     agent.add_tool(
         Tool(
             name="Search",

--- a/test/agents/test_agent_step.py
+++ b/test/agents/test_agent_step.py
@@ -1,0 +1,109 @@
+import pytest
+
+from haystack import Answer
+from haystack.agents import AgentStep
+from haystack.errors import AgentError
+
+
+@pytest.fixture
+def agent_step():
+    return AgentStep(
+        current_step=1, max_steps=10, final_answer_pattern=None, prompt_node_response="Hello", transcript="Hello"
+    )
+
+
+@pytest.mark.unit
+def test_create_next_step(agent_step):
+    # Test normal case
+    next_step = agent_step.create_next_step(["Hello again"])
+    assert next_step.current_step == 2
+    assert next_step.prompt_node_response == "Hello again"
+    assert next_step.transcript == "Hello"
+
+    # Test with invalid prompt_node_response
+    with pytest.raises(AgentError):
+        agent_step.create_next_step({})
+
+    # Test with empty prompt_node_response
+    with pytest.raises(AgentError):
+        agent_step.create_next_step([])
+
+
+@pytest.mark.unit
+def test_final_answer(agent_step):
+    # Test normal case
+    result = agent_step.final_answer("query")
+    assert result["query"] == "query"
+    assert isinstance(result["answers"][0], Answer)
+    assert result["answers"][0].answer == "Hello"
+    assert result["answers"][0].type == "generative"
+    assert result["transcript"] == "Hello"
+
+    # Test with max_steps reached
+    agent_step.current_step = 11
+    result = agent_step.final_answer("query")
+    assert result["answers"][0].answer == ""
+
+
+@pytest.mark.unit
+def test_is_last():
+    # Test is last, and it is last because of valid prompt_node_response and default final_answer_pattern
+    agent_step = AgentStep(current_step=1, max_steps=10, prompt_node_response="Hello", transcript="Hello")
+    assert agent_step.is_last()
+
+    # Test not last
+    agent_step.current_step = 1
+    agent_step.prompt_node_response = "final answer not satisfying pattern"
+    agent_step.final_answer_pattern = r"Final Answer\s*:\s*(.*)"
+    assert not agent_step.is_last()
+
+    # Test border cases for max_steps
+    agent_step.current_step = 9
+    assert not agent_step.is_last()
+    agent_step.current_step = 10
+    assert not agent_step.is_last()
+
+    # Test when last due to max_steps
+    agent_step.current_step = 11
+    assert agent_step.is_last()
+
+
+@pytest.mark.unit
+def test_completed(agent_step):
+    # Test without observation
+    agent_step.completed(None)
+    assert agent_step.transcript == "HelloHello"
+
+    # Test with observation, adds Hello from prompt_node_response
+    agent_step.completed("observation")
+    assert agent_step.transcript == "HelloHelloHello\nObservation: observation\nThought:"
+
+
+@pytest.mark.unit
+def test_repr(agent_step):
+    assert repr(agent_step) == (
+        "AgentStep(current_step=1, max_steps=10, "
+        "prompt_node_response=Hello, final_answer_pattern=^([\\s\\S]+)$, "
+        "transcript=Hello)"
+    )
+
+
+@pytest.mark.unit
+def test_parse_final_answer(agent_step):
+    # Test when pattern matches
+    assert agent_step.parse_final_answer() == "Hello"
+
+    # Test when pattern does not match
+    agent_step.final_answer_pattern = "goodbye"
+    assert agent_step.parse_final_answer() is None
+
+
+@pytest.mark.unit
+def test_format_react_answer():
+    step = AgentStep(
+        final_answer_pattern=r"Final Answer\s*:\s*(.*)",
+        prompt_node_response="have the final answer to the question.\nFinal Answer: Florida",
+    )
+    formatted_answer = step.final_answer(query="query")
+    assert formatted_answer["query"] == "query"
+    assert formatted_answer["answers"] == [Answer(answer="Florida", type="generative")]

--- a/test/agents/test_conversational_agent.py
+++ b/test/agents/test_conversational_agent.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import MagicMock
+
+from haystack.agents.conversational import ConversationalAgent
+from haystack.agents.memory import ConversationSummaryMemory, ConversationMemory, NoMemory
+from haystack.agents.types import PromptParametersResolver
+from haystack.nodes import PromptNode
+
+
+@pytest.mark.unit
+def test_init():
+    prompt_node = PromptNode()
+    agent = ConversationalAgent(prompt_node)
+    # Test normal case
+    assert isinstance(agent.memory, ConversationMemory)
+    assert isinstance(agent.prompt_parameters_resolver, PromptParametersResolver)
+    assert agent.max_steps == 2
+    assert agent.final_answer_pattern == r"^([\s\S]+)$"
+
+    # ConversationalAgent doesn't have tools
+    assert not agent.tm.tools
+
+    # Test with summary memory
+    agent = ConversationalAgent(prompt_node, memory=ConversationSummaryMemory(prompt_node))
+    assert isinstance(agent.memory, ConversationSummaryMemory)
+
+    # Test with no memory
+    agent = ConversationalAgent(prompt_node, memory=NoMemory())
+    assert isinstance(agent.memory, NoMemory)
+
+
+@pytest.mark.unit
+def test_run():
+    prompt_node = PromptNode()
+    agent = ConversationalAgent(prompt_node)
+
+    # Mock the Agent run method
+    agent.run = MagicMock(return_value="Hello")
+    assert agent.run("query") == "Hello"
+    agent.run.assert_called_once_with("query")

--- a/test/agents/test_conversational_agent.py
+++ b/test/agents/test_conversational_agent.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 
 from haystack.agents.conversational import ConversationalAgent
 from haystack.agents.memory import ConversationSummaryMemory, ConversationMemory, NoMemory
-from haystack.agents.types import PromptParametersResolver
 from haystack.nodes import PromptNode
 
 
@@ -13,7 +12,7 @@ def test_init():
     agent = ConversationalAgent(prompt_node)
     # Test normal case
     assert isinstance(agent.memory, ConversationMemory)
-    assert isinstance(agent.prompt_parameters_resolver, PromptParametersResolver)
+    assert callable(agent.prompt_parameters_resolver)
     assert agent.max_steps == 2
     assert agent.final_answer_pattern == r"^([\s\S]+)$"
 

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -28,7 +28,7 @@ def get_api_key(request):
 def test_add_and_remove_template():
     with patch("haystack.nodes.prompt.prompt_node.PromptModel"):
         node = PromptNode()
-    total_count = 15
+    total_count = 16
     # Verifies default
     assert len(node.get_prompt_template_names()) == total_count
 


### PR DESCRIPTION
### Related Issues
- adds ConversationalAgent
- adjusts Agent base to handle different kinds of Agents


### Proposed Changes:
We are adding a new class of Agents - ConversationalAgent, which uses recently integrated Memory

### How did you test it?
Unit tests, examples, see `examples` directory
During manual testing, a bug was discovered in `haystack/agents/memory/conversation_summary_memory.py`, and a new unit test was added (2a2dc50c3b1f792c237d1e0f508bc071a2e886b4) I ran manual checks and debugger checks to ensure correct execution of summary memory. Repeat these tests yourself.  

### Notes for the reviewer
Run `examples/agent_multihop_qa.py` to ensure no regressions were introduced and run `examples/conversational_agent.py` with regular memory (default) and change memory to use `ConversationSummaryMemory`. Run at least 5-10 rounds of chats, and check memory contents with both types of memory by simply typing `memory` instead of a new chat message. 

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
