### PR TITLE
test: Convert two HFLocalInvocationLayer integration to unit tests

### DIFF
--- a/releasenotes/notes/improve-hf-invocation-layer-tests-c42250d11d1d06c1.yaml
+++ b/releasenotes/notes/improve-hf-invocation-layer-tests-c42250d11d1d06c1.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Minor PromptNode HFLocalInvocationLayer test improvements

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -481,46 +481,73 @@ def test_stop_words_not_being_found(stop_words: List[str]):
         assert word in result[0]
 
 
-@pytest.mark.integration
-def test_generation_kwargs_from_constructor():
+@pytest.mark.unit
+def test_generation_kwargs_from_constructor(mock_auto_tokenizer, mock_pipeline, mock_get_task):
     """
     Test that generation_kwargs are correctly passed to pipeline invocation from constructor
     """
     the_question = "What does 42 mean?"
     # test that generation_kwargs are passed to the underlying HF model
     layer = HFLocalInvocationLayer(generation_kwargs={"do_sample": True})
-    with patch.object(layer.pipe, "run_single", MagicMock()) as mock_call:
-        layer.invoke(prompt=the_question)
+    layer.invoke(prompt=the_question)
+    invocation_found = False
+    for call in mock_pipeline.mock_calls:
+        # find the call to pipeline invocation, and check that the kwargs are correct
+        if the_question in call.args:
+            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100}
+            if found_kwargs:
+                invocation_found = True
+                break
 
-    mock_call.assert_called_with(the_question, {}, {"do_sample": True, "max_length": 100}, {})
+    assert invocation_found
 
     # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
     layer = HFLocalInvocationLayer(generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
-    with patch.object(layer.pipe, "run_single", MagicMock()) as mock_call:
-        layer.invoke(prompt=the_question)
+    layer.invoke(prompt=the_question)
+    invocation_found = False
+    for call in mock_pipeline.mock_calls:
+        # find the call to pipeline invocation, and check that the kwargs are correct
+        if the_question in call.args:
+            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100, "top_p": 0.9}
+            if found_kwargs:
+                invocation_found = True
+                break
 
-    mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9, "max_length": 100}, {})
+    assert invocation_found
 
 
-@pytest.mark.integration
-def test_generation_kwargs_from_invoke():
+@pytest.mark.unit
+def test_generation_kwargs_from_invoke(mock_auto_tokenizer, mock_pipeline, mock_get_task):
     """
     Test that generation_kwargs passed to invoke are passed to the underlying HF model
     """
     the_question = "What does 42 mean?"
     # test that generation_kwargs are passed to the underlying HF model
     layer = HFLocalInvocationLayer()
-    with patch.object(layer.pipe, "run_single", MagicMock()) as mock_call:
-        layer.invoke(prompt=the_question, generation_kwargs={"do_sample": True})
+    layer.invoke(prompt=the_question, generation_kwargs={"do_sample": True})
+    invocation_found = False
+    for call in mock_pipeline.mock_calls:
+        # find the call to pipeline invocation, and check that the kwargs are correct
+        if the_question in call.args:
+            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100}
+            if found_kwargs:
+                invocation_found = True
+                break
 
-    mock_call.assert_called_with(the_question, {}, {"do_sample": True, "max_length": 100}, {})
+    assert invocation_found
 
-    # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
     layer = HFLocalInvocationLayer()
