### PR TITLE
chore: change import paths under `preview`

### DIFF
--- a/haystack/preview/__init__.py
+++ b/haystack/preview/__init__.py
@@ -1,4 +1,3 @@
 from canals.component import component
-from haystack.preview.document_stores.decorator import document_store
-from haystack.preview.dataclasses import Document, ContentType, ExtractedAnswer, GeneratedAnswer, Answer
+from haystack.preview.dataclasses import *
 from haystack.preview.pipeline import Pipeline, PipelineError, NoSuchDocumentStoreError, load_pipelines, save_pipelines

--- a/haystack/preview/components/__init__.py
+++ b/haystack/preview/components/__init__.py
@@ -1,5 +1,0 @@
-from haystack.preview.components.audio.whisper_local import LocalWhisperTranscriber
-from haystack.preview.components.audio.whisper_remote import RemoteWhisperTranscriber
-from haystack.preview.components.file_converters import TextFileToDocument
-from haystack.preview.components.classifiers import FileExtensionClassifier
-from haystack.preview.components.writers.document_writer import DocumentWriter

--- a/haystack/preview/components/audio/__init__.py
+++ b/haystack/preview/components/audio/__init__.py
@@ -1,0 +1,4 @@
+from haystack.preview.components.audio.whisper_local import LocalWhisperTranscriber
+from haystack.preview.components.audio.whisper_remote import RemoteWhisperTranscriber
+
+__all__ = ["LocalWhisperTranscriber", "RemoteWhisperTranscriber"]

--- a/haystack/preview/components/classifiers/__init__.py
+++ b/haystack/preview/components/classifiers/__init__.py
@@ -1,1 +1,3 @@
 from haystack.preview.components.classifiers.file_classifier import FileExtensionClassifier
+
+__all__ = ["FileExtensionClassifier"]

--- a/haystack/preview/components/file_converters/__init__.py
+++ b/haystack/preview/components/file_converters/__init__.py
@@ -1,1 +1,3 @@
 from haystack.preview.components.file_converters.txt import TextFileToDocument
+
+__all__ = ["TextFileToDocument"]

--- a/haystack/preview/components/retrievers/__init__.py
+++ b/haystack/preview/components/retrievers/__init__.py
@@ -1,0 +1,3 @@
+from haystack.preview.components.retrievers.memory import MemoryRetriever
+
+__all__ = ["MemoryRetriever"]

--- a/haystack/preview/components/writers/__init__.py
+++ b/haystack/preview/components/writers/__init__.py
@@ -1,0 +1,3 @@
+from haystack.preview.components.writers.document_writer import DocumentWriter
+
+__all__ = ["DocumentWriter"]

--- a/haystack/preview/document_stores/__init__.py
+++ b/haystack/preview/document_stores/__init__.py
@@ -3,3 +3,14 @@ from haystack.preview.document_stores.mixins import DocumentStoreAwareMixin
 from haystack.preview.document_stores.memory.document_store import MemoryDocumentStore
 from haystack.preview.document_stores.errors import DocumentStoreError, DuplicateDocumentError, MissingDocumentError
 from haystack.preview.document_stores.decorator import document_store
+
+__all__ = [
+    "DocumentStore",
+    "DuplicatePolicy",
+    "DocumentStoreAwareMixin",
+    "MemoryDocumentStore",
+    "DocumentStoreError",
+    "DuplicateDocumentError",
+    "MissingDocumentError",
+    "document_store",
+]

--- a/releasenotes/notes/change-import-paths-3d4eae690412e545.yaml
+++ b/releasenotes/notes/change-import-paths-3d4eae690412e545.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Change import paths under the "preview" package to minimize
+    module namespace pollution.

--- a/test/preview/components/audio/__init__.py
+++ b/test/preview/components/audio/__init__.py
@@ -1,1 +1,0 @@
-from haystack.preview.components.audio.whisper_remote import RemoteWhisperTranscriber

--- a/test/preview/components/audio/test_whisper_local.py
+++ b/test/preview/components/audio/test_whisper_local.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from haystack.preview.dataclasses import Document
-from haystack.preview.components import LocalWhisperTranscriber
+from haystack.preview.components.audio import LocalWhisperTranscriber
 
 from test.preview.components.base import BaseTestComponent
 

--- a/test/preview/pipeline/test_pipeline.py
+++ b/test/preview/pipeline/test_pipeline.py
@@ -2,8 +2,9 @@ from typing import Any, Optional, Dict, List
 
 import pytest
 
-from haystack.preview import Pipeline, component, document_store, NoSuchDocumentStoreError, Document
-from haystack.preview.pipeline import NotADocumentStoreError
+from haystack.preview import Pipeline, component, Document
+from haystack.preview.document_stores import document_store
+from haystack.preview.pipeline import NotADocumentStoreError, NoSuchDocumentStoreError
 from haystack.preview.document_stores import DocumentStoreAwareMixin, DuplicatePolicy, DocumentStore
 
 


### PR DESCRIPTION
### Related Issues

The import paths have several issues at the moment:
- they are not consistent, some names are exported up to the `preview.*` namespace, others are not
- components are exported up to `preview.*` but they shouldn't be, currently (for example) audio dependencies are always imported, even if you only need a text-to-document converter

### Proposed Changes:

- Leave a handful of names at the `preview.*` level, namely `component` and the types from `dataclasses`
- use `__all__` extensively, so we can control what we expose at each level
- limit pollution as much as possible

### How did you test it?

unit tests

### Notes for the reviewer

I left out imports of `Pipeline` to minize conflicts with other ongoing PRs removing that code

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
