### PR TITLE
refactor: Update WebRetriever to use LinkContentFetcher

### DIFF
--- a/examples/web_lfqa.py
+++ b/examples/web_lfqa.py
@@ -1,6 +1,7 @@
+import logging
 import os
 
-from haystack.nodes import PromptNode, PromptTemplate
+from haystack.nodes import PromptNode, PromptTemplate, TopPSampler
 from haystack.nodes.retriever.web import WebRetriever
 from haystack.pipelines import WebQAPipeline
 
@@ -23,8 +24,8 @@ prompt_node = PromptNode(
     "text-davinci-003", default_prompt_template=PromptTemplate(prompt_text), api_key=openai_key, max_length=256
 )
 
-web_retriever = WebRetriever(api_key=search_key, top_search_results=2, mode="preprocessed_documents")
-pipeline = WebQAPipeline(retriever=web_retriever, prompt_node=prompt_node)
+web_retriever = WebRetriever(api_key=search_key, top_search_results=5, mode="preprocessed_documents", top_k=30)
+pipeline = WebQAPipeline(retriever=web_retriever, prompt_node=prompt_node, sampler=TopPSampler(top_p=0.8))
 
 # Long-Form QA requiring multiple context paragraphs for the synthesis of an elaborate generative answer
 questions = [
@@ -32,6 +33,13 @@ questions = [
     "What are the advantages of PromptNode in Haystack?",
     "What PromptModelInvocationLayer implementations are available in Haystack?",
 ]
+
+# Avoid all failed html parsing logs
+logger = logging.getLogger("haystack.nodes.retriever.link_content")
+logger.setLevel(logging.CRITICAL)
+logger = logging.getLogger("boilerpy3")
+logger.setLevel(logging.CRITICAL)
+
 
 for q in questions:
     print(f"Question: {q}")

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -229,7 +229,7 @@ class WebRetriever(BaseRetriever):
 
         # If query is not cached, fetch from web
         if not extracted_docs:
-            extracted_docs = self._retrieve_from_web(query_norm, preprocessor, top_k)
+            extracted_docs = self._retrieve_from_web(query_norm, preprocessor)
 
         # Save results to cache
         if cache_document_store and extracted_docs:
@@ -241,26 +241,23 @@ class WebRetriever(BaseRetriever):
                 )
         return extracted_docs[:top_k]
 
-    def _retrieve_from_web(
-        self, query_norm: str, preprocessor: Optional[PreProcessor], top_k: Optional[int]
-    ) -> List[Document]:
+    def _retrieve_from_web(self, query_norm: str, preprocessor: Optional[PreProcessor]) -> List[Document]:
         """
         Retrieve documents from the web based on the query.
 
         :param query_norm: The normalized query string.
         :param preprocessor: The PreProcessor to be used to split documents into paragraphs.
-        :param top_k: The number of documents to be returned by the retriever. If None, the default value is used.
         :return: List of Document objects.
         """
 
         search_results, _ = self.web_search.run(query=query_norm)
         search_results_docs = search_results["documents"]
         if self.mode == "snippets":
-            return search_results_docs[:top_k]  # type: ignore
-
-        links: List[SearchResult] = self._prepare_links(search_results_docs)
-        logger.debug("Starting to fetch %d links from WebSearch results", len(links))
-        return self._scrape_links(links, query_norm, preprocessor)
+            return search_results_docs
+        else:
+            links: List[SearchResult] = self._prepare_links(search_results_docs)
+            logger.debug("Starting to fetch %d links from WebSearch results", len(links))
+            return self._scrape_links(links, query_norm, preprocessor)
 
     def _prepare_links(self, search_results: List[Document]) -> List[SearchResult]:
         """

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -314,7 +314,7 @@ class WebRetriever(BaseRetriever):
                 )
             except Exception as e:
                 # Log the exception for debugging
-                logging.debug(f"Error fetching documents from {link.url}: {str(e)}")
+                logging.debug("Error fetching documents from %s : %s", link.url, str(e))
 
             return docs
 

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -273,7 +273,7 @@ class WebRetriever(BaseRetriever):
             return []
 
         links: List[SearchResult] = [
-            SearchResult(r.meta["link"], r.content, r.meta.get("score"), r.meta.get("position"))
+            SearchResult(r.meta["link"], r.content, float(r.meta.get("score", 0.0)), r.meta.get("position"))
             for r in search_results
             if r.meta.get("link")
         ]

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -293,12 +293,13 @@ class WebRetriever(BaseRetriever):
         if not links:
             return []
 
+        fetcher = (
+            LinkContentFetcher(processor=preprocessor, raise_on_failure=True)
+            if self.mode == "preprocessed_documents" and preprocessor
+            else LinkContentFetcher(raise_on_failure=True)
+        )
+
         def scrape_direct(link: SearchResult) -> List[Document]:
-            fetcher = (
-                LinkContentFetcher(processor=preprocessor, raise_on_failure=True)
-                if self.mode == "preprocessed_documents" and preprocessor
-                else LinkContentFetcher(raise_on_failure=True)
-            )
             docs: List[Document] = []
             try:
                 docs = fetcher.fetch(
@@ -311,9 +312,9 @@ class WebRetriever(BaseRetriever):
                         "snippet_text": link.snippet,
                     },
                 )
-            except Exception:
-                #  ignore fetching and parsing errors
-                pass
+            except Exception as e:
+                # Log the exception for debugging
+                logging.debug(f"Error fetching documents from {link.url}: {str(e)}")
 
             return docs
 

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -3,16 +3,14 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from multiprocessing import cpu_count
-from typing import Any, Dict, Iterator, List, Optional, Literal, Union
+from typing import Dict, Iterator, List, Optional, Literal, Union
 from unicodedata import combining, normalize
 
-import requests
-from boilerpy3 import extractors
-
-from haystack import Document, __version__
+from haystack import Document
 from haystack.document_stores.base import BaseDocumentStore
 from haystack.nodes.preprocessor import PreProcessor
 from haystack.nodes.retriever.base import BaseRetriever
+from haystack.nodes.retriever.link_content import LinkContentFetcher
 from haystack.nodes.search_engine.web import SearchEngine
 from haystack.nodes.search_engine.web import WebSearch
 from haystack.schema import FilterType
@@ -23,34 +21,29 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SearchResult:
     url: str
+    snippet: str
     score: Optional[str]
     position: Optional[str]
 
 
 class WebRetriever(BaseRetriever):
     """
