### PR TITLE
feat: add a REST API streaming endpoint for the query pipeline

### DIFF
--- a/rest_api/releasenotes/notes/add-fastapi-streaming-endpoint-f9264b4a0a27eb06.yaml
+++ b/rest_api/releasenotes/notes/add-fastapi-streaming-endpoint-f9264b4a0a27eb06.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    add a FastAPI streaming endpoint for the query pipeline

--- a/rest_api/releasenotes/notes/add-fastapi-streaming-endpoint-f9264b4a0a27eb06.yaml
+++ b/rest_api/releasenotes/notes/add-fastapi-streaming-endpoint-f9264b4a0a27eb06.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    add a FastAPI streaming endpoint for the query pipeline
+    add a REST API streaming endpoint for the query pipeline

--- a/rest_api/rest_api/controller/search.py
+++ b/rest_api/rest_api/controller/search.py
@@ -106,13 +106,13 @@ async def query_streaming(request: QueryRequest):
         run_signature_args = inspect.signature(last_node_component).parameters.keys()
 
         if isinstance(last_node_component, PromptNode):
-            result = _process_streaming_request(
+            result = _process_request_streaming(
                 query_pipeline, request, run_signature_args, last_node_component, last_node_name
             )
             return result
         else:
             if "stream_handler" in run_signature_args:
-                result = _process_streaming_request(
+                result = _process_request_streaming(
                     query_pipeline, request, run_signature_args, last_node_component, last_node_name
                 )
             else:
@@ -139,7 +139,7 @@ def _process_request(pipeline, request) -> Dict[str, Any]:
     return result
 
 
-def _process_streaming_request(
+def _process_request_streaming(
     pipeline, request, run_signature_args, last_node_component, last_node_name
 ) -> StreamingResponse:
     params = request.params or {}

--- a/rest_api/rest_api/controller/search.py
+++ b/rest_api/rest_api/controller/search.py
@@ -109,6 +109,7 @@ async def query_streaming(request: QueryRequest):
             result = _process_streaming_request(
                 query_pipeline, request, run_signature_args, last_node_component, last_node_name
             )
+            return result
         else:
             if "stream_handler" in run_signature_args:
                 result = _process_streaming_request(
@@ -117,7 +118,7 @@ async def query_streaming(request: QueryRequest):
             else:
                 result = _process_request(query_pipeline, request)
 
-        return result
+            return result
 
 
 def _process_request(pipeline, request) -> Dict[str, Any]:

--- a/rest_api/rest_api/controller/search.py
+++ b/rest_api/rest_api/controller/search.py
@@ -174,9 +174,9 @@ def _process_request_streaming(pipeline, request) -> StreamingResponse:
             stream_handler(warning_msg)
             g.close()
 
-        def token_generator(warning_msg: str):
+        def warning_message_generator(warning_msg: str):
             g = ThreadedGenerator()
             threading.Thread(target=warning_message_thread, args=(g, warning_msg)).start()
             return g
 
-        return StreamingResponse(token_generator(warning_msg), media_type="text/event-stream")
+        return StreamingResponse(warning_message_generator(warning_msg), media_type="text/event-stream")

--- a/rest_api/rest_api/controller/search.py
+++ b/rest_api/rest_api/controller/search.py
@@ -147,7 +147,7 @@ def _process_streaming_request(pipeline, request) -> StreamingResponse:
                     params[last_node_name] = {"invocation_context": {"stream_handler": FastAPITokenStreamingHandler(g)}}
             else:
                 logging.warning(
-                    "The he last component in the pipeline is not a PromptNode or it does not accept the parameter `stream_handler`. The output will not be streamed."
+                    "The last component in the pipeline is not a PromptNode or it does not accept the parameter `stream_handler`. The output will not be streamed."
                 )
 
             pipeline.run(query=prompt, params=params)

--- a/rest_api/rest_api/controller/search.py
+++ b/rest_api/rest_api/controller/search.py
@@ -3,16 +3,21 @@ from typing import Dict, Any
 import logging
 import time
 import json
+import threading
+import queue
+import inspect
 
 from pydantic import BaseConfig
 from fastapi import FastAPI, APIRouter
+from fastapi.responses import StreamingResponse
 import haystack
 from haystack import Pipeline
+from haystack.nodes.prompt.invocation_layer import TokenStreamingHandler
+from haystack.nodes import PromptNode
 
 from rest_api.utils import get_app, get_pipelines
 from rest_api.config import LOG_LEVEL
 from rest_api.schema import QueryRequest, QueryResponse
-
 
 logging.getLogger("haystack").setLevel(LOG_LEVEL)
 logger = logging.getLogger("haystack")
@@ -20,7 +25,34 @@ logger = logging.getLogger("haystack")
 
 BaseConfig.arbitrary_types_allowed = True
 
+class ThreadedGenerator:
+    def __init__(self):
+        self.queue = queue.Queue()
 
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        item = self.queue.get()
+        if item is StopIteration: raise item
+        return item
+
+    def send(self, data):
+        self.queue.put(data)
+
+    def close(self):
+        self.queue.put(StopIteration)
+
+
+class FastAPITokenStreamingHandler(TokenStreamingHandler):
+    def __init__(self, generator: ThreadedGenerator):
+        self.generator = generator
+
+    def __call__(self, token_received, **kwargs):
+        self.generator.send(token_received)
+        return token_received
+    
+    
 router = APIRouter()
 app: FastAPI = get_app()
 query_pipeline: Pipeline = get_pipelines().get("query_pipeline", None)
@@ -58,6 +90,18 @@ def query(request: QueryRequest):
         return result
 
 
+@router.post("/query-streaming", response_model=QueryResponse, response_model_exclude_none=True)
+async def query_streaming(request: QueryRequest):
+    """
+    This endpoint receives the question as a string and allows the requester to set
+    additional parameters that will be passed on to the Haystack pipeline. If the last node in the pipeline 
+    is a PromptNode, the output of the last note will be a streaming text. Otherwise, the output will not be streamed. 
+    """
+    with concurrency_limiter.run():
+        result = _process_streaming_request(query_pipeline, request)
+        return result    
+    
+
 def _process_request(pipeline, request) -> Dict[str, Any]:
     start_time = time.time()
 
@@ -74,3 +118,39 @@ def _process_request(pipeline, request) -> Dict[str, Any]:
         json.dumps({"request": request, "response": result, "time": f"{(time.time() - start_time):.2f}"}, default=str)
     )
     return result
+
+
+def _process_streaming_request(pipeline, request) -> StreamingResponse:
+    params = request.params or {}
+    last_node_name = list(query_pipeline.graph.nodes)[-1]
+    last_node_component = query_pipeline.graph.nodes.get(last_node_name)['component']
+    run_signature_args = inspect.signature(last_node_component).parameters.keys()
+
+    def prompt_node_invocation_thread(pipeline, g, prompt):
+        try:
+            if "stream_hanlder" in run_signature_args:
+                if last_node_name in params:
+                    params[last_node_name]["stream_handler"] = FastAPITokenStreamingHandler(g)
+                else:
+                    params[last_node_name] = {"stream_handler": FastAPITokenStreamingHandler(g)}
+            elif isinstance(last_node_component, PromptNode):
+                if last_node_name in params:
+                    if "invocation_context" in params[last_node_name].keys():
+                        params[last_node_name]["invocation_context"]["stream_handler"] = FastAPITokenStreamingHandler(g)
+                    else:
+                            params[last_node_name]["invocation_context"] = {"stream_handler": FastAPITokenStreamingHandler(g)}
+                else:
+                    params[last_node_name] = {"invocation_context": {"stream_handler": FastAPITokenStreamingHandler(g)}}
+            else:
+                logging.warning("The he last component in the pipeline is not a PromptNode or it does not accept the parameter `stream_handler`. The output will not be streamed.")
+
+            pipeline.run(query=prompt, params=params)
+        finally:
+            g.close()
+            
+    def token_generator(prompt: str):
+        g = ThreadedGenerator()
+        threading.Thread(target=prompt_node_invocation_thread, args=(pipeline, g, prompt)).start()
+        return g
+
+    return StreamingResponse(token_generator(request.query), media_type='text/event-stream')


### PR DESCRIPTION
### Related Issues
Following the suggestion in PR #4889, I implemented a streaming endpoint in my application. I thought this feature might be interesting for other users as well, which leads to this PR.

### Proposed Changes:
- add a new endpoint `query-streaming`, which outputs the result of the last component in the pipeline in streaming form
- this feature has one prerequisite: the last node in the pipeline should be a PromptNode or a node that accepts `stream_handler` in their `run` method. Otherwise, a warning message will be returned.

### How did you test it?
- locally with the following example yaml file
```yaml
components:
- name: AnswerParser
  params: {}
  type: AnswerParser
- name: custom-at-query-time
  params:
    output_parser: AnswerParser
    prompt: "Please answer the following question. Question: {query} \n\n Answer:"
  type: PromptTemplate
- name: generator
  params:
    api_key: <your openai api key>
    default_prompt_template: custom-at-query-time
    model_name_or_path: text-davinci-003
  type: PromptNode
pipelines:
- name: query
  nodes:
  - inputs:
    - Query
    name: generator
version: 1.20.0rc0
```
To start the backend, run 
```bash
export PIPELINE_YAML_PATH=/home/user/workspace/example.yaml 
export QUERY_PIPELINE_NAME=query 
uvicorn rest_api.application:app --reload --workers 1
```
To query the results, run
```bash 
curl -w "\n" -N -X POST -H "Content-Type: application/json" -d '{"query": "Why do airplanes leave contrails in the sky?"}' http://localhost:8000/query-streaming
```

### Notes for the reviewer
There is another PR #5646 of mine which enables passing an object to `pipeline.run()`. This PR will only work if that PR gets merged first. @ZanSara 

The "exception handling" in my solution (the warning message) is not optimal, pls let me know if you have a better idea.
Also please let me know if a unit test is needed here.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
