### PR TITLE
fix:Rename SageMakerInvocationLayer -> SageMakerHFTextGenerationInvocationLayer

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/__init__.py
+++ b/haystack/nodes/prompt/invocation_layer/__init__.py
@@ -8,4 +8,4 @@ from haystack.nodes.prompt.invocation_layer.hugging_face_inference import HFInfe
 from haystack.nodes.prompt.invocation_layer.open_ai import OpenAIInvocationLayer
 from haystack.nodes.prompt.invocation_layer.anthropic_claude import AnthropicClaudeInvocationLayer
 from haystack.nodes.prompt.invocation_layer.cohere import CohereInvocationLayer
-from haystack.nodes.prompt.invocation_layer.sagemaker import SageMakerInvocationLayer
+from haystack.nodes.prompt.invocation_layer.sagemaker_hf_text_gen import SageMakerHFTextGenerationInvocationLayer

--- a/haystack/nodes/prompt/invocation_layer/sagemaker_hf_text_gen.py
+++ b/haystack/nodes/prompt/invocation_layer/sagemaker_hf_text_gen.py
@@ -17,7 +17,7 @@ with LazyImport(message="Run 'pip install farm-haystack[aws]'") as boto3_import:
     from botocore.exceptions import ClientError, BotoCoreError
 
 
-class SageMakerInvocationLayer(PromptModelInvocationLayer):
+class SageMakerHFTextGenerationInvocationLayer(PromptModelInvocationLayer):
     """
     SageMaker Invocation Layer
 
@@ -84,7 +84,7 @@ class SageMakerInvocationLayer(PromptModelInvocationLayer):
         boto3_import.check()
         super().__init__(model_name_or_path)
         try:
-            session = SageMakerInvocationLayer.create_session(
+            session = SageMakerHFTextGenerationInvocationLayer.create_session(
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_session_token=aws_session_token,


### PR DESCRIPTION
### What?
We are changing the class name `SageMakerInvocationLayer` to `SageMakerHFTextGenerationInvocationLayer`.

### Why?

What seems to be occurring is a transition within SageMaker to use containers running the latest Hugging Face project, known as [text-generation-inference](https://github.com/huggingface/text-generation-inference). The client API of this project has an input/output data format that closely aligns with our `SageMakerHFTextGenerationInvocationLayer`. You can see this in the project's [client.py](https://github.com/huggingface/text-generation-inference/blob/main/clients/python/text_generation/client.py#L17) file. For the time being, until the full transition to `text-generation-interface` project, it will be crucial for us to continue supporting both `SageMakerHFTextGenerationInvocationLayer` and `SageMakerHFInferenceInvocationLayer` to ensure a seamless experience for those using SageMaker PromptNode. Once the transition has been completed we can retire `SageMakerHFInferenceInvocationLayer`. At the time of this writing - the only model running `SageMakerHFTextGenerationInvocationLayer` is Falcon. 

The name change is in preparation for the addition of a new class, `SageMakerHFInferenceInvocationLayer`, in a subsequent [PR](https://github.com/deepset-ai/haystack/pull/5205). During our ongoing SageMaker testing, we discovered two distinct SageMaker hugging face layers. 

The newly named `SageMakerHFTextGenerationInvocationLayer` supports the Falcon family of models and uses a different JSON payload format than the older layer, which will be supported by `SageMakerHFInferenceInvocationLayer`. The older layer supports a variety of text generation models such as MPT, Dolly V2, Flan-U2, Flan-T5, RedPajama, Open Llama, GPT-J-6B and others.

The chosen names for these layers are derived from the container names used during their SageMaker deployment. These names were identified through the `describe_endpoint` SageMaker service calls.

### How can it be used?
Despite the name change, the `SageMakerHFTextGenerationInvocationLayer` (formerly `SageMakerInvocationLayer`) will continue to function as it did before, supporting the Falcon family of models. There are no changes in functionality as a result of this renaming.

Here is an example of how one can use Falcon model deployed in SageMaker via PromptNode:
```python
from haystack.nodes.prompt import PromptNode
model = "jumpstart-dft-hf-llm-falcon-7b-instruct-bf16"
pn = PromptNode(model_name_or_path=model,
                max_length=128,
                model_kwargs={"aws_profile_name": "default",
                              "aws_region_name": "us-east-1"})

response = pn("What are the three most interesting facts about Berlin?")
print(response)
```



### How did you test it?
The changes were manually tested by deploying a Falcon model in SageMaker. Unit tests were also adjusted and executed to ensure the continued proper functioning of the class after renaming.

### Notes for the reviewer:
While the diff for this pull request may initially seem extensive, please note that this change is primarily a simple renaming operation with no changes to the core functionality. As such, it should not introduce any unexpected behavior or side effects.