### PR TITLE
feat: Allow WebRetrieve to use custom LinkContentFetcher

### DIFF
--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -51,6 +51,7 @@ class WebRetriever(BaseRetriever):
         api_key: str,
         search_engine_provider: Union[str, SearchEngine] = "SerperDev",
         allowed_domains: Optional[List[str]] = None,
+        link_content_fetcher: Optional[LinkContentFetcher] = None,
         top_search_results: Optional[int] = 10,
         top_k: Optional[int] = 5,
         mode: Literal["snippets", "raw_documents", "preprocessed_documents"] = "snippets",
@@ -64,6 +65,8 @@ class WebRetriever(BaseRetriever):
         :param api_key: API key for the search engine provider.
         :param search_engine_provider: Name of the search engine provider class, see `providers.py` for a list of supported providers.
         :param allowed_domains: List of domains to restrict the search to. If not provided, the search is unrestricted.
+        :param link_content_fetcher: LinkContentFetcher to be used to fetch the content from the links. If not provided,
+        the default LinkContentFetcher is used.
         :param top_search_results: Number of top search results to be retrieved.
         :param top_k: Top k documents to be returned by the retriever.
         :param mode: Whether to return snippets, raw documents, or preprocessed documents. Snippets are the default.
@@ -80,6 +83,7 @@ class WebRetriever(BaseRetriever):
             allowed_domains=allowed_domains,
             search_engine_provider=search_engine_provider,
         )
+        self.link_content_fetcher = link_content_fetcher or LinkContentFetcher()
         self.mode = mode
         self.cache_document_store = cache_document_store
         self.document_store = cache_document_store
@@ -186,15 +190,13 @@ class WebRetriever(BaseRetriever):
         if not links:
             return []
 
-        fetcher = LinkContentFetcher(raise_on_failure=True)
-
         def link_fetch(link: SearchResult) -> List[Document]:
             """
             Encapsulate the link fetching logic in a function to be used in a ThreadPoolExecutor.
             """
             docs: List[Document] = []
             try:
-                docs = fetcher.fetch(
+                docs = self.link_content_fetcher.fetch(
                     url=link.url,
                     doc_kwargs={
                         "id_hash_keys": ["meta.url"],

--- a/releasenotes/notes/web-retriever-allow-custom-link-content-fetcher-8728141d81d7a5e5.yaml
+++ b/releasenotes/notes/web-retriever-allow-custom-link-content-fetcher-8728141d81d7a5e5.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Allow WebRetriever users to specify a custom LinkContentFetcher instance


### PR DESCRIPTION
### Why:
The purpose of this change is to enhance the flexibility and customization options available to users of the `WebRetriever` component. Previously, users were limited to the default `LinkContentFetcher` settings, which might not be suitable for all use-cases. For example, users might want to specify a custom user-agent setting for web content fetching. By allowing users to provide their custom `LinkContentFetcher`, we enable them to fine-tune its behavior according to their specific needs.

### What:
The change is focused on the `init` method of the `WebRetriever` component. The method has been modified to accept a custom `LinkContentFetcher` object as an optional parameter, allowing users to specify their customized fetcher.

### How can it be used:
Here is how users can specify their custom LinkContentFetcher. 
```python
alt_user_agents = [
    "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15"
]

custom_link_content_fetcher = LinkContentFetcher(user_agents=alt_user_agents)

web_retriever = WebRetriever(
    api_key=search_key,
    link_content_fetcher=custom_link_content_fetcher,
    mode="preprocessed_documents")

...
...
```
### How did you test it:
No new unit tests were added for this change. However, the existing tests should cover the basic functionality of the `WebRetriever` with the default `LinkContentFetcher`.

### Notes For Reviewer:
During your review, please pay close attention to the changes in the `init` method and ensure that the new optional parameter for the custom `LinkContentFetcher` is implemented correctly. Verify that this change doesn't introduce any unintended side effects or break existing functionality. 