### PR TITLE
Add terminate-runner job in benchmarks.yml

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,13 +34,15 @@ jobs:
         env:
           repo_token: ${{ secrets.HAYSTACK_BOT_TOKEN }}
         run: |
-          cml runner launch \
-            --single \
-            --cloud aws \
-            --cloud-region ${{ env.AWS_REGION }} \
-            --cloud-type=p3.2xlarge \
-            --cloud-hdd-size=64 \
-            --labels=cml
+          OUTPUT=$(cml runner launch \
+          --cloud aws \
+          --cloud-region ${{ env.AWS_REGION }} \
+          --cloud-type=p3.2xlarge \
+          --cloud-hdd-size=64 \
+          --labels=cml 2>&1 | tee /dev/fd/2)
+          # Extract 'id' from the log and set it as an environment variable
+          ID_VALUE=$(echo "$OUTPUT" | jq -r '.message? | fromjson? | select(.id != null) | .id // empty')
+          echo "cml_runner_id=$ID_VALUE" >> "$GITHUB_OUTPUT"
 
   run-reader-benchmarks:
     needs: deploy-runner
@@ -226,3 +228,24 @@ jobs:
         with:
           name: benchmark-results-opensearch
           path: test/benchmarks/out/
+
+  terminate-runner:
+    if: always()
+    needs:
+      - deploy-runner
+      - run-opensearch-benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: AWS authentication
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+
+      - name: Terminate EC2 instance
+        env:
+          CML_RUNNER_ID: ${{needs.deploy-runner.outputs.cml_runner_id}}
+        run: |
+          # Get the instance ID using its Name tag and terminate the instance
+          INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=${{ env.CML_RUNNER_ID }}" --query "Reservations[*].Instances[*].[InstanceId]" --output text)
+          aws ec2 terminate-instances --instance-ids "$INSTANCE_ID"


### PR DESCRIPTION
### Proposed Changes:

Add back the `terminate-runner` job in `benchmarks.yml` since the `cml` tool is not 100% reliable as if we use the `--single` flag it stops the runner after the first job finished instead of waiting for the whole workflow.

See [this run](https://github.com/deepset-ai/haystack/actions/runs/5914287605) as an example.

### How did you test it?

We triggered a new run in branch `fix-benchmarks-run`.
https://github.com/deepset-ai/haystack/actions/runs/5940401105

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
