### PR TITLE
feat: make `GPT35Generator` non batch

### DIFF
--- a/e2e/preview/components/test_gpt35_generator.py
+++ b/e2e/preview/components/test_gpt35_generator.py
@@ -10,21 +10,14 @@ from haystack.preview.components.generators.openai.gpt35 import GPT35Generator
 )
 def test_gpt35_generator_run():
     component = GPT35Generator(api_key=os.environ.get("OPENAI_API_KEY"), n=1)
-    results = component.run(prompts=["What's the capital of France?", "What's the capital of Germany?"])
+    results = component.run(prompt="What's the capital of France?")
 
-    assert len(results["replies"]) == 2
-    assert len(results["replies"][0]) == 1
-    assert "Paris" in results["replies"][0][0]
-    assert len(results["replies"][1]) == 1
-    assert "Berlin" in results["replies"][1][0]
+    assert len(results["replies"]) == 1
+    assert "Paris" in results["replies"][0]
 
-    assert len(results["metadata"]) == 2
-    assert len(results["metadata"][0]) == 1
-    assert "gpt-3.5-turbo" in results["metadata"][0][0]["model"]
-    assert "stop" == results["metadata"][0][0]["finish_reason"]
-    assert len(results["metadata"][1]) == 1
-    assert "gpt-3.5-turbo" in results["metadata"][1][0]["model"]
-    assert "stop" == results["metadata"][1][0]["finish_reason"]
+    assert len(results["metadata"]) == 1
+    assert "gpt-3.5-turbo" in results["metadata"][0]["model"]
+    assert "stop" == results["metadata"][0]["finish_reason"]
 
 
 @pytest.mark.skipif(
@@ -34,7 +27,7 @@ def test_gpt35_generator_run():
 def test_gpt35_generator_run_wrong_model_name():
     component = GPT35Generator(model_name="something-obviously-wrong", api_key=os.environ.get("OPENAI_API_KEY"), n=1)
     with pytest.raises(openai.InvalidRequestError, match="The model `something-obviously-wrong` does not exist"):
-        component.run(prompts=["What's the capital of France?"])
+        component.run(prompt="What's the capital of France?")
 
 
 @pytest.mark.skipif(
@@ -48,7 +41,7 @@ def test_gpt35_generator_run_above_context_length():
         match="This model's maximum context length is 4097 tokens. However, your messages resulted in 70008 tokens. "
         "Please reduce the length of the messages.",
     ):
-        component.run(prompts=["What's the capital of France? " * 10_000])
+        component.run(prompt="What's the capital of France? " * 10_000)
 
 
 @pytest.mark.skipif(
@@ -66,21 +59,13 @@ def test_gpt35_generator_run_streaming():
 
     callback = Callback()
     component = GPT35Generator(os.environ.get("OPENAI_API_KEY"), streaming_callback=callback, n=1)
-    results = component.run(prompts=["What's the capital of France?", "What's the capital of Germany?"])
+    results = component.run(prompt="What's the capital of France?")
 
-    assert len(results["replies"]) == 2
-    assert len(results["replies"][0]) == 1
-    assert "Paris" in results["replies"][0][0]
-    assert len(results["replies"][1]) == 1
-    assert "Berlin" in results["replies"][1][0]
+    assert len(results["replies"]) == 1
+    assert "Paris" in results["replies"][0]
 
-    assert callback.responses == results["replies"][0][0] + results["replies"][1][0]
+    assert len(results["metadata"]) == 1
+    assert "gpt-3.5-turbo" in results["metadata"][0]["model"]
+    assert "stop" == results["metadata"][0]["finish_reason"]
 
-    assert len(results["metadata"]) == 2
-    assert len(results["metadata"][0]) == 1
-
-    assert "gpt-3.5-turbo" in results["metadata"][0][0]["model"]
-    assert "stop" == results["metadata"][0][0]["finish_reason"]
-    assert len(results["metadata"][1]) == 1
-    assert "gpt-3.5-turbo" in results["metadata"][1][0]["model"]
-    assert "stop" == results["metadata"][1][0]["finish_reason"]
+    assert callback.responses == results["replies"][0]

--- a/haystack/preview/components/generators/openai/gpt35.py
+++ b/haystack/preview/components/generators/openai/gpt35.py
@@ -130,70 +130,63 @@ class GPT35Generator:
             data["init_parameters"]["streaming_callback"] = streaming_callback
         return default_from_dict(cls, data)
 
-    @component.output_types(replies=List[List[str]], metadata=List[Dict[str, Any]])
-    def run(self, prompts: List[str]):
+    @component.output_types(replies=List[str], metadata=List[Dict[str, Any]])
+    def run(self, prompt: str):
         """
         Queries the LLM with the prompts to produce replies.
 
         :param prompts: The prompts to be sent to the generative model.
         """
-        chats = []
-        for prompt in prompts:
-            message = _ChatMessage(content=prompt, role="user")
-            if self.system_prompt:
-                chats.append([_ChatMessage(content=self.system_prompt, role="system"), message])
-            else:
-                chats.append([message])
+        message = _ChatMessage(content=prompt, role="user")
+        if self.system_prompt:
+            chat = [_ChatMessage(content=self.system_prompt, role="system"), message]
+        else:
+            chat = [message]
 
-        all_replies, all_metadata = [], []
-        for chat in chats:
-            completion = openai.ChatCompletion.create(
-                model=self.model_name,
-                api_key=self.api_key,
-                messages=[asdict(message) for message in chat],
-                stream=self.streaming_callback is not None,
-                **self.model_parameters,
-            )
+        completion = openai.ChatCompletion.create(
+            model=self.model_name,
+            api_key=self.api_key,
+            messages=[asdict(message) for message in chat],
+            stream=self.streaming_callback is not None,
+            **self.model_parameters,
+        )
 
-            replies: List[str]
-            metadata: List[Dict[str, Any]]
-            if self.streaming_callback:
-                replies_dict = {}
-                metadata_dict: Dict[str, Dict[str, Any]] = {}
-                for chunk in completion:
-                    chunk = self.streaming_callback(chunk)
-                    for choice in chunk.choices:
-                        if choice.index not in replies_dict:
-                            replies_dict[choice.index] = ""
-                            metadata_dict[choice.index] = {}
+        replies: List[str]
+        metadata: List[Dict[str, Any]]
+        if self.streaming_callback:
+            replies_dict = {}
+            metadata_dict: Dict[str, Dict[str, Any]] = {}
+            for chunk in completion:
+                chunk = self.streaming_callback(chunk)
+                for choice in chunk.choices:
+                    if choice.index not in replies_dict:
+                        replies_dict[choice.index] = ""
+                        metadata_dict[choice.index] = {}
 
-                        if hasattr(choice.delta, "content"):
-                            replies_dict[choice.index] += choice.delta.content
-                        metadata_dict[choice.index] = {
-                            "model": chunk.model,
-                            "index": choice.index,
-                            "finish_reason": choice.finish_reason,
-                        }
-                all_replies.append(list(replies_dict.values()))
-                all_metadata.append(list(metadata_dict.values()))
-                self._check_truncated_answers(list(metadata_dict.values()))
-
-            else:
-                metadata = [
-                    {
-                        "model": completion.model,
+                    if hasattr(choice.delta, "content"):
+                        replies_dict[choice.index] += choice.delta.content
+                    metadata_dict[choice.index] = {
+                        "model": chunk.model,
                         "index": choice.index,
                         "finish_reason": choice.finish_reason,
-                        "usage": dict(completion.usage.items()),
                     }
-                    for choice in completion.choices
-                ]
-                replies = [choice.message.content.strip() for choice in completion.choices]
-                all_replies.append(replies)
-                all_metadata.append(metadata)
-                self._check_truncated_answers(metadata)
+            replies = list(replies_dict.values())
+            metadata = list(metadata_dict.values())
+            self._check_truncated_answers(metadata)
+            return {"replies": replies, "metadata": metadata}
 
-        return {"replies": all_replies, "metadata": all_metadata}
+        metadata = [
+            {
+                "model": completion.model,
+                "index": choice.index,
+                "finish_reason": choice.finish_reason,
+                "usage": dict(completion.usage.items()),
+            }
+            for choice in completion.choices
+        ]
+        replies = [choice.message.content.strip() for choice in completion.choices]
+        self._check_truncated_answers(metadata)
+        return {"replies": replies, "metadata": metadata}
 
     def _check_truncated_answers(self, metadata: List[Dict[str, Any]]):
         """

--- a/test/preview/components/generators/openai/test_gpt35_generator.py
+++ b/test/preview/components/generators/openai/test_gpt35_generator.py
@@ -163,42 +163,22 @@ class TestGPT35Generator:
         with patch("haystack.preview.components.generators.openai.gpt35.openai.ChatCompletion") as gpt35_patch:
             gpt35_patch.create.side_effect = mock_openai_response
             component = GPT35Generator(api_key="test-api-key")
-            results = component.run(prompts=["test-prompt-1", "test-prompt-2"])
+            results = component.run(prompt="test-prompt-1")
             assert results == {
-                "replies": [
-                    ["response for these messages --> user: test-prompt-1"],
-                    ["response for these messages --> user: test-prompt-2"],
-                ],
+                "replies": ["response for these messages --> user: test-prompt-1"],
                 "metadata": [
-                    [
-                        {
-                            "model": "gpt-3.5-turbo",
-                            "index": "0",
-                            "finish_reason": "stop",
-                            "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
-                        }
-                    ],
-                    [
-                        {
-                            "model": "gpt-3.5-turbo",
-                            "index": "0",
-                            "finish_reason": "stop",
-                            "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
-                        }
-                    ],
+                    {
+                        "model": "gpt-3.5-turbo",
+                        "index": "0",
+                        "finish_reason": "stop",
+                        "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+                    }
                 ],
             }
-            assert gpt35_patch.create.call_count == 2
-            gpt35_patch.create.assert_any_call(
+            gpt35_patch.create.assert_called_once_with(
                 model="gpt-3.5-turbo",
                 api_key="test-api-key",
                 messages=[{"role": "user", "content": "test-prompt-1"}],
-                stream=False,
-            )
-            gpt35_patch.create.assert_any_call(
-                model="gpt-3.5-turbo",
-                api_key="test-api-key",
-                messages=[{"role": "user", "content": "test-prompt-2"}],
                 stream=False,
             )
 
@@ -207,47 +187,24 @@ class TestGPT35Generator:
         with patch("haystack.preview.components.generators.openai.gpt35.openai.ChatCompletion") as gpt35_patch:
             gpt35_patch.create.side_effect = mock_openai_response
             component = GPT35Generator(api_key="test-api-key", system_prompt="test-system-prompt")
-            results = component.run(prompts=["test-prompt-1", "test-prompt-2"])
+            results = component.run(prompt="test-prompt-1")
             assert results == {
-                "replies": [
-                    ["response for these messages --> system: test-system-prompt - user: test-prompt-1"],
-                    ["response for these messages --> system: test-system-prompt - user: test-prompt-2"],
-                ],
+                "replies": ["response for these messages --> system: test-system-prompt - user: test-prompt-1"],
                 "metadata": [
-                    [
-                        {
-                            "model": "gpt-3.5-turbo",
-                            "index": "0",
-                            "finish_reason": "stop",
-                            "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
-                        }
-                    ],
-                    [
-                        {
-                            "model": "gpt-3.5-turbo",
-                            "index": "0",
-                            "finish_reason": "stop",
-                            "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
-                        }
-                    ],
+                    {
+                        "model": "gpt-3.5-turbo",
+                        "index": "0",
+                        "finish_reason": "stop",
+                        "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+                    }
                 ],
             }
-            assert gpt35_patch.create.call_count == 2
-            gpt35_patch.create.assert_any_call(
+            gpt35_patch.create.assert_called_once_with(
                 model="gpt-3.5-turbo",
                 api_key="test-api-key",
                 messages=[
                     {"role": "system", "content": "test-system-prompt"},
                     {"role": "user", "content": "test-prompt-1"},
-                ],
-                stream=False,
-            )
-            gpt35_patch.create.assert_any_call(
-                model="gpt-3.5-turbo",
-                api_key="test-api-key",
-                messages=[
-                    {"role": "system", "content": "test-system-prompt"},
-                    {"role": "user", "content": "test-prompt-2"},
                 ],
                 stream=False,
             )
@@ -257,19 +214,11 @@ class TestGPT35Generator:
         with patch("haystack.preview.components.generators.openai.gpt35.openai.ChatCompletion") as gpt35_patch:
             gpt35_patch.create.side_effect = mock_openai_response
             component = GPT35Generator(api_key="test-api-key", max_tokens=10)
-            component.run(prompts=["test-prompt-1", "test-prompt-2"])
-            assert gpt35_patch.create.call_count == 2
-            gpt35_patch.create.assert_any_call(
+            component.run(prompt="test-prompt-1")
+            gpt35_patch.create.assert_called_once_with(
                 model="gpt-3.5-turbo",
                 api_key="test-api-key",
                 messages=[{"role": "user", "content": "test-prompt-1"}],
-                stream=False,
-                max_tokens=10,
-            )
-            gpt35_patch.create.assert_any_call(
-                model="gpt-3.5-turbo",
-                api_key="test-api-key",
-                messages=[{"role": "user", "content": "test-prompt-2"}],
                 stream=False,
                 max_tokens=10,
             )
@@ -283,35 +232,19 @@ class TestGPT35Generator:
             component = GPT35Generator(
                 api_key="test-api-key", system_prompt="test-system-prompt", streaming_callback=mock_callback
             )
-            results = component.run(prompts=["test-prompt-1", "test-prompt-2"])
+            results = component.run(prompt="test-prompt-1")
             assert results == {
-                "replies": [
-                    ["response for these messages --> system: test-system-prompt - user: test-prompt-1 "],
-                    ["response for these messages --> system: test-system-prompt - user: test-prompt-2 "],
-                ],
-                "metadata": [
-                    [{"model": "gpt-3.5-turbo", "index": "0", "finish_reason": "stop"}],
-                    [{"model": "gpt-3.5-turbo", "index": "0", "finish_reason": "stop"}],
-                ],
+                "replies": ["response for these messages --> system: test-system-prompt - user: test-prompt-1 "],
+                "metadata": [{"model": "gpt-3.5-turbo", "index": "0", "finish_reason": "stop"}],
             }
-            # Calls count: (10 tokens per prompt + 1 token for the role + 1 empty termination token) * 2 prompts
-            assert mock_callback.call_count == 24
-            assert gpt35_patch.create.call_count == 2
-            gpt35_patch.create.assert_any_call(
+            # Calls count: 10 tokens per prompt + 1 token for the role + 1 empty termination token
+            assert mock_callback.call_count == 12
+            gpt35_patch.create.assert_called_once_with(
                 model="gpt-3.5-turbo",
                 api_key="test-api-key",
                 messages=[
                     {"role": "system", "content": "test-system-prompt"},
                     {"role": "user", "content": "test-prompt-1"},
-                ],
-                stream=True,
-            )
-            gpt35_patch.create.assert_any_call(
-                model="gpt-3.5-turbo",
-                api_key="test-api-key",
-                messages=[
-                    {"role": "system", "content": "test-system-prompt"},
-                    {"role": "user", "content": "test-prompt-2"},
                 ],
                 stream=True,
             )


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5763

### Proposed Changes:

- Changes the input of `GPT35Generator` to accept a single prompt.
- Fixes all the tests

### How did you test it?

Unit and e2e tests

### Notes for the reviewer

See https://github.com/deepset-ai/haystack/issues/5754

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
