### PR TITLE
feat: Add embed_meta_fields to Ranker nodes

### DIFF
--- a/haystack/nodes/ranker/base.py
+++ b/haystack/nodes/ranker/base.py
@@ -4,6 +4,9 @@ import logging
 from abc import abstractmethod
 from functools import wraps
 from time import perf_counter
+from copy import deepcopy
+
+import pandas as pd
 
 from haystack.schema import Document
 from haystack.nodes.base import BaseComponent
@@ -31,6 +34,34 @@ class BaseRanker(BaseComponent):
         batch_size: Optional[int] = None,
     ) -> Union[List[Document], List[List[Document]]]:
         pass
+
+    def _add_meta_fields_to_docs(
+        self, docs: List[Document], embed_meta_fields: Optional[List[str]] = None
+    ) -> List[Document]:
+        """
+        Concatenates specified metadata fields with the text representations.
+
+        :param docs: List of documents to add metadata to.
+        :param embed_meta_fields: Concatenate the provided meta fields and into the text passage that is then used in
+            reranking.
+        :return: List of documents with metadata.
+        """
+        linearized_docs = []
+        for doc in docs:
+            doc = deepcopy(doc)
+            # Gather all relevant metadata fields
+            meta_data_fields = []
+            for key in embed_meta_fields:
+                if key in doc.meta and doc.meta[key]:
+                    if isinstance(doc.meta[key], list):
+                        meta_data_fields.extend([item for item in doc.meta[key]])
+                    else:
+                        meta_data_fields.append(doc.meta[key])
+            # Convert to type string (e.g. for ints or floats)
+            meta_data_fields = [str(field) for field in meta_data_fields]
+            doc.content = "\n".join(meta_data_fields + [doc.content])
+            linearized_docs.append(doc)
+        return linearized_docs
 
     def run(self, query: str, documents: List[Document], top_k: Optional[int] = None):  # type: ignore
         self.query_count += 1

--- a/haystack/nodes/ranker/base.py
+++ b/haystack/nodes/ranker/base.py
@@ -6,8 +6,6 @@ from functools import wraps
 from time import perf_counter
 from copy import deepcopy
 
-import pandas as pd
-
 from haystack.schema import Document
 from haystack.nodes.base import BaseComponent
 
@@ -46,7 +44,10 @@ class BaseRanker(BaseComponent):
             reranking.
         :return: List of documents with metadata.
         """
-        linearized_docs = []
+        if not embed_meta_fields:
+            return docs
+
+        docs_with_meta = []
         for doc in docs:
             doc = deepcopy(doc)
             # Gather all relevant metadata fields
@@ -60,8 +61,8 @@ class BaseRanker(BaseComponent):
             # Convert to type string (e.g. for ints or floats)
             meta_data_fields = [str(field) for field in meta_data_fields]
             doc.content = "\n".join(meta_data_fields + [doc.content])
-            linearized_docs.append(doc)
-        return linearized_docs
+            docs_with_meta.append(doc)
+        return docs_with_meta
 
     def run(self, query: str, documents: List[Document], top_k: Optional[int] = None):  # type: ignore
         self.query_count += 1

--- a/haystack/nodes/ranker/base.py
+++ b/haystack/nodes/ranker/base.py
@@ -34,21 +34,21 @@ class BaseRanker(BaseComponent):
         pass
 
     def _add_meta_fields_to_docs(
-        self, docs: List[Document], embed_meta_fields: Optional[List[str]] = None
+        self, documents: List[Document], embed_meta_fields: Optional[List[str]] = None
     ) -> List[Document]:
         """
         Concatenates specified metadata fields with the text representations.
 
