### PR TITLE
feat: Add `top_k` parameter to `DiversityRanker` init method

### DIFF
--- a/releasenotes/notes/diversity-ranker-add-topk-24f23136f316129a.yaml
+++ b/releasenotes/notes/diversity-ranker-add-topk-24f23136f316129a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add top_k parameter to the DiversityRanker init method.

--- a/test/nodes/test_diversity_ranker.py
+++ b/test/nodes/test_diversity_ranker.py
@@ -231,3 +231,37 @@ def test_predict_real_world_use_case(similarity: str):
     result = ranker.predict(query=query, documents=documents)
     expected_order = [doc5, doc7, doc3, doc1, doc4, doc2, doc6, doc8]
     assert result == expected_order
+
+
+@pytest.mark.integration
+def test_diversity_ranker_with_top_k():
+    # Tests that predict method returns the correct order of documents
+    ranker = DiversityRanker(similarity="cosine", top_k=1)
+    query = "test"
+    documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+    result = ranker.predict(query=query, documents=documents)
+    assert len(result) == 1
+
+
+@pytest.mark.integration
+def test_diversity_ranker_with_top_k_edge():
+    # Tests that predict method returns the correct order of documents for edge cases
+    ranker = DiversityRanker(similarity="cosine", top_k=5)
+    query = "test"
+    documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+    result = ranker.predict(query=query, documents=documents)
+    assert len(result) == 3
+
+    # negative top_k should return empty list
+    ranker = DiversityRanker(similarity="cosine", top_k=-5)
+    query = "test"
+    documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+    result = ranker.predict(query=query, documents=documents)
+    assert len(result) == 0
+
+    # we know None is ignored in slice notation, but let's make sure it works
+    ranker = DiversityRanker(similarity="cosine", top_k=None)
+    query = "test"
+    documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+    result = ranker.predict(query=query, documents=documents)
+    assert len(result) == 3


### PR DESCRIPTION
### What
This PR introduces a `top_k` parameter to the `DiversityRanker` class. The `top_k` parameter allows users to specify the number of top documents to be returned after the ranking process.

### Why
The `top_k` parameter provides more flexibility and control to the users over the ranking process. It allows users to limit the number of documents returned, which can be beneficial in scenarios where only the top few documents are of interest.

- fixes https://github.com/deepset-ai/haystack/issues/5489

### How can it be used
The `top_k` parameter can be used during the initialization of the `DiversityRanker` class. Here's an example:

```python
ranker = DiversityRanker(top_k=5)
```

In this example, the `DiversityRanker` will return the top 5 documents after the ranking process.

### How did you test it
The new feature was tested by adding unit tests that check the correct functionality of the `top_k` parameter. The tests ensure that the `DiversityRanker` returns the correct number of documents.

### Notes for the reviewer
Please check the added unit tests for completeness and correctness. Also, please test the new feature in different scenarios to ensure it works as expected.