### PR TITLE
fix: remove `prompt_text` in examples

### DIFF
--- a/examples/agent_multihop_qa.py
+++ b/examples/agent_multihop_qa.py
@@ -84,7 +84,7 @@ Question: {query}
 Thought:
 {transcript}
 """
-few_shot_agent_template = PromptTemplate("few-shot-react", prompt_text=few_shot_prompt)
+few_shot_agent_template = PromptTemplate(few_shot_prompt)
 prompt_node = PromptNode(
     "gpt-3.5-turbo", api_key=os.environ.get("OPENAI_API_KEY"), max_length=512, stop_words=["Observation:"]
 )

--- a/examples/web_lfqa.py
+++ b/examples/web_lfqa.py
@@ -20,10 +20,7 @@ Your answer should be in your own words and be no longer than 50 words.
 """
 
 prompt_node = PromptNode(
-    "text-davinci-003",
-    default_prompt_template=PromptTemplate("lfqa", prompt_text=prompt_text),
-    api_key=openai_key,
-    max_length=256,
+    "text-davinci-003", default_prompt_template=PromptTemplate(prompt_text), api_key=openai_key, max_length=256
 )
 
 web_retriever = WebRetriever(api_key=search_key, top_search_results=2, mode="preprocessed_documents")


### PR DESCRIPTION
### Related Issues
- fixes n/a

### Proposed Changes:
- Remove mentions to `prompt_text` in the examples

### How did you test it?
n/a

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
