### PR TITLE
feat!: Add extra for inference dependencies such as torch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,7 +210,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[elasticsearch,dev,preprocessing]
+        run: pip install .[elasticsearch,dev,preprocessing,inference]
 
       - name: Run tests
         run: |
@@ -608,7 +608,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,preprocessing]
+        run: pip install .[dev,preprocessing,inference]
 
       - name: Run tests
         run: |
@@ -662,7 +662,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,preprocessing]
+        run: pip install .[dev,preprocessing,inference]
 
       - name: Run tests
         run: |
@@ -716,7 +716,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,preprocessing]
+        run: pip install .[dev,preprocessing,inference]
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ This command installs everything needed for basic Pipelines that use an in-memor
 
 **Full Installation**
 
-To use more advanced features, like certain DocumentStores, FileConverters, OCR, or Ray,
+To use more advanced features, like certain DocumentStores, FileConverters, OCR, local inference with pytorch, or Ray,
 you need to install further dependencies. The following command installs the [latest release](https://github.com/deepset-ai/haystack/releases) of Haystack and all its dependencies:
 
 ```sh
 pip install 'farm-haystack[all]' ## or 'all-gpu' for the GPU-enabled dependencies
+```
+
+If you want to install only the dependencies needed for model inference on your local hardware (not remote API endpoints), such as torch and sentence-transformers, you can use the following command:
+```sh
+pip install 'farm-haystack[inference]' ## installs torch, sentence-transformers, sentencepiece, and huggingface-hub
 ```
 
 If you want to try out the newest features that are not in an official release yet, you can install the unstable version from the main branch with the following command:

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -25,7 +25,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
     import torch
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
 

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -25,7 +25,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_import:
     import torch
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
 

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -113,6 +113,8 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self.bm25_parameters = bm25_parameters
         self.bm25: Dict[str, rank_bm25.BM25] = {}
 
+        torch_import.check()
+
         self.devices, _ = initialize_device_settings(devices=devices, use_cuda=self.use_gpu, multi_gpu=False)
         if len(self.devices) > 1:
             logger.warning(

--- a/haystack/document_stores/memory.py
+++ b/haystack/document_stores/memory.py
@@ -92,6 +92,7 @@ class InMemoryDocumentStore(KeywordDocumentStore):
                                 You can learn more about these parameters by visiting https://github.com/dorianbrown/rank_bm25
                                 By default, no parameters are set.
         """
+        torch_import.check()
         if bm25_parameters is None:
             bm25_parameters = {}
         super().__init__()
@@ -112,8 +113,6 @@ class InMemoryDocumentStore(KeywordDocumentStore):
         self.bm25_algorithm = bm25_algorithm
         self.bm25_parameters = bm25_parameters
         self.bm25: Dict[str, rank_bm25.BM25] = {}
-
-        torch_import.check()
 
         self.devices, _ = initialize_device_settings(devices=devices, use_cuda=self.use_gpu, multi_gpu=False)
         if len(self.devices) > 1:

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 from haystack import __version__
 from haystack.lazy_imports import LazyImport
 
-with LazyImport() as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
     import torch
 
 with LazyImport() as transformers_import:

--- a/haystack/environment.py
+++ b/haystack/environment.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 from haystack import __version__
 from haystack.lazy_imports import LazyImport
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_import:
     import torch
 
 with LazyImport() as transformers_import:

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -11,6 +11,7 @@ from haystack.modeling.data_handler.samples import SampleBasket
 from haystack.modeling.data_handler.inputs import QAInput
 from haystack.modeling.model.adaptive_model import AdaptiveModel, BaseAdaptiveModel
 from haystack.modeling.model.predictions import QAPred
+from haystack.lazy_imports import LazyImport
 
 with LazyImport() as torch_import:
     import torch

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -3,21 +3,17 @@ from typing import List, Optional, Dict, Union, Set, Any
 import os
 import logging
 from tqdm.auto import tqdm
-
+import torch
+from torch.utils.data.sampler import SequentialSampler
+from torch.utils.data import Dataset
 
 from haystack.modeling.data_handler.dataloader import NamedDataLoader
 from haystack.modeling.data_handler.processor import Processor, InferenceProcessor
 from haystack.modeling.data_handler.samples import SampleBasket
+from haystack.modeling.utils import initialize_device_settings, set_all_seeds
 from haystack.modeling.data_handler.inputs import QAInput
 from haystack.modeling.model.adaptive_model import AdaptiveModel, BaseAdaptiveModel
 from haystack.modeling.model.predictions import QAPred
-from haystack.lazy_imports import LazyImport
-
-with LazyImport() as torch_import:
-    import torch
-    from torch.utils.data.sampler import SequentialSampler
-    from torch.utils.data import Dataset
-    from haystack.modeling.utils import initialize_device_settings, set_all_seeds  # pylint: disable=ungrouped-imports
 
 
 logger = logging.getLogger(__name__)
@@ -77,7 +73,6 @@ class Inferencer:
         :return: An instance of the Inferencer.
 
         """
-        torch_import.check()
         # Init device and distributed settings
         self.devices, _ = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)
         if len(self.devices) > 1:

--- a/haystack/modeling/infer.py
+++ b/haystack/modeling/infer.py
@@ -3,17 +3,20 @@ from typing import List, Optional, Dict, Union, Set, Any
 import os
 import logging
 from tqdm.auto import tqdm
-import torch
-from torch.utils.data.sampler import SequentialSampler
-from torch.utils.data import Dataset
+
 
 from haystack.modeling.data_handler.dataloader import NamedDataLoader
 from haystack.modeling.data_handler.processor import Processor, InferenceProcessor
 from haystack.modeling.data_handler.samples import SampleBasket
-from haystack.modeling.utils import initialize_device_settings, set_all_seeds
 from haystack.modeling.data_handler.inputs import QAInput
 from haystack.modeling.model.adaptive_model import AdaptiveModel, BaseAdaptiveModel
 from haystack.modeling.model.predictions import QAPred
+
+with LazyImport() as torch_import:
+    import torch
+    from torch.utils.data.sampler import SequentialSampler
+    from torch.utils.data import Dataset
+    from haystack.modeling.utils import initialize_device_settings, set_all_seeds  # pylint: disable=ungrouped-imports
 
 
 logger = logging.getLogger(__name__)
@@ -73,6 +76,7 @@ class Inferencer:
         :return: An instance of the Inferencer.
 
         """
+        torch_import.check()
         # Init device and distributed settings
         self.devices, _ = initialize_device_settings(devices=devices, use_cuda=gpu, multi_gpu=False)
         if len(self.devices) > 1:

--- a/haystack/modeling/model/feature_extraction.py
+++ b/haystack/modeling/model/feature_extraction.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 SPECIAL_TOKENIZER_CHARS = r"^(##|Ġ|▁)"
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as transformers_import:
     import transformers
     from transformers import PreTrainedTokenizer, RobertaTokenizer, AutoConfig, AutoFeatureExtractor, AutoTokenizer
 

--- a/haystack/modeling/model/feature_extraction.py
+++ b/haystack/modeling/model/feature_extraction.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 SPECIAL_TOKENIZER_CHARS = r"^(##|Ġ|▁)"
 
 
-with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'.") as transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as transformers_import:
     import transformers
     from transformers import PreTrainedTokenizer, RobertaTokenizer, AutoConfig, AutoFeatureExtractor, AutoTokenizer
 

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import (
         RagTokenizer,

--- a/haystack/nodes/answer_generator/transformers.py
+++ b/haystack/nodes/answer_generator/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import (
         RagTokenizer,

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -11,7 +11,7 @@ from haystack.utils.import_utils import is_whisper_available
 from haystack.lazy_imports import LazyImport
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_import:
     import torch
 
 

--- a/haystack/nodes/audio/whisper_transcriber.py
+++ b/haystack/nodes/audio/whisper_transcriber.py
@@ -11,7 +11,7 @@ from haystack.utils.import_utils import is_whisper_available
 from haystack.lazy_imports import LazyImport
 
 
-with LazyImport() as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
     import torch
 
 

--- a/haystack/nodes/doc_language_classifier/transformers.py
+++ b/haystack/nodes/doc_language_classifier/transformers.py
@@ -12,7 +12,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/doc_language_classifier/transformers.py
+++ b/haystack/nodes/doc_language_classifier/transformers.py
@@ -12,7 +12,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/document_classifier/transformers.py
+++ b/haystack/nodes/document_classifier/transformers.py
@@ -8,7 +8,7 @@ from haystack.schema import Document
 from haystack.nodes.document_classifier.base import BaseDocumentClassifier
 from haystack.lazy_imports import LazyImport
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/document_classifier/transformers.py
+++ b/haystack/nodes/document_classifier/transformers.py
@@ -8,7 +8,7 @@ from haystack.schema import Document
 from haystack.nodes.document_classifier.base import BaseDocumentClassifier
 from haystack.lazy_imports import LazyImport
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -33,7 +33,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from torch.utils.data import Dataset, DataLoader
     from transformers import AutoTokenizer, AutoModelForTokenClassification

--- a/haystack/nodes/extractor/entity.py
+++ b/haystack/nodes/extractor/entity.py
@@ -33,7 +33,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from torch.utils.data import Dataset, DataLoader
     from transformers import AutoTokenizer, AutoModelForTokenClassification

--- a/haystack/nodes/image_to_text/transformers.py
+++ b/haystack/nodes/image_to_text/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/image_to_text/transformers.py
+++ b/haystack/nodes/image_to_text/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/label_generator/pseudo_label_generator.py
+++ b/haystack/nodes/label_generator/pseudo_label_generator.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from sentence_transformers import CrossEncoder
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/label_generator/pseudo_label_generator.py
+++ b/haystack/nodes/label_generator/pseudo_label_generator.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from sentence_transformers import CrossEncoder
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -10,7 +10,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import (
         pipeline,

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -10,7 +10,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import (
         pipeline,

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -6,7 +6,7 @@ from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
 from haystack.schema import Document, MultiLabel
 from haystack.lazy_imports import LazyImport
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_import:
     import torch
 
 

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -6,7 +6,7 @@ from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
 from haystack.schema import Document, MultiLabel
 from haystack.lazy_imports import LazyImport
 
-with LazyImport() as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
     import torch
 
 

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -10,7 +10,7 @@ from haystack.nodes.prompt.prompt_model import PromptModel
 from haystack.nodes.prompt.prompt_template import PromptTemplate
 from haystack.lazy_imports import LazyImport
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_import:
     import torch
 
 

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -10,7 +10,7 @@ from haystack.nodes.prompt.prompt_model import PromptModel
 from haystack.nodes.prompt.prompt_template import PromptTemplate
 from haystack.lazy_imports import LazyImport
 
-with LazyImport() as torch_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_import:
     import torch
 
 

--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -11,7 +11,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -11,7 +11,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/question_generator/question_generator.py
+++ b/haystack/nodes/question_generator/question_generator.py
@@ -93,6 +93,7 @@ class QuestionGenerator(BaseComponent):
                         parameter is not used and a single CPU device is used for inference.
 
         """
+        torch_and_transformers_import.check()
         super().__init__()
         self.devices, _ = initialize_device_settings(devices=devices, use_cuda=use_gpu, multi_gpu=False)
         if len(self.devices) > 1:

--- a/haystack/nodes/question_generator/question_generator.py
+++ b/haystack/nodes/question_generator/question_generator.py
@@ -14,7 +14,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import AutoModelForSeq2SeqLM
     from transformers import AutoTokenizer

--- a/haystack/nodes/question_generator/question_generator.py
+++ b/haystack/nodes/question_generator/question_generator.py
@@ -14,7 +14,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import AutoModelForSeq2SeqLM
     from transformers import AutoTokenizer

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from torch.nn import DataParallel
     from transformers import AutoModelForSequenceClassification, AutoTokenizer

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from torch.nn import DataParallel
     from transformers import AutoModelForSequenceClassification, AutoTokenizer

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -24,7 +24,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from haystack.modeling.data_handler.data_silo import DataSilo, DistillationDataSilo
     from haystack.modeling.data_handler.processor import SquadProcessor, Processor

--- a/haystack/nodes/reader/farm.py
+++ b/haystack/nodes/reader/farm.py
@@ -24,7 +24,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from haystack.modeling.data_handler.data_silo import DataSilo, DistillationDataSilo
     from haystack.modeling.data_handler.processor import SquadProcessor, Processor

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 TableQuestionAnsweringPipeline = object
 TapasPreTrainedModel = object
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import (  # type: ignore
         TapasTokenizer,

--- a/haystack/nodes/reader/table.py
+++ b/haystack/nodes/reader/table.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 TableQuestionAnsweringPipeline = object
 TapasPreTrainedModel = object
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import (  # type: ignore
         TapasTokenizer,

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -12,7 +12,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from transformers.data.processors.squad import SquadExample

--- a/haystack/nodes/reader/transformers.py
+++ b/haystack/nodes/reader/transformers.py
@@ -12,7 +12,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from transformers.data.processors.squad import SquadExample

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from sentence_transformers import InputExample, SentenceTransformer
     from torch.utils.data import DataLoader

--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from sentence_transformers import InputExample, SentenceTransformer
     from torch.utils.data import DataLoader

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -26,7 +26,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from torch.nn import DataParallel
     from torch.utils.data.sampler import SequentialSampler

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -26,7 +26,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from torch.nn import DataParallel
     from torch.utils.data.sampler import SequentialSampler

--- a/haystack/nodes/retriever/multimodal/embedder.py
+++ b/haystack/nodes/retriever/multimodal/embedder.py
@@ -15,7 +15,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from haystack.utils.torch_utils import get_devices  # pylint: disable=ungrouped-imports
     from haystack.modeling.model.multimodal import get_model  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/retriever/multimodal/embedder.py
+++ b/haystack/nodes/retriever/multimodal/embedder.py
@@ -15,7 +15,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from haystack.utils.torch_utils import get_devices  # pylint: disable=ungrouped-imports
     from haystack.modeling.model.multimodal import get_model  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/retriever/multimodal/retriever.py
+++ b/haystack/nodes/retriever/multimodal/retriever.py
@@ -15,7 +15,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
 
 

--- a/haystack/nodes/retriever/multimodal/retriever.py
+++ b/haystack/nodes/retriever/multimodal/retriever.py
@@ -15,7 +15,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
 
 

--- a/haystack/nodes/sampler/top_p_sampler.py
+++ b/haystack/nodes/sampler/top_p_sampler.py
@@ -11,7 +11,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from sentence_transformers import CrossEncoder
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/sampler/top_p_sampler.py
+++ b/haystack/nodes/sampler/top_p_sampler.py
@@ -11,7 +11,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from sentence_transformers import CrossEncoder
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport() as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
     import torch
     from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/haystack/nodes/translator/transformers.py
+++ b/haystack/nodes/translator/transformers.py
@@ -13,7 +13,7 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'.") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
     import torch
     from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,11 +216,11 @@ formatting = [
 ]
 
 all = [
-  "farm-haystack[docstores,audio,crawler,preprocessing,file-conversion,pdf,ocr,ray,onnx,beir,metrics]",
+  "farm-haystack[inference,docstores,audio,crawler,preprocessing,file-conversion,pdf,ocr,ray,onnx,beir,metrics]",
 ]
 all-gpu = [
   # beir is incompatible with faiss-gpu: https://github.com/beir-cellar/beir/issues/71
-  "farm-haystack[docstores-gpu,audio,crawler,preprocessing,file-conversion,pdf,ocr,ray,onnx-gpu,metrics]",
+  "farm-haystack[inference,docstores-gpu,audio,crawler,preprocessing,file-conversion,pdf,ocr,ray,onnx-gpu,metrics]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
   "requests",
   "pydantic",
-  "transformers[torch,sentencepiece]==4.30.1",
+  "transformers==4.30.1",
   "pandas",
   "rank_bm25",
   "scikit-learn>=1.0.0", # TF-IDF, SklearnQueryClassifier and metrics
@@ -62,16 +62,15 @@ dependencies = [
   "quantulum3",  # quantities extraction from text
   "posthog",  # telemetry
   # audio's espnet-model-zoo requires huggingface-hub version <0.8 while we need >=0.5 to be able to use create_repo in FARMReader
-  "huggingface-hub>=0.5.0",
   "tenacity",  # retry decorator
   "sseclient-py",  # server side events for OpenAI streaming
   "more_itertools",  # utilities
 
   # Web Retriever
   "boilerpy3",
-
-  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
-  "sentence-transformers>=2.2.0",
+  
+  # Multimodal Embedder haystack/nodes/retriever/multimodal/embedder.py
+  "Pillow",
 
   # OpenAI tokenizer
   "tiktoken>=0.3.2",
@@ -89,6 +88,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+inference = [
+  "transformers[torch,sentencepiece]==4.30.1",
+  "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
+  "huggingface-hub>=0.5.0",
+]
 elasticsearch = [
   "elasticsearch>=7.17,<8",
 ]


### PR DESCRIPTION
### Related Issues

- fixes #4233 
- fixes #4417 
- Users who want to just use PromptNode with OpenAI or with a model from transformers should not need to install torch and cuda dependencies, sentencepiece or the huggingface hub dependencies but at the moment it's a must.

### Proposed Changes:

- **TLDR**:  `pip install farm-haystack` -> `pip install farm-haystack[inference]`. Users who ran the former in the past now need to run the latter to install the same set of dependencies.
- This PR adds a new extra, for now called `inference`. ~~Let's discuss the name of this extra.~~
- The `inference` extra contains torch, sentencepiece extras of transformers so that the versions that are compatible with transformers are installed. It also contains the huggingface hub dependency and sentence-transformers.
- The standard Haystack installation will not install torch, sentencepiece, sentence-transformers, and huggingface hub but instead just install transformers without those extras. As a result users can run for example PromptNode with different API providers, such as OpenAI or Hugging Face inference endpoints and api inference. 
- Nice side effect: most of the integration tests become several minutes faster because they can skip installing torch.

### How did you test it?

- Manually tested running a PromptNode with OpenAI after installing from this branch. More tests with other model providers  pending.

### Notes for the reviewer
- Pillow shouldn't be part of the core dependencies but for now it's required. Otherwise the import fails. Should be addressed in a separate PR. https://github.com/deepset-ai/haystack/blob/7731713a1e0d68b44e2f3e8d0dc0035fe26e8c9f/haystack/nodes/retriever/multimodal/embedder.py#L8
- It's a big breaking change for how Haystack is installed, for example in all tutorials, the docs, and the readme. Let's talk with @bilgeyucel and @TuanaCelik about how to roll this out before merging and let's doublecheck that an error message with simple instructions is shown if torch is not installed but required. Should be the case already thanks to #5101 .
- I ~~still need to~~ checked whether it makes more sense to keep `huggingface-hub` as a core dependency
  - huggingface_hub import is used only used very few times in the code base: https://github.com/search?q=repo%3Adeepset-ai%2Fhaystack%20_hub&type=code One use case is to push a finetuned reader model to the hub and the other use case is to check whether a model that shall be downloaded from the model hub is of type "sentence_transformers". In both cases a torch import is required early so there is no situation when a user reaches the code where huggingface_hub is used before the torch import fails. Therefore, `huggingface-hub` can be part of the inference extra.
- ~~Once we have agreed on the name of the extra, I will add a message to all the lazy `torch_imports` and `torch_and_transformers_imports` saying `message="Run 'pip install farm-haystack[inference]'"`~~ done

### Alternatives
An alternative would be to also remove plain transformers (without extras) from Haystack's standard dependencies. I think we shouldn't do that. It further reduces the installation to a minimum and thus saves installation time and memory but transformers is required for many things users can do with Haystack and even a PromptNode with a transformers model requires it. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
