### PR TITLE
fix: Use correct type for points in datadog (benchmarks)

### DIFF
--- a/test/benchmarks/datadog/metric_handler.py
+++ b/test/benchmarks/datadog/metric_handler.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from itertools import chain
 from time import time
 from typing import Dict, List, Optional
 
@@ -55,7 +54,7 @@ class CustomDatadogMetric:
     tags: List[Tag]
 
     def __init__(self, name: str, value: float, tags: Optional[List[Tag]] = None) -> None:
-        self.timestamp = time()
+        self.timestamp = int(time())
         self.name = name
         self.value = value
         self.tags = self.validate_tags(tags) if tags is not None else []
@@ -121,7 +120,7 @@ class MetricsAPI:
 
         tags: List[str] = list(map(lambda t: str(t.value), metric.tags))
         post_metric_response: Dict = datadog.api.Metric.send(
-            metric=metric.name, points=[metric.timestamp, metric.value], tags=tags
+            metric=metric.name, points=[(metric.timestamp, metric.value)], tags=tags
         )
 
         if post_metric_response.get("status") != "ok":


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Datadog's `send` method expects a list of (timestamp, value) pairs as points, so this PR changes the type of the value passed to the `points` parameter to `List[Tuple]`. Also, the timestamp should be an int instead of a float.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I manually sent metrics to datadog, which are now displayed correctly. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
