### PR TITLE
Rework `DocumentWriter`

### DIFF
--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -1,23 +1,22 @@
 from typing import List, Optional
 
 from haystack.preview import component, Document
-from haystack.preview.document_stores import DocumentStoreAwareMixin, DocumentStore, DuplicatePolicy
+from haystack.preview.document_stores import DocumentStore, DuplicatePolicy
 
 
 @component
-class DocumentWriter(DocumentStoreAwareMixin):
+class DocumentWriter:
     """
     A component for writing documents to a DocumentStore.
     """
 
-    supported_document_stores = [DocumentStore]  # type: ignore
-
-    def __init__(self, policy: DuplicatePolicy = DuplicatePolicy.FAIL):
+    def __init__(self, document_store: DocumentStore, policy: DuplicatePolicy = DuplicatePolicy.FAIL):
         """
         Create a DocumentWriter component.
 
         :param policy: The policy to use when encountering duplicate documents (default is DuplicatePolicy.FAIL).
         """
+        self.document_store = document_store
         self.policy = policy
 
     def run(self, documents: List[Document], policy: Optional[DuplicatePolicy] = None):
@@ -30,11 +29,6 @@ class DocumentWriter(DocumentStoreAwareMixin):
 
         :raises ValueError: If the specified document store is not found.
         """
-        if not self.document_store:
-            raise ValueError(
-                "DocumentWriter needs a DocumentStore to run: set the DocumentStore instance to the self.document_store attribute."
-            )
-
         if policy is None:
             policy = self.policy
 

--- a/releasenotes/notes/rework-document-writer-4958db2024070f6f.yaml
+++ b/releasenotes/notes/rework-document-writer-4958db2024070f6f.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Rework `DocumentWriter` to remove `DocumentStoreAwareMixin`.
+    Now we require a generic `DocumentStore` when initialisating the writer.

--- a/test/preview/components/writers/document_writer.py
+++ b/test/preview/components/writers/document_writer.py
@@ -11,26 +11,12 @@ from test.preview.components.base import BaseTestComponent
 class TestDocumentWriter(BaseTestComponent):
     @pytest.mark.unit
     def test_run(self):
-        writer = DocumentWriter()
+        mocked_document_store = MagicMock()
+        writer = DocumentWriter(mocked_document_store)
         documents = [
             Document(content="This is the text of a document."),
             Document(content="This is the text of another document."),
         ]
 
-        mocked_document_store = MagicMock()
-        mocked_document_store.__haystack_document_store__ = True
-        writer.document_store = mocked_document_store
         writer.run(documents=documents)
-
         mocked_document_store.write_documents.assert_called_once_with(documents=documents, policy=DuplicatePolicy.FAIL)
-
-    @pytest.mark.unit
-    def test_run_without_store(self):
-        writer = DocumentWriter()
-        documents = [Document(content="test")]
-        with pytest.raises(
-            ValueError,
-            match="DocumentWriter needs a DocumentStore to run: set the DocumentStore instance to the "
-            "self.document_store attribute",
-        ):
-            writer.run(documents=documents)


### PR DESCRIPTION
### Proposed Changes:

Rework `DocumentWriter` so it doesn't inhering the `DocumentStoreAwareMixin` anymore.

The required `DocumentStore` is set at init time. I think this is much better as it also makes it clear that this `Component` requires that `DocumentStore` to behave correctly.

As you notice we also don't require the check in `DocumentWriter.run()` anymore as we can be sure `self.document_store` has been set.

### How did you test it?

I updated `DocumentWriter` tests and run all `preview` package tests.

### Notes for the reviewer

Depends on #5582.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
