### PR TITLE
fix: Fix handling of streaming response in AnthropicClaudeInvocationLayer

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
+++ b/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
@@ -10,7 +10,7 @@ from tokenizers import Tokenizer, Encoding
 
 from haystack.errors import AnthropicError, AnthropicRateLimitError, AnthropicUnauthorizedError
 from haystack.nodes.prompt.invocation_layer.base import PromptModelInvocationLayer
-from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler, DefaultTokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler, AnthropicTokenStreamingHandler
 from haystack.utils.requests import request_with_retry
 from haystack.environment import HAYSTACK_REMOTE_API_MAX_RETRIES, HAYSTACK_REMOTE_API_TIMEOUT_SEC
 
@@ -126,21 +126,21 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
             return [res.json()["completion"].strip()]
 
         res = self._post(data=data, stream=True)
-        handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", DefaultTokenStreamingHandler())
+        # Anthropic streamed response always includes the whole string that has been
+        # streamed until that point, so we use a stream handler built ad hoc for this
+        # invocation layer.
+        handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", AnthropicTokenStreamingHandler())
         client = sseclient.SSEClient(res)
-        tokens = ""
+        tokens = []
         try:
             for event in client.events():
                 if event.data == TokenStreamingHandler.DONE_MARKER:
                     continue
                 ed = json.loads(event.data)
-                # Anthropic streamed response always includes the whole
-                # string that has been streamed until that point, so
-                # we can just store the last received event
-                tokens = handler(ed["completion"])
+                tokens.append(handler(ed["completion"]))
         finally:
             client.close()
-        return [tokens.strip()]  # return a list of strings just like non-streaming
+        return ["".join(tokens)]  # return a list of strings just like non-streaming
 
     def _ensure_token_limit(self, prompt: Union[str, List[Dict[str, str]]]) -> Union[str, List[Dict[str, str]]]:
         """Make sure the length of the prompt and answer is within the max tokens limit of the model.

--- a/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
+++ b/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
@@ -10,7 +10,11 @@ from tokenizers import Tokenizer, Encoding
 
 from haystack.errors import AnthropicError, AnthropicRateLimitError, AnthropicUnauthorizedError
 from haystack.nodes.prompt.invocation_layer.base import PromptModelInvocationLayer
-from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler, AnthropicTokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer.handlers import (
+    TokenStreamingHandler,
+    AnthropicTokenStreamingHandler,
+    DefaultTokenStreamingHandler,
+)
 from haystack.utils.requests import request_with_retry
 from haystack.environment import HAYSTACK_REMOTE_API_MAX_RETRIES, HAYSTACK_REMOTE_API_TIMEOUT_SEC
 
@@ -129,7 +133,8 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         # Anthropic streamed response always includes the whole string that has been
         # streamed until that point, so we use a stream handler built ad hoc for this
         # invocation layer.
-        handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", AnthropicTokenStreamingHandler())
+        handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", DefaultTokenStreamingHandler())
+        handler = AnthropicTokenStreamingHandler(handler)
         client = sseclient.SSEClient(res)
         tokens = []
         try:

--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -51,7 +51,7 @@ class AnthropicTokenStreamingHandler(TokenStreamingHandler):
     # Text received previously by the handler
     previous_text = ""
 
-    def __call__(self, text: str) -> str:
+    def __call__(self, token_received: str, **kwargs) -> str:
         """
         When the handler is called directly with a response string from Anthropic
         we split it comparing with the previously received text by this handler
@@ -60,20 +60,20 @@ class AnthropicTokenStreamingHandler(TokenStreamingHandler):
         If the text is completely different from the previously received one we
         replace it and return it in full.
 
-        :param text: Text response received by Anthropic backend.
-        :type text: str
+        :param token_received: Text response received by Anthropic backend.
+        :type token_received: str
         :return: The part of text that has not been received previously.
         :rtype: str
         """
-        if self.previous_text not in text:
+        if self.previous_text not in token_received:
             # The handler is being reused, we want to handle this case gracefully
             # so we just cleanup the previously received text and keep going
             self.previous_text = ""
 
         previous_text_length = len(self.previous_text)
-        chopped_text = text[previous_text_length:]
+        chopped_text = token_received[previous_text_length:]
         print(chopped_text, flush=True, end="")
-        self.previous_text = text
+        self.previous_text = token_received
         return chopped_text
 
 

--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -38,13 +38,13 @@ class DefaultTokenStreamingHandler(TokenStreamingHandler):
 
 class AnthropicTokenStreamingHandler(TokenStreamingHandler):
     """
-    Anthropic has a peculiar way of handling streaming responses
+    Anthropic has an unusual way of handling streaming responses
     as it returns all the tokens generated up to that point for each
     response.
     This makes it hard to use DefaultTokenStreamingHandler as the user
     would see the generated text printed multiple times.
 
-    This streaming handler handles the repeating text gracefully and prints
+    This streaming handler tackles the repeating text and prints
     only the newly generated part.
     """
 
@@ -54,11 +54,11 @@ class AnthropicTokenStreamingHandler(TokenStreamingHandler):
 
     def __call__(self, token_received: str, **kwargs) -> str:
         """
-        When the handler is called directly with a response string from Anthropic
-        we split it comparing with the previously received text by this handler
-        and returns only the part that is new.
+        When the handler is called directly with a response string from Anthropic,
+        we split it, comparing it with the previously received text by this handler,
+        and return only the new part.
 