-    WebRetriever makes it possible to query the web for relevant documents. It downloads web page results returned by WebSearch, strips HTML, and extracts raw text, which is then
-    split into smaller documents using the optional PreProcessor.
+    The WebRetriever is an effective tool designed to extract relevant documents from the web. It leverages the WebSearch
+    class to obtain web page results, strips the HTML from those pages, and extracts the raw text content. Depending on
+    the operation mode, this text can be further broken down into smaller documents with the help of a PreProcessor.
 
-    WebRetriever operates in two modes:
+    The WebRetriever supports three distinct modes of operation:
 
-    - snippets mode: WebRetriever returns a list of Documents. Each Document is a snippet of the search result.
-    - raw_documents mode: WebRetriever returns a list of Documents. Each Document is a full website returned by the search, stripped of HTML.
-    - preprocessed_documents mode: WebRetriever return a list of Documents. Each Document is a preprocessed split of the full website stripped of HTML.
+    - Snippets Mode: In this mode, the WebRetriever generates a list of Document instances, where each Document
+    represents a snippet or a segment from a web page result. It's important to note that this mode does not involve
+    actual web page retrieval.
 
-    In the preprocessed_documents mode, after WebSearch receives the query through the `run()` method, it fetches the top_k URLs relevant to the query. WebSearch then downloads and processes these URLs.
-    The processing involves stripping HTML tags and producing
-    a clean, raw text wrapped in the Document objects. WebRetriever then splits raw text into Documents according to the PreProcessor settings.
-    Finally, WebRetriever returns the top_k preprocessed Documents.
+    - Raw Documents Mode: In this mode, the WebRetriever generates a list of Document instances, where each Document
+    represents an entire web page (retrieved from the search result link) devoid of any HTML and containing only the raw
+    text content.
 
-    Finding the right balance between top_k and top_p is crucial to obtain high-quality and diverse results in the document
-    mode. To explore potential results, we recommend that you set top_k for WebSearch close to 10.
-    However, keep in mind that setting a high top_k value results in fetching and processing numerous web pages and is heavier on the resources.
-
-    We recommend you use the default value for top_k and adjust it based on your specific
-    use case. The default value is 5. This means WebRetriever returns at most
-    five of the most relevant processed documents, ensuring the search results are diverse but still of high
-    quality. To get more results, increase top_k.
+    - Preprocessed Documents Mode: This mode is similar to the Raw Documents Mode but includes an additional step -
+    the raw text from each retrieved web page is divided into smaller Document instances using a specified PreProcessor.
     """
 
     def __init__(
@@ -89,9 +82,10 @@ class WebRetriever(BaseRetriever):
         self.cache_headers = cache_headers
         self.cache_time = cache_time
         self.top_k = top_k
+        self.preprocessor = None
         if preprocessor is not None:
             self.preprocessor = preprocessor
-        else:
+        elif mode == "preprocessed_documents":
             self.preprocessor = PreProcessor(progress_bar=False)
 
     def _normalize_query(self, query: str) -> str:
@@ -104,10 +98,21 @@ class WebRetriever(BaseRetriever):
         cache_headers: Optional[Dict[str, str]] = None,
         cache_time: Optional[int] = None,
     ) -> List[Document]:
-        """Check documents retrieved based on the query in cache."""
+        """
+        Private method to check if the documents for a given query are already cached. The documents are fetched from
+        the specified DocumentStore. It retrieves documents that are newer than the cache_time limit.
 
+        :param query: The query string to check in the cache.
+        :param cache_index: Optional index name in the DocumentStore to fetch the documents. Defaults to the instance's
+        cache_index.
+        :param cache_headers: Optional headers to be used when fetching documents from the DocumentStore. Defaults to
+        the instance's cache_headers.
+        :param cache_time: Optional time limit in seconds to check the cache. Only documents newer than cache_time are
+        returned. Defaults to the instance's cache_time.
+        :returns: A list of Document instances fetched from the cache. If no documents are found in the cache, an empty
+        list is returned.
+        """
         cache_document_store = self.cache_document_store
-
         documents = []
 
         if cache_document_store is not None:
@@ -136,6 +141,21 @@ class WebRetriever(BaseRetriever):
         cache_headers: Optional[Dict[str, str]] = None,
         cache_time: Optional[int] = None,
     ) -> bool:
+        """
+        Private method to cache the retrieved documents for a given query.
+        The documents are saved in the specified DocumentStore. If the same document already exists, it is
+        overwritten.
+
+        :param query: The query string for which the documents are being cached.
+        :param documents: The list of Document instances to be cached.
+        :param cache_index: Optional index name in the DocumentStore to save the documents. Defaults to the
+        instance's cache_index.
+        :param cache_headers: Optional headers to be used when saving documents in the DocumentStore. Defaults to
+        the instance's cache_headers.
+        :param cache_time: Optional time limit in seconds to check the cache. Documents older than the
+        cache_time are deleted. Defaults to the instance's cache_time.
+        :returns: True if the documents are successfully saved in the cache, False otherwise.
+        """
         cache_document_store = self.cache_document_store
 
         if cache_document_store is not None:
@@ -172,11 +192,18 @@ class WebRetriever(BaseRetriever):
         **kwargs,
     ) -> List[Document]:
         """
-        Retrieve documents based on the list of URLs from the WebSearchEngine. The documents are scraped from the web
-        at real-time. You can then store the documents in a DocumentStore for later use. You can cache them in a
-        DocumentStore to improve retrieval time.
+        Retrieve documents in real-time from the web based on the URLs provided by the WebSearch.
+
+        This method takes a search query as input, retrieves the corresponding web documents, and
+        returns them in a structured format suitable for further processing or analysis. The documents
+        are retrieved at runtime, ensuring up-to-date information.
+
+        Optionally, the retrieved documents can be stored in a DocumentStore for future use, saving time
+        and resources on repeated retrievals. This caching mechanism can significantly improve retrieval times
+        for frequently accessed information.
+
         :param query: The query string.
