### PR TITLE
refactor: remove Elasticsearch client version 8 deprecation warnings

### DIFF
--- a/haystack/document_stores/elasticsearch/es8.py
+++ b/haystack/document_stores/elasticsearch/es8.py
@@ -1,7 +1,8 @@
 import logging
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 
 from haystack.lazy_imports import LazyImport
+from haystack import Document
 
 with LazyImport("Run 'pip install farm-haystack[elasticsearch8]'") as es_import:
     from elasticsearch import Elasticsearch, RequestError
@@ -187,6 +188,7 @@ class ElasticsearchDocumentStore(_ElasticsearchDocumentStore):
 
     def _do_bulk(self, *args, **kwargs):
         """Override the base class method to use the Elasticsearch client"""
+        headers = kwargs.pop("headers", {})
         return bulk(*args, **kwargs)
 
     def _do_scan(self, *args, **kwargs):
@@ -294,3 +296,63 @@ class ElasticsearchDocumentStore(_ElasticsearchDocumentStore):
                 f"correct credentials if you are using a secured Elasticsearch instance."
             )
         return client
+
+    def _index_exists(self, index_name: str, headers: Optional[Dict[str, str]] = None) -> bool:
+        if logger.isEnabledFor(logging.DEBUG):
+            if self.client.options(headers=headers).indices.exists_alias(name=index_name):
+                logger.debug("Index name %s is an alias.", index_name)
+
+        return self.client.options(headers=headers).indices.exists(index=index_name)
+
+    def _index_delete(self, index):
+        if self._index_exists(index):
+            self.client.options(ignore_status=[400, 404]).indices.delete(index=index)
+            logger.info("Index '%s' deleted.", index)
+
+    def _index_refresh(self, index, headers):
+        if self._index_exists(index):
+            self.client.options(headers=headers).indices.refresh(index=index)
+
+    def _index_create(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        return self.client.options(headers=headers).indices.create(*args, **kwargs)
+
+    def _index_get(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        return self.client.options(headers=headers).indices.get(*args, **kwargs)
+
+    def _index_put_mapping(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        body = kwargs.pop("body", {})
+        return self.client.options(headers=headers).indices.put_mapping(*args, **kwargs, **body)
+
+    def _search(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        return self.client.options(headers=headers).search(*args, **kwargs)
+
+    def _update(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        return self.client.options(headers=headers).update(*args, **kwargs)
+
+    def _count(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        body = kwargs.pop("body", {})
+        return self.client.options(headers=headers).count(*args, **kwargs, **body)
+
+    def _delete_by_query(self, *args, **kwargs):
+        headers = kwargs.pop("headers", {})
+        ignore_status = kwargs.pop("ignore", [])
+        body = kwargs.pop("body", {})
+        return self.client.options(headers=headers, ignore_status=ignore_status).delete_by_query(
+            *args, **kwargs, **body
+        )
+
+    def _execute_msearch(self, index: str, body: List[Dict[str, Any]], scale_score: bool) -> List[List[Document]]:
+        responses = self.client.msearch(index=index, body=body)
+        documents = []
+        for response in responses["responses"]:
+            result = response["hits"]["hits"]
+            cur_documents = [self._convert_es_hit_to_document(hit, scale_score=scale_score) for hit in result]
+            documents.append(cur_documents)
+
+        return documents

--- a/haystack/document_stores/elasticsearch/es8.py
+++ b/haystack/document_stores/elasticsearch/es8.py
@@ -188,7 +188,6 @@ class ElasticsearchDocumentStore(_ElasticsearchDocumentStore):
 
     def _do_bulk(self, *args, **kwargs):
         """Override the base class method to use the Elasticsearch client"""
-        headers = kwargs.pop("headers", {})
         return bulk(*args, **kwargs)
 
     def _do_scan(self, *args, **kwargs):

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -1636,6 +1636,15 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         if self._index_exists(index):
             self.client.indices.refresh(index=index, headers=headers)
 
+    def _index_create(self, *args, **kwargs):
+        return self.client.indices.create(*args, **kwargs)
+
+    def _index_get(self, *args, **kwargs):
+        return self.client.indices.get(*args, **kwargs)
+
+    def _index_put_mapping(self, *args, **kwargs):
+        return self.client.indices.put_mapping(*args, **kwargs)
+
     def _search(self, *args, **kwargs):
         return self.client.search(*args, **kwargs)
 


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/2810

### Proposed Changes:

Remove deprecation warnings by using the new client api.

### How did you test it?

manual verification after running integration tests locally:
```sh
pytest -m"integration and document_store" test/document_stores/test_elasticsearch.py 
```

### Notes for the reviewer

- `es_converter.py` still needs to be adjusted - instead of using a document store instance it uses the client directly, so it requires quite some rework, probably too much for this PR.
- the PR contains some leftovers from the previous iteration, where I didn't port the calls to `self.client.*` in `base.py`


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
