### PR TITLE
build: add `inference` dependency group to docker images

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -45,7 +45,7 @@ target "base-cpu" {
     build_image = "python:3.10-slim"
     base_image = "python:3.10-slim"
     haystack_version = "${HAYSTACK_VERSION}"
-    haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores,crawler,preprocessing,file-conversion,ocr,onnx,metrics,beir]"
+    haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores,inference,crawler,preprocessing,file-conversion,ocr,onnx,metrics,beir]"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }
@@ -59,7 +59,7 @@ target "base-gpu" {
     build_image = "pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime"
     base_image = "pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime"
     haystack_version = "${HAYSTACK_VERSION}"
-    haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores-gpu,crawler,preprocessing,file-conversion,ocr,onnx-gpu,metrics]"
+    haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[docstores-gpu,inference,crawler,preprocessing,file-conversion,ocr,onnx-gpu,metrics]"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
### Related Issues

- None

### Proposed Changes:

Related to https://github.com/deepset-ai/haystack/pull/5147.
`inference` group install the following dependencies
https://github.com/deepset-ai/haystack/blob/5ee393226d31bd3ab2249def9af5fefc738b12a0/pyproject.toml#L92-L94
that are currently needed to run most of the Haystack nodes.

### How did you test it?

No need?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
