### PR TITLE
fix: restrict `supports` method in the OpenAI invocation layer and a similar method in the `EmbeddingRetriever`

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/azure_open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/azure_open_ai.py
@@ -42,5 +42,7 @@ class AzureOpenAIInvocationLayer(OpenAIInvocationLayer):
         Ensures Azure OpenAI Invocation Layer is selected when `azure_base_url` and `azure_deployment_name` are provided in
         addition to a list of supported models.
         """
-        valid_model = any(m for m in ["ada", "babbage", "davinci", "curie"] if m in model_name_or_path)
+        valid_model = model_name_or_path in ["ada", "babbage", "davinci", "curie"] or any(
+            m in model_name_or_path for m in ["-ada-", "-babbage-", "-davinci-", "-curie-"]
+        )
         return valid_model and has_azure_parameters(**kwargs)

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -231,5 +231,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        valid_model = any(m for m in ["ada", "babbage", "davinci", "curie"] if m in model_name_or_path)
+        valid_model = model_name_or_path in ["ada", "babbage", "davinci", "curie"] or any(
+            m in model_name_or_path for m in ["-ada-", "-babbage-", "-davinci-", "-curie-"]
+        )
         return valid_model and not has_azure_parameters(**kwargs)

--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1873,7 +1873,10 @@ class EmbeddingRetriever(DenseRetriever):
 
     @staticmethod
     def _infer_model_format(model_name_or_path: str, use_auth_token: Optional[Union[str, bool]]) -> str:
-        if any(m in model_name_or_path for m in ["ada", "babbage", "davinci", "curie"]):
+        valid_openai_model_name = model_name_or_path in ["ada", "babbage", "davinci", "curie"] or any(
+            m in model_name_or_path for m in ["-ada-", "-babbage-", "-davinci-", "-curie-"]
+        )
+        if valid_openai_model_name:
             return "openai"
         if model_name_or_path in ["small", "medium", "large", "multilingual-22-12", "finance-sentiment"]:
             return "cohere"

--- a/releasenotes/notes/restrict-openai-supports-method-fb126583e4beb057.yaml
+++ b/releasenotes/notes/restrict-openai-supports-method-fb126583e4beb057.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Restricts the criteria for identifying an OpenAI model in the PromptNode and in the EmbeddingRetriever.
-    Previously, the criteria was quite loose, leading to more false positives.
+    Previously, the criteria were quite loose, leading to more false positives.

--- a/releasenotes/notes/restrict-openai-supports-method-fb126583e4beb057.yaml
+++ b/releasenotes/notes/restrict-openai-supports-method-fb126583e4beb057.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Restricts the criteria for identifying an OpenAI model in the PromptNode.
+    Restricts the criteria for identifying an OpenAI model in the PromptNode and in the EmbeddingRetriever.
     Previously, the criteria was quite loose, leading to more false positives.

--- a/releasenotes/notes/restrict-openai-supports-method-fb126583e4beb057.yaml
+++ b/releasenotes/notes/restrict-openai-supports-method-fb126583e4beb057.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Restricts the criteria for identifying an OpenAI model in the PromptNode.
+    Previously, the criteria was quite loose, leading to more false positives.

--- a/test/prompt/invocation_layer/test_openai.py
+++ b/test/prompt/invocation_layer/test_openai.py
@@ -120,3 +120,18 @@ def test_openai_organization(mock_open_ai_request, load_openai_tokenizer):
 
     invocation_layer.invoke(prompt="dummy_prompt")
     assert mock_open_ai_request.call_args.kwargs["headers"]["OpenAI-Organization"] == "fake_organization"
+
+
+@pytest.mark.unit
+def test_supports(load_openai_tokenizer):
+    layer = OpenAIInvocationLayer(api_key="some_fake_key")
+
+    assert layer.supports("ada")
+    assert layer.supports("babbage")
+    assert layer.supports("curie")
+    assert layer.supports("davinci")
+    assert layer.supports("text-ada-001")
+    assert layer.supports("text-davinci-002")
+
+    # the following model contains "ada" in the name, but it's not from OpenAI
+    assert not layer.supports("ybelkada/mpt-7b-bf16-sharded")


### PR DESCRIPTION
### Related Issues

- fixes #5419

### Proposed Changes:

I found out that the OpenAI invocation layer intercepted the HF model "ybelkada/flan-t5-xl-sharded-bf16" because it has the string "ada" in its name. (In HF, there are > 1000 models containing the string "ada")

We don't particularly like the current invocation layers' "magic" mechanism, but in the meantime, I restricted the criteria to identify an OpenAI model by name.


### How did you test it?
- New unit test: it only tests that now the OpenAI invocation layer recognizes a more limited set of model names.
- Manual test to check the overall behavior.
- (existing tests).

### Notes for the reviewer
Similarly, I updated the Azure invocation layer and the OpenAI model identification in the Retriever.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
