### PR TITLE
feat: make openai_base configurable

### DIFF
--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -32,6 +32,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         api_key: str,
         azure_base_url: Optional[str] = None,
         azure_deployment_name: Optional[str] = None,
+        base_url: str = "https://api.openai.com/v1",
         model: str = "text-davinci-003",
         max_tokens: int = 50,
         api_version: str = "2022-12-01",
@@ -53,6 +54,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
 
         :param azure_deployment_name: The name of the Azure OpenAI API deployment. If not supplied, Azure OpenAI API
                                      will not be used.
+        :param base_url: The base URL for the OpenAI API, defaults to `"https://api.openai.com/v1"`
         :param model: ID of the engine to use for generating the answer. You can select one of `"text-ada-001"`,
                      `"text-babbage-001"`, `"text-curie-001"`, or `"text-davinci-003"`
                      (from worst to best and from cheapest to most expensive). For more information about the models,
@@ -144,6 +146,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         self.azure_base_url = azure_base_url
         self.azure_deployment_name = azure_deployment_name
         self.api_version = api_version
+        self.base_url = base_url
         self.model = model
         self.max_tokens = max_tokens
         self.top_k = top_k
@@ -217,7 +220,7 @@ class OpenAIAnswerGenerator(BaseGenerator):
         if self.using_azure:
             url = f"{self.azure_base_url}/openai/deployments/{self.azure_deployment_name}/completions?api-version={self.api_version}"
         else:
-            url = "https://api.openai.com/v1/completions"
+            url = f"{self.base_url}/completions"
 
         headers = {"Content-Type": "application/json"}
         if self.using_azure:

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -40,6 +40,7 @@ class WhisperTranscriber(BaseComponent):
         self,
         api_key: Optional[str] = None,
         model_name_or_path: WhisperModel = "medium",
+        base_url: str = "https://api.openai.com/v1",
         device: Optional[Union[str, torch.device]] = None,
     ) -> None:
         """
@@ -53,7 +54,7 @@ class WhisperTranscriber(BaseComponent):
         """
         super().__init__()
         self.api_key = api_key
-
+        self.base_url = (base_url,)
         self.use_local_whisper = is_whisper_available() and self.api_key is None
 
         if self.use_local_whisper:
@@ -107,11 +108,7 @@ class WhisperTranscriber(BaseComponent):
         else:
             headers = {"Authorization": f"Bearer {self.api_key}"}
             request = PreparedRequest()
