### PR TITLE
test: Re-activate end-to-end tests workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false  # Avoid cancelling the others if one of these fails
       matrix:
         folder:
-          - "document_stores"
+          - "document_search"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ name: end-to-end
 
 on:
   workflow_dispatch: # Activate this workflow manually
+  push:
+    branches:
+      - e2e-tests-workflow
   schedule:
     - cron: "0 0 * * *"
 
@@ -45,15 +48,17 @@ jobs:
       id: cache-hf-models
       uses: actions/cache@v3
       with:
-        path: ~/.cache/huggingface/transformers/
-        key: hf-models
+        path: ./e2e
+        key: ${{ runner.os }}-${{ hashFiles('**/models_to_cache.txt') }}
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 15
     - name: Download models
       if: steps.cache-hf-models.outputs.cache-hit != 'true'
+      shell: python
       run: |
-         python -c "from transformers import AutoModel;[AutoModel.from_pretrained(model_name) for model_name in ['vblagoje/dpr-ctx_encoder-single-lfqa-wiki', 'vblagoje/dpr-question_encoder-single-lfqa-wiki', 'facebook/dpr-question_encoder-single-nq-base', 'facebook/dpr-ctx_encoder-single-nq-base', 'elastic/distilbert-base-cased-finetuned-conll03-english', 'deepset/bert-medium-squad2-distilled']]"
-
+        from transformers import AutoModel
+        with open("./e2e/models_to_cache.txt") as file:
+          AutoModel.from_pretrained(file.readline())
     - name: Run tests
       env:
         TOKENIZERS_PARALLELISM: 'false'  # Avoid logspam by tokenizers

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install Haystack
       run: pip install .[inference,elasticsearch7,faiss,weaviate,opensearch,dev]
-      
+
     - name: Cache HF models
       id: cache-hf-models
       uses: actions/cache@v3
@@ -51,6 +51,9 @@ jobs:
 
     - name: Run Weaviate
       run: docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' --env ENABLE_EXPERIMENTAL_BM25='true' --env DISK_USE_READONLY_PERCENTAGE='95' semitechnologies/weaviate:1.17.2
+
+    - name: Sleep
+      run: sleep 30
 
     - name: Run tests
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,6 @@ name: end-to-end
 
 on:
   workflow_dispatch: # Activate this workflow manually
-  push:
-    branches:
-      - e2e-tests-workflow
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,17 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Run Elasticsearch
+      run: |
+        docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx256m" elasticsearch:7.9.2
+
+    - name: Run Opensearch
+      run: |
+        docker run -d -p 9201:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:1.3.5
+
+    - name: Run Weaviate
+      run: docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' --env ENABLE_EXPERIMENTAL_BM25='true' --env DISK_USE_READONLY_PERCENTAGE='95' semitechnologies/weaviate:1.17.2
+
     - name: Install Haystack
       run: pip install .[inference,elasticsearch7,faiss,weaviate,opensearch,dev]
 
@@ -40,20 +51,6 @@ jobs:
       if: steps.cache-hf-models.outputs.cache-hit != 'true'
       run: |
          python -c "from transformers import AutoModel;[AutoModel.from_pretrained(model_name) for model_name in ['vblagoje/dpr-ctx_encoder-single-lfqa-wiki', 'vblagoje/dpr-question_encoder-single-lfqa-wiki', 'facebook/dpr-question_encoder-single-nq-base', 'facebook/dpr-ctx_encoder-single-nq-base', 'elastic/distilbert-base-cased-finetuned-conll03-english', 'deepset/bert-medium-squad2-distilled']]"
-
-    - name: Run Elasticsearch
-      run: |
-        docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx256m" elasticsearch:7.9.2
-
-    - name: Run Opensearch
-      run: |
-        docker run -d -p 9201:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:1.3.5
-
-    - name: Run Weaviate
-      run: docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' --env ENABLE_EXPERIMENTAL_BM25='true' --env DISK_USE_READONLY_PERCENTAGE='95' semitechnologies/weaviate:1.17.2
-
-    - name: Sleep
-      run: sleep 30s
 
     - name: Run tests
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,7 @@ jobs:
       run: docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' --env ENABLE_EXPERIMENTAL_BM25='true' --env DISK_USE_READONLY_PERCENTAGE='95' semitechnologies/weaviate:1.17.2
 
     - name: Sleep
