### PR TITLE
fix: Pin typing_extensions to fix Pydantic issue

### DIFF
--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -5,11 +5,6 @@ import inspect
 
 from typing import Any, Optional, Dict, List, Union
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
-
 from pathlib import Path
 from uuid import uuid4
 import logging
@@ -17,6 +12,12 @@ import time
 import json
 import ast
 from dataclasses import asdict
+
+# The Literal type from typing_extension is safer to use as
+# the one from typing has different bugs in the different versions.
+# For more info see typing_extensions official docs:
+# https://typing-extensions.readthedocs.io/en/latest/#Literal
+from typing_extensions import Literal
 
 import numpy as np
 from numpy import ndarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ classifiers = [
 dependencies = [
   "requests",
   "pydantic",
+  # FIXME: typing_extensions 4.6.0 broke Pydantic, so we pin it temporarily
+  # waiting for the release. For more info see this issue:
+  # https://github.com/pydantic/pydantic/issues/5821
+  "typing_extensions==4.5.0",
   "transformers[torch]==4.29.1",
   "protobuf<=3.20.2",  # same version they use in transformers[sentencepiece]
   "pandas",
@@ -184,7 +188,6 @@ dev = [
   "pre-commit",
   # Type check
   "mypy",
-  "typing_extensions; python_version < '3.8'",
   # Test
   "pytest",
   "pytest-cov",


### PR DESCRIPTION
### Proposed Changes:

Pin `typing_extensions` to version `4.5.0` to fix Pydantic failing when trying to import Haystack.

`typing_extensions` version `4.6.0` was released 8 hours ago, that version causes Pydantic to fail.

### How did you test it?

Created a new virtualenv with Python `3.8.16`, run `pip install .` and then `python -c 'import haystack'`.

### Notes for the reviewer

Some additional info regarding the failure in here can be found in the Pydantic issue: pydantic/pydantic#5821.

Imports have been moved around in `schema.py` to please `pylint`.

