### PR TITLE
chore: add new `sagemaker_meta` invocation layer to API reference

### DIFF
--- a/docs/pydoc/config/invocation-layers.yml
+++ b/docs/pydoc/config/invocation-layers.yml
@@ -14,6 +14,7 @@ loaders:
         "sagemaker_base",
         "sagemaker_hf_infer",
         "sagemaker_hf_text_gen",
+        "sagemaker_meta",
       ]
     ignore_when_discovered: ["__init__"]
 processors:


### PR DESCRIPTION
### Proposed Changes:

- add new `sagemaker_meta` invocation layer to API reference

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
