### PR TITLE
Add `cpu-remote-inference` Docker image

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -79,19 +79,21 @@ jobs:
         run: |
           TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
 
+          # docker commands below always output a non-empty string, otherwise the step will exit abnormally
           PLATFORM="linux/amd64"
-          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error::Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch || echo 'not found')
+          [[ "$TORCH_INSTALLED" != "not found" ]] || echo "::error::Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM"
 
           PLATFORM="linux/arm64"
-          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error::Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch || echo 'not found')
+          [[ "$TORCH_INSTALLED" != "not found" ]] || echo "::error::Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM"
 
       - name: Test inference image
         if: contains(matrix.target, 'inference')
         run: |
           TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
 
+          # docker commands below always output a non-empty string, otherwise the step will exit abnormally
           PLATFORM="linux/amd64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" sh -c "pip list | grep torch || echo 'not found'")
           [[ "$TORCH_INSTALLED" == "not found" ]] || echo "::error::Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM"

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - cpu_remote_inference
     tags:
       - "v[0-9].[0-9]+.[0-9]+*"
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -73,6 +73,26 @@ jobs:
           # Remove image after test to avoid filling the GitHub runner and prevent its failure
           docker rmi "deepset/haystack:$TAG"
 
+      - name: Test non-inference image
+        if: contains(matrix.target, 'inference') != true
+        run: |
+          PLATFORM="linux/amd64"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
+          [[ "$TORCH_INSTALLED" = "" ]] || echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
+
+          PLATFORM="linux/arm64"
+          [[ "$TORCH_INSTALLED" = "" ]] || echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
+
+      - name: Test inference image
+        if: contains(matrix.target, 'inference')
+        run: |
+          PLATFORM="linux/amd64"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
+          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
+
+          PLATFORM="linux/arm64"
+          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
+
       - name: Build api images
         uses: docker/bake-action@v2
         env:
@@ -82,6 +102,36 @@ jobs:
           workdir: docker
           targets: ${{ matrix.target }}
           push: true
