### PR TITLE
fix: the retriever tool only returns 1 document for top_k=3

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -109,9 +109,7 @@ class Tool:
                         return_content = joined_documents
                     else:
                         return_content = first_result
-                else:
-                    return_content = []
-                return self._process_result(return_content)
+                return self._process_result(return_content if result else [])
             elif isinstance(result, dict):
                 if self.output_variable not in result:
                     raise ValueError(

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -99,7 +99,14 @@ class Tool:
         # Recursive case: process the result based on its type and return the result
         else:
             if isinstance(result, (tuple, list)):
-                return self._process_result(result[0] if result else [])
+                if isinstance(result[0], Document):
+                    joined_documents = ""
+                    for doc in result:
+                        content = doc.content
+                        joined_documents = joined_documents + "" + content
+                    return self._process_result(joined_documents)
+                else:
+                    return self._process_result(result[0] if result else [])
             elif isinstance(result, dict):
                 if self.output_variable not in result:
                     raise ValueError(

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -99,14 +99,19 @@ class Tool:
         # Recursive case: process the result based on its type and return the result
         else:
             if isinstance(result, (tuple, list)):
-                if isinstance(result[0], Document):
-                    joined_documents = ""
-                    for doc in result:
-                        content = doc.content
-                        joined_documents = joined_documents + "" + content
-                    return self._process_result(joined_documents)
+                if result:
+                    first_result = result[0]
+                    if isinstance(first_result, Document):
+                        joined_documents = ""
+                        for doc in result:
+                            content = doc.content
+                            joined_documents = joined_documents + "" + content
+                        return_content = joined_documents
+                    else:
+                        return_content = first_result
                 else:
-                    return self._process_result(result[0] if result else [])
+                    return_content = []
+                return self._process_result(return_content)
             elif isinstance(result, dict):
                 if self.output_variable not in result:
                     raise ValueError(

--- a/releasenotes/notes/enable-retriever-tool-return-more-than-one-document-5cca541f76200c36.yaml
+++ b/releasenotes/notes/enable-retriever-tool-return-more-than-one-document-5cca541f76200c36.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the bug that the retriever tool always return 1 document back regardless how many documents the user wants him to return 

--- a/releasenotes/notes/enable-retriever-tool-return-more-than-one-document-5cca541f76200c36.yaml
+++ b/releasenotes/notes/enable-retriever-tool-return-more-than-one-document-5cca541f76200c36.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix the bug that the retriever tool always return 1 document back regardless how many documents the user wants him to return 
+    Fix the bug that the retriever tool always return 1 document regardless how many documents the user wants him to return


### PR DESCRIPTION
### Related Issues

- fixes #5496 

### Proposed Changes:
- check whether the list contains a Document object, if yes, we should concatenate the content of all Documents together.

### How did you test it?
local test will add unit test if this proposal is accepted

### Notes for the reviewer
In my opinion, this is a bug. But I am not sure whether you guys have some other considerations in the tool logic here. So the proposed change is open for discussion.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
