### PR TITLE
fix: Don't log info message in DataSilo with SquadProcessor about clipping

### DIFF
--- a/haystack/modeling/data_handler/data_silo.py
+++ b/haystack/modeling/data_handler/data_silo.py
@@ -14,7 +14,7 @@ from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler, SequentialSampler
 
 from haystack.modeling.data_handler.dataloader import NamedDataLoader
-from haystack.modeling.data_handler.processor import Processor
+from haystack.modeling.data_handler.processor import Processor, SquadProcessor
 from haystack.utils.experiment_tracking import Tracker as tracker
 from haystack.modeling.visual import TRACTOR_SMALL
 
@@ -412,7 +412,8 @@ class DataSilo:
         logger.info("Total examples   : %s", self.counts["train"] + self.counts["dev"] + self.counts["test"])
         logger.info("")
         if self.data["train"]:
-            if "input_ids" in self.tensor_names:
+            # SquadProcessor does not clip sequences, but splits them into multiple samples
+            if "input_ids" in self.tensor_names and not isinstance(self.processor, SquadProcessor):
                 logger.info("Longest sequence length observed after clipping:     %s", max(seq_lens))
                 logger.info("Average sequence length after clipping: %s", ave_len)
                 logger.info("Proportion clipped:      %s", clipped)


### PR DESCRIPTION
### Related Issues

- fixes #4977

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR makes sure that we don't log any info message about clipped sequences when using `DataSilo` in combination with `SquadProcessor`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manual verification.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
As explained in #4977, `SquadProcessor` doesn't clip sequences but generates multiple overlapping samples in case a sequence exceeds `max_seq_len`. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
