### PR TITLE
Rework `MemoryRetriever`

### DIFF
--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -1,29 +1,39 @@
 from typing import Dict, List, Any, Optional
 
 from haystack.preview import component, Document
-from haystack.preview.document_stores import MemoryDocumentStore, DocumentStoreAwareMixin
+from haystack.preview.document_stores import MemoryDocumentStore
 
 
 @component
-class MemoryRetriever(DocumentStoreAwareMixin):
+class MemoryRetriever:
     """
     A component for retrieving documents from a MemoryDocumentStore using the BM25 algorithm.
 
     Needs to be connected to a MemoryDocumentStore to run.
     """
 
-    supported_document_stores = [MemoryDocumentStore]
-
-    def __init__(self, filters: Optional[Dict[str, Any]] = None, top_k: int = 10, scale_score: bool = True):
+    def __init__(
+        self,
+        document_store: MemoryDocumentStore,
+        filters: Optional[Dict[str, Any]] = None,
+        top_k: int = 10,
+        scale_score: bool = True,
+    ):
         """
         Create a MemoryRetriever component.
 
+        :param document_store: A instance of MemoryDocumentStore.
         :param filters: A dictionary with filters to narrow down the search space (default is None).
         :param top_k: The maximum number of documents to retrieve (default is 10).
         :param scale_score: Whether to scale the BM25 score or not (default is True).
 
         :raises ValueError: If the specified top_k is not > 0.
         """
+        if not isinstance(document_store, MemoryDocumentStore):
+            raise ValueError("document_store must be an instance of MemoryDocumentStore")
+
+        self.document_store = document_store
+
         if top_k <= 0:
             raise ValueError(f"top_k must be > 0, but got {top_k}")
 
@@ -51,12 +61,6 @@ class MemoryRetriever(DocumentStoreAwareMixin):
 
         :raises ValueError: If the specified DocumentStore is not found or is not a MemoryDocumentStore instance.
         """
-        self.document_store: MemoryDocumentStore
-        if not self.document_store:
-            raise ValueError(
-                "MemoryRetriever needs a DocumentStore to run: set the DocumentStore instance to the self.document_store attribute"
-            )
-
         if filters is None:
             filters = self.filters
         if top_k is None:

--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -22,7 +22,7 @@ class MemoryRetriever:
         """
         Create a MemoryRetriever component.
 
-        :param document_store: A instance of MemoryDocumentStore.
+        :param document_store: An instance of MemoryDocumentStore.
         :param filters: A dictionary with filters to narrow down the search space (default is None).
         :param top_k: The maximum number of documents to retrieve (default is 10).
         :param scale_score: Whether to scale the BM25 score or not (default is True).

--- a/releasenotes/notes/rework-memory-retriever-73c5d3221bd96759.yaml
+++ b/releasenotes/notes/rework-memory-retriever-73c5d3221bd96759.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Rework `MemoryRetriever` to remove `DocumentStoreAwareMixin`.
+    Now we require a `MemoryDocumentStore` when initialisating the retriever.


### PR DESCRIPTION
### Proposed Changes:

Rework `MemoryRetriever` so it doesn't inhering the `DocumentStoreAwareMixin` anymore.

The required `MemoryDocumentStore` is set at init time. I think this is much better as it also makes it clear that this `Component` requires that `DocumentStore` to behave correctly.

It's also easier to check if the `DocumentStore` provided is supported by the retriever this way.

As you notice we also don't require the check in `MemoryRetriever.run()` anymore as we can be sure `self.document_store` has been set.

### How did you test it?

I updated `MemoryRetriever` tests and run all `preview` package tests.

### Notes for the reviewer

I had to comment out two `MemoryRetriever` tests as they are related to serialisation.
We'll update them after we close #5550 and when implmenting `to_dict` and `from_dict`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
