### PR TITLE
fix: update WebRetriever docstrings and default mode

### DIFF
--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -59,7 +59,7 @@ class WebRetriever(BaseRetriever):
         search_engine_provider: Union[str, SearchEngine] = "SerperDev",
         top_search_results: Optional[int] = 10,
         top_k: Optional[int] = 5,
-        mode: Literal["snippets", "raw_documents", "preprocessed_documents"] = "snippets",
+        mode: Literal["snippets", "raw_documents", "preprocessed_documents"] = "preprocessed_documents",
         preprocessor: Optional[PreProcessor] = None,
         cache_document_store: Optional[BaseDocumentStore] = None,
         cache_index: Optional[str] = None,
@@ -67,6 +67,9 @@ class WebRetriever(BaseRetriever):
         cache_time: int = 1 * 24 * 60 * 60,
     ):
         """
+        :param api_key: API key for the search engine provider.
+        :param search_engine_provider: Name of the search engine provider class, see `providers.py` for a list of supported providers.
+        :param top_search_results: Number of top search results to be retrieved.
         :param top_k: Top k documents to be returned by the retriever.
         :param mode: Whether to return snippets, raw documents, or preprocessed documents. Preprocessed documents are the default.
         :param preprocessor: Optional PreProcessor to be used to split documents into paragraphs. If not provided, the default PreProcessor is used.

--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -59,7 +59,7 @@ class WebRetriever(BaseRetriever):
         search_engine_provider: Union[str, SearchEngine] = "SerperDev",
         top_search_results: Optional[int] = 10,
         top_k: Optional[int] = 5,
-        mode: Literal["snippets", "raw_documents", "preprocessed_documents"] = "preprocessed_documents",
+        mode: Literal["snippets", "raw_documents", "preprocessed_documents"] = "snippets",
         preprocessor: Optional[PreProcessor] = None,
         cache_document_store: Optional[BaseDocumentStore] = None,
         cache_index: Optional[str] = None,
@@ -71,7 +71,7 @@ class WebRetriever(BaseRetriever):
         :param search_engine_provider: Name of the search engine provider class, see `providers.py` for a list of supported providers.
         :param top_search_results: Number of top search results to be retrieved.
         :param top_k: Top k documents to be returned by the retriever.
-        :param mode: Whether to return snippets, raw documents, or preprocessed documents. Preprocessed documents are the default.
+        :param mode: Whether to return snippets, raw documents, or preprocessed documents. Snippets are the default.
         :param preprocessor: Optional PreProcessor to be used to split documents into paragraphs. If not provided, the default PreProcessor is used.
         :param cache_document_store: DocumentStore to be used to cache search results.
         :param cache_index: Index name to be used to cache search results.


### PR DESCRIPTION
### Related Issues

- fixes #5214 

### Proposed Changes:

- added docstrings for `api_key`, `search_engine_provider` and `top_search_results`
- changed default `mode` to "preprocessed_documents" as stated in docstrings

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
