### PR TITLE
refactor: isolate Elasticsearch client calls

### DIFF
--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -1456,7 +1456,7 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
         ef_search = 20 if "ef_search" not in self.knn_parameters else self.knn_parameters["ef_search"]
         return ef_search
 
-    def _delete_index(self, index: str):
+    def _index_delete(self, index: str):
         if self._index_exists(index):
             self.client.indices.delete(index=index, ignore=[400, 404])
             self._delete_ivf_model(index)

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -1618,7 +1618,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
                 index,
                 self.__class__.__name__,
             )
-        self._index_delete(index, {})
+        self._index_delete(index)
 
     def _index_exists(self, index_name: str, headers: Optional[Dict[str, str]] = None) -> bool:
         if logger.isEnabledFor(logging.DEBUG):

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -1618,7 +1618,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
                 index,
                 self.__class__.__name__,
             )
-        self._index_delete(index)
+        self._index_delete(index, {})
 
     def _index_exists(self, index_name: str, headers: Optional[Dict[str, str]] = None) -> bool:
         if logger.isEnabledFor(logging.DEBUG):

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -108,13 +108,13 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             )
 
         self._init_indices(
-            index=index, label_index=label_index, create_index=create_index, recreate_index=recreate_index, headers={}
+            index=index, label_index=label_index, create_index=create_index, recreate_index=recreate_index
         )
 
-    def _init_indices(self, index: str, label_index: str, create_index: bool, recreate_index: bool, headers) -> None:
+    def _init_indices(self, index: str, label_index: str, create_index: bool, recreate_index: bool) -> None:
         if recreate_index:
-            self._index_delete(index, headers)
-            self._index_delete(label_index, headers)
+            self._index_delete(index)
+            self._index_delete(label_index)
 
         if not self._index_exists(index) and (create_index or recreate_index):
             self._create_document_index(index)
@@ -1627,7 +1627,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
 
         return self.client.indices.exists(index=index_name, headers=headers)
 
-    def _index_delete(self, index, headers):
+    def _index_delete(self, index):
         if self._index_exists(index):
             self.client.indices.delete(index=index, ignore=[400, 404])
             logger.info("Index '%s' deleted.", index)

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -1553,7 +1553,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             query["query"]["ids"] = {"values": ids}
         else:
             query["query"] = {"match_all": {}}
-        self.client.delete_by_query(index=index, body=query, ignore=[404], headers=headers)
+        self._delete_by_query(index=index, body=query, ignore=[404], headers=headers)
         # We want to be sure that all docs are deleted before continuing (delete_by_query doesn't support wait_for)
         if self.refresh_type == "wait_for":
             self._index_refresh(index, headers)

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -113,8 +113,8 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
 
     def _init_indices(self, index: str, label_index: str, create_index: bool, recreate_index: bool) -> None:
         if recreate_index:
-            self._delete_index(index)
-            self._delete_index(label_index)
+            self._index_delete(index)
+            self._index_delete(label_index)
 
         if not self._index_exists(index) and (create_index or recreate_index):
             self._create_document_index(index)
@@ -162,13 +162,6 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
     @abstractmethod
     def _create_label_index(self, index_name: str, headers: Optional[Dict[str, str]] = None):
         pass
-
-    def _index_exists(self, index_name: str, headers: Optional[Dict[str, str]] = None) -> bool:
-        if logger.isEnabledFor(logging.DEBUG):
-            if self.client.indices.exists_alias(name=index_name):
-                logger.debug("Index name %s is an alias.", index_name)
-
-        return self.client.indices.exists(index=index_name, headers=headers)
 
     @abstractmethod
     def _validate_and_adjust_document_index(self, index_name: str, headers: Optional[Dict[str, str]] = None):
@@ -280,7 +273,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             query = {"size": len(ids_for_batch), "query": {"ids": {"values": ids_for_batch}}}
             if not self.return_embedding and self.embedding_field:
                 query["_source"] = {"excludes": [self.embedding_field]}
