### PR TITLE
docs: Pin `PyYAML` to `5.3.1`

### DIFF
--- a/docs/pydoc/requirements.txt
+++ b/docs/pydoc/requirements.txt
@@ -2,3 +2,4 @@ pydoc-markdown==4.6.4
 # pin docspec while waiting for https://github.com/NiklasRosenstein/docspec/issues/91 to be fixed
 docspec-python<2.1.0
 requests==2.31.0
+PyYAML==5.3.1


### PR DESCRIPTION
### Related Issues

- [Failing workflow](https://github.com/deepset-ai/haystack/pull/5400#issue-1813916701) on `main`

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR pins `PyYAML` to `5.3.1` for our `Sync docs with Readme` workflow. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Workflow is running in the CI of this PR.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
There was a release of a new major version of Cython which doesn't seem to be compatible with PyYAML 5.4.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
