### PR TITLE
ci: let dependabot update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
### Related Issues

As suggested in https://github.com/deepset-ai/haystack/pull/5787

### Proposed Changes:

Let dependabot update the version of github actions in use


