### PR TITLE
chore: serialization methods for `SentenceTransformersDocumentEmbedder`

### DIFF
--- a/haystack/preview/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/preview/components/embedders/sentence_transformers_document_embedder.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Union, Dict, Any
 
-from haystack.preview import component
-from haystack.preview import Document
+from haystack.preview import component, Document, default_to_dict, default_from_dict
 from haystack.preview.embedding_backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
@@ -54,14 +53,24 @@ class SentenceTransformersDocumentEmbedder:
         """
         Serialize this component to a dictionary.
         """
-        # return default_to_dict(self, ...)
+        return default_to_dict(
+            self,
+            model_name_or_path=self.model_name_or_path,
+            device=str(self.device) if self.device else None,
+            use_auth_token=self.use_auth_token,
+            batch_size=self.batch_size,
+            progress_bar=self.progress_bar,
+            normalize_embeddings=self.normalize_embeddings,
+            metadata_fields_to_embed=self.metadata_fields_to_embed,
+            embedding_separator=self.embedding_separator,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SentenceTransformersDocumentEmbedder":
         """
         Deserialize this component from a dictionary.
         """
-        # return default_from_dict(cls, data)
+        return default_from_dict(cls, data)
 
     def warm_up(self):
         """

--- a/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
@@ -18,6 +18,8 @@ class TestSentenceTransformersDocumentEmbedder:
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
         assert embedder.normalize_embeddings is False
+        assert embedder.metadata_fields_to_embed == []
+        assert embedder.embedding_separator == "\n"
 
     @pytest.mark.unit
     def test_init_with_parameters(self):
@@ -28,6 +30,8 @@ class TestSentenceTransformersDocumentEmbedder:
             batch_size=64,
             progress_bar=False,
             normalize_embeddings=True,
+            metadata_fields_to_embed=["test_field"],
+            embedding_separator=" | ",
         )
         assert embedder.model_name_or_path == "model"
         assert embedder.device == "cpu"
@@ -35,6 +39,78 @@ class TestSentenceTransformersDocumentEmbedder:
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.normalize_embeddings is True
+        assert embedder.metadata_fields_to_embed == ["test_field"]
+        assert embedder.embedding_separator == " | "
+
+    @pytest.mark.unit
+    def test_to_dict(self):
+        component = SentenceTransformersDocumentEmbedder(model_name_or_path="model")
+        data = component.to_dict()
+        assert data == {
+            "type": "SentenceTransformersDocumentEmbedder",
+            "init_parameters": {
+                "model_name_or_path": "model",
+                "device": None,
+                "use_auth_token": None,
+                "batch_size": 32,
+                "progress_bar": True,
+                "normalize_embeddings": False,
+                "embedding_separator": "\n",
+                "metadata_fields_to_embed": [],
+            },
+        }
+
+    @pytest.mark.unit
+    def test_to_dict_with_custom_init_parameters(self):
+        component = SentenceTransformersDocumentEmbedder(
+            model_name_or_path="model",
+            device="cpu",
+            use_auth_token="the-token",
+            batch_size=64,
+            progress_bar=False,
+            normalize_embeddings=True,
+            metadata_fields_to_embed=["meta_field"],
+            embedding_separator=" - ",
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "SentenceTransformersDocumentEmbedder",
+            "init_parameters": {
+                "model_name_or_path": "model",
+                "device": "cpu",
+                "use_auth_token": "the-token",
+                "batch_size": 64,
+                "progress_bar": False,
+                "normalize_embeddings": True,
+                "embedding_separator": " - ",
+                "metadata_fields_to_embed": ["meta_field"],
+            },
+        }
+
+    @pytest.mark.unit
+    def test_from_dict(self):
+        data = {
+            "type": "SentenceTransformersDocumentEmbedder",
+            "init_parameters": {
+                "model_name_or_path": "model",
+                "device": "cpu",
+                "use_auth_token": "the-token",
+                "batch_size": 64,
+                "progress_bar": False,
+                "normalize_embeddings": False,
+                "embedding_separator": " - ",
+                "metadata_fields_to_embed": ["meta_field"],
+            },
+        }
+        component = SentenceTransformersDocumentEmbedder.from_dict(data)
+        assert component.model_name_or_path == "model"
+        assert component.device == "cpu"
+        assert component.use_auth_token == "the-token"
+        assert component.batch_size == 64
+        assert component.progress_bar is False
+        assert component.normalize_embeddings is False
+        assert component.metadata_fields_to_embed == ["meta_field"]
+        assert component.embedding_separator == " - "
 
     @pytest.mark.unit
     @patch(


### PR DESCRIPTION
### Related Issues

- See https://github.com/deepset-ai/haystack/pull/5647 for all the context.

### Proposed Changes:

- Serialization methods for `SentenceTransformersDocumentEmbedder`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