-            result = self.client.search(index=index, **query, headers=headers)["hits"]["hits"]
+            result = self._search(index=index, **query, headers=headers)["hits"]["hits"]
             documents.extend([self._convert_es_hit_to_document(hit) for hit in result])
         return documents
 
@@ -343,7 +336,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             if not body.get("query"):
                 body["query"] = {"bool": {}}
             body["query"]["bool"].update({"filter": LogicalFilterClause.parse(filters).convert_to_elasticsearch()})
-        result = self.client.search(**body, index=index, headers=headers)
+        result = self._search(**body, index=index, headers=headers)
 
         values = []
         current_buckets = result["aggregations"]["metadata_agg"]["buckets"]
@@ -354,7 +347,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         # Only 10 results get returned at a time, so apply pagination
         while after_key:
             body["aggs"]["metadata_agg"]["composite"]["after"] = after_key
-            result = self.client.search(**body, index=index, headers=headers)
+            result = self._search(**body, index=index, headers=headers)
             current_buckets = result["aggregations"]["metadata_agg"]["buckets"]
             after_key = result["aggregations"]["metadata_agg"].get("after_key", False)
             for bucket in current_buckets:
@@ -524,7 +517,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         if not index:
             index = self.index
         body = {"doc": meta}
-        self.client.update(index=index, id=id, **body, refresh=self.refresh_type, headers=headers)
+        self._update(index=index, id=id, **body, refresh=self.refresh_type, headers=headers)
 
     def get_document_count(
         self,
@@ -545,7 +538,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         if filters:
             body["query"]["bool"]["filter"] = LogicalFilterClause.parse(filters).convert_to_elasticsearch()
 
-        result = self.client.count(index=index, body=body, headers=headers)
+        result = self._count(index=index, body=body, headers=headers)
         count = result["count"]
         return count
 
@@ -572,7 +565,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         if filters:
             body["query"]["bool"]["filter"] = LogicalFilterClause.parse(filters).convert_to_elasticsearch()
 
-        result = self.client.count(index=index, body=body, headers=headers)
+        result = self._count(index=index, body=body, headers=headers)
         count = result["count"]
         return count
 
@@ -911,7 +904,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             all_terms_must_match=all_terms_must_match,
         )
 
-        result = self.client.search(index=index, **body, headers=headers)["hits"]["hits"]
+        result = self._search(index=index, **body, headers=headers)["hits"]["hits"]
 
         documents = [self._convert_es_hit_to_document(hit, scale_score=scale_score) for hit in result]
         return documents
@@ -1392,7 +1385,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         batch_size = batch_size or self.batch_size
 
         if self.refresh_type == "false":
-            self.client.indices.refresh(index=index, headers=headers)
+            self._index_refresh(index, headers)
 
         if not self.embedding_field:
             raise RuntimeError("Please specify the arg `embedding_field` when initializing the Document Store")
@@ -1563,7 +1556,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         self.client.delete_by_query(index=index, body=query, ignore=[404], headers=headers)
         # We want to be sure that all docs are deleted before continuing (delete_by_query doesn't support wait_for)
         if self.refresh_type == "wait_for":
-            self.client.indices.refresh(index=index)
+            self._index_refresh(index, headers)
 
     def delete_labels(
         self,
@@ -1625,9 +1618,32 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
                 index,
                 self.__class__.__name__,
             )
-        self._delete_index(index)
+        self._index_delete(index)
 
-    def _delete_index(self, index: str):
+    def _index_exists(self, index_name: str, headers: Optional[Dict[str, str]] = None) -> bool:
+        if logger.isEnabledFor(logging.DEBUG):
+            if self.client.indices.exists_alias(name=index_name):
+                logger.debug("Index name %s is an alias.", index_name)
+
+        return self.client.indices.exists(index=index_name, headers=headers)
+
+    def _index_delete(self, index, headers):
         if self._index_exists(index):
             self.client.indices.delete(index=index, ignore=[400, 404])
             logger.info("Index '%s' deleted.", index)
