### PR TITLE
chore: pin `scikit-learn>=1.3.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "transformers==4.30.1",
   "pandas",
   "rank_bm25",
-  "scikit-learn>=1.0.0", # TF-IDF, SklearnQueryClassifier and metrics
+  "scikit-learn>=1.3.0", # TF-IDF, SklearnQueryClassifier and metrics
   "lazy-imports==0.3.1", # Optional imports
   "prompthub-py==4.0.0",
   "platformdirs",


### PR DESCRIPTION
### Related Issues

- part of #5321

### Proposed Changes:

Simply pin `scikit-learn>=1.3.0`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
