### PR TITLE
fix: azure openai authentication error

### DIFF
--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -1,5 +1,6 @@
-from typing import Dict, List, Optional, Tuple, Union, Any, Type, overload
 import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
 import torch
 
@@ -81,9 +82,16 @@ class PromptModel(BaseComponent):
             return invocation_layer_class(
                 model_name_or_path=self.model_name_or_path, max_length=self.max_length, **all_kwargs
             )
-        # search all invocation layer classes and find the first one that supports the model,
+
+        potential_invocation_layer = PromptModelInvocationLayer.invocation_layer_providers
+        # if azure_base_url exist as an argument, invocation layer classes are filtered to only keep the ones relatives to azure
+        if "azure_base_url" in self.model_kwargs:
+            potential_invocation_layer = [
+                layer for layer in potential_invocation_layer if re.search(r"azure", layer.__name__, re.IGNORECASE)
+            ]
+        # search all invocation layer classes candidates and find the first one that supports the model,
         # then create an instance of that invocation layer
-        for invocation_layer in PromptModelInvocationLayer.invocation_layer_providers:
+        for invocation_layer in potential_invocation_layer:
             if invocation_layer.supports(self.model_name_or_path, **all_kwargs):
                 return invocation_layer(
                     model_name_or_path=self.model_name_or_path, max_length=self.max_length, **all_kwargs


### PR DESCRIPTION
### Related Issues

- fixes #5069

### Proposed Changes:

 When using Azure OpenAI services, the wrong invocation layer class was taken in prompt_model.py because of the order of the invocation layer classes.

To correct this, I added a filter that take only Azure invocation layer classes when AZURE_BASE_URL is filled.

### How did you test it?

Manual verification to ensure it was working correctly.
Pytest was run successfully.

### Notes for the reviewer

N/A

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
