### PR TITLE
Change 'history' to 'memory' in the ConversationalAgent prompts

### DIFF
--- a/haystack/agents/utils.py
+++ b/haystack/agents/utils.py
@@ -37,7 +37,7 @@ def agent_without_tools_parameter_resolver(query: str, agent: "Agent", **kwargs)
     """
     A parameter resolver for simple chat agents without tools that returns the query and the history.
     """
-    return {"query": query, "history": agent.memory.load()}
+    return {"query": query, "memory": agent.memory.load()}
 
 
 def conversational_agent_parameter_resolver(
@@ -52,5 +52,5 @@ def conversational_agent_parameter_resolver(
         "tool_names": agent.tm.get_tool_names(),
         "tool_names_with_descriptions": agent.tm.get_tool_names_with_descriptions(),
         "transcript": agent_step.transcript,
-        "history": agent.memory.load(),
+        "memory": agent.memory.load(),
     }

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -158,7 +158,7 @@ LEGACY_DEFAULT_TEMPLATES: Dict[str, Dict] = {
         "If the AI Agent is uncertain or concerned that the information may be outdated or inaccurate, it must use the available tools to find the most up-to-date information. The AI has access to these tools:\n"
         "{tool_names_with_descriptions}\n"
         "The following is the previous conversation between a human and an AI:\n"
-        "{history}\n"
+        "{memory}\n"
         "AI Agent responses must start with one of the following:\n"
         "Thought: [AI Agent's reasoning process]\n"
         "Tool: [{tool_names}] (on a new line) Tool Input: [input for the selected tool WITHOUT quotation marks and on a new line] (These must always be provided together and on separate lines.)\n"
@@ -174,7 +174,7 @@ LEGACY_DEFAULT_TEMPLATES: Dict[str, Dict] = {
         "prompt": "Condense the following chat transcript by shortening and summarizing the content without losing important information:\n{chat_transcript}\nCondensed Transcript:"
     },
     "conversational-agent-without-tools": {
-        "prompt": "The following is a conversation between a human and an AI.\n{history}\nHuman: {query}\nAI:"
+        "prompt": "The following is a conversation between a human and an AI.\n{memory}\nHuman: {query}\nAI:"
     },
     # DO NOT ADD ANY NEW TEMPLATE IN HERE!
 }


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/prompthub/issues/40

### Proposed Changes:

Rename `{history}` as `{memory}` to have a better consistency

### How did you test it?

Ran conversational_agent.py

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
