### PR TITLE
fix: Improve imports for new rankers

### DIFF
--- a/examples/talk_to_website.py
+++ b/examples/talk_to_website.py
@@ -5,7 +5,7 @@ from typing import Dict, Any
 from haystack import Pipeline
 from haystack.document_stores import InMemoryDocumentStore
 from haystack.nodes import PromptNode, PromptTemplate, TopPSampler
-from haystack.nodes.ranker.lost_in_the_middle import LostInTheMiddleRanker
+from haystack.nodes.ranker import LostInTheMiddleRanker
 from haystack.nodes.retriever.web import WebRetriever
 
 search_key = os.environ.get("SERPERDEV_API_KEY")

--- a/examples/web_lfqa_with_rankers.py
+++ b/examples/web_lfqa_with_rankers.py
@@ -4,9 +4,9 @@ from typing import Dict, Any
 
 from haystack import Pipeline
 from haystack.nodes import PromptNode, PromptTemplate, TopPSampler
-from haystack.nodes.ranker.diversity import DiversityRanker
-from haystack.nodes.ranker.lost_in_the_middle import LostInTheMiddleRanker
-from haystack.nodes.retriever.web import WebRetriever
+from haystack.nodes.ranker import DiversityRanker
+from haystack.nodes.ranker import LostInTheMiddleRanker
+from haystack.nodes.retriever import WebRetriever
 
 search_key = os.environ.get("SERPERDEV_API_KEY")
 if not search_key:

--- a/examples/web_lfqa_with_rankers.py
+++ b/examples/web_lfqa_with_rankers.py
@@ -4,8 +4,7 @@ from typing import Dict, Any
 
 from haystack import Pipeline
 from haystack.nodes import PromptNode, PromptTemplate, TopPSampler
-from haystack.nodes.ranker import DiversityRanker
-from haystack.nodes.ranker import LostInTheMiddleRanker
+from haystack.nodes.ranker import DiversityRanker, LostInTheMiddleRanker
 from haystack.nodes.retriever import WebRetriever
 
 search_key = os.environ.get("SERPERDEV_API_KEY")

--- a/haystack/nodes/ranker/__init__.py
+++ b/haystack/nodes/ranker/__init__.py
@@ -1,3 +1,6 @@
 from haystack.nodes.ranker.base import BaseRanker
 from haystack.nodes.ranker.sentence_transformers import SentenceTransformersRanker
 from haystack.nodes.ranker.cohere import CohereRanker
+from haystack.nodes.ranker.lost_in_the_middle import LostInTheMiddleRanker
+from haystack.nodes.ranker.diversity import DiversityRanker
+from haystack.nodes.ranker.recentness_ranker import RecentnessRanker

--- a/haystack/nodes/ranker/diversity.py
+++ b/haystack/nodes/ranker/diversity.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import List, Literal, Optional, Union
 
-from haystack.nodes import BaseRanker
+from haystack.nodes.ranker.base import BaseRanker
 from haystack.schema import Document
 from haystack.lazy_imports import LazyImport
 


### PR DESCRIPTION
### Why:
The PR aims to standardize how new rankers: `RecentnessRanker`, `DiversityRanker`, and `LostInTheMiddleRanker` are imported in Haystack. Currently, these rankers are inconsistently imported compared to existing rankers. By modifying `haystack/nodes/ranker/__init__.py`, we make it possible for users to import these rankers in a manner consistent with existing ones.

### What:
Updated `haystack/nodes/ranker/__init__.py` to include the new rankers and also updated examples to reflect this change.

### How can it be used:
After this change, users can import the new rankers as shown below, which is consistent with how existing rankers are imported:
```python
from haystack.nodes.ranker import DiversityRanker, LostInTheMiddleRanker, RecentnessRanker
```

### How did you test it:
Manually tested the new import paths in the `haystack/examples` directory to ensure they work as expected.

### Notes For Reviewer:
Please double-check the examples on this branch to ensure that the new import paths are correctly implemented and that there are no unintended side effects.
