### PR TITLE
docs: Add Elasticsearch to API config

### DIFF
--- a/docs/pydoc/config/document-store.yml
+++ b/docs/pydoc/config/document-store.yml
@@ -1,10 +1,11 @@
 loaders:
   - type: python
-    search_path: [../../../haystack/document_stores]
+    search_path: [../../../haystack/document_stores, ../../../haystack/document_stores/elasticsearch]
     modules:
       [
         "base",
-        "elasticsearch",
+        "es7",
+        "es8",
         "opensearch",
         "memory",
         "sql",
@@ -13,6 +14,7 @@ loaders:
         "deepsetcloud",
         "pinecone",
         "search_engine",
+        "elasticsearch.base",
         "utils",
       ]
     ignore_when_discovered: ["__init__"]


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
In #5226, we changed the structure of the `document_stores` package by adding an `elasticsearch` package. This PR adapts the configuration of the of the API reference documentation of the document stores such that we display `ElasticsearchDocumentStore` again.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I manually ran pydoc-markdown, which generated the following markdown file: [document_store_api.md](https://github.com/deepset-ai/haystack/files/12146844/document_store_api.md)

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
