### PR TITLE
chore: Rework docs generation

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8.10
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"


### PR DESCRIPTION
### Proposed Changes:

Change the generated frontmatter in docs markdown to use `parentDoc` ID instead of `parentDocSlug`.
This should fix this kind of failures: https://github.com/deepset-ai/haystack/actions/runs/5724634323/job/15511516957

### How did you test it?

Can't really test it without merging in `main` first.

### Notes for the reviewer

The problem stems from `rdme` CLI fetching the existing document from Readme.io and then updating with the fields from the markdown frontmatter. See [this code snippet](https://github.com/readmeio/rdme/blob/01ed07d63eeeda9be92b4907c59bdf1283a0b4ce/src/cmds/docs/edit.ts#L97-L99).

This causes upload to fail with this message:

> We couldn't save this doc (received both a `parentDoc` and a `parentDocSlug`, expecting only one).

This happens because internally they use `parentDoc` to create hierarchies, so they return that when fetching a doc data. Since we were using `parentDocSlug` in the doc frontmatter merging that with the existing data both keys would be present.

We still use `parentDocSlug` in the yaml configs since it's clearer than the IDs.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
