### PR TITLE
feat: Consider prompt_node's default_prompt_template in agent

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -258,7 +258,7 @@ class Agent:
         self.memory = memory or NoMemory()
         self.callback_manager = Events(("on_agent_start", "on_agent_step", "on_agent_finish", "on_new_token"))
         self.prompt_node = prompt_node
-        prompt_template = prompt_template or "zero-shot-react"
+        prompt_template = prompt_template or prompt_node.default_prompt_template or "zero-shot-react"
         resolved_prompt_template = prompt_node.get_prompt_template(prompt_template)
         if not resolved_prompt_template:
             raise ValueError(

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -235,10 +235,9 @@ class Agent:
 
         :param prompt_node: The PromptNode that the Agent uses to decide which tool to use and what input to provide to
         it in each iteration.
-        :param prompt_template: The name of a PromptTemplate for the PromptNode. It's used for generating thoughts and
-        choosing tools to answer queries step-by-step. You can use the default `zero-shot-react` template or create a
-        new template in a similar format.
-        with `add_tool()` before running the Agent.
+        :param prompt_template: A new PromptTemplate or the name of an existing PromptTemplate for the PromptNode. It's
+        used for generating thoughts and choosing tools to answer queries step-by-step. If it's not set, the PromptNode's
+        default template is used and if it's not set either, the Agent's default `zero-shot-react` template is used.
         :param tools_manager: A ToolsManager instance that the Agent uses to run tools. Each tool must have a unique name.
         You can also add tools with `add_tool()` before running the Agent.
         :param memory: A Memory instance that the Agent uses to store information between iterations.

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from typing import Tuple
+from unittest.mock import patch
 
 from test.conftest import MockRetriever, MockPromptNode
 from unittest import mock
@@ -300,8 +301,11 @@ def test_invalid_agent_template():
     assert a.prompt_template.name == "zero-shot-react"
 
 
-def test_default_template_order():
-    pn = PromptNode()
+@pytest.mark.unit
+@patch.object(PromptNode, "prompt")
+@patch("haystack.nodes.prompt.prompt_node.PromptModel")
+def test_default_template_order(mock_model, mock_prompt):
+    pn = PromptNode("abc")
     a = Agent(prompt_node=pn)
     assert a.prompt_template.name == "zero-shot-react"
 

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -298,3 +298,16 @@ def test_invalid_agent_template():
     a = Agent(prompt_node=pn, prompt_template=None)
     assert isinstance(a.prompt_template, PromptTemplate)
     assert a.prompt_template.name == "zero-shot-react"
+
+
+def test_default_template_order():
+    pn = PromptNode()
+    a = Agent(prompt_node=pn)
+    assert a.prompt_template.name == "zero-shot-react"
+
+    pn.default_prompt_template = "language-detection"
+    a = Agent(prompt_node=pn)
+    assert a.prompt_template.name == "language-detection"
+
+    a = Agent(prompt_node=pn, prompt_template="translation")
+    assert a.prompt_template.name == "translation"


### PR DESCRIPTION
### Related Issues

- fixes #5010 

### Proposed Changes:
- Consider the prompt node's default prompt template when initializing the Agent
- Add a unit test checking that prompt template passed to Agent directly overrules prompt template set as default of the prompt node, which again overrules the default prompt template set in the Agent's implementation

### How did you test it?

- Added new test case and ran it locally

### Notes for the reviewer

The changes in this PR are consistent with ConversationalAgent (open PR https://github.com/deepset-ai/haystack/pull/5065/files#diff-25bbf5718d62689cb1c872451bb4562d145d08d66641b5dd9b06d33720e291d6R79 ) and I expect ConversationalAgentWithTools to not be added. It's also consistent with Memory: https://github.com/deepset-ai/haystack/blob/main/haystack/agents/memory/conversation_summary_memory.py#L35

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
