### PR TITLE
chore: serialization methods for `TextFileToDocument`

### DIFF
--- a/haystack/preview/components/file_converters/txt.py
+++ b/haystack/preview/components/file_converters/txt.py
@@ -6,7 +6,7 @@ from canals.errors import PipelineRuntimeError
 from tqdm import tqdm
 
 from haystack.preview.lazy_imports import LazyImport
-from haystack.preview import Document, component
+from haystack.preview import Document, component, default_to_dict, default_from_dict
 
 with LazyImport("Run 'pip install farm-haystack[preprocessing]'") as langdetect_import:
     import langdetect
@@ -65,14 +65,22 @@ class TextFileToDocument:
         """
         Serialize this component to a dictionary.
         """
-        # return default_to_dict(self, ...)
+        return default_to_dict(
+            self,
+            encoding=self.encoding,
+            remove_numeric_tables=self.remove_numeric_tables,
+            numeric_row_threshold=self.numeric_row_threshold,
+            valid_languages=self.valid_languages,
+            id_hash_keys=self.id_hash_keys,
+            progress_bar=self.progress_bar,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TextFileToDocument":
         """
         Deserialize this component from a dictionary.
         """
-        # return default_from_dict(cls, data)
+        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(

--- a/test/preview/components/file_converters/test_textfile_to_document.py
+++ b/test/preview/components/file_converters/test_textfile_to_document.py
@@ -12,6 +12,66 @@ from haystack.preview.components.file_converters.txt import TextFileToDocument
 
 class TestTextfileToDocument:
     @pytest.mark.unit
+    def test_to_dict(self):
+        component = TextFileToDocument()
+        data = component.to_dict()
+        assert data == {
+            "type": "TextFileToDocument",
+            "init_parameters": {
+                "encoding": "utf-8",
+                "remove_numeric_tables": False,
+                "numeric_row_threshold": 0.4,
+                "valid_languages": [],
+                "id_hash_keys": [],
+                "progress_bar": True,
+            },
+        }
+
+    @pytest.mark.unit
+    def test_to_dict_with_custom_init_parameters(self):
+        component = TextFileToDocument(
+            encoding="latin-1",
+            remove_numeric_tables=True,
+            numeric_row_threshold=0.7,
+            valid_languages=["en", "de"],
+            id_hash_keys=["name"],
+            progress_bar=False,
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "TextFileToDocument",
+            "init_parameters": {
+                "encoding": "latin-1",
+                "remove_numeric_tables": True,
+                "numeric_row_threshold": 0.7,
+                "valid_languages": ["en", "de"],
+                "id_hash_keys": ["name"],
+                "progress_bar": False,
+            },
+        }
+
+    @pytest.mark.unit
+    def test_from_dict(self):
+        data = {
+            "type": "TextFileToDocument",
+            "init_parameters": {
+                "encoding": "latin-1",
+                "remove_numeric_tables": True,
+                "numeric_row_threshold": 0.7,
+                "valid_languages": ["en", "de"],
+                "id_hash_keys": ["name"],
+                "progress_bar": False,
+            },
+        }
+        component = TextFileToDocument.from_dict(data)
+        assert component.encoding == "latin-1"
+        assert component.remove_numeric_tables
+        assert component.numeric_row_threshold == 0.7
+        assert component.valid_languages == ["en", "de"]
+        assert component.id_hash_keys == ["name"]
+        assert not component.progress_bar
+
+    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly.


### PR DESCRIPTION
### Related Issues

- See https://github.com/deepset-ai/haystack/pull/5647 for all the context.

### Proposed Changes:

- Serialization methods for `TextFileToDocument`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
