### PR TITLE
feat: support search_fields in DeepsetCloudDocumentStore

### DIFF
--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -428,7 +428,6 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
             scale_score=scale_score,
             headers=headers,
             use_prefiltering=self.use_prefiltering,
-            search_fields=self.search_fields,
         )
         docs = [Document.from_dict(doc) for doc in doc_dicts]
         return docs

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -91,7 +91,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param use_prefiltering: By default, DeepsetCloudDocumentStore uses post-filtering when querying with filters.
                                  To use pre-filtering instead, set this parameter to `True`. Note that pre-filtering
                                  comes at the cost of higher latency.
-        :param search_fields: Name of fields used by BM25Retriever to find matches in the docs to our incoming query, e.g. ["title", "full_text"]
+        :param search_fields: Names of fields BM25Retriever uses to find matches to the incoming query in the documents, for example: ["title", "full_text"].
         """
         self.index = index
         self.label_index = label_index

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -47,6 +47,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         label_index: str = "default",
         embedding_dim: int = 768,
         use_prefiltering: bool = False,
+        search_fields: Union[str, list] = "content",
     ):
         """
         A DocumentStore facade enabling you to interact with the documents stored in deepset Cloud.
@@ -90,6 +91,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param use_prefiltering: By default, DeepsetCloudDocumentStore uses post-filtering when querying with filters.
                                  To use pre-filtering instead, set this parameter to `True`. Note that pre-filtering
                                  comes at the cost of higher latency.
+        :param search_fields: Name of fields used by BM25Retriever to find matches in the docs to our incoming query, e.g. ["title", "full_text"]
         """
         self.index = index
         self.label_index = label_index
@@ -98,6 +100,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         self.return_embedding = return_embedding
         self.embedding_dim = embedding_dim
         self.use_prefiltering = use_prefiltering
+        self.search_fields = search_fields
         self.client = DeepsetCloud.get_index_client(
             api_key=api_key, api_endpoint=api_endpoint, workspace=workspace, index=index
         )
@@ -425,6 +428,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
             scale_score=scale_score,
             headers=headers,
             use_prefiltering=self.use_prefiltering,
+            search_fields=self.search_fields,
         )
         docs = [Document.from_dict(doc) for doc in doc_dicts]
         return docs

--- a/haystack/document_stores/deepsetcloud.py
+++ b/haystack/document_stores/deepsetcloud.py
@@ -91,7 +91,7 @@ class DeepsetCloudDocumentStore(KeywordDocumentStore):
         :param use_prefiltering: By default, DeepsetCloudDocumentStore uses post-filtering when querying with filters.
                                  To use pre-filtering instead, set this parameter to `True`. Note that pre-filtering
                                  comes at the cost of higher latency.
-        :param search_fields: Names of fields BM25Retriever uses to find matches to the incoming query in the documents, for example: ["title", "full_text"].
+        :param search_fields: Names of fields BM25Retriever uses to find matches to the incoming query in the documents, for example: ["content", "title"].
         """
         self.index = index
         self.label_index = label_index

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -381,7 +381,6 @@ class IndexClient:
         scale_score: bool = True,
         headers: Optional[dict] = None,
         use_prefiltering: Optional[bool] = None,
-        search_fields: Optional[Union[str, list]] = None,
     ) -> List[dict]:
         index_url = self._build_index_url(workspace=workspace, index=index)
         query_url = f"{index_url}/documents-query"
@@ -395,7 +394,6 @@ class IndexClient:
             "all_terms_must_match": all_terms_must_match,
             "scale_score": scale_score,
             "use_prefiltering": use_prefiltering,
-            "search_fields": search_fields,
         }
         response = self.client.post(url=query_url, json=request, headers=headers)
         return response.json()

--- a/haystack/utils/deepsetcloud.py
+++ b/haystack/utils/deepsetcloud.py
@@ -381,6 +381,7 @@ class IndexClient:
         scale_score: bool = True,
         headers: Optional[dict] = None,
         use_prefiltering: Optional[bool] = None,
+        search_fields: Optional[Union[str, list]] = None,
     ) -> List[dict]:
         index_url = self._build_index_url(workspace=workspace, index=index)
         query_url = f"{index_url}/documents-query"
@@ -394,6 +395,7 @@ class IndexClient:
             "all_terms_must_match": all_terms_must_match,
             "scale_score": scale_score,
             "use_prefiltering": use_prefiltering,
+            "search_fields": search_fields,
         }
         response = self.client.post(url=query_url, json=request, headers=headers)
         return response.json()

--- a/releasenotes/notes/deepset-cloud-document-store-search-fields-40b2322466f808a3.yaml
+++ b/releasenotes/notes/deepset-cloud-document-store-search-fields-40b2322466f808a3.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    `DeepsetCloudDocumentStore` supports searching multiple fields in sparse queries.
+    `DeepsetCloudDocumentStore` supports searching multiple fields in sparse queries. This enables you to search meta fields as well when using `BM25Retriever`. For example set `search_fields=["content", "title"]` to search the `title` meta field along with the document `content`. 

--- a/releasenotes/notes/deepset-cloud-document-store-search-fields-40b2322466f808a3.yaml
+++ b/releasenotes/notes/deepset-cloud-document-store-search-fields-40b2322466f808a3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    `DeepsetCloudDocumentStore` supports searching multiple fields in sparse queries.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5456

### Proposed Changes:
- add `search_fields` to `DeepsetCloudDocumentStore`

### How did you test it?
- no explicit tests needed, we only want that this param is allowed during Haystack schema validation

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
