### PR TITLE
build: Remove dill dependency

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -18,7 +18,6 @@ generalimport(
     "beir",
     "boilerpy3",
     "canals",
-    "dill",
     "docx",
     "elasticsearch",
     "events",

--- a/haystack/modeling/training/base.py
+++ b/haystack/modeling/training/base.py
@@ -5,7 +5,6 @@ import shutil
 import logging
 from pathlib import Path
 
-import dill
 import numpy
 from tqdm.auto import tqdm
 import torch
@@ -510,7 +509,6 @@ class Trainer:
                 "cuda_rng_state": torch.cuda.get_rng_state() if torch.cuda.is_available() else None,
             },
             checkpoint_path / "trainer",
-            pickle_module=dill,
         )
 
         checkpoint_name = f"epoch_{self.from_epoch}_step_{self.from_step-1}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
   "generalimport", # Optional imports
 
   # Utils
-  "dill",  # pickle extension for (de-)serialization
   "tqdm",  # progress bars in model download and training scripts
   "networkx",  # graphs library
   "quantulum3",  # quantities extraction from text


### PR DESCRIPTION
### Related Issues
- Part of https://github.com/deepset-ai/haystack/pull/4417

### Proposed Changes:
Remove dill dependency and remove dill from from saving models via torch.save with pickle_module set to dill.

### How did you test it?
- Trained a tiny DPR model with the dill module installed: https://colab.research.google.com/drive/1jgjn_4cdbmxK7ZFXeRXTbjxrgqKDQBHD?usp=sharing
- Loaded the trained DPR model here without installing dill: https://colab.research.google.com/drive/1xDpRXh-ArDKLqz4q1PzYyVrWVwefiZfm?usp=sharing

### Notes for the reviewer
dill was introduced in FARM in https://github.com/deepset-ai/FARM/pull/271 At that time we used torch.save to not only store the state dicts but also the model itself. As the AdaptiveModel allows defining a loss function as a callable, it was not serializable out of the box and we introduced dill to save it.
In Haystack, we're not storing the model class though and thus I believe dill is not necessary anymore. What remains to be checked is whether model saved with dill can be loaded without. If it's compatible, we can remove dill otherwise we need to keep it.

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
