### PR TITLE
feat: Add prompt_template to conversational agent init params

### DIFF
--- a/haystack/agents/conversational.py
+++ b/haystack/agents/conversational.py
@@ -1,8 +1,8 @@
-from typing import Optional, Callable
+from typing import Optional, Callable, Union
 
 from haystack.agents import Agent
 from haystack.agents.memory import Memory, ConversationMemory
-from haystack.nodes import PromptNode
+from haystack.nodes import PromptNode, PromptTemplate
 
 
 class ConversationalAgent(Agent):
@@ -36,6 +36,7 @@ class ConversationalAgent(Agent):
     def __init__(
         self,
         prompt_node: PromptNode,
+        prompt_template: Optional[Union[str, PromptTemplate]] = None,
         memory: Optional[Memory] = None,
         prompt_parameters_resolver: Optional[Callable] = None,
     ):
@@ -43,6 +44,8 @@ class ConversationalAgent(Agent):
         Creates a new ConversationalAgent instance
 
         :param prompt_node: A PromptNode used to communicate with LLM.
+        :param prompt_template: A string or PromptTemplate instance to use as the prompt template. If no prompt_template
+        is provided, the agent will use the "conversational-agent" template.
         :param memory: A memory instance for storing conversation history and other relevant data, defaults to
         ConversationMemory.
         :param prompt_parameters_resolver: An optional callable for resolving prompt template parameters,
@@ -50,9 +53,7 @@ class ConversationalAgent(Agent):
         """
         super().__init__(
             prompt_node=prompt_node,
-            prompt_template=prompt_node.default_prompt_template
-            if prompt_node.default_prompt_template is not None
-            else "conversational-agent",
+            prompt_template=prompt_template or "conversational-agent",
             max_steps=2,
             memory=memory if memory else ConversationMemory(),
             prompt_parameters_resolver=prompt_parameters_resolver


### PR DESCRIPTION
### Related Issues
- Follow-up on @TuanaCelik comment in the ConversationalAgentWithTools PR: https://github.com/deepset-ai/haystack/pull/4940/files#r1202130074

### Proposed Changes:
- Make the use of PromptTemplate in Agent, ConversationalAgent and ConversationalAgentWithTools (PR pending for the latter) consistent
- Add a prompt_template param the the init of ConversationalAgent and thus ignore the default_prompt_tempalte of the PromptNode just as in Agent and ConversationalAgentWithTools

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
