### PR TITLE
fix: Error message about weight param in RecentnessRanker

### DIFF
--- a/haystack/nodes/ranker/recentness_ranker.py
+++ b/haystack/nodes/ranker/recentness_ranker.py
@@ -48,7 +48,8 @@ class RecentnessRanker(BaseRanker):
         if self.weight < 0 or self.weight > 1:
             raise NodeError(
                 """
-                Param <weight> needs to be '0', '0.5' or '1' but was set to '{}'. \n
+                Param <weight> needs to be in range [0,1] but was set to '{}'.\n
+                '0' disables sorting by recency, '0.5' gives equal weight to previous relevance scores and recency, and '1' ranks by recency only.\n
                 Please change param <weight> when initializing the RecentnessRanker.
                 """.format(
                     self.weight


### PR DESCRIPTION
### Related Issues

- The error message suggested that only 0, 0.5 and 1.0 are valid values but any value in range [0,1] is valid.

### Proposed Changes:

 Change error message so that it mentions that any value in range [0,1] is valid.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
