### PR TITLE
feat: Update Claude support with the latest models, new streaming API, context window sizes

### DIFF
--- a/examples/link_content_blog_post_summary.py
+++ b/examples/link_content_blog_post_summary.py
@@ -2,9 +2,9 @@ import os
 from haystack.nodes import PromptNode, LinkContentFetcher, PromptTemplate
 from haystack import Pipeline
 
-claude_key = os.environ.get("CLAUDE_API_KEY")
-if not claude_key:
-    raise ValueError("Please set the CLAUDE_API_KEY environment variable")
+anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+if not anthropic_key:
+    raise ValueError("Please set the ANTHROPIC_API_KEY environment variable")
 
 retriever = LinkContentFetcher()
 pt = PromptTemplate(
@@ -14,7 +14,7 @@ pt = PromptTemplate(
 )
 
 prompt_node = PromptNode(
-    "claude-instant-1", api_key=claude_key, max_length=512, default_prompt_template=pt, model_kwargs={"stream": True}
+    "claude-instant-1", api_key=anthropic_key, max_length=512, default_prompt_template=pt, model_kwargs={"stream": True}
 )
 
 pipeline = Pipeline()

--- a/examples/link_content_blog_post_summary.py
+++ b/examples/link_content_blog_post_summary.py
@@ -2,9 +2,9 @@ import os
 from haystack.nodes import PromptNode, LinkContentFetcher, PromptTemplate
 from haystack import Pipeline
 
-openai_key = os.environ.get("OPENAI_API_KEY")
-if not openai_key:
-    raise ValueError("Please set the OPENAI_API_KEY environment variable")
+claude_key = os.environ.get("CLAUDE_API_KEY")
+if not claude_key:
+    raise ValueError("Please set the CLAUDE_API_KEY environment variable")
 
 retriever = LinkContentFetcher()
 pt = PromptTemplate(
@@ -14,11 +14,7 @@ pt = PromptTemplate(
 )
 
 prompt_node = PromptNode(
-    "gpt-3.5-turbo-16k-0613",
-    api_key=openai_key,
-    max_length=512,
-    default_prompt_template=pt,
-    model_kwargs={"stream": True},
+    "claude-instant-1", api_key=claude_key, max_length=512, default_prompt_template=pt, model_kwargs={"stream": True}
 )
 
 pipeline = Pipeline()

--- a/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
+++ b/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
@@ -10,11 +10,7 @@ from tokenizers import Tokenizer, Encoding
 
 from haystack.errors import AnthropicError, AnthropicRateLimitError, AnthropicUnauthorizedError
 from haystack.nodes.prompt.invocation_layer.base import PromptModelInvocationLayer
-from haystack.nodes.prompt.invocation_layer.handlers import (
-    TokenStreamingHandler,
-    AnthropicTokenStreamingHandler,
-    DefaultTokenStreamingHandler,
-)
+from haystack.nodes.prompt.invocation_layer.handlers import TokenStreamingHandler, DefaultTokenStreamingHandler
 from haystack.utils import request_with_retry
 from haystack.environment import HAYSTACK_REMOTE_API_MAX_RETRIES, HAYSTACK_REMOTE_API_TIMEOUT_SEC
 
@@ -28,6 +24,11 @@ logger = logging.getLogger(__name__)
 # This is a JSON config to load the tokenizer used for Anthropic Claude.
 CLAUDE_TOKENIZER_REMOTE_FILE = "https://public-json-tokenization-0d8763e8-0d7e-441b-a1e2-1c73b8e79dc3.storage.googleapis.com/claude-v1-tokenization.json"
 
+# these seem identical, but we keep both in case the first one is deprecated
+CLAUDE_TOKENIZER_REMOTE_FILE_2 = (
+    "https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/src/anthropic/tokenizer.json"
+)
+
 
 class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
     """
@@ -35,7 +36,7 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
     This layer invokes the Claude API provided by Anthropic.
     """
 
-    def __init__(self, api_key: str, model_name_or_path: str = "claude-v1", max_length=200, **kwargs):
+    def __init__(self, api_key: str, model_name_or_path: str = "claude-2", max_length=200, **kwargs):
         """
          Creates an instance of PromptModelInvocation Layer for Claude models by Anthropic.
         :param model_name_or_path: The name or path of the underlying model.
@@ -59,19 +60,30 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         supported_kwargs = ["temperature", "top_p", "top_k", "stop_sequences", "stream", "stream_handler"]
         self.model_input_kwargs = {k: v for (k, v) in kwargs.items() if k in supported_kwargs}
 
-        # Number of max tokens is based on the official Anthropic model pricing from:
-        # https://cdn2.assets-servd.host/anthropic-website/production/images/FINAL-PRICING.pdf
-        self.max_tokens_limit = 9000
+        # Number of max tokens is based on the official Anthropic documentation
+        # at https://docs.anthropic.com/claude/docs but it is unclear if older models (i.e. claude-v1)
+        # have a different limit. Allow users to override it with model_max_length
+
+        self.max_tokens_limit = kwargs.get("model_max_length", 100000)
         self.tokenizer: Tokenizer = self._init_tokenizer()
 
     def _init_tokenizer(self) -> Tokenizer:
         # Expire cache after a day
         expire_after = 60 * 60 * 60 * 24
-        # Cache the JSON config to avoid downloading it each time as it's a big file
-        with requests_cache.enabled(expire_after=expire_after):
-            res = request_with_retry(method="GET", url=CLAUDE_TOKENIZER_REMOTE_FILE)
-            res.raise_for_status()
-        return Tokenizer.from_str(res.text)
+        urls = [CLAUDE_TOKENIZER_REMOTE_FILE, CLAUDE_TOKENIZER_REMOTE_FILE_2]
+
+        for url in urls:
+            try:
+                # Cache the JSON config to avoid downloading it each time as it's a big file
+                with requests_cache.enabled(expire_after=expire_after):
+                    res = request_with_retry(method="GET", url=url)
+                    res.raise_for_status()
+                return Tokenizer.from_str(res.text)
+            except Exception as e:
+                logger.warning("Failed to initialize tokenizer from URL %s: %s", url, e)
+
+        # If we've exhausted all URLs without a successful initialization, raise an exception
+        raise Exception(f"Failed to initialize Claude tokenizer from all provided URLs: {', '.join(urls)}")
 
     def invoke(self, *args, **kwargs):
         """
@@ -80,7 +92,7 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         """
 
         human_prompt = "\n\nHuman: "
-        assitant_prompt = "\n\nAssistant: "
+        assistant_prompt = "\n\nAssistant: "
 
         prompt = kwargs.get("prompt")
         if not prompt:
@@ -112,7 +124,7 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         # As specified by Anthropic the prompt must contain both
         # the human and assistant prompt to be valid:
         # https://console.anthropic.com/docs/prompt-design#what-is-a-prompt-
-        prompt = f"{human_prompt}{prompt}{assitant_prompt}"
+        prompt = f"{human_prompt}{prompt}{assistant_prompt}"
 
         data = {
             "model": self.model_name_or_path,
@@ -134,15 +146,13 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         # streamed until that point, so we use a stream handler built ad hoc for this
         # invocation layer.
         handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", DefaultTokenStreamingHandler())
-        handler = AnthropicTokenStreamingHandler(handler)
         client = sseclient.SSEClient(res)
         tokens = []
         try:
             for event in client.events():
-                if event.data == TokenStreamingHandler.DONE_MARKER:
-                    continue
                 ed = json.loads(event.data)
-                tokens.append(handler(ed["completion"]))
+                if "completion" in ed:
+                    tokens.append(handler(ed["completion"]))
         finally:
             client.close()
         return ["".join(tokens)]  # return a list of strings just like non-streaming
@@ -211,7 +221,11 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
                 status_codes_to_retry=status_codes_to_retry,
                 method="POST",
                 url="https://api.anthropic.com/v1/complete",
-                headers={"x-api-key": self.api_key, "Content-Type": "application/json"},
+                headers={
+                    "x-api-key": self.api_key,
+                    "Content-Type": "application/json",
+                    "anthropic-version": "2023-06-01",
+                },
                 data=json.dumps(data),
                 timeout=timeout,
                 **kwargs,
@@ -236,4 +250,5 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         Ensures Anthropic Claude Invocation Layer is selected only when Claude models are specified in
         the model name.
         """
-        return model_name_or_path.startswith(("claude-v1", "claude-instant-v1"))
+        # see https://docs.anthropic.com/claude/reference/selecting-a-model
+        return model_name_or_path.startswith("claude-")

--- a/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
+++ b/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
@@ -22,10 +22,7 @@ logger = logging.getLogger(__name__)
 # Taken from:
 # https://github.com/anthropics/anthropic-sdk-python/blob/main/anthropic/tokenizer.py#L7
 # This is a JSON config to load the tokenizer used for Anthropic Claude.
-CLAUDE_TOKENIZER_REMOTE_FILE = "https://public-json-tokenization-0d8763e8-0d7e-441b-a1e2-1c73b8e79dc3.storage.googleapis.com/claude-v1-tokenization.json"
-
-# these seem identical, but we keep both in case the first one is deprecated
-CLAUDE_TOKENIZER_REMOTE_FILE_2 = (
+CLAUDE_TOKENIZER_REMOTE_FILE = (
     "https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/src/anthropic/tokenizer.json"
 )
 
@@ -70,20 +67,11 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
     def _init_tokenizer(self) -> Tokenizer:
         # Expire cache after a day
         expire_after = 60 * 60 * 60 * 24
-        urls = [CLAUDE_TOKENIZER_REMOTE_FILE, CLAUDE_TOKENIZER_REMOTE_FILE_2]
-
-        for url in urls:
-            try:
-                # Cache the JSON config to avoid downloading it each time as it's a big file
-                with requests_cache.enabled(expire_after=expire_after):
-                    res = request_with_retry(method="GET", url=url)
-                    res.raise_for_status()
-                return Tokenizer.from_str(res.text)
-            except Exception as e:
-                logger.warning("Failed to initialize tokenizer from URL %s: %s", url, e)
-
-        # If we've exhausted all URLs without a successful initialization, raise an exception
-        raise Exception(f"Failed to initialize Claude tokenizer from all provided URLs: {', '.join(urls)}")
+        # Cache the JSON config to avoid downloading it each time as it's a big file
+        with requests_cache.enabled(expire_after=expire_after):
+            res = request_with_retry(method="GET", url=CLAUDE_TOKENIZER_REMOTE_FILE)
+            res.raise_for_status()
+        return Tokenizer.from_str(res.text)
 
     def invoke(self, *args, **kwargs):
         """

--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -40,48 +40,6 @@ class DefaultTokenStreamingHandler(TokenStreamingHandler):
         return token_received
 
 
-class AnthropicTokenStreamingHandler(TokenStreamingHandler):
-    """
-    Anthropic has an unusual way of handling streaming responses
-    as it returns all the tokens generated up to that point for each
-    response.
-    This makes it hard to use DefaultTokenStreamingHandler as the user
-    would see the generated text printed multiple times.
-
-    This streaming handler tackles the repeating text and prints
-    only the newly generated part.
-    """
-
-    def __init__(self, token_handler: TokenStreamingHandler):
-        self.token_handler = token_handler
-        self.previous_text = ""
-
-    def __call__(self, token_received: str, **kwargs) -> str:
-        """
-        When the handler is called directly with a response string from Anthropic,
-        we split it, comparing it with the previously received text by this handler,
-        and return only the new part.
-
-        If the text is completely different from the previously received one, we
-        replace it and return it in full.
-
-        :param token_received: Text response received by Anthropic backend.
-        :type token_received: str
-        :return: The part of text that has not been received previously.
-        :rtype: str
-        """
-        if self.previous_text not in token_received:
-            # The handler is being reused, we want to handle this case gracefully
-            # so we just cleanup the previously received text and keep going
-            self.previous_text = ""
-
-        previous_text_length = len(self.previous_text)
-        chopped_text = token_received[previous_text_length:]
-        self.token_handler(chopped_text)
-        self.previous_text = token_received
-        return chopped_text
-
-
 class HFTokenStreamingHandler(TextStreamer):  # pylint: disable=useless-object-inheritance
     def __init__(
         self,

--- a/test/prompt/test_handlers.py
+++ b/test/prompt/test_handlers.py
@@ -2,11 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from haystack.nodes.prompt.invocation_layer.handlers import (
-    DefaultTokenStreamingHandler,
-    DefaultPromptHandler,
-    AnthropicTokenStreamingHandler,
-)
+from haystack.nodes.prompt.invocation_layer.handlers import DefaultPromptHandler
 
 
 @pytest.mark.unit
@@ -140,29 +136,3 @@ def test_flan_prompt_handler_none():
         "model_max_length": 20,
         "new_prompt_length": 0,
     }
-
-
-@pytest.mark.unit
-@patch("builtins.print")
-def test_anthropic_token_streaming_handler(mock_print):
-    handler = AnthropicTokenStreamingHandler(DefaultTokenStreamingHandler())
-
-    res = handler(" This")
-    assert res == " This"
-    mock_print.assert_called_with(" This", flush=True, end="")
-
-    res = handler(" This is a new")
-    assert res == " is a new"
-    mock_print.assert_called_with(" is a new", flush=True, end="")
-
-    res = handler(" This is a new token")
-    assert res == " token"
-    mock_print.assert_called_with(" token", flush=True, end="")
-
-    res = handler("And now")
-    assert res == "And now"
-    mock_print.assert_called_with("And now", flush=True, end="")
-
-    res = handler("And now something completely different")
-    assert res == " something completely different"
-    mock_print.assert_called_with(" something completely different", flush=True, end="")


### PR DESCRIPTION
### What?

This PR updates several parameters in the AnthropicClaudeInvocationLayer to align it with the recent updates of the Anthropic Claude models, specifically related to their ability to handle larger context window sizes. Additionally, the `examples/link_content_blog_post_summary.py` script has been converted to use Claude models to foster a practice of easy interaction and testing of Anthropic models more often.

### Why?

We want to enable our community to use the latest Anthropic Claude models. These models now offer larger context window sizes, and updating our AnthropicClaudeInvocationLayer will enable us to leverage these improvements fully. Additionally, by integrating Claude models into our example scripts, we provide a straightforward way for users and developers to interact with and test these cutting-edge models.

### How can it be used?

After this update, the AnthropicClaudeInvocationLayer will enable the use of the newer Claude models, yet still enable the use of the old ones (i.e. `claude-v1`). The modifications in `examples/link_content_blog_post_summary.py` offer a live demonstration of how to use Claude models for summarizing blog posts directly from hyperlinks.

### How did you test it?

The functionality of the updated parameters was verified through updated unit tests, ensuring backward compatibility and proper integration with the rest of the system. Manual testing was also conducted using `examples/link_content_blog_post_summary.py` to confirm the correct operation in a practical application context.

### Notes for the reviewer

Be careful in your review :-) 
Test using both old models, i.e. `claude-v1` and the new ones. See https://docs.anthropic.com/claude/reference/selecting-a-model for more details.