### PR TITLE
chore: mark some unit tests as such

### DIFF
--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -164,6 +164,7 @@ def test_to_code_creates_same_pipelines(samples_path):
 #
 
 
+@pytest.mark.unit
 def test_get_config_creates_dependent_component():
     child = ChildComponent()
     parent = ParentComponent(dependent=child)
@@ -183,6 +184,7 @@ def test_get_config_creates_dependent_component():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_creates_only_one_dependent_component_referenced_by_multiple_parents():
     child = ChildComponent()
     parent = ParentComponent(dependent=child)
@@ -217,6 +219,7 @@ def test_get_config_creates_only_one_dependent_component_referenced_by_multiple_
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_creates_two_different_dependent_components_of_same_type():
     child_a = ChildComponent(some_key="A")
     child_b = ChildComponent(some_key="B")
@@ -253,6 +256,7 @@ def test_get_config_creates_two_different_dependent_components_of_same_type():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_reuses_same_dependent_components():
     child = ChildComponent()
     parent = ParentComponent(dependent=child)
@@ -276,6 +280,7 @@ def test_get_config_reuses_same_dependent_components():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_creates_different_components_if_instances_differ():
     child_a = ChildComponent()
     child_b = ChildComponent()
@@ -313,6 +318,7 @@ def test_get_config_creates_different_components_if_instances_differ():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_reuses_same_unnamed_dependent_components():
     child = ChildComponent()
     parent = ParentComponent(dependent=child)
@@ -338,6 +344,7 @@ def test_get_config_reuses_same_unnamed_dependent_components():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_multi_level_dependencies():
     child = ChildComponent()
     intermediate = ParentComponent(dependent=child)
@@ -360,6 +367,7 @@ def test_get_config_multi_level_dependencies():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_multi_level_dependencies_of_same_type():
     child = ChildComponent()
     second_intermediate = ParentComponent(dependent=child)
@@ -384,6 +392,7 @@ def test_get_config_multi_level_dependencies_of_same_type():
         assert expected_component in config["components"]
 
 
+@pytest.mark.unit
 def test_get_config_component_with_superclass_arguments():
     class CustomBaseDocumentStore(MockDocumentStore):
         def __init__(self, base_parameter: str):
@@ -409,6 +418,7 @@ def test_get_config_component_with_superclass_arguments():
     assert pipeline.get_document_store().base_parameter == "something"
 
 
+@pytest.mark.unit
 def test_get_config_custom_node_with_params():
     class CustomNode(MockNode):
         def __init__(self, param: int):
@@ -422,6 +432,7 @@ def test_get_config_custom_node_with_params():
     assert pipeline.get_config()["components"][0]["params"] == {"param": 10}
 
 
+@pytest.mark.unit
 def test_get_config_custom_node_with_positional_params():
     class CustomNode(MockNode):
         def __init__(self, param: int = 1):
@@ -435,6 +446,7 @@ def test_get_config_custom_node_with_positional_params():
     assert pipeline.get_config()["components"][0]["params"] == {"param": 10}
 
 
+@pytest.mark.unit
 def test_get_config_multi_output_node():
     class MultiOutputNode(BaseComponent):
         outgoing_edges = 2
@@ -475,6 +487,7 @@ def test_get_config_multi_output_node():
     assert "fork_2" in nodes[3]["inputs"]
 
 
+@pytest.mark.unit
 def test_generate_code_simple_pipeline():
     config = {
         "version": "ignore",
@@ -503,6 +516,7 @@ def test_generate_code_simple_pipeline():
     )
 
 
+@pytest.mark.unit
 def test_generate_code_imports():
     pipeline_config = {
         "version": "ignore",
@@ -536,6 +550,7 @@ def test_generate_code_imports():
     )
 
 
