### PR TITLE
fix: MultiLabel `to_json` works with Table Labels

### DIFF
--- a/test/others/test_schema.py
+++ b/test/others/test_schema.py
@@ -933,6 +933,52 @@ def test_multilabel_serialization():
 
 
 @pytest.mark.unit
+def test_table_multilabel_serialization():
+    tabel_label_dict = {
+        "id": "011079cf-c93f-49e6-83bb-42cd850dce12",
+        "query": "What is the first number?",
+        "document": {
+            "content": [["col1", "col2"], [1, 3], [2, 4]],
+            "content_type": "table",
+            "id": "table1",
+            "meta": {},
+            "score": None,
+            "embedding": None,
+        },
+        "is_correct_answer": True,
+        "is_correct_document": True,
+        "origin": "user-feedback",
+        "answer": {
+            "answer": "1",
+            "type": "extractive",
+            "score": None,
+            "context": [["col1", "col2"], [1, 3], [2, 4]],
+            "offsets_in_document": [{"row": 0, "col": 0}],
+            "offsets_in_context": [{"row": 0, "col": 0}],
+            "document_ids": ["table1"],
+            "meta": {},
+        },
+        "no_answer": False,
+        "pipeline_id": None,
+        "created_at": "2022-07-22T13:29:33.699781+00:00",
+        "updated_at": "2022-07-22T13:29:33.784895+00:00",
+        "meta": {"answer_id": "374394", "document_id": "604995", "question_id": "345530"},
+        "filters": None,
+    }
+
+    label = Label.from_dict(tabel_label_dict)
+    original_multilabel = MultiLabel([label])
+
+    deserialized_multilabel = MultiLabel.from_dict(original_multilabel.to_dict())
+    assert deserialized_multilabel == original_multilabel
+    assert deserialized_multilabel.labels[0] == label
+
+    json_deserialized_multilabel = MultiLabel.from_json(original_multilabel.to_json())
+    assert json_deserialized_multilabel == original_multilabel
+    assert json_deserialized_multilabel.labels[0] == label
+
+
+@pytest.mark.unit
 def test_span_in():
     assert 10 in Span(5, 15)
     assert 20 not in Span(1, 15)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5256

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Update `MultiLabel` to convert `Label`s to dicts using `Label.to_dict()`. `Label.to_dict()` already converts pandas dataframes into a lists of lists which is json serliazable which allows `Multilable.to_json()` to work as expected for Table Labels.
- Similarily the `MultiLabel.from_dict()` method was updated to use `Label.from_dict()`

### How did you test it?
- added a new unit test

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
