### PR TITLE
Revert "build(deps): bump readmeio/rdme from 8.3.1 to 8.6.6"

### DIFF
--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -48,7 +48,7 @@ jobs:
           echo "id=$SPECS_ID" >> "$GITHUB_OUTPUT"
 
       - name: Sync OpenAPI specs
-        uses: readmeio/rdme@8.6.6
+        uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
           README_API_DEFINITION_ID: ${{ steps.openapi-specs.outputs.id }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -47,7 +47,7 @@ jobs:
         # will always be synced to the current `X.Y-unstable` version on Readme
         id: sync-main
         if: github.ref_name == 'main' && github.event_name == 'push'
-        uses: readmeio/rdme@8.6.6
+        uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
         with:
@@ -58,7 +58,7 @@ jobs:
         # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
         # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
         if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
-        uses: readmeio/rdme@8.6.6
+        uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
         with:


### PR DESCRIPTION
Reverts deepset-ai/haystack#5789

I optimistically merged the dependabot PR,
but now our [docs sync actions fails](https://github.com/deepset-ai/haystack/actions/runs/6170299645/job/16746320164).

We should better investigate why, but in the meantime, I'm reverting the PR...