### PR TITLE
build: pin safetensors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
   "requests",
   "pydantic<2",
   "transformers==4.31.0",
+  "safetensors<0.3.2", # related issue: https://github.com/huggingface/safetensors/issues/314
   "pandas",
   "rank_bm25",
   "scikit-learn>=1.3.0", # TF-IDF, SklearnQueryClassifier and metrics
@@ -90,6 +91,7 @@ dependencies = [
 [project.optional-dependencies]
 inference = [
   "transformers[torch,sentencepiece]==4.31.0",
+  "safetensors<0.3.2", # related issue: https://github.com/huggingface/safetensors/issues/314
   "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
   "huggingface-hub>=0.5.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ dependencies = [
 [project.optional-dependencies]
 inference = [
   "transformers[torch,sentencepiece]==4.31.0",
-  "safetensors<0.3.2", # related issue: https://github.com/huggingface/safetensors/issues/314
   "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
   "huggingface-hub>=0.5.0",
 ]


### PR DESCRIPTION
### Related Issues

Docker image builds are failing: https://github.com/deepset-ai/haystack/actions/runs/5797416046/job/15712906773

It is related to the new release of safetensors (0.3.2).
[safetensors issue](https://github.com/huggingface/safetensors/issues/314)

### Proposed Changes:
Pin safetensors<0.3.2

Should be unpinned when saftensor issue is solved.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
