### PR TITLE
build: upgrade transformers to v4.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
   "requests",
   "pydantic<2",
-  "transformers==4.30.1",
+  "transformers==4.31.0",
   "pandas",
   "rank_bm25",
   "scikit-learn>=1.3.0", # TF-IDF, SklearnQueryClassifier and metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
 
 [project.optional-dependencies]
 inference = [
-  "transformers[torch,sentencepiece]==4.30.1",
+  "transformers[torch,sentencepiece]==4.31.0",
   "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
   "huggingface-hub>=0.5.0",
 ]


### PR DESCRIPTION
### Proposed Changes:
Upgrade transformers to most recent release (18th of July) https://github.com/huggingface/transformers/releases/tag/v4.31.0

### How did you test it?
Let's see whether CI tests pass

### Notes for the reviewer
Some features of the release that are relevant to us are:

- Llama v2
- RoPE scaling for LLaMa and GPTNeoX families of models
