### PR TITLE
feat: Add LostInTheMiddleRanker

### DIFF
--- a/docs/pydoc/config/ranker.yml
+++ b/docs/pydoc/config/ranker.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: python
     search_path: [../../../haystack/nodes/ranker]
-    modules: ["base", "sentence_transformers", "recentness_ranker", "diversity"]
+    modules: ["base", "sentence_transformers", "recentness_ranker", "diversity", "lost_in_the_middle"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/examples/web_lfqa_improved.py
+++ b/examples/web_lfqa_improved.py
@@ -2,8 +2,9 @@ import logging
 import os
 
 from haystack import Pipeline
-from haystack.nodes import PromptNode, PromptTemplate, TopPSampler, DocumentMerger
+from haystack.nodes import PromptNode, PromptTemplate, TopPSampler
 from haystack.nodes.ranker.diversity import DiversityRanker
+from haystack.nodes.ranker.lost_in_the_middle import LostInTheMiddleRanker
 from haystack.nodes.retriever.web import WebRetriever
 
 search_key = os.environ.get("SERPERDEV_API_KEY")
@@ -22,21 +23,21 @@ Your answer should be in your own words and be no longer than 50 words.
 """
 
 prompt_node = PromptNode(
-    "gpt-3.5-turbo", default_prompt_template=PromptTemplate(prompt_text), api_key=openai_key, max_length=256
+    "gpt-3.5-turbo", default_prompt_template=PromptTemplate(prompt_text), api_key=openai_key, max_length=640
 )
 
-web_retriever = WebRetriever(api_key=search_key, top_search_results=10, mode="preprocessed_documents", top_k=25)
+web_retriever = WebRetriever(api_key=search_key, top_search_results=5, mode="preprocessed_documents", top_k=50)
 
-sampler = TopPSampler(top_p=0.95)
-ranker = DiversityRanker()
-merger = DocumentMerger(separator="\n\n")
+sampler = TopPSampler(top_p=0.97)
+diversity_ranker = DiversityRanker()
+litm_ranker = LostInTheMiddleRanker(word_count_threshold=1024)
 
 pipeline = Pipeline()
 pipeline.add_node(component=web_retriever, name="Retriever", inputs=["Query"])
 pipeline.add_node(component=sampler, name="Sampler", inputs=["Retriever"])
-pipeline.add_node(component=ranker, name="Ranker", inputs=["Sampler"])
-pipeline.add_node(component=merger, name="Merger", inputs=["Ranker"])
-pipeline.add_node(component=prompt_node, name="PromptNode", inputs=["Merger"])
+pipeline.add_node(component=diversity_ranker, name="DiversityRanker", inputs=["Sampler"])
+pipeline.add_node(component=litm_ranker, name="LostInTheMiddleRanker", inputs=["DiversityRanker"])
+pipeline.add_node(component=prompt_node, name="PromptNode", inputs=["LostInTheMiddleRanker"])
 
 logger = logging.getLogger("boilerpy3")
 logger.setLevel(logging.CRITICAL)

--- a/examples/web_lfqa_improved.py
+++ b/examples/web_lfqa_improved.py
@@ -23,7 +23,7 @@ Your answer should be in your own words and be no longer than 50 words.
 """
 
 prompt_node = PromptNode(
-    "gpt-3.5-turbo", default_prompt_template=PromptTemplate(prompt_text), api_key=openai_key, max_length=640
+    "gpt-3.5-turbo", default_prompt_template=PromptTemplate(prompt_text), api_key=openai_key, max_length=768
 )
 
 web_retriever = WebRetriever(api_key=search_key, top_search_results=5, mode="preprocessed_documents", top_k=50)

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -131,19 +131,3 @@ class LostInTheMiddleRanker(BaseRanker):
                 assert isinstance(cur_docs, list)
                 results.append(self.predict(query="", documents=cur_docs, top_k=top_k))
             return results
-
-    def _truncate(self, document: Document, word_count_threshold: int) -> Document:
-        """
-        Shortens a document by cutting off the content after a specified number of words.
-
-        :param document: Document to truncate.
-        :param word_count_threshold: An integer representing the maximum number of words
-                                     allowed in the truncated document.
-        :return: Document with truncated content.
-        """
-        words = document.content.split()
-        if len(words) > word_count_threshold:
-            # -1 to remove trailing whitespace
-            cut_off = sum(len(word) + 1 for word in words[:word_count_threshold]) - 1
-            document.content = document.content[:cut_off]
-        return document

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -1,0 +1,126 @@
+from typing import Optional, Union, List
+import logging
+
+from haystack.schema import Document
+from haystack.nodes.ranker.base import BaseRanker
+
+logger = logging.getLogger(__name__)
+
+
+class LostInTheMiddleRanker(BaseRanker):
+    """
+    The LostInTheMiddleRanker implements a ranker that reorders documents based on the lost in the middle order.
+    "Lost in the Middle: How Language Models Use Long Contexts" by Liu et al. aims to layout paragraphs into LLM
+    context so that relevant paragraphs are at the beginning or end of the input context, while the least relevant
+    information should be in the middle of a context.
+
+    See https://arxiv.org/abs/2307.03172 for more details.
+    """
+
+    def __init__(self, word_count_threshold: Optional[int] = None, truncate_document: Optional[bool] = False):
+        """
+        Creates an instance of LostInTheMiddleRanker.
+
+        If truncate_document is set to True, you must specify a word_count_threshold as well.
+
+        :param word_count_threshold: The maximum number of words in all ordered documents.
+        :param truncate_document: Whether to truncate the last document that overflows the word count threshold.
+        """
+        super().__init__()
+        if truncate_document and not word_count_threshold:
+            raise ValueError("If truncate_document is set to True, you must specify a word_count_threshold as well.")
+        self.word_count_threshold = word_count_threshold
+        self.truncate_document = truncate_document
+
+    def reorder_documents(self, documents: List[Document]) -> List[Document]:
+        """
+        Orders documents based on the lost in the middle order.
+
+        :param documents: List of Documents to merge.
+        :return: Documents in the lost in the middle order.
+        """
+        if not documents:
+            return []
+        if len(documents) == 1:
+            return documents
+
+        if any(not doc.content_type == "text" for doc in documents):
+            raise ValueError("Some provided documents are not textual; LostInTheMiddleRanker can process only text.")
+
+        word_count = 0
+        document_index = list(range(len(documents)))
+        lost_in_the_middle_indices = [0]
+        if self.word_count_threshold:
+            word_count = len(documents[0].content.split())
+            if word_count >= self.word_count_threshold:
+                return [documents[0]]
+
+        for doc_idx in document_index[1:]:
+            insertion_index = len(lost_in_the_middle_indices) // 2 + len(lost_in_the_middle_indices) % 2
+            lost_in_the_middle_indices.insert(insertion_index, doc_idx)
+            if self.word_count_threshold:
+                word_count += len(documents[doc_idx].content.split())
+                # if threshold is specified, check if we have enough words in all selected documents
+                # if yes, we can stop adding documents
+                if word_count >= self.word_count_threshold:
+                    if self.truncate_document:
+                        # truncate the last document that overflows the word count threshold
+                        last_docs_length = len(documents[doc_idx].content.split())
+                        truncate_last_doc_length = last_docs_length - (word_count - self.word_count_threshold)
+                        documents[doc_idx] = self._truncate(documents[doc_idx], truncate_last_doc_length)
+                    break
+
+        return [documents[idx] for idx in lost_in_the_middle_indices]
+
+    def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None) -> List[Document]:
+        """
+        Reorders documents based on the lost in the middle order.
+
+        :param query: The query to rerank documents for.
+        :param documents: List of Documents to reorder.
+        :param top_k: The number of documents to return.
+
+        :return: The reranked documents.
+        """
+        ordered_docs = self.reorder_documents(documents=documents)
+        return ordered_docs[:top_k] if top_k else ordered_docs
+
+    def predict_batch(
+        self,
+        queries: List[str],
+        documents: Union[List[Document], List[List[Document]]],
+        top_k: Optional[int] = None,
+        batch_size: Optional[int] = None,
+    ) -> Union[List[Document], List[List[Document]]]:
+        """
+        Reorders batch of documents based on the lost in the middle order.
+
+        :param queries: The queries to rerank documents for (ignored).
+        :param documents: List of Documents to reorder.
+        :param top_k: The number of documents to return.
+        :param batch_size: The number of queries to process in one batch.
+
+        :return: The reordered documents.
+        """
+        if len(documents) > 0 and isinstance(documents[0], Document):
+            return self.predict(query="", documents=documents, top_k=top_k)  # type: ignore
+        else:
+            # Docs case 2: list of lists of Documents -> rerank each list of Documents
+            results = []
+            for cur_docs in documents:
+                assert isinstance(cur_docs, list)
+                results.append(self.predict(query="", documents=cur_docs, top_k=top_k))
+            return results
+
+    def _truncate(self, document: Document, word_count_threshold: int) -> Document:
+        """
+        Shortens a document by cutting off the content after a specified number of words.
+
+        :param document: Document to truncate.
+        :param word_count_threshold: integer representing the maximum number of words
+                                     allowed in the truncated document.
+
+        :return: Document with truncated content.
+        """
+        document.content = " ".join(document.content.split()[:word_count_threshold])
+        return document

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -30,6 +30,11 @@ class LostInTheMiddleRanker(BaseRanker):
         :param top_k: The maximum number of documents to return.
         """
         super().__init__()
+        if isinstance(word_count_threshold, int) and word_count_threshold <= 0:
+            raise ValueError(
+                f"Invalid value for word_count_threshold: {word_count_threshold}. "
+                f"word_count_threshold must be a positive integer."
+            )
         self.word_count_threshold = word_count_threshold
         self.top_k = top_k
 
@@ -89,7 +94,7 @@ class LostInTheMiddleRanker(BaseRanker):
         """
         Reranks documents based on the "lost in the middle" order.
 
