### PR TITLE
fix: Set model_max_length in the Tokenizer of `DefaultPromptHandler`

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -63,6 +63,7 @@ class DefaultPromptHandler:
 
     def __init__(self, model_name_or_path: str, model_max_length: int, max_length: int = 100):
         self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.tokenizer.model_max_length = model_max_length
         self.model_max_length = model_max_length
         self.max_length = max_length
 

--- a/releasenotes/notes/fix-model_max_length-prompt_handler-7f34c40c62a8c55b.yaml
+++ b/releasenotes/notes/fix-model_max_length-prompt_handler-7f34c40c62a8c55b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix model_max_length not being set in the Tokenizer in DefaultPromptHandler.

--- a/test/prompt/test_handlers.py
+++ b/test/prompt/test_handlers.py
@@ -57,6 +57,13 @@ def test_prompt_handler_negative():
     }
 
 
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.handlers.AutoTokenizer.from_pretrained")
+def test_prompt_handler_model_max_length_set_in_tokenizer(mock_tokenizer):
+    prompt_handler = DefaultPromptHandler(model_name_or_path="model_path", model_max_length=10, max_length=3)
+    assert prompt_handler.tokenizer.model_max_length == 10
+
+
 @pytest.mark.integration
 def test_prompt_handler_basics():
     handler = DefaultPromptHandler(model_name_or_path="gpt2", model_max_length=20, max_length=10)
@@ -64,6 +71,9 @@ def test_prompt_handler_basics():
 
     handler = DefaultPromptHandler(model_name_or_path="gpt2", model_max_length=20)
     assert handler.max_length == 100
+
+    # test model_max_length is set in tokenizer
+    assert handler.tokenizer.model_max_length == 20
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #5589 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR sets the `model_max_length` parameter of the tokenizer of `DefaultPromptHandler`. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added a unit test + added a test case in an integration test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
Without this change, users are getting a warning message from the transformers library that the sequence length is too long for the model they are using in case they are using models supporting larger sequence length than 1024.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
