### PR TITLE
test: reactivate unit tests in `test_eval.py`

### DIFF
--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -538,18 +538,19 @@ class DocumentStoreBaseTestAbstract:
         # Some document stores normalize the embedding on save, let's just compare the length
         assert doc_to_write["custom_embedding_field"].shape == documents[0].embedding.shape
 
-    @pytest.mark.integration
-    @pytest.mark.parametrize("batch_size", [None, 20])
-    def test_add_eval_data(self, ds, batch_size, samples_path):
-        # add eval data (SQUAD format)
-        ds.add_eval_data(
-            filename=samples_path / "squad" / "small.json",
-            doc_index=ds.index,
-            label_index=ds.label_index,
-            batch_size=batch_size,
-        )
-        assert ds.get_document_count() == 87
-        assert ds.get_label_count() == 1214
+    # TODO This currently fails for Weaviate and Pinecone
+    # @pytest.mark.integration
+    # @pytest.mark.parametrize("batch_size", [None, 20])
+    # def test_add_eval_data(self, ds, batch_size, samples_path):
+    #     # add eval data (SQUAD format)
+    #     ds.add_eval_data(
+    #         filename=samples_path / "squad" / "small.json",
+    #         doc_index=ds.index,
+    #         label_index=ds.label_index,
+    #         batch_size=batch_size,
+    #     )
+    #     assert ds.get_document_count() == 87
+    #     assert ds.get_label_count() == 1214
 
     #
     # Unit tests

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -538,19 +538,19 @@ class DocumentStoreBaseTestAbstract:
         # Some document stores normalize the embedding on save, let's just compare the length
         assert doc_to_write["custom_embedding_field"].shape == documents[0].embedding.shape
 
-    # TODO This currently fails for Weaviate and Pinecone
-    # @pytest.mark.integration
-    # @pytest.mark.parametrize("batch_size", [None, 20])
-    # def test_add_eval_data(self, ds, batch_size, samples_path):
-    #     # add eval data (SQUAD format)
-    #     ds.add_eval_data(
-    #         filename=samples_path / "squad" / "small.json",
-    #         doc_index=ds.index,
-    #         label_index=ds.label_index,
-    #         batch_size=batch_size,
-    #     )
-    #     assert ds.get_document_count() == 87
-    #     assert ds.get_label_count() == 1214
+    @pytest.mark.skip(reason="This currently fails for Weaviate and Pinecone")
+    @pytest.mark.integration
+    @pytest.mark.parametrize("batch_size", [None, 20])
+    def test_add_eval_data(self, ds, batch_size, samples_path):
+        # add eval data (SQUAD format)
+        ds.add_eval_data(
+            filename=samples_path / "squad" / "small.json",
+            doc_index=ds.index,
+            label_index=ds.label_index,
+            batch_size=batch_size,
+        )
+        assert ds.get_document_count() == 87
+        assert ds.get_label_count() == 1214
 
     #
     # Unit tests

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -538,6 +538,19 @@ class DocumentStoreBaseTestAbstract:
         # Some document stores normalize the embedding on save, let's just compare the length
         assert doc_to_write["custom_embedding_field"].shape == documents[0].embedding.shape
 
