### PR TITLE
Fix license compliance workflow

### DIFF
--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -67,7 +67,11 @@ jobs:
           fi
 
       - name: Send event to Datadog
-        if: (success() || failure())
+        # This step would fail when running in PRs opened from forks since
+        # secrets are not accessible.
+        # To prevent showing bogus failures in those PRs we skip the step.
+        # The workflow will fail in any case if the actual check fails in the previous steps.
+        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
@@ -137,7 +141,11 @@ jobs:
           fi
 
       - name: Send event to Datadog
-        if: (success() || failure())
+        # This step would fail when running in PRs opened from forks since
+        # secrets are not accessible.
+        # To prevent showing bogus failures in those PRs we skip the step.
+        # The workflow will fail in any case if the actual check fails in the previous steps.
+        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
@@ -206,7 +214,11 @@ jobs:
           fi
 
       - name: Send event to Datadog
-        if: (success() || failure())
+        # This step would fail when running in PRs opened from forks since
+        # secrets are not accessible.
+        # To prevent showing bogus failures in those PRs we skip the step.
+        # The workflow will fail in any case if the actual check fails in the previous steps.
+        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
@@ -275,7 +287,11 @@ jobs:
           fi
 
       - name: Send event to Datadog
-        if: (success() || failure())
+        # This step would fail when running in PRs opened from forks since
+        # secrets are not accessible.
+        # To prevent showing bogus failures in those PRs we skip the step.
+        # The workflow will fail in any case if the actual check fails in the previous steps.
+        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -16,75 +16,75 @@ jobs:
       REQUIREMENTS_FILE: requirements_direct.txt
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
+      - name: Checkout the code
+        uses: actions/checkout@v4
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: Get direct dependencies, all extras
-      run: |
-        pip install toml
-        python .github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
+      - name: Get direct dependencies, all extras
+        run: |
+          pip install toml
+          python .github/utils/pyproject_to_requirements.py pyproject.toml --extra all > ${{ env.REQUIREMENTS_FILE }}
 
-    - name: Check Licenses
-      id: license_check_report
-      uses: pilosus/action-pip-license-checker@v2
-      with:
-        github-token: ${{ secrets.GH_ACCESS_TOKEN }}
-        requirements: ${{ env.REQUIREMENTS_FILE }}
-        fail: 'Copyleft,Other,Error'
-        # Exclusions in the vanilla distribution must be explicitly motivated
-        #
-        # - tqdm is MLP but there are no better alternatives
-        # - PyMuPDF is optional
-        # - pinecone-client is optional
-        # - psycopg2 is optional
-        exclude: '(?i)^(PyMuPDF|tqdm|pinecone-client|psycopg2).*'
+      - name: Check Licenses
+        id: license_check_report
+        uses: pilosus/action-pip-license-checker@v2
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          requirements: ${{ env.REQUIREMENTS_FILE }}
+          fail: "Copyleft,Other,Error"
+          # Exclusions in the vanilla distribution must be explicitly motivated
+          #
+          # - tqdm is MLP but there are no better alternatives
+          # - PyMuPDF is optional
+          # - pinecone-client is optional
+          # - psycopg2 is optional
+          exclude: "(?i)^(PyMuPDF|tqdm|pinecone-client|psycopg2).*"
 
-    # We keep the license inventory on FOSSA
-    - name: Send license report to Fossa
-      uses: fossas/fossa-action@v1.3.1
-      continue-on-error: true  # not critical
-      with:
-        api-key: ${{ secrets.FOSSA_LICENSE_SCAN_TOKEN }}
+      # We keep the license inventory on FOSSA
+      - name: Send license report to Fossa
+        uses: fossas/fossa-action@v1.3.1
+        continue-on-error: true # not critical
+        with:
+          api-key: ${{ secrets.FOSSA_LICENSE_SCAN_TOKEN }}
 
-    - name: Print report
-      if: ${{ always() }}
-      run: echo "${{ steps.license_check_report.outputs.report }}"
+      - name: Print report
+        if: ${{ always() }}
+        run: echo "${{ steps.license_check_report.outputs.report }}"
 