+
+      - name: Test inference API invocation
+        if: contains(matrix.target, 'inference')
+        env:
+          SERPERDEV_API_KEY: ${{ secrets.SERPERDEV_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          TAG="${{ matrix.target }}-${{ steps.meta.outputs.version }}"
+
+          PLATFORMS=("linux/amd64" "linux/arm64")
+          for PLATFORM in "${PLATFORMS[@]}"; do
+            docker run --name test-container -d \
+              --platform "$PLATFORM" \
+              -e PIPELINE_YAML_PATH=/opt/venv/lib/python3.10/site-packages/rest_api/pipeline/pipelines_web_lfqa.haystack-pipeline.yaml \
+              -e "RETRIEVER_PARAMS_API_KEY=$SERPERDEV_API_KEY" \
+              -e "PROMPTNODE_PARAMS_API_KEY=$OPENAI_API_KEY" \
+              -p 8080:8000 "deepset/haystack:$TAG"
+
+            I=0
+            until docker logs test-container 2>&1 | grep "Uvicorn running"; do
+              echo "Waiting"
+              sleep 2
+              ((I++)) && ((I==100)) && echo "::error 'Timeout waiting for Uvicorn to start using deepset/haystack:$TAG image for $PLATFORM'"
+            done
+
+            RESULT=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"query\": \"Where in Europe, should I live?\"}" http://localhost:8080/query)
+            [[ -n "$RESULT" ]] || echo "::error 'No response from inference API using deepset/haystack:$TAG image for $PLATFORM'"
+
+            docker rm -f test-container
+          done
 
       - name: Get latest version of Haystack
         id: latest-version

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Test non-inference image
         if: contains(matrix.target, 'inference') != true
         run: |
+          TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
+
           PLATFORM="linux/amd64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
           [[ "$TORCH_INSTALLED" = "" ]] || echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
@@ -87,6 +89,8 @@ jobs:
       - name: Test inference image
         if: contains(matrix.target, 'inference')
         run: |
+          TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
+
           PLATFORM="linux/amd64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
           [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - cpu_remote_inference
     tags:
       - "v[0-9].[0-9]+.[0-9]+*"
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         target:
           - "cpu"
+          - "cpu-remote-inference"
           - "gpu"
 
     steps:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -81,11 +81,11 @@ jobs:
 
           PLATFORM="linux/amd64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          echo "$TORCH_INSTALLED"
+          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error::Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM"
 
           PLATFORM="linux/arm64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          echo "$TORCH_INSTALLED"
+          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error::Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM"
 
       - name: Test inference image
         if: contains(matrix.target, 'inference')
@@ -98,7 +98,7 @@ jobs:
 
           PLATFORM="linux/arm64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" sh -c "pip list | grep torch || echo 'not found'")
-          [[ "$TORCH_INSTALLED" == "not found" ]] || echo "::error::Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
+          [[ "$TORCH_INSTALLED" == "not found" ]] || echo "::error::Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM"
 
       - name: Build api images
         uses: docker/bake-action@v2

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -81,10 +81,11 @@ jobs:
 
           PLATFORM="linux/amd64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ "$TORCH_INSTALLED" = "" ]] || echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
+          [[ -z $TORCH_INSTALLED ]] && echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
 
           PLATFORM="linux/arm64"
-          [[ "$TORCH_INSTALLED" = "" ]] || echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
+          [[ -z $TORCH_INSTALLED ]] && echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
 
       - name: Test inference image
         if: contains(matrix.target, 'inference')
@@ -96,6 +97,7 @@ jobs:
           [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
 
           PLATFORM="linux/arm64"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
           [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
 
       - name: Build api images

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -81,11 +81,11 @@ jobs:
 
           PLATFORM="linux/amd64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ -z $TORCH_INSTALLED ]] && echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
+          echo "$TORCH_INSTALLED"
 
           PLATFORM="linux/arm64"
           TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ -z $TORCH_INSTALLED ]] && echo "::error 'Pytorch is not installed in deepset/haystack:$TAG image for $PLATFORM'"
+          echo "$TORCH_INSTALLED"
 
       - name: Test inference image
         if: contains(matrix.target, 'inference')

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -93,12 +93,12 @@ jobs:
           TAG="base-${{ matrix.target }}-${{ steps.meta.outputs.version }}"
 
           PLATFORM="linux/amd64"
-          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" sh -c "pip list | grep torch || echo 'not found'")
+          [[ "$TORCH_INSTALLED" == "not found" ]] || echo "::error::Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM"
 
           PLATFORM="linux/arm64"
-          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" pip list | grep torch)
-          [[ "$TORCH_INSTALLED" != "" ]] || echo "::error 'Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
+          TORCH_INSTALLED=$(docker run --platform "$PLATFORM" --rm "deepset/haystack:$TAG" sh -c "pip list | grep torch || echo 'not found'")
+          [[ "$TORCH_INSTALLED" == "not found" ]] || echo "::error::Pytorch is installed in deepset/haystack:$TAG image for $PLATFORM'"
 
       - name: Build api images
         uses: docker/bake-action@v2

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -23,19 +23,19 @@ variable "HAYSTACK_EXTRAS" {
 }
 
 group "base" {
-  targets = ["base-cpu", "base-gpu"]
+  targets = ["base-cpu", "base-gpu", "base-cpu-remote-inference"]
 }
 
 group "api" {
-  targets = ["cpu", "gpu"]
+  targets = ["cpu", "gpu", "cpu-remote-inference"]
 }
 
 group "api-latest" {
-  targets = ["cpu-latest", "gpu-latest"]
+  targets = ["cpu-latest", "gpu-latest", "cpu-remote-inference-latest"]
 }
 
 group "all" {
-  targets = ["base", "base-gpu", "cpu", "gpu"]
+  targets = ["base", "base-gpu", "cpu", "gpu", "cpu-remote-inference"]
 }
 
 target "base-cpu" {

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -51,17 +51,12 @@ target "base-cpu" {
 }
 
 target "base-cpu-remote-inference" {
-  dockerfile = "Dockerfile.base"
+  inherits = ["base-cpu"]
   tags = ["${IMAGE_NAME}:base-cpu-remote-inference-${IMAGE_TAG_SUFFIX}"]
   args = {
-    base_image = "python:3.10-slim"
-    build_image = "python:3.10-slim"
-    haystack_version = "${HAYSTACK_VERSION}"
     haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[preprocessing]"
   }
-  platforms = ["linux/amd64", "linux/arm64"]
 }
-
 
 target "base-gpu" {
   dockerfile = "Dockerfile.base"

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -97,6 +97,12 @@ target "cpu-remote-inference" {
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
+target "cpu-remote-inference-latest" {
+  inherits = ["cpu-remote-inference"]
+  tags = ["${IMAGE_NAME}:cpu-remote-inference"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
 target "cpu-latest" {
   inherits = ["cpu"]
   tags = ["${IMAGE_NAME}:cpu"]

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -95,7 +95,6 @@ target "cpu-remote-inference" {
 target "cpu-remote-inference-latest" {
   inherits = ["cpu-remote-inference"]
   tags = ["${IMAGE_NAME}:cpu-remote-inference"]
-  platforms = ["linux/amd64", "linux/arm64"]
 }
 
 target "cpu-latest" {

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -50,6 +50,19 @@ target "base-cpu" {
   platforms = ["linux/amd64", "linux/arm64"]
 }
 
+target "base-cpu-remote-inference" {
+  dockerfile = "Dockerfile.base"
+  tags = ["${IMAGE_NAME}:base-cpu-remote-inference-${IMAGE_TAG_SUFFIX}"]
+  args = {
+    base_image = "python:3.10-slim"
+    build_image = "python:3.10-slim"
+    haystack_version = "${HAYSTACK_VERSION}"
+    haystack_extras = notequal("",HAYSTACK_EXTRAS) ? "${HAYSTACK_EXTRAS}" : "[preprocessing]"
+  }
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+
 target "base-gpu" {
   dockerfile = "Dockerfile.base"
   tags = ["${IMAGE_NAME}:base-gpu-${IMAGE_TAG_SUFFIX}"]
@@ -70,6 +83,16 @@ target "cpu" {
   args = {
     base_image = "${IMAGE_NAME}"
     base_image_tag = "base-cpu-${BASE_IMAGE_TAG_SUFFIX}"
+  }
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "cpu-remote-inference" {
+  dockerfile = "Dockerfile.api"
+  tags = ["${IMAGE_NAME}:cpu-remote-inference-${IMAGE_TAG_SUFFIX}"]
+  args = {
+    base_image = "${IMAGE_NAME}"
+    base_image_tag = "base-cpu-remote-inference-${BASE_IMAGE_TAG_SUFFIX}"
   }
   platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -81,6 +81,7 @@ class WebRetriever(BaseRetriever):
         )
         self.mode = mode
         self.cache_document_store = cache_document_store
+        self.document_store = cache_document_store
         self.cache_index = cache_index
         self.cache_headers = cache_headers
         self.cache_time = cache_time

--- a/rest_api/rest_api/pipeline/pipelines_web_lfqa.haystack-pipeline.yaml
+++ b/rest_api/rest_api/pipeline/pipelines_web_lfqa.haystack-pipeline.yaml
@@ -1,0 +1,42 @@
+version: ignore
+
+components:
+- name: Retriever
+  params:
+    api_key: RETRIEVER_PARAMS_API_KEY
+  type: WebRetriever
+- name: Shaper
+  params:
+    func: join_documents_and_scores
+    inputs:
+      documents: documents
+    outputs:
+    - documents
+  type: Shaper
+- name: custom-at-query-time
+  params:
+    prompt: "\nSynthesize a comprehensive answer from the following most relevant\
+      \ paragraphs and the given question.\nProvide a clear and concise response that\
+      \ summarizes the key points and information presented in the paragraphs.\nYour\
+      \ answer should be in your own words and be no longer than 50 words.\n\n\n Paragraphs:\
+      \ {documents} \n\n Question: {query} \n\n Answer:\n"
+  type: PromptTemplate
+- name: PromptNode
+  params:
+    api_key: PROMPTNODE_PARAMS_API_KEY
+    default_prompt_template: custom-at-query-time
+    max_length: 256
+    model_name_or_path: gpt-3.5-turbo
+  type: PromptNode
+pipelines:
+- name: query
+  nodes:
+  - inputs:
+    - Query
+    name: Retriever
+  - inputs:
+    - Retriever
+    name: Shaper
+  - inputs:
+    - Shaper
+    name: PromptNode


### PR DESCRIPTION
### What?
Introduces a new Docker image, `haystack:cpu-remote-inference-<version>`, to our existing images: `haystack:gpu-<version>` and `haystack:cpu-<version>`. This image is a slimmed-down version of cpu/gpu images, specifically designed for PromptNode inferencing using remote-hosted models such as HuggingFace Inference, OpenAI, Cohere, Anthropic etc.

- fixes #5172

### Why?

The motivation behind the introduction of this new Docker image is to provide a more efficient and lightweight option for users who primarily perform remote Large Language Model (LLM) inference. The existing Docker images for Haystack are comprehensive and can be larger than necessary for users primarily using remote LLM inferencing. By introducing this new Docker image, we offer a more streamlined and efficient option for Haystack users.


### How can it be used?
The new `haystack:cpu-remote-inference-<version>` image can be used the same way as the existing gpu and cpu Docker images in Haystack. Users can pull this image and run their applications, benefiting from the reduced size and specific tuning for remote LLM inferencing. 

Follow these steps to test the new image:

1. Checkout `cpu_remote_inference` branch on your Linux machine; go to the docker directory of the project
2. Bake the base image, in your terminal window, type:
```text
HAYSTACK_VERSION=cpu_remote_inference docker buildx bake --no-cache base-cpu-remote-inference --set "*.platform=linux/amd64"
```
3. Bake the image,  in your terminal window, type:
```text
docker buildx bake cpu-remote-inference --set "*.platform=linux/amd64"
```
4. Run the image using the following command. Replace <SERPERDEV_API_KEY> and <OPENAI_API_KEY> with your respective API keys:
```text
docker run -d -e PIPELINE_YAML_PATH=/opt/venv/lib/python3.10/site-packages/rest_api/pipeline/pipelines_web_lfqa.haystack-pipeline.yaml -e RETRIEVER_PARAMS_API_KEY=<SERPERDEV_API_KEY> -e PROMPTNODE_PARAMS_API_KEY=<OPENAI_API_KEY> -p 8080:8000 deepset/haystack:cpu-remote-inference-local
```
5. Hit the server, type:
```text
curl -s -X POST -H "Content-Type: application/json" -d "{\"query\": \"Where in Europe, should I live?\"}" http://localhost:8080/query | jq ".results"
```



### How did you test it?

The new Docker image was tested by baking and running both the amd64 and arm64 versions.  

### Notes for the reviewer

Please build images yourself and run the steps outlined in `How can it be used?` section

Thank you for reviewing, your feedback is greatly appreciated.