### PR TITLE
test: Adapt batch size in retriever-reader benchmarks

### DIFF
--- a/test/benchmarks/configs/retriever_reader/mpnetbase-debertabase-opensearch-100k.yml
+++ b/test/benchmarks/configs/retriever_reader/mpnetbase-debertabase-opensearch-100k.yml
@@ -4,7 +4,7 @@ components:
   - name: DocumentStore
     type: OpenSearchDocumentStore
     params:
-      batch_size: 5000
+      batch_size: 1000
       similarity: dot_product
       embedding_dim: 768
   - name: TextConverter

--- a/test/benchmarks/configs/retriever_reader/mpnetbase-debertalarge-opensearch-100k.yml
+++ b/test/benchmarks/configs/retriever_reader/mpnetbase-debertalarge-opensearch-100k.yml
@@ -4,7 +4,7 @@ components:
   - name: DocumentStore
     type: OpenSearchDocumentStore
     params:
-      batch_size: 5000
+      batch_size: 1000
       similarity: dot_product
       embedding_dim: 768
   - name: TextConverter

--- a/test/benchmarks/configs/retriever_reader/mpnetbase-tinyroberta-opensearch-100k.yml
+++ b/test/benchmarks/configs/retriever_reader/mpnetbase-tinyroberta-opensearch-100k.yml
@@ -4,7 +4,7 @@ components:
   - name: DocumentStore
     type: OpenSearchDocumentStore
     params:
-      batch_size: 5000
+      batch_size: 1000
       similarity: dot_product
       embedding_dim: 768
   - name: TextConverter


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adapts the batch size parameter of `OpenSearchDocumentStore` for three of the retriever-reader configurations. This is needed as the benchmarks fail with a batch size of 5000 on a p3.2xlarge instance.

### How did you test it?
I manually ran the changed configurations on a p3.2xlarge instance.

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
