### PR TITLE
Rename `question` to `query` in `Answer` dataclass (2.0)

### DIFF
--- a/haystack/preview/dataclasses/answer.py
+++ b/haystack/preview/dataclasses/answer.py
@@ -6,7 +6,7 @@ from haystack.preview.dataclasses.document import Document
 @dataclass(frozen=True)
 class Answer:
     data: Any
-    question: str
+    query: str
     metadata: Dict[str, Any]
 
 


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

This PR renames the `question` field of the `Answer` dataclass to `query`. We use `query` much more often in the codebase and should be consistent with naming.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
