### PR TITLE
fix: Fix request_with_retry kwargs

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
+++ b/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
@@ -178,13 +178,13 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         self,
         data: Dict,
         attempts: int = ANTHROPIC_MAX_RETRIES,
-        status_codes: Optional[List[int]] = None,
+        status_codes_to_retry: Optional[List[int]] = None,
         timeout: float = ANTHROPIC_TIMEOUT,
         **kwargs,
     ):
         """
         Post data to Anthropic.
-        Retries request in case it fails with any code in status_codes
+        Retries request in case it fails with any code in status_codes_to_retry
         or with timeout.
         All kwargs are passed to ``requests.request``, so it accepts the same arguments.
         Returns a ``requests.Response`` object.
@@ -197,13 +197,13 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         :raises AnthropicError: Raised if requests fail for any other reason.
         :return: :class:`Response <Response>` object
         """
-        if status_codes is None:
-            status_codes = [429]
+        if status_codes_to_retry is None:
+            status_codes_to_retry = [429]
 
         try:
             res = request_with_retry(
                 attempts=attempts,
-                status_codes=status_codes,
+                status_codes_to_retry=status_codes_to_retry,
                 method="POST",
                 url="https://api.anthropic.com/v1/complete",
                 headers={"x-api-key": self.api_key, "Content-Type": "application/json"},

--- a/haystack/nodes/prompt/invocation_layer/cohere.py
+++ b/haystack/nodes/prompt/invocation_layer/cohere.py
@@ -150,7 +150,7 @@ class CohereInvocationLayer(PromptModelInvocationLayer):
         data: Dict[str, Any],
         stream: bool = False,
         attempts: int = RETRIES,
-        status_codes: Optional[List[int]] = None,
+        status_codes_to_retry: Optional[List[int]] = None,
         timeout: float = TIMEOUT,
         **kwargs,
     ) -> requests.Response:
@@ -160,17 +160,17 @@ class CohereInvocationLayer(PromptModelInvocationLayer):
         :param data: The data to be sent to the model.
         :param stream: Whether to stream the response.
         :param attempts: The number of attempts to make.
-        :param status_codes: The status codes to retry on.
+        :param status_codes_to_retry: The status codes to retry on.
         :param timeout: The timeout for the request.
         :return: The response from the model as a requests.Response object.
         """
         response: requests.Response
-        if status_codes is None:
-            status_codes = [429]
+        if status_codes_to_retry is None:
+            status_codes_to_retry = [429]
         try:
             response = request_with_retry(
                 method="POST",
-                status_codes=status_codes,
+                status_codes_to_retry=status_codes_to_retry,
                 attempts=attempts,
                 url=self.url,
                 headers=self.headers,

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -217,7 +217,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
         data: Dict[str, Any],
         stream: bool = False,
         attempts: int = HF_RETRIES,
-        status_codes: Optional[List[int]] = None,
+        status_codes_to_retry: Optional[List[int]] = None,
         timeout: float = HF_TIMEOUT,
     ) -> requests.Response:
         """
@@ -225,17 +225,17 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
         :param data: The data to be sent to the model.
         :param stream: Whether to stream the response.
         :param attempts: The number of attempts to make.
-        :param status_codes: The status codes to retry on.
+        :param status_codes_to_retry: The status codes to retry on.
         :param timeout: The timeout for the request.
         :return: The responses are being returned.
         """
         response: requests.Response
-        if status_codes is None:
-            status_codes = [429]
+        if status_codes_to_retry is None:
+            status_codes_to_retry = [429]
         try:
             response = request_with_retry(
                 method="POST",
-                status_codes=status_codes,
+                status_codes_to_retry=status_codes_to_retry,
                 attempts=attempts,
                 url=self.url,
                 headers=self.headers,


### PR DESCRIPTION
### Proposed Changes:

Recently we changed a keyword argument in `request_with_retry` from `status_codes` to `status_codes_to_retry`.
That broke some invocation layers that retry on custom status codes.
PR that introduced the change: #4950

This PR fixes the issue by using the correct kwarg.

### How did you test it?

I ran `AnthropicClaudeInvocationLayer` integration tests locally. 

### Notes for the reviewer

As of now `AnthropicClaudeInvocationLayer` integration tests are not run in CI as the `ANTHROPIC_CLAUDE_API_KEY` env var is not set.