### PR TITLE
fix: Add dependecies to build lxml successfully in base Docker image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -10,7 +10,9 @@ ARG haystack_extras
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
-    git
+    git \
+    libxml2-dev \
+    libxslt1-dev
 
 # Shallow clone Haystack repo, we'll install from the local sources
 RUN git clone --depth=1 --branch=${haystack_version} https://github.com/deepset-ai/haystack.git /opt/haystack


### PR DESCRIPTION
### What?
This PR introduces a fix for our Docker base image build by adding explicit dependencies for `libxml2-dev` and `libxslt1-dev` packages.  We added them to the RUN apt-get directive in our Dockerfile.

### Why?
The Docker base image build has been failing because of missing dependencies required by `python-docx` and its dependency `lxml`. These two Python packages require `libxml2-dev` and `libxslt1-dev` to be present in the environment. Since `python-docx` is included in the base image as a part of our file-conversion optional dependency, it is crucial that these packages are installed for successful image builds.

### How can it be used?
This is an internal change and does not affect users. It only ensures that our Docker images can be built successfully.

### How did you test it?
The absence of `libxml2-dev` and `libxslt1-dev` was noticed during the Docker build of the base image, where the `lxml` package installation was failing with the following message:

```text
#0 31.10 Collecting lxml>=2.3.2 (from python-docx->farm-haystack==1.19.0rc0)
#0 31.11   Downloading lxml-4.9.3.tar.gz (3.6 MB)
#0 31.14      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.6/3.6 MB 169.3 MB/s eta 0:00:00
#0 31.50   Preparing metadata (setup.py): started
#0 31.76   Preparing metadata (setup.py): finished with status 'error'
#0 31.76   error: subprocess-exited-with-error
#0 31.76   
#0 31.76   × python setup.py egg_info did not run successfully.
#0 31.76   │ exit code: 1
#0 31.76   ╰─> [3 lines of output]
#0 31.76       Building lxml version 4.9.3.
#0 31.76       Building without Cython.
#0 31.76       Error: Please make sure the libxml2 and libxslt development packages are installed.
#0 31.76       [end of output]
#0 31.76   
```
After including `libxml2-dev` and `libxslt1-dev` in the Dockerfile, these error messages were gone, and the Docker image was built successfully.

### Notes for the reviewer
This change is straightforward and solely focused on ensuring successful Docker image builds. 