### PR TITLE
build: Install protobuf via transformers extra sentencepiece

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,7 @@ dependencies = [
   # waiting for the release. For more info see this issue:
   # https://github.com/pydantic/pydantic/issues/5821
   "typing_extensions==4.5.0",
-  "transformers[torch]==4.29.1",
-  "protobuf<=3.20.2",  # same version they use in transformers[sentencepiece]
+  "transformers[torch,sentencepiece]==4.29.1",
   "pandas",
   "rank_bm25",
   "scikit-learn>=1.0.0", # TF-IDF, SklearnQueryClassifier and metrics


### PR DESCRIPTION
### Related Issues
- fixes #4988 

### Proposed Changes:
This PR changes how we install protobuf. With this PR, we now install protobuf through a transformers extra called sentencepiece. In addition to protobuf it also installs sentencepiece, which we anyway need for Haystack's core dependency sentence-transformers. They can't be used separately anyway and transformers pins protobuf to the working version.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
