### PR TITLE
build: Remove upper bound for weaviate client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,12 +146,12 @@ beir = [
   "beir; platform_system != 'Windows'",
 ]
 aws = [
-  "boto3",
+  "boto3<1.28.17",
   # Costraint botocore to avoid taking to much time to resolve the dependency tree.
   # boto3 used to constraint it at this version more than a year ago. To avoid breaking
   # people using old versions we use a similar constraint without upper bound.
   # https://github.com/boto/boto3/blob/dae73bef223abbedfa7317a783070831febc0c90/setup.py#L16
-  "botocore>=1.27",
+  "botocore>=1.27,<1.31.17",
 ]
 crawler = [
   "selenium>=4.0.0,!=4.1.4",  # Avoid 4.1.4 due to https://github.com/SeleniumHQ/selenium/issues/10612

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ faiss-gpu = [
   "farm-haystack[sql,only-faiss-gpu]",
 ]
 weaviate = [
-  "weaviate-client>=3,<3.19.0",
+  "weaviate-client>2",
 ]
 only-pinecone = [
   "pinecone-client>=2.0.11,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ faiss-gpu = [
   "farm-haystack[sql,only-faiss-gpu]",
 ]
 weaviate = [
-  "weaviate-client<3.19.0",
+  "weaviate-client>=3,<3.19.0",
 ]
 only-pinecone = [
   "pinecone-client>=2.0.11,<3",
@@ -146,12 +146,12 @@ beir = [
   "beir; platform_system != 'Windows'",
 ]
 aws = [
-  "boto3<1.28.17",
+  "boto3",
   # Costraint botocore to avoid taking to much time to resolve the dependency tree.
   # boto3 used to constraint it at this version more than a year ago. To avoid breaking
   # people using old versions we use a similar constraint without upper bound.
   # https://github.com/boto/boto3/blob/dae73bef223abbedfa7317a783070831febc0c90/setup.py#L16
-  "botocore>=1.27,<1.31.17",
+  "botocore>=1.27",
 ]
 crawler = [
   "selenium>=4.0.0,!=4.1.4",  # Avoid 4.1.4 due to https://github.com/SeleniumHQ/selenium/issues/10612

--- a/releasenotes/notes/remove-upper-bound-for-weaviate-client-126daeccdbbe6939.yaml
+++ b/releasenotes/notes/remove-upper-bound-for-weaviate-client-126daeccdbbe6939.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Remove upper bound for the version of the Weaviate client.

--- a/releasenotes/notes/remove-upper-bound-for-weaviate-client-126daeccdbbe6939.yaml
+++ b/releasenotes/notes/remove-upper-bound-for-weaviate-client-126daeccdbbe6939.yaml
@@ -1,4 +1,0 @@
----
-enhancements:
-  - |
-    Remove upper bound for the version of the Weaviate client.


### PR DESCRIPTION
### Related Issues

- failing Weaviate tests due to installing version 2 of the client (see this [workflow run](https://github.com/deepset-ai/haystack/actions/runs/5728939628/job/15531313930?pr=5314) for example)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR removes the upper bound for the version of the Weaviate client and ensure to install at least version 3.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Ci is running through.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
