### PR TITLE
ci: Add workflow id to Datadog event tags

### DIFF
--- a/.github/workflows/examples_tests.yml
+++ b/.github/workflows/examples_tests.yml
@@ -71,5 +71,6 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -89,6 +89,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -145,5 +146,6 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -166,6 +167,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -235,6 +237,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -287,6 +290,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -347,6 +351,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -399,6 +404,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -451,6 +457,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -513,6 +520,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -567,6 +575,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -619,6 +628,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -671,6 +681,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
@@ -723,6 +734,7 @@ jobs:
               tags:
                 - "project:${{ github.repository }}"
                 - "job:${{ github.job }}"
+                - "workflow:${{ github.run_id }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 


### PR DESCRIPTION
### Related Issues

Add the workflow run id to event tags sent to Datadog.

Related to #4957.