### PR TITLE
fix: StopWordsCriteria doesn't compare the stop word token ids with the input ids in a continuous and sequential order

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -61,7 +61,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
             generated_text_ids = generated_text_ids[-1]
             len_generated_text_ids = generated_text_ids.size(0)
             len_stop_word = stop_word.size(0)
-            result = generated_text_ids[len_generated_text_ids - len_stop_word :].eq(stop_word).all().item()
+            result = all(generated_text_ids[len_generated_text_ids - len_stop_word :].eq(stop_word))
             return result
 
 

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -51,16 +51,18 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
             self.stop_words = encoded_stop_words.input_ids.to(device)
 
         def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-            stop_result: List[List[bool]] = []
             for stop_word in self.stop_words:
-                stop_result.append([])
-                stop_word_len = len(stop_word)
-                input_id = input_ids[-1]
-                if stop_word_len > len(input_id):
-                    stop_result[-1].append(False)
-                else:
-                    stop_result[-1].append(all(stop_word == input_id[-stop_word_len:]))
-            return any(all(stop_word) for stop_word in stop_result)
+                found_stop_word = self.is_stop_word_found(input_ids, stop_word)
+                if found_stop_word:
+                    return True
+            return False
+
+        def is_stop_word_found(self, generated_text_ids: torch.Tensor, stop_word: torch.Tensor) -> bool:
+            generated_text_ids = generated_text_ids[-1]
+            len_generated_text_ids = generated_text_ids.size(0)
+            len_stop_word = stop_word.size(0)
+            result = generated_text_ids[len_generated_text_ids - len_stop_word :].eq(stop_word).all().item()
+            return result
 
 
 class HFLocalInvocationLayer(PromptModelInvocationLayer):

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -51,7 +51,16 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
             self.stop_words = encoded_stop_words.input_ids.to(device)
 
         def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-            stop_result = torch.isin(self.stop_words, input_ids[-1])
+            stop_result = []
+            for stop_word in self.stop_words:
+                stop_result.append([])
+                stop_word_len = len(stop_word)
+                input_id = input_ids[-1]
+                if stop_word_len > len(input_id):
+                    stop_result[-1].append(False)
+                else:
+                    stop_result[-1].append(all(stop_word == input_id[-stop_word_len:]))
+
             return any(all(stop_word) for stop_word in stop_result)
 
 

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -51,7 +51,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
             self.stop_words = encoded_stop_words.input_ids.to(device)
 
         def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
-            stop_result = []
+            stop_result: List[List[bool]] = []
             for stop_word in self.stop_words:
                 stop_result.append([])
                 stop_word_len = len(stop_word)
@@ -60,7 +60,6 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
                     stop_result[-1].append(False)
                 else:
                     stop_result[-1].append(all(stop_word == input_id[-stop_word_len:]))
-
             return any(all(stop_word) for stop_word in stop_result)
 
 

--- a/releasenotes/notes/fix-stop-words-criteria-check-order-bug-4badfcc021dfc92a.yaml
+++ b/releasenotes/notes/fix-stop-words-criteria-check-order-bug-4badfcc021dfc92a.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix the bug that StopWordsCriteria doesn't check the stop word tokens in a continuous and sequential order
+    Fix StopWordsCriteria not checking stop word tokens in a continuous and sequential order

--- a/releasenotes/notes/fix-stop-words-criteria-check-order-bug-4badfcc021dfc92a.yaml
+++ b/releasenotes/notes/fix-stop-words-criteria-check-order-bug-4badfcc021dfc92a.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix the bug that StopWordsCriteria doesn't check the stop word tokens in a sequential order
+    Fix the bug that StopWordsCriteria doesn't check the stop word tokens in a continuous and sequential order

--- a/releasenotes/notes/fix-stop-words-criteria-check-order-bug-4badfcc021dfc92a.yaml
+++ b/releasenotes/notes/fix-stop-words-criteria-check-order-bug-4badfcc021dfc92a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the bug that StopWordsCriteria doesn't check the stop word tokens in a sequential order

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -481,14 +481,14 @@ def test_stop_words_criteria():
     # input ids for "This is unambiguously"
     input_ids2 = torch.tensor([[100, 19, 73, 24621, 11937]])
 
