### PR TITLE
feat: add filename to Document meta

### DIFF
--- a/haystack/nodes/audio/__init__.py
+++ b/haystack/nodes/audio/__init__.py
@@ -1,9 +1,1 @@
-from haystack.utils.import_utils import safe_import
 from haystack.nodes.audio.whisper_transcriber import WhisperTranscriber, WhisperModel
-
-AnswerToSpeech = safe_import(
-    "haystack.nodes.audio.answer_to_speech", "AnswerToSpeech", "audio"
-)  # Has optional dependencies
-DocumentToSpeech = safe_import(
-    "haystack.nodes.audio.document_to_speech", "DocumentToSpeech", "audio"
-)  # Has optional dependencies

--- a/haystack/nodes/file_converter/docx.py
+++ b/haystack/nodes/file_converter/docx.py
@@ -86,5 +86,10 @@ class DocxToTextConverter(BaseConverter):
         file = docx.Document(file_path)  # Creating word reader object.
         paragraphs = [para.text for para in file.paragraphs]
         text = "\n".join(paragraphs)
+
+        if meta is None:
+            meta = {"filename": file_path.name}
+        else:
+            meta["filename"] = file_path.name
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]

--- a/haystack/nodes/file_converter/image.py
+++ b/haystack/nodes/file_converter/image.py
@@ -155,6 +155,12 @@ class ImageToTextConverter(BaseConverter):
                 )
 
         text = "\f".join(cleaned_pages)
+
+        if meta is None:
+            meta = {"filename": file_path.name}
+        else:
+            meta["filename"] = file_path.name
+            
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 

--- a/haystack/nodes/file_converter/json.py
+++ b/haystack/nodes/file_converter/json.py
@@ -87,9 +87,11 @@ class JsonConverter(BaseConverter):
                     doc_dict["id_hash_keys"] = id_hash_keys
 
                 if meta is not None:
+                    meta["filename"] = file_path.name
                     existing_meta = doc_dict.get("meta", {})
                     # In case of duplicate keys, the newly specified vals (in `meta`) take precedence
                     doc_dict["meta"] = {**existing_meta, **meta}
+                    
 
                 docs.append(Document.from_dict(doc_dict))
 

--- a/haystack/nodes/file_converter/markdown.py
+++ b/haystack/nodes/file_converter/markdown.py
@@ -115,6 +115,11 @@ class MarkdownConverter(BaseConverter):
         else:
             text = soup.get_text()
 
+        if meta is None:
+            meta = {"filename": file_path.name}
+        else:
+            meta["filename"] = file_path.name
+
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 

--- a/haystack/nodes/file_converter/pdf.py
+++ b/haystack/nodes/file_converter/pdf.py
@@ -207,6 +207,12 @@ class PDFToTextConverter(BaseConverter):
                 )
 
         text = "\f".join(cleaned_pages)
+
+        if meta is None:
+            meta = {"filename": file_path.name}
+        else:
+            meta["filename"] = file_path.name
+            
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 

--- a/haystack/nodes/file_converter/pdf_xpdf.py
+++ b/haystack/nodes/file_converter/pdf_xpdf.py
@@ -152,6 +152,12 @@ class PDFToTextConverter(BaseConverter):
                 )
 
         text = "\f".join(cleaned_pages)
+
+        if meta is None:
+            meta = {"filename": file_path.name}
+        else:
+            meta["filename"] = file_path.name
+            
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 

--- a/haystack/nodes/file_converter/txt.py
+++ b/haystack/nodes/file_converter/txt.py
@@ -82,5 +82,11 @@ class TextConverter(BaseConverter):
                 )
 
         text = "".join(cleaned_pages)
+
+        if meta is None:
+            meta = {"filename": file_path.name}
+        else:
+            meta["filename"] = file_path.name
+            
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]


### PR DESCRIPTION
### Proposed Changes:

This PR add `filename` to `Document`'s `meta`, this helps later retrieval when need of locating original file.
Note: not all the converter has this field yet, since there are couple converter which I'm unfamiliar w/ its structure. 

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

Added unit tests
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
