### PR TITLE
Fix license compliance check failing when running in PR from forks

### DIFF
--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 
+env:
+  CORE_DATADOG_API_KEY: ${{ secrets.CORE_DATADOG_API_KEY }}
+
 jobs:
   license_check_direct:
     name: Direct dependencies only
@@ -71,10 +74,10 @@ jobs:
         # secrets are not accessible.
         # To prevent showing bogus failures in those PRs we skip the step.
         # The workflow will fail in any case if the actual check fails in the previous steps.
-        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
+        if: (success() || failure()) && env.CORE_DATADOG_API_KEY != ''
         uses: masci/datadog@v1
         with:
-          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-key: ${{ env.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
           events: |
             - title: "${{ github.job }} in ${{ github.workflow }} workflow"
@@ -145,10 +148,10 @@ jobs:
         # secrets are not accessible.
         # To prevent showing bogus failures in those PRs we skip the step.
         # The workflow will fail in any case if the actual check fails in the previous steps.
-        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
+        if: (success() || failure()) && env.CORE_DATADOG_API_KEY != ''
         uses: masci/datadog@v1
         with:
-          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-key: ${{ env.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
           events: |
             - title: "${{ github.job }} in ${{ github.workflow }} workflow"
@@ -218,10 +221,10 @@ jobs:
         # secrets are not accessible.
         # To prevent showing bogus failures in those PRs we skip the step.
         # The workflow will fail in any case if the actual check fails in the previous steps.
-        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
+        if: (success() || failure()) && env.CORE_DATADOG_API_KEY != ''
         uses: masci/datadog@v1
         with:
-          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-key: ${{ env.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
           events: |
             - title: "${{ github.job }} in ${{ github.workflow }} workflow"
@@ -291,10 +294,10 @@ jobs:
         # secrets are not accessible.
         # To prevent showing bogus failures in those PRs we skip the step.
         # The workflow will fail in any case if the actual check fails in the previous steps.
-        if: (success() || failure()) && github.repository == 'deepset-ai/haystack'
+        if: (success() || failure()) && env.CORE_DATADOG_API_KEY != ''
         uses: masci/datadog@v1
         with:
-          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-key: ${{ env.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
           events: |
             - title: "${{ github.job }} in ${{ github.workflow }} workflow"


### PR DESCRIPTION
### Proposed Changes:

Run the step that send the license check outcome to Datadog only if the api key is set.

### How did you test it?

I didn't. Setting a testing ground for this takes more time that testing directly in CI and it doesn't block development so I believe it's still worth.

### Notes for the reviewer

Attempted fix with #5791 but it didn't work as the `github.repository` is set to `deepset-ai/haystack` even if PR comes from a fork.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
