### PR TITLE
Add `to_dict` and `from_dict` methods for Stores

### DIFF
--- a/haystack/preview/document_stores/errors.py
+++ b/haystack/preview/document_stores/errors.py
@@ -8,3 +8,7 @@ class DuplicateDocumentError(StoreError):
 
 class MissingDocumentError(StoreError):
     pass
+
+
+class StoreDeserializationError(StoreError):
+    pass

--- a/haystack/preview/document_stores/memory/document_store.py
+++ b/haystack/preview/document_stores/memory/document_store.py
@@ -47,6 +47,13 @@ class MemoryDocumentStore:
         self.bm25_algorithm = algorithm_class
         self.bm25_parameters = bm25_parameters or {}
 
+        # Used to convert this instance to a dictionary for serialization
+        self.init_parameters = {
+            "bm25_tokenization_regex": bm25_tokenization_regex,
+            "bm25_algorithm": bm25_algorithm,
+            "bm25_parameters": self.bm25_parameters,
+        }
+
     def count_documents(self) -> int:
         """
         Returns the number of how many documents are present in the document store.

--- a/haystack/preview/document_stores/protocols.py
+++ b/haystack/preview/document_stores/protocols.py
@@ -25,6 +25,17 @@ class Store(Protocol):
     you're using.
     """
 
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes this store to a dictionary.
+        """
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Store":
+        """
+        Deserializes the store from a dictionary.
+        """
+
     def count_documents(self) -> int:
         """
         Returns the number of documents stored.

--- a/releasenotes/notes/stores-serialisation-a09398d158b01ae6.yaml
+++ b/releasenotes/notes/stores-serialisation-a09398d158b01ae6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Add `from_dict` and `to_dict` methods to `Store` `Protocol`
+  - Add default `from_dict` and `to_dict` implementations to classes decorated with `@store`

--- a/test/preview/document_stores/test_decorator.py
+++ b/test/preview/document_stores/test_decorator.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock
+
+import pytest
+
+from haystack.preview.testing.factory import store_class
+from haystack.preview.document_stores.decorator import _default_store_to_dict, _default_store_from_dict
+from haystack.preview.document_stores.errors import StoreDeserializationError
+
+
+@pytest.mark.unit
+def test_default_store_to_dict():
+    MyStore = store_class("MyStore")
+    comp = MyStore()
+    res = _default_store_to_dict(comp)
+    assert res == {"hash": id(comp), "type": "MyStore", "init_parameters": {}}
+
+
+@pytest.mark.unit
+def test_default_store_from_dict():
+    MyStore = store_class("MyStore")
+    comp = _default_store_from_dict(MyStore, {"type": "MyStore"})
+    assert isinstance(comp, MyStore)
+
+
+@pytest.mark.unit
+def test_default_store_from_dict_without_type():
+    with pytest.raises(StoreDeserializationError, match="Missing 'type' in store serialization data"):
+        _default_store_from_dict(Mock, {})
+
+
+@pytest.mark.unit
+def test_default_store_from_dict_unregistered_store(request):
+    # We use the test function name as store name to make sure it's not registered.
+    # Since the registry is global we risk to have a store with the same name registered in another test.
+    store_name = request.node.name
+
+    with pytest.raises(StoreDeserializationError, match=f"Store '{store_name}' can't be deserialized as 'Mock'"):
+        _default_store_from_dict(Mock, {"type": store_name})

--- a/test/preview/document_stores/test_decorator.py
+++ b/test/preview/document_stores/test_decorator.py
@@ -16,10 +16,31 @@ def test_default_store_to_dict():
 
 
 @pytest.mark.unit
+def test_default_store_to_dict_with_custom_init_parameters():
+    extra_fields = {"init_parameters": {"custom_param": True}}
+    MyStore = store_class("MyStore", extra_fields=extra_fields)
+    comp = MyStore()
+    res = _default_store_to_dict(comp)
+    assert res == {"hash": id(comp), "type": "MyStore", "init_parameters": {"custom_param": True}}
+
+
+@pytest.mark.unit
 def test_default_store_from_dict():
     MyStore = store_class("MyStore")
     comp = _default_store_from_dict(MyStore, {"type": "MyStore"})
     assert isinstance(comp, MyStore)
+
+
+@pytest.mark.unit
+def test_default_store_from_dict_with_custom_init_parameters():
+    def store_init(self, custom_param: int):
+        self.custom_param = custom_param
+
+    extra_fields = {"__init__": store_init}
+    MyStore = store_class("MyStore", extra_fields=extra_fields)
+    comp = _default_store_from_dict(MyStore, {"type": "MyStore", "init_parameters": {"custom_param": 100}})
+    assert isinstance(comp, MyStore)
+    assert comp.custom_param == 100
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Proposed Changes:

Add `to_dict` and `from_dict` methods to `Store` `Protocol`.
Also add a default implementation to all classes decoratored with `@store`.

### How did you test it?

Added unit tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
