### PR TITLE
Add ConversationalAgentWithTools adapted for v.17.x branch

### DIFF
--- a/examples/conversational_agent_with_tools.py
+++ b/examples/conversational_agent_with_tools.py
@@ -1,0 +1,75 @@
+import os
+
+from haystack.agents import Tool
+from haystack.agents.base import ToolsManager
+from haystack.agents.conversational import ConversationalAgentWithTools
+from haystack.agents.types import Color
+from haystack.nodes import PromptNode, WebRetriever, PromptTemplate
+from haystack.pipelines import WebQAPipeline
+
+search_key = os.environ.get("SERPERDEV_API_KEY")
+if not search_key:
+    raise ValueError("Please set the SERPERDEV_API_KEY environment variable")
+
+openai_key = os.environ.get("OPENAI_API_KEY")
+if not search_key:
+    raise ValueError("Please set the OPENAI_API_KEY environment variable")
+
+prompt_text = """
+Synthesize a comprehensive answer from the following most relevant paragraphs and the given question.
+Provide a clear and concise answer, no longer than 10-20 words.
+\n\n Paragraphs: {documents} \n\n Question: {query} \n\n Answer:
+"""
+
+prompt_node = PromptNode(
+    "gpt-3.5-turbo",
+    default_prompt_template=PromptTemplate("lfqa", prompt_text=prompt_text),
+    api_key=openai_key,
+    max_length=256,
+)
+
+web_retriever = WebRetriever(api_key=search_key, top_search_results=3, mode="snippets")
+pipeline = WebQAPipeline(retriever=web_retriever, prompt_node=prompt_node)
+
+conversation_history = Tool(
+    name="conversation_history",
+    pipeline_or_node=lambda tool_input: agent.memory.load(),  # type: ignore
+    description="useful for when you need to remember what you've already discussed.",
+    logging_color=Color.MAGENTA,
+)
+web_qa_tool = Tool(
+    name="Search",
+    pipeline_or_node=pipeline,
+    description="useful for when you need to Google questions.",
+    output_variable="results",
+)
+pn = PromptNode(
+    "gpt-3.5-turbo",
+    api_key=os.environ.get("OPENAI_API_KEY"),
+    max_length=256,
+    stop_words=["Observation:"],
+    model_kwargs={"temperature": 0.5, "top_p": 0.9},
+)
+
+agent = ConversationalAgentWithTools(pn, tools_manager=ToolsManager(tools=[web_qa_tool, conversation_history]))
+
+test = False
+if test:
+    questions = [
+        "Why was Jamie Foxx recently hospitalized?",
+        "Where was he hospitalized?",
+        "What movie was he filming at the time?",
+        "Who is Jamie's female co-star in the movie he was filing at that time?",
+        "Tell me more about her, who is her partner?",
+    ]
+    for question in questions:
+        agent.run(question)
+else:
+    while True:
+        user_input = input("\nHuman (type 'exit' or 'quit' to quit, 'memory' for agent's memory): ")
+        if user_input.lower() == "exit" or user_input.lower() == "quit":
+            break
+        if user_input.lower() == "memory":
+            print("\nMemory:\n", agent.memory.load())
+        else:
+            assistant_response = agent.run(user_input)

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -206,6 +206,19 @@ class ToolsManager:
         return None, None
 
 
