### PR TITLE
chore: rename `store` to `document_store` for clarity

### DIFF
--- a/haystack/preview/__init__.py
+++ b/haystack/preview/__init__.py
@@ -1,4 +1,4 @@
 from canals.component import component
-from haystack.preview.document_stores.decorator import store
+from haystack.preview.document_stores.decorator import document_store
 from haystack.preview.dataclasses import Document
-from haystack.preview.pipeline import Pipeline, PipelineError, NoSuchStoreError, load_pipelines, save_pipelines
+from haystack.preview.pipeline import Pipeline, PipelineError, NoSuchDocumentStoreError, load_pipelines, save_pipelines

--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -12,7 +12,7 @@ class MemoryRetriever(DocumentStoreAwareMixin):
     Needs to be connected to a MemoryDocumentStore to run.
     """
 
-    supported_stores = [MemoryDocumentStore]
+    supported_document_stores = [MemoryDocumentStore]
 
     def __init__(self, filters: Optional[Dict[str, Any]] = None, top_k: int = 10, scale_score: bool = True):
         """

--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -1,11 +1,11 @@
 from typing import Dict, List, Any, Optional
 
 from haystack.preview import component, Document
-from haystack.preview.document_stores import MemoryDocumentStore, StoreAwareMixin
+from haystack.preview.document_stores import MemoryDocumentStore, DocumentStoreAwareMixin
 
 
 @component
-class MemoryRetriever(StoreAwareMixin):
+class MemoryRetriever(DocumentStoreAwareMixin):
     """
     A component for retrieving documents from a MemoryDocumentStore using the BM25 algorithm.
 
@@ -46,14 +46,16 @@ class MemoryRetriever(StoreAwareMixin):
         :param filters: A dictionary with filters to narrow down the search space.
         :param top_k: The maximum number of documents to return.
         :param scale_score: Whether to scale the BM25 scores or not.
-        :param stores: A dictionary mapping document store names to instances.
+        :param document_stores: A dictionary mapping DocumentStore names to instances.
         :return: The retrieved documents.
 
-        :raises ValueError: If the specified document store is not found or is not a MemoryDocumentStore instance.
+        :raises ValueError: If the specified DocumentStore is not found or is not a MemoryDocumentStore instance.
         """
-        self.store: MemoryDocumentStore
-        if not self.store:
-            raise ValueError("MemoryRetriever needs a store to run: set the store instance to the self.store attribute")
+        self.document_store: MemoryDocumentStore
+        if not self.document_store:
+            raise ValueError(
+                "MemoryRetriever needs a DocumentStore to run: set the DocumentStore instance to the self.document_store attribute"
+            )
 
         if filters is None:
             filters = self.filters
@@ -64,5 +66,7 @@ class MemoryRetriever(StoreAwareMixin):
 
         docs = []
         for query in queries:
-            docs.append(self.store.bm25_retrieval(query=query, filters=filters, top_k=top_k, scale_score=scale_score))
+            docs.append(
+                self.document_store.bm25_retrieval(query=query, filters=filters, top_k=top_k, scale_score=scale_score)
+            )
         return {"documents": docs}

--- a/haystack/preview/document_stores/__init__.py
+++ b/haystack/preview/document_stores/__init__.py
@@ -1,5 +1,5 @@
 from haystack.preview.document_stores.protocols import DocumentStore, DuplicatePolicy
 from haystack.preview.document_stores.mixins import DocumentStoreAwareMixin
 from haystack.preview.document_stores.memory.document_store import MemoryDocumentStore
-from haystack.preview.document_stores.errors import DocumentStore, DuplicateDocumentError, MissingDocumentError
+from haystack.preview.document_stores.errors import DocumentStoreError, DuplicateDocumentError, MissingDocumentError
 from haystack.preview.document_stores.decorator import document_store

--- a/haystack/preview/document_stores/__init__.py
+++ b/haystack/preview/document_stores/__init__.py
@@ -1,5 +1,5 @@
-from haystack.preview.document_stores.protocols import Store, DuplicatePolicy
-from haystack.preview.document_stores.mixins import StoreAwareMixin
+from haystack.preview.document_stores.protocols import DocumentStore, DuplicatePolicy
+from haystack.preview.document_stores.mixins import DocumentStoreAwareMixin
 from haystack.preview.document_stores.memory.document_store import MemoryDocumentStore
-from haystack.preview.document_stores.errors import StoreError, DuplicateDocumentError, MissingDocumentError
-from haystack.preview.document_stores.decorator import store
+from haystack.preview.document_stores.errors import DocumentStore, DuplicateDocumentError, MissingDocumentError
+from haystack.preview.document_stores.decorator import document_store

--- a/haystack/preview/document_stores/decorator.py
+++ b/haystack/preview/document_stores/decorator.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Type
 import logging
 
 from haystack.preview.document_stores.protocols import DocumentStore
-from haystack.preview.document_stores.errors import StoreDeserializationError
+from haystack.preview.document_stores.errors import DocumentStoreDeserializationError
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +30,6 @@ class _DocumentStore:
         self.registry[cls.__name__] = cls
         logger.debug("Registered DocumentStore %s", cls)
 
-        cls.to_dict = _default_document_store_to_dict
-        cls.from_dict = classmethod(_default_document_store_from_dict)
-
         return cls
 
     def __call__(self, cls=None):
@@ -45,7 +42,7 @@ class _DocumentStore:
 document_store = _DocumentStore()
 
 
-def _default_document_store_to_dict(store_: DocumentStore) -> Dict[str, Any]:
+def default_document_store_to_dict(store_: DocumentStore) -> Dict[str, Any]:
     """
     Default DocumentStore serializer.
     Serializes a DocumentStore to a dictionary.
@@ -57,14 +54,16 @@ def _default_document_store_to_dict(store_: DocumentStore) -> Dict[str, Any]:
     }
 
 
-def _default_document_store_from_dict(cls: Type[DocumentStore], data: Dict[str, Any]) -> DocumentStore:
+def default_document_store_from_dict(cls: Type[DocumentStore], data: Dict[str, Any]) -> DocumentStore:
     """
     Default DocumentStore deserializer.
     The "type" field in `data` must match the class that is being deserialized into.
     """
     init_params = data.get("init_parameters", {})
     if "type" not in data:
-        raise StoreDeserializationError("Missing 'type' in DocumentStore serialization data")
+        raise DocumentStoreDeserializationError("Missing 'type' in DocumentStore serialization data")
     if data["type"] != cls.__name__:
-        raise StoreDeserializationError(f"DocumentStore '{data['type']}' can't be deserialized as '{cls.__name__}'")
+        raise DocumentStoreDeserializationError(
+            f"DocumentStore '{data['type']}' can't be deserialized as '{cls.__name__}'"
+        )
     return cls(**init_params)

--- a/haystack/preview/document_stores/decorator.py
+++ b/haystack/preview/document_stores/decorator.py
@@ -1,37 +1,37 @@
 from typing import Dict, Any, Type
 import logging
 
-from haystack.preview.document_stores.protocols import Store
+from haystack.preview.document_stores.protocols import DocumentStore
 from haystack.preview.document_stores.errors import StoreDeserializationError
 
 logger = logging.getLogger(__name__)
 
 
-class _Store:
+class _DocumentStore:
     """
