### PR TITLE
feat: `current_datetime` shaper function

### DIFF
--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -1,6 +1,7 @@
 from functools import reduce
 import inspect
 import re
+from datetime import datetime
 from string import Template
 from typing import Literal, Optional, List, Dict, Any, Tuple, Union, Callable
 
@@ -24,6 +25,19 @@ def rename(value: Any) -> Any:
     ```
     """
     return value
+
+
+def current_datetime(format: str = "%H:%M:%S %d/%m/%y") -> str:
+    """
+    Function that outputs the current time and/or date formatted according to the parameters.
+
+    Example:
+
+    ```python
+    assert current_datetime("%d.%m.%y %H:%M:%S") == 01.01.2023 12:30:10
+    ```
+    """
+    return datetime.now().strftime(format)
 
 
 def value_to_list(value: Any, target_list: List[Any]) -> List[Any]:
@@ -544,6 +558,7 @@ def documents_to_strings(
 
 REGISTERED_FUNCTIONS: Dict[str, Callable[..., Any]] = {
     "rename": rename,
+    "current_datetime": current_datetime,
     "value_to_list": value_to_list,
     "join_lists": join_lists,
     "join_strings": join_strings,

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -22,6 +22,7 @@ from haystack.nodes.prompt.shapers import (  # pylint: disable=unused-import
     BaseOutputParser,
     AnswerParser,
     to_strings,
+    current_datetime,
     join,  # used as shaping function
     format_document,
     format_answer,
@@ -37,7 +38,10 @@ from haystack.environment import (
 logger = logging.getLogger(__name__)
 
 PROMPT_TEMPLATE_ALLOWED_FUNCTIONS = json.loads(
-    os.environ.get(HAYSTACK_PROMPT_TEMPLATE_ALLOWED_FUNCTIONS, '["join", "to_strings", "replace", "enumerate", "str"]')
+    os.environ.get(
+        HAYSTACK_PROMPT_TEMPLATE_ALLOWED_FUNCTIONS,
+        '["join", "to_strings", "replace", "enumerate", "str", "current_datetime"]',
+    )
 )
 PROMPT_TEMPLATE_SPECIAL_CHAR_ALIAS = {"new_line": "\n", "tab": "\t", "double_quote": '"', "carriage_return": "\r"}
 PROMPT_TEMPLATE_STRIPS = ["'", '"']
@@ -289,7 +293,8 @@ class _FstringParamsTransformer(ast.NodeTransformer):
     def visit_FormattedValue(self, node: ast.FormattedValue) -> Optional[ast.AST]:
         """
         Replaces the f-string expression with a unique ID and stores the corresponding expression in a dictionary.
-        If the expression is the raw `documents` variable, it is encapsulated into a call to `documents_to_strings` to ensure that the documents get rendered correctly.
+        If the expression is the raw `documents` variable, it is encapsulated into a call to `documents_to_strings`
+        to ensure that the documents get rendered correctly.
         """
         super().generic_visit(node)
 

--- a/haystack/nodes/prompt/shapers.py
+++ b/haystack/nodes/prompt/shapers.py
@@ -4,6 +4,7 @@ from haystack.schema import Answer, Document
 
 from haystack.nodes.other.shaper import (  # pylint: disable=unused-import
     Shaper,
+    current_datetime,  # used as shaping function
     join_documents_to_string as join,  # used as shaping function
     format_document,
     format_answer,

--- a/test/nodes/test_shaper.py
+++ b/test/nodes/test_shaper.py
@@ -1,5 +1,7 @@
-import pytest
+from datetime import datetime
 import logging
+
+import pytest
 
 import haystack
 from haystack import Pipeline, Document, Answer
@@ -189,6 +191,46 @@ def test_rename_yaml(tmp_path):
     result = pipeline.run(query="test query")
     assert result["invocation_context"]["query"] == "test query"
     assert result["invocation_context"]["questions"] == "test query"
+
+
+#
+# current_datetime
+#
+
+
+@pytest.mark.unit
+def test_current_datetime():
+    shaper = Shaper(func="current_datetime", inputs={}, outputs=["date_time"], params={"format": "%y-%m-%d"})
+    results, _ = shaper.run()
+    assert results["invocation_context"]["date_time"] == datetime.now().strftime("%y-%m-%d")
+
+
+@pytest.mark.unit
+def test_current_datetime_yaml(tmp_path):
+    with open(tmp_path / "tmp_config.yml", "w") as tmp_file:
+        tmp_file.write(
+            f"""
+            version: ignore
+            components:
+            - name: shaper
+              type: Shaper
+              params:
+                func: current_datetime
+                params:
+                  format: "%y-%m-%d"
+                outputs:
+                  - date_time
+            pipelines:
+              - name: query
+                nodes:
+                  - name: shaper
+                    inputs:
+                      - Query
+        """
+        )
+    pipeline = Pipeline.load_from_yaml(path=tmp_path / "tmp_config.yml")
+    result = pipeline.run()
+    assert result["invocation_context"]["date_time"] == datetime.now().strftime("%y-%m-%d")
 
 
 #


### PR DESCRIPTION
### Related Issues

- fixes #5111

### Proposed Changes:
- Adds the `current_datetime` shaper function.
- Explicitly adds it to the default allowed function of `PromptTemplate`.

Example usage:

- as code:
```python
shaper = Shaper(func="current_datetime", inputs={}, outputs=["date_time"], params={"format": "%y-%m-%d"})
```

- as a Shaper:
```yaml
  components:
  - name: shaper
    type: Shaper
    params:
      func: current_datetime
      params:
        format: "%y-%m-%d"
      outputs:
        - date_time
```
- as a prompt template function
```python
prompt = PromptTemplate("It's now {current_datetime(format='%m/%d/%y')}. Given the context and keeping in mind the current time, please answer the question. Context: {join(documents)}; Question: ")
```
Note: in all examples, the `format` parameter is optional and defaults to `"%H:%M:%S %d/%m/%y"`

### How did you test it?
- Local run of new tests

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
