### PR TITLE
feat: Add `AnswersBuilder` component (2.0)

### DIFF
--- a/haystack/preview/components/builders/answers_builder.py
+++ b/haystack/preview/components/builders/answers_builder.py
@@ -145,14 +145,8 @@ class AnswersBuilder:
                 if not match.lastindex:
                     extracted_answers.append(match.group(0))
                 # One capture group in pattern -> use the capture group as answer
-                elif match.lastindex == 1:
-                    extracted_answers.append(match.group(1))
-                # Multiple capture groups in pattern -> raise error
                 else:
-                    raise ValueError(
-                        f"Pattern '{pattern}' contains multiple capture groups. "
-                        f"Please specify a pattern with at most one capture group."
-                    )
+                    extracted_answers.append(match.group(1))
             else:
                 extracted_answers.append("")
 

--- a/haystack/preview/components/builders/answers_builder.py
+++ b/haystack/preview/components/builders/answers_builder.py
@@ -83,15 +83,18 @@ class AnswersBuilder:
             if doc_list and reference_pattern:
                 reference_idxs = AnswersBuilder._extract_reference_idxs(reply_list, reference_pattern)
             else:
-                reference_idxs = [[doc_idx for doc_idx, _ in enumerate(docs, start=1)] for docs in doc_list]
+                reference_idxs = [[doc_idx for doc_idx, _ in enumerate(doc_list)] * len(reply_list)]
 
+            answers_for_cur_query = []
             for answer_string, doc_idxs, meta in zip_longest(extracted_answer_strings, reference_idxs, meta_list):
                 referenced_docs = []
                 if doc_idxs:
                     referenced_docs = [doc_list[idx] for idx in doc_idxs if idx < len(doc_list)]
 
                 answer = GeneratedAnswer(data=answer_string, query=query, documents=referenced_docs, metadata=meta)
-                all_answers.append(answer)
+                answers_for_cur_query.append(answer)
+
+            all_answers.append(answers_for_cur_query)
 
         return all_answers
 

--- a/haystack/preview/components/builders/answers_builder.py
+++ b/haystack/preview/components/builders/answers_builder.py
@@ -21,14 +21,14 @@ class AnswersBuilder:
                         most one capture group. If a capture group is present, the text matched by the capture group
                         is used as the answer. If no capture group is present, the whole match is used as the answer.
                         Examples:
-                            `[^\\n]+$` finds "this is an answer" in string "this is an argument.\nthis is an answer".
-                            `Answer: (.*)` finds "this is an answer" in string "this is an argument. Answer: this is an answer".
+                            `[^\\n]+$` finds "this is an answer" in a string "this is an argument.\nthis is an answer".
+                            `Answer: (.*)` finds "this is an answer" in a string "this is an argument. Answer: this is an answer".
                         Default: `None`.
         :param reference_pattern: The regular expression pattern to use for parsing the document references.
                                   We assume that references are specified as indices of the input documents and that
                                   indices start at 1.
-                                  Example: `\\[(\\d+)\\]` finds "1" in string "this is an answer[1]".
-                                  If not specified, no parsing is done and all documents are referenced.
+                                  Example: `\\[(\\d+)\\]` finds "1" in a string "this is an answer[1]".
+                                  If not specified, no parsing is done, and all documents are referenced.
                                   Default: `None`.
         """
         if pattern:
@@ -63,14 +63,14 @@ class AnswersBuilder:
                         most one capture group. If a capture group is present, the text matched by the capture group
                         is used as the answer. If no capture group is present, the whole match is used as the answer.
                         Examples:
-                            `[^\\n]+$` finds "this is an answer" in string "this is an argument.\nthis is an answer".
-                            `Answer: (.*)` finds "this is an answer" in string "this is an argument. Answer: this is an answer".
+                            `[^\\n]+$` finds "this is an answer" in a string "this is an argument.\nthis is an answer".
+                            `Answer: (.*)` finds "this is an answer" in a string "this is an argument. Answer: this is an answer".
                         Default: `None`.
         :param reference_pattern: The regular expression pattern to use for parsing the document references.
                                   We assume that references are specified as indices of the input documents and that
                                   indices start at 1.
-                                  Example: `\\[(\\d+)\\]` finds "1" in string "this is an answer[1]".
-                                  If not specified, no parsing is done and all documents are referenced.
+                                  Example: `\\[(\\d+)\\]` finds "1" in a string "this is an answer[1]".
+                                  If not specified, no parsing is done, and all documents are referenced.
                                   Default: `None`.
         """
         if len(queries) != len(replies) != len(metadata):

