### PR TITLE
chore: Unpin typing_extensions and remove all its uses

### DIFF
--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -1,9 +1,4 @@
-from typing import Any, Dict, List, Optional, Union, Generator
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Any, Dict, List, Optional, Union, Generator, Literal
 
 import time
 import logging

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -18,12 +18,7 @@ Thanks for the great work!
 """
 
 import logging
-from typing import List, Union, Dict, Optional, Tuple, Any
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import List, Union, Dict, Optional, Tuple, Any, Literal
 
 import itertools
 import torch

--- a/haystack/nodes/file_converter/parsr.py
+++ b/haystack/nodes/file_converter/parsr.py
@@ -1,10 +1,5 @@
 import sys
-from typing import Optional, Dict, List, Any, Union, Tuple
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Optional, Dict, List, Any, Union, Tuple, Literal
 
 import json
 import copy

--- a/haystack/nodes/preprocessor/base.py
+++ b/haystack/nodes/preprocessor/base.py
@@ -1,9 +1,4 @@
-from typing import List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import List, Optional, Union, Literal
 
 from abc import abstractmethod
 

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -1,9 +1,4 @@
-from typing import List, Optional, Tuple, Dict, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import List, Optional, Tuple, Dict, Union, Literal
 
 import logging
 import itertools

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -2,13 +2,8 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, Literal
 from tenacity import retry, retry_if_exception_type, wait_exponential, stop_after_attempt
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
 
 import numpy as np
 import requests

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1,10 +1,5 @@
 from abc import abstractmethod
-from typing import List, Dict, Union, Optional, Any
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import List, Dict, Union, Optional, Any, Literal
 
 import logging
 from pathlib import Path

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -6,12 +6,7 @@ import itertools
 from functools import partial
 from hashlib import md5
 from time import time
-from typing import Dict, List, Optional, Any, Set, Tuple, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Dict, List, Optional, Any, Set, Tuple, Union, Literal
 
 import copy
 import json

--- a/haystack/pipelines/standard_pipelines.py
+++ b/haystack/pipelines/standard_pipelines.py
@@ -3,12 +3,7 @@ from abc import ABC
 from copy import deepcopy
 from functools import wraps
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Any, Dict, List, Optional, Union, Literal
 
 from haystack.document_stores.base import BaseDocumentStore, FilterType
 from haystack.nodes.answer_generator.base import BaseGenerator

--- a/haystack/pipelines/utils.py
+++ b/haystack/pipelines/utils.py
@@ -1,9 +1,4 @@
-from typing import Any, Dict, List, Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Any, Dict, List, Optional, Literal
 
 import re
 import sys

--- a/haystack/schema.py
+++ b/haystack/schema.py
@@ -3,7 +3,7 @@ import csv
 import hashlib
 import inspect
 
-from typing import Any, Optional, Dict, List, Union
+from typing import Any, Optional, Dict, List, Union, Literal
 
 from pathlib import Path
 from uuid import uuid4
@@ -12,12 +12,6 @@ import time
 import json
 import ast
 from dataclasses import asdict
-
-# The Literal type from typing_extension is safer to use as
-# the one from typing has different bugs in the different versions.
-# For more info see typing_extensions official docs:
-# https://typing-extensions.readthedocs.io/en/latest/#Literal
-from typing_extensions import Literal
 
 import numpy as np
 from numpy import ndarray

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -1,12 +1,7 @@
 import json
 from mimetypes import guess_type
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union, Literal
 
 import logging
 import os

--- a/haystack/utils/early_stopping.py
+++ b/haystack/utils/early_stopping.py
@@ -1,11 +1,6 @@
 import logging
 
-from typing import Optional, Tuple, List, Dict, Callable, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
+from typing import Optional, Tuple, List, Dict, Callable, Union, Literal
 
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,6 @@ classifiers = [
 dependencies = [
   "requests",
   "pydantic",
-  # FIXME: typing_extensions 4.6.0 broke Pydantic, so we pin it temporarily
-  # waiting for the release. For more info see this issue:
-  # https://github.com/pydantic/pydantic/issues/5821
-  "typing_extensions==4.5.0",
   "transformers[torch,sentencepiece]==4.29.1",
   "pandas",
   "rank_bm25",

--- a/rest_api/rest_api/schema.py
+++ b/rest_api/rest_api/schema.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Literal
 import numpy as np
 import pandas as pd
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
 
 from pydantic import BaseModel, Field, Extra
 from pydantic import BaseConfig


### PR DESCRIPTION
### Related Issues
- fixes #4997

### Proposed Changes:

Remove the pinned version of `typing_extensions` and all its uses in the codebase as it's not necessary.

### How did you test it?

`python -c 'import haystack'` and it went smooth.

### Notes for the reviewer

Installing `pydantic` still brings in `typing_extensions` but we must not rely on it.