-        :param query: The query to rerank documents for (ignored).
+        :param query: The query to reorder documents for (ignored).
         :param documents: List of Documents to reorder.
         :param top_k: The number of documents to return.
 

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -12,7 +12,7 @@ class LostInTheMiddleRanker(BaseRanker):
     The LostInTheMiddleRanker implements a ranker that reorders documents based on the lost in the middle order.
     "Lost in the Middle: How Language Models Use Long Contexts" by Liu et al. aims to layout paragraphs into LLM
     context so that relevant paragraphs are at the beginning or end of the input context, while the least relevant
-    information should be in the middle of a context.
+    information is in the middle of the context.
 
     See https://arxiv.org/abs/2307.03172 for more details.
     """

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -131,12 +131,14 @@ class LostInTheMiddleRanker(BaseRanker):
     def _truncate(self, document: Document, word_count_threshold: int) -> Document:
         """
         Shortens a document by cutting off the content after a specified number of words.
-
         :param document: Document to truncate.
         :param word_count_threshold: integer representing the maximum number of words
                                      allowed in the truncated document.
-
         :return: Document with truncated content.
         """
-        document.content = " ".join(document.content.split()[:word_count_threshold])
+        words = document.content.split()
+        if len(words) > word_count_threshold:
+            # -1 to remove trailing whitespace
+            cut_off = sum(len(word) + 1 for word in words[:word_count_threshold]) - 1
+            document.content = document.content[:cut_off]
         return document

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -83,7 +83,8 @@ class LostInTheMiddleRanker(BaseRanker):
         :return: The re-ranked documents.
         """
         ordered_docs = self.reorder_documents(documents=documents)
