### PR TITLE
build: Add `elasticsearch7` and `elasticsearch8` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,15 @@ inference = [
   "huggingface-hub>=0.5.0",
 ]
 elasticsearch = [
+  "farm-haystack[elasticsearch7]",
+]
+elasticsearch7 = [
   "elasticsearch>=7.17,<8",
   "elastic_transport<8"
+]
+elasticsearch8 = [
+  "elasticsearch>=8,<9",
+  "elastic_transport>=8,<9"
 ]
 sql = [
   "sqlalchemy>=1.4.2,<2",


### PR DESCRIPTION
### Related Issues

- related to #5027

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds the installation extras `elasticsearch7` and `elasticsearch8` and points the installation extra `elasticsearch` to `elasticsearch7`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I manually executed `pip install .[elasticsearch]`, `pip install .[elasticsearch7]`, and `pip install .[elasticsearch8]`.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
We decided that with Haystack 1.21, Elasticsearch 8 will become the default one and we will remove the extra `elasticsearch8`. Instead, the extra `elasticsearch` will install version 8 of the Elasticsearch client.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
