### PR TITLE
feat: add ensure token limit for direct prompting of ChatGPT

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -126,17 +126,34 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
         elif isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], dict):
             messages = prompt
 
-        n_prompt_tokens = count_openai_tokens_messages(messages, self._tokenizer)
+        n_message_tokens = count_openai_tokens_messages(messages, self._tokenizer)
         n_answer_tokens = self.max_length
-        if (n_prompt_tokens + n_answer_tokens) <= self.max_tokens_limit:
+        if (n_message_tokens + n_answer_tokens) <= self.max_tokens_limit:
             return prompt
 
-        # TODO: support truncation as in _ensure_token_limit methods for other invocation layers
-        raise ValueError(
-            f"The prompt or the messages are too long ({n_prompt_tokens} tokens). "
-            f"The length of the prompt or messages and the answer ({n_answer_tokens} tokens) should be within the max token limit ({self.max_tokens_limit} tokens). "
-            f"Reduce the length of the prompt or messages."
-        )
+        if isinstance(prompt, str):
+            logger.warning(
+                "The prompt has been truncated from %s tokens to %s tokens so that the prompt length and "
+                "answer length (%s tokens) fit within the max token limit (%s tokens). "
+                "Reduce the length of the prompt to prevent it from being cut off.",
+                n_message_tokens,
+                self.max_tokens_limit - n_answer_tokens,
+                n_answer_tokens,
+                self.max_tokens_limit,
+            )
+            tokenized_payload = self._tokenizer.encode(prompt)
+            n_other_tokens = n_message_tokens - len(tokenized_payload)
+            truncated_prompt_length = self.max_tokens_limit - n_answer_tokens - n_other_tokens
+            truncated_prompt = self._tokenizer.decode(tokenized_payload[:truncated_prompt_length])
+            return truncated_prompt
+        else:
+            # TODO: support truncation when there is a chat history
+            raise ValueError(
+                f"The prompt or the messages are too long ({n_message_tokens} tokens). "
+                f"The length of the prompt or messages and the answer ({n_answer_tokens} tokens) should be within the max "
+                f"token limit ({self.max_tokens_limit} tokens). "
+                f"Reduce the length of the prompt or messages."
+            )
 
     @property
     def url(self) -> str:

--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -132,21 +132,21 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
             return prompt
 
         if isinstance(prompt, str):
-            tokenized_payload = self._tokenizer.encode(prompt)
-            n_other_tokens = n_message_tokens - len(tokenized_payload)
+            tokenized_prompt = self._tokenizer.encode(prompt)
+            n_other_tokens = n_message_tokens - len(tokenized_prompt)
+            truncated_prompt_length = self.max_tokens_limit - n_answer_tokens - n_other_tokens
 
             logger.warning(
                 "The prompt has been truncated from %s tokens to %s tokens so that the prompt length and "
                 "answer length (%s tokens) fit within the max token limit (%s tokens). "
                 "Reduce the length of the prompt to prevent it from being cut off.",
-                n_message_tokens,
-                self.max_tokens_limit - n_answer_tokens - n_other_tokens,
+                len(tokenized_prompt),
+                truncated_prompt_length,
                 n_answer_tokens,
                 self.max_tokens_limit,
             )
 
-            truncated_prompt_length = self.max_tokens_limit - n_answer_tokens - n_other_tokens
-            truncated_prompt = self._tokenizer.decode(tokenized_payload[:truncated_prompt_length])
+            truncated_prompt = self._tokenizer.decode(tokenized_prompt[:truncated_prompt_length])
             return truncated_prompt
         else:
             # TODO: support truncation when there is a chat history

--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -132,17 +132,19 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
             return prompt
 
         if isinstance(prompt, str):
