### PR TITLE
test: Mock request from prompt hub in unit test

### DIFF
--- a/test/agents/test_conversational_agent.py
+++ b/test/agents/test_conversational_agent.py
@@ -25,10 +25,12 @@ def test_init():
 
 @pytest.mark.unit
 def test_init_with_summary_memory():
-    prompt_node = PromptNode(default_prompt_template="this is a test")
-    # Test with summary memory
-    agent = ConversationalAgent(prompt_node, memory=ConversationSummaryMemory(prompt_node))
-    assert isinstance(agent.memory, ConversationSummaryMemory)
+    with patch("haystack.nodes.prompt.prompt_template.PromptTemplate._fetch_from_prompthub") as mock_prompthub:
+        mock_prompthub.side_effect = [("This is a test prompt. Use your knowledge to answer this question: {question}")]
+        prompt_node = PromptNode(default_prompt_template="this is a test")
+        # Test with summary memory
+        agent = ConversationalAgent(prompt_node, memory=ConversationSummaryMemory(prompt_node))
+        assert isinstance(agent.memory, ConversationSummaryMemory)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR mocks the `_fetch_from_prompthub` in `test/agents/test_conversational_agent.py::test_init_with_summary_memory`. The test was previously failing as we don't allow making http requests in unit tests.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
