### PR TITLE
fix:Improve log warnings in REST API /health endpoint

### DIFF
--- a/rest_api/rest_api/controller/health.py
+++ b/rest_api/rest_api/controller/health.py
@@ -95,7 +95,7 @@ def get_health_status():
             gpus.append(gpu_info)
 
     except pynvml.NVMLError as e:
-        logger.warning(f"Couldn't collect GPU stats: {str(e)}")
+        logger.warning("Couldn't collect GPU stats: %s", str(e))
     finally:
         pynvml.nvmlShutdown()
 

--- a/rest_api/rest_api/controller/health.py
+++ b/rest_api/rest_api/controller/health.py
@@ -80,10 +80,15 @@ def get_health_status():
                 info = pynvml.nvmlDeviceGetMemoryInfo(handle)
                 gpu_mem_total = float(info.total) / 1024 / 1024
                 gpu_mem_used = None
-                for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
-                    if proc.pid == os.getpid():
-                        gpu_mem_used = float(proc.usedGpuMemory) / 1024 / 1024
-                        break
+                try:
+                    for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                        if proc.pid == os.getpid():
+                            gpu_mem_used = float(proc.usedGpuMemory) / 1024 / 1024
+                            break
+                except pynvml.NVMLError:
+                    # ignore if nvmlDeviceGetComputeRunningProcesses is not supported
+                    # this can happen for outdated drivers
+                    pass
                 gpu_info = GPUInfo(
                     index=i,
                     usage=GPUUsage(

--- a/rest_api/rest_api/controller/health.py
+++ b/rest_api/rest_api/controller/health.py
@@ -92,13 +92,13 @@ def get_health_status():
                     memory_used=round(gpu_mem_used) if gpu_mem_used is not None else None,
                 ),
             )
-
             gpus.append(gpu_info)
-    except pynvml.NVMLError:
-        logger.warning("No NVIDIA GPU found.")
 
-    p_cpu_usage = 0
-    p_memory_usage = 0
+    except pynvml.NVMLError as e:
+        logger.warning(f"Couldn't collect GPU stats: {str(e)}")
+    finally:
+        pynvml.nvmlShutdown()
+
     cpu_count = os.cpu_count() or 1
     p = psutil.Process()
     p_cpu_usage = p.cpu_percent() / cpu_count


### PR DESCRIPTION

### What?
In this PR, we make an improvement to the log warning in the REST API /health endpoint. Specifically, we change the warning message from "No NVIDIA GPU found." to "Couldn't collect GPU stats: <the actual underlying nvml error>".

### Why?
The current warning message is misleading and may cause confusion among users, potentially leading to unnecessary new issues being created. By giving a more descriptive and accurate warning, we aim to provide a better user experience and minimize confusion.

### How can it be used?
This change is internal and does not affect the way users interact with the REST API /health endpoint. The improvement will only affect the content of the log messages generated when a request is made to this endpoint.

### How did you test it?
The testing for this change is still ongoing. Manual testing is currently being conducted to ensure the updated log warning is accurate and provides the desired clarity.

### Notes for the reviewer
Do not integrate yet. This PR is issued to ease communication between the stakeholders involved. 