--- a/haystack/preview/components/builders/answers_builder.py
+++ b/haystack/preview/components/builders/answers_builder.py
@@ -1,0 +1,150 @@
+from itertools import zip_longest
+import re
+from typing import List, Dict, Any, Optional
+
+from haystack.preview import component, GeneratedAnswer, Document, default_to_dict, default_from_dict
+
+
+@component
+class AnswersBuilder:
+    """
+    A component to parse the output of a Generator to `Answer` objects using regular expressions.
+    """
+
+    def __init__(self, pattern: Optional[str] = None, reference_pattern: Optional[str] = None):
+        """
+        :param pattern: The regular expression pattern to use to extract the answer text from the generator output.
+                        If not specified, the whole string is used as the answer. The regular expression can have at
+                        most one capture group. If a capture group is present, the text matched by the capture group
+                        is used as the answer. If no capture group is present, the whole match is used as the answer.
+                        Examples:
+                            `[^\\n]+$` finds "this is an answer" in string "this is an argument.\nthis is an answer".
+                            `Answer: (.*)` finds "this is an answer" in string "this is an argument. Answer: this is an answer".
+                        Default: `None`.
+        :param reference_pattern: The regular expression pattern to use for parsing the document references.
+                                  We assume that references are specified as indices of the input documents and that
+                                  indices start at 1.
+                                  Example: `\\[(\\d+)\\]` finds "1" in string "this is an answer[1]".
+                                  If not specified, no parsing is done and all documents are referenced.
+                                  Default: `None`.
+        """
+        self.pattern = pattern
+        self.reference_pattern = reference_pattern
+
+    @component.output_types(answers=List[List[GeneratedAnswer]])
+    def run(
+        self,
+        queries: List[str],
+        replies: List[List[str]],
+        metadata: List[List[Dict[str, Any]]],
+        documents: Optional[List[List[Document]]] = None,
+        pattern: Optional[str] = None,
+        reference_pattern: Optional[str] = None,
+    ):
+        """
+        Parse the output of a Generator to `Answer` objects using regular expressions.
+
+        :param queries: The queries used in the prompts for the Generator. A list of strings.
+        :param replies: The output of the Generator. A list of lists of strings.
+        :param metadata: The metadata returned by the Generator. A list of lists of dictionaries.
+        :param documents: The documents used as input to the Generator. A list of lists of `Document` objects. If
+                          `documents` are specified, they are added to the `Answer` objects.
+                          If both `documents` and `reference_pattern` are specified, the documents referenced in the
+                          Generator output are extracted from the input documents and added to the `Answer` objects.
+                          Default: `None`.
+        :param pattern: The regular expression pattern to use to extract the answer text from the generator output.
+                        If not specified, the whole string is used as the answer. The regular expression can have at
+                        most one capture group. If a capture group is present, the text matched by the capture group
+                        is used as the answer. If no capture group is present, the whole match is used as the answer.
+                        Examples:
+                            `[^\\n]+$` finds "this is an answer" in string "this is an argument.\nthis is an answer".
+                            `Answer: (.*)` finds "this is an answer" in string "this is an argument. Answer: this is an answer".
+                        Default: `None`.
+        :param reference_pattern: The regular expression pattern to use for parsing the document references.
+                                  We assume that references are specified as indices of the input documents and that
+                                  indices start at 1.
+                                  Example: `\\[(\\d+)\\]` finds "1" in string "this is an answer[1]".
+                                  If not specified, no parsing is done and all documents are referenced.
+                                  Default: `None`.
+        """
+        if len(queries) != len(replies) != len(metadata):
+            raise ValueError(
+                f"Number of queries ({len(queries)}), replies ({len(replies)}), and metadata "
+                f"({len(metadata)}) must match."
+            )
+
+        documents = documents or []
+        pattern = pattern or self.pattern
+        reference_pattern = reference_pattern or self.reference_pattern
+
+        all_answers = []
+        for query, reply_list, doc_list, meta_list in zip_longest(queries, replies, documents, metadata, fillvalue=[]):
+            extracted_answer_strings = AnswersBuilder._extract_answer_strings(reply_list, pattern)
+            if doc_list and reference_pattern:
+                reference_idxs = AnswersBuilder._extract_reference_idxs(reply_list, reference_pattern)
+            else:
+                reference_idxs = [[doc_idx for doc_idx, _ in enumerate(docs, start=1)] for docs in doc_list]
+
+            for answer_string, doc_idxs, meta in zip_longest(extracted_answer_strings, reference_idxs, meta_list):
+                referenced_docs = []
+                if doc_idxs:
+                    referenced_docs = [doc_list[idx] for idx in doc_idxs if idx < len(doc_list)]
+
+                answer = GeneratedAnswer(data=answer_string, query=query, documents=referenced_docs, metadata=meta)
+                all_answers.append(answer)
+
+        return all_answers
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        return default_to_dict(self, pattern=self.pattern, reference_pattern=self.reference_pattern)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AnswersBuilder":
+        """
+        Deserialize this component from a dictionary.
+        """
+        return default_from_dict(cls, data)
+
+    @staticmethod
+    def _extract_answer_strings(replies: List[str], pattern: Optional[str] = None) -> List[str]:
+        """
+        Extract the answer strings from the generator output using the specified pattern.
+        If no pattern is specified, the whole string is used as the answer.
+
+        :param replies: The output of the Generator. A list of strings.
+        :param pattern: The regular expression pattern to use to extract the answer text from the generator output.
+        """
+        if pattern is None:
+            return replies
+
+        extracted_answers = []
+        for reply in replies:
+            if match := re.search(pattern, reply):
+                # No capture group in pattern -> use the whole match as answer
+                if not match.lastindex:
+                    extracted_answers.append(match.group(0))
+                # One capture group in pattern -> use the capture group as answer
+                elif match.lastindex == 1:
+                    extracted_answers.append(match.group(1))
+                # Multiple capture groups in pattern -> raise error
+                else:
+                    raise ValueError(
+                        f"Pattern '{pattern}' contains multiple capture groups. "
+                        f"Please specify a pattern with at most one capture group."
+                    )
+            else:
+                extracted_answers.append("")
+
+        return extracted_answers
+
+    @staticmethod
+    def _extract_reference_idxs(replies: List[str], reference_pattern: str) -> List[List[int]]:
+        reference_idxs = []
+        for reply in replies:
+            document_idxs = re.findall(reference_pattern, reply)
+            reference_idxs.append([int(idx) - 1 for idx in document_idxs])
+
+        return reference_idxs