-    - name: Calculate alert data
-      id: calculator
-      shell: bash
-      if: (success() || failure())
-      run: |
-        if [ "${{ job.status }}" = "success" ]; then
-          echo "alert_type=success" >> "$GITHUB_OUTPUT";
-        else
-          echo "alert_type=error" >> "$GITHUB_OUTPUT";
-        fi
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure())
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
 
-    - name: Send event to Datadog
-      if: (success() || failure())
-      uses: masci/datadog@v1
-      with:
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
-        api-url: https://api.datadoghq.eu
-        events: |
-          - title: "${{ github.job }} in ${{ github.workflow }} workflow"
-            text: "License compliance check: direct dependencies only."
-            alert_type: "${{ steps.calculator.outputs.alert_type }}"
-            source_type_name: "Github"
-            host: ${{ github.repository_owner }}
-            tags:
-              - "project:${{ github.repository }}"
-              - "job:${{ github.job }}"
-              - "run_id:${{ github.run_id }}"
-              - "workflow:${{ github.workflow }}"
-              - "branch:${{ github.ref_name }}"
-              - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send event to Datadog
+        if: (success() || failure())
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.job }} in ${{ github.workflow }} workflow"
+              text: "License compliance check: direct dependencies only."
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   license_check_vanilla:
     name: Core dependencies, no extras
@@ -92,69 +92,69 @@ jobs:
       REQUIREMENTS_FILE: requirements_vanilla.txt
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
+      - name: Checkout the code
+        uses: actions/checkout@v4
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: Get explicit and transitive dependencies
-      run: |
-        pip install .
-        pip freeze > ${{ env.REQUIREMENTS_FILE }}
+      - name: Get explicit and transitive dependencies
+        run: |
+          pip install .
+          pip freeze > ${{ env.REQUIREMENTS_FILE }}
 
-    - name: Check Licenses
-      id: license_check_report
-      uses: pilosus/action-pip-license-checker@v2
-      with:
-        github-token: ${{ secrets.GH_ACCESS_TOKEN }}
-        requirements: ${{ env.REQUIREMENTS_FILE }}
-        fail: 'Copyleft,Other,Error'
-        # Exclusions in the vanilla distribution must be explicitly motivated
-        #
-        # - certifi is pulled in by requests
-        # - num2words is pulled in by quantulum3
-        # - tqdm is MLP but there are no better alternatives
-        # - nvidia libraries are brought in by torch on Linux,
-        #   FIXME: to be removed once we stop depending on torch with the vanilla install
-        exclude: '(?i)^(certifi|num2words|tqdm|nvidia-).*'
+      - name: Check Licenses
+        id: license_check_report
+        uses: pilosus/action-pip-license-checker@v2
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          requirements: ${{ env.REQUIREMENTS_FILE }}
+          fail: "Copyleft,Other,Error"
+          # Exclusions in the vanilla distribution must be explicitly motivated
+          #
+          # - certifi is pulled in by requests
+          # - num2words is pulled in by quantulum3
+          # - tqdm is MLP but there are no better alternatives
+          # - nvidia libraries are brought in by torch on Linux,
+          #   FIXME: to be removed once we stop depending on torch with the vanilla install
+          exclude: "(?i)^(certifi|num2words|tqdm|nvidia-).*"
 
-    - name: Print report
-      if: ${{ always() }}
-      run: echo "${{ steps.license_check_report.outputs.report }}"
+      - name: Print report
+        if: ${{ always() }}
+        run: echo "${{ steps.license_check_report.outputs.report }}"
 
-    - name: Calculate alert data
-      id: calculator
-      shell: bash
-      if: (success() || failure())
-      run: |
-        if [ "${{ job.status }}" = "success" ]; then
-          echo "alert_type=success" >> "$GITHUB_OUTPUT";
-        else
-          echo "alert_type=error" >> "$GITHUB_OUTPUT";
-        fi
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure())
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
 