-    Marks a class as an Haystack Store.
-    All classes decorated with @store will be registered here and can be used in Haystack Pipelines.
+    Marks a class as an Haystack _DocumentStore.
+    All classes decorated with @document_store will be registered here and can be used in Haystack Pipelines.
     """
 
     def __init__(self):
         self.registry = {}
 
     def _decorate(self, cls):
-        cls.__haystack_store__ = True
+        cls.__haystack_document_store__ = True
 
         if cls.__name__ in self.registry:
             logger.error(
-                "Store %s is already registered. Previous imported from '%s', new imported from '%s'",
+                "DocumentStore %s is already registered. Previous imported from '%s', new imported from '%s'",
                 cls.__name__,
                 self.registry[cls.__name__],
                 cls,
             )
 
         self.registry[cls.__name__] = cls
-        logger.debug("Registered Store %s", cls)
+        logger.debug("Registered DocumentStore %s", cls)
 
-        cls.to_dict = _default_store_to_dict
-        cls.from_dict = classmethod(_default_store_from_dict)
+        cls.to_dict = _default_document_store_to_dict
+        cls.from_dict = classmethod(_default_document_store_from_dict)
 
         return cls
 
@@ -42,13 +42,13 @@ class _Store:
         return self._decorate
 
 
-store = _Store()
+document_store = _DocumentStore()
 
 
-def _default_store_to_dict(store_: Store) -> Dict[str, Any]:
+def _default_document_store_to_dict(store_: DocumentStore) -> Dict[str, Any]:
     """
-    Default store serializer.
-    Serializes a store to a dictionary.
+    Default DocumentStore serializer.
+    Serializes a DocumentStore to a dictionary.
     """
     return {
         "hash": id(store_),
@@ -57,14 +57,14 @@ def _default_store_to_dict(store_: Store) -> Dict[str, Any]:
     }
 
 
-def _default_store_from_dict(cls: Type[Store], data: Dict[str, Any]) -> Store:
+def _default_document_store_from_dict(cls: Type[DocumentStore], data: Dict[str, Any]) -> DocumentStore:
     """
-    Default store deserializer.
+    Default DocumentStore deserializer.
     The "type" field in `data` must match the class that is being deserialized into.
     """
     init_params = data.get("init_parameters", {})
     if "type" not in data:
-        raise StoreDeserializationError("Missing 'type' in store serialization data")
+        raise StoreDeserializationError("Missing 'type' in DocumentStore serialization data")
     if data["type"] != cls.__name__:
-        raise StoreDeserializationError(f"Store '{data['type']}' can't be deserialized as '{cls.__name__}'")
+        raise StoreDeserializationError(f"DocumentStore '{data['type']}' can't be deserialized as '{cls.__name__}'")
     return cls(**init_params)

--- a/haystack/preview/document_stores/errors.py
+++ b/haystack/preview/document_stores/errors.py
@@ -1,16 +1,16 @@
-class DocumentStore(Exception):
+class DocumentStoreError(Exception):
     pass
 
 
-class FilterError(DocumentStore):
+class FilterError(DocumentStoreError):
     pass
 
 
-class DuplicateDocumentError(DocumentStore):
+class DuplicateDocumentError(DocumentStoreError):
     pass
 
 
-class MissingDocumentError(DocumentStore):
+class MissingDocumentError(DocumentStoreError):
     pass
 
 

--- a/haystack/preview/document_stores/errors.py
+++ b/haystack/preview/document_stores/errors.py
@@ -14,5 +14,5 @@ class MissingDocumentError(DocumentStoreError):
     pass
 
 
-class StoreDeserializationError(StoreError):
+class DocumentStoreDeserializationError(DocumentStoreError):
     pass

--- a/haystack/preview/document_stores/errors.py
+++ b/haystack/preview/document_stores/errors.py
@@ -1,16 +1,16 @@
-class StoreError(Exception):
+class DocumentStore(Exception):
     pass
 
 
-class FilterError(StoreError):
+class FilterError(DocumentStore):
     pass
 
 
-class DuplicateDocumentError(StoreError):
+class DuplicateDocumentError(DocumentStore):
     pass
 
 
-class MissingDocumentError(StoreError):
+class MissingDocumentError(DocumentStore):
     pass
 
 

--- a/haystack/preview/document_stores/memory/document_store.py
+++ b/haystack/preview/document_stores/memory/document_store.py
@@ -7,9 +7,13 @@ import numpy as np
 import rank_bm25
 from tqdm.auto import tqdm
 
-from haystack.preview.document_stores.decorator import document_store
+from haystack.preview.document_stores.decorator import (
+    document_store,
+    default_document_store_to_dict,
+    default_document_store_from_dict,
+)
 from haystack.preview.dataclasses import Document
-from haystack.preview.document_stores.protocols import DuplicatePolicy
+from haystack.preview.document_stores.protocols import DuplicatePolicy, DocumentStore
 from haystack.preview.document_stores.memory._filters import match
 from haystack.preview.document_stores.errors import DuplicateDocumentError, MissingDocumentError
 from haystack.utils.scipy_utils import expit
@@ -53,6 +57,19 @@ class MemoryDocumentStore:
             "bm25_algorithm": bm25_algorithm,
             "bm25_parameters": self.bm25_parameters,
         }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes this store to a dictionary.
+        """
+        return default_document_store_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentStore":
+        """
+        Deserializes the store from a dictionary.
+        """
+        return default_document_store_from_dict(cls, data)
 
     def count_documents(self) -> int:
         """

--- a/haystack/preview/document_stores/memory/document_store.py
+++ b/haystack/preview/document_stores/memory/document_store.py
@@ -7,7 +7,7 @@ import numpy as np
 import rank_bm25
 from tqdm.auto import tqdm
 
-from haystack.preview.document_stores.decorator import store
+from haystack.preview.document_stores.decorator import document_store
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores.protocols import DuplicatePolicy
 from haystack.preview.document_stores.memory._filters import match
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 SCALING_FACTOR = 8
 
 
-@store
+@document_store
 class MemoryDocumentStore:
     """
     Stores data in-memory. It's ephemeral and cannot be saved to disk.
