### PR TITLE
chore: remove `self.warm_up()`

### DIFF
--- a/haystack/preview/components/audio/whisper_local.py
+++ b/haystack/preview/components/audio/whisper_local.py
@@ -111,7 +111,6 @@ class LocalWhisperTranscriber:
         :param audio_files: a list of paths or binary streams to transcribe
         :returns: a list of transcriptions.
         """
-        self.warm_up()
         return_segments = kwargs.pop("return_segments", False)
         transcriptions = []
         for audio_file in audio_files:


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:
- Update `LocalWhisperTranscriber` to not call `warm_up()` when transcribing to be coherent with all other Haystack 2.0 components.

### How did you test it?

Local tests run

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