+@pytest.mark.unit
 def test_generate_code_imports_no_pipeline_cls():
     pipeline_config = {
         "version": "ignore",
@@ -565,6 +580,7 @@ def test_generate_code_imports_no_pipeline_cls():
     )
 
 
+@pytest.mark.unit
 def test_generate_code_comment():
     pipeline_config = {
         "version": "ignore",
@@ -593,6 +609,7 @@ def test_generate_code_comment():
     )
 
 
+@pytest.mark.unit
 def test_generate_code_is_component_order_invariant():
     pipeline_config = {
         "version": "ignore",
@@ -649,6 +666,7 @@ def test_generate_code_is_component_order_invariant():
         assert code == expected_code
 
 
+@pytest.mark.unit
 def test_generate_code_can_handle_weak_cyclic_pipelines():
     config = {
         "version": "ignore",
@@ -674,6 +692,7 @@ def test_generate_code_can_handle_weak_cyclic_pipelines():
     )
 
 
+@pytest.mark.unit
 def test_pipeline_classify_type(tmp_path):
     pipe = GenerativeQAPipeline(generator=MockSeq2SegGenerator(), retriever=MockRetriever())
     assert pipe.get_type().startswith("GenerativeQAPipeline")
@@ -1592,6 +1611,7 @@ def test_undeploy_on_deepset_cloud_timeout():
         )
 
 
+@pytest.mark.unit
 def test_graph_validation_invalid_edge():
     docstore = MockDocumentStore()
     retriever = DummyRetriever(document_store=docstore)
@@ -1602,6 +1622,7 @@ def test_graph_validation_invalid_edge():
         pipeline.add_node(name="Retriever", component=retriever, inputs=["DocStore.output_2"])
 
 
+@pytest.mark.unit
 def test_graph_validation_non_existing_edge():
     docstore = MockDocumentStore()
     retriever = DummyRetriever(document_store=docstore)
@@ -1612,6 +1633,7 @@ def test_graph_validation_non_existing_edge():
         pipeline.add_node(name="Retriever", component=retriever, inputs=["DocStore.wrong_edge_label"])
 
 
+@pytest.mark.unit
 def test_graph_validation_invalid_node():
     docstore = MockDocumentStore()
     retriever = DummyRetriever(document_store=docstore)
@@ -1622,6 +1644,7 @@ def test_graph_validation_invalid_node():
         pipeline.add_node(name="Retriever", component=retriever, inputs=["InvalidNode"])
 
 
+@pytest.mark.unit
 def test_graph_validation_invalid_root_node():
     docstore = MockDocumentStore()
     pipeline = Pipeline()
@@ -1630,6 +1653,7 @@ def test_graph_validation_invalid_root_node():
         pipeline.add_node(name="DocStore", component=docstore, inputs=["InvalidNode"])
 
 
+@pytest.mark.unit
 def test_graph_validation_no_root_node():
     docstore = MockNode()
     pipeline = Pipeline()
@@ -1638,6 +1662,7 @@ def test_graph_validation_no_root_node():
         pipeline.add_node(name="Node", component=docstore, inputs=[])
 
 
+@pytest.mark.unit
 def test_graph_validation_two_root_nodes():
     docstore = MockNode()
     pipeline = Pipeline()
@@ -1649,6 +1674,7 @@ def test_graph_validation_two_root_nodes():
         pipeline.add_node(name="Node", component=docstore, inputs=["Query", "Query"])
 
 
+@pytest.mark.unit
 def test_graph_validation_duplicate_node_instance():
     node = MockNode()
     pipeline = Pipeline()
@@ -1658,6 +1684,7 @@ def test_graph_validation_duplicate_node_instance():
         pipeline.add_node(name="node_b", component=node, inputs=["node_a"])
 
 
+@pytest.mark.unit
 def test_graph_validation_duplicate_node():
     node = MockNode()
     other_node = MockNode()
@@ -1668,6 +1695,7 @@ def test_graph_validation_duplicate_node():
 
 
 # See https://github.com/deepset-ai/haystack/issues/2568
