### PR TITLE
chore: remove `sklearn` module from configuration for docs generation

### DIFF
--- a/docs/pydoc/config/query-classifier.yml
+++ b/docs/pydoc/config/query-classifier.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: loaders.CustomPythonLoader
     search_path: [../../../haystack/nodes/query_classifier]
-    modules: ["sklearn", "transformers"]
+    modules: ["transformers"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter


### PR DESCRIPTION
[Sync docs with Readme workflow is failing](https://github.com/deepset-ai/haystack/actions/runs/6172238899/job/16752102024).

After #5779, we should also remove `sklearn` module from query-classifier.yml (configuration for docs generation)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