-            url: str = (
-                "https://api.openai.com/v1/audio/transcriptions"
-                if not translate
-                else "https://api.openai.com/v1/audio/translations"
-            )
+            url: str = "{self.base_url}/audio/transcriptions" if not translate else "{self.base_url}/audio/translations"
 
             request.prepare(
                 method="POST",

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -55,7 +55,7 @@ class WhisperTranscriber(BaseComponent):
         """
         super().__init__()
         self.api_key = api_key
-        self.base_url = (base_url,)
+        self.base_url = base_url
         self.use_local_whisper = is_whisper_available() and self.api_key is None
 
         if self.use_local_whisper:

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -49,6 +49,7 @@ class WhisperTranscriber(BaseComponent):
         :param api_key: OpenAI API key. If None, a local installation of Whisper is used.
         :param model_name_or_path: Name of the model to use. If using a local installation of Whisper, set this to one of the following values: "tiny", "small", "medium", "large", "large-v2". If using
         the API, set thsi value to: "whisper-1" (default).
+        :param base_url: The OpenAI API Base url, defaults to `https://api.openai.com/v1`.
         :param device: Device to use for inference. Only used if you're using a local
         installation of Whisper. If None, the device is automatically selected.
         """

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -108,7 +108,9 @@ class WhisperTranscriber(BaseComponent):
         else:
             headers = {"Authorization": f"Bearer {self.api_key}"}
             request = PreparedRequest()
-            url: str = "{self.base_url}/audio/transcriptions" if not translate else "{self.base_url}/audio/translations"
+            url: str = (
+                f"{self.base_url}/audio/transcriptions" if not translate else f"{self.base_url}/audio/translations"
+            )
 
             request.prepare(
                 method="POST",

--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -20,9 +20,14 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
     """
 
     def __init__(
-        self, api_key: str, model_name_or_path: str = "gpt-3.5-turbo", max_length: Optional[int] = 500, **kwargs
+        self,
+        api_key: str,
+        model_name_or_path: str = "gpt-3.5-turbo",
+        max_length: Optional[int] = 500,
+        base_url: str = "https://api.openai.com/v1",
+        **kwargs,
     ):
-        super().__init__(api_key, model_name_or_path, max_length, **kwargs)
+        super().__init__(api_key, model_name_or_path, max_length, base_url=base_url, **kwargs)
 
     def invoke(self, *args, **kwargs):
         """
@@ -125,7 +130,7 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
 
     @property
     def url(self) -> str:
-        return "https://api.openai.com/v1/chat/completions"
+        return "{self.base_url}/chat/completions"
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:

--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -27,6 +27,16 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
         base_url: str = "https://api.openai.com/v1",
         **kwargs,
     ):
+        """
+         Creates an instance of ChatGPTInvocationLayer for OpenAI's GPT-3.5 GPT-4 models.
+
+        :param model_name_or_path: The name or path of the underlying model.
+        :param max_length: The maximum number of tokens the output text can have.
+        :param api_key: The OpenAI API key.
+        :param base_url: The OpenAI API Base url, defaults to `https://api.openai.com/v1`.
+        :param kwargs: Additional keyword arguments passed to the underlying model.
+        [documentation](https://platform.openai.com/docs/api-reference/chat).
+        """
         super().__init__(api_key, model_name_or_path, max_length, base_url=base_url, **kwargs)
 
     def invoke(self, *args, **kwargs):

--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -130,7 +130,7 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
 
     @property
     def url(self) -> str:
-        return "{self.base_url}/chat/completions"
+        return f"{self.base_url}/chat/completions"
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -53,7 +53,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
                 f"api_key {api_key} must be a valid OpenAI key. Visit https://openai.com/api/ to get one."
             )
         self.api_key = api_key
-        self.base_url = self.base_url
+        self.base_url = base_url
 
         # 16 is the default length for answers from OpenAI shown in the docs
         # here, https://platform.openai.com/docs/api-reference/completions/create.
@@ -92,7 +92,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
 
     @property
     def url(self) -> str:
-        return "{self.base_url}/completions"
+        return f"{self.base_url}/completions"
 
     @property
     def headers(self) -> Dict[str, str]:

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -40,6 +40,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
         :param model_name_or_path: The name or path of the underlying model.
         :param max_length: The maximum number of tokens the output text can have.
         :param api_key: The OpenAI API key.
+        :param base_url: The OpenAI API Base url, defaults to `https://api.openai.com/v1`.
         :param kwargs: Additional keyword arguments passed to the underlying model. Due to reflective construction of
         all PromptModelInvocationLayer instances, this instance of OpenAIInvocationLayer might receive some unrelated
         kwargs. Only the kwargs relevant to OpenAIInvocationLayer are considered. The list of OpenAI-relevant

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -27,7 +27,12 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
     """
 
     def __init__(
-        self, api_key: str, model_name_or_path: str = "text-davinci-003", max_length: Optional[int] = 100, **kwargs
+        self,
+        api_key: str,
+        model_name_or_path: str = "text-davinci-003",
+        max_length: Optional[int] = 100,
+        base_url: str = "https://api.openai.com/v1",
+        **kwargs,
     ):
         """
          Creates an instance of OpenAIInvocationLayer for OpenAI's GPT-3 InstructGPT models.
@@ -48,6 +53,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
                 f"api_key {api_key} must be a valid OpenAI key. Visit https://openai.com/api/ to get one."
             )
         self.api_key = api_key
+        self.base_url = self.base_url
 
         # 16 is the default length for answers from OpenAI shown in the docs
         # here, https://platform.openai.com/docs/api-reference/completions/create.
@@ -86,7 +92,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
 
     @property
     def url(self) -> str:
