### PR TITLE
chore: deprecate `SklearnQueryClassifier`

### DIFF
--- a/haystack/nodes/query_classifier/sklearn.py
+++ b/haystack/nodes/query_classifier/sklearn.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Union, Any, List, Optional, Iterator, Dict
 import pickle
 import urllib
+import warnings
 
 from tqdm import tqdm
 from sklearn.ensemble._gb_losses import BinomialDeviance
@@ -16,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 class SklearnQueryClassifier(BaseQueryClassifier):
     """
+    This component is now deprecated and will be removed in future versions. Use `TransformersQueryClassifier` instead of `SklearnQueryClassifier`.
+
     A node to classify an incoming query into one of two categories using a lightweight sklearn model. Depending on the result, the query flows to a different branch in your pipeline
     and the further processing can be customized. You can define this by connecting the further pipeline to either `output_1` or `output_2` from this node.
 
@@ -75,6 +78,11 @@ class SklearnQueryClassifier(BaseQueryClassifier):
         :param batch_size: Number of queries to process at a time.
         :param progress_bar: Whether to show a progress bar.
         """
+        warnings.warn(
+            "`SklearnQueryClassifier` component is deprecated and will be removed in future versions. Use `TransformersQueryClassifier` "
+            "instead of `SklearnQueryClassifier`.",
+            category=DeprecationWarning,
+        )
         if ((not isinstance(model_name_or_path, Path)) and (not isinstance(model_name_or_path, str))) or (
             (not isinstance(vectorizer_name_or_path, Path)) and (not isinstance(vectorizer_name_or_path, str))
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "transformers==4.30.1",
   "pandas",
   "rank_bm25",
-  "scikit-learn>=1.0.0", # TF-IDF, SklearnQueryClassifier and metrics
+  "scikit-learn>=1.3.0", # TF-IDF, SklearnQueryClassifier and metrics
   "lazy-imports==0.3.1", # Optional imports
   "prompthub-py==4.0.0",
   "platformdirs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "transformers==4.30.1",
   "pandas",
   "rank_bm25",
-  "scikit-learn>=1.3.0", # TF-IDF, SklearnQueryClassifier and metrics
+  "scikit-learn>=1.0.0", # TF-IDF, SklearnQueryClassifier and metrics
   "lazy-imports==0.3.1", # Optional imports
   "prompthub-py==4.0.0",
   "platformdirs",

--- a/test/nodes/test_query_classifier.py
+++ b/test/nodes/test_query_classifier.py
@@ -1,5 +1,18 @@
 import pytest
-from haystack.nodes.query_classifier.transformers import TransformersQueryClassifier
+from pathlib import Path
+from urllib.error import URLError
+from haystack.nodes.query_classifier import TransformersQueryClassifier, SklearnQueryClassifier
+from ..conftest import fail_at_version
+
+
+@pytest.mark.unit
+@fail_at_version(1, 21)
+def test_sklearnqueryclassifier_deprecation():
+    with pytest.warns(DeprecationWarning):
+        try:
+            SklearnQueryClassifier(Path("fake_model"), Path("fake_vectorizer"))
+        except URLError:
+            pass
 
 
 @pytest.fixture


### PR DESCRIPTION
### Related Issues

- fixes #5323

### Proposed Changes:

Classic deprecation procedure for `SklearnQueryClassifier`

### How did you test it?

New deprecation warning test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
