### PR TITLE
ci: Use pylint to set limits on code complexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,6 @@ packages = [
 line-length = 120
 skip_magic_trailing_comma = true  # For compatibility with pydoc>=4.6, check if still needed.
 
-
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length=120
 load-plugins = "haystack_linter"
@@ -297,18 +296,14 @@ disable = [
   "too-few-public-methods",
   "raise-missing-from",
   "invalid-name",
-  "too-many-locals",
   "duplicate-code",
-  "too-many-arguments",
   "arguments-differ",
   "consider-using-f-string",
   "no-else-return",
   "attribute-defined-outside-init",
-  "too-many-instance-attributes",
   "super-with-arguments",
   "redefined-builtin",
   "abstract-method",
-  "too-many-branches",
   "unspecified-encoding",
   "unidiomatic-typecheck",
   "no-name-in-module",
@@ -321,12 +316,9 @@ disable = [
   "subprocess-run-check",
   "singleton-comparison",
   "consider-iterating-dictionary",
-  "too-many-nested-blocks",
   "undefined-loop-variable",
-  "too-many-statements",
   "consider-using-in",
   "bare-except",
-  "too-many-lines",
   "unexpected-keyword-arg",
   "simplifiable-if-expression",
   "use-list-literal",
@@ -338,7 +330,11 @@ disable = [
   "deprecated-method",
 ]
 [tool.pylint.'DESIGN']
-max-args=7
+max-args = 37  # Default is 5
+max-attributes = 27  # Default is 7
+max-branches = 33  # Default is 12
+max-locals = 44  # Default is 15
+max-statements = 205  # Default is 50
 [tool.pylint.'SIMILARITIES']
 min-similarity-lines=6
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:
By setting upper limits on code complexity we can use the code review process to require contributors who want to increase the limits to justify why increased complexity is required. These can also be metrics for continuous improvement.
```toml
[tool.pylint.'DESIGN']
max-args = 37  # Default is 5
max-attributes = 27  # Default is 7
max-branches = 33  # Default is 12
max-locals = 44  # Default is 15
max-statements = 205  # Default is 50
```
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

% `pipx run pylint haystack`
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
