### PR TITLE
fix: Change `use_auth_token` to `token` in `TransformersQueryClassifier`

### DIFF
--- a/haystack/nodes/query_classifier/transformers.py
+++ b/haystack/nodes/query_classifier/transformers.py
@@ -121,7 +121,7 @@ class TransformersQueryClassifier(BaseQueryClassifier):
             tokenizer=tokenizer,
             device=resolved_devices[0],
             revision=model_version,
-            use_auth_token=use_auth_token,
+            token=use_auth_token,
         )
 
         self.labels = labels

--- a/test/nodes/test_query_classifier.py
+++ b/test/nodes/test_query_classifier.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import pytest
 from pathlib import Path
 from urllib.error import URLError
@@ -13,6 +14,14 @@ def test_sklearnqueryclassifier_deprecation():
             SklearnQueryClassifier(Path("fake_model"), Path("fake_vectorizer"))
         except URLError:
             pass
+
+
+@pytest.mark.unit
+def test_query_classifier_initialized_with_token_instead_of_use_auth_token():
+    with patch("haystack.nodes.query_classifier.transformers.pipeline") as mock_transformers_pipeline:
+        classifier = TransformersQueryClassifier(task="zero-shot-classification")
+        assert "token" in mock_transformers_pipeline.call_args.kwargs
+        assert "use_auth_token" not in mock_transformers_pipeline.call_args.kwargs
 
 
 @pytest.fixture


### PR DESCRIPTION
### Related Issues

- fixes #5637

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
`use_auth_token` is deprecated in transformers in favor of `token`. This PR changes the parameter `use_auth_token` to `token` in `TransformersQueryClassifier`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added a unit test and tested it manually.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
