### PR TITLE
Memory embedding retrieval 2

### DIFF
--- a/releasenotes/notes/memory-embedding-retrieval-06f384baa04a63f7.yaml
+++ b/releasenotes/notes/memory-embedding-retrieval-06f384baa04a63f7.yaml
@@ -1,0 +1,6 @@
+---
+preview:
+  - |
+    Add `embedding_retrieval` method to `MemoryDocumentStore`,
+    which allows to retrieve the relevant Documents, given a query embedding.
+    It will be called by the `MemoryEmbeddingRetriever`.

--- a/test/preview/document_stores/test_memory.py
+++ b/test/preview/document_stores/test_memory.py
@@ -29,13 +29,17 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
                 "bm25_tokenization_regex": r"(?u)\b\w\w+\b",
                 "bm25_algorithm": "BM25Okapi",
                 "bm25_parameters": {},
+                "embedding_similarity_function": "dot_product",
             },
         }
 
     @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         store = MemoryDocumentStore(
-            bm25_tokenization_regex="custom_regex", bm25_algorithm="BM25Plus", bm25_parameters={"key": "value"}
+            bm25_tokenization_regex="custom_regex",
+            bm25_algorithm="BM25Plus",
+            bm25_parameters={"key": "value"},
+            embedding_similarity_function="cosine",
         )
         data = store.to_dict()
         assert data == {
@@ -44,6 +48,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
                 "bm25_tokenization_regex": "custom_regex",
                 "bm25_algorithm": "BM25Plus",
                 "bm25_parameters": {"key": "value"},
+                "embedding_similarity_function": "cosine",
             },
         }
 
@@ -251,3 +256,150 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         df = results[0].content
         assert isinstance(df, pd.DataFrame)
         assert df.equals(table_content)
+
+    @pytest.mark.unit
+    def test_embedding_retrieval(self):
+        docstore = MemoryDocumentStore(embedding_similarity_function="cosine")
+        # Tests if the embedding retrieval method returns the correct document based on the input query embedding.
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
+        ]
+        docstore.write_documents(docs)
+        results = docstore.embedding_retrieval(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters={}, scale_score=False
+        )
+        assert len(results) == 1
+        assert results[0].content == "Haystack supports multiple languages"
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_invalid_query(self):
+        docstore = MemoryDocumentStore()
+        with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
+            docstore.embedding_retrieval(query_embedding="string")
+        with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
+            docstore.embedding_retrieval(query_embedding=[])
+        with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
+            docstore.embedding_retrieval(query_embedding=["invalid", "list", "of", "strings"])
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_no_embeddings(self, caplog):
+        caplog.set_level(logging.INFO)
+        docstore = MemoryDocumentStore()
+        docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
+        docstore.write_documents(docs)
+        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
+        assert len(results) == 0
+        assert "No Documents found with embeddings. Returning empty list." in caplog.text
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_some_documents_wo_embeddings(self, caplog):
+        caplog.set_level(logging.INFO)
+        docstore = MemoryDocumentStore()
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Haystack supports multiple languages"),
+        ]
+        docstore.write_documents(docs)
+        docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
+        assert "Skipping some Documents that don't have an embedding." in caplog.text
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_documents_different_embedding_sizes(self):
+        docstore = MemoryDocumentStore()
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Haystack supports multiple languages", embedding=[1.0, 1.0]),
+        ]
+        docstore.write_documents(docs)
+
+        with pytest.raises(ValueError, match="The embedding size of all Documents should be the same."):
+            docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_query_documents_different_embedding_sizes(self):
+        docstore = MemoryDocumentStore()
+        docs = [Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4])]
+        docstore.write_documents(docs)
+
+        with pytest.raises(
+            ValueError,
+            match="The embedding size of the query should be the same as the embedding size of the Documents.",
+        ):
+            docstore.embedding_retrieval(query_embedding=[0.1, 0.1])
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_with_different_top_k(self):
+        docstore = MemoryDocumentStore()
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="Python is a popular programming language", embedding=[0.5, 0.5, 0.5, 0.5]),
+        ]
+        docstore.write_documents(docs)
+
+        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=2)
+        assert len(results) == 2
+
+        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=3)
+        assert len(results) == 3
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_with_scale_score(self):
+        docstore = MemoryDocumentStore()
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(content="Python is a popular programming language", embedding=[0.5, 0.5, 0.5, 0.5]),
+        ]
+        docstore.write_documents(docs)
+
+        results1 = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, scale_score=True)
+        # Confirm that score is scaled between 0 and 1
+        assert 0 <= results1[0].score <= 1
+
+        # Same query, different scale, scores differ when not scaled
+        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, scale_score=False)
+        assert results[0].score != results1[0].score
+
+    @pytest.mark.unit
+    def test_embedding_retrieval_return_embedding(self):
+        docstore = MemoryDocumentStore(embedding_similarity_function="cosine")
+        docs = [
+            Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(content="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
+        ]
+        docstore.write_documents(docs)
+
+        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, return_embedding=False)
+        assert results[0].embedding is None
+
+        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, return_embedding=True)
+        assert results[0].embedding == [1.0, 1.0, 1.0, 1.0]
+
+    @pytest.mark.unit
+    def test_compute_cosine_similarity_scores(self):
+        docstore = MemoryDocumentStore(embedding_similarity_function="cosine")
+        docs = [
+            Document(content="Document 1", embedding=[1.0, 0.0, 0.0, 0.0]),
+            Document(content="Document 2", embedding=[1.0, 1.0, 1.0, 1.0]),
+        ]
+
+        scores = docstore._compute_embedding_similarity_scores(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], documents=docs, scale_score=False
+        )
+        assert scores == [0.5, 1.0]
+
+    @pytest.mark.unit
+    def test_compute_dot_product_similarity_scores(self):
+        docstore = MemoryDocumentStore(embedding_similarity_function="dot_product")
+        docs = [
+            Document(content="Document 1", embedding=[1.0, 0.0, 0.0, 0.0]),
+            Document(content="Document 2", embedding=[1.0, 1.0, 1.0, 1.0]),
+        ]
+
+        scores = docstore._compute_embedding_similarity_scores(
+            query_embedding=[0.1, 0.1, 0.1, 0.1], documents=docs, scale_score=False
+        )
+        print(scores)
+        assert scores == [0.1, 0.4]


### PR DESCRIPTION
### Related Issues

- part of #4843 

### Proposed Changes:

Add `embedding_retrieval` method to `MemoryDocumentStore`, 
which allows to retrieve the relevant Documents, given a query embedding.
It will be called by the `MemoryEmbeddingRetriever` (to be introduced in a separate PR).

I adapted and refactored [the implementation of `query_by_embedding` of the `InMemoryDocumentStore`](https://github.com/deepset-ai/haystack/blob/c5369a39ef64c2825230e96564eb744d9fad8204/haystack/document_stores/memory.py#L390).

### How did you test it?
Some nice unit tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
