### PR TITLE
Updating WebRetriver API docs

### DIFF
--- a/haystack/nodes/retriever/web.py
+++ b/haystack/nodes/retriever/web.py
@@ -63,7 +63,7 @@ class WebRetriever(BaseRetriever):
     ):
         """
         :param api_key: API key for the search engine provider.
-        :param search_engine_provider: Name of the search engine provider class, see `providers.py` for a list of supported providers.
+        :param search_engine_provider: Name of the search engine provider class. The options are "SerperDev" (default), "SerpAPI", "BingAPI" or "GoogleAPI"
         :param top_search_results: Number of top search results to be retrieved.
         :param top_k: Top k documents to be returned by the retriever.
         :param mode: Whether to return snippets, raw documents, or preprocessed documents. Snippets are the default.


### PR DESCRIPTION
Small improvement. Easier to know what to put in the `search_engine_providers` without having to look in the source code