-        return "https://api.openai.com/v1/completions"
+        return "{self.base_url}/completions"
 
     @property
     def headers(self) -> Dict[str, str]:

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -37,7 +37,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         if self.using_azure:
             self.url = f"{retriever.azure_base_url}/openai/deployments/{retriever.azure_deployment_name}/embeddings?api-version={retriever.api_version}"
         else:
-            self.url = "https://api.openai.com/v1/embeddings"
+            self.url = "{self.base_url}/embeddings"
 
         self.api_key = retriever.api_key
         self.batch_size = min(64, retriever.batch_size)

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -37,7 +37,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         if self.using_azure:
             self.url = f"{retriever.azure_base_url}/openai/deployments/{retriever.azure_deployment_name}/embeddings?api-version={retriever.api_version}"
         else:
-            self.url = f"{self.base_url}/embeddings"
+            self.url = f"{retriever.base_url}/embeddings"
 
         self.api_key = retriever.api_key
         self.batch_size = min(64, retriever.batch_size)

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -37,7 +37,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         if self.using_azure:
             self.url = f"{retriever.azure_base_url}/openai/deployments/{retriever.azure_deployment_name}/embeddings?api-version={retriever.api_version}"
         else:
-            self.url = f"{retriever.base_url}/embeddings"
+            self.url = f"{retriever.api_base}/embeddings"
 
         self.api_key = retriever.api_key
         self.batch_size = min(64, retriever.batch_size)

--- a/haystack/nodes/retriever/_openai_encoder.py
+++ b/haystack/nodes/retriever/_openai_encoder.py
@@ -37,7 +37,7 @@ class _OpenAIEmbeddingEncoder(_BaseEmbeddingEncoder):
         if self.using_azure:
             self.url = f"{retriever.azure_base_url}/openai/deployments/{retriever.azure_deployment_name}/embeddings?api-version={retriever.api_version}"
         else:
-            self.url = "{self.base_url}/embeddings"
+            self.url = f"{self.base_url}/embeddings"
 
         self.api_key = retriever.api_key
         self.batch_size = min(64, retriever.batch_size)

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1455,6 +1455,7 @@ class EmbeddingRetriever(DenseRetriever):
         scale_score: bool = True,
         embed_meta_fields: Optional[List[str]] = None,
         api_key: Optional[str] = None,
+        api_base: str = "https://api.openai.com/v1",
         azure_api_version: str = "2022-12-01",
         azure_base_url: Optional[str] = None,
         azure_deployment_name: Optional[str] = None,
@@ -1512,6 +1513,7 @@ class EmbeddingRetriever(DenseRetriever):
                                   If no value is provided, a default empty list will be created.
         :param api_key: The OpenAI API key or the Cohere API key. Required if one wants to use OpenAI/Cohere embeddings.
                         For more details see https://beta.openai.com/account/api-keys and https://dashboard.cohere.ai/api-keys
+        :param api_base: The OpenAI API key base, defaults to `"https://api.openai.com/v1"`
         :param api_version: The version of the Azure OpenAI API to use. The default is `2022-12-01` version.
         :param azure_base_url: The base URL for the Azure OpenAI API. If not supplied, Azure OpenAI API will not be used.
                                This parameter is an OpenAI Azure endpoint, usually in the form `https://<your-endpoint>.openai.azure.com'

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1542,6 +1542,7 @@ class EmbeddingRetriever(DenseRetriever):
         self.use_auth_token = use_auth_token
         self.scale_score = scale_score
         self.api_key = api_key
+        self.api_base = api_base
         self.api_version = azure_api_version
         self.azure_base_url = azure_base_url
         self.azure_deployment_name = azure_deployment_name

--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -56,6 +56,7 @@ class RemoteWhisperTranscriber:
             raise ValueError("API key is None.")
 
         self.api_key = api_key
+        self.api_base = api_base
 
         self.model_name = model_name
 

--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -38,11 +38,14 @@ class RemoteWhisperTranscriber:
     class Output(ComponentOutput):
         documents: List[Document]
 
-    def __init__(self, api_key: str, model_name: WhisperRemoteModel = "whisper-1"):
+    def __init__(
+        self, api_key: str, model_name: WhisperRemoteModel = "whisper-1", api_base: str = "https://api.openai.com/v1"
+    ):
         """
         Transcribes a list of audio files into a list of Documents.
 
         :param api_key: OpenAI API key.
+        :param api_base: OpenAI url base, default to `https://api.openai.com/v1`
         :param model_name_or_path: Name of the model to use. It now accepts only `whisper-1`.
         """
         if model_name not in get_args(WhisperRemoteModel):
@@ -109,7 +112,7 @@ class RemoteWhisperTranscriber:
         :returns: a list of transcriptions as they are produced by the Whisper API (JSON).
         """
         translate = kwargs.pop("translate", False)