+@pytest.mark.unit
 def test_pipeline_nodes_can_have_uncopiable_objects_as_args():
     class DummyNode(MockNode):
         def __init__(self, uncopiable: ssl.SSLContext):
@@ -1682,6 +1710,7 @@ def test_pipeline_nodes_can_have_uncopiable_objects_as_args():
     get_component_definitions(pipeline.get_config())
 
 
+@pytest.mark.unit
 def test_pipeline_env_vars_do_not_modify__component_config(caplog, monkeypatch):
     class DummyNode(MockNode):
         def __init__(self, replaceable: str):
@@ -1718,6 +1747,7 @@ def test_pipeline_env_vars_do_not_modify__component_config(caplog, monkeypatch):
     assert new_pipeline_config["components"][0]["params"]["replaceable"] == "init value"
 
 
+@pytest.mark.unit
 def test_pipeline_env_vars_do_not_modify_pipeline_config(monkeypatch):
     class DummyNode(MockNode):
         def __init__(self, replaceable: str):
@@ -1739,6 +1769,7 @@ def test_pipeline_env_vars_do_not_modify_pipeline_config(monkeypatch):
     assert pipeline_config["components"][0]["params"]["replaceable"] == "init value"
 
 
+@pytest.mark.unit
 def test_parallel_paths_in_pipeline_graph():
     class A(RootNode):
         def run(self):
@@ -1790,6 +1821,7 @@ def test_parallel_paths_in_pipeline_graph():
     assert output["test"] == "ABCABD"
 
 
+@pytest.mark.unit
 def test_parallel_paths_in_pipeline_graph_with_branching():
     class AWithOutput1(RootNode):
         outgoing_edges = 2
@@ -1871,6 +1903,7 @@ def test_parallel_paths_in_pipeline_graph_with_branching():
     assert output["output"] == "ACABEABD"
 
 
+@pytest.mark.unit
 def test_pipeline_components():
     class Node(BaseComponent):
         outgoing_edges = 1
@@ -1901,6 +1934,7 @@ def test_pipeline_components():
     assert pipeline.components["E"] == e
 
 
+@pytest.mark.unit
 def test_pipeline_get_document_store_from_components():
     doc_store = MockDocumentStore()
     pipeline = Pipeline()
@@ -1909,6 +1943,7 @@ def test_pipeline_get_document_store_from_components():
     assert doc_store == pipeline.get_document_store()
 
 
+@pytest.mark.unit
 def test_pipeline_get_document_store_from_components_multiple_doc_stores():
     doc_store_a = MockDocumentStore()
     doc_store_b = MockDocumentStore()
@@ -1920,6 +1955,7 @@ def test_pipeline_get_document_store_from_components_multiple_doc_stores():
         pipeline.get_document_store()
 
 
+@pytest.mark.unit
 def test_pipeline_get_document_store_from_retriever():
     doc_store = MockDocumentStore()
     retriever = DummyRetriever(document_store=doc_store)
@@ -1929,6 +1965,7 @@ def test_pipeline_get_document_store_from_retriever():
     assert doc_store == pipeline.get_document_store()
 
 
+@pytest.mark.unit
 def test_pipeline_get_document_store_from_dual_retriever():
     doc_store = MockDocumentStore()
     retriever_a = DummyRetriever(document_store=doc_store)
@@ -1942,6 +1979,7 @@ def test_pipeline_get_document_store_from_dual_retriever():
     assert doc_store == pipeline.get_document_store()
 
 
+@pytest.mark.unit
 def test_pipeline_get_document_store_multiple_doc_stores_from_dual_retriever():
     doc_store_a = MockDocumentStore()
     doc_store_b = MockDocumentStore()
@@ -1988,6 +2026,7 @@ def test_batch_querying_multiple_queries(document_store_with_docs, samples_path)
     assert len(result["answers"][0]) == 5  # top-k of 5 for collection of docs
 
 