+def react_parameter_resolver(query: str, agent: Agent, agent_step: AgentStep, **kwargs) -> Dict[str, Any]:
+    """
+    A parameter resolver for ReAct based agents that returns the query, the tool names, the tool names
+    with descriptions, and the transcript (internal monologue).
+    """
+    return {
+        "query": query,
+        "tool_names": agent.tm.get_tool_names(),
+        "tool_names_with_descriptions": agent.tm.get_tool_names_with_descriptions(),
+        "transcript": agent_step.transcript,
+    }
+
+
 class Agent:
     """
     An Agent answers queries using the tools you give to it. The tools are pipelines or nodes. The Agent uses a large
@@ -268,14 +281,6 @@ class Agent:
                 f"Prompt template '{prompt_template}' not found. Please check the spelling of the template name."
             )
         self.prompt_template = resolved_prompt_template
-        react_parameter_resolver: Callable[
-            [str, Agent, AgentStep, Dict[str, Any]], Dict[str, Any]
-        ] = lambda query, agent, agent_step, **kwargs: {
-            "query": query,
-            "tool_names": agent.tm.get_tool_names(),
-            "tool_names_with_descriptions": agent.tm.get_tool_names_with_descriptions(),
-            "transcript": agent_step.transcript,
-        }
         self.prompt_parameters_resolver = (
             prompt_parameters_resolver if prompt_parameters_resolver else react_parameter_resolver
         )

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -63,6 +63,7 @@ class Tool:
             TranslationWrapperPipeline,
             RetrieverQuestionGenerationPipeline,
             WebQAPipeline,
+            Callable[[Any], str],
         ],
         description: str,
         output_variable: str = "results",
@@ -85,6 +86,8 @@ class Tool:
             result = self.pipeline_or_node.run(query=tool_input, params=params)
         elif isinstance(self.pipeline_or_node, BaseRetriever):
             result = self.pipeline_or_node.run(query=tool_input, root_node="Query")
+        elif callable(self.pipeline_or_node):
+            result = self.pipeline_or_node(tool_input)
         else:
             result = self.pipeline_or_node.run(query=tool_input)
         return self._process_result(result)

--- a/haystack/agents/conversational.py
+++ b/haystack/agents/conversational.py
@@ -1,8 +1,9 @@
-from typing import Optional, Callable
+from typing import Optional, Callable, Union
 
 from haystack.agents import Agent
-from haystack.agents.memory import Memory, ConversationMemory
-from haystack.nodes import PromptNode
+from haystack.agents.base import ToolsManager
+from haystack.agents.memory import Memory, ConversationMemory, ConversationSummaryMemory
+from haystack.nodes import PromptNode, PromptTemplate
 
 
 class ConversationalAgent(Agent):
@@ -59,4 +60,82 @@ class ConversationalAgent(Agent):
             if prompt_parameters_resolver
             else lambda query, agent, **kwargs: {"query": query, "history": agent.memory.load()},
             final_answer_pattern=r"^([\s\S]+)$",
+        )
+
+
+class ConversationalAgentWithTools(Agent):
+    """
+    A ConversationalAgentWithTools is an extension of the Agent class that supports the use of tools in
+    conversational chat applications. This agent can make use of the ToolsManager to manage a set of tools
+    and seamlessly integrate them into the conversation.
+
+    Example usage:
+
+    ```
+    import os
+
+    from haystack.agents.base import ConversationalAgentWithTools
+    from haystack.agents.memory import ConversationSummaryMemory
+    from haystack.nodes import PromptNode
+    from haystack.tools import ToolsManager, Tool
+
+    # Initialize a PromptNode and a ToolsManager with the desired tools
+    pn = PromptNode("gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"), max_length=256)
+    tools_manager = ToolsManager([Tool(name="ExampleTool", pipeline_or_node=example_tool_node)])
+
+    # Create the ConversationalAgentWithTools instance
+    agent = ConversationalAgentWithTools(pn, tools_manager=tools_manager)
+
+    # Use the agent in a chat application
+    while True:
+        user_input = input("Human (type 'exit' or 'quit' to quit): ")
+        if user_input.lower() == "exit" or user_input.lower() == "quit":
+            break
+        else:
+            assistant_response = agent.run(user_input)
+            print("\nAssistant:", assistant_response)
+    ```
+    """
+
+    def __init__(
+        self,
+        prompt_node: PromptNode,
+        prompt_template: Optional[Union[str, PromptTemplate]] = None,
+        tools_manager: Optional[ToolsManager] = None,
+        max_steps: int = 5,
+        memory: Optional[Memory] = None,
+        prompt_parameters_resolver: Optional[Callable] = None,
+        final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
+    ):
+        """
+        Creates an instance of ConversationalAgentWithTools.
+
+        :param prompt_node: A PromptNode used to communicate with LLM.
+        :param prompt_template: A string or PromptTemplate instance to use as the prompt template. If no prompt_template
+        is provided, the agent will use the "conversational-agent-with-tools" template.
+        :param tools_manager: A ToolsManager instance to manage tools for the agent. If no tools_manager is provided,
+        the agent will install an empty ToolsManager instance.
+        :param max_steps: The maximum number of steps for the agent to take, defaults to 5.
+        :param memory: A memory object for storing conversation history and other relevant data, defaults to
+        ConversationSummaryMemory if no memory is provided.
+        :param prompt_parameters_resolver: An optional callable for resolving prompt template parameters,
+        defaults to keys: query, tool_names, tool_names_with_descriptions, transcript. Their values are set appropriately.
+        :param final_answer_pattern: A string or AgentAnswerParser instance for parsing the final answer, defaults to
+        a regex pattern capturing "Final Answer: " followed by any text.
+        """
+        super().__init__(
+            prompt_node=prompt_node,
+            prompt_template=prompt_template or "conversational-agent-with-tools",
+            tools_manager=tools_manager,
+            max_steps=max_steps,
+            memory=memory if memory else ConversationSummaryMemory(prompt_node),
+            prompt_parameters_resolver=prompt_parameters_resolver
+            if prompt_parameters_resolver
+            else lambda query, agent, agent_step, **kwargs: {
+                "query": query,
+                "tool_names": agent.tm.get_tool_names(),
+                "tool_names_with_descriptions": agent.tm.get_tool_names_with_descriptions(),
+                "transcript": agent_step.transcript,
+            },
+            final_answer_pattern=final_answer_pattern,
         )

--- a/haystack/agents/conversational.py
+++ b/haystack/agents/conversational.py
@@ -120,8 +120,7 @@ class ConversationalAgentWithTools(Agent):
         ConversationSummaryMemory if no memory is provided.
         :param prompt_parameters_resolver: An optional callable for resolving prompt template parameters,
         defaults to keys: query, tool_names, tool_names_with_descriptions, transcript. Their values are set appropriately.
-        :param final_answer_pattern: A string or AgentAnswerParser instance for parsing the final answer, defaults to
-        a regex pattern capturing "Final Answer: " followed by any text.
+        :param final_answer_pattern: A regular expression to extract the final answer from the text the Agent generated.
         """
         super().__init__(
             prompt_node=prompt_node,

--- a/haystack/agents/conversational.py
+++ b/haystack/agents/conversational.py
@@ -1,7 +1,7 @@
 from typing import Optional, Callable, Union
 
 from haystack.agents import Agent
-from haystack.agents.base import ToolsManager
+from haystack.agents.base import ToolsManager, react_parameter_resolver
 from haystack.agents.memory import Memory, ConversationMemory, ConversationSummaryMemory
 from haystack.nodes import PromptNode, PromptTemplate
 
@@ -130,11 +130,6 @@ class ConversationalAgentWithTools(Agent):
             memory=memory if memory else ConversationSummaryMemory(prompt_node),
             prompt_parameters_resolver=prompt_parameters_resolver
             if prompt_parameters_resolver
-            else lambda query, agent, agent_step, **kwargs: {
-                "query": query,
-                "tool_names": agent.tm.get_tool_names(),
-                "tool_names_with_descriptions": agent.tm.get_tool_names_with_descriptions(),
-                "transcript": agent_step.transcript,
-            },
+            else react_parameter_resolver,
             final_answer_pattern=final_answer_pattern,
         )

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -442,4 +442,23 @@ def get_predefined_prompt_templates() -> List[PromptTemplate]:
             name="conversational-summary",
             prompt_text="Condense the following chat transcript by shortening and summarizing the content without losing important information:\n{chat_transcript}\nCondensed Transcript:",
         ),
