### PR TITLE
Add missing integration tests to catch-all required step in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -841,6 +841,8 @@ jobs:
       - integration-tests-weaviate
       - integration-tests-pinecone
       - integration-tests-memory
+      - integration-tests-promptnode
+      - integration-tests-agents
 
     steps:
       - name: Finisher


### PR DESCRIPTION
### Proposed Changes:

`catch-all` step is meant to run only after all other jobs have finished sucessfully. 
Some jobs were missing from the list, this PR adds the missing ones.

### How did you test it?

Can't test it.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
