### PR TITLE
fix: Use `add_isolated_node_eval` of `eval_batch` in `run_batch`

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -1366,6 +1366,9 @@ class Pipeline:
             event_name="Evaluation",
             event_properties={"pipeline.classname": self.__class__.__name__, "pipeline.config_hash": self.config_hash},
         )
+        if add_isolated_node_eval:
+            params = {} if params is None else params.copy()
+            params["add_isolated_node_eval"] = True
 
         predictions_batches = self.run_batch(
             queries=[label.query for label in labels], labels=labels, documents=documents, params=params, debug=True
@@ -1373,11 +1376,9 @@ class Pipeline:
 
         eval_result = self._generate_eval_result_from_batch_preds(
             predictions_batches=predictions_batches,
-            params=params,
             sas_model_name_or_path=sas_model_name_or_path,
             sas_batch_size=sas_batch_size,
             sas_use_gpu=sas_use_gpu,
-            add_isolated_node_eval=add_isolated_node_eval,
             custom_document_id_field=custom_document_id_field,
             context_matching_min_length=context_matching_min_length,
             context_matching_boost_split_overlaps=context_matching_boost_split_overlaps,
@@ -1390,11 +1391,9 @@ class Pipeline:
     def _generate_eval_result_from_batch_preds(
         self,
         predictions_batches: Dict,
-        params: Optional[dict] = None,
         sas_model_name_or_path: Optional[str] = None,
         sas_batch_size: int = 32,
         sas_use_gpu: bool = True,
-        add_isolated_node_eval: bool = False,
         custom_document_id_field: Optional[str] = None,
         context_matching_min_length: int = 100,
         context_matching_boost_split_overlaps: bool = True,
@@ -1402,9 +1401,6 @@ class Pipeline:
         use_auth_token: Optional[Union[str, bool]] = None,
     ) -> EvaluationResult:
         eval_result = EvaluationResult()
-        if add_isolated_node_eval:
-            params = {} if params is None else params.copy()
-            params["add_isolated_node_eval"] = True
 
         for node_name in predictions_batches["_debug"].keys():
             node_output = predictions_batches["_debug"][node_name]["output"]

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -1,4 +1,6 @@
 import logging
+from unittest.mock import patch
+
 import pytest
 import sys
 from copy import deepcopy
@@ -19,6 +21,16 @@ from haystack.pipelines.standard_pipelines import (
 )
 from haystack.nodes.translator.transformers import TransformersTranslator
 from haystack.schema import Answer, Document, EvaluationResult, Label, MultiLabel, Span
+
+
+@pytest.mark.unit
+@patch("haystack.pipelines.base.Pipeline.run_batch")
+def test_eval_batch_add_isolated_node_eval_passed_to_run_batch(mock_run_batch):
+    pipeline = Pipeline()
+    pipeline.eval_batch(labels=EVAL_LABELS, add_isolated_node_eval=True)
+    _, kwargs = mock_run_batch.call_args
+    assert "add_isolated_node_eval" in kwargs["params"]
+    assert kwargs["params"]["add_isolated_node_eval"] is True
 
 
 @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="Causes OOM on windows github runner")


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds `add_isolated_node_eval` of `eval_batch` to `run_batch` parameters. It fixes a bug introduced in #5001. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added a unit test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
