### PR TITLE
test: avoid importing the weaviate client directly from the test module

### DIFF
--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -8,7 +8,6 @@ import numpy as np
 from haystack.document_stores.weaviate import WeaviateDocumentStore
 from haystack.schema import Document
 from haystack.testing import DocumentStoreBaseTestAbstract
-from haystack.document_stores import weaviate
 
 embedding_dim = 768
 
@@ -64,17 +63,10 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         """
         This fixture provides an instance of the WeaviateDocumentStore equipped with a mocked Weaviate client.
         """
-
-        class DSMock(WeaviateDocumentStore):
-            pass
-
-        mocked_client = mock.MagicMock()
-        mocked_client.Client().is_ready.return_value = True
-        mocked_client.Client().schema.contains.return_value = False
-        weaviate.client = mocked_client
-        mocked_ds = DSMock()
-
-        return mocked_ds
+        with mock.patch("haystack.document_stores.weaviate.client") as mocked_client:
+            mocked_client.Client().is_ready.return_value = True
+            mocked_client.Client().schema.contains.return_value = False
+            yield WeaviateDocumentStore()
 
     @pytest.mark.skip(reason="Weaviate does not support labels")
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues
-n/a 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Fix the mocking introduced with #4805 to avoid importing the client from the test module

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested locally

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->
Stumbled upon this while trying to unblock #4028

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
