### PR TITLE
chore: serialization methods for `SentenceTransformersTextEmbedder`

### DIFF
--- a/haystack/preview/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/preview/components/embedders/sentence_transformers_text_embedder.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union, Dict, Any
 
-from haystack.preview import component
+from haystack.preview import component, default_to_dict, default_from_dict
 from haystack.preview.embedding_backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
@@ -40,7 +40,7 @@ class SentenceTransformersTextEmbedder:
 
         self.model_name_or_path = model_name_or_path
         # TODO: remove device parameter and use Haystack's device management once migrated
-        self.device = device
+        self.device = device or "cpu"
         self.use_auth_token = use_auth_token
         self.prefix = prefix
         self.suffix = suffix
@@ -52,14 +52,24 @@ class SentenceTransformersTextEmbedder:
         """
         Serialize this component to a dictionary.
         """
-        # return default_to_dict(self, ...)
+        return default_to_dict(
+            self,
+            model_name_or_path=self.model_name_or_path,
+            device=self.device,
+            use_auth_token=self.use_auth_token,
+            prefix=self.prefix,
+            suffix=self.suffix,
+            batch_size=self.batch_size,
+            progress_bar=self.progress_bar,
+            normalize_embeddings=self.normalize_embeddings,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SentenceTransformersTextEmbedder":
         """
         Deserialize this component from a dictionary.
         """
-        # return default_from_dict(cls, data)
+        return default_from_dict(cls, data)
 
     def warm_up(self):
         """

--- a/test/preview/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_text_embedder.py
@@ -11,7 +11,7 @@ class TestSentenceTransformersTextEmbedder:
     def test_init_default(self):
         embedder = SentenceTransformersTextEmbedder(model_name_or_path="model")
         assert embedder.model_name_or_path == "model"
-        assert embedder.device is None
+        assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.prefix == ""
         assert embedder.suffix == ""
@@ -23,7 +23,7 @@ class TestSentenceTransformersTextEmbedder:
     def test_init_with_parameters(self):
         embedder = SentenceTransformersTextEmbedder(
             model_name_or_path="model",
-            device="cpu",
+            device="cuda-0",
             use_auth_token=True,
             prefix="prefix",
             suffix="suffix",
@@ -32,13 +32,83 @@ class TestSentenceTransformersTextEmbedder:
             normalize_embeddings=True,
         )
         assert embedder.model_name_or_path == "model"
-        assert embedder.device == "cpu"
+        assert embedder.device == "cuda-0"
         assert embedder.use_auth_token is True
         assert embedder.prefix == "prefix"
         assert embedder.suffix == "suffix"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.normalize_embeddings is True
+
+    @pytest.mark.unit
+    def test_to_dict(self):
+        component = SentenceTransformersTextEmbedder(model_name_or_path="model")
+        data = component.to_dict()
+        assert data == {
+            "type": "SentenceTransformersTextEmbedder",
+            "init_parameters": {
+                "model_name_or_path": "model",
+                "device": "cpu",
+                "use_auth_token": None,
+                "prefix": "",
+                "suffix": "",
+                "batch_size": 32,
+                "progress_bar": True,
+                "normalize_embeddings": False,
+            },
+        }
+
+    @pytest.mark.unit
+    def test_to_dict_with_custom_init_parameters(self):
+        component = SentenceTransformersTextEmbedder(
+            model_name_or_path="model",
+            device="cuda-0",
+            use_auth_token=True,
+            prefix="prefix",
+            suffix="suffix",
+            batch_size=64,
+            progress_bar=False,
+            normalize_embeddings=True,
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "SentenceTransformersTextEmbedder",
+            "init_parameters": {
+                "model_name_or_path": "model",
+                "device": "cuda-0",
+                "use_auth_token": True,
+                "prefix": "prefix",
+                "suffix": "suffix",
+                "batch_size": 64,
+                "progress_bar": False,
+                "normalize_embeddings": True,
+            },
+        }
+
+    @pytest.mark.unit
+    def test_from_dict(self):
+        data = {
+            "type": "SentenceTransformersTextEmbedder",
+            "init_parameters": {
+                "model_name_or_path": "model",
+                "device": "cuda-0",
+                "use_auth_token": True,
+                "prefix": "prefix",
+                "suffix": "suffix",
+                "batch_size": 64,
+                "progress_bar": False,
+                "normalize_embeddings": True,
+            },
+        }
+        component = SentenceTransformersTextEmbedder.from_dict(data)
+        assert component.model_name_or_path == "model"
+        assert component.device == "cuda-0"
+        assert component.use_auth_token is True
+        assert component.prefix == "prefix"
+        assert component.suffix == "suffix"
+        assert component.batch_size == 64
+        assert component.progress_bar is False
+        assert component.normalize_embeddings is True
 
     @pytest.mark.unit
     @patch(
@@ -49,7 +119,7 @@ class TestSentenceTransformersTextEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name_or_path="model", device=None, use_auth_token=None
+            model_name_or_path="model", device="cpu", use_auth_token=None
         )
 
     @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- See https://github.com/deepset-ai/haystack/pull/5647 for all the context.

### Proposed Changes:

- Serialization methods for `SentenceTransformersTextEmbedder`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
