### PR TITLE
test: Adding unit tests to Ranker

### DIFF
--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -273,9 +273,8 @@ class SentenceTransformersRanker(BaseRanker):
 
             return result
 
-    @staticmethod
     def _preprocess_batch_queries_and_docs(
-        queries: List[str], documents: Union[List[Document], List[List[Document]]]
+        self, queries: List[str], documents: Union[List[Document], List[List[Document]]]
     ) -> Tuple[List[int], List[str], List[Document], bool]:
         number_of_docs = []
         all_queries = []

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -273,8 +273,9 @@ class SentenceTransformersRanker(BaseRanker):
 
             return result
 
+    @staticmethod
     def _preprocess_batch_queries_and_docs(
-        self, queries: List[str], documents: Union[List[Document], List[List[Document]]]
+        queries: List[str], documents: Union[List[Document], List[List[Document]]]
     ) -> Tuple[List[int], List[str], List[Document], bool]:
         number_of_docs = []
         all_queries = []

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -289,5 +289,4 @@ def test_predict_batch_returns_correct_number_of_docs(ranker):
     docs = [Document(content=f"test {number}") for number in range(5)]
 
     assert len(ranker.predict("where is test 3?", docs, top_k=4)) == 4
-
     assert len(ranker.predict_batch(["where is test 3?"], docs, batch_size=2, top_k=4)) == 4

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -27,7 +27,7 @@ def test_ranker_preprocess_batch_queries_and_docs_single_query_single_doc_list()
     with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
         mock_ranker_init.return_value = None
         ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
