### PR TITLE
style: `max_new_tokens` are set twice with the same value    

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -235,7 +235,6 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
             # Thus only generated text is returned (excluding prompt)
             if is_text_generation and "return_full_text" not in model_input_kwargs:
                 model_input_kwargs["return_full_text"] = False
-                model_input_kwargs["max_new_tokens"] = self.max_length
             if stop_words:
                 sw = StopWordsCriteria(tokenizer=self.pipe.tokenizer, stop_words=stop_words, device=self.pipe.device)
                 model_input_kwargs["stopping_criteria"] = StoppingCriteriaList([sw])


### PR DESCRIPTION
### Related Issues
In the following code snippet, we can see that for text-generation task, `max_new_tokens` are set twice: first set to self.max_length and then overwritten by `max_length` or self.max_length. But the first definition actually doesn't take any effect, because it will be overwritten by the second definition anyway. 
```python
            if is_text_generation and "return_full_text" not in model_input_kwargs:
                model_input_kwargs["return_full_text"] = False
                model_input_kwargs["max_new_tokens"] = self.max_length
            if stop_words:
                sw = StopWordsCriteria(tokenizer=self.pipe.tokenizer, stop_words=stop_words, device=self.pipe.device)
                model_input_kwargs["stopping_criteria"] = StoppingCriteriaList([sw])

            if "num_beams" in model_input_kwargs:
                num_beams = model_input_kwargs["num_beams"]
                if (
                    "num_return_sequences" in model_input_kwargs
                    and model_input_kwargs["num_return_sequences"] > num_beams
                ):
                    num_return_sequences = model_input_kwargs["num_return_sequences"]
                    logger.warning(
                        "num_return_sequences %s should not be larger than num_beams %s, hence setting it equal to num_beams",
                        num_return_sequences,
                        num_beams,
                    )
                    model_input_kwargs["num_return_sequences"] = num_beams

            # max_new_tokens is used for text-generation and max_length for text2text-generation
            if is_text_generation:
                model_input_kwargs["max_new_tokens"] = model_input_kwargs.pop("max_length", self.max_length)
            else:
                model_input_kwargs["max_length"] = self.max_length
```

### Proposed Changes:
Remove the first one

### How did you test it?
N/A

### Notes for the reviewer
N/A
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
