### PR TITLE
feat: Remove template variables from PromptNode invocation kwargs

### DIFF
--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -159,7 +159,7 @@ class PromptNode(BaseComponent):
         if template_to_fill:
             # prompt template used, yield prompts from inputs args
             for prompt in template_to_fill.fill(*args, **kwargs):
-                kwargs_copy = copy.copy(kwargs)
+                kwargs_copy = template_to_fill.remove_template_params(copy.copy(kwargs))
                 # and pass the prepared prompt and kwargs copy to the model
                 prompt = self.prompt_model._ensure_token_limit(prompt)
                 prompt_collector.append(prompt)

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -585,9 +585,12 @@ class PromptTemplate(BasePromptTemplate, ABC):
         :param kwargs: Keyword arguments to remove template parameters from.
         :return: A modified dictionary with the template parameters removed.
         """
-        for param in self.prompt_params:
-            kwargs.pop(param, None)
-        return kwargs
+        if kwargs:
+            for param in self.prompt_params:
+                kwargs.pop(param, None)
+            return kwargs
+        else:
+            return {}
 
     def __repr__(self):
         return f"PromptTemplate(name={self.name}, prompt_text={self.prompt_text}, prompt_params={self.prompt_params})"

--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -578,5 +578,16 @@ class PromptTemplate(BasePromptTemplate, ABC):
             )
             yield prompt_prepared
 
+    def remove_template_params(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Removes template parameters from kwargs.
+
+        :param kwargs: Keyword arguments to remove template parameters from.
+        :return: A modified dictionary with the template parameters removed.
+        """
+        for param in self.prompt_params:
+            kwargs.pop(param, None)
+        return kwargs
+
     def __repr__(self):
         return f"PromptTemplate(name={self.name}, prompt_text={self.prompt_text}, prompt_params={self.prompt_params})"

--- a/releasenotes/notes/remove-template-vars-invocation-kwargs-060f186fd1250fe4.yaml
+++ b/releasenotes/notes/remove-template-vars-invocation-kwargs-060f186fd1250fe4.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Remove template variables from invocation layer kwargs

--- a/test/prompt/test_prompt_template.py
+++ b/test/prompt/test_prompt_template.py
@@ -468,3 +468,26 @@ class TestPromptTemplateSyntax:
         prompt_template = PromptTemplate(prompt_text)
         prompts = [prompt for prompt in prompt_template.fill(documents=documents, query=query)]
         assert prompts == expected_prompts
+
+    def test_prompt_template_remove_template_params(self):
+        kwargs = {"query": "query", "documents": "documents", "other": "other"}
+        expected_kwargs = {"other": "other"}
+        prompt_text = "Here is prompt text with two variables that are also in kwargs: {query} and {documents}"
+        prompt_template = PromptTemplate(prompt_text)
+        assert prompt_template.remove_template_params(kwargs) == expected_kwargs
+
+    def test_prompt_template_remove_template_params_edge_cases(self):
+        """
+        Test that the function works with a variety of edge cases
+        """
+        kwargs = {"query": "query", "documents": "documents"}
+        prompt_text = "Here is prompt text with two variables that are also in kwargs: {query} and {documents}"
+        prompt_template = PromptTemplate(prompt_text)
+        assert prompt_template.remove_template_params(kwargs) == {}
+
+        assert prompt_template.remove_template_params({}) == {}
+
+        assert prompt_template.remove_template_params(None) == {}
+
+        totally_unrelated = {"totally_unrelated": "totally_unrelated"}
+        assert prompt_template.remove_template_params(totally_unrelated) == totally_unrelated


### PR DESCRIPTION
### Why?
The primary motivation behind this change is to simplify the way we handle `kwargs` in the `PromptModel` invocation layers. By removing template parameters from all `kwargs` passed to these layers, we aim to eliminate the "kwarg guards" present in each underlying layer. This change will shift the responsibility of passing the correct `kwargs` to the `PromptNode` user, ensuring a cleaner and more maintainable codebase.

### What?
A new function, `remove_template_params`, has been added to the `PromptTemplate`. This function is designed to process and remove any template parameters from `kwargs` before they are passed on to the invocation layers. This ensures that only the necessary arguments are passed down, reducing the complexity and potential for errors.

### How can it be used?
It's important to note that this is an internal change and won't be directly visible to `PromptNode` users. The primary beneficiaries will be developers and maintainers who will experience a more streamlined and less error-prone codebase.

### How did you test it?
To ensure the robustness of this change, a unit test has been added. This test checks the functionality of the `remove_template_params` function and ensures that it correctly processes `kwargs` before they are passed to the invocation layers.

### Notes For Reviewer
While reviewing this PR, please pay close attention to the implementation of the `remove_template_params` function and its integration with the existing codebase. Ensure that no unintended side effects arise from this change and that all existing functionalities remain intact.
