### PR TITLE
ci: Add job for ES8 integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ on:
       - "pyproject.toml"
       - "!.github/**/*.py"
       - "!rest_api/**/*.py"
+      - ".github/workflows/tests.yml"
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,7 +275,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_elasticsearch8.py
+          pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_elasticsearch.py
 
       - name: Calculate alert data
         id: calculator

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ on:
       - "pyproject.toml"
       - "!.github/**/*.py"
       - "!rest_api/**/*.py"
-      - ".github/workflows/tests.yml"
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch:
@@ -252,7 +252,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,23 +183,21 @@ jobs:
         with:
           parallel-finished: true
 
-  integration-tests-elasticsearch:
-    name: Integration / Elasticsearch / ${{ matrix.os }}
+  integration-tests-elasticsearch7:
+    name: Integration / Elasticsearch7 / ${{ matrix.os }}
     needs:
       - unit-tests
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch:
-        image: elasticsearch:8.7.1
+        image: elasticsearch:7.17.6
         env:
           discovery.type: "single-node"
-          xpack.security.enabled: "false"
           ES_JAVA_OPTS: "-Xms128m -Xmx256m"
-          ELASTIC_CLIENT_APIVERSIONING: 1
         ports:
           - 9200:9200
     steps:
@@ -215,6 +213,69 @@ jobs:
       - name: Run tests
         run: |
           pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_elasticsearch.py
+
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure()) && github.ref_name == 'main'
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
+
+      - name: Send event to Datadog
+        if: (success() || failure()) && github.ref_name == 'main'
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.workflow }} workflow"
+              text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  integration-tests-elasticsearch8:
+    name: Integration / Elasticsearch8 / ${{ matrix.os }}
+    needs:
+      - unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    services:
+      elasticsearch:
+        image: elasticsearch:8.8.0
+        env:
+          discovery.type: "single-node"
+          xpack.security.enabled: "false"
+          ES_JAVA_OPTS: "-Xms128m -Xmx256m"
+        ports:
+          - 9200:9200
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Haystack
+        run: pip install .[elasticsearch8,dev,preprocessing,inference]
+
+      - name: Run tests
+        run: |
+          pytest --maxfail=5 -m "document_store and integration" test/document_stores/test_elasticsearch8.py
 
       - name: Calculate alert data
         id: calculator
@@ -761,7 +822,8 @@ jobs:
     # This way we'll be able to mark only this test as required
     # and skip it accordingly.
     needs:
-      - integration-tests-elasticsearch
+      - integration-tests-elasticsearch7
+      - integration-tests-elasticsearch8
       - integration-tests-sql
       - integration-tests-opensearch
       - integration-tests-dc


### PR DESCRIPTION
### Related Issues

- related to #5027
- depends on #5296 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR renames the job `integration-tests-elasticsearch` to `integration-tests-elasticsearch7` and lets it run using Elasticsearch 7.17.6 to test `es7.ElasticsearchDocumentStore`. 

Furthermore, it adds the job `integration-tests-elasticsearch8` which installs the installation extra `elasticsearch8` and, therefore, uses  `es8.ElasticsearchDocumentStore` for the integration tests using Elasticsearch 8.8.0.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
This PR depends on #5296.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