@@ -37,7 +37,7 @@ class MemoryDocumentStore:
         bm25_parameters: Optional[Dict] = None,
     ):
         """
-        Initializes the store.
+        Initializes the DocumentStore.
         """
         self.storage: Dict[str, Document] = {}
         self.tokenizer = re.compile(bm25_tokenization_regex).findall
@@ -56,7 +56,7 @@ class MemoryDocumentStore:
 
     def count_documents(self) -> int:
         """
-        Returns the number of how many documents are present in the document store.
+        Returns the number of how many documents are present in the DocumentStore.
         """
         return len(self.storage.keys())
 
@@ -137,11 +137,11 @@ class MemoryDocumentStore:
 
     def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> None:
         """
-        Writes (or overwrites) documents into the store.
+        Writes (or overwrites) documents into the DocumentStore.
 
         :param documents: a list of documents.
         :param policy: documents with the same ID count as duplicates. When duplicates are met,
-            the store can:
+            the DocumentStore can:
              - skip: keep the existing document and ignore the new one.
              - overwrite: remove the old document and write the new one.
              - fail: an error is raised
@@ -165,8 +165,8 @@ class MemoryDocumentStore:
 
     def delete_documents(self, document_ids: List[str]) -> None:
         """
-        Deletes all documents with a matching document_ids from the document store.
-        Fails with `MissingDocumentError` if no document with this id is present in the store.
+        Deletes all documents with a matching document_ids from the DocumentStore.
+        Fails with `MissingDocumentError` if no document with this id is present in the DocumentStore.
 
         :param object_ids: the object_ids to delete
         """
@@ -218,7 +218,7 @@ class MemoryDocumentStore:
                 csv_content = str_content.to_csv(index=False)
                 lower_case_documents.append(csv_content.lower())
 
-        # Tokenize the entire content of the document store
+        # Tokenize the entire content of the DocumentStore
         tokenized_corpus = [
             self.tokenizer(doc) for doc in tqdm(lower_case_documents, unit=" docs", desc="Ranking by BM25...")
         ]

--- a/haystack/preview/document_stores/mixins.py
+++ b/haystack/preview/document_stores/mixins.py
@@ -21,7 +21,7 @@ class DocumentStoreAwareMixin:
 
     @property
     def document_store(self) -> Optional[DocumentStore]:
-        return self._store
+        return self._document_store
 
     @document_store.setter
     def document_store(self, document_store: DocumentStore):
@@ -30,7 +30,7 @@ class DocumentStoreAwareMixin:
         if not self._is_supported(document_store):
             raise ValueError(
                 f"DocumentStore type '{type(document_store).__name__}' is not compatible with this component. "
-                f"Compatible DocumentStore types: {[type_.__name__ for type_ in type(self).supported_stores]}"
+                f"Compatible DocumentStore types: {[type_.__name__ for type_ in type(self).supported_document_stores]}"
             )
         self._document_store = document_store
 

--- a/haystack/preview/document_stores/mixins.py
+++ b/haystack/preview/document_stores/mixins.py
@@ -25,8 +25,8 @@ class DocumentStoreAwareMixin:
 
     @document_store.setter
     def document_store(self, document_store: DocumentStore):
-        if not getattr(document_store, "__haystack_store__", False):
-            raise ValueError(f"'{type(document_store).__name__}' is not decorate with @store.")
+        if not getattr(document_store, "__haystack_document_store__", False):
+            raise ValueError(f"'{type(document_store).__name__}' is not decorate with @document_store.")
         if not self._is_supported(document_store):
             raise ValueError(
                 f"DocumentStore type '{type(document_store).__name__}' is not compatible with this component. "

--- a/haystack/preview/document_stores/mixins.py
+++ b/haystack/preview/document_stores/mixins.py
@@ -1,40 +1,40 @@
 from typing import List, Optional, Type
 
 
-from haystack.preview.document_stores.protocols import Store
+from haystack.preview.document_stores.protocols import DocumentStore
 
 
-class StoreAwareMixin:
+class DocumentStoreAwareMixin:
     """
-    Adds the capability of a component to use a single document store from the `self.store` property.
+    Adds the capability of a component to use a single DocumentStore from the `self.document_store` property.
 
-    To use this mixin you must specify which document stores to support by setting a value to `supported_stores`.
-    To support any document store, set it to `[Store]`.
+    To use this mixin you must specify which DocumentStores to support by setting a value to `supported_stores`.
+    To support any DocumentStore, set it to `[DocumentStore]`.
     """
 
-    _store: Optional[Store] = None
+    _document_store: Optional[DocumentStore] = None
     # This is necessary to ease serialisation when converting a Component that uses
-    # a Store into a dictionary.
+    # a DocumentStore into a dictionary.
     # This is only set when calling `Pipeline.add_component()`.
-    _store_name: str = ""
-    supported_stores: List[Type[Store]]  # type: ignore # (see https://github.com/python/mypy/issues/4717)
+    _document_store_name: str = ""
+    supported_document_stores: List[Type[DocumentStore]]  # type: ignore # (see https://github.com/python/mypy/issues/4717)
 
     @property
-    def store(self) -> Optional[Store]:
+    def document_store(self) -> Optional[DocumentStore]:
         return self._store
 
-    @store.setter
-    def store(self, store: Store):
-        if not getattr(store, "__haystack_store__", False):
-            raise ValueError(f"'{type(store).__name__}' is not decorate with @store.")
-        if not self._is_supported(store):
+    @document_store.setter
+    def document_store(self, document_store: DocumentStore):
+        if not getattr(document_store, "__haystack_store__", False):
+            raise ValueError(f"'{type(document_store).__name__}' is not decorate with @store.")
+        if not self._is_supported(document_store):
             raise ValueError(
-                f"Store type '{type(store).__name__}' is not compatible with this component. "
-                f"Compatible store types: {[type_.__name__ for type_ in type(self).supported_stores]}"
+                f"DocumentStore type '{type(document_store).__name__}' is not compatible with this component. "
+                f"Compatible DocumentStore types: {[type_.__name__ for type_ in type(self).supported_stores]}"
             )
-        self._store = store
+        self._document_store = document_store
 
-    def _is_supported(self, store: Store):
-        if Store in self.supported_stores:
+    def _is_supported(self, document_store: DocumentStore):
+        if DocumentStore in self.supported_document_stores:
             return True
-        return any(isinstance(store, type_) for type_ in self.supported_stores)
+        return any(isinstance(document_store, type_) for type_ in self.supported_document_stores)

--- a/haystack/preview/document_stores/protocols.py
+++ b/haystack/preview/document_stores/protocols.py
@@ -31,7 +31,7 @@ class DocumentStore(Protocol):
         """
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Store":
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentStore":
         """
         Deserializes the store from a dictionary.
         """

