### PR TITLE
fix: install `inference` in REST API tests

### DIFF
--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install REST API
         run: |
           pip install -U "./rest_api[dev]"
-          pip install ".[dev]"
+          pip install ".[inference,dev]"
           pip install .
 
       - name: Run tests

--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -2,6 +2,7 @@
 name: REST API Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/rest_api_tests.yml
+++ b/.github/workflows/rest_api_tests.yml
@@ -2,7 +2,6 @@
 name: REST API Tests
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/rest_api/rest_api/controller/feedback.py
+++ b/rest_api/rest_api/controller/feedback.py
@@ -113,7 +113,7 @@ def export_feedback(
 
         offset_start_in_document = 0
         if label.answer and label.answer.offsets_in_document:
-            offset_start_in_document = label.answer.offsets_in_document[0].start
+            offset_start_in_document = label.answer.offsets_in_document[0].col
 
         if full_document_context:
             context = label.document.content

--- a/rest_api/rest_api/controller/feedback.py
+++ b/rest_api/rest_api/controller/feedback.py
@@ -113,7 +113,7 @@ def export_feedback(
 
         offset_start_in_document = 0
         if label.answer and label.answer.offsets_in_document:
-            offset_start_in_document = label.answer.offsets_in_document[0].col
+            offset_start_in_document = label.answer.offsets_in_document[0].row
 
         if full_document_context:
             context = label.document.content

--- a/rest_api/rest_api/controller/feedback.py
+++ b/rest_api/rest_api/controller/feedback.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from fastapi import FastAPI, APIRouter
-from haystack.schema import Label
+from haystack.schema import Label, Span
 from haystack.document_stores import BaseDocumentStore
 from rest_api.schema import FilterRequest, CreateLabelSerialized
 from rest_api.utils import get_app, get_pipelines
@@ -113,7 +113,10 @@ def export_feedback(
 
         offset_start_in_document = 0
         if label.answer and label.answer.offsets_in_document:
-            offset_start_in_document = label.answer.offsets_in_document[0].row
+            if isinstance(label.answer.offsets_in_document[0], Span):
+                offset_start_in_document = label.answer.offsets_in_document[0].start
+            else:
+                offset_start_in_document = label.answer.offsets_in_document[0].row
 
         if full_document_context:
             context = label.document.content

--- a/rest_api/rest_api/utils.py
+++ b/rest_api/rest_api/utils.py
@@ -64,8 +64,7 @@ def get_openapi_specs() -> dict:
     """
     Used to autogenerate OpenAPI specs file to use in the documentation.
 
-    Returns `servers` to specify base URL for OpenAPI Playground
-    (see https://swagger.io/docs/specification/api-host-and-base-path/)
+    Returns `servers` to specify base URL for OpenAPI Playground (see https://swagger.io/docs/specification/api-host-and-base-path/)
 
     See `.github/utils/generate_openapi_specs.py`
     """

--- a/rest_api/rest_api/utils.py
+++ b/rest_api/rest_api/utils.py
@@ -64,7 +64,8 @@ def get_openapi_specs() -> dict:
     """
     Used to autogenerate OpenAPI specs file to use in the documentation.
 
-    Returns `servers` to specify base URL for OpenAPI Playground (see https://swagger.io/docs/specification/api-host-and-base-path/)
+    Returns `servers` to specify base URL for OpenAPI Playground
+    (see https://swagger.io/docs/specification/api-host-and-base-path/)
 
     See `.github/utils/generate_openapi_specs.py`
     """


### PR DESCRIPTION
### Related Issues

- fixes [failing REST API CI](https://github.com/deepset-ai/haystack/actions/runs/5442095146/jobs/9896900307)

### Proposed Changes:
- `InMemoryDocumentStore` requires `inference` and is used in the REST API tests. This PR adds that extra to the CI.

### How did you test it?
CI

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
