### PR TITLE
fix: TransformersImageToText.generate_captions accepts "str" #5485

### DIFF
--- a/haystack/nodes/image_to_text/transformers.py
+++ b/haystack/nodes/image_to_text/transformers.py
@@ -155,10 +155,19 @@ class TransformersImageToText(BaseImageToText):
         generation_kwargs = generation_kwargs or self.generation_kwargs
         batch_size = batch_size or self.batch_size
 
+    
         if len(image_file_paths) == 0:
             raise ImageToTextError("ImageToText needs at least one file path to produce a caption.")
+        
+        #Handling the case where the user passes a String instead of a List as "image_file_paths"
+        image_file_paths = []
+        if type(image_file_paths) is str:
+            #optional: logger.warning("Expected List, got String instead")
+            image_file_paths2.append(image_file_paths)
+        else: 
+            image_file_paths2 = image_file_paths
 
-        images_dataset = ListDataset(image_file_paths)
+        images_dataset = ListDataset(image_file_paths2)
 
         captions: List[str] = []
 

--- a/haystack/nodes/image_to_text/transformers.py
+++ b/haystack/nodes/image_to_text/transformers.py
@@ -155,16 +155,15 @@ class TransformersImageToText(BaseImageToText):
         generation_kwargs = generation_kwargs or self.generation_kwargs
         batch_size = batch_size or self.batch_size
 
-    
         if len(image_file_paths) == 0:
             raise ImageToTextError("ImageToText needs at least one file path to produce a caption.")
-        
-        #Handling the case where the user passes a String instead of a List as "image_file_paths"
-        image_file_paths = []
+
+        # Handling the case where the user passes a String instead of a List as "image_file_paths"
+        image_file_paths2: List[str] = []
         if type(image_file_paths) is str:
-            #optional: logger.warning("Expected List, got String instead")
-            image_file_paths2.append(image_file_paths)
-        else: 
+            # optional: logger.warning("Expected List, got String instead")
+            image_file_paths2.append(str(image_file_paths))
+        else:
             image_file_paths2 = image_file_paths
 
         images_dataset = ListDataset(image_file_paths2)

--- a/haystack/nodes/image_to_text/transformers.py
+++ b/haystack/nodes/image_to_text/transformers.py
@@ -158,15 +158,12 @@ class TransformersImageToText(BaseImageToText):
         if len(image_file_paths) == 0:
             raise ImageToTextError("ImageToText needs at least one file path to produce a caption.")
 
-        # Handling the case where the user passes a String instead of a List as "image_file_paths"
-        image_file_paths2: List[str] = []
-        if type(image_file_paths) is str:
-            # optional: logger.warning("Expected List, got String instead")
-            image_file_paths2.append(str(image_file_paths))
-        else:
-            image_file_paths2 = image_file_paths
+        if type(image_file_paths) is not list:
+            raise ImageToTextError(
+                "Expected List[str] for image_file_paths, got %s instead" % str(type(image_file_paths))
+            )
 
-        images_dataset = ListDataset(image_file_paths2)
+        images_dataset = ListDataset(image_file_paths)
 
         captions: List[str] = []
 

--- a/releasenotes/notes/fix-issue-#5485-efa4486a414ce584.yaml
+++ b/releasenotes/notes/fix-issue-#5485-efa4486a414ce584.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - fix issue 5485, TransformersImageToText.generate_captions accepts "str"


### PR DESCRIPTION
### Related Issues

- fixes #5485
### Proposed Changes:
If the user passes a string as image_file_paths, an Exception is raised.

### How did you test it?
Manual verification with the code snippet provided by @bilgeyucel in issue #5485 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