--- a/haystack/preview/document_stores/protocols.py
+++ b/haystack/preview/document_stores/protocols.py
@@ -14,14 +14,14 @@ class DuplicatePolicy(Enum):
     FAIL = "fail"
 
 
-class Store(Protocol):
+class DocumentStore(Protocol):
     """
     Stores Documents to be used by the components of a Pipeline.
 
     Classes implementing this protocol often store the documents permanently and allow specialized components to
     perform retrieval on them, either by embedding, by keyword, hybrid, and so on, depending on the backend used.
 
-    In order to retrieve documents, consider using a Retriever that supports the document store implementation that
+    In order to retrieve documents, consider using a Retriever that supports the DocumentStore implementation that
     you're using.
     """
 
@@ -115,11 +115,11 @@ class Store(Protocol):
 
     def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> None:
         """
-        Writes (or overwrites) documents into the store.
+        Writes (or overwrites) documents into the DocumentStore.
 
         :param documents: a list of documents.
         :param policy: documents with the same ID count as duplicates. When duplicates are met,
-            the store can:
+            the DocumentStore can:
              - skip: keep the existing document and ignore the new one.
              - overwrite: remove the old document and write the new one.
              - fail: an error is raised
@@ -129,8 +129,8 @@ class Store(Protocol):
 
     def delete_documents(self, document_ids: List[str]) -> None:
         """
-        Deletes all documents with a matching document_ids from the document store.
-        Fails with `MissingDocumentError` if no document with this id is present in the store.
+        Deletes all documents with a matching document_ids from the DocumentStore.
+        Fails with `MissingDocumentError` if no document with this id is present in the DocumentStore.
 
         :param object_ids: the object_ids to delete
         """

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -9,100 +9,100 @@ from canals.pipeline import (
     save_pipelines as save_canals_pipelines,
 )
 
-from haystack.preview.document_stores.protocols import Store
-from haystack.preview.document_stores.mixins import StoreAwareMixin
+from haystack.preview.document_stores.protocols import DocumentStore
+from haystack.preview.document_stores.mixins import DocumentStoreAwareMixin
 
 
-class NotAStoreError(PipelineError):
+class NotADocumentStoreError(PipelineError):
     pass
 
 
-class NoSuchStoreError(PipelineError):
+class NoSuchDocumentStoreError(PipelineError):
     pass
 
 
 class Pipeline(CanalsPipeline):
     """
-    Haystack Pipeline is a thin wrapper over Canals' Pipelines to add support for Stores.
+    Haystack Pipeline is a thin wrapper over Canals' Pipelines to add support for DocumentStores.
     """
 
     def __init__(self):
         super().__init__()
-        self._stores: Dict[str, Store] = {}
+        self._document_stores: Dict[str, DocumentStore] = {}
 
-    def add_store(self, name: str, store: Store) -> None:
+    def add_document_store(self, name: str, document_store: DocumentStore) -> None:
         """
-        Make a store available to all nodes of this pipeline.
+        Make a DocumentStore available to all nodes of this pipeline.
 
-        :param name: the name of the store.
-        :param store: the store object.
+        :param name: the name of the DocumentStore.
+        :param document_store: the DocumentStore object.
         :returns: None
         """
-        if not getattr(store, "__haystack_store__", False):
-            raise NotAStoreError(
-                f"'{type(store).__name__}' is not decorated with @store, "
-                "so it can't be added to the pipeline with Pipeline.add_store()."
+        if not getattr(document_store, "__haystack_document_store__", False):
+            raise NotADocumentStoreError(
+                f"'{type(document_store).__name__}' is not decorated with @document_store, "
+                "so it can't be added to the pipeline with Pipeline.add_document_store()."
             )
-        self._stores[name] = store
+        self._document_stores[name] = document_store
 
-    def list_stores(self) -> List[str]:
+    def list_document_stores(self) -> List[str]:
         """
-        Returns a dictionary with all the stores that are attached to this Pipeline.
+        Returns a dictionary with all the DocumentStores that are attached to this Pipeline.
 
-        :returns: a dictionary with all the stores attached to this Pipeline.
+        :returns: a dictionary with all the DocumentStores attached to this Pipeline.
         """
-        return list(self._stores.keys())
+        return list(self._document_stores.keys())
 
-    def get_store(self, name: str) -> Store:
+    def get_document_store(self, name: str) -> DocumentStore:
         """
-        Returns the store associated with the given name.
+        Returns the DocumentStore associated with the given name.
 
-        :param name: the name of the store
-        :returns: the store
+        :param name: the name of the DocumentStore
+        :returns: the DocumentStore
         """
         try:
-            return self._stores[name]
+            return self._document_stores[name]
         except KeyError as e:
-            raise NoSuchStoreError(f"No store named '{name}' is connected to this pipeline.") from e
+            raise NoSuchDocumentStoreError(f"No DocumentStore named '{name}' was added to this pipeline.") from e
 
-    def add_component(self, name: str, instance: Any, store: Optional[str] = None) -> None:
+    def add_component(self, name: str, instance: Any, document_store: Optional[str] = None) -> None:
         """
         Make this component available to the pipeline. Components are not connected to anything by default:
         use `Pipeline.connect()` to connect components together.
 
         Component names must be unique, but component instances can be reused if needed.
 
