### PR TITLE
refactor: Simplify selection of Azure vs OpenAI invocation layers

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/azure_chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/azure_chatgpt.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional
 
 from haystack.nodes.prompt.invocation_layer.chatgpt import ChatGPTInvocationLayer
+from haystack.nodes.prompt.invocation_layer.utils import has_azure_parameters
 
 
 class AzureChatGPTInvocationLayer(ChatGPTInvocationLayer):
@@ -41,7 +42,6 @@ class AzureChatGPTInvocationLayer(ChatGPTInvocationLayer):
         Ensures Azure ChatGPT Invocation Layer is selected when `azure_base_url` and `azure_deployment_name` are provided in
         addition to a list of supported models.
         """
+
         valid_model = any(m for m in ["gpt-35-turbo", "gpt-4", "gpt-4-32k"] if m in model_name_or_path)
-        return (
-            valid_model and kwargs.get("azure_base_url") is not None and kwargs.get("azure_deployment_name") is not None
-        )
+        return valid_model and has_azure_parameters(**kwargs)

--- a/haystack/nodes/prompt/invocation_layer/azure_open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/azure_open_ai.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional
 
 from haystack.nodes.prompt.invocation_layer.open_ai import OpenAIInvocationLayer
+from haystack.nodes.prompt.invocation_layer.utils import has_azure_parameters
 
 
 class AzureOpenAIInvocationLayer(OpenAIInvocationLayer):
@@ -42,6 +43,4 @@ class AzureOpenAIInvocationLayer(OpenAIInvocationLayer):
         addition to a list of supported models.
         """
         valid_model = any(m for m in ["ada", "babbage", "davinci", "curie"] if m in model_name_or_path)
-        return (
-            valid_model and kwargs.get("azure_base_url") is not None and kwargs.get("azure_deployment_name") is not None
-        )
+        return valid_model and has_azure_parameters(**kwargs)

--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -3,6 +3,7 @@ from typing import Optional, List, Dict, Union, Any
 
 from haystack.nodes.prompt.invocation_layer.handlers import DefaultTokenStreamingHandler, TokenStreamingHandler
 from haystack.nodes.prompt.invocation_layer.open_ai import OpenAIInvocationLayer
+from haystack.nodes.prompt.invocation_layer.utils import has_azure_parameters
 from haystack.utils.openai_utils import openai_request, _check_openai_finish_reason, count_openai_tokens_messages
 
 logger = logging.getLogger(__name__)
@@ -135,4 +136,5 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        return any(m for m in ["gpt-3.5-turbo", "gpt-4"] if m in model_name_or_path)
+        valid_model = any(m for m in ["gpt-3.5-turbo", "gpt-4"] if m in model_name_or_path)
+        return valid_model and not has_azure_parameters(**kwargs)

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -5,6 +5,7 @@ import logging
 import sseclient
 
 from haystack.errors import OpenAIError
+from haystack.nodes.prompt.invocation_layer.utils import has_azure_parameters
 from haystack.utils.openai_utils import (
     openai_request,
     _openai_text_completion_tokenization_details,
@@ -224,4 +225,4 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
         valid_model = any(m for m in ["ada", "babbage", "davinci", "curie"] if m in model_name_or_path)
-        return valid_model and kwargs.get("azure_base_url") is None
+        return valid_model and not has_azure_parameters(**kwargs)

--- a/haystack/nodes/prompt/invocation_layer/utils.py
+++ b/haystack/nodes/prompt/invocation_layer/utils.py
@@ -1,0 +1,3 @@
+def has_azure_parameters(**kwargs) -> bool:
+    azure_params = ["azure_base_url", "azure_deployment_name"]
+    return any(kwargs.get(param) for param in azure_params)

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -87,15 +87,7 @@ class PromptModel(BaseComponent):
                 model_name_or_path=self.model_name_or_path, max_length=self.max_length, **all_kwargs
             )
 
-        potential_invocation_layer = PromptModelInvocationLayer.invocation_layer_providers
-        # if azure_base_url exist as an argument, invocation layer classes are filtered to only keep the ones relatives to azure
-        if "azure_base_url" in self.model_kwargs:
-            potential_invocation_layer = [
-                layer for layer in potential_invocation_layer if re.search(r"azure", layer.__name__, re.IGNORECASE)
-            ]
-        # search all invocation layer classes candidates and find the first one that supports the model,
-        # then create an instance of that invocation layer
-        for invocation_layer in potential_invocation_layer:
+        for invocation_layer in PromptModelInvocationLayer.invocation_layer_providers:
             if inspect.isabstract(invocation_layer):
                 continue
             if invocation_layer.supports(self.model_name_or_path, **all_kwargs):

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import re
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
 from haystack.nodes.base import BaseComponent

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -10,7 +10,14 @@ from transformers import GenerationConfig, TextStreamer
 from haystack import Document, Pipeline, BaseComponent, MultiLabel
 from haystack.nodes.prompt import PromptTemplate, PromptNode, PromptModel
 from haystack.nodes.prompt.prompt_template import LEGACY_DEFAULT_TEMPLATES
