### PR TITLE
chore: Add a workflow to check the presence of release notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,39 @@
+name: Check Release Notes
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - "!.github/**/*.py"
+      - "!rest_api/**/*.py"
+
+jobs:
+  reno:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+            # With the default value of 1, there are corner cases where tj-actions/changed-files
+            # fails with a `no merge base` error
+            fetch-depth: 0
+
+      - name: Get release note files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: releasenotes/notes/*.yaml
+
+      - name: Check release notes
+        if: steps.changed-files.outputs.any_changed == 'false' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
+        run: |
+            echo "::error::The release notes file is missing, please add one or attach the label 'ignore-for-release-notes' to this PR."
+            exit 1


### PR DESCRIPTION
### Related Issues

- fixes #5426 

### Proposed Changes:

Add a workflow that checks for the presence of a `.yaml` file in the `releasenotes/notes` folder in each PR. The check is skipped if the PR has the `ignore-for-release-notes` label attached.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manually tested on a different repo

### Notes for the reviewer

This check doesn't validate the actual content of the release notes, this might be a nice-to-have follow up.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