-        return self._exclude_middle_elements(ordered_docs, top_k) if top_k else ordered_docs
+        valid_top_k = isinstance(top_k, int) and 0 < top_k < len(ordered_docs)
+        return self._exclude_middle_elements(ordered_docs, top_k) if valid_top_k else ordered_docs  # type: ignore
 
     def predict_batch(
         self,
@@ -113,6 +114,8 @@ class LostInTheMiddleRanker(BaseRanker):
             return results
 
     def _exclude_middle_elements(self, ordered_docs: List[Document], top_k: int):
+        if top_k < 1 or top_k > len(ordered_docs):
+            raise ValueError(f"top_k must be between 1 and {len(ordered_docs)}")
         exclude_count = len(ordered_docs) - top_k
         middle_index = len(ordered_docs) // 2
         half_top_k = exclude_count // 2

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -21,7 +21,9 @@ class LostInTheMiddleRanker(BaseRanker):
         """
         Creates an instance of LostInTheMiddleRanker.
 
-        If truncate_document is set to True, you must specify a word_count_threshold as well.
+        If truncate_document is True, you must specify a word_count_threshold as well. If truncate_document is False
+        and word_count_threshold is specified, the word_count_threshold will be used as a soft limit. The last document
+        breaching the word_count_threshold will be included in the resulting list of Documents but won't be truncated.
 
         :param word_count_threshold: The maximum number of words in all ordered documents.
         :param truncate_document: Whether to truncate the last document that overflows the word count threshold.
@@ -34,7 +36,7 @@ class LostInTheMiddleRanker(BaseRanker):
 
     def reorder_documents(self, documents: List[Document]) -> List[Document]:
         """
-        Orders documents based on the lost in the middle order.
+        Orders documents based on the lost in the middle order. Assumes that all documents are ordered by relevance.
 
         :param documents: List of Documents to merge.
         :return: Documents in the lost in the middle order.

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -80,10 +80,10 @@ class LostInTheMiddleRanker(BaseRanker):
         :param documents: List of Documents to reorder.
         :param top_k: The number of documents to return.
 
-        :return: The reranked documents.
+        :return: The re-ranked documents.
         """
         ordered_docs = self.reorder_documents(documents=documents)
-        return ordered_docs[:top_k] if top_k else ordered_docs
+        return self._exclude_middle_elements(ordered_docs, top_k) if top_k else ordered_docs
 
     def predict_batch(
         self,
@@ -111,6 +111,17 @@ class LostInTheMiddleRanker(BaseRanker):
                 assert isinstance(cur_docs, list)
                 results.append(self.predict(query="", documents=cur_docs, top_k=top_k))
             return results
+
+    def _exclude_middle_elements(self, ordered_docs: List[Document], top_k: int):
+        exclude_count = len(ordered_docs) - top_k
+        middle_index = len(ordered_docs) // 2
+        half_top_k = exclude_count // 2
+
+        start_index = middle_index - half_top_k + len(ordered_docs) % 2
+        end_index = start_index + exclude_count
+        remaining_elements = ordered_docs[:start_index] + ordered_docs[end_index:]
+
+        return remaining_elements
 
     def _truncate(self, document: Document, word_count_threshold: int) -> Document:
         """

--- a/haystack/nodes/ranker/lost_in_the_middle.py
+++ b/haystack/nodes/ranker/lost_in_the_middle.py
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 class LostInTheMiddleRanker(BaseRanker):
     """
-    The LostInTheMiddleRanker implements a ranker that reorders documents based on the lost in the middle order.
-    "Lost in the Middle: How Language Models Use Long Contexts" by Liu et al. aims to layout paragraphs into LLM
-    context so that relevant paragraphs are at the beginning or end of the input context, while the least relevant
+    The LostInTheMiddleRanker implements a ranker that reorders documents based on the "lost in the middle" order.
+    "Lost in the Middle: How Language Models Use Long Contexts" paper by Liu et al. aims to lay out paragraphs into LLM
+    context so that the relevant paragraphs are at the beginning or end of the input context, while the least relevant
     information is in the middle of the context.
 
     See https://arxiv.org/abs/2307.03172 for more details.
@@ -36,10 +36,10 @@ class LostInTheMiddleRanker(BaseRanker):
 
     def reorder_documents(self, documents: List[Document]) -> List[Document]:
         """
-        Orders documents based on the lost in the middle order. Assumes that all documents are ordered by relevance.
+        Ranks documents based on the "lost in the middle" order. Assumes that all documents are ordered by relevance.
 
         :param documents: List of Documents to merge.
-        :return: Documents in the lost in the middle order.
+        :return: Documents in the "lost in the middle" order.
         """
 
         # Return empty list if no documents are provided
@@ -93,13 +93,13 @@ class LostInTheMiddleRanker(BaseRanker):
 
     def predict(self, query: str, documents: List[Document], top_k: Optional[int] = None) -> List[Document]:
         """
-        Reorders documents based on the lost in the middle order.
+        Reranks documents based on the "lost in the middle" order.
 
-        :param query: The query to rerank documents for.
+        :param query: The query to reorder documents for.
         :param documents: List of Documents to reorder.
         :param top_k: The number of documents to return.
 
-        :return: The re-ranked documents.
+        :return: The reordered documents.
         """
         ordered_docs = self.reorder_documents(documents=documents)
         valid_top_k = isinstance(top_k, int) and 0 < top_k < len(ordered_docs)
@@ -113,9 +113,9 @@ class LostInTheMiddleRanker(BaseRanker):
         batch_size: Optional[int] = None,
     ) -> Union[List[Document], List[List[Document]]]:
         """
-        Reorders batch of documents based on the lost in the middle order.
+        Reranks batch of documents based on the "lost in the middle" order.
 
-        :param queries: The queries to rerank documents for (ignored).
+        :param queries: The queries to reorder documents for (ignored).
         :param documents: List of Documents to reorder.
         :param top_k: The number of documents to return.
         :param batch_size: The number of queries to process in one batch.
@@ -148,8 +148,9 @@ class LostInTheMiddleRanker(BaseRanker):
     def _truncate(self, document: Document, word_count_threshold: int) -> Document:
         """
         Shortens a document by cutting off the content after a specified number of words.
+
         :param document: Document to truncate.
-        :param word_count_threshold: integer representing the maximum number of words
+        :param word_count_threshold: An integer representing the maximum number of words
                                      allowed in the truncated document.
         :return: Document with truncated content.
         """

--- a/releasenotes/notes/add-lost-in-the-middle-ranker-6ad7dda754fad5a9.yaml
+++ b/releasenotes/notes/add-lost-in-the-middle-ranker-6ad7dda754fad5a9.yaml
@@ -1,0 +1,16 @@
+---
+prelude: >
+    We're excited to introduce a new ranker to Haystack - LostInTheMiddleRanker.
+    It reorders documents based on the "Lost in the Middle" order, a strategy that
+    places the most relevant paragraphs at the beginning or end of the context,
+    while less relevant paragraphs are positioned in the middle. This ranker,
+    based on the research paper "Lost in the Middle: How Language Models Use Long
+    Contexts" by Liu et al., can be leveraged in Retrieval-Augmented Generation
+    (RAG) pipelines.
+features:
+  - |
+    The LostInTheMiddleRanker can be used like other rankers in Haystack. After
+    initializing LostInTheMiddleRanker with the desired parameters, it can be
+    used to rank/reorder a list of documents based on the "Lost in the Middle"
+    order. We advice that you use this ranker in combination with other
+    rankers, and to place it towards the end of the pipeline.

--- a/releasenotes/notes/add-lost-in-the-middle-ranker-6ad7dda754fad5a9.yaml
+++ b/releasenotes/notes/add-lost-in-the-middle-ranker-6ad7dda754fad5a9.yaml
@@ -12,5 +12,7 @@ features:
     The LostInTheMiddleRanker can be used like other rankers in Haystack. After
     initializing LostInTheMiddleRanker with the desired parameters, it can be
     used to rank/reorder a list of documents based on the "Lost in the Middle"
-    order. We advice that you use this ranker in combination with other
-    rankers, and to place it towards the end of the pipeline.
+    order - the most relevant documents are located at the top and bottom of
+    the returned list, while the least relevant documents are found in the
+    middle. We advise that you use this ranker in combination with other rankers,
+    and to place it towards the end of the pipeline.

--- a/test/nodes/test_lost_in_the_middle.py
+++ b/test/nodes/test_lost_in_the_middle.py
@@ -8,8 +8,8 @@ from haystack.nodes.ranker.lost_in_the_middle import LostInTheMiddleRanker
 def test_lost_in_the_middle_order_odd():
     # tests that lost_in_the_middle order works with an odd number of documents
     docs = [Document(str(i)) for i in range(1, 10)]
-    litm = LostInTheMiddleRanker()
-    result, _ = litm.run(query="", documents=docs)
+    ranker = LostInTheMiddleRanker()
+    result, _ = ranker.run(query="", documents=docs)
     assert result["documents"]
     expected_order = "1 3 5 7 9 8 6 4 2".split()
     assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
@@ -23,8 +23,8 @@ def test_batch_lost_in_the_middle_order():
         [Document("5"), Document("6")],
         [Document("7"), Document("8"), Document("9")],
     ]
