### PR TITLE
docs: update description of crawler_depth param

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -58,9 +58,11 @@ class Crawler(BaseComponent):
         Init object with basic params for crawling (can be overwritten later).
 
         :param urls: List of http(s) address(es) (can also be supplied later when calling crawl())
-        :param crawler_depth: How many sublinks to follow from the initial list of URLs. Current options:
-            0: Only initial list of urls
-            1: Follow links found on the initial URLs (but no further)
+        :param crawler_depth: How many sublinks to follow from the initial list of URLs. Can be any integer >= 0.  
+                                For example:  
+                                0: Only initial list of urls.  
+                                1: Follow links found on the initial URLs (but no further).  
+                                2: Additionally follow links found on the second-level URLs.
         :param filter_urls: Optional list of regular expressions that the crawled URLs must comply with.
             All URLs not matching at least one of the regular expressions will be dropped.
         :param id_hash_keys: Generate the document id from a custom list of strings that refer to the document's
@@ -153,9 +155,11 @@ class Crawler(BaseComponent):
         If no parameters are provided to this method, the instance attributes that were passed during __init__ will be used.
 
         :param urls: List of http addresses or single http address
-        :param crawler_depth: How many sublinks to follow from the initial list of URLs. Current options:
-                              0: Only initial list of urls
-                              1: Follow links found on the initial URLs (but no further)
+        :param crawler_depth: How many sublinks to follow from the initial list of URLs. Can be any integer >= 0.  
+                                For example:  
+                                0: Only initial list of urls.  
+                                1: Follow links found on the initial URLs (but no further).  
+                                2: Additionally follow links found on the second-level URLs.
         :param filter_urls: Optional list of regular expressions that the crawled URLs must comply with.
                            All URLs not matching at least one of the regular expressions will be dropped.
         :param overwrite_existing_files: Whether to overwrite existing files in output_dir with new content
@@ -374,9 +378,11 @@ class Crawler(BaseComponent):
 
         :param output_dir: Path for the directory to store files
         :param urls: List of http addresses or single http address
-        :param crawler_depth: How many sublinks to follow from the initial list of URLs. Current options:
-                              0: Only initial list of urls
-                              1: Follow links found on the initial URLs (but no further)
+        :param crawler_depth: How many sublinks to follow from the initial list of URLs. Can be any integer >= 0.  
+                                For example:  
+                                0: Only initial list of urls.  
+                                1: Follow links found on the initial URLs (but no further).  
+                                2: Additionally follow links found on the second-level URLs.
         :param filter_urls: Optional list of regular expressions that the crawled URLs must comply with.
                            All URLs not matching at least one of the regular expressions will be dropped.
         :param overwrite_existing_files: Whether to overwrite existing files in output_dir with new content


### PR DESCRIPTION
### Related Issues

- fixes #5373 

### Proposed Changes:

- Updating docstrings to explain that `crawler_depth` can be values >1.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