-    # We used to implement stop words algorithm using the torch.isin function as below.
+    # We used to implement stop words algorithm using the torch.isin function like `all(torch.isin(stop_words_id, input_ids1)[0])`
     # However, this algorithm is not correct as it will return True for presence of "unambiguously" in input_ids1
     # and True for presence of "unambiguously" in input_ids2. This is because the algorithm below will check
     # if the stop word tokens are present in the input_ids, but it does not check if the stop word tokens are
     # present in a continuous/sequential order.
 
     # In "This is ambiguously, but is unrelated." sentence the "un" token comes from "unrelated" and the
-    # "ambiguously" token comes from "ambiguously". The algorithm below will return True for presence of
+    # "ambiguously" token comes from "ambiguously". The algorithm will return True for presence of
     # "unambiguously" in input_ids1 which is not correct.
 
     stop_words_criteria = StopWordsCriteria(tokenizer=Mock(), stop_words=["mock data"])

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -481,7 +481,8 @@ def test_stop_words_criteria():
     # input ids for "This is unambiguously"
     input_ids2 = torch.tensor([[100, 19, 73, 24621, 11937]])
 
-    # We used to implement stop words algorithm using the torch.isin function like `all(torch.isin(stop_words_id, input_ids1)[0])`
+    # We used to implement stop words algorithm using the torch.isin function like this:
+    # `all(torch.isin(stop_words_id, input_ids1)[0])`
     # However, this algorithm is not correct as it will return True for presence of "unambiguously" in input_ids1
     # and True for presence of "unambiguously" in input_ids2. This is because the algorithm will check
     # if the stop word tokens are present in the input_ids, but it does not check if the stop word tokens are

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -467,6 +467,14 @@ def test_stop_words_multiple_token(stop_words: List[str]):
     assert "good" not in result[0]
     assert "health" not in result[0]
 
+    if stop_words == ["unambiguously"]:
+        result = layer.invoke(
+            prompt="Generate a sentence `This is unrelated, but is ambiguously. So unambiguously.`",
+            stop_words=stop_words,
+        )
+        assert len(result) > 0
+        assert "So" in result[0]
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("stop_words", [["Berlin"], ["Berlin", "Brandenburg"], ["Berlin", "Brandenburg", "Germany"]])

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -483,7 +483,7 @@ def test_stop_words_criteria():
 
     # We used to implement stop words algorithm using the torch.isin function like `all(torch.isin(stop_words_id, input_ids1)[0])`
     # However, this algorithm is not correct as it will return True for presence of "unambiguously" in input_ids1
-    # and True for presence of "unambiguously" in input_ids2. This is because the algorithm below will check
+    # and True for presence of "unambiguously" in input_ids2. This is because the algorithm will check
     # if the stop word tokens are present in the input_ids, but it does not check if the stop word tokens are
     # present in a continuous/sequential order.
 

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -473,7 +473,6 @@ def test_stop_words_criteria():
     """
     Test that StopWordsCriteria will check stop word tokens in a continuous and sequential order
     """
-    stop_words = ["unambiguously"]
     # input ids for "unambiguously"
     stop_words_id = torch.tensor([[73, 24621, 11937]])
 
@@ -491,13 +490,8 @@ def test_stop_words_criteria():
     # In "This is ambiguously, but is unrelated." sentence the "un" token comes from "unrelated" and the
     # "ambiguously" token comes from "ambiguously". The algorithm below will return True for presence of
     # "unambiguously" in input_ids1 which is not correct.
-    torch_isin1 = all(torch.isin(stop_words_id, input_ids1)[0])
-    torch_isin2 = all(torch.isin(stop_words_id, input_ids2)[0])
-    assert torch_isin1
-    assert torch_isin2
 
-    tokenizer = Mock()
-    stop_words_criteria = StopWordsCriteria(tokenizer=tokenizer, stop_words=stop_words)
+    stop_words_criteria = StopWordsCriteria(tokenizer=Mock(), stop_words=["mock data"])
     # because we are mocking the tokenizer, we need to set the stop words manually
     stop_words_criteria.stop_words = stop_words_id
 


### PR DESCRIPTION
### Related Issues

- fixes #5502 

### Proposed Changes:
- remove `torch.isin()`
- add logic to examine the sublist in a continuous and sequential order

### How did you test it?
unit test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