-    litm = LostInTheMiddleRanker()
-    result, _ = litm.run_batch(queries=[""], documents=docs)
+    ranker = LostInTheMiddleRanker()
+    result, _ = ranker.run_batch(queries=[""], documents=docs)
 
     assert " ".join(doc.content for doc in result["documents"][0]) == "1 3 4 2"
     assert " ".join(doc.content for doc in result["documents"][1]) == "5 6"
@@ -35,8 +35,8 @@ def test_batch_lost_in_the_middle_order():
 def test_lost_in_the_middle_order_even():
     # tests that lost_in_the_middle order works with an even number of documents
     docs = [Document(str(i)) for i in range(1, 11)]
-    litm = LostInTheMiddleRanker()
-    result, _ = litm.run(query="", documents=docs)
+    ranker = LostInTheMiddleRanker()
+    result, _ = ranker.run(query="", documents=docs)
     expected_order = "1 3 5 7 9 10 8 6 4 2".split()
     assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
 
@@ -44,21 +44,21 @@ def test_lost_in_the_middle_order_even():
 @pytest.mark.unit
 def test_lost_in_the_middle_order_corner():
     # tests that lost_in_the_middle order works with some basic corner cases
-    litm = LostInTheMiddleRanker()
+    ranker = LostInTheMiddleRanker()
 
     # empty doc list
     docs = []