-        If `store` has a value, the pipeline will also connect this component to the requested document store.
-        Note that only components that inherit from StoreAwareMixin can be connected to stores.
+        If `document_store` is not None, the pipeline will also connect this component to the requested DocumentStore.
+        Note that only components that inherit from DocumentStoreAwareMixin can be connected to DocumentStores.
 
         :param name: the name of the component.
         :param instance: the component instance.
-        :param store: the store this component needs access to, if any.
+        :param document_store: the DocumentStore this component needs access to, if any.
         :raises ValueError: if:
             - a component with the same name already exists
-            - a component requiring a store didn't receive it
-            - a component that didn't expect a store received it
+            - a component requiring a DocumentStore didn't receive it
+            - a component that didn't expect a DocumentStore received it
         :raises PipelineValidationError: if the given instance is not a component
-        :raises NoSuchStoreError: if the given store name is not known to the pipeline
+        :raises NoSuchDocumentStoreError: if the given DocumentStore name is not known to the pipeline
         """
-        if isinstance(instance, StoreAwareMixin):
-            if not store:
-                raise ValueError(f"Component '{name}' needs a store.")
+        if isinstance(instance, DocumentStoreAwareMixin):
+            if not document_store:
+                raise ValueError(f"Component '{name}' needs a DocumentStore.")
 
-            if store not in self._stores:
-                raise NoSuchStoreError(
-                    f"Store named '{store}' not found. "
-                    f"Add it with 'pipeline.add_store('{store}', <the docstore instance>)'."
+            if document_store not in self._document_stores:
+                raise NoSuchDocumentStoreError(
+                    f"DocumentStore named '{document_store}' not found. "
+                    f"Add it with 'pipeline.add_store('{document_store}', <the DocumentStore instance>)'."
                 )
 
-            if instance.store:
-                raise ValueError("Reusing components with stores is not supported (yet). Create a separate instance.")
+            if instance.document_store:
+                raise ValueError("Reusing components with DocumentStores is not supported. Create a separate instance.")
 
-            instance.store = self._stores[store]
-            instance._store_name = store
+            instance.document_store = self._document_stores[document_store]
+            instance._document_store_name = document_store
 
-        elif store:
-            raise ValueError(f"Component '{name}' doesn't support stores.")
+        elif document_store:
+            raise ValueError(f"Component '{name}' doesn't support DocumentStores.")
 
         super().add_component(name, instance)
 

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -92,7 +92,7 @@ class Pipeline(CanalsPipeline):
             if document_store not in self._document_stores:
                 raise NoSuchDocumentStoreError(
                     f"DocumentStore named '{document_store}' not found. "
-                    f"Add it with 'pipeline.add_store('{document_store}', <the DocumentStore instance>)'."
+                    f"Add it with 'pipeline.add_document_store('{document_store}', <the DocumentStore instance>)'."
                 )
 
             if instance.document_store:

--- a/haystack/preview/testing/factory.py
+++ b/haystack/preview/testing/factory.py
@@ -1,18 +1,18 @@
 from typing import Any, Dict, Optional, Tuple, Type, List
 
 from haystack.preview.dataclasses import Document
-from haystack.preview.document_stores import store, Store, DuplicatePolicy
+from haystack.preview.document_stores import document_store, DocumentStore, DuplicatePolicy
 
 
-def store_class(
+def document_store_class(
     name: str,
     documents: Optional[List[Document]] = None,
     documents_count: Optional[int] = None,
     bases: Optional[Tuple[type, ...]] = None,
     extra_fields: Optional[Dict[str, Any]] = None,
-) -> Type[Store]:
+) -> Type[DocumentStore]:
     """
-    Utility function to create a Store class with the given name and list of documents.
+    Utility function to create a DocumentStore class with the given name and list of documents.
 
     If `documents` is set but `documents_count` is not, `documents_count` will be the length
     of `documents`.
