### PR TITLE
fix: Unpin safetensors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
   "requests",
   "pydantic<2",
   "transformers==4.32.0",
-  "safetensors<0.3.2", # related issue: https://github.com/huggingface/safetensors/issues/314
   "pandas",
   "rank_bm25",
   "scikit-learn>=1.3.0", # TF-IDF, SklearnQueryClassifier and metrics


### PR DESCRIPTION
### Related Issues

- fixes #5529 

It seems that the issue has been fixed in safetensors 0.3.3 release. This release is a dependency of transformers 4.32.0. Let's give it a try on CI. 