### PR TITLE
chore: fix tests for serialization of STEmbedders

### DIFF
--- a/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
@@ -13,7 +13,7 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_init_default(self):
         embedder = SentenceTransformersDocumentEmbedder(model_name_or_path="model")
         assert embedder.model_name_or_path == "model"
-        assert embedder.device is None
+        assert embedder.device == "cpu"
         assert embedder.use_auth_token is None
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
@@ -25,7 +25,7 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_init_with_parameters(self):
         embedder = SentenceTransformersDocumentEmbedder(
             model_name_or_path="model",
-            device="cpu",
+            device="cuda",
             use_auth_token=True,
             batch_size=64,
             progress_bar=False,
@@ -34,7 +34,7 @@ class TestSentenceTransformersDocumentEmbedder:
             embedding_separator=" | ",
         )
         assert embedder.model_name_or_path == "model"
-        assert embedder.device == "cpu"
+        assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
@@ -50,7 +50,7 @@ class TestSentenceTransformersDocumentEmbedder:
             "type": "SentenceTransformersDocumentEmbedder",
             "init_parameters": {
                 "model_name_or_path": "model",
-                "device": None,
+                "device": "cpu",
                 "use_auth_token": None,
                 "batch_size": 32,
                 "progress_bar": True,
@@ -64,7 +64,7 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_to_dict_with_custom_init_parameters(self):
         component = SentenceTransformersDocumentEmbedder(
             model_name_or_path="model",
-            device="cpu",
+            device="cuda",
             use_auth_token="the-token",
             batch_size=64,
             progress_bar=False,
@@ -77,7 +77,7 @@ class TestSentenceTransformersDocumentEmbedder:
             "type": "SentenceTransformersDocumentEmbedder",
             "init_parameters": {
                 "model_name_or_path": "model",
-                "device": "cpu",
+                "device": "cuda",
                 "use_auth_token": "the-token",
                 "batch_size": 64,
                 "progress_bar": False,
@@ -93,7 +93,7 @@ class TestSentenceTransformersDocumentEmbedder:
             "type": "SentenceTransformersDocumentEmbedder",
             "init_parameters": {
                 "model_name_or_path": "model",
-                "device": "cpu",
+                "device": "cuda",
                 "use_auth_token": "the-token",
                 "batch_size": 64,
                 "progress_bar": False,
@@ -104,7 +104,7 @@ class TestSentenceTransformersDocumentEmbedder:
         }
         component = SentenceTransformersDocumentEmbedder.from_dict(data)
         assert component.model_name_or_path == "model"
-        assert component.device == "cpu"
+        assert component.device == "cuda"
         assert component.use_auth_token == "the-token"
         assert component.batch_size == 64
         assert component.progress_bar is False
@@ -121,7 +121,7 @@ class TestSentenceTransformersDocumentEmbedder:
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once_with(
-            model_name_or_path="model", device=None, use_auth_token=None
+            model_name_or_path="model", device="cpu", use_auth_token=None
         )
 
     @pytest.mark.unit

--- a/test/preview/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_text_embedder.py
@@ -23,7 +23,7 @@ class TestSentenceTransformersTextEmbedder:
     def test_init_with_parameters(self):
         embedder = SentenceTransformersTextEmbedder(
             model_name_or_path="model",
-            device="cuda-0",
+            device="cuda",
             use_auth_token=True,
             prefix="prefix",
             suffix="suffix",
@@ -32,7 +32,7 @@ class TestSentenceTransformersTextEmbedder:
             normalize_embeddings=True,
         )
         assert embedder.model_name_or_path == "model"
-        assert embedder.device == "cuda-0"
+        assert embedder.device == "cuda"
         assert embedder.use_auth_token is True
         assert embedder.prefix == "prefix"
         assert embedder.suffix == "suffix"
@@ -62,7 +62,7 @@ class TestSentenceTransformersTextEmbedder:
     def test_to_dict_with_custom_init_parameters(self):
         component = SentenceTransformersTextEmbedder(
             model_name_or_path="model",
-            device="cuda-0",
+            device="cuda",
             use_auth_token=True,
             prefix="prefix",
             suffix="suffix",
@@ -75,7 +75,7 @@ class TestSentenceTransformersTextEmbedder:
             "type": "SentenceTransformersTextEmbedder",
             "init_parameters": {
                 "model_name_or_path": "model",
-                "device": "cuda-0",
+                "device": "cuda",
                 "use_auth_token": True,
                 "prefix": "prefix",
                 "suffix": "suffix",
@@ -91,7 +91,7 @@ class TestSentenceTransformersTextEmbedder:
             "type": "SentenceTransformersTextEmbedder",
             "init_parameters": {
                 "model_name_or_path": "model",
-                "device": "cuda-0",
+                "device": "cuda",
                 "use_auth_token": True,
                 "prefix": "prefix",
                 "suffix": "suffix",
@@ -102,7 +102,7 @@ class TestSentenceTransformersTextEmbedder:
         }
         component = SentenceTransformersTextEmbedder.from_dict(data)
         assert component.model_name_or_path == "model"
-        assert component.device == "cuda-0"
+        assert component.device == "cuda"
         assert component.use_auth_token is True
         assert component.prefix == "prefix"
         assert component.suffix == "suffix"


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- Fix tests of both STEmbedders by checking for the correct device name.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
