### PR TITLE
chore: Remove `add_tool` from `ToolsManager`

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -134,22 +134,6 @@ class ToolsManager:
         self.tool_pattern = tool_pattern
         self.callback_manager = Events(("on_tool_start", "on_tool_finish", "on_tool_error"))
 
-    def add_tool(self, tool: Tool):
-        """
-        Add a tool to the Agent. This also updates the PromptTemplate for the Agent's PromptNode with the tool name.
-
-        :param tool: The tool to add to the Agent. Any previously added tool with the same name will be overwritten.
-        Example:
-        `agent.add_tool(
-            Tool(
-                name="Calculator",
-                pipeline_or_node=calculator
-                description="Useful when you need to answer questions about math."
-            )
-        )
-        """
-        self.tools[tool.name] = tool
-
     @property
     def tools(self):
         return self._tools
@@ -330,7 +314,11 @@ class Agent:
             )
         )
         """
-        self.tm.add_tool(tool)
+        if tool.name in self.tm.tools:
+            logger.warning(
+                f"The agent already has a tool named '{tool.name}'. The new tool will overwrite the existing one."
+            )
+        self.tm.tools[tool.name] = tool
 
     def has_tool(self, tool_name: str) -> bool:
         """

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -316,7 +316,7 @@ class Agent:
         """
         if tool.name in self.tm.tools:
             logger.warning(
-                f"The agent already has a tool named '{tool.name}'. The new tool will overwrite the existing one."
+                "The agent already has a tool named '%s'. The new tool will overwrite the existing one.", tool.name
             )
         self.tm.tools[tool.name] = tool
 

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -18,7 +18,7 @@ from haystack.pipelines import ExtractiveQAPipeline, DocumentSearchPipeline, Bas
 
 
 @pytest.mark.unit
-def test_add_and_overwrite_tool():
+def test_add_and_overwrite_tool(caplog):
     # Add a Node as a Tool to an Agent
     agent = Agent(prompt_node=MockPromptNode())
     retriever = MockRetriever()
@@ -43,12 +43,16 @@ def test_add_and_overwrite_tool():
 
     # Add a Pipeline as a Tool to an Agent and overwrite the previously added Tool
     retriever_pipeline = DocumentSearchPipeline(MockRetriever())
-    agent.add_tool(
-        Tool(
-            name="Retriever",
-            pipeline_or_node=retriever_pipeline,
-            description="useful for when you need to retrieve documents from your index",
+    with caplog.at_level(logging.WARNING):
+        agent.add_tool(
+            Tool(
+                name="Retriever",
+                pipeline_or_node=retriever_pipeline,
+                description="useful for when you need to retrieve documents from your index",
+            )
         )
+    assert (
+        "The agent already has a tool named 'Retriever'. The new tool will overwrite the existing one." in caplog.text
     )
     assert len(agent.tm.tools) == 1
     assert agent.has_tool(tool_name="Retriever")

--- a/test/agents/test_tools_manager.py
+++ b/test/agents/test_tools_manager.py
@@ -26,14 +26,6 @@ def test_using_callable_as_tool():
 
 
 @pytest.mark.unit
-def test_add_tool(tools_manager):
-    new_tool = Tool(name="ToolC", pipeline_or_node=mock.Mock(), description="Tool C Description")
-    tools_manager.add_tool(new_tool)
-    assert "ToolC" in tools_manager.tools
-    assert tools_manager.tools["ToolC"] == new_tool
-
-
-@pytest.mark.unit
 def test_get_tool_names(tools_manager):
     assert tools_manager.get_tool_names() == "ToolA, ToolB"
 


### PR DESCRIPTION
### Related Issues

- fixes #5108 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR removed the `add_tool` method from `ToolsManager`. Also, it adds a warning log to the `add_tool` method of `Agent` that is triggered if the Agent already contains a tool with the same name.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I adapted a unit test to check for the warning message.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
