### PR TITLE
Add workflow to trigger preview package release

### DIFF
--- a/.github/workflows/pypi_release_preview.yml
+++ b/.github/workflows/pypi_release_preview.yml
@@ -1,0 +1,23 @@
+name: Trigger preview release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "haystack/preview/**.py"
+
+jobs:
+  release-on-pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger preview release
+        env:
+          HAYSTACK_BOT_REPO_DISPATCH_PA_TOKEN: ${{ secrets.HAYSTACK_BOT_REPO_DISPATCH_PA_TOKEN }}
+        run: |
+          curl -L \
+            -X POST \
+            -H "Authorization: Bearer $HAYSTACK_BOT_REPO_DISPATCH_PA_TOKEN" \
+            https://api.github.com/repos/deepset-ai/haystack-preview-package/dispatches \
+            -d '{"event_type":"preview_release"}'


### PR DESCRIPTION
### Proposed Changes:

Add a new workflow to send a `repository_dispatch` to `deepset-ai/haystack-preview-package` to trigger the release of the Haystack preview package workflow.

The workflow to be triggered: https://github.com/deepset-ai/haystack-preview-package/blob/main/.github/workflows/pypi_release.yml

### How did you test it?

I recreated the workflows setup in two personal repositories to verify the required permissions by the API call to trigger the `repository_dispatch` event in the other repository.

### Notes for the reviewer

As the default `GITHUB_TOKEN` can't be used as it only has permissions for the repository that triggered the workflow, in this case `deepset-ai/haystack-preview-package`, I created another Personal Access Token using the HaystackBot with the necessary permissions.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
