### PR TITLE
chore: serialization methods for `FileExtensionClassifier`

### DIFF
--- a/haystack/preview/components/classifiers/file_classifier.py
+++ b/haystack/preview/components/classifiers/file_classifier.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Union, Optional, Dict, Any
 
-from haystack.preview import component
+from haystack.preview import component, default_from_dict, default_to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +38,6 @@ class FileExtensionClassifier:
                     f"Unknown mime type: '{mime_type}'. Ensure you passed a list of strings in the 'mime_types' parameter"
                 )
 
-        # save the init parameters for serialization
-        self.init_parameters = {"mime_types": mime_types}
-
         component.set_output_types(self, unclassified=List[Path], **{mime_type: List[Path] for mime_type in mime_types})
         self.mime_types = mime_types
 
@@ -48,14 +45,14 @@ class FileExtensionClassifier:
         """
         Serialize this component to a dictionary.
         """
-        # return default_to_dict(self, model_name_or_path=self.model_name, device=self.device, whisper_params=self.whisper_params)
+        return default_to_dict(self, mime_types=self.mime_types)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "FileExtensionClassifier":
         """
         Deserialize this component from a dictionary.
         """
-        # return default_from_dict(cls, data)
+        return default_from_dict(cls, data)
 
     def run(self, paths: List[Union[str, Path]]):
         """

--- a/test/preview/components/classifiers/test_file_classifier.py
+++ b/test/preview/components/classifiers/test_file_classifier.py
@@ -12,8 +12,8 @@ from haystack.preview.components.classifiers.file_classifier import FileExtensio
 class TestFileExtensionClassifier:
     @pytest.mark.unit
     def test_to_dict(self):
-        transcriber = FileExtensionClassifier(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
-        data = transcriber.to_dict()
+        component = FileExtensionClassifier(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
+        data = component.to_dict()
         assert data == {
             "type": "FileExtensionClassifier",
             "init_parameters": {"mime_types": ["text/plain", "audio/x-wav", "image/jpeg"]},
@@ -25,8 +25,8 @@ class TestFileExtensionClassifier:
             "type": "FileExtensionClassifier",
             "init_parameters": {"mime_types": ["text/plain", "audio/x-wav", "image/jpeg"]},
         }
-        transcriber = FileExtensionClassifier.from_dict(data)
-        assert transcriber.mime_types == ["text/plain", "audio/x-wav", "image/jpeg"]
+        component = FileExtensionClassifier.from_dict(data)
+        assert component.mime_types == ["text/plain", "audio/x-wav", "image/jpeg"]
 
     @pytest.mark.unit
     def test_run(self, preview_samples_path):

--- a/test/preview/components/classifiers/test_file_classifier.py
+++ b/test/preview/components/classifiers/test_file_classifier.py
@@ -11,6 +11,24 @@ from haystack.preview.components.classifiers.file_classifier import FileExtensio
 )
 class TestFileExtensionClassifier:
     @pytest.mark.unit
+    def test_to_dict(self):
+        transcriber = FileExtensionClassifier(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
+        data = transcriber.to_dict()
+        assert data == {
+            "type": "FileExtensionClassifier",
+            "init_parameters": {"mime_types": ["text/plain", "audio/x-wav", "image/jpeg"]},
+        }
+
+    @pytest.mark.unit
+    def test_from_dict(self):
+        data = {
+            "type": "FileExtensionClassifier",
+            "init_parameters": {"mime_types": ["text/plain", "audio/x-wav", "image/jpeg"]},
+        }
+        transcriber = FileExtensionClassifier.from_dict(data)
+        assert transcriber.mime_types == ["text/plain", "audio/x-wav", "image/jpeg"]
+
+    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly in the simplest happy path.


### PR DESCRIPTION
### Related Issues  

- See https://github.com/deepset-ai/haystack/pull/5647 for all the context.

### Proposed Changes:

- Serialization methods for `FileExtensionClassifier`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