-        :param top_k: The number of documents to be returned by the retriever. If None, the default value is used.
+        :param top_k: The number of documents to be returned by the retriever.
         :param preprocessor: The PreProcessor to be used to split documents into paragraphs.
         :param cache_document_store: The DocumentStore to cache the documents to.
         :param cache_index: The index name to save the documents to.
@@ -184,6 +211,7 @@ class WebRetriever(BaseRetriever):
         :param cache_time: The time limit in seconds to check the cache. The default is 24 hours.
         """
 
+        # Initialize default parameters
         preprocessor = preprocessor or self.preprocessor
         cache_document_store = cache_document_store or self.cache_document_store
         cache_index = cache_index or self.cache_index
@@ -191,87 +219,112 @@ class WebRetriever(BaseRetriever):
         cache_time = cache_time or self.cache_time
         top_k = top_k or self.top_k
 
+        # Normalize query
         query_norm = self._normalize_query(query)
 
+        # Check cache for query
         extracted_docs = self._check_cache(
             query_norm, cache_index=cache_index, cache_headers=cache_headers, cache_time=cache_time
         )
 
-        # cache miss
+        # If query is not cached, fetch from web
         if not extracted_docs:
-            search_results, _ = self.web_search.run(query=query)
-            search_results = search_results["documents"]
-            if self.mode == "snippets":
-                return search_results[:top_k]  # type: ignore
+            extracted_docs = self._retrieve_from_web(query_norm, preprocessor, top_k)
 
-            links: List[SearchResult] = [
-                SearchResult(r.meta["link"], r.meta.get("score", None), r.meta.get("position", None))
-                for r in search_results
-                if r.meta.get("link")
-            ]
-            logger.debug("Starting to fetch %d links from WebSearch results", len(links))
-
-            def scrape_direct(link: SearchResult) -> Dict[str, Any]:
-                extractor = extractors.ArticleExtractor(raise_on_failure=False)
-                try:
-                    extracted_doc = {}
-                    response = requests.get(link.url, headers=self._request_headers(), timeout=10)
-                    if response.status_code == 200 and len(response.text) > 0:
-                        extracted_content = extractor.get_content(response.text)
-                        if extracted_content:
-                            extracted_doc = {
-                                "text": extracted_content,
-                                "url": link.url,
-                                "search.score": link.score,
-                                "search.position": link.position,
-                            }
-                    return extracted_doc
-
-                except Exception as e:
-                    logger.error("Error retrieving URL %s: %s", link.url, e)
-                    return {}
-
-            thread_count = cpu_count() if len(links) > cpu_count() else len(links)
-            with ThreadPoolExecutor(max_workers=thread_count) as executor:
-                scraped_pages: Iterator[Dict[str, Any]] = executor.map(scrape_direct, links)
-
-                failed = 0
-                extracted_docs = []
-                for scraped_page, search_result_doc in zip(scraped_pages, search_results):
-                    if scraped_page and "text" in scraped_page:
-                        document = self._document_from_scraped_page(search_result_doc, scraped_page, query_norm)
-                        extracted_docs.append(document)
-                    else:
-                        logger.debug(
-                            "Could not extract text from URL %s. Using search snippet.", search_result_doc.meta["link"]
-                        )
-                        snippet_doc = self._document_from_snippet(search_result_doc, query_norm)
-                        extracted_docs.append(snippet_doc)
-                        failed += 1
-
-                logger.debug(
-                    "Extracted %d documents / %s snippets from %s URLs.",
-                    len(extracted_docs) - failed,
-                    failed,
-                    len(links),
-                )
-
-        if cache_document_store:
+        # Save results to cache
+        if cache_document_store and extracted_docs:
             cached = self._save_cache(query_norm, extracted_docs, cache_index=cache_index, cache_headers=cache_headers)
             if not cached:
                 logger.warning(
                     "Could not save retrieved documents to the DocumentStore cache. "
                     "Check your document store configuration."
                 )
+        return extracted_docs[:top_k]
 
-        processed_docs = (
-            [t for d in extracted_docs for t in preprocessor.process([d])]
-            if self.mode == "preprocessed_documents"
-            else extracted_docs
-        )
+    def _retrieve_from_web(
+        self, query_norm: str, preprocessor: Optional[PreProcessor], top_k: Optional[int]
+    ) -> List[Document]:
+        """
+        Retrieve documents from the web based on the query.
 
