### PR TITLE
chore: Add support for hierarchical docs

### DIFF
--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -18,6 +18,7 @@ title: {title}
 excerpt: {excerpt}
 category: {category}
 slug: {slug}
+parentDocSlug: {parent_doc_slug}
 order: {order}
 hidden: false
 ---
@@ -39,6 +40,7 @@ class ReadmeRenderer(Renderer):
     excerpt: str
     slug: str
     order: int
+    parent_doc_slug: str = ""
     # Docs categories fetched from Readme.io
     categories: t.Dict[str, str] = dataclasses.field(init=False)
     # This exposes a special `markdown` settings value that can be used to pass
@@ -95,6 +97,7 @@ class ReadmeRenderer(Renderer):
         return README_FRONTMATTER.format(
             title=self.title,
             category=self.categories[self.category_slug],
+            parent_doc_slug=self.parent_doc_slug,
             excerpt=self.excerpt,
             slug=self.slug,
             order=self.order,


### PR DESCRIPTION
### Proposed Changes:

Add `parentDocSlug` in API reference docs frontmatter. 
Set `renderer.parent_doc_slug` in docs config yamls to create the hierarchy.

### How did you test it?

I generated docs locally and uploaded them to Readme.io to verify the hierarchy would be created correctly.

### Notes for the reviewer

An empty or unset `parent_doc_slug` won't make render or upload fail.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
