### PR TITLE
fix: Remove instruction following warning

### DIFF
--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -10,10 +10,6 @@ from haystack.schema import Document, MultiLabel
 logger = logging.getLogger(__name__)
 
 
-def instruction_following_models() -> List[str]:
-    return ["flan", "mt0", "bloomz", "davinci", "opt-iml", "gpt-3.5-turbo", "gpt-4", "gpt-35-turbo", "gpt-4-32k"]
-
-
 class PromptModel(BaseComponent):
     """
     The PromptModel class is a component that uses a pre-trained model to perform tasks defined in a prompt. Out of
@@ -69,14 +65,6 @@ class PromptModel(BaseComponent):
 
         self.model_kwargs = model_kwargs if model_kwargs else {}
         self.model_invocation_layer = self.create_invocation_layer(invocation_layer_class=invocation_layer_class)
-        is_instruction_following: bool = any(m in model_name_or_path for m in instruction_following_models())
-        if not is_instruction_following:
-            logger.warning(
-                "PromptNode has been potentially initialized with a language model not fine-tuned on instruction-following tasks. "
-                "Many of the default prompts and PromptTemplates may not work as intended. "
-                "Use custom prompts and PromptTemplates specific to the %s model",
-                model_name_or_path,
-            )
 
     def create_invocation_layer(
         self, invocation_layer_class: Optional[Type[PromptModelInvocationLayer]]


### PR DESCRIPTION
### Related Issues
No related issue. We should remove this warning as more and more LLMs (and instructions following LLMs) are being released daily, and it is impossible to track them. This warning has become inaccurate and moot. 

### Proposed Changes:
Remove the warning

### How did you test it?
No tests were added

### Notes for the reviewer

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