-    (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
+    num_of_docs, all_queries, all_docs, single_list_of_docs = ranker._preprocess_batch_queries_and_docs(
         queries=[query1], documents=docs1
     )
     assert single_list_of_docs is True
@@ -45,7 +45,7 @@ def test_ranker_preprocess_batch_queries_and_docs_multiple_queries_multiple_doc_
     with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
         mock_ranker_init.return_value = None
         ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
-    (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
+    num_of_docs, all_queries, all_docs, single_list_of_docs = ranker._preprocess_batch_queries_and_docs(
         queries=[query_1, query_2], documents=[docs1, docs2]
     )
     assert single_list_of_docs is False

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -289,4 +289,5 @@ def test_predict_batch_returns_correct_number_of_docs(ranker):
     docs = [Document(content=f"test {number}") for number in range(5)]
 
     assert len(ranker.predict("where is test 3?", docs, top_k=4)) == 4
+
     assert len(ranker.predict_batch(["where is test 3?"], docs, batch_size=2, top_k=4)) == 4

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -7,6 +7,37 @@ from haystack.nodes.ranker.base import BaseRanker
 from haystack.nodes.ranker.sentence_transformers import SentenceTransformersRanker
 
 
+@pytest.mark.unit
+def test_ranker_preprocess_batch_queries_and_docs_raises():
+    query_1 = "query 1"
+    query_2 = "query 2"
+    docs = [Document(content="dummy doc 1")]
+    with pytest.raises(HaystackError):
+        _, _, _, _ = SentenceTransformersRanker._preprocess_batch_queries_and_docs(
+            queries=[query_1, query_2], documents=[docs]
+        )
+
+
+@pytest.mark.unit
+def test_ranker_preprocess_batch_queries_and_docs():
+    query_1 = "query 1"
+    query_2 = "query 2"
+    docs1 = [Document(content="dummy doc 1"), Document(content="dummy doc 2")]
+    docs2 = [Document(content="dummy doc 3")]
+    (
+        num_of_docs,
+        all_queries,
+        all_docs,
+        single_list_of_docs,
+    ) = SentenceTransformersRanker._preprocess_batch_queries_and_docs(
+        queries=[query_1, query_2], documents=[docs1, docs2]
+    )
+    assert single_list_of_docs is False
+    assert num_of_docs == [2, 1]
+    assert len(all_queries) == 3
+    assert len(all_docs) == 3
+
+
 def test_ranker(ranker):
     query = "What is the most important building in King's Landing that has a religious background?"
     docs = [

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -1,5 +1,6 @@
 import pytest
 import math
+from unittest.mock import patch
 
 from haystack.errors import HaystackError
 from haystack.schema import Document
@@ -12,26 +13,27 @@ def test_ranker_preprocess_batch_queries_and_docs_raises():
     query_1 = "query 1"
     query_2 = "query 2"
     docs = [Document(content="dummy doc 1")]
-    with pytest.raises(HaystackError):
-        _, _, _, _ = SentenceTransformersRanker._preprocess_batch_queries_and_docs(
-            queries=[query_1, query_2], documents=docs
-        )
+    with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
+        mock_ranker_init.return_value = None
+        ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
+        with pytest.raises(HaystackError):
+            _, _, _, _ = ranker._preprocess_batch_queries_and_docs(queries=[query_1, query_2], documents=docs)
 
 
 @pytest.mark.unit
 def test_ranker_preprocess_batch_queries_and_docs_single_query_single_doc_list():
     query1 = "query 1"
     docs1 = [Document(content="dummy doc 1"), Document(content="dummy doc 2")]
-    (
-        num_of_docs,
-        all_queries,
-        all_docs,
-        single_list_of_docs,
-    ) = SentenceTransformersRanker._preprocess_batch_queries_and_docs(queries=[query1], documents=docs1)
-    assert single_list_of_docs is True
-    assert num_of_docs == [2]
-    assert len(all_queries) == 2
-    assert len(all_docs) == 2
+    with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
+        mock_ranker_init.return_value = None
+        ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
+        (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
+            queries=[query1], documents=docs1
+        )
+        assert single_list_of_docs is True
+        assert num_of_docs == [2]
+        assert len(all_queries) == 2
+        assert len(all_docs) == 2
 
 
 @pytest.mark.unit
@@ -40,18 +42,16 @@ def test_ranker_preprocess_batch_queries_and_docs_multiple_queries_multiple_doc_
     query_2 = "query 2"
     docs1 = [Document(content="dummy doc 1"), Document(content="dummy doc 2")]
     docs2 = [Document(content="dummy doc 3")]
-    (
-        num_of_docs,
-        all_queries,
-        all_docs,
-        single_list_of_docs,
-    ) = SentenceTransformersRanker._preprocess_batch_queries_and_docs(
-        queries=[query_1, query_2], documents=[docs1, docs2]
-    )
-    assert single_list_of_docs is False
-    assert num_of_docs == [2, 1]
-    assert len(all_queries) == 3
-    assert len(all_docs) == 3
+    with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
+        mock_ranker_init.return_value = None
+        ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
+        (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
+            queries=[query_1, query_2], documents=[docs1, docs2]
+        )
+        assert single_list_of_docs is False
+        assert num_of_docs == [2, 1]
+        assert len(all_queries) == 3
+        assert len(all_docs) == 3
 
 
 @pytest.mark.unit

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -14,12 +14,28 @@ def test_ranker_preprocess_batch_queries_and_docs_raises():
     docs = [Document(content="dummy doc 1")]
     with pytest.raises(HaystackError):
         _, _, _, _ = SentenceTransformersRanker._preprocess_batch_queries_and_docs(
-            queries=[query_1, query_2], documents=[docs]
+            queries=[query_1, query_2], documents=docs
         )
 
 
 @pytest.mark.unit
-def test_ranker_preprocess_batch_queries_and_docs():
+def test_ranker_preprocess_batch_queries_and_docs_single_query_single_doc_list():
+    query1 = "query 1"
+    docs1 = [Document(content="dummy doc 1"), Document(content="dummy doc 2")]
+    (
+        num_of_docs,
+        all_queries,
+        all_docs,
+        single_list_of_docs,
+    ) = SentenceTransformersRanker._preprocess_batch_queries_and_docs(queries=[query1], documents=docs1)
+    assert single_list_of_docs is True
+    assert num_of_docs == [2]
+    assert len(all_queries) == 2
+    assert len(all_docs) == 2
+
+
+@pytest.mark.unit
+def test_ranker_preprocess_batch_queries_and_docs_multiple_queries_multiple_doc_lists():
     query_1 = "query 1"
     query_2 = "query 2"
     docs1 = [Document(content="dummy doc 1"), Document(content="dummy doc 2")]
@@ -36,6 +52,17 @@ def test_ranker_preprocess_batch_queries_and_docs():
     assert num_of_docs == [2, 1]
     assert len(all_queries) == 3
     assert len(all_docs) == 3
+
+
+@pytest.mark.unit
+def test_ranker_get_batches():
+    all_queries = ["query 1", "query 1"]
+    all_docs = [Document(content="dummy doc 1"), Document(content="dummy doc 2")]
+    batches = SentenceTransformersRanker._get_batches(all_queries=all_queries, all_docs=all_docs, batch_size=None)
+    assert next(batches) == (all_queries, all_docs)
+
+    batches = SentenceTransformersRanker._get_batches(all_queries=all_queries, all_docs=all_docs, batch_size=1)
+    assert next(batches) == (all_queries[0:1], all_docs[0:1])
 
 
 def test_ranker(ranker):

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -16,8 +16,8 @@ def test_ranker_preprocess_batch_queries_and_docs_raises():
     with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
         mock_ranker_init.return_value = None
         ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
-        with pytest.raises(HaystackError):
-            _, _, _, _ = ranker._preprocess_batch_queries_and_docs(queries=[query_1, query_2], documents=docs)
+    with pytest.raises(HaystackError, match="Number of queries must be 1 if a single list of Documents is provided."):
+        _, _, _, _ = ranker._preprocess_batch_queries_and_docs(queries=[query_1, query_2], documents=docs)
 
 
 @pytest.mark.unit
@@ -27,13 +27,13 @@ def test_ranker_preprocess_batch_queries_and_docs_single_query_single_doc_list()
     with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
         mock_ranker_init.return_value = None
         ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
-        (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
-            queries=[query1], documents=docs1
-        )
-        assert single_list_of_docs is True
-        assert num_of_docs == [2]
-        assert len(all_queries) == 2
-        assert len(all_docs) == 2
+    (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
+        queries=[query1], documents=docs1
+    )
+    assert single_list_of_docs is True
+    assert num_of_docs == [2]
+    assert len(all_queries) == 2
+    assert len(all_docs) == 2
 
 
 @pytest.mark.unit
@@ -45,13 +45,13 @@ def test_ranker_preprocess_batch_queries_and_docs_multiple_queries_multiple_doc_
     with patch("haystack.nodes.ranker.sentence_transformers.SentenceTransformersRanker.__init__") as mock_ranker_init:
         mock_ranker_init.return_value = None
         ranker = SentenceTransformersRanker(model_name_or_path="fake_model")
-        (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
-            queries=[query_1, query_2], documents=[docs1, docs2]
-        )
-        assert single_list_of_docs is False
-        assert num_of_docs == [2, 1]
-        assert len(all_queries) == 3
-        assert len(all_docs) == 3
+    (num_of_docs, all_queries, all_docs, single_list_of_docs) = ranker._preprocess_batch_queries_and_docs(
+        queries=[query_1, query_2], documents=[docs1, docs2]
+    )
+    assert single_list_of_docs is False
+    assert num_of_docs == [2, 1]
+    assert len(all_queries) == 3
+    assert len(all_docs) == 3
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- fixes N/A

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Adding unit tests to test private methods of `SentenceTransformersRanker`

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
- I only added unit tests for private methods in the Ranker node. In the future, we can use mocking to add unit tests for the `predict` and `predict_batch` methods. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
