### PR TITLE
chore: leftover from #5580

### DIFF
--- a/haystack/preview/components/file_converters/txt.py
+++ b/haystack/preview/components/file_converters/txt.py
@@ -5,7 +5,7 @@ from typing import Optional, List, Union, Dict
 from canals.errors import PipelineRuntimeError
 from tqdm import tqdm
 
-from haystack.lazy_imports import LazyImport
+from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import Document, component
 
 with LazyImport("Run 'pip install farm-haystack[preprocessing]'") as langdetect_import:


### PR DESCRIPTION
### Related Issues

#5580 introduced lazy imports but `preview` is still depending on haystack v1.x in one place

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