-        url = f"https://api.openai.com/v1/audio/{'translations' if translate else 'transcriptions'}"
+        url = f"{self.base_url}/audio/{'translations' if translate else 'transcriptions'}"
         data = {"model": self.model_name, **kwargs}
         headers = {"Authorization": f"Bearer {self.api_key}"}
 

--- a/test/nodes/test_generator.py
+++ b/test/nodes/test_generator.py
@@ -233,7 +233,9 @@ def test_openai_answer_generator_pipeline_max_tokens():
 
     # mock load_openai_tokenizer to avoid accessing the internet to init tiktoken
     with patch("haystack.nodes.answer_generator.openai.load_openai_tokenizer"):
-        openai_generator = OpenAIAnswerGenerator(api_key="fake_api_key", model="text-babbage-001", top_k=1)
+        openai_generator = OpenAIAnswerGenerator(
+            api_key="fake_api_key", model="text-babbage-001", top_k=1, base_url="https://api.openai.com/v1"
+        )
 
         pipeline.add_node(component=openai_generator, name="generator", inputs=["Query"])
         openai_generator.run = create_autospec(openai_generator.run)

--- a/test/preview/components/audio/test_whisper_remote.py
+++ b/test/preview/components/audio/test_whisper_remote.py
@@ -26,9 +26,10 @@ class TestRemoteWhisperTranscriber(BaseTestComponent):
 
     @pytest.mark.unit
     def test_init_default(self):
-        transcriber = RemoteWhisperTranscriber(api_key="just a test")
+        transcriber = RemoteWhisperTranscriber(api_key="just a test", api_base="https://api.openai.com/v1")
         assert transcriber.model_name == "whisper-1"
         assert transcriber.api_key == "just a test"
+        assert transcriber.api_base == "https://api.openai.com/v1"
 
     @pytest.mark.unit
     def test_init_no_key(self):
@@ -150,7 +151,7 @@ class TestRemoteWhisperTranscriber(BaseTestComponent):
             requests_params.pop("files")
             assert requests_params == {
                 "method": "post",
-                "url": "https://api.openai.com/v1/audio/translations",
+                "url": "{self.base_url}/audio/translations",
                 "data": {"model": "whisper-1"},
                 "headers": {"Authorization": f"Bearer whatever"},
                 "timeout": OPENAI_TIMEOUT,

--- a/test/preview/components/audio/test_whisper_remote.py
+++ b/test/preview/components/audio/test_whisper_remote.py
@@ -151,7 +151,7 @@ class TestRemoteWhisperTranscriber(BaseTestComponent):
             requests_params.pop("files")
             assert requests_params == {
                 "method": "post",
-                "url": "{self.base_url}/audio/translations",
+                "url": "https://api.openai.com/v1/audio/translations",
                 "data": {"model": "whisper-1"},
                 "headers": {"Authorization": f"Bearer whatever"},
                 "timeout": OPENAI_TIMEOUT,


### PR DESCRIPTION
### Related Issues
- fixes #4923 

### Proposed Changes:
Not changing the current behaviour, by adding `api_base` similar to openai.api_base.
This makes the openai api simple to reach, in case of a proxy address.

### How did you test it?
- Did not manage yet to run the tests locally.
### Notes for the reviewer
<!-- E.g. point out section where the reviewer  -->

### Checklist
- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added tests that demonstrate the correct behavior of the change
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