-    - name: Send event to Datadog
-      if: (success() || failure())
-      uses: masci/datadog@v1
-      with:
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
-        api-url: https://api.datadoghq.eu
-        events: |
-          - title: "${{ github.job }} in ${{ github.workflow }} workflow"
-            text: "License compliance check: core dependencies, no extras."
-            alert_type: "${{ steps.calculator.outputs.alert_type }}"
-            source_type_name: "Github"
-            host: ${{ github.repository_owner }}
-            tags:
-              - "project:${{ github.repository }}"
-              - "job:${{ github.job }}"
-              - "run_id:${{ github.run_id }}"
-              - "workflow:${{ github.workflow }}"
-              - "branch:${{ github.ref_name }}"
-              - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send event to Datadog
+        if: (success() || failure())
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.job }} in ${{ github.workflow }} workflow"
+              text: "License compliance check: core dependencies, no extras."
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   license_check_all:
     name: All extras
@@ -162,68 +162,68 @@ jobs:
       REQUIREMENTS_FILE: requirements_all.txt
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
+      - name: Checkout the code
+        uses: actions/checkout@v4
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: Get explicit and transitive dependencies
-      run: |
-        pip install -U pip
-        pip install .[all]
-        pip freeze > ${{ env.REQUIREMENTS_FILE }}
+      - name: Get explicit and transitive dependencies
+        run: |
+          pip install -U pip
+          pip install .[all]
+          pip freeze > ${{ env.REQUIREMENTS_FILE }}
 
-    - name: Check Licenses
-      id: license_check_report
-      uses: pilosus/action-pip-license-checker@v2
-      with:
-        github-token: ${{ secrets.GH_ACCESS_TOKEN }}
-        requirements: ${{ env.REQUIREMENTS_FILE }}
-        fail: 'Copyleft,Other,Error'
-        # We allow incompatible licenses when they come from optional dependencies.
-        #
-        # Special cases:
-        # - pyzmq is flagged because dual-licensed, but we assume using BSD
-        # - tqdm is MLP but there are no better alternatives
-        exclude: '(?i)^(astroid|certifi|chardet|num2words|nvidia-|pathspec|pinecone-client|psycopg2|pylint|PyMuPDF|pyzmq|tqdm).*'
+      - name: Check Licenses
+        id: license_check_report
+        uses: pilosus/action-pip-license-checker@v2
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          requirements: ${{ env.REQUIREMENTS_FILE }}
+          fail: "Copyleft,Other,Error"
+          # We allow incompatible licenses when they come from optional dependencies.
+          #
+          # Special cases:
+          # - pyzmq is flagged because dual-licensed, but we assume using BSD
+          # - tqdm is MLP but there are no better alternatives
+          exclude: "(?i)^(astroid|certifi|chardet|num2words|nvidia-|pathspec|pinecone-client|psycopg2|pylint|PyMuPDF|pyzmq|tqdm).*"
 
-    - name: Print report
-      if: ${{ always() }}
-      run: echo "${{ steps.license_check_report.outputs.report }}"
+      - name: Print report
+        if: ${{ always() }}
+        run: echo "${{ steps.license_check_report.outputs.report }}"
 
-    - name: Calculate alert data
-      id: calculator
-      shell: bash
-      if: (success() || failure())
-      run: |
-        if [ "${{ job.status }}" = "success" ]; then
-          echo "alert_type=success" >> "$GITHUB_OUTPUT";
-        else
-          echo "alert_type=error" >> "$GITHUB_OUTPUT";
-        fi
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure())
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
 
-    - name: Send event to Datadog
-      if: (success() || failure())
-      uses: masci/datadog@v1
-      with:
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
-        api-url: https://api.datadoghq.eu
-        events: |
-          - title: "${{ github.job }} in ${{ github.workflow }} workflow"
-            text: "License compliance check: all available extras."
-            alert_type: "${{ steps.calculator.outputs.alert_type }}"
-            source_type_name: "Github"
-            host: ${{ github.repository_owner }}
-            tags:
-              - "project:${{ github.repository }}"
-              - "job:${{ github.job }}"
-              - "run_id:${{ github.run_id }}"
-              - "workflow:${{ github.workflow }}"
-              - "branch:${{ github.ref_name }}"
-              - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send event to Datadog
+        if: (success() || failure())
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.job }} in ${{ github.workflow }} workflow"
+              text: "License compliance check: all available extras."
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   license_check_all_GPU:
     name: All extras, GPU version
