### PR TITLE
fix: Use queries from aggregated labels in benchmarks

### DIFF
--- a/test/benchmarks/retriever.py
+++ b/test/benchmarks/retriever.py
@@ -91,8 +91,9 @@ def benchmark_querying(pipeline: Pipeline, eval_set: Path) -> Dict:
     """
     try:
         # Load eval data
-        labels, queries = load_eval_data(eval_set)
+        labels, _ = load_eval_data(eval_set)
         multi_labels = aggregate_labels(labels)
+        queries = [label.query for label in multi_labels]
 
         # Run querying
         start_time = perf_counter()

--- a/test/benchmarks/retriever_reader.py
+++ b/test/benchmarks/retriever_reader.py
@@ -41,8 +41,9 @@ def benchmark_querying(pipeline: Pipeline, eval_set: Path) -> Dict:
     """
     try:
         # Load eval data
-        labels, queries = load_eval_data(eval_set)
+        labels, _ = load_eval_data(eval_set)
         multi_labels = aggregate_labels(labels)
+        queries = [label.query for label in multi_labels]
 
         # Run querying
         start_time = perf_counter()

--- a/test/benchmarks/run.py
+++ b/test/benchmarks/run.py
@@ -59,7 +59,8 @@ def run_benchmark(pipeline_yaml: Path) -> Dict:
     else:
         raise ValueError("Pipeline must be a retriever, reader, or retriever-reader pipeline.")
 
-    results["config_file"] = pipeline_config
+    pipeline_config["benchmark_config"] = benchmark_config
+    results["config"] = pipeline_config
     return results
 
 


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR changes the benchmark script such that we use the queries from the aggregated labels to run the benchmarks on. Also, it adds the benchmark config to the final JSON file. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Manual verification.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
