### PR TITLE
Add `to_dict` and `from_dict` in `MemoryRetriever`

### DIFF
--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -54,6 +54,12 @@ class RemoteWhisperTranscriber:
         self.whisper_params = whisper_params or {}
 
         self.model_name = model_name
+        self.init_parameters = {
+            "api_key": self.api_key,
+            "model_name": self.model_name,
+            "api_base": self.api_base,
+            "whisper_params": self.whisper_params,
+        }
 
     @component.output_types(documents=List[Document])
     def run(self, audio_files: List[Path], whisper_params: Optional[Dict[str, Any]] = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
   "jsonschema",
 
   # Preview
-  "canals==0.4.0",
+  "canals==0.5.0",
 
   # Agent events
   "events",

--- a/releasenotes/notes/memory-retriever-serialisation-b85bcda1ba60ee26.yaml
+++ b/releasenotes/notes/memory-retriever-serialisation-b85bcda1ba60ee26.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add `to_dict` and `from_dict` in `MemoryRetriever`


### PR DESCRIPTION
### Proposed Changes:

Add `to_dict` and `from_dict` in `MemoryRetriever`.
This is the first `Component` with a `DocumentStore` that supports serialisation to a dictionary.

### How did you test it?

Added unit tests.

### Notes for the reviewer

Part of #5342, depends on #5564.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
