### PR TITLE
chore: remove flaky end2end test for `GPT35Generator`

### DIFF
--- a/e2e/preview/components/test_gpt35_generator.py
+++ b/e2e/preview/components/test_gpt35_generator.py
@@ -41,20 +41,6 @@ def test_gpt35_generator_run_wrong_model_name():
     not os.environ.get("OPENAI_API_KEY", None),
     reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
-def test_gpt35_generator_run_above_context_length():
-    component = GPT35Generator(api_key=os.environ.get("OPENAI_API_KEY"), n=1)
-    with pytest.raises(
-        openai.InvalidRequestError,
-        match="This model's maximum context length is 4097 tokens. However, your messages resulted in 70008 tokens. "
-        "Please reduce the length of the messages.",
-    ):
-        component.run(prompts=["What's the capital of France? " * 10_000])
-
-
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY", None),
-    reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
-)
 def test_gpt35_generator_run_streaming():
     class Callback:
         def __init__(self):


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/actions/runs/6122946746/job/16619792413?pr=5744

### Proposed Changes:
- Remove remove `test_gpt35_generator_run_above_context_length` from the GPT35Generator end2end tests

### How did you test it?

n/a

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
