### PR TITLE
chore: bump pydoc-markdown version

### DIFF
--- a/docs/pydoc/requirements.txt
+++ b/docs/pydoc/requirements.txt
@@ -1,5 +1,1 @@
-pydoc-markdown==4.6.4
-# pin docspec while waiting for https://github.com/NiklasRosenstein/docspec/issues/91 to be fixed
-docspec-python<2.1.0
-requests==2.31.0
-PyYAML==5.3.1
+pydoc-markdown==4.8.2


### PR DESCRIPTION
### Related Issues

- fixes pinning a version of PyYAML that's too old

### Proposed Changes:

Update `pydoc-markdown` so we can unpin everything else and get more recent versions of its dependencies

### How did you test it?

Manualyl tested locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