-    with patch.object(layer.pipe, "run_single", MagicMock()) as mock_call:
-        layer.invoke(prompt=the_question, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
+    layer.invoke(prompt=the_question, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
+    invocation_found = False
+    for call in mock_pipeline.mock_calls:
+        # find the call to pipeline invocation, and check that the kwargs are correct
+        if the_question in call.args:
+            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100, "top_p": 0.9}
+            if found_kwargs:
+                invocation_found = True
+                break
 
-    mock_call.assert_called_with(the_question, {}, {"do_sample": True, "top_p": 0.9, "max_length": 100}, {})
+    assert invocation_found
 
 
 @pytest.mark.unit

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -486,34 +486,22 @@ def test_generation_kwargs_from_constructor(mock_auto_tokenizer, mock_pipeline, 
     """
     Test that generation_kwargs are correctly passed to pipeline invocation from constructor
     """
-    the_question = "What does 42 mean?"
+    query = "What does 42 mean?"
     # test that generation_kwargs are passed to the underlying HF model
     layer = HFLocalInvocationLayer(generation_kwargs={"do_sample": True})
-    layer.invoke(prompt=the_question)
-    invocation_found = False
-    for call in mock_pipeline.mock_calls:
-        # find the call to pipeline invocation, and check that the kwargs are correct
-        if the_question in call.args:
-            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100}
-            if found_kwargs:
-                invocation_found = True
-                break
-
-    assert invocation_found
+    layer.invoke(prompt=query)
+    assert any(
+        (call.kwargs == {"do_sample": True, "max_length": 100}) and (query in call.args)
+        for call in mock_pipeline.mock_calls
+    )
 
     # test that generation_kwargs in the form of GenerationConfig are passed to the underlying HF model
     layer = HFLocalInvocationLayer(generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
-    layer.invoke(prompt=the_question)
-    invocation_found = False
-    for call in mock_pipeline.mock_calls:
-        # find the call to pipeline invocation, and check that the kwargs are correct
-        if the_question in call.args:
-            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100, "top_p": 0.9}
-            if found_kwargs:
-                invocation_found = True
-                break
-
-    assert invocation_found
+    layer.invoke(prompt=query)
+    assert any(
+        (call.kwargs == {"do_sample": True, "max_length": 100, "top_p": 0.9}) and (query in call.args)
+        for call in mock_pipeline.mock_calls
+    )
 
 
 @pytest.mark.unit
@@ -521,33 +509,21 @@ def test_generation_kwargs_from_invoke(mock_auto_tokenizer, mock_pipeline, mock_
     """
     Test that generation_kwargs passed to invoke are passed to the underlying HF model
     """
-    the_question = "What does 42 mean?"
+    query = "What does 42 mean?"
     # test that generation_kwargs are passed to the underlying HF model
     layer = HFLocalInvocationLayer()
-    layer.invoke(prompt=the_question, generation_kwargs={"do_sample": True})
-    invocation_found = False
-    for call in mock_pipeline.mock_calls:
-        # find the call to pipeline invocation, and check that the kwargs are correct
-        if the_question in call.args:
-            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100}
-            if found_kwargs:
-                invocation_found = True
-                break
-
-    assert invocation_found
+    layer.invoke(prompt=query, generation_kwargs={"do_sample": True})
+    assert any(
+        (call.kwargs == {"do_sample": True, "max_length": 100}) and (query in call.args)
+        for call in mock_pipeline.mock_calls
+    )
 
     layer = HFLocalInvocationLayer()
-    layer.invoke(prompt=the_question, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
-    invocation_found = False
-    for call in mock_pipeline.mock_calls:
-        # find the call to pipeline invocation, and check that the kwargs are correct
-        if the_question in call.args:
-            found_kwargs = call.kwargs == {"do_sample": True, "max_length": 100, "top_p": 0.9}
-            if found_kwargs:
-                invocation_found = True
-                break
-
-    assert invocation_found
+    layer.invoke(prompt=query, generation_kwargs=GenerationConfig(do_sample=True, top_p=0.9))
+    assert any(
+        (call.kwargs == {"do_sample": True, "max_length": 100, "top_p": 0.9}) and (query in call.args)
+        for call in mock_pipeline.mock_calls
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What?
This pull request modifies two existing tests for the `HFLocalInvocationLayer` class, specifically `test_generation_kwargs_from_constructor` and `test_generation_kwargs_from_invoke`. The tests were previously marked as integration tests but have been converted to unit tests in this PR.

### Why?
Unit tests are generally faster and more isolated than integration tests, making them more suitable for testing individual components of a system. By converting these tests from integration to unit tests, we can improve the speed of our test suite overall.

### How can it be used?
These changes do not directly affect the usage of the `HFLocalInvocationLayer` class. However, they do improve the speed of our test suite.

### How did you test it?
The modified tests were run as part of the existing test suite to ensure they still pass after being converted to unit tests. 

### Notes for the reviewer
Please review the changes to ensure that the conversion from integration to unit tests has been done correctly and that all necessary aspects of the `HFLocalInvocationLayer` class are still being tested.
