### PR TITLE
fix: `fitz` import switcher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[all,pdf,dev]
+        run: pip install .[all,dev]
 
       - name: Run
         run: pytest --cov-report xml:coverage.xml --cov="haystack" -m "unit" test/${{ matrix.topic }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[all,dev]
+        run: pip install .[all,pdf,dev]
 
       - name: Run
         run: pytest --cov-report xml:coverage.xml --cov="haystack" -m "unit" test/${{ matrix.topic }}

--- a/haystack/nodes/file_converter/__init__.py
+++ b/haystack/nodes/file_converter/__init__.py
@@ -11,6 +11,12 @@ from haystack.nodes.file_converter.txt import TextConverter
 from haystack.nodes.file_converter.azure import AzureConverter
 from haystack.nodes.file_converter.parsr import ParsrConverter
 
+# Try to use PyMuPDF, if not available fall back to xpdf
+from haystack.nodes.file_converter.pdf import PDFToTextConverter
+
+if not is_imported("fitz"):
+    from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore  # pylint: disable=reimported
+
 
 MarkdownConverter = safe_import(
     "haystack.nodes.file_converter.markdown", "MarkdownConverter", "preprocessing"
@@ -18,9 +24,3 @@ MarkdownConverter = safe_import(
 ImageToTextConverter = safe_import(
     "haystack.nodes.file_converter.image", "ImageToTextConverter", "ocr"
 )  # Has optional dependencies
-
-# Try to use PyMuPDF, if not available fall back to xpdf
-from haystack.nodes.file_converter.pdf import PDFToTextConverter
-
-if not is_imported("fitz"):
-    from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore  # pylint: disable

--- a/haystack/nodes/file_converter/__init__.py
+++ b/haystack/nodes/file_converter/__init__.py
@@ -1,3 +1,4 @@
+from haystack import is_imported
 from haystack.nodes.file_converter.base import BaseConverter
 
 from haystack.utils.import_utils import safe_import
@@ -19,7 +20,7 @@ ImageToTextConverter = safe_import(
 )  # Has optional dependencies
 
 # Try to use PyMuPDF, if not available fall back to xpdf
-try:
+if is_imported("fitz"):
     from haystack.nodes.file_converter.pdf import PDFToTextConverter
-except ImportError:
+else:
     from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore

--- a/haystack/nodes/file_converter/__init__.py
+++ b/haystack/nodes/file_converter/__init__.py
@@ -23,4 +23,4 @@ ImageToTextConverter = safe_import(
 from haystack.nodes.file_converter.pdf import PDFToTextConverter
 
 if not is_imported("fitz"):
-    from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore  # pylint: disable=reimported
+    from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore  # pylint: disable

--- a/haystack/nodes/file_converter/__init__.py
+++ b/haystack/nodes/file_converter/__init__.py
@@ -23,4 +23,4 @@ ImageToTextConverter = safe_import(
 from haystack.nodes.file_converter.pdf import PDFToTextConverter
 
 if not is_imported("fitz"):
-    from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore
+    from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore  # pylint: disable=reimported

--- a/haystack/nodes/file_converter/__init__.py
+++ b/haystack/nodes/file_converter/__init__.py
@@ -20,7 +20,7 @@ ImageToTextConverter = safe_import(
 )  # Has optional dependencies
 
 # Try to use PyMuPDF, if not available fall back to xpdf
-if is_imported("fitz"):
-    from haystack.nodes.file_converter.pdf import PDFToTextConverter
-else:
+from haystack.nodes.file_converter.pdf import PDFToTextConverter
+
+if not is_imported("fitz"):
     from haystack.nodes.file_converter.pdf_xpdf import PDFToTextConverter  # type: ignore


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
- Fix the PyMuPDF/xpdf import switcher. Since the introduction of `generalimport`, no import errors were raised, causing Haystack to select always PyMuPDF

### How did you test it?
n/a

### Notes for the reviewer
n/a

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
