### PR TITLE
chore: move `test_summarization_pipelines.py` into `test_standard_pipelines.py`

### DIFF
--- a/e2e/document_search/test_standard_pipeline.py
+++ b/e2e/document_search/test_standard_pipeline.py
@@ -1,7 +1,10 @@
 import pytest
 
-from haystack.nodes import EmbeddingRetriever
-from haystack.pipelines import DocumentSearchPipeline
+from haystack import Document
+from haystack.nodes import EmbeddingRetriever, BM25Retriever, TransformersSummarizer
+from haystack.pipelines import DocumentSearchPipeline, SearchSummarizationPipeline
+from haystack.document_stores import InMemoryDocumentStore
+
 
 from ..conftest import document_store
 
@@ -33,3 +36,71 @@ def test_document_search_standard_pipeline(document_store_name, docs, tmp_path):
             [0.9149981737136841, 0.6895168423652649, 0.641706794500351, 0.6206043660640717, 0.5837393924593925],
             abs=1e-3,
         )
+
+
+def test_summarization_pipeline():
+    docs = [
+        Document(
+            content="""
+    PG&E stated it scheduled the blackouts in response to forecasts for high winds amid dry conditions.
+    The aim is to reduce the risk of wildfires. Nearly 800 thousand customers were scheduled to be affected
+    by the shutoffs which were expected to last through at least midday tomorrow.
+    """
+        ),
+        Document(
+            content="""
+    The Eiffel Tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest
+    structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction,
+    the Eiffel Tower surpassed the Washington Monument to become the tallest man-made structure in the world, a
+    title it held for 41 years until the Chrysler Building in New York City was finished in 1930. It was the first
+    structure to reach a height of 300 metres. Due to the addition of a broadcasting aerial at the top of the tower
+    in 1957, it is now taller than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel
+    Tower is the second tallest free-standing structure in France after the Millau Viaduct.
+    """
+        ),
+    ]
+    summarizer = TransformersSummarizer(model_name_or_path="sshleifer/distilbart-xsum-12-6", use_gpu=False)
+
+    ds = InMemoryDocumentStore(use_bm25=True)
+    retriever = BM25Retriever(document_store=ds)
+    ds.write_documents(docs)
+
+    query = "Eiffel Tower"
+    pipeline = SearchSummarizationPipeline(retriever=retriever, summarizer=summarizer, return_in_answer_format=True)
+    output = pipeline.run(query=query, params={"Retriever": {"top_k": 1}})
+    answers = output["answers"]
+    assert len(answers) == 1
+    assert "The Eiffel Tower is one of the world's tallest structures" == answers[0]["answer"].strip()
+
+
+def test_summarization_pipeline_one_summary():
+    split_docs = [
+        Document(
+            content="""
+    The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure in Paris.
+    Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower surpassed the
+    Washington Monument to become the tallest man-made structure in the world, a title it held for 41 years until the Chrysler
+    Building in New York City was finished in 1930.
+    """
+        ),
+        Document(
+            content="""
+    It was the first structure to reach a height of 300 metres. Due to the addition of a broadcasting aerial at the
+    top of the tower in 1957, it is now taller than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters,
+    the Eiffel Tower is the second tallest free-standing structure in France after the Millau Viaduct.
+    """
+        ),
+    ]
+    ds = InMemoryDocumentStore(use_bm25=True)
+    retriever = BM25Retriever(document_store=ds)
+    ds.write_documents(split_docs)
+    summarizer = TransformersSummarizer(model_name_or_path="sshleifer/distilbart-xsum-12-6", use_gpu=False)
+
+    query = "Eiffel Tower"
+    pipeline = SearchSummarizationPipeline(
+        retriever=retriever, summarizer=summarizer, generate_single_summary=True, return_in_answer_format=True
+    )
+    output = pipeline.run(query=query, params={"Retriever": {"top_k": 2}})
+    answers = output["answers"]
+    assert len(answers) == 1
+    assert answers[0]["answer"].strip() == "The Eiffel Tower was built in 1924 in Paris, France."

--- a/releasenotes/notes/e2e-summarization-pipelines-c4262fc82a7207c0.yaml
+++ b/releasenotes/notes/e2e-summarization-pipelines-c4262fc82a7207c0.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - move `test_summarization_pipelines.py` into `test_standard_pipelines.py`


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/5387, point 3

### Proposed Changes:

Move `test_summarization_pipelines.py` into `test_standard_pipelines.py`

### How did you test it?
n/a

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
