### PR TITLE
feat: make `MemoryBM25Retriever` non batch

### DIFF
--- a/haystack/preview/components/retrievers/memory.py
+++ b/haystack/preview/components/retrievers/memory.py
@@ -68,10 +68,10 @@ class MemoryBM25Retriever:
         data["init_parameters"]["document_store"] = docstore
         return default_from_dict(cls, data)
 
-    @component.output_types(documents=List[List[Document]])
+    @component.output_types(documents=List[Document])
     def run(
         self,
-        queries: List[str],
+        query: str,
         filters: Optional[Dict[str, Any]] = None,
         top_k: Optional[int] = None,
         scale_score: Optional[bool] = None,
@@ -94,11 +94,7 @@ class MemoryBM25Retriever:
         if scale_score is None:
             scale_score = self.scale_score
 
-        docs = []
-        for query in queries:
-            docs.append(
-                self.document_store.bm25_retrieval(query=query, filters=filters, top_k=top_k, scale_score=scale_score)
-            )
+        docs = self.document_store.bm25_retrieval(query=query, filters=filters, top_k=top_k, scale_score=scale_score)
         return {"documents": docs}
 
 

--- a/test/preview/components/retrievers/test_memory_retriever.py
+++ b/test/preview/components/retrievers/test_memory_retriever.py
@@ -172,14 +172,11 @@ class TestMemoryRetrievers:
         ds.write_documents(mock_docs)
 
         retriever = MemoryBM25Retriever(ds, top_k=top_k)
-        result = retriever.run(queries=["PHP", "Java"])
+        result = retriever.run(query="PHP")
 
         assert "documents" in result
-        assert len(result["documents"]) == 2
-        assert len(result["documents"][0]) == top_k
-        assert len(result["documents"][1]) == top_k
-        assert result["documents"][0][0].text == "PHP is a popular programming language"
-        assert result["documents"][1][0].text == "Java is a popular programming language"
+        assert len(result["documents"]) == top_k
+        assert result["documents"][0].text == "PHP is a popular programming language"
 
     @pytest.mark.unit
     def test_embedding_retriever_valid_run(self):
@@ -224,22 +221,22 @@ class TestMemoryRetrievers:
 
         pipeline = Pipeline()
         pipeline.add_component("retriever", retriever)
-        result: Dict[str, Any] = pipeline.run(data={"retriever": {"queries": [query]}})
+        result: Dict[str, Any] = pipeline.run(data={"retriever": {"query": query}})
 
         assert result
         assert "retriever" in result
         results_docs = result["retriever"]["documents"]
         assert results_docs
-        assert results_docs[0][0].text == query_result
+        assert results_docs[0].text == query_result
 
     @pytest.mark.integration
     def test_run_embedding_retriever_with_pipeline(self):
         ds = MemoryDocumentStore(embedding_similarity_function="cosine")
         top_k = 2
         docs = [
-            Document(content="my document", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(content="another document", embedding=[1.0, 1.0, 1.0, 1.0]),
-            Document(content="third document", embedding=[0.5, 0.7, 0.5, 0.7]),
+            Document(text="my document", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(text="another document", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(text="third document", embedding=[0.5, 0.7, 0.5, 0.7]),
         ]
         ds.write_documents(docs)
         retriever = MemoryEmbeddingRetriever(ds, top_k=top_k)
@@ -280,11 +277,11 @@ class TestMemoryRetrievers:
 
         pipeline = Pipeline()
         pipeline.add_component("retriever", retriever)
-        result: Dict[str, Any] = pipeline.run(data={"retriever": {"queries": [query], "top_k": top_k}})
+        result: Dict[str, Any] = pipeline.run(data={"retriever": {"query": query, "top_k": top_k}})
 
         assert result
         assert "retriever" in result
         results_docs = result["retriever"]["documents"]
         assert results_docs
-        assert len(results_docs[0]) == top_k
-        assert results_docs[0][0].text == query_result
+        assert len(results_docs) == top_k
+        assert results_docs[0].text == query_result


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5767

### Proposed Changes:

 - Changes the input of `MemoryBM25Retriever` to accept a single query.
 - Fixes all the tests

### How did you test it?

Local unit tests run

### Notes for the reviewer

See https://github.com/deepset-ai/haystack/issues/5754

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