-      run: sleep 30
+      run: sleep 30s
 
     - name: Run tests
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,9 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Install Haystack
+      run: pip install .[inference,elasticsearch7,faiss,weaviate,opensearch,dev]
+      
     - name: Cache HF models
       id: cache-hf-models
       uses: actions/cache@v3
@@ -33,7 +36,7 @@ jobs:
         key: hf-models
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 15
-
+      
     - name: Download models
       if: steps.cache-hf-models.outputs.cache-hit != 'true'
       run: |
@@ -49,9 +52,6 @@ jobs:
 
     - name: Run Weaviate
       run: docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' --env ENABLE_EXPERIMENTAL_BM25='true' --env DISK_USE_READONLY_PERCENTAGE='95' semitechnologies/weaviate:1.17.2
-
-    - name: Install Haystack
-      run: pip install .
 
     - name: Run tests
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,9 @@
 name: end-to-end
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Activate this workflow manually
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,6 @@ jobs:
         key: hf-models
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 15
-      
     - name: Download models
       if: steps.cache-hf-models.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         from transformers import AutoModel
         with open("./e2e/models_to_cache.txt") as file:
-          AutoModel.from_pretrained(file.readline())
+          AutoModel.from_pretrained(file.readline().rstrip())
     - name: Run tests
       env:
         TOKENIZERS_PARALLELISM: 'false'  # Avoid logspam by tokenizers

--- a/e2e/document_search/test_standard_pipeline.py
+++ b/e2e/document_search/test_standard_pipeline.py
@@ -1,0 +1,35 @@
+import pytest
+
+from haystack.nodes import EmbeddingRetriever
+from haystack.pipelines import DocumentSearchPipeline
+
+from ..conftest import document_store
+
+
+@pytest.mark.parametrize("document_store_name", ["memory", "faiss", "weaviate", "elasticsearch"])
+def test_document_search_standard_pipeline(document_store_name, docs, tmp_path):
+    """
+    Testing the DocumentSearchPipeline with most common parameters according to our template:
+    https://github.com/deepset-ai/templates/blob/main/pipelines/DenseDocSearch.yaml
+    The common multi-qa-mpnet-base-dot-v1 model is replaced with the very similar paraphrase-MiniLM-L3-v2,
+    which reduces runtime and model size by ~6x
+    """
+    with document_store(document_store_name, docs, tmp_path, embedding_dim=384) as ds:
+        retriever = EmbeddingRetriever(
+            document_store=ds, embedding_model="sentence-transformers/paraphrase-MiniLM-L3-v2"
+        )
+        ds.update_embeddings(retriever)
+        pipeline = DocumentSearchPipeline(retriever)
+        prediction = pipeline.run("Paul lives in New York")
+        scores = [document.score for document in prediction["documents"]]
+        assert [document.content for document in prediction["documents"]] == [
+            "My name is Paul and I live in New York",
+            "My name is Matteo and I live in Rome",
+            "My name is Christelle and I live in Paris",
+            "My name is Carla and I live in Berlin",
+            "My name is Camila and I live in Madrid",
+        ]
+        assert scores == pytest.approx(
+            [0.9149981737136841, 0.6895168423652649, 0.641706794500351, 0.6206043660640717, 0.5837393924593925],
+            abs=1e-3,
+        )

--- a/e2e/models_to_cache.txt
+++ b/e2e/models_to_cache.txt
@@ -1,0 +1,1 @@
+sentence-transformers/paraphrase-MiniLM-L3-v2


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5333

### Proposed Changes:
We want to set up end-to-end tests and as a first step aim to re-enable the existing e2e workflow.
- Update installation of Haystack with required extras
- Start spinning up docker containers for document stores earlier to give more time for starting up while Haystack is installed 
- Trigger by cron job for nightly runs (plus manually)
- Use only one simple end-to-end test with a DocumentSearchPipeline with common parameter settings and deactivate all other tests. Refactoring of old, deactivated tests is a separate issue: https://github.com/deepset-ai/haystack/issues/5350

### Notes for the reviewer

I tested the docker commands and `pytest e2e/document_stores` locally. The tests themselves took only 2 minutes. 
I also tested `pip install .[inference,elasticsearch7,faiss,weaviate,opensearch,dev]` locally. Just had to add quotes because of zsh locally.
The GitHub action itself also runs through now too. Earlier there was an issue about opensearch still starting up when the first test was run.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