+
+    def _index_refresh(self, index, headers):
+        if self._index_exists(index):
+            self.client.indices.refresh(index=index, headers=headers)
+
+    def _search(self, *args, **kwargs):
+        return self.client.search(*args, **kwargs)
+
+    def _update(self, *args, **kwargs):
+        return self.client.update(*args, **kwargs)
+
+    def _count(self, *args, **kwargs):
+        return self.client.count(*args, **kwargs)
+
+    def _delete_by_query(self, *args, **kwargs):
+        return self.client.delete_by_query(*args, **kwargs)

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -108,13 +108,13 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
             )
 
         self._init_indices(
-            index=index, label_index=label_index, create_index=create_index, recreate_index=recreate_index
+            index=index, label_index=label_index, create_index=create_index, recreate_index=recreate_index, headers={}
         )
 
-    def _init_indices(self, index: str, label_index: str, create_index: bool, recreate_index: bool) -> None:
+    def _init_indices(self, index: str, label_index: str, create_index: bool, recreate_index: bool, headers) -> None:
         if recreate_index:
-            self._index_delete(index)
-            self._index_delete(label_index)
+            self._index_delete(index, headers)
+            self._index_delete(label_index, headers)
 
         if not self._index_exists(index) and (create_index or recreate_index):
             self._create_document_index(index)

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -518,7 +518,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         mocked_document_store.client.indices.exists_alias.return_value = True
 
         with caplog.at_level(logging.DEBUG, logger="haystack.document_stores.search_engine"):
-            mocked_document_store._init_indices(self.index_name, "labels", False, False)
+            mocked_document_store._init_indices(self.index_name, "labels", False, False, {})
 
         assert f"Index name {self.index_name} is an alias." in caplog.text
 
@@ -759,7 +759,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         self, mocked_document_store, create_index, recreate_index
     ):
         mocked_document_store._validate_and_adjust_document_index = MagicMock()
-        mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index)
+        mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index, {})
 
         mocked_document_store._validate_and_adjust_document_index.assert_called_once()
 
@@ -775,27 +775,33 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         mocked_document_store._validate_and_adjust_document_index = MagicMock()
 
         with caplog.at_level(logging.WARNING):
-            mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index)
+            mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index, {})
             assert "Skipping index validation" in caplog.text
             mocked_document_store._validate_and_adjust_document_index.assert_not_called()
 
     @pytest.mark.unit
     def test__init_indices_creates_index_if_not_exists(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = False
-        mocked_document_store._init_indices(self.index_name, "label_index", create_index=True, recreate_index=False)
+        mocked_document_store._init_indices(
+            self.index_name, "label_index", create_index=True, recreate_index=False, headers={}
+        )
 
         mocked_document_store.client.indices.create.assert_called()
 
     @pytest.mark.unit
     def test__init_indices_does_not_create_index_if_exists(self, mocked_document_store):
-        mocked_document_store._init_indices(self.index_name, "label_index", create_index=True, recreate_index=False)
+        mocked_document_store._init_indices(
+            self.index_name, "label_index", create_index=True, recreate_index=False, headers={}
+        )
 
         mocked_document_store.client.indices.create.assert_not_called()
 
     @pytest.mark.unit
     def test__init_indices_does_not_create_index_if_not_create_index(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = False
-        mocked_document_store._init_indices(self.index_name, "label_index", create_index=False, recreate_index=False)
+        mocked_document_store._init_indices(
+            self.index_name, "label_index", create_index=False, recreate_index=False, headers={}
+        )
 
         mocked_document_store.client.indices.create.assert_not_called()
 
@@ -805,7 +811,9 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         # + one check for both if ivf model exists
         # create_index asks two times: one for doc index, one for label index
         mocked_document_store.client.indices.exists.side_effect = [True, False, True, False, False, False]
-        mocked_document_store._init_indices(self.index_name, "label_index", create_index=True, recreate_index=True)
+        mocked_document_store._init_indices(
+            self.index_name, "label_index", create_index=True, recreate_index=True, headers={}
+        )
 
         mocked_document_store.client.indices.delete.assert_called()
         mocked_document_store.client.indices.create.assert_called()
@@ -1147,7 +1155,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
     def test__create_label_index_already_exists(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = True
 
-        mocked_document_store._init_indices("doc_index", "label_index", True, False)
+        mocked_document_store._init_indices("doc_index", "label_index", True, False, {})
         mocked_document_store.client.indices.create.assert_not_called()
 
     @pytest.mark.unit

--- a/test/document_stores/test_opensearch.py
+++ b/test/document_stores/test_opensearch.py
@@ -518,7 +518,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         mocked_document_store.client.indices.exists_alias.return_value = True
 
         with caplog.at_level(logging.DEBUG, logger="haystack.document_stores.search_engine"):
-            mocked_document_store._init_indices(self.index_name, "labels", False, False, {})
+            mocked_document_store._init_indices(self.index_name, "labels", False, False)
 
         assert f"Index name {self.index_name} is an alias." in caplog.text
 
@@ -759,7 +759,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         self, mocked_document_store, create_index, recreate_index
     ):
         mocked_document_store._validate_and_adjust_document_index = MagicMock()
-        mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index, {})
+        mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index)
 
         mocked_document_store._validate_and_adjust_document_index.assert_called_once()
 