+@pytest.mark.unit
 def test_fix_to_pipeline_execution_when_join_follows_join():
     # wire up 4 retrievers, each with one document
     document_store_1 = InMemoryDocumentStore()

--- a/test/pipelines/test_pipeline_debug_and_validation.py
+++ b/test/pipelines/test_pipeline_debug_and_validation.py
@@ -173,6 +173,7 @@ def test_global_debug_attributes_override_node_ones(document_store_with_docs, tm
     assert prediction["_debug"]["Reader"]["output"]
 
 
+@pytest.mark.unit
 def test_missing_top_level_arg():
     pipeline = Pipeline()
     pipeline.add_node(component=MockRetriever(), name="Retriever", inputs=["Query"])
@@ -183,6 +184,7 @@ def test_missing_top_level_arg():
     assert "Must provide a 'query' parameter" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_unexpected_top_level_arg():
     pipeline = Pipeline()
     pipeline.add_node(component=MockRetriever(), name="Retriever", inputs=["Query"])
@@ -193,6 +195,7 @@ def test_unexpected_top_level_arg():
     assert "run() got an unexpected keyword argument 'invalid_query'" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_unexpected_node_arg():
     pipeline = Pipeline()
     pipeline.add_node(component=MockRetriever(), name="Retriever", inputs=["Query"])
@@ -203,6 +206,7 @@ def test_unexpected_node_arg():
     assert "Invalid parameter 'invalid' for the node 'Retriever'" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_debug_info_propagation():
     class A(RootNode):
         def run(self):

--- a/test/pipelines/test_pipeline_yaml.py
+++ b/test/pipelines/test_pipeline_yaml.py
@@ -114,6 +114,7 @@ def test_load_and_save_from_yaml(tmp_path, samples_path):
 #
 
 
+@pytest.mark.unit
 def test_load_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -141,6 +142,7 @@ def test_load_yaml(tmp_path):
     assert isinstance(pipeline.get_node("reader"), MockReader)
 
 
+@pytest.mark.unit
 def test_load_yaml_elasticsearch_not_responding(tmp_path):
     # Test if DocumentStoreError is raised if elasticsearch instance is not responding (due to wrong port)
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
@@ -181,11 +183,13 @@ def test_load_yaml_elasticsearch_not_responding(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml", pipeline_name="indexing_pipeline")
 
 
+@pytest.mark.unit
 def test_load_yaml_non_existing_file(samples_path):
     with pytest.raises(FileNotFoundError):
         Pipeline.load_from_yaml(path=samples_path / "pipeline" / "I_dont_exist.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_invalid_yaml(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write("this is not valid YAML!")
@@ -193,6 +197,7 @@ def test_load_yaml_invalid_yaml(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_missing_version(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -213,6 +218,7 @@ def test_load_yaml_missing_version(tmp_path):
         assert "version" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_non_existing_version(tmp_path, caplog):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -235,6 +241,7 @@ def test_load_yaml_non_existing_version(tmp_path, caplog):
         assert f"Haystack {haystack.__version__}" in caplog.text
 
 
+@pytest.mark.unit
 def test_load_yaml_non_existing_version_strict(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -255,6 +262,7 @@ def test_load_yaml_non_existing_version_strict(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml", strict_version_check=True)
 
 
+@pytest.mark.unit
 def test_load_yaml_incompatible_version(tmp_path, caplog):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -277,6 +285,7 @@ def test_load_yaml_incompatible_version(tmp_path, caplog):
         assert f"Haystack {haystack.__version__}" in caplog.text
 
 
+@pytest.mark.unit
 def test_load_yaml_incompatible_version_strict(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -297,6 +306,7 @@ def test_load_yaml_incompatible_version_strict(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml", strict_version_check=True)
 
 
+@pytest.mark.unit
 def test_load_yaml_no_components(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -313,6 +323,7 @@ def test_load_yaml_no_components(tmp_path):
         assert "components" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_wrong_component(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -334,6 +345,7 @@ def test_load_yaml_wrong_component(tmp_path):
         assert "ImaginaryDocumentStore" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component(tmp_path):
     class CustomNode(MockNode):
         def __init__(self, param: int):
@@ -361,6 +373,7 @@ def test_load_yaml_custom_component(tmp_path):
     assert pipeline.get_node("custom_node").param == 1
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_null_values(tmp_path):
     class CustomNode(MockNode):
         def __init__(self, param: Optional[str], lst_param: Optional[List[Any]], dict_param: Optional[Dict[str, Any]]):
@@ -395,6 +408,7 @@ def test_load_yaml_custom_component_with_null_values(tmp_path):
     assert pipeline.get_node("custom_node").dict_param is None
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_no_init(tmp_path):
     class CustomNode(MockNode):
         pass
@@ -418,6 +432,7 @@ def test_load_yaml_custom_component_with_no_init(tmp_path):
     assert isinstance(pipeline.get_node("custom_node"), CustomNode)
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_neednt_call_super(tmp_path):
     """This is a side-effect. Here for behavior documentation only"""
 
@@ -455,6 +470,7 @@ def test_load_yaml_custom_component_neednt_call_super(tmp_path):
     assert pipeline.get_node("custom_node").param == 1
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_cant_be_abstract(tmp_path):
     class CustomNode(MockNode):
         @abstractmethod
@@ -482,6 +498,7 @@ def test_load_yaml_custom_component_cant_be_abstract(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_name_can_include_base(tmp_path):
     class BaseCustomNode(MockNode):
         def __init__(self):
@@ -506,6 +523,7 @@ def test_load_yaml_custom_component_name_can_include_base(tmp_path):
     assert isinstance(pipeline.get_node("custom_node"), BaseCustomNode)
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_must_subclass_basecomponent(tmp_path):
     class SomeCustomNode:
         def run(self, *a, **k):
@@ -532,6 +550,7 @@ def test_load_yaml_custom_component_must_subclass_basecomponent(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_referencing_other_node_in_init(tmp_path):
     class OtherNode(MockNode):
         def __init__(self, another_param: str):
@@ -571,6 +590,7 @@ def test_load_yaml_custom_component_referencing_other_node_in_init(tmp_path):
     assert pipeline.get_node("custom_node").other_node.name == "other_node"
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_helper_class_in_init(tmp_path):
     """
     This test can work from the perspective of YAML schema validation:
@@ -609,6 +629,7 @@ def test_load_yaml_custom_component_with_helper_class_in_init(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_helper_class_in_yaml(tmp_path):
     """
     This test can work from the perspective of YAML schema validation:
@@ -648,6 +669,7 @@ def test_load_yaml_custom_component_with_helper_class_in_yaml(tmp_path):
     assert pipe.get_node("custom_node").some_exotic_parameter == 'HelperClass("hello")'
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_enum_in_init(tmp_path):
     """
     This test can work from the perspective of YAML schema validation:
@@ -685,6 +707,7 @@ def test_load_yaml_custom_component_with_enum_in_init(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_enum_in_yaml(tmp_path):
     """
     This test can work from the perspective of YAML schema validation:
@@ -724,6 +747,7 @@ def test_load_yaml_custom_component_with_enum_in_yaml(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_external_constant(tmp_path):
     """
     This is a potential pitfall. The code should work as described here.
@@ -759,6 +783,7 @@ def test_load_yaml_custom_component_with_external_constant(tmp_path):
     assert node.some_exotic_parameter == "AnotherClass.CLASS_CONSTANT"
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_superclass(tmp_path):
     class BaseCustomNode(MockNode):
         def __init__(self):
@@ -789,6 +814,7 @@ def test_load_yaml_custom_component_with_superclass(tmp_path):
     Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_variadic_args(tmp_path):
     class BaseCustomNode(MockNode):
         def __init__(self, base_parameter: int):
@@ -822,6 +848,7 @@ def test_load_yaml_custom_component_with_variadic_args(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_custom_component_with_variadic_kwargs(tmp_path):
     class BaseCustomNode(MockNode):
         def __init__(self, base_parameter: int):
@@ -855,6 +882,7 @@ def test_load_yaml_custom_component_with_variadic_kwargs(tmp_path):
         Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_no_pipelines(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -871,6 +899,7 @@ def test_load_yaml_no_pipelines(tmp_path):
         assert "pipeline" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_invalid_pipeline_name(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -892,6 +921,7 @@ def test_load_yaml_invalid_pipeline_name(tmp_path):
         assert "invalid" in str(e) and "pipeline" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_pipeline_with_wrong_nodes(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -913,6 +943,7 @@ def test_load_yaml_pipeline_with_wrong_nodes(tmp_path):
         assert "not_existing_node" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_pipeline_not_acyclic_graph(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -940,6 +971,7 @@ def test_load_yaml_pipeline_not_acyclic_graph(tmp_path):
         assert "loop" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_wrong_root(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -962,6 +994,7 @@ def test_load_yaml_wrong_root(tmp_path):
         assert "root" in str(e).lower()
 
 
+@pytest.mark.unit
 def test_load_yaml_two_roots_invalid(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -988,6 +1021,7 @@ def test_load_yaml_two_roots_invalid(tmp_path):
     assert "File" in str(e) or "Query" in str(e)
 
 
+@pytest.mark.unit
 def test_load_yaml_two_roots_valid(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -1012,6 +1046,7 @@ def test_load_yaml_two_roots_valid(tmp_path):
     Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
 
 
+@pytest.mark.unit
 def test_load_yaml_two_roots_in_separate_pipelines(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -1045,6 +1080,7 @@ def test_load_yaml_two_roots_in_separate_pipelines(tmp_path):
     Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml", pipeline_name="pipeline_2")
 
 
+@pytest.mark.unit
 def test_load_yaml_disconnected_component(tmp_path):
     with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
         tmp_file.write(
@@ -1069,6 +1105,7 @@ def test_load_yaml_disconnected_component(tmp_path):
     assert not pipeline.get_node("retriever")
 
 
+@pytest.mark.unit
 def test_load_yaml_unusual_chars_in_values(tmp_path):
     class DummyNode(BaseComponent):
         outgoing_edges = 1
@@ -1108,6 +1145,7 @@ def test_load_yaml_unusual_chars_in_values(tmp_path):
     assert pipeline.components["DummyNode"].non_alphanumeric_param == "\\[ümlaut\\]"
 
 
+@pytest.mark.unit
 def test_save_yaml(tmp_path):
     pipeline = Pipeline()
     pipeline.add_node(MockRetriever(), name="retriever", inputs=["Query"])
@@ -1122,6 +1160,7 @@ def test_save_yaml(tmp_path):
         assert f"version: {haystack.__version__}" in content
 
 
+@pytest.mark.unit
 def test_save_yaml_overwrite(tmp_path):
     pipeline = Pipeline()
     retriever = MockRetriever()
@@ -1137,6 +1176,7 @@ def test_save_yaml_overwrite(tmp_path):
         assert content != ""
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("pipeline_file", ["ray.simple.haystack-pipeline.yml", "ray.advanced.haystack-pipeline.yml"])
 def test_load_yaml_ray_args_in_pipeline(samples_path, pipeline_file):
     with pytest.raises(PipelineConfigError) as e:


### PR DESCRIPTION
### Proposed Changes:
- As I noticed in another PR that almost no pipeline unit tests are run, this PR marks several unit tests under `test/pipeline`

### How did you test it?
- CI

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