+    @pytest.mark.integration
+    @pytest.mark.parametrize("batch_size", [None, 20])
+    def test_add_eval_data(self, ds, batch_size, samples_path):
+        # add eval data (SQUAD format)
+        ds.add_eval_data(
+            filename=samples_path / "squad" / "small.json",
+            doc_index=ds.index,
+            label_index=ds.label_index,
+            batch_size=batch_size,
+        )
+        assert ds.get_document_count() == 87
+        assert ds.get_label_count() == 1214
+
     #
     # Unit tests
     #

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -60,54 +60,6 @@ def test_summarizer_calculate_metrics(document_store_with_docs: ElasticsearchDoc
     assert metrics["Summarizer"]["ndcg"] == 1.0
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
-@pytest.mark.parametrize("batch_size", [None, 20])
-def test_add_eval_data(document_store, batch_size, samples_path):
-    # add eval data (SQUAD format)
-    document_store.add_eval_data(
-        filename=samples_path / "squad" / "small.json",
-        doc_index=document_store.index,
-        label_index=document_store.label_index,
-        batch_size=batch_size,
-    )
-
-    assert document_store.get_document_count() == 87
-    assert document_store.get_label_count() == 1214
-
-    # test documents
-    docs = document_store.get_all_documents(filters={"name": ["Normans"]})
-    assert docs[0].meta["name"] == "Normans"
-    assert len(docs[0].meta.keys()) == 1
-
-    # test labels
-    labels = document_store.get_all_labels()
-    label = None
-    for l in labels:
-        if l.query == "In what country is Normandy located?":
-            label = l
-            break
-    assert label.answer.answer == "France"
-    assert label.no_answer == False
-    assert label.is_correct_answer == True
-    assert label.is_correct_document == True
-    assert label.query == "In what country is Normandy located?"
-    assert label.origin == "gold-label"
-    assert label.answer.offsets_in_document[0].start == 159
-    assert (
-        label.answer.context[label.answer.offsets_in_context[0].start : label.answer.offsets_in_context[0].end]
-        == "France"
-    )
-    assert label.answer.document_ids == [label.document.id]
-
-    # check combination
-    doc = document_store.get_document_by_id(label.document.id)
-    start = label.answer.offsets_in_document[0].start
-    end = label.answer.offsets_in_document[0].end
-    assert end == start + len(label.answer.answer)
-    assert doc.content[start:end] == "France"
-
-
 @pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
 @pytest.mark.parametrize("reader", ["farm"], indirect=True)
 @pytest.mark.parametrize("use_confidence_scores", [True, False])
@@ -453,7 +405,6 @@ EVAL_TABLE_LABELS = [
 ]
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["table_text_retriever"], indirect=True)
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small"], indirect=True)
@@ -1026,7 +977,6 @@ def test_reader_eval_in_pipeline(reader):
     assert metrics["Reader"]["f1"] == 1.0
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval_document_scope(retriever_with_docs):
@@ -1092,7 +1042,6 @@ def test_extractive_qa_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 1.0
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_eval_document_scope(retriever_with_docs):
@@ -1158,7 +1107,6 @@ def test_document_search_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_id_only_eval_document_scope(retriever_with_docs):
@@ -1224,7 +1172,6 @@ def test_document_search_id_only_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_file_search_eval_document_scope(retriever_with_docs):
@@ -1291,7 +1238,6 @@ def test_file_search_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == pytest.approx(0.6934, 0.0001)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize(
@@ -1707,7 +1653,6 @@ def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
     pipeline.print_eval_report(eval_result)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_calculate_metrics(retriever_with_docs):
@@ -1738,7 +1683,6 @@ def test_document_search_calculate_metrics(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_isolated(retriever_with_docs):

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -2141,8 +2141,43 @@ def test_load_evaluation_result(tmp_path):
         )
 
     eval_result = EvaluationResult.load(tmp_path)
+    known_result = {
+        "multilabel_id": {0: "ddc1562602f2d6d895b91e53f83e4c16"},
+        "query": {0: "who is written in the book of life"},
+        "filters": {0: b"null"},
+        "gold_answers": {
+            0: [
+                "every person who is destined for Heaven or the World to Come",
+                "all people considered righteous before God",
+            ]
+        },
+        "answer": {0: None},
+        "context": {0: None},
+        "exact_match": {0: 0.0},
+        "f1": {0: 0.0},
+        "exact_match_context_scope": {0: 0.0},
+        "f1_context_scope": {0: 0.0},
+        "exact_match_document_id_scope": {0: 0.0},
+        "f1_document_id_scope": {0: 0.0},
+        "exact_match_document_id_and_context_scope": {0: 0.0},
+        "f1_document_id_and_context_scope": {0: 0.0},
+        "gold_contexts": {0: ["Book of Life - wikipedia Book of Life Jump to: navigation, search..."]},
+        "rank": {0: 1.0},
+        "document_ids": {0: None},
+        "gold_document_ids": {0: ["de2fd2f109e11213af1ea189fd1488a3-0", "de2fd2f109e11213af1ea189fd1488a3-0"]},
+        "offsets_in_document": {0: [{"start": 0, "end": 0}]},
+        "gold_offsets_in_documents": {0: [{"start": 374, "end": 434}, {"start": 1107, "end": 1149}]},
+        "offsets_in_context": {0: [{"start": 0, "end": 0}]},
+        "gold_offsets_in_contexts": {0: [{"start": 374, "end": 434}, {"start": 1107, "end": 1149}]},
+        "gold_answers_exact_match": {0: [0, 0]},
+        "gold_answers_f1": {0: [0, 0]},
+        "gold_documents_id_match": {0: [0.0, 0.0]},
+        "gold_contexts_similarity": {0: [0.0, 0.0]},
+        "type": {0: "answer"},
+        "node": {0: "Reader"},
+        "eval_mode": {0: "integrated"},
+        "index": {0: None},
+    }
     assert "Reader" in eval_result
     assert len(eval_result) == 1
-    assert eval_result["Reader"].iloc[0].answer is None
-    assert eval_result["Reader"].iloc[0].context is None
-    assert eval_result["Reader"].iloc[0].document_ids is None
+    assert eval_result["Reader"].to_dict() == known_result

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -152,7 +152,6 @@ def test_eval_pipeline(document_store, reader, retriever, samples_path):
     assert metrics_sas_cross_encoder["Reader"]["sas"] == pytest.approx(0.71063, 1e-4)
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 def test_eval_data_split_word(document_store, samples_path):
     # splitting by word
@@ -178,7 +177,6 @@ def test_eval_data_split_word(document_store, samples_path):
     assert len(set(labels[0].document_ids)) == 2
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 def test_eval_data_split_passage(document_store, samples_path):
     # splitting by passage

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -419,6 +419,8 @@ EVAL_TABLE_LABELS = [
 ]
 
 
+@pytest.mark.skip(reason="Should be an end-to-end test since it uses model inferencing")
+@pytest.mark.integration
 @pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("retriever", ["table_text_retriever"], indirect=True)
 @pytest.mark.parametrize("table_reader_and_param", ["tapas_small"], indirect=True)

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -7,7 +7,6 @@ import pandas as pd
 from copy import deepcopy
 
 import responses
-from haystack.document_stores.memory import InMemoryDocumentStore
 from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.nodes.answer_generator.openai import OpenAIAnswerGenerator
 from haystack.nodes.preprocessor import PreProcessor
@@ -61,7 +60,8 @@ def test_summarizer_calculate_metrics(document_store_with_docs: ElasticsearchDoc
     assert metrics["Summarizer"]["ndcg"] == 1.0
 
 
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
+@pytest.mark.integration
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 @pytest.mark.parametrize("batch_size", [None, 20])
 def test_add_eval_data(document_store, batch_size, samples_path):
     # add eval data (SQUAD format)
@@ -200,7 +200,8 @@ def test_eval_pipeline(document_store, reader, retriever, samples_path):
     assert metrics_sas_cross_encoder["Reader"]["sas"] == pytest.approx(0.71063, 1e-4)
 
 
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
+@pytest.mark.unit
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 def test_eval_data_split_word(document_store, samples_path):
     # splitting by word
     preprocessor = PreProcessor(
@@ -225,7 +226,8 @@ def test_eval_data_split_word(document_store, samples_path):
     assert len(set(labels[0].document_ids)) == 2
 
 
-@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
+@pytest.mark.unit
+@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
 def test_eval_data_split_passage(document_store, samples_path):
     # splitting by passage
     preprocessor = PreProcessor(
@@ -1024,6 +1026,7 @@ def test_reader_eval_in_pipeline(reader):
     assert metrics["Reader"]["f1"] == 1.0
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval_document_scope(retriever_with_docs):
@@ -1089,6 +1092,7 @@ def test_extractive_qa_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 1.0
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_eval_document_scope(retriever_with_docs):
@@ -1154,6 +1158,7 @@ def test_document_search_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_id_only_eval_document_scope(retriever_with_docs):
@@ -1219,6 +1224,7 @@ def test_document_search_id_only_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_file_search_eval_document_scope(retriever_with_docs):
@@ -1285,6 +1291,7 @@ def test_file_search_eval_document_scope(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == pytest.approx(0.6934, 0.0001)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 @pytest.mark.parametrize(
@@ -1700,6 +1707,7 @@ def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
     pipeline.print_eval_report(eval_result)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_calculate_metrics(retriever_with_docs):
@@ -1730,6 +1738,7 @@ def test_document_search_calculate_metrics(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_isolated(retriever_with_docs):
@@ -2069,6 +2078,7 @@ def test_empty_documents_dont_fail_pipeline(reader, retriever_with_docs):
     )
 
 
+@pytest.mark.unit
 def test_load_legacy_evaluation_result(tmp_path):
     legacy_csv = Path(tmp_path) / "legacy.csv"
     with open(legacy_csv, "w") as legacy_csv:
@@ -2100,6 +2110,7 @@ def test_load_legacy_evaluation_result(tmp_path):
     assert "content" not in eval_result["legacy"]
 
 
+@pytest.mark.unit
 def test_load_evaluation_result_w_none_values(tmp_path):
     eval_result_csv = Path(tmp_path) / "Reader.csv"
     with open(eval_result_csv, "w") as eval_result_csv:

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -2111,7 +2111,7 @@ def test_load_legacy_evaluation_result(tmp_path):
 
 
 @pytest.mark.unit
-def test_load_evaluation_result_w_none_values(tmp_path):
+def test_load_evaluation_result(tmp_path):
     eval_result_csv = Path(tmp_path) / "Reader.csv"
     with open(eval_result_csv, "w") as eval_result_csv:
         columns = [

--- a/test/pipelines/test_eval.py
+++ b/test/pipelines/test_eval.py
@@ -152,7 +152,7 @@ def test_eval_pipeline(document_store, reader, retriever, samples_path):
     assert metrics_sas_cross_encoder["Reader"]["sas"] == pytest.approx(0.71063, 1e-4)
 
 
-@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
 def test_eval_data_split_word(document_store, samples_path):
     # splitting by word
     preprocessor = PreProcessor(
@@ -177,7 +177,7 @@ def test_eval_data_split_word(document_store, samples_path):
     assert len(set(labels[0].document_ids)) == 2
 
 
-@pytest.mark.parametrize("document_store", ["memory"], indirect=True)
+@pytest.mark.parametrize("document_store", ["elasticsearch", "faiss", "memory"], indirect=True)
 def test_eval_data_split_passage(document_store, samples_path):
     # splitting by passage
     preprocessor = PreProcessor(

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -267,6 +267,7 @@ def test_reader_eval_in_pipeline(reader):
     assert metrics["Reader"]["f1"] == 1.0
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval_document_scope(retriever_with_docs):
@@ -723,6 +724,7 @@ def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
     pipeline.print_eval_report(eval_result)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_calculate_metrics(retriever_with_docs):
@@ -753,6 +755,7 @@ def test_document_search_calculate_metrics(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_faq_calculate_metrics(retriever_with_docs):

--- a/test/pipelines/test_eval_batch.py
+++ b/test/pipelines/test_eval_batch.py
@@ -267,7 +267,6 @@ def test_reader_eval_in_pipeline(reader):
     assert metrics["Reader"]["f1"] == 1.0
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_extractive_qa_eval_document_scope(retriever_with_docs):
@@ -724,7 +723,6 @@ def test_extractive_qa_print_eval_report(reader, retriever_with_docs):
     pipeline.print_eval_report(eval_result)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_document_search_calculate_metrics(retriever_with_docs):
@@ -755,7 +753,6 @@ def test_document_search_calculate_metrics(retriever_with_docs):
     assert metrics["Retriever"]["ndcg"] == 0.5
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize("retriever_with_docs", ["tfidf"], indirect=True)
 @pytest.mark.parametrize("document_store_with_docs", ["memory"], indirect=True)
 def test_faq_calculate_metrics(retriever_with_docs):


### PR DESCRIPTION
### Related Issues

- fixes N/A, but related to bug fix in PR https://github.com/deepset-ai/haystack/pull/5223 in the sense that the bug was originally missed due to pipeline.eval tests not being run in CI. 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- ~~Activates a subset of existing `pipeline.eval` tests by marking them with integration or unit if they follow the guidelines. I followed the guidelines outlined [here](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and I believe I gave each test an appropriate label. None of the tests request outside resources and the major difference between them relate to scope of logic being tested.~~
- [ ] Refactor tests into unit tests by reducing scope or leave to be converted into end to end tests


### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
