### PR TITLE
fix: Run HFLocalInvocationLayer.supports even if inference packages are not installed

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -328,7 +328,8 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         task_name: Optional[str] = kwargs.get("task_name", None)
         if os.path.exists(model_name_or_path):
             return True
-
+        if not torch_and_transformers_import.is_successful():
+            return False
         try:
             task_name = task_name or get_task(model_name_or_path, use_auth_token=kwargs.get("use_auth_token", None))
         except RuntimeError:

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -327,5 +327,5 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
             # This will fail for all non-HF models
             return False
         # if we are using an api_key it could be HF inference point
-        using_api_key = kwargs.get("api_key", None) is not None
+        using_api_key = bool(kwargs.get("api_key", None))
         return not using_api_key and task_name in ["text2text-generation", "text-generation"]

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -4,6 +4,7 @@ import os
 
 from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer, TokenStreamingHandler
 from haystack.nodes.prompt.invocation_layer.handlers import DefaultTokenStreamingHandler
+from haystack.nodes.prompt.invocation_layer.utils import get_task
 from haystack.lazy_imports import LazyImport
 
 
@@ -23,7 +24,6 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
     )
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
     from haystack.nodes.prompt.invocation_layer.handlers import HFTokenStreamingHandler
-    from haystack.nodes.prompt.invocation_layer.utils import get_task
 
     class StopWordsCriteria(StoppingCriteria):
         """

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -21,9 +21,9 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
         GenerationConfig,
         Pipeline,
     )
-    from huggingface_hub import model_info
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
     from haystack.nodes.prompt.invocation_layer.handlers import HFTokenStreamingHandler
+    from haystack.nodes.prompt.invocation_layer.utils import get_task
 
     class StopWordsCriteria(StoppingCriteria):
         """
@@ -42,15 +42,6 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
         def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
             stop_result = torch.isin(self.stop_words["input_ids"], input_ids[-1])
             return any(all(stop_word) for stop_word in stop_result)
-
-    def get_task(model: str, use_auth_token: Optional[Union[str, bool]] = None, timeout: float = 3.0) -> Optional[str]:
-        """
-        Simplified version of transformers.pipelines.get_task with support for timeouts
-        """
-        try:
-            return model_info(model, token=use_auth_token, timeout=timeout).pipeline_tag
-        except Exception as e:
-            raise RuntimeError(f"The task of {model} could not be checked because of the following error: {e}") from e
 
 
 class HFLocalInvocationLayer(PromptModelInvocationLayer):

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -317,10 +317,9 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
         task_name: Optional[str] = kwargs.get("task_name", None)
-        if not torch_and_transformers_import.is_successful():
-            return False
         if os.path.exists(model_name_or_path):
             return True
+
         try:
             task_name = task_name or get_task(model_name_or_path, use_auth_token=kwargs.get("use_auth_token", None))
         except RuntimeError:

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -326,10 +326,10 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
         task_name: Optional[str] = kwargs.get("task_name", None)
-        if os.path.exists(model_name_or_path):
-            return True
         if not torch_and_transformers_import.is_successful():
             return False
+        if os.path.exists(model_name_or_path):
+            return True
         try:
             task_name = task_name or get_task(model_name_or_path, use_auth_token=kwargs.get("use_auth_token", None))
         except RuntimeError:

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -294,7 +294,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
             is_inference_api = False
             try:
                 task_name = get_task(model_name_or_path, use_auth_token=kwargs.get("use_auth_token", None))
-                is_inference_api = "api_key" in kwargs
+                is_inference_api = bool(kwargs.get("api_key", None))
             except RuntimeError:
                 # This will fail for all non-HF models
                 return False

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -18,15 +18,12 @@ from haystack.nodes.prompt.invocation_layer import (
     DefaultTokenStreamingHandler,
 )
 from haystack.nodes.prompt.invocation_layer.handlers import DefaultPromptHandler
+from haystack.nodes.prompt.invocation_layer.utils import get_task
 from haystack.utils import request_with_retry
