### PR TITLE
Add `PromptBuilder`

### DIFF
--- a/haystack/preview/components/generators/prompt_builder.py
+++ b/haystack/preview/components/generators/prompt_builder.py
@@ -1,0 +1,45 @@
+from typing import Dict, Any
+
+from jinja2 import Template, meta
+
+from haystack.preview import component
+from haystack.preview import default_to_dict, default_from_dict
+
+
+@component
+class PromptBuilder:
+    """
+    PromptBuilder is a component that renders a prompt from a template string using Jinja2 engine.
+    The template variables found in the template string are used as input types for the component and are all required.
+
+    Usage:
+    ```python
+    template = "Translate the following context to {{ target_language }}. Context: {{ snippet }}; Translation:"
+    builder = PromptBuilder(template=template)
+    builder.run(target_language="spanish", snippet="I can't speak spanish.")
+    ```
+    """
+
+    def __init__(self, template: str):
+        """
+        Initialize the component with a template string.
+
+        :param template: Jinja2 template string, e.g. "Summarize this document: {documents}\nSummary:"
+        :type template: str
+        """
+        self._template_string = template
+        self.template = Template(template)
+        ast = self.template.environment.parse(template)
+        template_variables = meta.find_undeclared_variables(ast)
+        component.set_input_types(self, **{var: Any for var in template_variables})
+
+    def to_dict(self) -> Dict[str, Any]:
+        return default_to_dict(self, template=self._template_string)
+
+    @classmethod
+    def from_dict(cls, data) -> "PromptBuilder":
+        return default_from_dict(cls, data)
+
+    @component.output_types(prompt=str)
+    def run(self, **kwargs):
+        return {"prompt": self.template.render(kwargs)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
 
   # Preview
   "canals==0.8.0",
+  "Jinja2",
 
   # Agent events
   "events",

--- a/releasenotes/notes/prompt-builder-d22954ef9c4a2a7b.yaml
+++ b/releasenotes/notes/prompt-builder-d22954ef9c4a2a7b.yaml
@@ -1,3 +1,3 @@
 ---
 preview:
-  - Add PromptBuilder
+  - Add PromptBuilder component to render prompts from template strings

--- a/releasenotes/notes/prompt-builder-d22954ef9c4a2a7b.yaml
+++ b/releasenotes/notes/prompt-builder-d22954ef9c4a2a7b.yaml
@@ -1,0 +1,3 @@
+---
+preview:
+  - Add PromptBuilder

--- a/test/preview/components/generators/test_prompt_builder.py
+++ b/test/preview/components/generators/test_prompt_builder.py
@@ -1,0 +1,37 @@
+import pytest
+
+from haystack.preview.components.generators.prompt_builder import PromptBuilder
+
+
+@pytest.mark.unit
+def test_init():
+    builder = PromptBuilder(template="This is a {{ variable }}")
+    assert builder._template_string == "This is a {{ variable }}"
+
+
+@pytest.mark.unit
+def test_to_dict():
+    builder = PromptBuilder(template="This is a {{ variable }}")
+    res = builder.to_dict()
+    assert res == {"type": "PromptBuilder", "init_parameters": {"template": "This is a {{ variable }}"}}
+
+
+@pytest.mark.unit
+def test_from_dict():
+    data = {"type": "PromptBuilder", "init_parameters": {"template": "This is a {{ variable }}"}}
+    builder = PromptBuilder.from_dict(data)
+    builder._template_string == "This is a {{ variable }}"
+
+
+@pytest.mark.unit
+def test_run():
+    builder = PromptBuilder(template="This is a {{ variable }}")
+    res = builder.run(variable="test")
+    assert res == {"prompt": "This is a test"}
+
+
+@pytest.mark.unit
+def test_run_without_input():
+    builder = PromptBuilder(template="This is a template without input")
+    res = builder.run()
+    assert res == {"prompt": "This is a template without input"}

--- a/test/preview/components/generators/test_prompt_builder.py
+++ b/test/preview/components/generators/test_prompt_builder.py
@@ -35,3 +35,10 @@ def test_run_without_input():
     builder = PromptBuilder(template="This is a template without input")
     res = builder.run()
     assert res == {"prompt": "This is a template without input"}
+
+
+@pytest.mark.unit
+def test_run_with_missing_input():
+    builder = PromptBuilder(template="This is a {{ variable }}")
+    res = builder.run()
+    assert res == {"prompt": "This is a "}


### PR DESCRIPTION
### Related Issues

- Closes #[5622](https://github.com/deepset-ai/haystack/issues/5622)

### Proposed Changes:

Add minimal `PromptBuilder` implementation to render string templates to prompt strings so they can be passed to Generator Components.

Usage:
```
from haystack.preview.components.generators.prompt_builder import PromptBuilder

template = "Translate the following context to {{ target_language }}. Context: {{ snippet }}; Translation:"
builder = PromptBuilder(template=template)
res = builder.run(target_language="spanish", snippet="I can't speak spanish.")

assert res["prompt"] == "Translate the following context to spanish. Context: I can't speak spanish.; Translation:"
```

### How did you test it?

Added unit tests.

### Notes for the reviewer

I didn't add support for PromptHub as we still have no prompt templates using the new format. 
Also it can be easily added in the future and I wanted to keep the PR small.

I already added `Jinja2` as a dependency in [`haystack-ai` package](https://github.com/deepset-ai/haystack-preview-package/commit/91ede6e7b2021e28f0afe30dc7060eeaf960345f). 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