-from haystack.nodes.prompt.invocation_layer import HFLocalInvocationLayer, DefaultTokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer import (
+    HFLocalInvocationLayer,
+    DefaultTokenStreamingHandler,
+    AzureChatGPTInvocationLayer,
+    AzureOpenAIInvocationLayer,
+    OpenAIInvocationLayer,
+    ChatGPTInvocationLayer,
+)
 
 
 @pytest.fixture
@@ -194,6 +201,31 @@ def test_invalid_template_params(mock_model, mock_prompthub):
     node = PromptNode()
     with pytest.raises(ValueError, match="Expected prompt parameters"):
         node.prompt("question-answering-per-document", some_crazy_key="Berlin is the capital of Germany.")
+
+
+@pytest.mark.integration
+def test_azure_vs_open_ai_invocation_layer_selection():
+    """
+    Tests that the correct invocation layer is selected based on the model name and additional parameters.
+    As we support both OpenAI and Azure models, we need to make sure that the correct invocation layer is selected
+    based on the model name and additional parameters.
+    """
+    azure_model_kwargs = {
+        "azure_base_url": "https://some_unimportant_url",
+        "azure_deployment_name": "https://some_unimportant_url.azurewebsites.net/api/prompt",
+    }
+
+    node = PromptNode("gpt-4", api_key="some_key", model_kwargs=azure_model_kwargs)
+    assert isinstance(node.prompt_model.model_invocation_layer, AzureChatGPTInvocationLayer)
+
+    node = PromptNode("text-davinci-003", api_key="some_key", model_kwargs=azure_model_kwargs)
+    assert isinstance(node.prompt_model.model_invocation_layer, AzureOpenAIInvocationLayer)
+
+    node = PromptNode("gpt-4", api_key="some_key")
+    assert isinstance(node.prompt_model.model_invocation_layer, ChatGPTInvocationLayer)
+
+    node = PromptNode("text-davinci-003", api_key="some_key")
+    assert isinstance(node.prompt_model.model_invocation_layer, OpenAIInvocationLayer)
 
 
 @pytest.mark.skip

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -204,6 +204,7 @@ def test_invalid_template_params(mock_model, mock_prompthub):
 
 
 @pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer", lambda tokenizer_name: None)
 def test_azure_vs_open_ai_invocation_layer_selection():
     """
     Tests that the correct invocation layer is selected based on the model name and additional parameters.

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -203,7 +203,7 @@ def test_invalid_template_params(mock_model, mock_prompthub):
         node.prompt("question-answering-per-document", some_crazy_key="Berlin is the capital of Germany.")
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_azure_vs_open_ai_invocation_layer_selection():
     """
     Tests that the correct invocation layer is selected based on the model name and additional parameters.
@@ -222,10 +222,14 @@ def test_azure_vs_open_ai_invocation_layer_selection():
     assert isinstance(node.prompt_model.model_invocation_layer, AzureOpenAIInvocationLayer)
 
     node = PromptNode("gpt-4", api_key="some_key")
-    assert isinstance(node.prompt_model.model_invocation_layer, ChatGPTInvocationLayer)
+    assert isinstance(node.prompt_model.model_invocation_layer, ChatGPTInvocationLayer) and not isinstance(
+        node.prompt_model.model_invocation_layer, AzureChatGPTInvocationLayer
+    )
 
     node = PromptNode("text-davinci-003", api_key="some_key")
-    assert isinstance(node.prompt_model.model_invocation_layer, OpenAIInvocationLayer)
+    assert isinstance(node.prompt_model.model_invocation_layer, OpenAIInvocationLayer) and not isinstance(
+        node.prompt_model.model_invocation_layer, AzureChatGPTInvocationLayer
+    )
 
 
 @pytest.mark.skip


### PR DESCRIPTION
### What?
This PR introduces a refactoring change that removes the dependency on Azure layers check within the PromptModel (see loc [90-95](https://github.com/deepset-ai/haystack/blob/main/haystack/nodes/prompt/prompt_model.py#L90)). As part of this change, we have added a utility function `has_azure_parameters` which simplifies the logic of selecting the right invocation layer between Azure and OpenAI:

```python
def has_azure_parameters(**kwargs) -> bool:
    azure_params = ["azure_base_url", "azure_deployment_name"]
    return any(kwargs.get(param) for param in azure_params)
```    

### Why?
Currently, a small kludge in the PromptModel checks for the presence of Azure layers. However, PromptModel should not know specific implementation details related to Azure layers. This change relies on the existing logic from the `supports` method to select the right invocation layer and ensures a cleaner separation of responsibilities.

### How can it be used?
This is an internal change and does not affect any public APIs. Therefore, everything will function as before from the user's perspective. The utility function we added streamlines the internal selection process between Azure and OpenAI invocation layers.

### How did you test it?
We have strengthened our test coverage by adding an integration test. This new test uses PromptNode with Azure and OpenAI model parameters and checks for the right invocation layer selection. 

### Notes for the reviewer
This change should not affect functionality from a user's perspective. 
Your feedback or suggestions are welcome. 