### PR TITLE
fix: Make sure summary memory is cumulative

### DIFF
--- a/haystack/agents/memory/conversation_summary_memory.py
+++ b/haystack/agents/memory/conversation_summary_memory.py
@@ -61,7 +61,7 @@ class ConversationSummaryMemory(ConversationMemory):
 
         :return: A string containing the generated summary.
         """
-        most_recent_chat_snippets = self.load(window_size=self.summary_frequency)
+        most_recent_chat_snippets = super().load(window_size=self.summary_frequency)
         pn_response = self.prompt_node.prompt(self.template, chat_transcript=most_recent_chat_snippets)
         return pn_response[0]
 
@@ -97,7 +97,7 @@ class ConversationSummaryMemory(ConversationMemory):
         super().save(data)
         self.save_count += 1
         if self.needs_summary():
-            self.summary = self.summarize()
+            self.summary += self.summarize()
 
     def clear(self) -> None:
         """

--- a/test/agents/test_summary_memory.py
+++ b/test/agents/test_summary_memory.py
@@ -89,6 +89,43 @@ def test_conversation_summary_memory_lower_summary_frequency(mocked_prompt_node)
 
 
 @pytest.mark.unit
+def test_conversation_summary_is_accumulating(mocked_prompt_node):
+    # ensure that the summary memory works after being triggered twice
+    summary = "This is a fake summary definitely."
+    mocked_prompt_node.prompt.return_value = [summary]
+    summary_mem = ConversationSummaryMemory(mocked_prompt_node, summary_frequency=2)
+
+    data1: Dict[str, Any] = {"input": "Hello", "output": "Hi there"}
+    summary_mem.save(data1)
+    assert summary_mem.load() == "\nHuman: Hello\nAI: Hi there\n"
+    assert summary_mem.has_unsummarized_snippets()
+    assert summary_mem.unsummarized_snippets() == 1
+
+    # Test summarization
+    data2: Dict[str, Any] = {"input": "How are you?", "output": "I'm doing well, thanks."}
+    summary_mem.save(data2)
+    assert summary_mem.load() == summary
+    assert not summary_mem.has_unsummarized_snippets()
+    assert summary_mem.unsummarized_snippets() == 0
+
+    # Add more snippets
+    new_snippet = "\nHuman: What's the weather like?\nAI: It's sunny outside.\n"
+    data3: Dict[str, Any] = {"input": "What's the weather like?", "output": "It's sunny outside."}
+    summary_mem.save(data3)
+    assert summary_mem.load() == summary + new_snippet
+    assert summary_mem.has_unsummarized_snippets()
+    assert summary_mem.unsummarized_snippets() == 1
+
+    # Trigger summarization again
+    data3: Dict[str, Any] = {"input": "What's the weather tomorrow?", "output": "It will be sunny."}
+    summary_mem.save(data3)
+
+    # Ensure that the summary is accumulating
+    assert summary_mem.load() == summary + summary
+    assert not summary_mem.has_unsummarized_snippets()
+
+
+@pytest.mark.unit
 def test_conversation_summary_memory_with_template(mocked_prompt_node):
     pt = PromptTemplate("conversational-summary", "Summarize the conversation: {chat_transcript}")
     summary_mem = ConversationSummaryMemory(mocked_prompt_node, prompt_template=pt)


### PR DESCRIPTION
### Related Issues
- no issue, part of conversational agent integration
- let's integrate this fix first and then  #4931

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
Added a unit test

### Notes for the reviewer
This fix has been tested manually as well in the scope of conversational agent addition

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
