### PR TITLE
chore: enable e2e preview tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,9 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Install dependencies
+      run: sudo apt install ffmpeg  # for local Whisper tests
+
     - name: Run Elasticsearch
       run: |
         docker run -d -p 9200:9200 -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms128m -Xmx256m" elasticsearch:7.9.2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,7 @@ jobs:
         folder:
           - "document_search"
           - "pipelines"
+          - "preview"
 
     runs-on: ubuntu-latest
 

--- a/e2e/preview/components/test_whisper_local.py
+++ b/e2e/preview/components/test_whisper_local.py
@@ -2,7 +2,8 @@ from haystack.preview.components.audio.whisper_local import LocalWhisperTranscri
 
 
 def test_whisper_local_transcriber(preview_samples_path):
-    comp = LocalWhisperTranscriber(model_name_or_path="tiny")
+    comp = LocalWhisperTranscriber(model_name_or_path="medium")
+    comp.warm_up()
     docs = comp.transcribe(
         audio_files=[
             preview_samples_path / "audio" / "this is the content of the document.wav",

--- a/haystack/preview/__init__.py
+++ b/haystack/preview/__init__.py
@@ -1,4 +1,4 @@
 from canals import component, Pipeline
 from canals.serialization import default_from_dict, default_to_dict
-from canals.errors import DeserializationError
+from canals.errors import DeserializationError, ComponentError
 from haystack.preview.dataclasses import *

--- a/haystack/preview/components/audio/whisper_local.py
+++ b/haystack/preview/components/audio/whisper_local.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import torch
 import whisper
 
-from haystack.preview import component, Document, default_to_dict, default_from_dict
+from haystack.preview import component, Document, default_to_dict, default_from_dict, ComponentError
 
 
 logger = logging.getLogger(__name__)
@@ -85,6 +85,9 @@ class LocalWhisperTranscriber:
             alignment data. Another key called `audio_file` contains the path to the audio file used for the
             transcription.
         """
+        if self._model is None:
+            raise ComponentError("The component was not warmed up. Run `warm_up()` before calling `run()`.")
+
         if whisper_params is None:
             whisper_params = self.whisper_params
 

--- a/haystack/preview/components/audio/whisper_local.py
+++ b/haystack/preview/components/audio/whisper_local.py
@@ -86,7 +86,7 @@ class LocalWhisperTranscriber:
             transcription.
         """
         if self._model is None:
-            raise ComponentError("The component was not warmed up. Run `warm_up()` before calling `run()`.")
+            raise ComponentError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
 
         if whisper_params is None:
             whisper_params = self.whisper_params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
   # Preview
   "canals==0.8.0",
   "Jinja2",
+  "openai-whisper"  # FIXME https://github.com/deepset-ai/haystack/issues/5731
 
   # Agent events
   "events",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
   # Preview
   "canals==0.8.0",
   "Jinja2",
-  "openai-whisper"  # FIXME https://github.com/deepset-ai/haystack/issues/5731
+  "openai-whisper",  # FIXME https://github.com/deepset-ai/haystack/issues/5731
 
   # Agent events
   "events",


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

- As we began adding e2e tests to the CI under the `e2e/preview` folder, we should enable those too.
- Fix a `LocalWhisperTranscriber` e2e test that was failing.

### How did you test it?

Local run of the tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
