### PR TITLE
Remove requests_cache in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 import warnings
-from datetime import timedelta
 from typing import Any, List, Optional, Dict, Union
 
 import gc
@@ -10,7 +9,6 @@ import re
 from functools import wraps
 from unittest.mock import patch
 
-import requests_cache
 import responses
 import posthog
 
@@ -80,10 +78,6 @@ posthog.disabled = True
 
 # Disable caching from prompthub to avoid polluting the local environment.
 os.environ["PROMPTHUB_CACHE_ENABLED"] = "false"
-
-# Cache requests (e.g. huggingface model) to circumvent load protection
-# See https://requests-cache.readthedocs.io/en/stable/user_guide/filtering.html
-requests_cache.install_cache(urls_expire_after={"huggingface.co": timedelta(hours=1), "*": requests_cache.DO_NOT_CACHE})
 
 
 def fail_at_version(target_major, target_minor):


### PR DESCRIPTION
### Proposed Changes:

Remove caching of requests to `huggingface.co` when running tests to integration tests failures. 
`huggingface_hub` already handles caching by itself as [documented](https://huggingface.co/docs/huggingface_hub/guides/manage-cache) so this shouldn't affect our limits.

### How did you test it?

I ran CI with PR #5282 to troubleshoot the issue, turns out that removing cache makes tests run correctly.

### Notes for the reviewer

The failures weren't reproducible locally while running individual tests.
Failures examples: https://github.com/deepset-ai/haystack/actions/runs/5473396123

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
