### PR TITLE
build: Build the docker images `base-{cpu,gpu}`

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -103,8 +103,20 @@ jobs:
 
       # This step should only run when we release a new minor, so
       # that we can tag the most recent image without the version number.
-      # For example, if the previous step builds `deepset/haystack:cpu-1.8.0`,
-      # this builds `deepset/haystack:cpu`
+      # For example, if the previous step builds `deepset/haystack:base-cpu-1.8.0`,
+      # this builds `deepset/haystack:base-cpu`
+      - name: Build base images no version in tag
+        uses: docker/bake-action@v2
+        if: steps.version.outputs.comparison-result == '>'
+        env:
+          IMAGE_TAG_SUFFIX: ${{ steps.meta.outputs.version }}
+          HAYSTACK_VERSION: ${{ steps.meta.outputs.version }}
+        with:
+          workdir: docker
+          targets: base-${{ matrix.target }}-latest
+          push: true
+
+      # Following the logic of the previous step, this step should only run when we release a new minor.
       - name: Build api images no version in tag
         uses: docker/bake-action@v2
         if: steps.version.outputs.comparison-result == '>'

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -26,6 +26,10 @@ group "base" {
   targets = ["base-cpu", "base-gpu"]
 }
 
+group "base-latest" {
+  targets = ["base-cpu-latest", "base-gpu-latest"]
+}
+
 group "api" {
   targets = ["cpu", "gpu"]
 }
@@ -50,6 +54,12 @@ target "base-cpu" {
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
+target "base-cpu-latest" {
+  inherits = ["base-cpu"]
+  tags = ["${IMAGE_NAME}:base-cpu"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
 target "base-gpu" {
   dockerfile = "Dockerfile.base"
   tags = ["${IMAGE_NAME}:base-gpu-${IMAGE_TAG_SUFFIX}"]
@@ -61,6 +71,12 @@ target "base-gpu" {
     haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores-gpu,crawler,preprocessing,file-conversion,ocr,onnx-gpu,metrics]"
   }
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "base-gpu-latest" {
+  inherits = ["base-gpu"]
+  tags = ["${IMAGE_NAME}:base-gpu"]
   platforms = ["linux/amd64", "linux/arm64"]
 }
 


### PR DESCRIPTION
### Related Issues
- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adapt the Docker release workflow such that we build and publish the images `base-cpu` and `base-gpu` with each Haystack release. These images will point to the latest release and are the base equivalents of `cpu` and `gpu`.

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I built the base-cpu image locally using: `docker buildx bake base-cpu-latest --set "*.platform=linux/arm64"`

### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
