### PR TITLE
chore: Adapt import message for Elasticsearch7

### DIFF
--- a/haystack/document_stores/elasticsearch/es7.py
+++ b/haystack/document_stores/elasticsearch/es7.py
@@ -4,7 +4,16 @@ from typing import List, Optional, Type, Union
 from haystack.lazy_imports import LazyImport
 from haystack.document_stores.search_engine import prepare_hosts
 
-with LazyImport("Run 'pip install farm-haystack[elasticsearch]'") as es_import:
+
+failed_import_message = (
+    "Run 'pip install farm-haystack[elasticsearch]'.\n"
+    "Note that this installs the Elasticsearch 7 client and requires a running Elasticsearch 7 instance. Starting from "
+    "Haystack version 1.21 , the 'elasticsearch' extra will install the Elasticsearch 8 client and will require a "
+    "running Elasticsearch 8 instance. To continue using Elasticsearch 7 with Haystack 1.21 and beyond, install the "
+    "'elasticsearch7' extra.\n"
+    "If you want to already start using Elasticsearch 8, install the 'elasticsearch8' extra"
+)
+with LazyImport(failed_import_message) as es_import:
     from elasticsearch import Connection, Elasticsearch, RequestsHttpConnection, Urllib3HttpConnection
     from elasticsearch.helpers import bulk, scan
     from elasticsearch.exceptions import RequestError

--- a/haystack/document_stores/elasticsearch/es7.py
+++ b/haystack/document_stores/elasticsearch/es7.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Type, Union
 
 from haystack.lazy_imports import LazyImport
 from haystack.document_stores.search_engine import prepare_hosts
+from .base import _ElasticsearchDocumentStore
 
 
 failed_import_message = (
@@ -17,8 +18,6 @@ with LazyImport(failed_import_message) as es_import:
     from elasticsearch import Connection, Elasticsearch, RequestsHttpConnection, Urllib3HttpConnection
     from elasticsearch.helpers import bulk, scan
     from elasticsearch.exceptions import RequestError
-
-from .base import _ElasticsearchDocumentStore
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Related Issues

- related to #5027

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adapts the import error message for the `ElasticsearchDocumentStore` in `es7.py` to prepare the user for the fact that starting from Haystack 1.21, the `elasticsearch` extra will install client version 8 and require a Elasticsearch 8 instance.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I manually checked that the new error message is printed.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
