### PR TITLE
chore: add `preview` section to release notes

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -34,6 +34,10 @@ template: |
   fixes:
     - |
       Add normal bug fixes here, or remove this section.
+  preview:
+    - |
+      Add changes to Haystack version 2, or remove this section.
+      Haystack version 2 can be found under haystack/preview.
 sections:
   # The prelude section is implicitly included.
   - [upgrade, Upgrade Notes]
@@ -43,3 +47,4 @@ sections:
   - [deprecations, Deprecation Notes]
   - [security, Security Notes]
   - [fixes, Bug Fixes]
+  - [preview, Haystack 2.0 preview]

--- a/releasenotes/notes/add-file-extension-classifier-preview-40f31c27bbd7cff9.yaml
+++ b/releasenotes/notes/add-file-extension-classifier-preview-40f31c27bbd7cff9.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+preview:
   - |
     Adds FileExtensionClassifier to preview components.

--- a/releasenotes/notes/add-v2-answer-class-31bc8d3116922594.yaml
+++ b/releasenotes/notes/add-v2-answer-class-31bc8d3116922594.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+preview:
   - Add Answer base class for haystack v2
   - Add GeneratedAnswer and ExtractedAnswer

--- a/releasenotes/notes/canals-0.4.0-b69b19069c4a9e0f.yaml
+++ b/releasenotes/notes/canals-0.4.0-b69b19069c4a9e0f.yaml
@@ -1,4 +1,4 @@
 ---
-enhancements:
+preview:
   - "Migrate existing v2 components to Canals 0.4.0"
   - "Fix TextFileToDocument using wrong Document class"

--- a/releasenotes/notes/document-writer-v2-bbe0a62b3066f9cf.yaml
+++ b/releasenotes/notes/document-writer-v2-bbe0a62b3066f9cf.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+preview:
   - |
     Added new DocumentWriter component to Haystack v2 preview so that documents can be written to stores.

--- a/releasenotes/notes/lazy-import-v2-82902270867d9899.yaml
+++ b/releasenotes/notes/lazy-import-v2-82902270867d9899.yaml
@@ -1,2 +1,2 @@
-enhancements:
+preview:
   - copy lazy_imports.py to preview

--- a/releasenotes/notes/store-factory-91e7da46aeb7ff21.yaml
+++ b/releasenotes/notes/store-factory-91e7da46aeb7ff21.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+preview:
   - |
     Add utility function `store_class` factory to create `Store`s for testing purposes.

--- a/releasenotes/notes/stores-serialisation-a09398d158b01ae6.yaml
+++ b/releasenotes/notes/stores-serialisation-a09398d158b01ae6.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+preview:
   - Add `from_dict` and `to_dict` methods to `Store` `Protocol`
   - Add default `from_dict` and `to_dict` implementations to classes decorated with `@store`

--- a/releasenotes/notes/textfile-to-document-v2-341987623765ec95.yaml
+++ b/releasenotes/notes/textfile-to-document-v2-341987623765ec95.yaml
@@ -1,4 +1,4 @@
 ---
-features:
+preview:
   - |
     Add new TextFileToDocument component to Haystack v2 preview so that text files can be converted to Haystack Documents.


### PR DESCRIPTION
### Proposed Changes:

- Add a new section (`preview`)  to categorize changes related to Haystack 2.0
- Update the existing notes related to Haystack 2.0

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
