### PR TITLE
chore: block all HTTP requests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[all,dev]
+        run: |
+          pip install .[all,dev]
+          pip uninstall -y requests
 
       - name: Run
         run: pytest --cov-report xml:coverage.xml --cov="haystack" -m "unit" test/${{ matrix.topic }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,9 +128,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: |
-          pip install .[all,dev]
-          pip uninstall -y requests
+        run: pip install .[all,dev]
 
       - name: Run
         run: pytest --cov-report xml:coverage.xml --cov="haystack" -m "unit" test/${{ matrix.topic }}

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -3,7 +3,12 @@ import os
 import re
 from typing import Tuple
 from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+
+from events import Events
+
+from haystack.agents.types import AgentTokenStreamingHandler
 from test.conftest import MockRetriever, MockPromptNode
 from unittest import mock
 import pytest
@@ -290,17 +295,6 @@ def test_tool_processes_answer_result_and_document_result():
     assert tool._process_result(Document(content="content")) == "content"
 
 
-def test_invalid_agent_template():
-    pn = PromptNode()
-    with pytest.raises(ValueError, match="some_non_existing_template not supported"):
-        Agent(prompt_node=pn, prompt_template="some_non_existing_template")
-
-    # if prompt_template is None, then we'll use zero-shot-react
-    a = Agent(prompt_node=pn, prompt_template=None)
-    assert isinstance(a.prompt_template, PromptTemplate)
-    assert a.prompt_template.name == "zero-shot-react"
-
-
 @pytest.mark.unit
 @patch.object(PromptNode, "prompt")
 @patch("haystack.nodes.prompt.prompt_node.PromptModel")
@@ -315,3 +309,25 @@ def test_default_template_order(mock_model, mock_prompt):
 
     a = Agent(prompt_node=pn, prompt_template="translation")
     assert a.prompt_template.name == "translation"
+
+
+@pytest.mark.unit
+def test_agent_with_unknown_prompt_template():
+    prompt_node = Mock()
+    prompt_node.get_prompt_template.return_value = None
+    with pytest.raises(ValueError, match="Prompt template 'invalid' not found"):
+        Agent(prompt_node=prompt_node, prompt_template="invalid")
+
+
+@pytest.mark.unit
+def test_agent_token_streaming_handler():
+    e = Events("on_new_token")
+
+    mock_callback = Mock()
+    e.on_new_token += mock_callback  # register the mock callback to the event
+
+    handler = AgentTokenStreamingHandler(events=e)
+    result = handler("test")
+
+    assert result == "test"
+    mock_callback.assert_called_once_with("test")  # assert that the mock callback was called with "test"

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 from typing import Tuple
-from unittest.mock import patch
 from unittest.mock import Mock, patch
 
 

--- a/test/agents/test_conversational_agent.py
+++ b/test/agents/test_conversational_agent.py
@@ -1,17 +1,14 @@
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock
 
 from haystack.agents.conversational import ConversationalAgent
 from haystack.agents.memory import ConversationSummaryMemory, ConversationMemory, NoMemory
-from haystack.nodes import PromptNode
 
 
 @pytest.mark.unit
 def test_init():
-    with patch("haystack.nodes.prompt.prompt_template.fetch_from_prompthub") as mock_prompthub:
-        mock_prompthub.side_effect = [("This is a test prompt. Use your knowledge to answer this question: {question}")]
-        prompt_node = PromptNode()
-        agent = ConversationalAgent(prompt_node)
+    prompt_node = Mock()
+    agent = ConversationalAgent(prompt_node)
 
     # Test normal case
     assert isinstance(agent.memory, ConversationMemory)
@@ -25,32 +22,26 @@ def test_init():
 
 @pytest.mark.unit
 def test_init_with_summary_memory():
-    with patch("haystack.nodes.prompt.prompt_template.fetch_from_prompthub") as mock_prompthub:
-        mock_prompthub.side_effect = [("This is a test prompt. Use your knowledge to answer this question: {question}")]
-        prompt_node = PromptNode(default_prompt_template="this is a test")
-        # Test with summary memory
-        agent = ConversationalAgent(prompt_node, memory=ConversationSummaryMemory(prompt_node))
-        assert isinstance(agent.memory, ConversationSummaryMemory)
+    # Test with summary memory
+    prompt_node = Mock()
+    agent = ConversationalAgent(prompt_node, memory=ConversationSummaryMemory(prompt_node))
+    assert isinstance(agent.memory, ConversationSummaryMemory)
 
 
 @pytest.mark.unit
 def test_init_with_no_memory():
-    with patch("haystack.nodes.prompt.prompt_template.fetch_from_prompthub") as mock_prompthub:
-        mock_prompthub.side_effect = [("This is a test prompt. Use your knowledge to answer this question: {question}")]
-        prompt_node = PromptNode()
-        # Test with no memory
-        agent = ConversationalAgent(prompt_node, memory=NoMemory())
-        assert isinstance(agent.memory, NoMemory)
+    prompt_node = Mock()
+    # Test with no memory
+    agent = ConversationalAgent(prompt_node, memory=NoMemory())
+    assert isinstance(agent.memory, NoMemory)
 
 
 @pytest.mark.unit
 def test_run():
-    with patch("haystack.nodes.prompt.prompt_template.fetch_from_prompthub") as mock_prompthub:
-        mock_prompthub.side_effect = [("This is a test prompt. Use your knowledge to answer this question: {question}")]
-        prompt_node = PromptNode()
-        agent = ConversationalAgent(prompt_node)
+    prompt_node = Mock()
+    agent = ConversationalAgent(prompt_node)
 
-        # Mock the Agent run method
-        agent.run = MagicMock(return_value="Hello")
-        assert agent.run("query") == "Hello"
-        agent.run.assert_called_once_with("query")
+    # Mock the Agent run method
+    agent.run = MagicMock(return_value="Hello")
+    assert agent.run("query") == "Hello"
+    agent.run.assert_called_once_with("query")

--- a/test/agents/test_conversational_agent.py
+++ b/test/agents/test_conversational_agent.py
@@ -3,11 +3,12 @@ from unittest.mock import MagicMock, Mock
 
 from haystack.agents.conversational import ConversationalAgent
 from haystack.agents.memory import ConversationSummaryMemory, ConversationMemory, NoMemory
+from test.conftest import MockPromptNode
 
 
 @pytest.mark.unit
 def test_init():
-    prompt_node = Mock()
+    prompt_node = MockPromptNode()
     agent = ConversationalAgent(prompt_node)
 
     # Test normal case
@@ -23,14 +24,14 @@ def test_init():
 @pytest.mark.unit
 def test_init_with_summary_memory():
     # Test with summary memory
-    prompt_node = Mock()
+    prompt_node = MockPromptNode()
     agent = ConversationalAgent(prompt_node, memory=ConversationSummaryMemory(prompt_node))
     assert isinstance(agent.memory, ConversationSummaryMemory)
 
 
 @pytest.mark.unit
 def test_init_with_no_memory():
-    prompt_node = Mock()
+    prompt_node = MockPromptNode()
     # Test with no memory
     agent = ConversationalAgent(prompt_node, memory=NoMemory())
     assert isinstance(agent.memory, NoMemory)
@@ -38,10 +39,11 @@ def test_init_with_no_memory():
 
 @pytest.mark.unit
 def test_run():
-    prompt_node = Mock()
+    prompt_node = MockPromptNode()
     agent = ConversationalAgent(prompt_node)
 
     # Mock the Agent run method
-    agent.run = MagicMock(return_value="Hello")
-    assert agent.run("query") == "Hello"
-    agent.run.assert_called_once_with("query")
+    result = agent.run("query")
+
+    # empty answer
+    assert result["answers"][0].answer == ""

--- a/test/agents/test_tools_manager.py
+++ b/test/agents/test_tools_manager.py
@@ -1,9 +1,10 @@
 import unittest
+from typing import Optional, Union, List, Dict, Any
 from unittest import mock
 
 import pytest
 
-from haystack import Pipeline, Answer, Document
+from haystack import Pipeline, Answer, Document, BaseComponent, MultiLabel
 from haystack.agents.base import ToolsManager, Tool
 
 
@@ -160,3 +161,57 @@ def test_extract_tool_name_and_empty_tool_input(tools_manager):
     for example in examples:
         tool_name, tool_input = tools_manager.extract_tool_name_and_tool_input(example)
         assert tool_name == "Search" and tool_input == ""
+
+
+@pytest.mark.unit
+def test_node_as_tool():
+    # test that a component can be used as a tool
+    class ToolComponent(BaseComponent):
+        outgoing_edges = 1
+
+        def run_batch(
+            self,
+            queries: Optional[Union[str, List[str]]] = None,
+            file_paths: Optional[List[str]] = None,
+            labels: Optional[Union[MultiLabel, List[MultiLabel]]] = None,
+            documents: Optional[Union[List[Document], List[List[Document]]]] = None,
+            meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+            params: Optional[dict] = None,
+            debug: Optional[bool] = None,
+        ):
+            pass
+
+        def run(self, **kwargs):
+            return "mocked_output"
+
+    tool = Tool(name="ToolA", pipeline_or_node=ToolComponent(), description="Tool A Description")
+    assert tool.run("input") == "mocked_output"
+
+
+@pytest.mark.unit
+def test_tools_manager_exception():
+    # test that a component can be used as a tool
+    class ToolComponent(BaseComponent):
+        outgoing_edges = 1
+
+        def run_batch(
+            self,
+            queries: Optional[Union[str, List[str]]] = None,
+            file_paths: Optional[List[str]] = None,
+            labels: Optional[Union[MultiLabel, List[MultiLabel]]] = None,
+            documents: Optional[Union[List[Document], List[List[Document]]]] = None,
+            meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+            params: Optional[dict] = None,
+            debug: Optional[bool] = None,
+        ):
+            pass
+
+        def run(self, **kwargs):
+            raise Exception("mocked_exception")
+
+    fake_llm_response = "need to find out what city he was born.\nTool: Search\nTool Input: Where was Jeremy born"
+    tool = Tool(name="ToolA", pipeline_or_node=ToolComponent(), description="Tool A Description")
+    tools_manager = ToolsManager(tools=[tool])
+
+    with pytest.raises(Exception):
+        tools_manager.run_tool(llm_response=fake_llm_response)

--- a/test/agents/test_tools_manager.py
+++ b/test/agents/test_tools_manager.py
@@ -190,7 +190,7 @@ def test_node_as_tool():
 
 @pytest.mark.unit
 def test_tools_manager_exception():
-    # test that a component can be used as a tool
+    # tests exception raising in tools manager
     class ToolComponent(BaseComponent):
         outgoing_edges = 1
 
@@ -210,7 +210,7 @@ def test_tools_manager_exception():
             raise Exception("mocked_exception")
 
     fake_llm_response = "need to find out what city he was born.\nTool: Search\nTool Input: Where was Jeremy born"
-    tool = Tool(name="ToolA", pipeline_or_node=ToolComponent(), description="Tool A Description")
+    tool = Tool(name="Search", pipeline_or_node=ToolComponent(), description="Search")
     tools_manager = ToolsManager(tools=[tool])
 
     with pytest.raises(Exception):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -848,8 +848,6 @@ def request_blocker(request: pytest.FixtureRequest, monkeypatch):
     marker = request.node.get_closest_marker("unit")
     if marker is None:
         return
-    # monkeypatch.delattr("requests.sessions.Session")
-    # monkeypatch.delattr("requests_cache.session.CachedSession")
 
     def urlopen_mock(self, method, url, *args, **kwargs):
         raise RuntimeError(f"The test was about to {method} {self.scheme}://{self.host}{url}")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -847,5 +847,10 @@ def request_blocker(request: pytest.FixtureRequest, monkeypatch):
     marker = request.node.get_closest_marker("unit")
     if marker is None:
         return
-    monkeypatch.delattr("requests.sessions.Session")
-    monkeypatch.delattr("requests_cache.session.CachedSession")
+    # monkeypatch.delattr("requests.sessions.Session")
+    # monkeypatch.delattr("requests_cache.session.CachedSession")
+
+    def urlopen_mock(self, method, url, *args, **kwargs):
+        raise RuntimeError(f"The test was about to {method} {self.scheme}://{self.host}{url}")
+
+    monkeypatch.setattr("urllib3.connectionpool.HTTPConnectionPool.urlopen", urlopen_mock)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import os
 import re
 from functools import wraps
+from unittest.mock import patch
 
 import requests_cache
 import responses
@@ -854,3 +855,9 @@ def request_blocker(request: pytest.FixtureRequest, monkeypatch):
         raise RuntimeError(f"The test was about to {method} {self.scheme}://{self.host}{url}")
 
     monkeypatch.setattr("urllib3.connectionpool.HTTPConnectionPool.urlopen", urlopen_mock)
+
+
+@pytest.fixture
+def mock_auto_tokenizer():
+    with patch("transformers.AutoTokenizer.from_pretrained", autospec=True) as mock_from_pretrained:
+        yield mock_from_pretrained

--- a/test/nodes/test_generator.py
+++ b/test/nodes/test_generator.py
@@ -15,7 +15,7 @@ from ..conftest import fail_at_version
 
 @pytest.mark.unit
 @fail_at_version(1, 18)
-def test_seq2seq_deprecation():
+def test_seq2seq_deprecation(mock_auto_tokenizer):
     with pytest.warns(DeprecationWarning):
         try:
             Seq2SeqGenerator("non_existing_model/model")

--- a/test/prompt/invocation_layer/test_anthropic_claude.py
+++ b/test/prompt/invocation_layer/test_anthropic_claude.py
@@ -9,19 +9,19 @@ from haystack.nodes.prompt.invocation_layer import AnthropicClaudeInvocationLaye
 
 
 @pytest.fixture
-def mock_tokenizer():
+def mock_claude_tokenizer():
     with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.Tokenizer", autospec=True) as mock_tokenizer:
         yield mock_tokenizer
 
 
 @pytest.fixture
-def mock_request():
+def mock_claude_request():
     with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_request:
         yield mock_request
 
 
 @pytest.mark.unit
-def test_default_constructor(mock_tokenizer, mock_request):
+def test_default_constructor(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     assert layer.api_key == "some_fake_key"
@@ -31,7 +31,7 @@ def test_default_constructor(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_ignored_kwargs_are_filtered_in_init(mock_tokenizer, mock_request):
+def test_ignored_kwargs_are_filtered_in_init(mock_claude_tokenizer, mock_claude_request):
     kwargs = {
         "temperature": 1,
         "top_p": 5,
@@ -56,7 +56,7 @@ def test_ignored_kwargs_are_filtered_in_init(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_invoke_with_no_kwargs(mock_tokenizer, mock_request):
+def test_invoke_with_no_kwargs(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     with pytest.raises(ValueError) as e:
@@ -65,12 +65,12 @@ def test_invoke_with_no_kwargs(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_invoke_with_prompt_only(mock_tokenizer, mock_request):
+def test_invoke_with_prompt_only(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     # Create a fake response
     mock_response = Mock(**{"status_code": 200, "ok": True, "json.return_value": {"completion": "some_result "}})
-    mock_request.return_value = mock_response
+    mock_claude_request.return_value = mock_response
 
     res = layer.invoke(prompt="Some prompt")
     assert len(res) == 1
@@ -78,7 +78,7 @@ def test_invoke_with_prompt_only(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_invoke_with_kwargs(mock_tokenizer, mock_request):
+def test_invoke_with_kwargs(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     # Create a fake response
@@ -104,7 +104,7 @@ def test_invoke_with_kwargs(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_invoke_with_none_stop_words(mock_tokenizer, mock_request):
+def test_invoke_with_none_stop_words(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     # Create a fake response
@@ -130,7 +130,7 @@ def test_invoke_with_none_stop_words(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_invoke_with_stream(mock_tokenizer, mock_request):
+def test_invoke_with_stream(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     # Create a fake streamed response
@@ -155,7 +155,7 @@ def test_invoke_with_stream(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_invoke_with_custom_stream_handler(mock_tokenizer, mock_request):
+def test_invoke_with_custom_stream_handler(mock_claude_tokenizer, mock_claude_request):
     # Create a mock stream handler that always return the same token when called
     mock_stream_handler = Mock()
     mock_stream_handler.return_value = "token"
@@ -190,7 +190,7 @@ def test_invoke_with_custom_stream_handler(mock_tokenizer, mock_request):
 
 
 @pytest.mark.unit
-def test_ensure_token_limit_fails_if_called_with_list(mock_tokenizer, mock_request):
+def test_ensure_token_limit_fails_if_called_with_list(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
     with pytest.raises(ValueError):
         layer._ensure_token_limit(prompt=[])
@@ -229,7 +229,7 @@ def test_ensure_token_limit_with_huge_max_length(caplog):
 
 
 @pytest.mark.unit
-def test_supports(mock_tokenizer, mock_request):
+def test_supports(mock_claude_tokenizer, mock_claude_request):
     layer = AnthropicClaudeInvocationLayer(api_key="some_fake_key")
 
     assert not layer.supports("claude")

--- a/test/prompt/invocation_layer/test_anthropic_claude.py
+++ b/test/prompt/invocation_layer/test_anthropic_claude.py
@@ -83,8 +83,8 @@ def test_invoke_with_kwargs(mock_tokenizer, mock_request):
 
     # Create a fake response
     mock_response = Mock(**{"status_code": 200, "ok": True, "json.return_value": {"completion": "some_result "}})
-    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_request:
-        mock_request.return_value = mock_response
+    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_invocation_request:
+        mock_invocation_request.return_value = mock_response
         res = layer.invoke(prompt="Some prompt", max_length=300, stop_words=["stop", "here"])
     assert len(res) == 1
     assert res[0] == "some_result"
@@ -99,8 +99,8 @@ def test_invoke_with_kwargs(mock_tokenizer, mock_request):
         "stream": False,
         "stop_sequences": ["stop", "here", "\n\nHuman: "],
     }
-    mock_request.assert_called_once()
-    assert mock_request.call_args.kwargs["data"] == json.dumps(expected_data)
+    mock_invocation_request.assert_called_once()
+    assert mock_invocation_request.call_args.kwargs["data"] == json.dumps(expected_data)
 
 
 @pytest.mark.unit
@@ -109,8 +109,8 @@ def test_invoke_with_none_stop_words(mock_tokenizer, mock_request):
 
     # Create a fake response
     mock_response = Mock(**{"status_code": 200, "ok": True, "json.return_value": {"completion": "some_result "}})
-    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_request:
-        mock_request.return_value = mock_response
+    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_invocation_request:
+        mock_invocation_request.return_value = mock_response
         res = layer.invoke(prompt="Some prompt", max_length=300, stop_words=None)
     assert len(res) == 1
     assert res[0] == "some_result"
@@ -125,8 +125,8 @@ def test_invoke_with_none_stop_words(mock_tokenizer, mock_request):
         "stream": False,
         "stop_sequences": ["\n\nHuman: "],
     }
-    mock_request.assert_called_once()
-    assert mock_request.call_args.kwargs["data"] == json.dumps(expected_data)
+    mock_invocation_request.assert_called_once()
+    assert mock_invocation_request.call_args.kwargs["data"] == json.dumps(expected_data)
 
 
 @pytest.mark.unit
@@ -146,8 +146,8 @@ def test_invoke_with_stream(mock_tokenizer, mock_request):
     mock_response = Mock(**{"__iter__": mock_iter})
 
     # Verifies expected result is returned
-    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_request:
-        mock_request.return_value = mock_response
+    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_invocation_request:
+        mock_invocation_request.return_value = mock_response
         res = layer.invoke(prompt="Some prompt", stream=True)
 
     assert len(res) == 1
@@ -175,8 +175,8 @@ def test_invoke_with_custom_stream_handler(mock_tokenizer, mock_request):
 
     mock_response = Mock(**{"__iter__": mock_iter})
 
-    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_request:
-        mock_request.return_value = mock_response
+    with patch("haystack.nodes.prompt.invocation_layer.anthropic_claude.request_with_retry") as mock_invocation_request:
+        mock_invocation_request.return_value = mock_response
         res = layer.invoke(prompt="Some prompt")
 
     assert len(res) == 1

--- a/test/prompt/invocation_layer/test_cohere.py
+++ b/test/prompt/invocation_layer/test_cohere.py
@@ -1,16 +1,10 @@
 import unittest
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 from haystack.nodes.prompt.invocation_layer.handlers import DefaultTokenStreamingHandler, TokenStreamingHandler
 from haystack.nodes.prompt.invocation_layer import CohereInvocationLayer
-
-
-@pytest.fixture
-def mock_auto_tokenizer():
-    with patch("transformers.AutoTokenizer.from_pretrained", autospec=True) as mock_from_pretrained:
-        yield mock_from_pretrained
 
 
 @pytest.mark.unit

--- a/test/prompt/invocation_layer/test_cohere.py
+++ b/test/prompt/invocation_layer/test_cohere.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -98,7 +98,7 @@ def test_streaming_stream_param(using_constructor, stream, mock_auto_tokenizer):
         assert mock_post.called
 
         # Check if stop_words are passed to _post as stop parameter
-        called_args, called_kwargs = mock_post.call_args
+        _, called_kwargs = mock_post.call_args
 
         # stream is always passed to _post
         assert "stream" in called_kwargs
@@ -139,7 +139,7 @@ def test_streaming_stream_handler_param(using_constructor, stream_handler, mock_
         assert mock_post.called
 
         # Check if stop_words are passed to _post as stop parameter
-        called_args, called_kwargs = mock_post.call_args
+        _, called_kwargs = mock_post.call_args
 
         # stream is always passed to _post
         assert "stream" in called_kwargs
@@ -148,7 +148,7 @@ def test_streaming_stream_handler_param(using_constructor, stream_handler, mock_
         if stream_handler:
             assert called_kwargs["stream"]
             # and stream_handler is passed as an instance of TokenStreamingHandler
-            called_args, called_kwargs = mock_post_stream.call_args
+            _, called_kwargs = mock_post_stream.call_args
             assert "stream_handler" in called_kwargs
             assert isinstance(called_kwargs["stream_handler"], TokenStreamingHandler)
         # if stream_handler is not used then stream is always False

--- a/test/prompt/invocation_layer/test_cohere.py
+++ b/test/prompt/invocation_layer/test_cohere.py
@@ -67,8 +67,6 @@ def test_invoke_with_stop_words(mock_auto_tokenizer):
         layer.invoke(prompt="Tell me hello", stop_words=stop_words)
 
     assert mock_post.called
-
-    # Check if stop_words are passed to _post as stop parameter
     called_args, _ = mock_post.call_args
     assert "end_sequences" in called_args[0]
     assert called_args[0]["end_sequences"] == stop_words
@@ -88,8 +86,6 @@ def test_streaming_stream_param_from_init(mock_auto_tokenizer):
         layer.invoke(prompt="Tell me hello")
 
     assert mock_post.called
-
-    # Check if stop_words are passed to _post as stop parameter
     _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
@@ -110,8 +106,6 @@ def test_streaming_stream_param_from_init_no_stream(mock_auto_tokenizer):
         layer.invoke(prompt="Tell me hello")
 
     assert mock_post.called
-
-    # Check if stop_words are passed to _post as stop parameter
     _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
@@ -132,8 +126,6 @@ def test_streaming_stream_param_from_invoke(mock_auto_tokenizer):
         layer.invoke(prompt="Tell me hello", stream=True)
 
     assert mock_post.called
-
-    # Check if stop_words are passed to _post as stop parameter
     _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
@@ -146,16 +138,14 @@ def test_streaming_stream_param_from_invoke_no_stream(mock_auto_tokenizer):
     """
     Test stream parameter is correctly passed from PromptNode to wire in CohereInvocationLayer from invoke
     """
-    layer = CohereInvocationLayer(model_name_or_path="command", api_key="fake_key")
+    layer = CohereInvocationLayer(model_name_or_path="command", api_key="fake_key", stream=True)
 
     with unittest.mock.patch("haystack.nodes.prompt.invocation_layer.CohereInvocationLayer._post") as mock_post:
         # Mock the response
         mock_post.return_value = Mock(text='{"generations":[{"text": "Hello there"}]}')
-        layer.invoke(prompt="Tell me hello")
+        layer.invoke(prompt="Tell me hello", stream=False)
 
     assert mock_post.called
-
-    # Check if stop_words are passed to _post as stop parameter
     _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -47,7 +47,7 @@ def test_constructor_with_model_name_only(mock_pipeline, mock_get_task):
 
     mock_pipeline.assert_called_once()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
 
     # device is set to cpu by default and device_map is empty
     assert kwargs["device"] == device("cpu")
@@ -90,7 +90,7 @@ def test_constructor_with_model_name_and_device_map(mock_pipeline, mock_get_task
     mock_pipeline.assert_called_once()
     mock_get_task.assert_called_once()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
 
     # device is NOT set; device_map is auto because device_map takes precedence over device
     assert not kwargs["device"]
@@ -113,7 +113,7 @@ def test_constructor_with_torch_dtype(mock_pipeline, mock_get_task):
     mock_pipeline.assert_called_once()
     mock_get_task.assert_called_once()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
     assert kwargs["torch_dtype"] == torch.float16
 
 
@@ -129,7 +129,7 @@ def test_constructor_with_torch_dtype_as_str(mock_pipeline, mock_get_task):
     mock_pipeline.assert_called_once()
     mock_get_task.assert_called_once()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
     assert kwargs["torch_dtype"] == torch.float16
 
 
@@ -145,7 +145,7 @@ def test_constructor_with_torch_dtype_auto(mock_pipeline, mock_get_task):
     mock_pipeline.assert_called_once()
     mock_get_task.assert_called_once()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
     assert kwargs["torch_dtype"] == "auto"
 
 
@@ -223,7 +223,7 @@ def test_constructor_with_custom_pretrained_model(mock_pipeline, mock_get_task):
     # mock_get_task is not called as we provided task_name parameter
     mock_get_task.assert_not_called()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
 
     # correct tokenizer and model are set as well
     assert kwargs["tokenizer"] == tokenizer
@@ -241,7 +241,7 @@ def test_constructor_with_invalid_kwargs(mock_pipeline, mock_get_task):
     mock_pipeline.assert_called_once()
     mock_get_task.assert_called_once()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
 
     # invalid kwargs are ignored and not passed to the pipeline
     assert "some_invalid_kwarg" not in kwargs
@@ -273,7 +273,7 @@ def test_constructor_with_various_kwargs(mock_pipeline, mock_get_task):
     # mock_get_task is not called as we provided task_name parameter
     mock_get_task.assert_not_called()
 
-    args, kwargs = mock_pipeline.call_args
+    _, kwargs = mock_pipeline.call_args
 
     # invalid kwargs are ignored and not passed to the pipeline
     assert "first_invalid_kwarg" not in kwargs
@@ -330,7 +330,7 @@ def test_streaming_stream_param_in_constructor(mock_pipeline, mock_get_task):
 
     layer.invoke(prompt="Tell me hello")
 
-    args, kwargs = layer.pipe.call_args
+    _, kwargs = layer.pipe.call_args
     assert "streamer" in kwargs and isinstance(kwargs["streamer"], HFTokenStreamingHandler)
 
 
@@ -344,7 +344,7 @@ def test_streaming_stream_handler_param_in_constructor(mock_pipeline, mock_get_t
 
     layer.invoke(prompt="Tell me hello")
 
-    args, kwargs = layer.pipe.call_args
+    _, kwargs = layer.pipe.call_args
     assert "streamer" in kwargs
     hf_streamer = kwargs["streamer"]
 
@@ -404,7 +404,7 @@ def test_stop_words_criteria_set(mock_pipeline, mock_get_task):
 
     layer.invoke(prompt="Tell me hello", stop_words=["hello", "world"])
 
-    args, kwargs = layer.pipe.call_args
+    _, kwargs = layer.pipe.call_args
     assert "stopping_criteria" in kwargs
     assert isinstance(kwargs["stopping_criteria"], StoppingCriteriaList)
     assert len(kwargs["stopping_criteria"]) == 1

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch, Mock
 import pytest
 import torch
 from torch import device
-from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, BloomForCausalLM, StoppingCriteriaList, GenerationConfig
+from transformers import AutoTokenizer, BloomForCausalLM, StoppingCriteriaList, GenerationConfig
 
 from haystack.nodes.prompt.invocation_layer import HFLocalInvocationLayer
 from haystack.nodes.prompt.invocation_layer.handlers import HFTokenStreamingHandler, DefaultTokenStreamingHandler
@@ -13,8 +13,11 @@ from haystack.nodes.prompt.invocation_layer.hugging_face import StopWordsCriteri
 @pytest.fixture
 def mock_pipeline():
     # mock transformers pipeline
+    # model returning some mocked text for pipeline invocation
     with patch("haystack.nodes.prompt.invocation_layer.hugging_face.pipeline") as mocked_pipeline:
-        mocked_pipeline.return_value = Mock(**{"model_name_or_path": None, "tokenizer.model_max_length": 100})
+        pipeline_mock = Mock(**{"model_name_or_path": None, "tokenizer.model_max_length": 100})
+        pipeline_mock.side_effect = lambda *args, **kwargs: [{"generated_text": "some mocked text"}]
+        mocked_pipeline.return_value = pipeline_mock
         yield mocked_pipeline
 
 
@@ -206,9 +209,8 @@ def test_constructor_with_custom_pretrained_model(mock_pipeline, mock_get_task):
     """
     Test that the constructor sets the pipeline with the pretrained model (if provided)
     """
-    # actual model and tokenizer passed to the pipeline
-    model = AutoModelForSeq2SeqLM.from_pretrained("hf-internal-testing/tiny-random-t5")
-    tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-t5")
+    model = Mock()
+    tokenizer = Mock()
 
     HFLocalInvocationLayer(
         model_name_or_path="irrelevant_when_model_is_provided",
@@ -258,7 +260,7 @@ def test_constructor_with_various_kwargs(mock_pipeline, mock_get_task):
     HFLocalInvocationLayer(
         "google/flan-t5-base",
         task_name="text2text-generation",
-        tokenizer=AutoTokenizer.from_pretrained("google/flan-t5-base"),
+        tokenizer=Mock(),
         config=Mock(),
         revision="1.1",
         device="cpu",
@@ -287,7 +289,7 @@ def test_constructor_with_various_kwargs(mock_pipeline, mock_get_task):
     assert len(kwargs) == 13
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_text_generation_model():
     # test simple prompting with text generation model
     # by default, we force the model not return prompt text
@@ -303,7 +305,7 @@ def test_text_generation_model():
     assert len(r[0]) > 0 and r[0].startswith("Hello big science!")
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_text_generation_model_via_custom_pretrained_model():
     tokenizer = AutoTokenizer.from_pretrained("bigscience/bigscience-small-testing")
     model = BloomForCausalLM.from_pretrained("bigscience/bigscience-small-testing")
@@ -320,12 +322,11 @@ def test_text_generation_model_via_custom_pretrained_model():
 
 
 @pytest.mark.unit
-def test_streaming_stream_param_in_constructor():
+def test_streaming_stream_param_in_constructor(mock_pipeline, mock_get_task):
     """
     Test stream parameter is correctly passed to pipeline invocation via HF streamer parameter
     """
     layer = HFLocalInvocationLayer(stream=True)
-    layer.pipe = MagicMock()
 
     layer.invoke(prompt="Tell me hello")
 
@@ -334,13 +335,12 @@ def test_streaming_stream_param_in_constructor():
 
 
 @pytest.mark.unit
-def test_streaming_stream_handler_param_in_constructor():
+def test_streaming_stream_handler_param_in_constructor(mock_pipeline, mock_get_task):
     """
     Test stream parameter is correctly passed to pipeline invocation
     """
     dtsh = DefaultTokenStreamingHandler()
     layer = HFLocalInvocationLayer(stream_handler=dtsh)
-    layer.pipe = MagicMock()
 
     layer.invoke(prompt="Tell me hello")
 
@@ -394,14 +394,13 @@ def test_supports(tmp_path):
 
 
 @pytest.mark.unit
-def test_stop_words_criteria_set():
+def test_stop_words_criteria_set(mock_pipeline, mock_get_task):
     """
     Test that stop words criteria is correctly set in pipeline invocation
     """
     layer = HFLocalInvocationLayer(
         model_name_or_path="hf-internal-testing/tiny-random-t5", task_name="text2text-generation"
     )
-    layer.pipe = MagicMock()
 
     layer.invoke(prompt="Tell me hello", stop_words=["hello", "world"])
 
@@ -468,7 +467,7 @@ def test_stop_words_not_being_found():
         assert word in result[0]
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_generation_kwargs_from_constructor():
     """
     Test that generation_kwargs are correctly passed to pipeline invocation from constructor
@@ -489,7 +488,7 @@ def test_generation_kwargs_from_constructor():
     mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9, "max_length": 100}, {})
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 def test_generation_kwargs_from_invoke():
     """
     Test that generation_kwargs passed to invoke are passed to the underlying HF model

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -510,7 +510,7 @@ def test_generation_kwargs_from_invoke():
 
 
 @pytest.mark.unit
-def test_prompt_handler_positive(mock_pipeline, mock_get_task, mock_auto_tokenizer):
+def test_ensure_token_limit_positive_mock(mock_pipeline, mock_get_task, mock_auto_tokenizer):
     # prompt of length 5 + max_length of 3 = 8, which is less than model_max_length of 10, so no resize
     mock_tokens = ["I", "am", "a", "tokenized", "prompt"]
     mock_prompt = "I am a tokenized prompt"
@@ -526,7 +526,7 @@ def test_prompt_handler_positive(mock_pipeline, mock_get_task, mock_auto_tokeniz
 
 
 @pytest.mark.unit
-def test_prompt_handler_negative(mock_pipeline, mock_get_task, mock_auto_tokenizer):
+def test_ensure_token_limit_negative_mock(mock_pipeline, mock_get_task, mock_auto_tokenizer):
     # prompt of length 8 + max_length of 3 = 11, which is more than model_max_length of 10, so we resize to 7
     mock_tokens = ["I", "am", "a", "tokenized", "prompt", "of", "length", "eight"]
     correct_result = "I am a tokenized prompt of length"

--- a/test/prompt/invocation_layer/test_hugging_face_inference.py
+++ b/test/prompt/invocation_layer/test_hugging_face_inference.py
@@ -9,12 +9,6 @@ from haystack.nodes.prompt.invocation_layer import HFInferenceEndpointInvocation
 
 
 @pytest.fixture
-def mock_auto_tokenizer():
-    with patch("transformers.AutoTokenizer.from_pretrained", autospec=True) as mock_from_pretrained:
-        yield mock_from_pretrained
-
-
-@pytest.fixture
 def mock_get_task():
     # mock get_task function
     with patch("haystack.nodes.prompt.invocation_layer.hugging_face_inference.get_task") as mock_get_task:

--- a/test/prompt/invocation_layer/test_hugging_face_inference.py
+++ b/test/prompt/invocation_layer/test_hugging_face_inference.py
@@ -110,7 +110,7 @@ def test_invoke_with_stop_words(mock_auto_tokenizer):
     assert mock_post.called
 
     # Check if stop_words are passed to _post as stop parameter
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
     assert "stop" in called_kwargs["data"]["parameters"]
     assert called_kwargs["data"]["parameters"]["stop"] == stop_words
 
@@ -132,7 +132,7 @@ def test_streaming_stream_param_in_constructor(mock_auto_tokenizer, stream):
         layer.invoke(prompt="Tell me hello")
 
     assert mock_post.called
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
     assert "stream" in called_kwargs
@@ -155,13 +155,7 @@ def test_streaming_stream_param_in_method(mock_auto_tokenizer, stream):
         layer.invoke(prompt="Tell me hello", stream=stream)
 
     assert mock_post.called
-    called_args, called_kwargs = mock_post.call_args
-
-    # stream is always passed to _post
-    assert "stream" in called_kwargs
-
-    # Check if stop_words are passed to _post as stop parameter
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
     assert "stream" in called_kwargs
@@ -190,7 +184,7 @@ def test_streaming_stream_handler_param_in_constructor(mock_auto_tokenizer):
         layer.invoke(prompt="Tell me hello")
 
     assert mock_post.called
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
     assert "stream" in called_kwargs
@@ -198,7 +192,7 @@ def test_streaming_stream_handler_param_in_constructor(mock_auto_tokenizer):
     assert called_kwargs["stream"]
 
     # stream_handler is passed as an instance of TokenStreamingHandler
-    called_args, called_kwargs = mock_post_stream.call_args
+    called_args, _ = mock_post_stream.call_args
     assert isinstance(called_args[1], TokenStreamingHandler)
 
 
@@ -217,7 +211,7 @@ def test_streaming_no_stream_handler_param_in_constructor(mock_auto_tokenizer):
         layer.invoke(prompt="Tell me hello")
 
     assert mock_post.called
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
 
     # stream is always passed to _post
     assert "stream" in called_kwargs
@@ -272,7 +266,7 @@ def test_streaming_no_stream_handler_param_in_method(mock_auto_tokenizer):
 
     assert mock_post.called
 
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
 
     # stream is always correctly passed to _post
     assert "stream" in called_kwargs
@@ -333,7 +327,7 @@ def test_oasst_prompt_preprocessing(mock_auto_tokenizer):
     assert result == ["Hello"]
     assert mock_post.called
 
-    called_args, called_kwargs = mock_post.call_args
+    _, called_kwargs = mock_post.call_args
     # OpenAssistant/oasst-sft-1-pythia-12b prompts are preprocessed and wrapped in tokens below
     assert called_kwargs["data"]["inputs"] == "<|prompter|>Tell me hello<|endoftext|><|assistant|>"
 
@@ -341,13 +335,13 @@ def test_oasst_prompt_preprocessing(mock_auto_tokenizer):
 @pytest.mark.unit
 def test_invalid_key():
     with pytest.raises(ValueError, match="must be a valid Hugging Face token"):
-        layer = HFInferenceEndpointInvocationLayer("", "irrelevant_model_name")
+        HFInferenceEndpointInvocationLayer("", "irrelevant_model_name")
 
 
 @pytest.mark.unit
 def test_invalid_model():
     with pytest.raises(ValueError, match="cannot be None or empty string"):
-        layer = HFInferenceEndpointInvocationLayer("fake_api", "")
+        HFInferenceEndpointInvocationLayer("fake_api", "")
 
 
 @pytest.mark.unit

--- a/test/prompt/test_handlers.py
+++ b/test/prompt/test_handlers.py
@@ -9,6 +9,58 @@ from haystack.nodes.prompt.invocation_layer.handlers import (
 )
 
 
+@pytest.mark.unit
+def test_prompt_handler_positive():
+    # prompt of length 5 + max_length of 3 = 8, which is less than model_max_length of 10, so no resize
+    mock_tokens = ["I", "am", "a", "tokenized", "prompt"]
+    mock_prompt = "I am a tokenized prompt"
+
+    with patch(
+        "haystack.nodes.prompt.invocation_layer.handlers.AutoTokenizer.from_pretrained", autospec=True
+    ) as mock_tokenizer:
+        tokenizer_instance = mock_tokenizer.return_value
+        tokenizer_instance.tokenize.return_value = mock_tokens
+        tokenizer_instance.convert_tokens_to_string.return_value = mock_prompt
+
+        prompt_handler = DefaultPromptHandler("model_path", 10, 3)
+
+        # Test with a prompt that does not exceed model_max_length when tokenized
+        result = prompt_handler(mock_prompt)
+
+    assert result == {
+        "resized_prompt": mock_prompt,
+        "prompt_length": 5,
+        "new_prompt_length": 5,
+        "model_max_length": 10,
+        "max_length": 3,
+    }
+
+
+@pytest.mark.unit
+def test_prompt_handler_negative():
+    # prompt of length 8 + max_length of 3 = 11, which is more than model_max_length of 10, so we resize to 7
+    mock_tokens = ["I", "am", "a", "tokenized", "prompt", "of", "length", "eight"]
+    mock_prompt = "I am a tokenized prompt of length"
+
+    with patch(
+        "haystack.nodes.prompt.invocation_layer.handlers.AutoTokenizer.from_pretrained", autospec=True
+    ) as mock_tokenizer:
+        tokenizer_instance = mock_tokenizer.return_value
+        tokenizer_instance.tokenize.return_value = mock_tokens
+        tokenizer_instance.convert_tokens_to_string.return_value = mock_prompt
+
+        prompt_handler = DefaultPromptHandler("model_path", 10, 3)
+        result = prompt_handler(mock_prompt)
+
+    assert result == {
+        "resized_prompt": mock_prompt,
+        "prompt_length": 8,
+        "new_prompt_length": 7,
+        "model_max_length": 10,
+        "max_length": 3,
+    }
+
+
 @pytest.mark.integration
 def test_prompt_handler_basics():
     handler = DefaultPromptHandler(model_name_or_path="gpt2", model_max_length=20, max_length=10)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/4868

### Proposed Changes:
- Add fixture monkeypatching `urlopen` instead of `requests`

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
