### PR TITLE
chore: fix RemoteWhisperTranscriber e2e tests

### DIFF
--- a/e2e/preview/components/test_whisper_local.py
+++ b/e2e/preview/components/test_whisper_local.py
@@ -4,13 +4,14 @@ from haystack.preview.components.audio.whisper_local import LocalWhisperTranscri
 def test_whisper_local_transcriber(preview_samples_path):
     comp = LocalWhisperTranscriber(model_name_or_path="medium")
     comp.warm_up()
-    docs = comp.transcribe(
+    output = comp.run(
         audio_files=[
             preview_samples_path / "audio" / "this is the content of the document.wav",
             str((preview_samples_path / "audio" / "the context for this answer is here.wav").absolute()),
             open(preview_samples_path / "audio" / "answer.wav", "rb"),
         ]
     )
+    docs = output["documents"]
     assert len(docs) == 3
 
     assert "this is the content of the document." == docs[0].content.strip().lower()

--- a/e2e/preview/components/test_whisper_remote.py
+++ b/e2e/preview/components/test_whisper_remote.py
@@ -13,15 +13,13 @@ def test_whisper_remote_transcriber(preview_samples_path):
     comp = RemoteWhisperTranscriber(api_key=os.environ.get("OPENAI_API_KEY"))
 
     output = comp.run(
-        RemoteWhisperTranscriber.Input(
-            audio_files=[
-                preview_samples_path / "audio" / "this is the content of the document.wav",
-                str((preview_samples_path / "audio" / "the context for this answer is here.wav").absolute()),
-                open(preview_samples_path / "audio" / "answer.wav", "rb"),
-            ]
-        )
+        audio_files=[
+            preview_samples_path / "audio" / "this is the content of the document.wav",
+            str((preview_samples_path / "audio" / "the context for this answer is here.wav").absolute()),
+            open(preview_samples_path / "audio" / "answer.wav", "rb"),
+        ]
     )
-    docs = output.documents
+    docs = output["documents"]
     assert len(docs) == 3
 
     assert "this is the content of the document." == docs[0].content.strip().lower()


### PR DESCRIPTION
### Related Issues

- fixes CI failure

### Proposed Changes:

- The test was skipped in the PR that enabled it and did not fail the CI. At the first execution it actually failed.

### How did you test it?

Local test run

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