-from haystack.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
 HF_TIMEOUT = float(os.environ.get(HAYSTACK_REMOTE_API_TIMEOUT_SEC, 30))
 HF_RETRIES = int(os.environ.get(HAYSTACK_REMOTE_API_MAX_RETRIES, 5))
-
-with LazyImport() as transformers_import:
-    from haystack.nodes.prompt.invocation_layer.utils import get_task
 
 
 class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
@@ -52,7 +49,6 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
         :param api_key: The Hugging Face API token. You’ll need to provide your user token which can
         be found in your Hugging Face account [settings](https://huggingface.co/settings/tokens)
         """
-        transformers_import.check()
 
         super().__init__(model_name_or_path)
         self.prompt_preprocessors: Dict[str, Callable] = {}
@@ -284,8 +280,6 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        if not transformers_import.is_successful():
-            return False
         if cls.is_inference_endpoint(model_name_or_path):
             return True
         else:

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -26,7 +26,7 @@ HF_TIMEOUT = float(os.environ.get(HAYSTACK_REMOTE_API_TIMEOUT_SEC, 30))
 HF_RETRIES = int(os.environ.get(HAYSTACK_REMOTE_API_MAX_RETRIES, 5))
 
 with LazyImport() as transformers_import:
-    from haystack.nodes.prompt.invocation_layer.hugging_face import get_task
+    from haystack.nodes.prompt.invocation_layer.utils import get_task
 
 
 class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -284,6 +284,8 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
+        if not torch_and_transformers_import.is_successful():
+            return False
         if cls.is_inference_endpoint(model_name_or_path):
             return True
         else:

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -26,7 +26,7 @@ HF_TIMEOUT = float(os.environ.get(HAYSTACK_REMOTE_API_TIMEOUT_SEC, 30))
 HF_RETRIES = int(os.environ.get(HAYSTACK_REMOTE_API_MAX_RETRIES, 5))
 
 with LazyImport() as transformers_import:
-    from transformers.pipelines import get_task
+    from haystack.nodes.prompt.invocation_layer.hugging_face import get_task
 
 
 class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -284,7 +284,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        if not torch_and_transformers_import.is_successful():
+        if not transformers_import.is_successful():
             return False
         if cls.is_inference_endpoint(model_name_or_path):
             return True

--- a/haystack/nodes/prompt/invocation_layer/utils.py
+++ b/haystack/nodes/prompt/invocation_layer/utils.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
 
-from haystack.lazy_imports import LazyImport
+from huggingface_hub import model_info
 
 
 def has_azure_parameters(**kwargs) -> bool:
@@ -8,14 +8,13 @@ def has_azure_parameters(**kwargs) -> bool:
     return any(kwargs.get(param) for param in azure_params)
 
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'") as huggingface_import:
-    from huggingface_hub import model_info
+def get_task(model: str, use_auth_token: Optional[Union[str, bool]] = None, timeout: float = 3.0) -> Optional[str]:
+    """
+    Retrieve the task (pipeline tag) associated with a given model.
 
-    def get_task(model: str, use_auth_token: Optional[Union[str, bool]] = None, timeout: float = 3.0) -> Optional[str]:
-        """
-        Simplified version of transformers.pipelines.get_task with support for timeouts
-        """
-        try:
-            return model_info(model, token=use_auth_token, timeout=timeout).pipeline_tag
-        except Exception as e:
-            raise RuntimeError(f"The task of {model} could not be checked because of the following error: {e}") from e
+    Simplified version of transformers.pipelines.get_task with support for timeouts
+    """
+    try:
+        return model_info(model, token=use_auth_token, timeout=timeout).pipeline_tag
+    except Exception as e:
+        raise RuntimeError(f"The task for {model} couldn't be found!") from e

--- a/haystack/nodes/prompt/invocation_layer/utils.py
+++ b/haystack/nodes/prompt/invocation_layer/utils.py
@@ -1,3 +1,21 @@
+from typing import Optional, Union
+
+from haystack.lazy_imports import LazyImport
+
+
 def has_azure_parameters(**kwargs) -> bool:
     azure_params = ["azure_base_url", "azure_deployment_name"]
     return any(kwargs.get(param) for param in azure_params)
+
+
+with LazyImport(message="Run 'pip install farm-haystack[inference]'") as huggingface_import:
+    from huggingface_hub import model_info
+
+    def get_task(model: str, use_auth_token: Optional[Union[str, bool]] = None, timeout: float = 3.0) -> Optional[str]:
+        """
+        Simplified version of transformers.pipelines.get_task with support for timeouts
+        """
+        try:
+            return model_info(model, token=use_auth_token, timeout=timeout).pipeline_tag
+        except Exception as e:
+            raise RuntimeError(f"The task of {model} could not be checked because of the following error: {e}") from e

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -410,6 +410,9 @@ def test_supports(tmp_path):
         assert HFLocalInvocationLayer.supports("google/flan-t5-base")
         assert HFLocalInvocationLayer.supports("mosaicml/mpt-7b")
         assert HFLocalInvocationLayer.supports("CarperAI/stable-vicuna-13b-delta")
+        with patch("haystack.nodes.prompt.invocation_layer.hugging_face.torch_and_transformers_import") as mock_import:
+            mock_import.is_successful.return_value = False
+            assert not HFLocalInvocationLayer.supports("google/flan-t5-base")
         mock_get_task.side_effect = RuntimeError
         assert not HFLocalInvocationLayer.supports("google/flan-t5-base")
         assert mock_get_task.call_count == 4

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -399,28 +399,36 @@ def test_streaming_stream_handler_param_in_constructor(mock_pipeline, mock_get_t
 
 
 @pytest.mark.unit
-def test_supports(tmp_path):
+def test_supports(tmp_path, mock_get_task):
     """
     Test that supports returns True correctly for HFLocalInvocationLayer
     """
-    # mock get_task to avoid remote calls to HF hub
-    mock_get_task = Mock(return_value="text2text-generation")
 
-    with patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task", mock_get_task):
-        assert HFLocalInvocationLayer.supports("google/flan-t5-base")
-        assert HFLocalInvocationLayer.supports("mosaicml/mpt-7b")
-        assert HFLocalInvocationLayer.supports("CarperAI/stable-vicuna-13b-delta")
-        with patch("haystack.nodes.prompt.invocation_layer.hugging_face.torch_and_transformers_import") as mock_import:
-            mock_import.is_successful.return_value = False
-            assert not HFLocalInvocationLayer.supports("google/flan-t5-base")
-        mock_get_task.side_effect = RuntimeError
-        assert not HFLocalInvocationLayer.supports("google/flan-t5-base")
-        assert mock_get_task.call_count == 4
+    assert HFLocalInvocationLayer.supports("google/flan-t5-base")
+    assert HFLocalInvocationLayer.supports("mosaicml/mpt-7b")
+    assert HFLocalInvocationLayer.supports("CarperAI/stable-vicuna-13b-delta")
+    mock_get_task.side_effect = RuntimeError
+    assert not HFLocalInvocationLayer.supports("google/flan-t5-base")
+    assert mock_get_task.call_count == 4
 
     # some HF local model directory, let's use the one from test/prompt/invocation_layer
     assert HFLocalInvocationLayer.supports(str(tmp_path))
 
-    # but not some non text2text-generation or non text-generation model
+    # we can also specify the task name to override the default
+    # short-circuit the get_task call
+    assert HFLocalInvocationLayer.supports(
+        "vblagoje/bert-english-uncased-finetuned-pos", task_name="text2text-generation"
+    )
+
+
+@pytest.mark.unit
+def test_supports_not(mock_get_task):
+    """
+    Test that supports returns False correctly for HFLocalInvocationLayer
+    """
+    assert not HFLocalInvocationLayer.supports("google/flan-t5-base", api_key="some_key")
+
+    # also not some non text2text-generation or non text-generation model
     # i.e image classification model
     mock_get_task = Mock(return_value="image-classification")
     with patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task", mock_get_task):
@@ -432,12 +440,6 @@ def test_supports(tmp_path):
     with patch("haystack.nodes.prompt.invocation_layer.hugging_face.get_task", mock_get_task):
         assert not HFLocalInvocationLayer.supports("vblagoje/bert-english-uncased-finetuned-pos")
         assert mock_get_task.call_count == 1
-
-    # unless we specify the task name to override the default
-    # short-circuit the get_task call
-    assert HFLocalInvocationLayer.supports(
-        "vblagoje/bert-english-uncased-finetuned-pos", task_name="text2text-generation"
-    )
 
 
 @pytest.mark.unit

--- a/test/prompt/invocation_layer/test_hugging_face_inference.py
+++ b/test/prompt/invocation_layer/test_hugging_face_inference.py
@@ -362,7 +362,7 @@ def test_supports(mock_get_task):
     )
 
     with patch("haystack.nodes.prompt.invocation_layer.hugging_face_inference.transformers_import") as mock_import:
-        mock_import.is_successful.return_value = True
+        mock_import.is_successful.return_value = False
         assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
 
 

--- a/test/prompt/invocation_layer/test_hugging_face_inference.py
+++ b/test/prompt/invocation_layer/test_hugging_face_inference.py
@@ -353,24 +353,23 @@ def test_supports(mock_get_task):
     # supports google/flan-t5-xxl with api_key
     assert HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
 
-    # doesn't support google/flan-t5-xxl without api_key
-    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl")
-
     # supports HF Inference Endpoint with api_key
     assert HFInferenceEndpointInvocationLayer.supports(
         "https://<your-unique-deployment-id>.us-east-1.aws.endpoints.huggingface.cloud", api_key="fake_key"
     )
 
-    # doesn't support model if library not installed
-    with patch("haystack.nodes.prompt.invocation_layer.hugging_face_inference.transformers_import") as mock_import:
-        mock_import.is_successful.return_value = False
-        assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
-
-    # doesn't support model if hf server timeout
-    mock_get_task.side_effect = RuntimeError
-    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
-
 
 @pytest.mark.unit
 def test_supports_not(mock_get_task_invalid):
     assert not HFInferenceEndpointInvocationLayer.supports("fake_model", api_key="fake_key")
+
+    # doesn't support google/flan-t5-xxl without api_key
+    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl")
+
+    # doesn't support HF Inference Endpoint without proper api_key
+    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="")
+    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key=None)
+
+    # doesn't support model if hf server timeout
+    mock_get_task.side_effect = RuntimeError
+    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")

--- a/test/prompt/invocation_layer/test_hugging_face_inference.py
+++ b/test/prompt/invocation_layer/test_hugging_face_inference.py
@@ -361,6 +361,10 @@ def test_supports(mock_get_task):
         "https://<your-unique-deployment-id>.us-east-1.aws.endpoints.huggingface.cloud", api_key="fake_key"
     )
 
+    with patch("haystack.nodes.prompt.invocation_layer.hugging_face_inference.transformers_import") as mock_import:
+        mock_import.is_successful.return_value = True
+        assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
+
 
 @pytest.mark.unit
 def test_supports_not(mock_get_task_invalid):

--- a/test/prompt/invocation_layer/test_hugging_face_inference.py
+++ b/test/prompt/invocation_layer/test_hugging_face_inference.py
@@ -361,9 +361,14 @@ def test_supports(mock_get_task):
         "https://<your-unique-deployment-id>.us-east-1.aws.endpoints.huggingface.cloud", api_key="fake_key"
     )
 
+    # doesn't support model if library not installed
     with patch("haystack.nodes.prompt.invocation_layer.hugging_face_inference.transformers_import") as mock_import:
         mock_import.is_successful.return_value = False
         assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
+
+    # doesn't support model if hf server timeout
+    mock_get_task.side_effect = RuntimeError
+    assert not HFInferenceEndpointInvocationLayer.supports("google/flan-t5-xxl", api_key="fake_key")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- #4848 

### Proposed Changes:

HFLocalInvocationLayer.supports would previously fail if the optional inference dependencies are not installed. This PR causes it not to fail and instead to return false.

### How did you test it?
I added a test case in test_hugging_face.py::test_supports.

### Notes for the reviewer

@vblagoje originally discovered the bug and discussed the solution with me as #4848 affects when this problem occurs.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
