### PR TITLE
fix: Fix datadog client init in benchmarks

### DIFF
--- a/test/benchmarks/datadog/metric_handler.py
+++ b/test/benchmarks/datadog/metric_handler.py
@@ -117,7 +117,7 @@ class MetricsAPI:
 
     @retry(retry=retry_if_exception_type(ConnectionError), wait=wait_fixed(5), stop=stop_after_attempt(3), reraise=True)
     def send_custom_dd_metric(self, metric: CustomDatadogMetric) -> dict:
-        datadog.initialize(api_key=self.datadog_api_key, host_name=self.datadog_host)
+        datadog.initialize(api_key=self.datadog_api_key, api_host=self.datadog_host)
 
         tags: List[str] = list(map(lambda t: str(t.value), metric.tags))
         post_metric_response: Dict = datadog.api.Metric.send(


### PR DESCRIPTION
### Related Issues

Benchmarks data not being ingested

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