-    result, _ = litm.run(query="", documents=docs)
+    result, _ = ranker.run(query="", documents=docs)
     assert len(result["documents"]) == 0
 
     # single doc
     docs = [Document("1")]
-    result, _ = litm.run(query="", documents=docs)
+    result, _ = ranker.run(query="", documents=docs)
     assert result["documents"][0].content == "1"
 
     # two docs
     docs = [Document("1"), Document("2")]
-    result, _ = litm.run(query="", documents=docs)
+    result, _ = ranker.run(query="", documents=docs)
     assert result["documents"][0].content == "1"
     assert result["documents"][1].content == "2"
 
@@ -66,13 +66,13 @@ def test_lost_in_the_middle_order_corner():
 @pytest.mark.unit
 def test_lost_in_the_middle_init():
     # tests that LostInTheMiddleRanker initializes with default values
-    litm = LostInTheMiddleRanker()
-    assert litm.word_count_threshold is None
-    assert litm.truncate_document is False
+    ranker = LostInTheMiddleRanker()
+    assert ranker.word_count_threshold is None
+    assert ranker.truncate_document is False
 
-    litm = LostInTheMiddleRanker(word_count_threshold=10, truncate_document=True)
-    assert litm.word_count_threshold == 10
-    assert litm.truncate_document is True
+    ranker = LostInTheMiddleRanker(word_count_threshold=10, truncate_document=True)
+    assert ranker.word_count_threshold == 10
+    assert ranker.truncate_document is True
 
     with pytest.raises(
         ValueError, match="If truncate_document is set to True, you must specify a word_count_threshold"
@@ -83,14 +83,14 @@ def test_lost_in_the_middle_init():
 @pytest.mark.unit
 def test_lost_in_the_middle_with_word_count_threshold():
     # tests that lost_in_the_middle with word_count_threshold works as expected
-    litm = LostInTheMiddleRanker(word_count_threshold=6)
+    ranker = LostInTheMiddleRanker(word_count_threshold=6)
     docs = [Document("word" + str(i)) for i in range(1, 10)]
-    result, _ = litm.run(query="", documents=docs)
+    result, _ = ranker.run(query="", documents=docs)
     expected_order = "word1 word3 word5 word6 word4 word2".split()
     assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
 
-    litm = LostInTheMiddleRanker(word_count_threshold=9)
-    result, _ = litm.run(query="", documents=docs)
+    ranker = LostInTheMiddleRanker(word_count_threshold=9)
+    result, _ = ranker.run(query="", documents=docs)
     expected_order = "word1 word3 word5 word7 word9 word8 word6 word4 word2".split()
     assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
 
@@ -108,7 +108,7 @@ def test_word_count_threshold_greater_than_total_number_of_words_returns_all_doc
 @pytest.mark.unit
 def test_truncation_with_threshold():
     # tests that truncation works as expected
-    litm = LostInTheMiddleRanker(word_count_threshold=9, truncate_document=True)
+    ranker = LostInTheMiddleRanker(word_count_threshold=9, truncate_document=True)
     docs = [
         Document("word1 word1"),
         Document("word2 word2"),
@@ -120,7 +120,7 @@ def test_truncation_with_threshold():
         Document("word8 word8"),
         Document("word9 word9"),
     ]
-    result, _ = litm.run(query="", documents=docs)
+    result, _ = ranker.run(query="", documents=docs)
     expected_order = "word1 word1 word3 word3 word5 word4 word4 word2 word2"
     assert expected_order == " ".join(doc.content for doc in result["documents"])
 
@@ -141,11 +141,11 @@ def test_list_of_one_document_returns_same_document():
 @pytest.mark.unit
 def test_non_textual_documents():
     #  tests that merging a list of non-textual documents raises a ValueError
-    litm = LostInTheMiddleRanker()
+    ranker = LostInTheMiddleRanker()
     doc1 = Document(content="This is a textual document.")
     doc2 = Document(content_type="image", content="This is a non-textual document.")
     with pytest.raises(ValueError):
-        litm.reorder_documents([doc1, doc2])
+        ranker.reorder_documents([doc1, doc2])
 
 
 @pytest.mark.unit
@@ -153,8 +153,8 @@ def test_non_textual_documents():
 def test_lost_in_the_middle_order_odd_with_top_k(top_k: int):
     # tests that lost_in_the_middle order works with an odd number of documents and a top_k parameter
     docs = [Document(str(i)) for i in range(1, 10)]
-    litm = LostInTheMiddleRanker()
-    result = litm._exclude_middle_elements(docs, top_k=top_k)
+    ranker = LostInTheMiddleRanker()
+    result = ranker._exclude_middle_elements(docs, top_k=top_k)
     assert len(result) == top_k
 
     reverse_top_k = len(docs) - top_k
@@ -168,8 +168,8 @@ def test_lost_in_the_middle_order_odd_with_top_k(top_k: int):
 def test_lost_in_the_middle_order_even_with_top_k(top_k: int):
     # tests that lost_in_the_middle order works with an even number of documents and a top_k parameter
     docs = [Document(str(i)) for i in range(1, 9)]
-    litm = LostInTheMiddleRanker()
-    result = litm._exclude_middle_elements(docs, top_k=top_k)
+    ranker = LostInTheMiddleRanker()
+    result = ranker._exclude_middle_elements(docs, top_k=top_k)
     assert len(result) == top_k
 
     reverse_top_k = len(docs) - top_k

--- a/test/nodes/test_lost_in_the_middle.py
+++ b/test/nodes/test_lost_in_the_middle.py
@@ -64,6 +64,16 @@ def test_lost_in_the_middle_init():
 
 
 @pytest.mark.unit
+def test_lost_in_the_middle_init_invalid_word_count_threshold():
+    # tests that LostInTheMiddleRanker raises an error when word_count_threshold is <= 0
+    with pytest.raises(ValueError, match="Invalid value for word_count_threshold"):
+        LostInTheMiddleRanker(word_count_threshold=0)
+
+    with pytest.raises(ValueError, match="Invalid value for word_count_threshold"):
+        LostInTheMiddleRanker(word_count_threshold=-5)
+
+
+@pytest.mark.unit
 def test_lost_in_the_middle_with_word_count_threshold():
     # tests that lost_in_the_middle with word_count_threshold works as expected
     ranker = LostInTheMiddleRanker(word_count_threshold=6)

--- a/test/nodes/test_lost_in_the_middle.py
+++ b/test/nodes/test_lost_in_the_middle.py
@@ -176,3 +176,23 @@ def test_lost_in_the_middle_order_even_with_top_k(top_k: int):
     middle = len(docs) // 2
     expected_docs = docs[: middle - reverse_top_k // 2] + docs[middle + reverse_top_k // 2 + reverse_top_k % 2 :]
     assert result == expected_docs
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("top_k", [-5, 15])
+def test_lost_in_the_middle_order_odd_with_invalid_top_k(top_k: int):
+    # tests that lost_in_the_middle order works with an odd number of documents and a top_k parameter
+    docs = [Document(str(i)) for i in range(1, 10)]
+    ranker = LostInTheMiddleRanker()
+    with pytest.raises(ValueError):
+        ranker._exclude_middle_elements(docs, top_k=top_k)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("top_k", [-5, 15])
+def test_lost_in_the_middle_order_even_with_invalid_top_k(top_k: int):
+    # tests that lost_in_the_middle order works with an even number of documents and a top_k parameter
+    docs = [Document(str(i)) for i in range(1, 9)]
+    ranker = LostInTheMiddleRanker()
+    with pytest.raises(ValueError):
+        ranker._exclude_middle_elements(docs, top_k=top_k)

--- a/test/nodes/test_lost_in_the_middle.py
+++ b/test/nodes/test_lost_in_the_middle.py
@@ -1,0 +1,189 @@
+import pytest
+
+from haystack import Document
+from haystack.nodes.ranker.lost_in_the_middle import LostInTheMiddleRanker
+
+
+@pytest.mark.unit
+def test_lost_in_the_middle_order_odd():
+    # tests that lost_in_the_middle order works with an odd number of documents
+    docs = [
+        Document("1"),
+        Document("2"),
+        Document("3"),
+        Document("4"),
+        Document("5"),
+        Document("6"),
+        Document("7"),
+        Document("8"),
+        Document("9"),
+    ]
+    dm = LostInTheMiddleRanker()
+    result, _ = dm.run(query="", documents=docs)
+    assert result["documents"]
+    expected_order = "1 3 5 7 9 8 6 4 2".split()
+    assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
+
+
+@pytest.mark.unit
+def test_batch_lost_in_the_middle_order_():
+    # tests that lost_in_the_middle order works with a batch of documents
+    docs = [
+        [Document("1"), Document("2"), Document("3"), Document("4")],
+        [Document("5"), Document("6")],
+        [Document("7"), Document("8"), Document("9")],
+    ]
+    dm = LostInTheMiddleRanker()
+    result, _ = dm.run_batch(queries=[""], documents=docs)
+
+    assert " ".join(doc.content for doc in result["documents"][0]) == "1 3 4 2"
+    assert " ".join(doc.content for doc in result["documents"][1]) == "5 6"
+    assert " ".join(doc.content for doc in result["documents"][2]) == "7 9 8"
+
+
+@pytest.mark.unit
+def test_lost_in_the_middle_order_even():
+    # tests that lost_in_the_middle order works with an even number of documents
+    docs = [
+        Document("1"),
+        Document("2"),
+        Document("3"),
+        Document("4"),
+        Document("5"),
+        Document("6"),
+        Document("7"),
+        Document("8"),
+        Document("9"),
+        Document("10"),
+    ]
+    dm = LostInTheMiddleRanker()
+    result, _ = dm.run(query="", documents=docs)
+    expected_order = "1 3 5 7 9 10 8 6 4 2".split()
+    assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
+
+
+@pytest.mark.unit
+def test_lost_in_the_middle_order_corner():
+    # tests that lost_in_the_middle order works with some basic corner cases
+    dm = LostInTheMiddleRanker()
+
+    # empty doc list
+    docs = []
+    result, _ = dm.run(query="", documents=docs)
+    assert len(result["documents"]) == 0
+
+    # single doc
+    docs = [Document("1")]
+    result, _ = dm.run(query="", documents=docs)
+    assert result["documents"][0].content == "1"
+
+    # two docs
+    docs = [Document("1"), Document("2")]
+    result, _ = dm.run(query="", documents=docs)
+    assert result["documents"][0].content == "1"
+    assert result["documents"][1].content == "2"
+
+
+@pytest.mark.unit
+def test_lost_in_the_middle_init():
+    # tests that LostInTheMiddleRanker initializes with default values
+    litm = LostInTheMiddleRanker()
+    assert litm.word_count_threshold is None
+    assert litm.truncate_document is False
+
+    litm = LostInTheMiddleRanker(word_count_threshold=10, truncate_document=True)
+    assert litm.word_count_threshold == 10
+    assert litm.truncate_document is True
+
+    with pytest.raises(
+        ValueError, match="If truncate_document is set to True, you must specify a word_count_threshold"
+    ):
+        LostInTheMiddleRanker(truncate_document=True)
+
+
+@pytest.mark.unit
+def test_lost_in_the_middle_with_word_count_threshold():
+    # tests that lost_in_the_middle with word_count_threshold works as expected
+    litm = LostInTheMiddleRanker(word_count_threshold=6)
+    docs = [
+        Document("word1"),
+        Document("word2"),
+        Document("word3"),
+        Document("word4"),
+        Document("word5"),
+        Document("word6"),
+        Document("word7"),
+        Document("word8"),
+        Document("word9"),
+    ]
+    result, _ = litm.run(query="", documents=docs)
+    expected_order = "word1 word3 word5 word6 word4 word2".split()
+    assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
+
+    litm = LostInTheMiddleRanker(word_count_threshold=9)
+    result, _ = litm.run(query="", documents=docs)
+    expected_order = "word1 word3 word5 word7 word9 word8 word6 word4 word2".split()
+    assert all(doc.content == expected_order[idx] for idx, doc in enumerate(result["documents"]))
+
+
+@pytest.mark.unit
+def test_word_count_threshold_greater_than_total_number_of_words_returns_all_documents():
+    ranker = LostInTheMiddleRanker(word_count_threshold=100)
+    docs = [
+        Document("word1"),
+        Document("word2"),
+        Document("word3"),
+        Document("word4"),
+        Document("word5"),
+        Document("word6"),
+        Document("word7"),
+        Document("word8"),
+        Document("word9"),
+    ]
+    ordered_docs = ranker.predict(query="test", documents=docs)
+    assert len(ordered_docs) == len(docs)
+    expected_order = "word1 word3 word5 word7 word9 word8 word6 word4 word2".split()
+    assert all(doc.content == expected_order[idx] for idx, doc in enumerate(ordered_docs))
+
+
+@pytest.mark.unit
+def test_truncation_with_threshold():
+    # tests that truncation works as expected
+    litm = LostInTheMiddleRanker(word_count_threshold=9, truncate_document=True)
+    docs = [
+        Document("word1 word1"),
+        Document("word2 word2"),
+        Document("word3 word3"),
+        Document("word4 word4"),
+        Document("word5 word5"),
+        Document("word6 word6"),
+        Document("word7 word7"),
+        Document("word8 word8"),
+        Document("word9 word9"),
+    ]
+    result, _ = litm.run(query="", documents=docs)
+    expected_order = "word1 word1 word3 word3 word5 word4 word4 word2 word2"
+    assert expected_order == " ".join(doc.content for doc in result["documents"])
+
+
+@pytest.mark.unit
+def test_empty_documents_returns_empty_list():
+    ranker = LostInTheMiddleRanker()
+    assert ranker.predict(query="test", documents=[]) == []
+
+
+@pytest.mark.unit
+def test_list_of_one_document_returns_same_document():
+    ranker = LostInTheMiddleRanker()
+    doc = Document(content="test", content_type="text")
+    assert ranker.predict(query="test", documents=[doc]) == [doc]
+
+
+@pytest.mark.unit
+def test_non_textual_documents():
+    #  tests that merging a list of non-textual documents raises a ValueError
+    litm = LostInTheMiddleRanker()
+    doc1 = Document(content="This is a textual document.")
+    doc2 = Document(content_type="image", content="This is a non-textual document.")
+    with pytest.raises(ValueError):
+        litm.reorder_documents([doc1, doc2])

--- a/test/nodes/test_lost_in_the_middle.py
+++ b/test/nodes/test_lost_in_the_middle.py
@@ -42,19 +42,9 @@ def test_lost_in_the_middle_order_even():
 
 
 @pytest.mark.unit
-def test_lost_in_the_middle_order_corner():
-    # tests that lost_in_the_middle order works with some basic corner cases
+def test_lost_in_the_middle_order_two_docs():
+    # tests that lost_in_the_middle order works with two documents
     ranker = LostInTheMiddleRanker()
-
-    # empty doc list
-    docs = []
-    result, _ = ranker.run(query="", documents=docs)
-    assert len(result["documents"]) == 0
-
-    # single doc
-    docs = [Document("1")]
-    result, _ = ranker.run(query="", documents=docs)
-    assert result["documents"][0].content == "1"
 
     # two docs
     docs = [Document("1"), Document("2")]
@@ -144,7 +134,7 @@ def test_non_textual_documents():
     ranker = LostInTheMiddleRanker()
     doc1 = Document(content="This is a textual document.")
     doc2 = Document(content_type="image", content="This is a non-textual document.")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Some provided documents are not textual"):
         ranker.reorder_documents([doc1, doc2])
 
 
@@ -181,7 +171,7 @@ def test_lost_in_the_middle_order_even_with_top_k(top_k: int):
 @pytest.mark.unit
 @pytest.mark.parametrize("top_k", [-5, 15])
 def test_lost_in_the_middle_order_odd_with_invalid_top_k(top_k: int):
-    # tests that lost_in_the_middle order works with an odd number of documents and a top_k parameter
+    # tests that lost_in_the_middle order works with an odd number of documents and an invalid top_k parameter
     docs = [Document(str(i)) for i in range(1, 10)]
     ranker = LostInTheMiddleRanker()
     with pytest.raises(ValueError):
@@ -191,7 +181,7 @@ def test_lost_in_the_middle_order_odd_with_invalid_top_k(top_k: int):
 @pytest.mark.unit
 @pytest.mark.parametrize("top_k", [-5, 15])
 def test_lost_in_the_middle_order_even_with_invalid_top_k(top_k: int):
-    # tests that lost_in_the_middle order works with an even number of documents and a top_k parameter
+    # tests that lost_in_the_middle order works with an even number of documents and an invalid top_k parameter
     docs = [Document(str(i)) for i in range(1, 9)]
     ranker = LostInTheMiddleRanker()
     with pytest.raises(ValueError):


### PR DESCRIPTION
### What?
Introduces a new ranker, `LostInTheMiddleRanker`. This ranker ranks documents based on the "Lost in the Middle" order, designed to position "the best" documents (low index in the given list of documents) at the beginning and the end of the resulting list while placing "the worst" documents (high index in the given list of documents) in the middle. 

### Why?
The "Lost in the Middle" order is a strategy for laying out paragraphs in a way that places the most relevant paragraphs at the beginning or end of the LLMs context window while the least relevant paragraphs are placed in the middle. This strategy is based on the recent research [paper](https://arxiv.org/abs/2307.03172) "Lost in the Middle: How Language Models Use Long Contexts" by Liu et al. Implementing this strategy as a ranker in Haystack allows users to leverage this approach in their RAG pipelines. 

## How can it be used?
The `LostInTheMiddleRanker` can be used like other rankers in Haystack. After initializing the ranker with the desired parameters, it can be used to rank/reorder a list of documents based on the "Lost in the Middle" order.

## How did you test it?
The functionality of the `LostInTheMiddleRanker` has been tested via unit tests in `test/nodes/test_lost_in_the_middle.py` file. These tests ensure the ranker correctly reorders documents and handles edge cases appropriately.

## Notes for the reviewer
Please review the implementation of the `LostInTheMiddleRanker` and its associated tests; perhaps some edge unit test cases were not covered. 