@@ -775,33 +775,27 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         mocked_document_store._validate_and_adjust_document_index = MagicMock()
 
         with caplog.at_level(logging.WARNING):
-            mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index, {})
+            mocked_document_store._init_indices(self.index_name, "label_index", create_index, recreate_index)
             assert "Skipping index validation" in caplog.text
             mocked_document_store._validate_and_adjust_document_index.assert_not_called()
 
     @pytest.mark.unit
     def test__init_indices_creates_index_if_not_exists(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = False
-        mocked_document_store._init_indices(
-            self.index_name, "label_index", create_index=True, recreate_index=False, headers={}
-        )
+        mocked_document_store._init_indices(self.index_name, "label_index", create_index=True, recreate_index=False)
 
         mocked_document_store.client.indices.create.assert_called()
 
     @pytest.mark.unit
     def test__init_indices_does_not_create_index_if_exists(self, mocked_document_store):
-        mocked_document_store._init_indices(
-            self.index_name, "label_index", create_index=True, recreate_index=False, headers={}
-        )
+        mocked_document_store._init_indices(self.index_name, "label_index", create_index=True, recreate_index=False)
 
         mocked_document_store.client.indices.create.assert_not_called()
 
     @pytest.mark.unit
     def test__init_indices_does_not_create_index_if_not_create_index(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = False
-        mocked_document_store._init_indices(
-            self.index_name, "label_index", create_index=False, recreate_index=False, headers={}
-        )
+        mocked_document_store._init_indices(self.index_name, "label_index", create_index=False, recreate_index=False)
 
         mocked_document_store.client.indices.create.assert_not_called()
 
@@ -811,9 +805,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
         # + one check for both if ivf model exists
         # create_index asks two times: one for doc index, one for label index
         mocked_document_store.client.indices.exists.side_effect = [True, False, True, False, False, False]
-        mocked_document_store._init_indices(
-            self.index_name, "label_index", create_index=True, recreate_index=True, headers={}
-        )
+        mocked_document_store._init_indices(self.index_name, "label_index", create_index=True, recreate_index=True)
 
         mocked_document_store.client.indices.delete.assert_called()
         mocked_document_store.client.indices.create.assert_called()
@@ -1155,7 +1147,7 @@ class TestOpenSearchDocumentStore(DocumentStoreBaseTestAbstract, SearchEngineDoc
     def test__create_label_index_already_exists(self, mocked_document_store):
         mocked_document_store.client.indices.exists.return_value = True
 
-        mocked_document_store._init_indices("doc_index", "label_index", True, False, {})
+        mocked_document_store._init_indices("doc_index", "label_index", True, False)
         mocked_document_store.client.indices.create.assert_not_called()
 
     @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/2810

### Proposed Changes:

Isolate calls to `self.client.*` so that we can override them in the class supporting ES8

### How did you test it?

locally run the tests

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
