### PR TITLE
fix: `import_utils fetch_archive_from_http` -  improve url parsing for fetching archive from http

### DIFF
--- a/haystack/utils/import_utils.py
+++ b/haystack/utils/import_utils.py
@@ -106,7 +106,7 @@ def get_filename_extension_from_url(url: str) -> Tuple[str, str]:
     root, extension = splitext(parsed.path)
     archive_extension = extension[1:]
     file_name = unquote(basename(root[1:]))
-    return (file_name, archive_extension)
+    return file_name, archive_extension
 
 
 def fetch_archive_from_http(

--- a/haystack/utils/import_utils.py
+++ b/haystack/utils/import_utils.py
@@ -100,7 +100,7 @@ def get_filename_extension_from_url(url: str) -> Tuple[str, str]:
     Extracts the filename and file extension from an url.
 
     :param url: http address
-    :return: Tupel (filename, file extension) of the file at the url.
+    :return: Tuple (filename, file extension) of the file at the url.
     """
     parsed = urlparse(url)
     root, extension = splitext(parsed.path)

--- a/haystack/utils/import_utils.py
+++ b/haystack/utils/import_utils.py
@@ -96,6 +96,12 @@ def load_documents_from_hf_datasets(dataset_name: str, split: Optional[str] = "t
 
 
 def get_filename_extension_from_url(url: str) -> Tuple[str, str]:
+    """
+    Extracts the filename and file extension from an url.
+
+    :param url: http address
+    :return: Tupel (filename, file extension) of the file at the url.
+    """
     parsed = urlparse(url)
     root, extension = splitext(parsed.path)
     archive_extension = extension[1:]

--- a/haystack/utils/import_utils.py
+++ b/haystack/utils/import_utils.py
@@ -126,7 +126,7 @@ def fetch_archive_from_http(
 
         parsed = urlparse(url)
         root, extension = splitext(parsed.path)
-        archive_extension = extension[1:]        
+        archive_extension = extension[1:]
         request_data = requests.get(url, proxies=proxies, timeout=timeout)
 
         if archive_extension == "zip":

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -168,6 +168,7 @@ def test_convert_files_to_docs(samples_path):
     assert documents and len(documents) > 0
 
 
+@pytest.mark.unit
 def test_get_filename_extension_from_url_without_params_zip():
     url = "http://www.mysite.com/resources/myfile.zip"
     file_name, extension = get_filename_extension_from_url(url)
@@ -175,6 +176,7 @@ def test_get_filename_extension_from_url_without_params_zip():
     assert file_name == "myfile"
 
 
+@pytest.mark.unit
 def test_get_filename_extension_from_url_with_params_zip():
     url = "https:/<S3_BUCKET_NAME>.s3.<REGION>.amazonaws.com/filename.zip?response-content-disposition=inline&X-Amz-Security-Token=<TOKEN>&X-Amz-Algorithm=<X-AMZ-ALGORITHM>&X-Amz-Date=<X-AMZ-DATE>&X-Amz-SignedHeaders=host&X-Amz-Expires=<X-AMZ-EXPIRES>&X-Amz-Credential=<CREDENTIAL>&X-Amz-Signature=<SIGNATURE>"
     file_name, extension = get_filename_extension_from_url(url)
@@ -182,6 +184,7 @@ def test_get_filename_extension_from_url_with_params_zip():
     assert file_name == "filename"
 
 
+@pytest.mark.unit
 def test_get_filename_extension_from_url_with_params_xz():
     url = "https:/<S3_BUCKET_NAME>.s3.<REGION>.amazonaws.com/filename.tar.xz?response-content-disposition=inline&X-Amz-Security-Token=<TOKEN>&X-Amz-Algorithm=<X-AMZ-ALGORITHM>&X-Amz-Date=<X-AMZ-DATE>&X-Amz-SignedHeaders=host&X-Amz-Expires=<X-AMZ-EXPIRES>&X-Amz-Credential=<CREDENTIAL>&X-Amz-Signature=<SIGNATURE>"
     file_name, extension = get_filename_extension_from_url(url)

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -168,14 +168,21 @@ def test_convert_files_to_docs(samples_path):
     assert documents and len(documents) > 0
 
 
-def test_get_filename_extension_from_url_zip():
+def test_get_filename_extension_from_url_without_params_zip():
+    url = "http://www.mysite.com/resources/myfile.zip"
+    file_name, extension = get_filename_extension_from_url(url)
+    assert extension == "zip"
+    assert file_name == "myfile"
+
+
+def test_get_filename_extension_from_url_with_params_zip():
     url = "https:/<S3_BUCKET_NAME>.s3.<REGION>.amazonaws.com/filename.zip?response-content-disposition=inline&X-Amz-Security-Token=<TOKEN>&X-Amz-Algorithm=<X-AMZ-ALGORITHM>&X-Amz-Date=<X-AMZ-DATE>&X-Amz-SignedHeaders=host&X-Amz-Expires=<X-AMZ-EXPIRES>&X-Amz-Credential=<CREDENTIAL>&X-Amz-Signature=<SIGNATURE>"
     file_name, extension = get_filename_extension_from_url(url)
     assert extension == "zip"
     assert file_name == "filename"
 
 
-def test_get_filename_extension_from_url_xz():
+def test_get_filename_extension_from_url_with_params_xz():
     url = "https:/<S3_BUCKET_NAME>.s3.<REGION>.amazonaws.com/filename.tar.xz?response-content-disposition=inline&X-Amz-Security-Token=<TOKEN>&X-Amz-Algorithm=<X-AMZ-ALGORITHM>&X-Amz-Date=<X-AMZ-DATE>&X-Amz-SignedHeaders=host&X-Amz-Expires=<X-AMZ-EXPIRES>&X-Amz-Credential=<CREDENTIAL>&X-Amz-Signature=<SIGNATURE>"
     file_name, extension = get_filename_extension_from_url(url)
     assert extension == "xz"

--- a/test/others/test_utils.py
+++ b/test/others/test_utils.py
@@ -1,6 +1,5 @@
 import importlib
 import logging
-from random import random
 from typing import List
 from unittest import mock
 
@@ -15,6 +14,7 @@ import _pytest
 from haystack.schema import Answer, Document, Span, Label
 from haystack.utils import print_answers
 from haystack.utils.deepsetcloud import DeepsetCloud, DeepsetCloudExperiments
+from haystack.utils.import_utils import get_filename_extension_from_url
 from haystack.utils.labels import aggregate_labels
 from haystack.utils.preprocessing import convert_files_to_docs, tika_convert_files_to_docs
 from haystack.utils.cleaning import clean_wiki_text
@@ -166,6 +166,20 @@ def test_convert_files_to_docs(samples_path):
         dir_path=(samples_path).absolute(), clean_func=clean_wiki_text, split_paragraphs=True
     )
     assert documents and len(documents) > 0
+
+
+def test_get_filename_extension_from_url_zip():
+    url = "https:/<S3_BUCKET_NAME>.s3.<REGION>.amazonaws.com/filename.zip?response-content-disposition=inline&X-Amz-Security-Token=<TOKEN>&X-Amz-Algorithm=<X-AMZ-ALGORITHM>&X-Amz-Date=<X-AMZ-DATE>&X-Amz-SignedHeaders=host&X-Amz-Expires=<X-AMZ-EXPIRES>&X-Amz-Credential=<CREDENTIAL>&X-Amz-Signature=<SIGNATURE>"
+    file_name, extension = get_filename_extension_from_url(url)
+    assert extension == "zip"
+    assert file_name == "filename"
+
+
+def test_get_filename_extension_from_url_xz():
+    url = "https:/<S3_BUCKET_NAME>.s3.<REGION>.amazonaws.com/filename.tar.xz?response-content-disposition=inline&X-Amz-Security-Token=<TOKEN>&X-Amz-Algorithm=<X-AMZ-ALGORITHM>&X-Amz-Date=<X-AMZ-DATE>&X-Amz-SignedHeaders=host&X-Amz-Expires=<X-AMZ-EXPIRES>&X-Amz-Credential=<CREDENTIAL>&X-Amz-Signature=<SIGNATURE>"
+    file_name, extension = get_filename_extension_from_url(url)
+    assert extension == "xz"
+    assert file_name == "filename.tar"
 
 
 @pytest.mark.tika


### PR DESCRIPTION
### Related Issues

- fixes #5198

### Proposed Changes:

The extension of the archive was determined by splitting the URL at `"."` using `rpartition` and then using the string to the right of the `"."` as the file extension.

This pull request uses `urllib.parse.urlparse` to split the URL into its components. Then I use `splitext` to split the archive extension from the path in the URL. 

### How did you test it?
Manual test with the To Reproduce instruction from #5198


### Checklist

- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [X] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