-        logger.debug("Processed %d documents resulting in %s documents", len(extracted_docs), len(processed_docs))
-        return processed_docs[:top_k]
+        :param query_norm: The normalized query string.
+        :param preprocessor: The PreProcessor to be used to split documents into paragraphs.
+        :param top_k: The number of documents to be returned by the retriever. If None, the default value is used.
+        :return: List of Document objects.
+        """
+
+        search_results, _ = self.web_search.run(query=query_norm)
+        search_results_docs = search_results["documents"]
+        if self.mode == "snippets":
+            return search_results_docs[:top_k]  # type: ignore
+
+        links: List[SearchResult] = self._prepare_links(search_results_docs)
+        logger.debug("Starting to fetch %d links from WebSearch results", len(links))
+        return self._scrape_links(links, query_norm, preprocessor)
+
+    def _prepare_links(self, search_results: List[Document]) -> List[SearchResult]:
+        """
+        Prepare a list of SearchResult objects based on the search results from the search engine.
+
+        :param search_results: List of Document objects obtained from web search.
+        :return: List of SearchResult objects.
+        """
+        if not search_results:
+            return []
+
+        links: List[SearchResult] = [
+            SearchResult(r.meta["link"], r.content, r.meta.get("score"), r.meta.get("position"))
+            for r in search_results
+            if r.meta.get("link")
+        ]
+        return links
+
+    def _scrape_links(
+        self, links: List[SearchResult], query_norm: str, preprocessor: Optional[PreProcessor]
+    ) -> List[Document]:
+        """
+        Scrape the links and return the documents.
+
+        :param links: List of SearchResult objects.
+        :param query_norm: The normalized query string.
+        :param preprocessor: The PreProcessor object to be used to split documents into paragraphs.
+        :return: List of Document objects obtained from scraping the links.
+        """
+        if not links:
+            return []
+
+        def scrape_direct(link: SearchResult) -> List[Document]:
+            fetcher = (
+                LinkContentFetcher(processor=preprocessor, raise_on_failure=True)
+                if self.mode == "preprocessed_documents" and preprocessor
+                else LinkContentFetcher(raise_on_failure=True)
+            )
+            docs: List[Document] = []
+            try:
+                docs = fetcher.fetch(
+                    url=link.url,
+                    doc_kwargs={
+                        "search.score": link.score,
+                        "id_hash_keys": ["meta.url", "meta.search.query"],
+                        "search.query": query_norm,
+                        "search.position": link.position,
+                        "snippet_text": link.snippet,
+                    },
+                )
+            except Exception:
+                #  ignore fetching and parsing errors
+                pass
+
+            return docs
+
+        thread_count = cpu_count() if len(links) > cpu_count() else len(links)
+        with ThreadPoolExecutor(max_workers=thread_count) as executor:
+            scraped_pages: Iterator[List[Document]] = executor.map(scrape_direct, links)
+
+        # Flatten list of lists to a single list
+        extracted_docs = [doc for doc_list in scraped_pages for doc in doc_list]
+
+        return extracted_docs
 
     def retrieve_batch(  # type: ignore[override]
         self,
@@ -284,14 +337,30 @@ class WebRetriever(BaseRetriever):
         cache_headers: Optional[Dict[str, str]] = None,
         cache_time: Optional[int] = None,
     ) -> List[List[Document]]:
-        documents = []
+        """
+        Batch retrieval method that fetches documents for a list of queries. Each query is passed to the `retrieve`
+        method which fetches documents from the web in real-time or from a DocumentStore cache. The fetched documents
+        are then extended to a list of documents.
 