--- a/haystack/preview/dataclasses/answer.py
+++ b/haystack/preview/dataclasses/answer.py
@@ -6,7 +6,7 @@ from haystack.preview.dataclasses.document import Document
 @dataclass(frozen=True)
 class Answer:
     data: Any
-    question: str
+    query: str
     metadata: Dict[str, Any]
 
 

--- a/releasenotes/notes/add-answersbuilder-2.0-5dd255eeba68041f.yaml
+++ b/releasenotes/notes/add-answersbuilder-2.0-5dd255eeba68041f.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Add the `AnswersBuilder` component for Haystack 2.0 that creates Answer objects from the string output of Generators.

--- a/test/preview/components/builders/test_answers_builders.py
+++ b/test/preview/components/builders/test_answers_builders.py
@@ -1,0 +1,156 @@
+import pytest
+
+from haystack.preview import GeneratedAnswer, Document
+from haystack.preview.components.builders.answers_builder import AnswersBuilder
+
+
+class TestAnswersBuilder:
+    @pytest.mark.unit
+    def test_to_dict(self):
+        component = AnswersBuilder()
+        data = component.to_dict()
+        assert data == {"type": "AnswersBuilder", "init_parameters": {"pattern": None, "reference_pattern": None}}
+
+    @pytest.mark.unit
+    def test_to_dict_with_custom_init_parameters(self):
+        component = AnswersBuilder(pattern="pattern", reference_pattern="reference_pattern")
+        data = component.to_dict()
+        assert data == {
+            "type": "AnswersBuilder",
+            "init_parameters": {"pattern": "pattern", "reference_pattern": "reference_pattern"},
+        }
+
+    @pytest.mark.unit
+    def test_from_dict(self):
+        data = {
+            "type": "AnswersBuilder",
+            "init_parameters": {"pattern": "pattern", "reference_pattern": "reference_pattern"},
+        }
+        component = AnswersBuilder.from_dict(data)
+        assert component.pattern == "pattern"
+        assert component.reference_pattern == "reference_pattern"
+
+    @pytest.mark.unit
+    def test_run_unmatching_input_len(self):
+        component = AnswersBuilder()
+        with pytest.raises(ValueError):
+            component.run(queries=["query"], replies=[["reply1"], ["reply2"]], metadata=[[]])
+
+    def test_run_without_pattern(self):
+        component = AnswersBuilder()
+        answers = component.run(queries=["test query"], replies=[["Answer: AnswerString"]], metadata=[[{}]])
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "Answer: AnswerString"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert answers[0][0].documents == []
+        assert isinstance(answers[0][0], GeneratedAnswer)
+
+    def test_run_with_pattern_with_capturing_group(self):
+        component = AnswersBuilder(pattern=r"Answer: (.*)")
+        answers = component.run(queries=["test query"], replies=[["Answer: AnswerString"]], metadata=[[{}]])
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "AnswerString"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert answers[0][0].documents == []
+        assert isinstance(answers[0][0], GeneratedAnswer)
+
+    def test_run_with_pattern_without_capturing_group(self):
+        component = AnswersBuilder(pattern=r"'.*'")
+        answers = component.run(queries=["test query"], replies=[["Answer: 'AnswerString'"]], metadata=[[{}]])
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "'AnswerString'"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert answers[0][0].documents == []
+        assert isinstance(answers[0][0], GeneratedAnswer)
+
+    def test_run_with_pattern_with_more_than_one_capturing_group(self):
+        component = AnswersBuilder(pattern=r"Answer: (.*), (.*)")
+        with pytest.raises(ValueError, match="contains multiple capture groups"):
+            component.run(queries=["test query"], replies=[["Answer: AnswerString, AnswerString2"]], metadata=[[{}]])
+
+    def test_run_with_pattern_set_at_runtime(self):
+        component = AnswersBuilder()
+        answers = component.run(
+            queries=["test query"], replies=[["Answer: AnswerString"]], metadata=[[{}]], pattern=r"Answer: (.*)"
+        )
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "AnswerString"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert answers[0][0].documents == []
+        assert isinstance(answers[0][0], GeneratedAnswer)
+
+    def test_run_with_documents_without_reference_pattern(self):
+        component = AnswersBuilder()
+        answers = component.run(
+            queries=["test query"],
+            replies=[["Answer: AnswerString"]],
+            metadata=[[{}]],
+            documents=[[Document(content="test doc 1"), Document(content="test doc 2")]],
+        )
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "Answer: AnswerString"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert len(answers[0][0].documents) == 2
+        assert answers[0][0].documents[0].content == "test doc 1"
+        assert answers[0][0].documents[1].content == "test doc 2"
+
+    def test_run_with_documents_with_reference_pattern(self):
+        component = AnswersBuilder(reference_pattern="\\[(\\d+)\\]")
+        answers = component.run(
+            queries=["test query"],
+            replies=[["Answer: AnswerString[2]"]],
+            metadata=[[{}]],
+            documents=[[Document(content="test doc 1"), Document(content="test doc 2")]],
+        )
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "Answer: AnswerString[2]"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert len(answers[0][0].documents) == 1
+        assert answers[0][0].documents[0].content == "test doc 2"
+
+    def test_run_with_documents_with_reference_pattern_and_no_match(self):
+        component = AnswersBuilder(reference_pattern="\\[(\\d+)\\]")
+        answers = component.run(
+            queries=["test query"],
+            replies=[["Answer: AnswerString[3]"]],
+            metadata=[[{}]],
+            documents=[[Document(content="test doc 1"), Document(content="test doc 2")]],
+        )
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "Answer: AnswerString[3]"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert len(answers[0][0].documents) == 0
+
+    def test_run_with_reference_pattern_set_at_runtime(self):
+        component = AnswersBuilder()
+        answers = component.run(
+            queries=["test query"],
+            replies=[["Answer: AnswerString[2][3]"]],
+            metadata=[[{}]],
+            documents=[
+                [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
+            ],
+            reference_pattern="\\[(\\d+)\\]",
+        )
+        assert len(answers) == 1
+        assert len(answers[0]) == 1
+        assert answers[0][0].data == "Answer: AnswerString[2][3]"
+        assert answers[0][0].metadata == {}
+        assert answers[0][0].query == "test query"
+        assert len(answers[0][0].documents) == 2
+        assert answers[0][0].documents[0].content == "test doc 2"
+        assert answers[0][0].documents[1].content == "test doc 3"


### PR DESCRIPTION
### Related Issues

- fixes #5624

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR adds the `AnswersBuilder` component that would typically used after a `Generator` component. It takes the string output of `Generator` models and creates `GeneratedAnswer` objects of them based on regular expressions.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
`AnswersBuilder` corresponds to `AnswerParser` In Haystack 1.x.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