@@ -23,58 +23,58 @@ def store_class(
 
     ### Usage
 
-    Create a store class that returns no documents:
+    Create a DocumentStore class that returns no documents:
     ```python
-    MyFakeStore = store_class("MyFakeComponent")
-    store = MyFakeStore()
-    assert store.documents_count() == 0
-    assert store.filter_documents() == []
+    MyFakeStore = document_store_class("MyFakeComponent")
+    document_store = MyFakeStore()
+    assert document_store.documents_count() == 0
+    assert document_store.filter_documents() == []
     ```
 
-    Create a store class that returns a single document:
+    Create a DocumentStore class that returns a single document:
     ```python
     doc = Document(id="fake_id", content="Fake content")
-    MyFakeStore = store_class("MyFakeComponent", documents=[doc])
-    store = MyFakeStore()
-    assert store.documents_count() == 1
-    assert store.filter_documents() == [doc]
+    MyFakeStore = document_store_class("MyFakeComponent", documents=[doc])
+    document_store = MyFakeStore()
+    assert document_store.documents_count() == 1
+    assert document_store.filter_documents() == [doc]
     ```
 
-    Create a store class that returns no document but returns a custom count:
+    Create a DocumentStore class that returns no document but returns a custom count:
     ```python
-    MyFakeStore = store_class("MyFakeComponent", documents_count=100)
-    store = MyFakeStore()
-    assert store.documents_count() == 100
-    assert store.filter_documents() == []
+    MyFakeStore = document_store_class("MyFakeComponent", documents_count=100)
+    document_store = MyFakeStore()
+    assert document_store.documents_count() == 100
+    assert document_store.filter_documents() == []
     ```
 
-    Create a store class that returns a document and a custom count:
+    Create a DocumentStore class that returns a document and a custom count:
     ```python
     doc = Document(id="fake_id", content="Fake content")
-    MyFakeStore = store_class("MyFakeComponent", documents=[doc], documents_count=100)
-    store = MyFakeStore()
-    assert store.documents_count() == 100
-    assert store.filter_documents() == [doc]
+    MyFakeStore = document_store_class("MyFakeComponent", documents=[doc], documents_count=100)
+    document_store = MyFakeStore()
+    assert document_store.documents_count() == 100
+    assert document_store.filter_documents() == [doc]
     ```
 
-    Create a store class with a custom base class:
+    Create a DocumentStore class with a custom base class:
     ```python
-    MyFakeStore = store_class(
+    MyFakeStore = document_store_class(
         "MyFakeStore",
         bases=(MyBaseClass,)
     )
-    store = MyFakeStore()
+    document_store = MyFakeStore()
     assert isinstance(store, MyBaseClass)
     ```
 
-    Create a store class with an extra field `my_field`:
+    Create a DocumentStore class with an extra field `my_field`:
     ```python
-    MyFakeStore = store_class(
+    MyFakeStore = document_store_class(
         "MyFakeStore",
         extra_fields={"my_field": 10}
     )
-    store = MyFakeStore()
-    assert store.my_field == 10
+    document_store = MyFakeStore()
+    assert document_store.my_field == 10
     ```
     """
 
@@ -111,4 +111,4 @@ def store_class(
         bases = (object,)
 
     cls = type(name, bases, fields)
-    return store(cls)
+    return document_store(cls)

--- a/haystack/preview/testing/factory.py
+++ b/haystack/preview/testing/factory.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Type, List
+from typing import Any, Dict, Optional, Tuple, Type, List, Union
 
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores import document_store, DocumentStore, DuplicatePolicy
@@ -77,16 +77,13 @@ def document_store_class(
     assert document_store.my_field == 10
     ```
     """
-
     if documents is not None and documents_count is None:
-        _documents_count = len(documents)
+        documents_count = len(documents)
     elif documents_count is None:
-        _documents_count = 0
-    else:
-        raise ValueError("either 'documents' or 'documents_count' must be set")
+        documents_count = 0
 
-    def count_documents(self) -> int:
-        return _documents_count
+    def count_documents(self) -> Union[int, None]:
+        return documents_count
 
     def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         if documents is not None:

--- a/haystack/preview/testing/factory.py
+++ b/haystack/preview/testing/factory.py
@@ -79,12 +79,14 @@ def document_store_class(
     """
 
     if documents is not None and documents_count is None:
-        documents_count = len(documents)
+        _documents_count = len(documents)
     elif documents_count is None:
-        documents_count = 0
+        _documents_count = 0
+    else:
+        raise ValueError("either 'documents' or 'documents_count' must be set")
 
     def count_documents(self) -> int:
-        return documents_count
+        return _documents_count
 
     def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         if documents is not None:

--- a/test/preview/components/retrievers/test_memory_retriever.py
+++ b/test/preview/components/retrievers/test_memory_retriever.py
@@ -58,7 +58,7 @@ class TestMemoryRetriever(BaseTestComponent):
         ds.write_documents(mock_docs)
 
         retriever = MemoryRetriever(top_k=top_k)
-        retriever.store = ds
+        retriever.document_store = ds
         result = retriever.run(queries=["PHP", "Java"])
 
         assert "documents" in result
@@ -72,7 +72,8 @@ class TestMemoryRetriever(BaseTestComponent):
     def test_invalid_run_no_store(self):
         retriever = MemoryRetriever()
         with pytest.raises(
-            ValueError, match="MemoryRetriever needs a store to run: set the store instance to the self.store attribute"
+            ValueError,
+            match="MemoryRetriever needs a DocumentStore to run: set the DocumentStore instance to the self.document_store attribute",
         ):
             retriever.run(queries=["test"])
 
@@ -82,8 +83,8 @@ class TestMemoryRetriever(BaseTestComponent):
             ...
 
         retriever = MemoryRetriever()
-        with pytest.raises(ValueError, match="'MockStore' is not decorate with @store."):
-            retriever.store = MockStore()
+        with pytest.raises(ValueError, match="'MockStore' is not decorate with @document_store."):
+            retriever.document_store = MockStore()
 
     @pytest.mark.unit
     def test_invalid_run_wrong_store_type(self):
@@ -103,8 +104,8 @@ class TestMemoryRetriever(BaseTestComponent):
                 return None
 
         retriever = MemoryRetriever()
-        with pytest.raises(ValueError, match="'MockStore' is not decorate with @store."):
-            retriever.store = MockStore()
+        with pytest.raises(ValueError, match="'MockStore' is not decorate with @document_store."):
+            retriever.document_store = MockStore()
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
@@ -121,7 +122,7 @@ class TestMemoryRetriever(BaseTestComponent):
 
         pipeline = Pipeline()
         pipeline.add_store("memory", ds)
-        pipeline.add_component("retriever", retriever, store="memory")
+        pipeline.add_component("retriever", retriever, document_store="memory")
         result: Dict[str, Any] = pipeline.run(data={"retriever": {"queries": [query]}})
 
         assert result
@@ -146,7 +147,7 @@ class TestMemoryRetriever(BaseTestComponent):
 
         pipeline = Pipeline()
         pipeline.add_store("memory", ds)
-        pipeline.add_component("retriever", retriever, store="memory")
+        pipeline.add_component("retriever", retriever, document_store="memory")
         result: Dict[str, Any] = pipeline.run(data={"retriever": {"queries": [query], "top_k": top_k}})
 
         assert result

--- a/test/preview/document_stores/test_decorator.py
+++ b/test/preview/document_stores/test_decorator.py
@@ -2,32 +2,32 @@ from unittest.mock import Mock
 
 import pytest
 
-from haystack.preview.testing.factory import store_class
-from haystack.preview.document_stores.decorator import _default_store_to_dict, _default_store_from_dict
-from haystack.preview.document_stores.errors import StoreDeserializationError
+from haystack.preview.testing.factory import document_store_class
+from haystack.preview.document_stores.decorator import default_document_store_to_dict, default_document_store_from_dict
+from haystack.preview.document_stores.errors import DocumentStoreDeserializationError
 
 
 @pytest.mark.unit
 def test_default_store_to_dict():
-    MyStore = store_class("MyStore")
+    MyStore = document_store_class("MyStore")
     comp = MyStore()
-    res = _default_store_to_dict(comp)
+    res = default_document_store_to_dict(comp)
     assert res == {"hash": id(comp), "type": "MyStore", "init_parameters": {}}
 
 
 @pytest.mark.unit
 def test_default_store_to_dict_with_custom_init_parameters():
     extra_fields = {"init_parameters": {"custom_param": True}}
-    MyStore = store_class("MyStore", extra_fields=extra_fields)
+    MyStore = document_store_class("MyStore", extra_fields=extra_fields)
     comp = MyStore()
-    res = _default_store_to_dict(comp)
+    res = default_document_store_to_dict(comp)
     assert res == {"hash": id(comp), "type": "MyStore", "init_parameters": {"custom_param": True}}
 
 
 @pytest.mark.unit
 def test_default_store_from_dict():
-    MyStore = store_class("MyStore")
-    comp = _default_store_from_dict(MyStore, {"type": "MyStore"})
+    MyStore = document_store_class("MyStore")
+    comp = default_document_store_from_dict(MyStore, {"type": "MyStore"})
     assert isinstance(comp, MyStore)
 
 
@@ -37,16 +37,16 @@ def test_default_store_from_dict_with_custom_init_parameters():
         self.custom_param = custom_param
 
     extra_fields = {"__init__": store_init}
-    MyStore = store_class("MyStore", extra_fields=extra_fields)
-    comp = _default_store_from_dict(MyStore, {"type": "MyStore", "init_parameters": {"custom_param": 100}})
+    MyStore = document_store_class("MyStore", extra_fields=extra_fields)
+    comp = default_document_store_from_dict(MyStore, {"type": "MyStore", "init_parameters": {"custom_param": 100}})
     assert isinstance(comp, MyStore)
     assert comp.custom_param == 100
 
 
 @pytest.mark.unit
 def test_default_store_from_dict_without_type():
-    with pytest.raises(StoreDeserializationError, match="Missing 'type' in store serialization data"):
-        _default_store_from_dict(Mock, {})
+    with pytest.raises(DocumentStoreDeserializationError, match="Missing 'type' in DocumentStore serialization data"):
+        default_document_store_from_dict(Mock, {})
 
 
 @pytest.mark.unit
@@ -55,5 +55,7 @@ def test_default_store_from_dict_unregistered_store(request):
     # Since the registry is global we risk to have a store with the same name registered in another test.
     store_name = request.node.name
 
-    with pytest.raises(StoreDeserializationError, match=f"Store '{store_name}' can't be deserialized as 'Mock'"):
-        _default_store_from_dict(Mock, {"type": store_name})
+    with pytest.raises(
+        DocumentStoreDeserializationError, match=f"DocumentStore '{store_name}' can't be deserialized as 'Mock'"
+    ):
+        default_document_store_from_dict(Mock, {"type": store_name})

--- a/test/preview/document_stores/test_memory.py
+++ b/test/preview/document_stores/test_memory.py
@@ -79,7 +79,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
     @pytest.mark.unit
     def test_bm25_retrieval_with_empty_document_store(self, docstore: DocumentStore, caplog):
         caplog.set_level(logging.INFO)
-        # Tests if the bm25_retrieval method correctly returns an empty list when there are no documents in the store.
+        # Tests if the bm25_retrieval method correctly returns an empty list when there are no documents in the DocumentStore.
         results = docstore.bm25_retrieval(query="How to test this?", top_k=2)
         assert len(results) == 0
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
@@ -208,7 +208,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
     @pytest.mark.unit
     def test_bm25_retrieval_with_updated_docs(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method correctly updates the retrieved documents when new
-        # documents are added to the store.
+        # documents are added to the DocumentStore.
         docs = [Document(content="Hello world")]
         docstore.write_documents(docs)
 

--- a/test/preview/document_stores/test_memory.py
+++ b/test/preview/document_stores/test_memory.py
@@ -5,7 +5,8 @@ import pandas as pd
 import pytest
 
 from haystack.preview import Document
-from haystack.preview.document_stores import Store, MemoryDocumentStore
+from haystack.preview.document_stores import DocumentStore, MemoryDocumentStore
+
 from haystack.testing.preview.document_store import DocumentStoreBaseTests
 
 
@@ -66,7 +67,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert store.bm25_parameters == {"key": "value"}
 
     @pytest.mark.unit
-    def test_bm25_retrieval(self, docstore: Store):
+    def test_bm25_retrieval(self, docstore: DocumentStore):
         docstore = MemoryDocumentStore()
         # Tests if the bm25_retrieval method returns the correct document based on the input query.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
@@ -76,7 +77,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert results[0].content == "Haystack supports multiple languages"
 
     @pytest.mark.unit
-    def test_bm25_retrieval_with_empty_document_store(self, docstore: Store, caplog):
+    def test_bm25_retrieval_with_empty_document_store(self, docstore: DocumentStore, caplog):
         caplog.set_level(logging.INFO)
         # Tests if the bm25_retrieval method correctly returns an empty list when there are no documents in the store.
         results = docstore.bm25_retrieval(query="How to test this?", top_k=2)
@@ -84,7 +85,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
     @pytest.mark.unit
-    def test_bm25_retrieval_empty_query(self, docstore: Store):
+    def test_bm25_retrieval_empty_query(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         docstore.write_documents(docs)
@@ -92,7 +93,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
             docstore.bm25_retrieval(query="", top_k=1)
 
     @pytest.mark.unit
-    def test_bm25_retrieval_filter_only_one_allowed_doc_type_as_string(self, docstore: Store):
+    def test_bm25_retrieval_filter_only_one_allowed_doc_type_as_string(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [
             Document.from_dict({"content": pd.DataFrame({"language": ["Python", "Java"]}), "content_type": "table"}),
@@ -104,7 +105,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert results[0].content == "Haystack supports multiple languages"
 
     @pytest.mark.unit
-    def test_bm25_retrieval_filter_only_one_allowed_doc_type_as_list(self, docstore: Store):
+    def test_bm25_retrieval_filter_only_one_allowed_doc_type_as_list(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [
             Document.from_dict({"content": pd.DataFrame({"language": ["Python", "Java"]}), "content_type": "table"}),
@@ -116,7 +117,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert results[0].content == "Haystack supports multiple languages"
 
     @pytest.mark.unit
-    def test_bm25_retrieval_filter_two_allowed_doc_type_as_list(self, docstore: Store):
+    def test_bm25_retrieval_filter_two_allowed_doc_type_as_list(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [
             Document.from_dict({"content": pd.DataFrame({"language": ["Python", "Java"]}), "content_type": "table"}),
@@ -127,7 +128,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert len(results) == 2
 
     @pytest.mark.unit
-    def test_bm25_retrieval_filter_only_one_not_allowed_doc_type_as_string(self, docstore: Store):
+    def test_bm25_retrieval_filter_only_one_not_allowed_doc_type_as_string(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [
             Document(content=pd.DataFrame({"language": ["Python", "Java"]}), content_type="table"),
@@ -140,7 +141,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
             docstore.bm25_retrieval(query="Python", top_k=3, filters={"content_type": "audio"})
 
     @pytest.mark.unit
-    def test_bm25_retrieval_filter_only_one_not_allowed_doc_type_as_list(self, docstore: Store):
+    def test_bm25_retrieval_filter_only_one_not_allowed_doc_type_as_list(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [
             Document(content=pd.DataFrame({"language": ["Python", "Java"]}), content_type="table"),
@@ -153,7 +154,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
             docstore.bm25_retrieval(query="Python", top_k=3, filters={"content_type": ["audio"]})
 
     @pytest.mark.unit
-    def test_bm25_retrieval_filter_two_not_all_allowed_doc_type_as_list(self, docstore: Store):
+    def test_bm25_retrieval_filter_two_not_all_allowed_doc_type_as_list(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [
             Document.from_dict({"content": pd.DataFrame({"language": ["Python", "Java"]}), "content_type": "table"}),
@@ -166,7 +167,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
             docstore.bm25_retrieval(query="Python", top_k=3, filters={"content_type": ["text", "audio"]})
 
     @pytest.mark.unit
-    def test_bm25_retrieval_with_different_top_k(self, docstore: Store):
+    def test_bm25_retrieval_with_different_top_k(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method correctly changes the number of returned documents
         # based on the top_k parameter.
         docs = [
@@ -186,7 +187,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
 
     # Test two queries and make sure the results are different
     @pytest.mark.unit
-    def test_bm25_retrieval_with_two_queries(self, docstore: Store):
+    def test_bm25_retrieval_with_two_queries(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method returns different documents for different queries.
         docs = [
             Document(content="Javascript is a popular programming language"),
@@ -205,7 +206,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
 
     # Test a query, add a new document and make sure results are appropriately updated
     @pytest.mark.unit
-    def test_bm25_retrieval_with_updated_docs(self, docstore: Store):
+    def test_bm25_retrieval_with_updated_docs(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method correctly updates the retrieved documents when new
         # documents are added to the store.
         docs = [Document(content="Hello world")]
@@ -225,7 +226,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert results[0].content == "Python is a popular programming language"
 
     @pytest.mark.unit
-    def test_bm25_retrieval_with_scale_score(self, docstore: Store):
+    def test_bm25_retrieval_with_scale_score(self, docstore: DocumentStore):
         docs = [Document(content="Python programming"), Document(content="Java programming")]
         docstore.write_documents(docs)
 
@@ -238,7 +239,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         assert results[0].score != results1[0].score
 
     @pytest.mark.unit
-    def test_bm25_retrieval_with_table_content(self, docstore: Store):
+    def test_bm25_retrieval_with_table_content(self, docstore: DocumentStore):
         # Tests if the bm25_retrieval method correctly returns a dataframe when the content_type is table.
         table_content = pd.DataFrame({"language": ["Python", "Java"], "use": ["Data Science", "Web Development"]})
         docs = [

--- a/test/preview/testing/test_factory.py
+++ b/test/preview/testing/test_factory.py
@@ -1,13 +1,13 @@
 import pytest
 
 from haystack.preview.dataclasses import Document
-from haystack.preview.testing.factory import store_class
+from haystack.preview.testing.factory import document_store_class
 from haystack.preview.document_stores.decorator import store
 
 
 @pytest.mark.unit
-def test_store_class_default():
-    MyStore = store_class("MyStore")
+def test_document_store_class_default():
+    MyStore = document_store_class("MyStore")
     store = MyStore()
     assert store.count_documents() == 0
     assert store.filter_documents() == []
@@ -16,46 +16,46 @@ def test_store_class_default():
 
 
 @pytest.mark.unit
-def test_store_class_is_registered():
-    MyStore = store_class("MyStore")
+def test_document_store_class_is_registered():
+    MyStore = document_store_class("MyStore")
     assert store.registry["MyStore"] == MyStore
 
 
 @pytest.mark.unit
-def test_store_class_with_documents():
+def test_document_store_class_with_documents():
     doc = Document(id="fake_id", content="This is a document")
-    MyStore = store_class("MyStore", documents=[doc])
+    MyStore = document_store_class("MyStore", documents=[doc])
     store = MyStore()
     assert store.count_documents() == 1
     assert store.filter_documents() == [doc]
 
 
 @pytest.mark.unit
-def test_store_class_with_documents_count():
-    MyStore = store_class("MyStore", documents_count=100)
+def test_document_store_class_with_documents_count():
+    MyStore = document_store_class("MyStore", documents_count=100)
     store = MyStore()
     assert store.count_documents() == 100
     assert store.filter_documents() == []
 
 
 @pytest.mark.unit
-def test_store_class_with_documents_and_documents_count():
+def test_document_store_class_with_documents_and_documents_count():
     doc = Document(id="fake_id", content="This is a document")
-    MyStore = store_class("MyStore", documents=[doc], documents_count=100)
+    MyStore = document_store_class("MyStore", documents=[doc], documents_count=100)
     store = MyStore()
     assert store.count_documents() == 100
     assert store.filter_documents() == [doc]
 
 
 @pytest.mark.unit
-def test_store_class_with_bases():
-    MyStore = store_class("MyStore", bases=(Exception,))
+def test_document_store_class_with_bases():
+    MyStore = document_store_class("MyStore", bases=(Exception,))
     store = MyStore()
     assert isinstance(store, Exception)
 
 
 @pytest.mark.unit
-def test_store_class_with_extra_fields():
-    MyStore = store_class("MyStore", extra_fields={"my_field": 10})
+def test_document_store_class_with_extra_fields():
+    MyStore = document_store_class("MyStore", extra_fields={"my_field": 10})
     store = MyStore()
     assert store.my_field == 10

--- a/test/preview/testing/test_factory.py
+++ b/test/preview/testing/test_factory.py
@@ -2,7 +2,7 @@ import pytest
 
 from haystack.preview.dataclasses import Document
 from haystack.preview.testing.factory import document_store_class
-from haystack.preview.document_stores.decorator import store
+from haystack.preview.document_stores.decorator import document_store
 
 
 @pytest.mark.unit
@@ -18,7 +18,7 @@ def test_document_store_class_default():
 @pytest.mark.unit
 def test_document_store_class_is_registered():
     MyStore = document_store_class("MyStore")
-    assert store.registry["MyStore"] == MyStore
+    assert document_store.registry["MyStore"] == MyStore
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

Rename `@store` do `@document_store` and use `DocumentStore` instead of `Store` across the codebase

### How did you test it?

Unit tests

### Notes for the reviewer

No functional changes, only renaming

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