+        PromptTemplate(
+            name="conversational-agent-with-tools",
+            prompt_text="In the following conversation, a human user interacts with an AI Agent using the ChatGPT API. The human user poses questions, and the AI Agent goes through several steps to provide well-informed answers.\n"
+            "If the AI Agent knows the answer, the response begins with `Final Answer:` on a new line.\n"
+            "If the AI Agent is uncertain or concerned that the information may be outdated or inaccurate, it must use the available tools to find the most up-to-date information. The AI has access to these tools:\n"
+            "{tool_names_with_descriptions}\n"
+            "AI Agent responses must start with one of the following:\n"
+            "Thought: [AI Agent's reasoning process]\n"
+            "Tool: [{tool_names}] (on a new line) Tool Input: [input for the selected tool WITHOUT quotation marks and on a new line] (These must always be provided together and on separate lines.)\n"
+            "Final Answer: [final answer to the human user's question]\n"
+            "When selecting a tool, the AI Agent must provide both the `Tool:` and `Tool Input:` pair in the same response, but on separate lines. `Observation:` marks the beginning of a tool's result, and the AI Agent trusts these results.\n"
+            "The AI Agent must use the conversation_history tool to infer context when necessary.\n"
+            "If a question is vague or requires context, the AI Agent should explicitly use the conversation_history tool with a clear Tool Input focused on finding the relevant context.\n"
+            "The AI Agent should not ask the human user for additional information, clarification, or context.\n"
+            "If the AI Agent cannot find a specific answer after exhausting available tools and approaches, it answers with Final Answer: inconclusive\n"
+            "Question: {query}\n"
+            "Thought:\n"
+            "{transcript}\n",
+        ),
     ]

