### PR TITLE
fix: LinkContentFetcher - when no content retrieved (i.e. request blocked), default to snippet text

### DIFF
--- a/haystack/nodes/retriever/link_content.py
+++ b/haystack/nodes/retriever/link_content.py
@@ -200,8 +200,10 @@ class LinkContentFetcher(BaseComponent):
                 logger.debug("%s handler extracted content from %s", handler, url)
 
             extracted_doc["content"] = content
-            document = Document.from_dict(extracted_doc)
-            fetched_documents = self.processor.process(documents=[document]) if self.processor else [document]
+        else:
+            extracted_doc["content"] = extracted_doc.get("snippet_text", "")  # fallback to snippet_text
+        document = Document.from_dict(extracted_doc)
+        fetched_documents = self.processor.process(documents=[document]) if self.processor else [document]
 
         return fetched_documents
 

--- a/releasenotes/notes/link-content-include-snippet-if-blocked-53b0e3108f010315.yaml
+++ b/releasenotes/notes/link-content-include-snippet-if-blocked-53b0e3108f010315.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    If LinkContentFetcher encounters a block or receives any response code other than HTTPStatus.OK, return the search
+    engine snippet as content, if it's available.

--- a/test/nodes/test_link_content_fetcher.py
+++ b/test/nodes/test_link_content_fetcher.py
@@ -279,7 +279,9 @@ def test_handle_various_response_errors(caplog, mocked_requests, error_code: int
     docs = r.fetch(url=url)
 
     assert f"Couldn't retrieve content from {url}" in caplog.text
-    assert docs == []
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert docs[0].content == ""
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Why:
The primary motivation for this change is to improve the robustness and utility of the `LinkContentFetcher` and by extension `WebRetriever` component as well. Previously, if a request for content scraping from a URL link was blocked, these components would return empty content. This PR aims to address this limitation by returning search engine snippet text as a fallback. In certain scenarios, this snippet text might be sufficient to achieve the task objective, thereby enhancing the overall functionality of these components.

### What:
The core of this change revolves around the `LinkContentFetcher` fetch logic. The logic has been slightly modified to return search engine snippet text when content scraping from a URL is blocked. Additionally, the unit tests have been adjusted to validate this new behavior.

### How can it be used:
This is an internal change that does not break the existing API. It aims to improve the resilience and utility of the `LinkContentFetcher` and `WebRetriever` components by providing a fallback mechanism. Users of these components will benefit from this change automatically, without needing to make any adjustments to their existing setups.

### How did you test it:
The existing unit tests for `LinkContentFetcher` have been adjusted to account for the new fallback mechanism. These tests validate that the components behave as expected when content scraping is blocked or an error is raised and that they return the search engine snippet text in such cases (in our unit test, it is empty content i.e. `""` ).

### Notes For Reviewer:
During the review, please pay special attention to the changes in the fetch logic and the adjustments to the unit tests. Ensure that the new fallback mechanism aligns with the intended goals and that there are no unintended side effects or issues. 
