### PR TITLE
feat: batch mode for `MemoryRetriever` (v2)

### DIFF
--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -23,7 +23,7 @@ class MemoryRetriever:
         :param stores: A dictionary mapping document store names to instances.
         """
 
-        query: str
+        queries: List[str]
         filters: Dict[str, Any]
         top_k: int
         scale_score: bool
@@ -78,7 +78,12 @@ class MemoryRetriever:
         document_store = data.stores[self.document_store_name]
         if not isinstance(document_store, MemoryDocumentStore):
             raise ValueError("MemoryRetriever can only be used with a MemoryDocumentStore instance.")
-        docs = document_store.bm25_retrieval(
-            query=data.query, filters=data.filters, top_k=data.top_k, scale_score=data.scale_score
-        )
+
+        docs = []
+        for query in data.queries:
+            docs.append(
+                document_store.bm25_retrieval(
+                    query=query, filters=data.filters, top_k=data.top_k, scale_score=data.scale_score
+                )
+            )
         return MemoryRetriever.Output(documents=docs)

--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -37,7 +37,7 @@ class MemoryRetriever:
         :param documents: The retrieved documents.
         """
 
-        documents: List[Document]
+        documents: List[List[Document]]
 
     def __init__(
         self,


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5286

### Proposed Changes:

- Change `MemoryRetriever` to accept `queries: List[str]` in place of `query: str` and output `documents: List[List[Documents]]` in place of `documents: List[Documents]`.
- Update and add tests

### How did you test it?

Local tests run.

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
