### PR TITLE
fix: Relax ChatGPT model name check to support gpt-3.5-turbo-0613

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -144,4 +144,4 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        return model_name_or_path in ["gpt-3.5-turbo", "gpt-4", "gpt-4-32k"]
+        return any(m for m in ["gpt-3.5-turbo", "gpt-4"] if m in model_name_or_path)

--- a/test/prompt/invocation_layer/test_chatgpt.py
+++ b/test/prompt/invocation_layer/test_chatgpt.py
@@ -27,3 +27,15 @@ def test_custom_api_base(mock_request):
 
     invocation_layer.invoke(prompt="dummy_prompt")
     assert mock_request.call_args.kwargs["url"] == "https://fake_api_base.com/chat/completions"
+
+
+@pytest.mark.unit
+def test_supports_correct_model_names():
+    for model_name in ["gpt-3.5-turbo", "gpt-4", "gpt-4-32k", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0613"]:
+        assert ChatGPTInvocationLayer.supports(model_name)
+
+
+@pytest.mark.unit
+def test_does_not_support_wrong_model_names():
+    for model_name in ["got-3.5-turbo", "wrong_model_name"]:
+        assert not ChatGPTInvocationLayer.supports(model_name)


### PR DESCRIPTION
### Related Issues

- OpenAI announced new ChatGPT models, gpt-3.5-turbo-0613 and gpt-3.5-turbo-16k. Haystack currently doesn't allow using these models because our model name check is too strict. https://openai.com/blog/function-calling-and-other-api-updates

- fixes #5141

### Proposed Changes:

- Relax the name check in the ChatGPTInvocationLayer

### How did you test it?

- Tested locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
