### PR TITLE
Add default to_dict and from_dict in document stores built with factory

### DIFF
--- a/haystack/preview/testing/factory.py
+++ b/haystack/preview/testing/factory.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional, Tuple, Type, List, Union
 
+from haystack.preview import default_to_dict, default_from_dict
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores import document_store, DocumentStore, DuplicatePolicy
 
@@ -96,11 +97,16 @@ def document_store_class(
     def delete_documents(self, document_ids: List[str]) -> None:
         return
 
+    def to_dict(self) -> Dict[str, Any]:
+        return default_to_dict(self)
+
     fields = {
         "count_documents": count_documents,
         "filter_documents": filter_documents,
         "write_documents": write_documents,
         "delete_documents": delete_documents,
+        "to_dict": to_dict,
+        "from_dict": classmethod(default_from_dict),
     }
 
     if extra_fields is not None:

--- a/test/preview/testing/test_factory.py
+++ b/test/preview/testing/test_factory.py
@@ -13,6 +13,15 @@ def test_document_store_class_default():
     assert store.filter_documents() == []
     assert store.write_documents([]) is None
     assert store.delete_documents([]) is None
+    assert store.to_dict() == {"type": "MyStore", "init_parameters": {}}
+
+
+@pytest.mark.unit
+def test_document_store_from_dict():
+    MyStore = document_store_class("MyStore")
+
+    store = MyStore.from_dict({"type": "MyStore", "init_parameters": {}})
+    assert isinstance(store, MyStore)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Proposed Changes:

Add minimal default `to_dict` and `from_dict` in `DocumentStore` built using `document_store_class` factory.

### How did you test it?

Run `pytest test/preview` locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
