### PR TITLE
refactor: prepare support to Elasticsearch 8

### DIFF
--- a/haystack/document_stores/elasticsearch/__init__.py
+++ b/haystack/document_stores/elasticsearch/__init__.py
@@ -1,1 +1,1 @@
-from .es7 import ElasticsearchDocumentStore, Elasticsearch
+from .es7 import ElasticsearchDocumentStore

--- a/haystack/document_stores/elasticsearch/__init__.py
+++ b/haystack/document_stores/elasticsearch/__init__.py
@@ -1,0 +1,1 @@
+from .es7 import ElasticsearchDocumentStore, Elasticsearch

--- a/haystack/document_stores/elasticsearch/es7.py
+++ b/haystack/document_stores/elasticsearch/es7.py
@@ -7,7 +7,7 @@ from haystack.errors import DocumentStoreError
 from haystack.schema import Document, FilterType
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.lazy_imports import LazyImport
-from ..search_engine import SearchEngineDocumentStore, prepare_hosts
+from haystack.document_stores.search_engine import SearchEngineDocumentStore, prepare_hosts
 
 with LazyImport("Run 'pip install farm-haystack[elasticsearch]'") as es_import:
     from elasticsearch import Connection, Elasticsearch, RequestsHttpConnection, Urllib3HttpConnection

--- a/haystack/document_stores/elasticsearch/es7.py
+++ b/haystack/document_stores/elasticsearch/es7.py
@@ -7,7 +7,7 @@ from haystack.errors import DocumentStoreError
 from haystack.schema import Document, FilterType
 from haystack.document_stores.filter_utils import LogicalFilterClause
 from haystack.lazy_imports import LazyImport
-from .search_engine import SearchEngineDocumentStore, prepare_hosts
+from ..search_engine import SearchEngineDocumentStore, prepare_hosts
 
 with LazyImport("Run 'pip install farm-haystack[elasticsearch]'") as es_import:
     from elasticsearch import Connection, Elasticsearch, RequestsHttpConnection, Urllib3HttpConnection

--- a/test/document_stores/test_elasticsearch.py
+++ b/test/document_stores/test_elasticsearch.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore, Elasticsearch
+from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
+from haystack.document_stores.elasticsearch.es7 import Elasticsearch
 from haystack.document_stores.es_converter import elasticsearch_index_to_document_store
 from haystack.document_stores.memory import InMemoryDocumentStore
 from haystack.nodes import PreProcessor

--- a/test/document_stores/test_elasticsearch.py
+++ b/test/document_stores/test_elasticsearch.py
@@ -348,6 +348,6 @@ class TestElasticsearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngine
     @pytest.mark.unit
     def test_write_documents_req_for_each_batch(self, mocked_document_store, documents):
         mocked_document_store.batch_size = 2
-        with patch("haystack.document_stores.elasticsearch.bulk") as mocked_bulk:
+        with patch("haystack.document_stores.elasticsearch.es7.bulk") as mocked_bulk:
             mocked_document_store.write_documents(documents)
             assert mocked_bulk.call_count == 5


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/2810

### Proposed Changes:

As discussed in https://github.com/deepset-ai/haystack/pull/5216, in order to support version 8 of the Elasticsearch client, we're going to:
- introduce a base class for two new Document Stores, `Elasticsearch7DocumentStore` and `Elasticsearch8DocumentStore`
- Depending on the client available in the system, Haystack will import either of the two under the name `ElasticsearchDocumentStore` to keep backward compatibility

As pointed out in https://github.com/deepset-ai/haystack/pull/5216/files#r1245685837 the best course of action to keep the code well encapsulated and readable is to move `haystack.document_stores.elasticsearch` from a module into a package, where most of the subsequent refactoring will happen.


### How did you test it?

unit tests, integration tests, manual verification

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
