### PR TITLE
create invocation-layers API reference page

### DIFF
--- a/docs/pydoc/config/invocation-layers.yml
+++ b/docs/pydoc/config/invocation-layers.yml
@@ -1,0 +1,39 @@
+loaders:
+  - type: python
+    search_path: [../../../haystack/nodes/prompt/invocation_layer]
+    modules:
+      [
+        "anthropic_claude",
+        "azure_chatgpt",
+        "azure_open_ai",
+        "chatgpt",
+        "cohere",
+        "hugging_face",
+        "hugging_face_inference",
+        "open_ai",
+        "sagemaker_base",
+        "sagemaker_hf_infer",
+        "sagemaker_hf_text_gen",
+      ]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: renderers.ReadmeRenderer
+  excerpt: Enables use of Large Language Models from different providers with PromptNode.
+  category_slug: haystack-classes
+  title: Invocation Layers API
+  slug: invocation-layers-api
+  order: 117
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: invocation_layers_api.md

--- a/docs/pydoc/config/invocation-layers.yml
+++ b/docs/pydoc/config/invocation-layers.yml
@@ -31,6 +31,7 @@ renderer:
   title: Invocation Layers API
   slug: invocation-layers-api
   order: 117
+  parent_doc_slug: prompt-node-api
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true


### PR DESCRIPTION
### Related Issues

- fixes #5170 

### Proposed Changes:

Adding a new API reference page dedicated to invocation layers.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