-        If the text is completely different from the previously received one we
+        If the text is completely different from the previously received one, we
         replace it and return it in full.
 
         :param token_received: Text response received by Anthropic backend.

--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -48,8 +48,9 @@ class AnthropicTokenStreamingHandler(TokenStreamingHandler):
     only the newly generated part.
     """
 
-    # Text received previously by the handler
-    previous_text = ""
+    def __init__(self, token_handler: TokenStreamingHandler):
+        self.token_handler = token_handler
+        self.previous_text = ""
 
     def __call__(self, token_received: str, **kwargs) -> str:
         """
@@ -72,7 +73,7 @@ class AnthropicTokenStreamingHandler(TokenStreamingHandler):
 
         previous_text_length = len(self.previous_text)
         chopped_text = token_received[previous_text_length:]
-        print(chopped_text, flush=True, end="")
+        self.token_handler(chopped_text)
         self.previous_text = token_received
         return chopped_text
 

--- a/test/prompt/invocation_layer/test_anthropic_claude.py
+++ b/test/prompt/invocation_layer/test_anthropic_claude.py
@@ -177,15 +177,11 @@ def test_invoke_with_custom_stream_handler():
 
     assert len(res) == 1
     # This is not the real result but the values returned by the mock handler
-    assert res[0] == "tokentokentoken"
+    assert res[0] == " The sky appears blue to us due to how"
 
     # Verifies the handler has been called the expected times with the expected args
     assert mock_stream_handler.call_count == 3
-    expected_call_list = [
-        call(" The sky appears"),
-        call(" The sky appears blue to"),
-        call(" The sky appears blue to us due to how"),
-    ]
+    expected_call_list = [call(" The sky appears"), call(" blue to"), call(" us due to how")]
     assert mock_stream_handler.call_args_list == expected_call_list
 
 

--- a/test/prompt/invocation_layer/test_anthropic_claude.py
+++ b/test/prompt/invocation_layer/test_anthropic_claude.py
@@ -146,7 +146,7 @@ def test_invoke_with_stream():
         res = layer.invoke(prompt="Some prompt", stream=True)
 
     assert len(res) == 1
-    assert res[0] == "The sky appears blue to us due to how"
+    assert res[0] == " The sky appears blue to us due to how"
 
 
 @pytest.mark.unit
@@ -177,7 +177,7 @@ def test_invoke_with_custom_stream_handler():
 
     assert len(res) == 1
     # This is not the real result but the values returned by the mock handler
-    assert res[0] == "token"
+    assert res[0] == "tokentokentoken"
 
     # Verifies the handler has been called the expected times with the expected args
     assert mock_stream_handler.call_count == 3

--- a/test/prompt/test_handlers.py
+++ b/test/prompt/test_handlers.py
@@ -2,8 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-from haystack.nodes.prompt.invocation_layer.handlers import DefaultPromptHandler
-from haystack.nodes.prompt.invocation_layer.handlers import AnthropicTokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer.handlers import (
+    DefaultTokenStreamingHandler,
+    DefaultPromptHandler,
+    AnthropicTokenStreamingHandler,
+)
 
 
 @pytest.mark.integration
@@ -84,7 +87,7 @@ def test_flan_prompt_handler():
 @pytest.mark.unit
 @patch("builtins.print")
 def test_anthropic_token_streaming_handler(mock_print):
-    handler = AnthropicTokenStreamingHandler()
+    handler = AnthropicTokenStreamingHandler(DefaultTokenStreamingHandler())
 
     res = handler(" This")
     assert res == " This"

--- a/test/prompt/test_handlers.py
+++ b/test/prompt/test_handlers.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
 from haystack.nodes.prompt.invocation_layer.handlers import DefaultPromptHandler
+from haystack.nodes.prompt.invocation_layer.handlers import AnthropicTokenStreamingHandler
 
 
 @pytest.mark.integration
@@ -76,3 +79,29 @@ def test_flan_prompt_handler():
         "model_max_length": 20,
         "new_prompt_length": 0,
     }
+
+
+@pytest.mark.unit
+@patch("builtins.print")
+def test_anthropic_token_streaming_handler(mock_print):
+    handler = AnthropicTokenStreamingHandler()
+
+    res = handler(" This")
+    assert res == " This"
+    mock_print.assert_called_with(" This", flush=True, end="")
+
+    res = handler(" This is a new")
+    assert res == " is a new"
+    mock_print.assert_called_with(" is a new", flush=True, end="")
+
+    res = handler(" This is a new token")
+    assert res == " token"
+    mock_print.assert_called_with(" token", flush=True, end="")
+
+    res = handler("And now")
+    assert res == "And now"
+    mock_print.assert_called_with("And now", flush=True, end="")
+
+    res = handler("And now something completely different")
+    assert res == " something completely different"
+    mock_print.assert_called_with(" something completely different", flush=True, end="")


### PR DESCRIPTION
### Related Issues
- fixes #4990 

### Proposed Changes:

Change the default streaming handler in `AnthropicClaudeInvocationLayer` to a custom one, so that the received streamed response is handled gracefully.


### How did you test it?

I added new tests for the `AnthropicTokenStreamingHandler` and changed the `AnthropicClaudeInvocationLayer` tests.

### Notes for the reviewer

More info available in the linked issue.