### PR TITLE
fix: PromptNode falls back to empty list of documents if none are provided but expected

### DIFF
--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -482,6 +482,13 @@ class PromptTemplate(BasePromptTemplate, ABC):
                 if param in kwargs:
                     params_dict[param] = kwargs[param]
 
+        if "documents" in self.prompt_params and not "documents" in params_dict:
+            params_dict["documents"] = []
+            logger.warning(
+                "Expected prompt parameter 'documents' to be provided but it is missing. "
+                "Continuing with an empty list of documents."
+            )
+
         if not set(self.prompt_params).issubset(params_dict.keys()):
             available_params = {*params_dict.keys(), *kwargs.keys()}
             provided = set(self.prompt_params).intersection(available_params)

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -482,7 +482,7 @@ class PromptTemplate(BasePromptTemplate, ABC):
                 if param in kwargs:
                     params_dict[param] = kwargs[param]
 
-        if "documents" in self.prompt_params and not "documents" in params_dict:
+        if "documents" in self.prompt_params and "documents" not in params_dict:
             params_dict["documents"] = []
             logger.warning(
                 "Expected prompt parameter 'documents' to be provided but it is missing. "

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -1009,3 +1009,23 @@ def test_chatgpt_direct_prompting_w_messages(chatgpt_prompt_model):
 
     result = pn(messages)
     assert len(result) == 1 and all(w in result[0].casefold() for w in ["arlington", "texas"])
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.prompt_node.PromptModel")
+def test_prompt_node_warns_about_missing_documents(mock_model, caplog):
+    lfqa_prompt = PromptTemplate(
+        prompt="""Synthesize a comprehensive answer from the following text for the given question.
+        Provide a clear and concise response that summarizes the key points and information presented in the text.
+        Your answer should be in your own words and be no longer than 50 words.
+        If answer is not in .text. say i dont know.
+        \n\n Related text: {join(documents)} \n\n Question: {query} \n\n Answer:"""
+    )
+    prompt_node = PromptNode(default_prompt_template=lfqa_prompt)
+
+    with caplog.at_level(logging.WARNING):
+        results, _ = prompt_node.run(query="non-matching query")
+        assert (
+            "Expected prompt parameter 'documents' to be provided but it is missing. "
+            "Continuing with an empty list of documents." in caplog.text
+        )

--- a/test/prompt/test_prompt_template.py
+++ b/test/prompt/test_prompt_template.py
@@ -211,6 +211,19 @@ def test_prompt_template_deserialization(mock_prompt_model):
     assert isinstance(loaded_generator.default_prompt_template.output_parser, AnswerParser)
 
 
+@pytest.mark.unit
+def test_prompt_template_fills_in_missing_documents():
+    lfqa_prompt = PromptTemplate(
+        prompt="""Synthesize a comprehensive answer from the following text for the given question.
+        Provide a clear and concise response that summarizes the key points and information presented in the text.
+        Your answer should be in your own words and be no longer than 50 words.
+        If answer is not in .text. say i dont know.
+        \n\n Related text: {join(documents)} \n\n Question: {query} \n\n Answer:"""
+    )
+    prepared_prompt = next(lfqa_prompt.fill(query="What is the meaning of life?"))  # no documents provided but expected
+    assert "Related text:  \n\n Question: What is the meaning of life?" in prepared_prompt
+
+
 class TestPromptTemplateSyntax:
     @pytest.mark.unit
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues

- fixes #4878

### Proposed Changes:

- Show warning if documents are expected by prompt template but not provided
- Add empty list of documents to prompt parameters if documents parameter was expected but not provided
- Add two unit tests

### How did you test it?

- New unit tests
- Manually without mocking in a pipeline

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