-        :param docs: List of documents to add metadata to.
+        :param documents: List of documents to add metadata to.
         :param embed_meta_fields: Concatenate the provided meta fields and into the text passage that is then used in
             reranking.
         :return: List of documents with metadata.
         """
         if not embed_meta_fields:
-            return docs
+            return documents
 
         docs_with_meta = []
-        for doc in docs:
+        for doc in documents:
             doc = deepcopy(doc)
             # Gather all relevant metadata fields
             meta_data_fields = []

--- a/haystack/nodes/ranker/cohere.py
+++ b/haystack/nodes/ranker/cohere.py
@@ -147,7 +147,9 @@ class CohereRanker(BaseRanker):
             top_k = self.top_k
 
         # See https://docs.cohere.com/reference/rerank-1
-        docs_with_meta_fields = self._add_meta_fields_to_docs(docs=documents, embed_meta_fields=self.embed_meta_fields)
+        docs_with_meta_fields = self._add_meta_fields_to_docs(
+            documents=documents, embed_meta_fields=self.embed_meta_fields
+        )
         cohere_docs = [{"text": d.content} for d in docs_with_meta_fields]
         if len(cohere_docs) > 1000:
             logger.warning(
@@ -214,7 +216,7 @@ class CohereRanker(BaseRanker):
             # Docs case 1: single list of Documents -> rerank single list of Documents based on single query
             if len(queries) != 1:
                 raise HaystackError("Number of queries must be 1 if a single list of Documents is provided.")
-            docs = self._add_meta_fields_to_docs(docs=documents, embed_meta_fields=self.embed_meta_fields)
+            docs = self._add_meta_fields_to_docs(documents=documents, embed_meta_fields=self.embed_meta_fields)
             return self.predict(query=queries[0], documents=docs, top_k=top_k)  # type: ignore
         else:
             # Docs case 2: list of lists of Documents -> rerank each list of Documents based on corresponding query
@@ -227,6 +229,6 @@ class CohereRanker(BaseRanker):
             results = []
             for query, cur_docs in zip(queries, documents):
                 assert isinstance(cur_docs, list)
-                docs = self._add_meta_fields_to_docs(docs=cur_docs, embed_meta_fields=self.embed_meta_fields)
+                docs = self._add_meta_fields_to_docs(documents=cur_docs, embed_meta_fields=self.embed_meta_fields)
                 results.append(self.predict(query=query, documents=docs, top_k=top_k))  # type: ignore
             return results

--- a/haystack/nodes/ranker/cohere.py
+++ b/haystack/nodes/ranker/cohere.py
@@ -42,7 +42,12 @@ class CohereRanker(BaseRanker):
     """
 
     def __init__(
-        self, api_key: str, model_name_or_path: str, top_k: int = 10, max_chunks_per_doc: Optional[int] = None
+        self,
+        api_key: str,
+        model_name_or_path: str,
+        top_k: int = 10,
+        max_chunks_per_doc: Optional[int] = None,
+        embed_meta_fields: Optional[List[str]] = None,
     ):
         """
          Creates an instance of CohereInvocationLayer for the specified Cohere model.
@@ -54,6 +59,8 @@ class CohereRanker(BaseRanker):
             chunks a document can be split into. If None, the default of 10 is used.
             For example, if your document is 6000 tokens, with the default of 10, the document will be split into 10
             chunks each of 512 tokens and the last 880 tokens will be disregarded.
+        :param embed_meta_fields: Concatenate the provided meta fields and into the text passage that is then used in
+            reranking. The original documents are returned so the concatenated metadata is not included in the returned documents.
         """
         super().__init__()
         valid_api_key = isinstance(api_key, str) and api_key
@@ -71,6 +78,7 @@ class CohereRanker(BaseRanker):
         self.api_key = api_key
         self.top_k = top_k
         self.max_chunks_per_doc = max_chunks_per_doc
+        self.embed_meta_fields = embed_meta_fields
 
     @property
     def url(self) -> str:
@@ -139,7 +147,8 @@ class CohereRanker(BaseRanker):
             top_k = self.top_k
 
         # See https://docs.cohere.com/reference/rerank-1