+            tokenized_payload = self._tokenizer.encode(prompt)
+            n_other_tokens = n_message_tokens - len(tokenized_payload)
+
             logger.warning(
                 "The prompt has been truncated from %s tokens to %s tokens so that the prompt length and "
                 "answer length (%s tokens) fit within the max token limit (%s tokens). "
                 "Reduce the length of the prompt to prevent it from being cut off.",
                 n_message_tokens,
-                self.max_tokens_limit - n_answer_tokens,
+                self.max_tokens_limit - n_answer_tokens - n_other_tokens,
                 n_answer_tokens,
                 self.max_tokens_limit,
             )
-            tokenized_payload = self._tokenizer.encode(prompt)
-            n_other_tokens = n_message_tokens - len(tokenized_payload)
+
             truncated_prompt_length = self.max_tokens_limit - n_answer_tokens - n_other_tokens
             truncated_prompt = self._tokenizer.decode(tokenized_payload[:truncated_prompt_length])
             return truncated_prompt

--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -44,7 +44,7 @@ def count_openai_tokens_messages(messages: List[Dict[str, str]], tokenizer) -> i
     :param messages: The messages to be tokenized.
     :param tokenizer: An OpenAI tokenizer.
     """
-    # adapted from https://platform.openai.com/docs/guides/chat/introduction
+    # adapted from https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
     # should be kept up to date
     num_tokens = 0
     for message in messages:
@@ -53,7 +53,7 @@ def count_openai_tokens_messages(messages: List[Dict[str, str]], tokenizer) -> i
             num_tokens += len(tokenizer.encode(value))
             if key == "name":  # if there's a name, the role is omitted
                 num_tokens += -1  # role is always required and always 1 token
-    num_tokens += 2  # every reply is primed with <im_start>assistant
+    num_tokens += 3  # every reply is primed with <im_start>assistant<|message|>
     return num_tokens
 
 

--- a/test/prompt/invocation_layer/conftest.py
+++ b/test/prompt/invocation_layer/conftest.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+@pytest.fixture
+def mock_openai_tokenizer():
+    with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer") as mock_tokenizer_func:
+        mock_tokenizer = MagicMock()  # this will be our mock tokenizer
+        # "This is a test for a mock openai tokenizer."
+        mock_tokenizer.encode.return_value = [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192, 47058, 13]
+        # Returning truncated prompt: [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192]
+        mock_tokenizer.decode.return_value = "This is a test for a mock openai"
+        mock_tokenizer_func.return_value = mock_tokenizer
+        yield mock_tokenizer_func

--- a/test/prompt/invocation_layer/test_chatgpt.py
+++ b/test/prompt/invocation_layer/test_chatgpt.py
@@ -1,21 +1,9 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import logging
 import pytest
 
 from haystack.nodes.prompt.invocation_layer import ChatGPTInvocationLayer
-
-
-@pytest.fixture
-def mock_openai_tokenizer():
-    with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer") as mock_tokenizer_func:
-        mock_tokenizer = MagicMock()  # this will be our mock tokenizer
-        # "This is a test for a mock openai tokenizer."
-        mock_tokenizer.encode.return_value = [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192, 47058, 13]
-        # Returning truncated prompt: [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192]
-        mock_tokenizer.decode.return_value = "This is a test for a mock openai"
-        mock_tokenizer_func.return_value = mock_tokenizer
-        yield mock_tokenizer_func
 
 
 @pytest.mark.unit

--- a/test/prompt/invocation_layer/test_openai.py
+++ b/test/prompt/invocation_layer/test_openai.py
@@ -1,21 +1,9 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import logging
 import pytest
 
 from haystack.nodes.prompt.invocation_layer import OpenAIInvocationLayer
-
-
-@pytest.fixture
-def mock_openai_tokenizer():
-    with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer") as mock_tokenizer_func:
-        mock_tokenizer = MagicMock()  # this will be our mock tokenizer
-        # "This is a test for a mock openai tokenizer."
-        mock_tokenizer.encode.return_value = [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192, 47058, 13]
-        # Returning truncated prompt: [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192]
-        mock_tokenizer.decode.return_value = "This is a test for a mock openai"
-        mock_tokenizer_func.return_value = mock_tokenizer
-        yield mock_tokenizer_func
 
 
 @pytest.mark.unit

--- a/test/prompt/invocation_layer/test_openai.py
+++ b/test/prompt/invocation_layer/test_openai.py
@@ -1,8 +1,21 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
+import logging
 import pytest
 
 from haystack.nodes.prompt.invocation_layer import OpenAIInvocationLayer
+
+
+@pytest.fixture
+def mock_openai_tokenizer():
+    with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer") as mock_tokenizer_func:
+        mock_tokenizer = MagicMock()  # this will be our mock tokenizer
+        # "This is a test for a mock openai tokenizer."
+        mock_tokenizer.encode.return_value = [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192, 47058, 13]
+        # Returning truncated prompt: [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192]
+        mock_tokenizer.decode.return_value = "This is a test for a mock openai"
+        mock_tokenizer_func.return_value = mock_tokenizer
+        yield mock_tokenizer_func
 
 
 @pytest.mark.unit
@@ -27,3 +40,14 @@ def test_custom_api_base(mock_request):
 
     invocation_layer.invoke(prompt="dummy_prompt")
     assert mock_request.call_args.kwargs["url"] == "https://fake_api_base.com/completions"
+
+
+@pytest.mark.unit
+def test_openai_token_limit_warning(mock_openai_tokenizer, caplog):
+    invocation_layer = OpenAIInvocationLayer(
+        model_name_or_path="text-ada-001", api_key="fake_api_key", api_base="https://fake_api_base.com", max_length=2045
+    )
+    with caplog.at_level(logging.WARNING):
+        _ = invocation_layer._ensure_token_limit(prompt="This is a test for a mock openai tokenizer.")
+        assert "The prompt has been truncated from" in caplog.text
+        assert "and answer length (2045 tokens) fit within the max token limit (2049 tokens)." in caplog.text

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -907,7 +907,7 @@ class TestTokenLimit:
             assert "and answer length (2000 tokens) fit within the max token limit (2049 tokens)." in caplog.text
 
     # NOTE: This first time calling this test causes an url request to be made to get the tokenizer
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_chatgpt_token_limit_warning_single_prompt(self, caplog):
         prompt = "Repeating text" * 200 + "Docs: Berlin is an amazing city.; Answer:"
         prompt_node = PromptNode("gpt-3.5-turbo", max_length=4000, api_key="fake_key")

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -925,7 +925,7 @@ class TestTokenLimit:
             assert "and answer length (4090 tokens) fit within the max token limit (4096 tokens)." in caplog.text
 
     @pytest.mark.unit
-    def test_chatgpt_token_limit_warning_with_messages(self, caplog):
+    def test_chatgpt_token_limit_warning_with_messages(self, mock_openai_tokenizer, caplog):
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Who won the world series in 2020?"},

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -27,6 +27,18 @@ def mock_prompthub():
         yield mock_prompthub
 
 
+@pytest.fixture
+def mock_openai_tokenizer():
+    with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer") as mock_tokenizer_func:
+        mock_tokenizer = MagicMock()  # this will be our mock tokenizer
+        # "This is a test for a mock openai tokenizer."
+        mock_tokenizer.encode.return_value = [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192, 47058, 13]
+        # Returning truncated prompt: [2028, 374, 264, 1296, 369, 264, 8018, 1825, 2192]
+        mock_tokenizer.decode.return_value = "This is a test for a mock openai"
+        mock_tokenizer_func.return_value = mock_tokenizer
+        yield mock_tokenizer_func
+
+
 def skip_test_for_invalid_key(prompt_model):
     if prompt_model.api_key is not None and prompt_model.api_key == "KEY_NOT_FOUND":
         pytest.skip("No API key found, skipping test")
@@ -896,28 +908,23 @@ class TestTokenLimit:
             assert "The prompt has been truncated from 812 tokens to 412 tokens" in caplog.text
             assert "and answer length (100 tokens) fit within the max token limit (512 tokens)." in caplog.text
 
-    # NOTE: This first time calling this test causes an url request to be made to get the tokenizer
-    @pytest.mark.integration
-    def test_openai_token_limit_warning(self, caplog):
-        prompt = "Repeating text" * 200 + "Docs: Berlin is an amazing city.; Answer:"
-        prompt_node = PromptNode("text-ada-001", max_length=2000, api_key="fake_key")
+    @pytest.mark.unit
+    def test_openai_token_limit_warning(self, mock_openai_tokenizer, caplog):
+        prompt_node = PromptNode("text-ada-001", max_length=2045, api_key="fake_key")
         with caplog.at_level(logging.WARNING):
-            _ = prompt_node.prompt_model._ensure_token_limit(prompt=prompt)
+            _ = prompt_node.prompt_model._ensure_token_limit(prompt="This is a test for a mock openai tokenizer.")
             assert "The prompt has been truncated from" in caplog.text
-            assert "and answer length (2000 tokens) fit within the max token limit (2049 tokens)." in caplog.text
+            assert "and answer length (2045 tokens) fit within the max token limit (2049 tokens)." in caplog.text
 
-    # NOTE: This first time calling this test causes an url request to be made to get the tokenizer
-    @pytest.mark.integration
-    def test_chatgpt_token_limit_warning_single_prompt(self, caplog):
-        prompt = "Repeating text" * 200 + "Docs: Berlin is an amazing city.; Answer:"
-        prompt_node = PromptNode("gpt-3.5-turbo", max_length=4000, api_key="fake_key")
+    @pytest.mark.unit
+    def test_chatgpt_token_limit_warning_single_prompt(self, mock_openai_tokenizer, caplog):
+        prompt_node = PromptNode("gpt-3.5-turbo", max_length=4090, api_key="fake_key")
         with caplog.at_level(logging.WARNING):
-            _ = prompt_node.prompt_model._ensure_token_limit(prompt=prompt)
+            _ = prompt_node.prompt_model._ensure_token_limit(prompt="This is a test for a mock openai tokenizer.")
             assert "The prompt has been truncated from" in caplog.text
-            assert "and answer length (4000 tokens) fit within the max token limit (4096 tokens)." in caplog.text
+            assert "and answer length (4090 tokens) fit within the max token limit (4096 tokens)." in caplog.text
 
-    # NOTE: This first time calling this test causes a url request to be made to get the tokenizer
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_chatgpt_token_limit_warning_with_messages(self, caplog):
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -925,9 +932,11 @@ class TestTokenLimit:
             {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
             {"role": "user", "content": "Where was it played?"},
         ]
-        prompt_node = PromptNode("gpt-3.5-turbo", max_length=4060, api_key="fake_key")
-        with pytest.raises(ValueError):
-            _ = prompt_node.prompt_model._ensure_token_limit(prompt=messages)
+        with patch("haystack.utils.openai_utils.count_openai_tokens_messages") as mock_count_tokens:
+            mock_count_tokens.return_value = 40
+            prompt_node = PromptNode("gpt-3.5-turbo", max_length=4060, api_key="fake_key")
+            with pytest.raises(ValueError):
+                _ = prompt_node.prompt_model._ensure_token_limit(prompt=messages)
 
 
 class TestRunBatch:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/61

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Adds an implementation for the `ChatGPTInvocationLayer._ensure_token_limit` that closely follows the one for `OpenAIInvocationLayer`
- This PR only handles the token truncation for a single prompt. It does not handle the case when the prompt is a list of dictionaries (e.g. messages) which occurs when the prompt node is used in chat mode.
- These changes will work for both the OpenAI and Azure Invocation layers

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added new tests. Unfortunately, I could not make them unit tests because the library `tiktoken` makes an URL request to fetch the tokenizer for the corresponding OpenAI model. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