-        # TODO: parallelize using ProcessPoolExecutor and use Lock at document store methods
+        :param queries: List of query strings to retrieve documents for.
+        :param top_p: The number of documents to be returned by the retriever for each query. If None, the instance's
+        default value is used.
+        :param top_k: The maximum number of documents to be retrieved for each query. If None, the instance's default
+        value is used.
+        :param preprocessor: The PreProcessor to be used to split documents into paragraphs. If None, the instance's
+        default PreProcessor is used.
+        :param cache_document_store: The DocumentStore to cache the documents to. If None, the instance's default
+        DocumentStore is used.
+        :param cache_index: The index name to save the documents to. If None, the instance's default cache_index is used.
+        :param cache_headers: The headers to save the documents to. If None, the instance's default cache_headers is used.
+        :param cache_time: The time limit in seconds to check the cache. If None, the instance's default cache_time is used.
+        :returns: A list of lists where each inner list represents the documents fetched for a particular query.
+        """
+        documents = []
         for q in queries:
-            documents.extend(
+            documents.append(
                 self.retrieve(
-                    q,
-                    top_p=top_p,
+                    query=q,
                     top_k=top_k,
                     preprocessor=preprocessor,
                     cache_document_store=cache_document_store,
@@ -301,35 +370,4 @@ class WebRetriever(BaseRetriever):
                 )
             )
 
-        return [documents]
-
-    def _request_headers(self):
-        headers = {
-            "accept": "*/*",
-            "User-Agent": f"haystack/WebRetriever/{__version__}",
-            "Accept-Language": "en-US,en;q=0.9,it;q=0.8,es;q=0.7",
-            "referer": "https://www.google.com/",
-        }
-        return headers
-
-    def _document_from_snippet(self, doc, query_norm):
-        doc_dict = {
-            "text": doc.content,
-            "url": doc.meta["link"],
-            "id_hash_keys": ["meta.url", "meta.search.query"],
-            "search.query": query_norm,
-        }
-        d = Document.from_dict(doc_dict, field_map={"text": "content"})
-        d.meta["timestamp"] = int(datetime.utcnow().timestamp())
-        d.meta["search.position"] = doc.meta.pop("position", None)
-        d.meta["search.snippet"] = 1
-        return d
-
-    def _document_from_scraped_page(self, search_result_doc, scraped_page, query_norm):
-        scraped_page["id_hash_keys"] = ["meta.url", "meta.search.query"]
-        scraped_page["search.query"] = query_norm
-        scraped_page.pop("description", None)
-        document = Document.from_dict(scraped_page, field_map={"text": "content"})
-        document.meta["timestamp"] = int(datetime.utcnow().timestamp())
-        document.meta["search.position"] = search_result_doc.meta.get("position")
-        return document
+        return documents

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class SearchResult:
     url: str
     snippet: str
-    score: Optional[str]
+    score: float
     position: Optional[str]
 
 
@@ -323,6 +323,9 @@ class WebRetriever(BaseRetriever):
 
         # Flatten list of lists to a single list
         extracted_docs = [doc for doc_list in scraped_pages for doc in doc_list]
+
+        # Sort by score
+        extracted_docs = sorted(extracted_docs, key=lambda x: x.meta["search.score"], reverse=True)
 
         return extracted_docs
 

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -314,7 +314,7 @@ class WebRetriever(BaseRetriever):
                 )
             except Exception as e:
                 # Log the exception for debugging
-                logging.debug("Error fetching documents from %s : %s", link.url, str(e))
+                logger.debug("Error fetching documents from %s : %s", link.url, str(e))
 
             return docs
 

--- a/haystack/nodes/search_engine/web.py
+++ b/haystack/nodes/search_engine/web.py
@@ -81,7 +81,10 @@ class WebSearch(BaseComponent):
         # query is a required parameter for search, we need to keep the signature of run() the same as in other nodes
         if not query:
             raise ValueError("WebSearch run requires the `query` parameter")
-        return {"documents": self.search_engine.search(query, top_k=top_k)}, "output_1"
+        search_kwargs = {}
+        if top_k is not None:
+            search_kwargs["top_k"] = top_k
+        return {"documents": self.search_engine.search(query, **search_kwargs)}, "output_1"
 
     def run_batch(
         self,

--- a/releasenotes/notes/refactor-web-retriever-a0604ead72b84fdc.yaml
+++ b/releasenotes/notes/refactor-web-retriever-a0604ead72b84fdc.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Refactor and simplify WebRetriever to use LinkContentFetcher component

--- a/test/nodes/test_web_retriever.py
+++ b/test/nodes/test_web_retriever.py
@@ -1,163 +1,258 @@
 import os
-from typing import Dict, Tuple
-
-
+from unittest.mock import MagicMock, patch, Mock
+from test.conftest import MockDocumentStore
 import pytest
-import requests
-from boilerpy3.extractors import ArticleExtractor
 
 from haystack import Document, Pipeline
-from haystack.nodes import WebSearch, WebRetriever, PromptNode
+from haystack.document_stores.base import BaseDocumentStore
+from haystack.nodes import WebRetriever, PromptNode
+from haystack.nodes.preprocessor import PreProcessor
+from haystack.nodes.retriever.web import SearchResult
+
+
+@pytest.fixture
+def mocked_requests():
+    with patch("haystack.nodes.retriever.link_content.requests") as mock_requests:
+        mock_response = Mock()
+        mock_requests.get.return_value = mock_response
+        mock_response.status_code = 200
+        mock_response.text = "Sample content from webpage"
+        yield mock_requests
+
+
+@pytest.fixture
+def mocked_article_extractor():
+    with patch("boilerpy3.extractors.ArticleExtractor.get_content", return_value="Sample content from webpage"):
+        yield
 
 
 @pytest.mark.unit
-def test_web_retriever_mode_raw_documents(monkeypatch):
-    expected_search_results = {
-        "documents": [
-            Document(
-                content="Eddard Stark",
-                score=0.9090909090909091,
-                meta={"title": "Eddard Stark", "link": "", "score": 0.9090909090909091},
-                id_hash_keys=["content"],
-                id="f408db6de8de0ffad0cb47cf8830dbb8",
-            ),
-            Document(
-                content="The most likely answer for the clue is NED. How many solutions does Arya Stark's Father have? With crossword-solver.io you will find 1 solutions. We use ...",
-                score=0.09090909090909091,
-                meta={
-                    "title": "Arya Stark's Father - Crossword Clue Answers",
-                    "link": "https://crossword-solver.io/clue/arya-stark%27s-father/",
-                    "position": 1,
-                    "score": 0.09090909090909091,
-                },
-                id_hash_keys=["content"],
-                id="51779277acf94cf90e7663db137c0732",
-            ),
-        ]
-    }
+def test_init_default_parameters():
+    retriever = WebRetriever(api_key="test_key")
 
-    def mock_web_search_run(self, query: str) -> Tuple[Dict, str]:
-        return expected_search_results, "output_1"
+    assert retriever.top_k == 5
+    assert retriever.mode == "snippets"
+    assert retriever.preprocessor is None
+    assert retriever.cache_document_store is None
+    assert retriever.cache_index is None
+    assert retriever.cache_headers is None
+    assert retriever.cache_time == 1 * 24 * 60 * 60
 
-    class MockResponse:
-        def __init__(self, text, status_code):
-            self.text = text
-            self.status_code = status_code
 
-    def get(url, headers, timeout):
-        return MockResponse("mocked", 200)
+@pytest.mark.unit
+def test_init_custom_parameters():
+    preprocessor = PreProcessor()
+    document_store = MagicMock(spec=BaseDocumentStore)
+    headers = {"Test": "Header"}
 
-    def get_content(self, text: str) -> str:
-        return "What are the top solutions for\nArya Stark's Father\nWe found 1 solutions for\nArya Stark's Father\n.The top solutions is determined by popularity, ratings and frequency of searches. The most likely answer for the clue is NED..."
-
-    monkeypatch.setattr(WebSearch, "run", mock_web_search_run)
-    monkeypatch.setattr(ArticleExtractor, "get_content", get_content)
-    monkeypatch.setattr(requests, "get", get)
-
-    web_retriever = WebRetriever(api_key="", top_search_results=2, mode="raw_documents")
-    result = web_retriever.retrieve(query="Who is the father of Arya Stark?")
-    assert len(result) == 1
-    assert isinstance(result[0], Document)
-    assert (
-        result[0].content
-        == "What are the top solutions for\nArya Stark's Father\nWe found 1 solutions for\nArya Stark's Father\n.The top solutions is determined by popularity, ratings and frequency of searches. The most likely answer for the clue is NED..."
+    retriever = WebRetriever(
+        api_key="test_key",
+        search_engine_provider="SerperDev",
+        top_search_results=15,
+        top_k=7,
+        mode="preprocessed_documents",
+        preprocessor=preprocessor,
+        cache_document_store=document_store,
+        cache_index="custom_index",
+        cache_headers=headers,
+        cache_time=2 * 24 * 60 * 60,
     )
-    assert result[0].score == None
-    assert result[0].meta["url"] == "https://crossword-solver.io/clue/arya-stark%27s-father/"
-    # Only preprocessed docs but not raw docs should have the _split_id field
-    assert "_split_id" not in result[0].meta
+
+    assert retriever.top_k == 7
+    assert retriever.mode == "preprocessed_documents"
+    assert retriever.preprocessor == preprocessor
+    assert retriever.cache_document_store == document_store
+    assert retriever.cache_index == "custom_index"
+    assert retriever.cache_headers == headers
+    assert retriever.cache_time == 2 * 24 * 60 * 60
 
 
 @pytest.mark.unit
-def test_web_retriever_mode_preprocessed_documents(monkeypatch):
-    expected_search_results = {
-        "documents": [
-            Document(
-                content="Eddard Stark",
-                score=0.9090909090909091,
-                meta={"title": "Eddard Stark", "link": "", "score": 0.9090909090909091},
-                id_hash_keys=["content"],
-                id="f408db6de8de0ffad0cb47cf8830dbb8",
-            ),
-            Document(
-                content="The most likely answer for the clue is NED. How many solutions does Arya Stark's Father have? With crossword-solver.io you will find 1 solutions. We use ...",
-                score=0.09090909090909091,
-                meta={
-                    "title": "Arya Stark's Father - Crossword Clue Answers",
-                    "link": "https://crossword-solver.io/clue/arya-stark%27s-father/",
-                    "position": 1,
-                    "score": 0.09090909090909091,
-                },
-                id_hash_keys=["content"],
-                id="51779277acf94cf90e7663db137c0732",
-            ),
-        ]
-    }
+def test_retrieve_from_web_all_params(mock_web_search):
+    top_k = 7
+    wr = WebRetriever(api_key="fake_key")
 
-    def mock_web_search_run(self, query: str) -> Tuple[Dict, str]:
-        return expected_search_results, "output_1"
+    preprocessor = PreProcessor()
 
-    class MockResponse:
-        def __init__(self, text, status_code):
-            self.text = text
-            self.status_code = status_code
+    result = wr._retrieve_from_web("Who is the boyfriend of Olivia Wilde?", preprocessor, top_k)
 
-    def get(url, headers, timeout):
-        return MockResponse("mocked", 200)
+    assert isinstance(result, list)
+    assert all(isinstance(doc, Document) for doc in result)
+    # If top_k was provided and positive, we expect no more than that many documents in the result.
+    assert len(result) <= top_k
 
-    def get_content(self, text: str) -> str:
-        return "What are the top solutions for\nArya Stark's Father\nWe found 1 solutions for\nArya Stark's Father\n.The top solutions is determined by popularity, ratings and frequency of searches. The most likely answer for the clue is NED..."
 
-    monkeypatch.setattr(WebSearch, "run", mock_web_search_run)
-    monkeypatch.setattr(ArticleExtractor, "get_content", get_content)
-    monkeypatch.setattr(requests, "get", get)
+@pytest.mark.unit
+def test_retrieve_from_web_no_preprocessor(mock_web_search):
+    top_k = 7
+    wr = WebRetriever(api_key="fake_key")
+    result = wr._retrieve_from_web("query", None, top_k)
 
-    web_retriever = WebRetriever(api_key="", top_search_results=2, mode="preprocessed_documents")
-    result = web_retriever.retrieve(query="Who is the father of Arya Stark?")
-    assert len(result) == 1
-    assert isinstance(result[0], Document)
-    assert (
-        result[0].content
-        == "What are the top solutions for\nArya Stark's Father\nWe found 1 solutions for\nArya Stark's Father\n.The top solutions is determined by popularity, ratings and frequency of searches. The most likely answer for the clue is NED..."
+    assert isinstance(result, list)
+    assert all(isinstance(doc, Document) for doc in result)
+    assert len(result) <= top_k
+
+
+@pytest.mark.unit
+def test_retrieve_from_web_no_top_k(mock_web_search):
+    wr = WebRetriever(api_key="fake_key")
+    preprocessor = PreProcessor()
+
+    result = wr._retrieve_from_web("query", preprocessor, None)
+
+    assert isinstance(result, list)
+    assert all(isinstance(doc, Document) for doc in result)
+    assert len(result) >= 1
+
+
+@pytest.mark.unit
+def test_retrieve_from_web_no_preprocessor_no_top_k(mock_web_search):
+    wr = WebRetriever(api_key="fake_key")
+    result = wr._retrieve_from_web("query", None, None)
+
+    assert isinstance(result, list)
+    assert all(isinstance(doc, Document) for doc in result)
+    assert len(result) >= 1
+
+
+@pytest.mark.unit
+def test_prepare_links_empty_list():
+    wr = WebRetriever(api_key="fake_key")
+    result = wr._prepare_links([])
+    assert result == []
+
+    result = wr._prepare_links(None)
+    assert result == []
+
+
+@pytest.mark.unit
+def test_scrape_links_empty_list():
+    wr = WebRetriever(api_key="fake_key")
+    result = wr._scrape_links([], "query", None)
+    assert result == []
+
+
+@pytest.mark.unit
+def test_scrape_links_with_search_results(mocked_requests, mocked_article_extractor):
+    wr = WebRetriever(api_key="fake_key")
+
+    sr1 = SearchResult("https://pagesix.com", "Some text", "0.43", "1")
+    sr2 = SearchResult("https://www.yahoo.com/", "Some text", "0.43", "2")
+    fake_search_results = [sr1, sr2]
+
+    result = wr._scrape_links(fake_search_results, "query", None)
+
+    assert isinstance(result, list)
+    assert all(isinstance(r, Document) for r in result)
+    assert len(result) == 2
+
+
+@pytest.mark.unit
+def test_scrape_links_with_search_results_with_preprocessor(mocked_requests, mocked_article_extractor):
+    wr = WebRetriever(api_key="fake_key", mode="preprocessed_documents")
+    preprocessor = PreProcessor(progress_bar=False)
+
+    sr1 = SearchResult("https://pagesix.com", "Some text", "0.43", "1")
+    sr2 = SearchResult("https://www.yahoo.com/", "Some text", "0.43", "2")
+    fake_search_results = [sr1, sr2]
+
+    result = wr._scrape_links(fake_search_results, "query", preprocessor)
+
+    assert isinstance(result, list)
+    assert all(isinstance(r, Document) for r in result)
+    # the documents from above SearchResult are so small that they will not be split into multiple documents
+    # by the preprocessor
+    assert len(result) == 2
+
+
+@pytest.mark.unit
+def test_retrieve_uses_defaults():
+    wr = WebRetriever(api_key="fake_key")
+
+    with patch.object(wr, "_check_cache", return_value=[]) as mock_check_cache:
+        with patch.object(wr, "_retrieve_from_web", return_value=[]) as mock_retrieve_from_web:
+            wr.retrieve("query")
+
+    # cache is checked first, always
+    mock_check_cache.assert_called_with(
+        "query", cache_index=wr.cache_index, cache_headers=wr.cache_headers, cache_time=wr.cache_time
     )
-    assert result[0].score == None
-    assert result[0].meta["url"] == "https://crossword-solver.io/clue/arya-stark%27s-father/"
-    assert result[0].meta["_split_id"] == 0
+    mock_retrieve_from_web.assert_called_with("query", wr.preprocessor, wr.top_k)
 
 
 @pytest.mark.unit
-def test_web_retriever_mode_snippets(monkeypatch):
-    expected_search_results = {
-        "documents": [
-            Document(
-                content="Eddard Stark",
-                score=0.9090909090909091,
-                meta={"title": "Eddard Stark", "link": "", "score": 0.9090909090909091},
-                id_hash_keys=["content"],
-                id="f408db6de8de0ffad0cb47cf8830dbb8",
-            ),
-            Document(
-                content="The most likely answer for the clue is NED. How many solutions does Arya Stark's Father have? With crossword-solver.io you will find 1 solutions. We use ...",
-                score=0.09090909090909091,
-                meta={
-                    "title": "Arya Stark's Father - Crossword Clue Answers",
-                    "link": "https://crossword-solver.io/clue/arya-stark%27s-father/",
-                    "position": 1,
-                    "score": 0.09090909090909091,
-                },
-                id_hash_keys=["content"],
-                id="51779277acf94cf90e7663db137c0732",
-            ),
-        ]
-    }
+def test_retrieve_batch():
+    queries = ["query1", "query2"]
+    wr = WebRetriever(api_key="fake_key")
+    web_docs = [Document("doc1"), Document("doc2"), Document("doc3")]
+    with patch.object(wr, "_check_cache", return_value=[]) as mock_check_cache:
+        with patch.object(wr, "_retrieve_from_web", return_value=web_docs) as mock_retrieve_from_web:
+            result = wr.retrieve_batch(queries)
 
-    def mock_web_search_run(self, query: str) -> Tuple[Dict, str]:
-        return expected_search_results, "output_1"
+    assert mock_check_cache.call_count == len(queries)
+    assert mock_retrieve_from_web.call_count == len(queries)
+    # check that the result is a list of lists of Documents
+    # where each list of Documents is the result of a single query
+    assert len(result) == len(queries)
 
-    monkeypatch.setattr(WebSearch, "run", mock_web_search_run)
-    web_retriever = WebRetriever(api_key="", top_search_results=2)
-    result = web_retriever.retrieve(query="Who is the father of Arya Stark?")
-    assert result == expected_search_results["documents"]
+    # check that the result is a list of lists of Documents
+    assert all(isinstance(docs, list) for docs in result)
+    assert all(isinstance(doc, Document) for docs in result for doc in docs)
+
+    # check that the result is a list of lists of Documents, so that the number of Documents
+    # is equal to the number of queries * number of documents retrieved per query
+    assert len([doc for docs in result for doc in docs]) == len(web_docs) * len(queries)
+
+
+@pytest.mark.unit
+def test_retrieve_uses_cache():
+    wr = WebRetriever(api_key="fake_key")
+
+    cached_docs = [Document("doc1"), Document("doc2")]
+    with patch.object(wr, "_check_cache", return_value=cached_docs) as mock_check_cache:
+        with patch.object(wr, "_retrieve_from_web") as mock_retrieve_from_web:
+            with patch.object(wr, "_save_cache") as mock_save_cache:
+                result = wr.retrieve("query")
+
+    # checking cache is always called
+    mock_check_cache.assert_called()
+
+    # not called because we found docs in cache
+    mock_retrieve_from_web.assert_not_called()
+    mock_save_cache.assert_not_called()
+
+    assert result == cached_docs
+
+
+@pytest.mark.unit
+def test_retrieve_saves_to_cache():
+    wr = WebRetriever(api_key="fake_key", cache_document_store=MockDocumentStore())
+    web_docs = [Document("doc1"), Document("doc2"), Document("doc3")]
+
+    with patch.object(wr, "_check_cache", return_value=[]) as mock_check_cache:
+        with patch.object(wr, "_retrieve_from_web", return_value=web_docs) as mock_retrieve_from_web:
+            with patch.object(wr, "_save_cache") as mock_save_cache:
+                result = wr.retrieve("query")
+
+    mock_check_cache.assert_called()
+
+    # cache is empty, so we call _retrieve_from_web
+    mock_retrieve_from_web.assert_called()
+    # and save the results to cache
+    mock_save_cache.assert_called_with("query", web_docs, cache_index=wr.cache_index, cache_headers=wr.cache_headers)
+    assert result == web_docs
+
+
+@pytest.mark.unit
+def test_retrieve_returns_top_k():
+    wr = WebRetriever(api_key="", top_k=2)
+
+    with patch.object(wr, "_check_cache", return_value=[]):
+        web_docs = [Document("doc1"), Document("doc2"), Document("doc3")]
+        with patch.object(wr, "_retrieve_from_web", return_value=web_docs):
+            result = wr.retrieve("query")
+
+    assert result == web_docs[:2]
 
 
 @pytest.mark.unit
@@ -196,3 +291,20 @@ def test_top_k_parameter_in_pipeline(top_k):
     pipe.add_node(component=prompt_node, name="QAwithScoresPrompt", inputs=["WebRetriever"])
     result = pipe.run(query="What year was Obama president", params={"WebRetriever": {"top_k": top_k}})
     assert len(result["results"]) == top_k
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("SERPERDEV_API_KEY", None),
+    reason="Please export an env var called SERPERDEV_API_KEY containing the serper.dev API key to run this test.",
+)
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Please export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
+@pytest.mark.skip
+def test_web_retriever_speed():
+    retriever = WebRetriever(api_key=os.environ.get("SERPERDEV_API_KEY"), mode="preprocessed_documents")
+    result = retriever.retrieve(query="What's the meaning of it all?")
+    assert len(result) >= 5
+    assert all(isinstance(doc, Document) for doc in result)

--- a/test/nodes/test_web_retriever.py
+++ b/test/nodes/test_web_retriever.py
@@ -74,7 +74,7 @@ def test_retrieve_from_web_all_params(mock_web_search):
 
     preprocessor = PreProcessor()
 
-    result = wr._retrieve_from_web("Who is the boyfriend of Olivia Wilde?", preprocessor)
+    result = wr._retrieve_from_web(query="Who is the boyfriend of Olivia Wilde?", preprocessor=preprocessor)
 
     assert isinstance(result, list)
     assert all(isinstance(doc, Document) for doc in result)

--- a/test/nodes/test_web_retriever.py
+++ b/test/nodes/test_web_retriever.py
@@ -205,7 +205,7 @@ def test_retrieve_uses_cache():
     # checking cache is always called
     mock_check_cache.assert_called()
 
-    # not called because we found docs in cache
+    # these methods are not called because we found docs in cache
     mock_retrieve_from_web.assert_not_called()
     mock_save_cache.assert_not_called()
 

--- a/test/nodes/test_web_retriever.py
+++ b/test/nodes/test_web_retriever.py
@@ -74,7 +74,7 @@ def test_retrieve_from_web_all_params(mock_web_search):
 
     preprocessor = PreProcessor()
 
-    result = wr._retrieve_from_web(query="Who is the boyfriend of Olivia Wilde?", preprocessor=preprocessor)
+    result = wr._retrieve_from_web(query_norm="who is the boyfriend of olivia wilde?", preprocessor=preprocessor)
 
     assert isinstance(result, list)
     assert all(isinstance(doc, Document) for doc in result)

--- a/test/nodes/test_web_retriever.py
+++ b/test/nodes/test_web_retriever.py
@@ -70,40 +70,11 @@ def test_init_custom_parameters():
 
 @pytest.mark.unit
 def test_retrieve_from_web_all_params(mock_web_search):
-    # tests that we get top_k results even if PreProcessor is provided
-    top_k = 7
     wr = WebRetriever(api_key="fake_key")
 
     preprocessor = PreProcessor()
 
-    result = wr._retrieve_from_web("Who is the boyfriend of Olivia Wilde?", preprocessor, top_k)
-
-    assert isinstance(result, list)
-    assert all(isinstance(doc, Document) for doc in result)
-    # If top_k was provided and positive, we expect no more than that many documents in the result.
-    assert len(result) == top_k
-
-
-@pytest.mark.unit
-def test_retrieve_from_web_no_preprocessor(mock_web_search):
-    # tests that we get top_k results when no PreProcessor is provided
-    top_k = 7
-    wr = WebRetriever(api_key="fake_key")
-    result = wr._retrieve_from_web("query", None, top_k)
-
-    assert isinstance(result, list)
-    assert all(isinstance(doc, Document) for doc in result)
-    assert len(result) == top_k
-
-
-@pytest.mark.unit
-def test_retrieve_from_web_no_top_k(mock_web_search):
-    # tests that when top_k is None, we get all results
-    # even if PreProcessor is provided
-    wr = WebRetriever(api_key="fake_key")
-    preprocessor = PreProcessor()
-
-    result = wr._retrieve_from_web("query", preprocessor, None)
+    result = wr._retrieve_from_web("Who is the boyfriend of Olivia Wilde?", preprocessor)
 
     assert isinstance(result, list)
     assert all(isinstance(doc, Document) for doc in result)
@@ -111,10 +82,10 @@ def test_retrieve_from_web_no_top_k(mock_web_search):
 
 
 @pytest.mark.unit
-def test_retrieve_from_web_no_preprocessor_no_top_k(mock_web_search):
-    # tests that when no PreProcessor and top_k is None, we get all results
+def test_retrieve_from_web_no_preprocessor(mock_web_search):
+    # tests that we get top_k results when no PreProcessor is provided
     wr = WebRetriever(api_key="fake_key")
-    result = wr._retrieve_from_web("query", None, None)
+    result = wr._retrieve_from_web("query", None)
 
     assert isinstance(result, list)
     assert all(isinstance(doc, Document) for doc in result)
@@ -126,10 +97,10 @@ def test_retrieve_from_web_invalid_query(mock_web_search):
     # however, if query is None or empty, we expect an error
     wr = WebRetriever(api_key="fake_key")
     with pytest.raises(ValueError, match="WebSearch run requires"):
-        wr._retrieve_from_web("", None, None)
+        wr._retrieve_from_web("", None)
 
     with pytest.raises(ValueError, match="WebSearch run requires"):
-        wr._retrieve_from_web(None, None, None)
+        wr._retrieve_from_web(None, None)
 
 
 @pytest.mark.unit
@@ -194,7 +165,7 @@ def test_retrieve_uses_defaults():
     mock_check_cache.assert_called_with(
         "query", cache_index=wr.cache_index, cache_headers=wr.cache_headers, cache_time=wr.cache_time
     )
-    mock_retrieve_from_web.assert_called_with("query", wr.preprocessor, wr.top_k)
+    mock_retrieve_from_web.assert_called_with("query", wr.preprocessor)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What?

This pull request proposes simplifying the existing `WebRetriever` component by internally utilizing the recently isolated `LinkContentFetcher`(see #5227 for more details).

### Why?

After successfully extracting `LinkContentFetcher` from the existing code base, it's now appropriate to utilize this standalone component within `WebRetriever` as well. This refactoring not only improves the structure of our code but also enhances maintainability and readability.

### How can it be used?

The use of `WebRetriever` remains unaffected by this change. The refactoring does not alter any public APIs, so we can continue to use `WebRetriever` as we did previously.

### How did you test it?

The refactoring is validated by updating the existing unit tests and adding new comprehensive ones to ensure the robustness of the WebRetriever post-refactoring.
WebRetriever was also manually tested with `examples/web_qa.py` and `examples/web_lfqa.py`

### Notes for the reviewer:
While reviewing, please focus on the changes within `WebRetriever` and how it utilizes `LinkContentFetcher`. The public APIs remain unchanged. The refactoring aims to simplify the existing structure, so I would greatly appreciate any insights or suggestions for further simplification.