--- a/test/agents/test_conversational_agent_with_tools.py
+++ b/test/agents/test_conversational_agent_with_tools.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import MagicMock
+
+from haystack.agents import Tool
+from haystack.agents.conversational import ConversationalAgentWithTools
+from haystack.agents.memory import ConversationSummaryMemory, NoMemory
+from haystack.nodes import PromptNode
+
+
+@pytest.fixture
+def prompt_node():
+    prompt_node = PromptNode("google/flan-t5-xxl", api_key="fake_key", max_length=256)
+    return prompt_node
+
+
+@pytest.mark.unit
+def test_init(prompt_node):
+    agent = ConversationalAgentWithTools(prompt_node)
+
+    # Test normal case
+    assert isinstance(agent.memory, ConversationSummaryMemory)
+    assert callable(agent.prompt_parameters_resolver)
+    assert agent.max_steps == 5
+    assert agent.final_answer_pattern == r"Final Answer\s*:\s*(.*)"
+
+
+@pytest.mark.unit
+def test_tooling(prompt_node):
+    agent = ConversationalAgentWithTools(prompt_node)
+    # ConversationalAgentWithTools has no tools by default
+    assert not agent.tm.tools
+
+    # but can add tools
+    agent.tm.add_tool(Tool("ExampleTool", lambda x: x, description="Example tool"))
+    assert agent.tm.tools
+    assert agent.tm.tools["ExampleTool"].name == "ExampleTool"
+
+
+@pytest.mark.unit
+def test_agent_with_memory(prompt_node):
+    # Test with summary memory
+    agent = ConversationalAgentWithTools(prompt_node, memory=ConversationSummaryMemory(prompt_node))
+    assert isinstance(agent.memory, ConversationSummaryMemory)
+
+    # Test with no memory
+    agent = ConversationalAgentWithTools(prompt_node, memory=NoMemory())
+    assert isinstance(agent.memory, NoMemory)
+
+
+@pytest.mark.unit
+def test_run(prompt_node):
+    agent = ConversationalAgentWithTools(prompt_node)
+
+    # Mock the Agent run method
+    agent.run = MagicMock(return_value="Hello")
+    assert agent.run("query") == "Hello"
+    agent.run.assert_called_once_with("query")

--- a/test/agents/test_tools_manager.py
+++ b/test/agents/test_tools_manager.py
@@ -17,6 +17,14 @@ def tools_manager():
 
 
 @pytest.mark.unit
+def test_callable_tool():
+    # test that we can also pass a callable as a tool
+    tool_input = "Haystack"
+    tool = Tool(name="ToolA", pipeline_or_node=lambda x: x + x, description="Tool A Description")
+    assert tool.run(tool_input) == tool_input + tool_input
+
+
+@pytest.mark.unit
 def test_add_tool(tools_manager):
     new_tool = Tool(name="ToolC", pipeline_or_node=mock.Mock(), description="Tool C Description")
     tools_manager.add_tool(new_tool)

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -28,7 +28,7 @@ def get_api_key(request):
 def test_add_and_remove_template():
     with patch("haystack.nodes.prompt.prompt_node.PromptModel"):
         node = PromptNode()
-    total_count = 16
+    total_count = 17
     # Verifies default
     assert len(node.get_prompt_template_names()) == total_count
 


### PR DESCRIPTION
Related Issues
After adding ConversationalAgent with https://github.com/deepset-ai/haystack/pull/4931 we can now add support for ConversationalAgentWithTools
This PR is a v1.17.x adapted version of https://github.com/deepset-ai/haystack/pull/4940

Proposed Changes:
Adds widely discussed ConversationalAgentWithTools

How did you test it?
Unit tests, examples, see the examples directory

Notes for the reviewer
We also add an option to run callables as tools. Unit test added

### Checklist
- [ ] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added tests that demonstrate the correct behavior of the change
- [ ] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [ ] I documented my code
- [ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
