### PR TITLE
fix: Allow filtering on list fields in `InMemoryDocumentStore` with all operators

### DIFF
--- a/haystack/document_stores/filter_utils.py
+++ b/haystack/document_stores/filter_utils.py
@@ -482,8 +482,15 @@ class InOperation(ComparisonOperation):
     def evaluate(self, fields) -> bool:
         if self.field_name not in fields:
             return False
-        return fields[self.field_name] in self.comparison_value  # type: ignore
-        # is only initialized with lists, but changing the type annotation would mean duplicating __init__
+
+        if not isinstance(self.comparison_value, list):
+            raise FilterError("'$in' operation requires comparison value to be a list.")
+
+        # If the document field is a list, check if any of its values are in the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field in self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] in self.comparison_value
 
     def convert_to_elasticsearch(self) -> Dict[str, Dict[str, List]]:
         if not isinstance(self.comparison_value, list):
@@ -563,9 +570,16 @@ class NinOperation(ComparisonOperation):
 
     def evaluate(self, fields) -> bool:
         if self.field_name not in fields:
-            return False
-        return fields[self.field_name] not in self.comparison_value  # type: ignore
-        # is only initialized with lists, but changing the type annotation would mean duplicating __init__
+            return True
+
+        if not isinstance(self.comparison_value, list):
+            raise FilterError("'$nin' operation requires comparison value to be a list.")
+
+        # If the document field is a list, check if any of its values are in the comparison value
+        if isinstance(fields[self.field_name], list):
+            return not any(field in self.comparison_value for field in fields[self.field_name])
+
+        return fields[self.field_name] not in self.comparison_value
 
     def convert_to_elasticsearch(self) -> Dict[str, Dict[str, Dict[str, Dict[str, List]]]]:
         if not isinstance(self.comparison_value, list):
@@ -611,6 +625,11 @@ class GtOperation(ComparisonOperation):
     def evaluate(self, fields) -> bool:
         if self.field_name not in fields:
             return False
+
+        # If the document field is a list, check if any of its values are greater than the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field > self.comparison_value for field in fields[self.field_name])
+
         return fields[self.field_name] > self.comparison_value
 
     def convert_to_elasticsearch(self) -> Dict[str, Dict[str, Dict[str, Union[str, float, int]]]]:
@@ -650,6 +669,11 @@ class GteOperation(ComparisonOperation):
     def evaluate(self, fields) -> bool:
         if self.field_name not in fields:
             return False
+
+        # If the document field is a list, check if any of its values are greater than or equal to the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field >= self.comparison_value for field in fields[self.field_name])
+
         return fields[self.field_name] >= self.comparison_value
 
     def convert_to_elasticsearch(self) -> Dict[str, Dict[str, Dict[str, Union[str, float, int]]]]:
@@ -689,6 +713,11 @@ class LtOperation(ComparisonOperation):
     def evaluate(self, fields) -> bool:
         if self.field_name not in fields:
             return False
+
+        # If the document field is a list, check if any of its values are less than the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field < self.comparison_value for field in fields[self.field_name])
+
         return fields[self.field_name] < self.comparison_value
 
     def convert_to_elasticsearch(self) -> Dict[str, Dict[str, Dict[str, Union[str, float, int]]]]:
@@ -728,6 +757,11 @@ class LteOperation(ComparisonOperation):
     def evaluate(self, fields) -> bool:
         if self.field_name not in fields:
             return False
+
+        # If the document field is a list, check if any of its values are less than or equal to the comparison value
+        if isinstance(fields[self.field_name], list):
+            return any(field <= self.comparison_value for field in fields[self.field_name])
+
         return fields[self.field_name] <= self.comparison_value
 
     def convert_to_elasticsearch(self) -> Dict[str, Dict[str, Dict[str, Union[str, float, int]]]]:

--- a/test/document_stores/test_memory.py
+++ b/test/document_stores/test_memory.py
@@ -36,26 +36,6 @@ class TestInMemoryDocumentStore(DocumentStoreBaseTestAbstract):
         result = ds.get_all_documents(filters={"year": {"$ne": "2020"}})
         assert len(result) == 3
 
-    @pytest.mark.skip
-    @pytest.mark.integration
-    def test_nin_filters(self, ds, documents):
-        pass
-
-    @pytest.mark.skip
-    @pytest.mark.integration
-    def test_comparison_filters(self, ds, documents):
-        pass
-
-    @pytest.mark.skip
-    @pytest.mark.integration
-    def test_nested_condition_filters(self, ds, documents):
-        pass
-
-    @pytest.mark.skip
-    @pytest.mark.integration
-    def test_nested_condition_not_filters(self, ds, documents):
-        pass
-
     @pytest.mark.integration
     def test_get_documents_by_id(self, ds, documents):
         """


### PR DESCRIPTION
### Related Issues

- fixes #5146
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds support for filtering on list fields in `InMemoryDocumentStore` for the following operators
- `$in`/`$nin`
- `$gt`/`$gte`
- `$lt`/`$lte`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I removed the `skip` mark on the tests. These tests are passing now.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