-        cohere_docs = [{"text": d.content} for d in documents]
+        docs_with_meta_fields = self._add_meta_fields_to_docs(docs=documents, embed_meta_fields=self.embed_meta_fields)
+        cohere_docs = [{"text": d.content} for d in docs_with_meta_fields]
         if len(cohere_docs) > 1000:
             logger.warning(
                 "The Cohere reranking endpoint only supports 1000 documents. "
@@ -205,7 +214,8 @@ class CohereRanker(BaseRanker):
             # Docs case 1: single list of Documents -> rerank single list of Documents based on single query
             if len(queries) != 1:
                 raise HaystackError("Number of queries must be 1 if a single list of Documents is provided.")
-            return self.predict(query=queries[0], documents=documents, top_k=top_k)  # type: ignore
+            docs = self._add_meta_fields_to_docs(docs=documents, embed_meta_fields=self.embed_meta_fields)
+            return self.predict(query=queries[0], documents=docs, top_k=top_k)  # type: ignore
         else:
             # Docs case 2: list of lists of Documents -> rerank each list of Documents based on corresponding query
             # If queries contains a single query, apply it to each list of Documents
@@ -216,5 +226,7 @@ class CohereRanker(BaseRanker):
 
             results = []
             for query, cur_docs in zip(queries, documents):
-                results.append(self.predict(query=query, documents=cur_docs, top_k=top_k))  # type: ignore
+                assert isinstance(cur_docs, list)
+                docs = self._add_meta_fields_to_docs(docs=cur_docs, embed_meta_fields=self.embed_meta_fields)
+                results.append(self.predict(query=query, documents=docs, top_k=top_k))  # type: ignore
             return results

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -128,7 +128,9 @@ class SentenceTransformersRanker(BaseRanker):
         if top_k is None:
             top_k = self.top_k
 
-        docs_with_meta_fields = self._add_meta_fields_to_docs(docs=documents, embed_meta_fields=self.embed_meta_fields)
+        docs_with_meta_fields = self._add_meta_fields_to_docs(
+            documents=documents, embed_meta_fields=self.embed_meta_fields
+        )
         docs = [doc.content for doc in docs_with_meta_fields]
         features = self.transformer_tokenizer(
             [query for _ in documents], docs, padding=True, truncation=True, return_tensors="pt"
@@ -217,7 +219,7 @@ class SentenceTransformersRanker(BaseRanker):
             queries=queries, documents=documents
         )
         all_docs_with_meta_fields = self._add_meta_fields_to_docs(
-            docs=all_docs, embed_meta_fields=self.embed_meta_fields
+            documents=all_docs, embed_meta_fields=self.embed_meta_fields
         )
 
         batches = self._get_batches(all_queries=all_queries, all_docs=all_docs_with_meta_fields, batch_size=batch_size)

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -56,6 +56,7 @@ class SentenceTransformersRanker(BaseRanker):
         scale_score: bool = True,
         progress_bar: bool = True,
         use_auth_token: Optional[Union[str, bool]] = None,
+        embed_meta_fields: Optional[List[str]] = None,
     ):
         """
         :param model_name_or_path: Directory of a saved model or the name of a public model e.g.
@@ -78,6 +79,8 @@ class SentenceTransformersRanker(BaseRanker):
                         A list containing torch device objects and/or strings is supported (For example
                         [torch.device('cuda:0'), "mps", "cuda:1"]). When specifying `use_gpu=False` the devices
                         parameter is not used and a single cpu device is used for inference.
+        :param embed_meta_fields: Concatenate the provided meta fields and into the text passage that is then used in
+            reranking. The original documents are returned so the concatenated metadata is not included in the returned documents.
         """
         torch_and_transformers_import.check()
         super().__init__()
@@ -109,6 +112,7 @@ class SentenceTransformersRanker(BaseRanker):
             self.model = DataParallel(self.transformer_model, device_ids=self.devices)
 
         self.batch_size = batch_size
+        self.embed_meta_fields = embed_meta_fields
 
     def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None) -> List[Document]:
         """
@@ -124,12 +128,10 @@ class SentenceTransformersRanker(BaseRanker):
         if top_k is None:
             top_k = self.top_k
 
+        docs_with_meta_fields = self._add_meta_fields_to_docs(docs=documents, embed_meta_fields=self.embed_meta_fields)
+        docs = [doc.content for doc in docs_with_meta_fields]
         features = self.transformer_tokenizer(
-            [query for _ in documents],
-            [doc.content for doc in documents],
-            padding=True,
-            truncation=True,
-            return_tensors="pt",
+            [query for _ in documents], docs, padding=True, truncation=True, return_tensors="pt"
         ).to(self.devices[0])
 
         # SentenceTransformerRanker uses:
@@ -214,9 +216,12 @@ class SentenceTransformersRanker(BaseRanker):
         number_of_docs, all_queries, all_docs, single_list_of_docs = self._preprocess_batch_queries_and_docs(
             queries=queries, documents=documents
         )
+        all_docs_with_meta_fields = self._add_meta_fields_to_docs(
+            docs=all_docs, embed_meta_fields=self.embed_meta_fields
+        )
 
-        batches = self._get_batches(all_queries=all_queries, all_docs=all_docs, batch_size=batch_size)
-        pb = tqdm(total=len(all_docs), disable=not self.progress_bar, desc="Ranking")
+        batches = self._get_batches(all_queries=all_queries, all_docs=all_docs_with_meta_fields, batch_size=batch_size)
+        pb = tqdm(total=len(all_docs_with_meta_fields), disable=not self.progress_bar, desc="Ranking")
         preds = []
         for cur_queries, cur_docs in batches:
             features = self.transformer_tokenizer(


### PR DESCRIPTION
### Related Issues

- fixes #5354 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Adds the option `embed_meta_fields` to the Ranker nodes using a similar implementation to the one used in EmbeddingRetrievers.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a new unit test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
This feature is complete, but I would like to test it out on some data first to see how well it performs. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