@@ -231,65 +231,65 @@ jobs:
       REQUIREMENTS_FILE: requirements_all_gpu.txt
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
+      - name: Checkout the code
+        uses: actions/checkout@v4
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: Get explicit and transitive dependencies
-      run: |
-        pip install -U pip
-        pip install .[all-gpu]
-        pip freeze > ${{ env.REQUIREMENTS_FILE }}
+      - name: Get explicit and transitive dependencies
+        run: |
+          pip install -U pip
+          pip install .[all-gpu]
+          pip freeze > ${{ env.REQUIREMENTS_FILE }}
 
-    - name: Check Licenses
-      id: license_check_report
-      uses: pilosus/action-pip-license-checker@v2
-      with:
-        github-token: ${{ secrets.GH_ACCESS_TOKEN }}
-        requirements: ${{ env.REQUIREMENTS_FILE }}
-        fail: 'Copyleft,Other,Error'
-        # We allow incompatible licenses when they come from optional dependencies.
-        #
-        # Special cases:
-        # - pyzmq is flagged because dual-licensed, but we assume using BSD
-        # - tqdm is MLP but there are no better alternatives
-        exclude: '(?i)^(astroid|certifi|chardet|num2words|nvidia-|pathspec|pinecone-client|psycopg2|pylint|PyMuPDF|pyzmq|tqdm).*'
+      - name: Check Licenses
+        id: license_check_report
+        uses: pilosus/action-pip-license-checker@v2
+        with:
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          requirements: ${{ env.REQUIREMENTS_FILE }}
+          fail: "Copyleft,Other,Error"
+          # We allow incompatible licenses when they come from optional dependencies.
+          #
+          # Special cases:
+          # - pyzmq is flagged because dual-licensed, but we assume using BSD
+          # - tqdm is MLP but there are no better alternatives
+          exclude: "(?i)^(astroid|certifi|chardet|num2words|nvidia-|pathspec|pinecone-client|psycopg2|pylint|PyMuPDF|pyzmq|tqdm).*"
 
-    - name: Print report
-      if: ${{ always() }}
-      run: echo "${{ steps.license_check_report.outputs.report }}"
+      - name: Print report
+        if: ${{ always() }}
+        run: echo "${{ steps.license_check_report.outputs.report }}"
 
-    - name: Calculate alert data
-      id: calculator
-      shell: bash
-      if: (success() || failure())
-      run: |
-        if [ "${{ job.status }}" = "success" ]; then
-          echo "alert_type=success" >> "$GITHUB_OUTPUT";
-        else
-          echo "alert_type=error" >> "$GITHUB_OUTPUT";
-        fi
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure())
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
 
-    - name: Send event to Datadog
-      if: (success() || failure())
-      uses: masci/datadog@v1
-      with:
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
-        api-url: https://api.datadoghq.eu
-        events: |
-          - title: "${{ github.job }} in ${{ github.workflow }} workflow"
-            text: "License compliance check: all available extras, GPU version."
-            alert_type: "${{ steps.calculator.outputs.alert_type }}"
-            source_type_name: "Github"
-            host: ${{ github.repository_owner }}
-            tags:
-              - "project:${{ github.repository }}"
-              - "job:${{ github.job }}"
-              - "run_id:${{ github.run_id }}"
-              - "workflow:${{ github.workflow }}"
-              - "branch:${{ github.ref_name }}"
-              - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send event to Datadog
+        if: (success() || failure())
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.job }} in ${{ github.workflow }} workflow"
+              text: "License compliance check: all available extras, GPU version."
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
`license_compliance.yml` workflow always fail when running in PRs opened from forks. That happens cause we try to send check result event to Datadog but since `secrets` are not accessible from those PRs it always fails. 

That can cause confusion so this PR disables the step sending the event in PRs opened from forks. The workflow will still fail when the license check fails for a proper reason.

Example failure: https://github.com/deepset-ai/haystack/actions/runs/6168513914?pr=5783

The first commit of this PR is just a reformatting of the workflow file, feel free to ignore it.

