### PR TITLE
refactor: Move filter utilities (2.0)

### DIFF
--- a/haystack/preview/document_stores/errors.py
+++ b/haystack/preview/document_stores/errors.py
@@ -2,10 +2,6 @@ class DocumentStoreError(Exception):
     pass
 
 
-class FilterError(DocumentStoreError):
-    pass
-
-
 class DuplicateDocumentError(DocumentStoreError):
     pass
 

--- a/haystack/preview/document_stores/memory/__init__.py
+++ b/haystack/preview/document_stores/memory/__init__.py
@@ -1,4 +1,3 @@
 from haystack.preview.document_stores.memory.document_store import MemoryDocumentStore
-from haystack.preview.document_stores.memory.errors import MemoryDocumentStoreFilterError
 
-__all__ = ["MemoryDocumentStore", "MemoryDocumentStoreFilterError"]
+__all__ = ["MemoryDocumentStore"]

--- a/haystack/preview/document_stores/memory/document_store.py
+++ b/haystack/preview/document_stores/memory/document_store.py
@@ -11,7 +11,7 @@ from haystack.preview import default_from_dict, default_to_dict
 from haystack.preview.document_stores.decorator import document_store
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores.protocols import DuplicatePolicy, DocumentStore
-from haystack.preview.document_stores.memory._filters import match
+from haystack.preview.utils.filters import document_matches_filter
 from haystack.preview.document_stores.errors import DuplicateDocumentError, MissingDocumentError, DocumentStoreError
 from haystack.preview.utils import expit
 
@@ -160,7 +160,7 @@ class MemoryDocumentStore:
         :return: A list of Documents that match the given filters.
         """
         if filters:
-            return [doc for doc in self.storage.values() if match(conditions=filters, document=doc)]
+            return [doc for doc in self.storage.values() if document_matches_filter(conditions=filters, document=doc)]
         return list(self.storage.values())
 
     def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> None:

--- a/haystack/preview/document_stores/memory/errors.py
+++ b/haystack/preview/document_stores/memory/errors.py
@@ -1,5 +1,0 @@
-from haystack.preview.document_stores.errors import FilterError
-
-
-class MemoryDocumentStoreFilterError(FilterError):
-    pass

--- a/haystack/preview/errors.py
+++ b/haystack/preview/errors.py
@@ -1,0 +1,2 @@
+class FilterError(Exception):
+    pass

--- a/haystack/preview/testing/document_store.py
+++ b/haystack/preview/testing/document_store.py
@@ -7,7 +7,8 @@ import pandas as pd
 
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores import DocumentStore, DuplicatePolicy
-from haystack.preview.document_stores.errors import FilterError, MissingDocumentError, DuplicateDocumentError
+from haystack.preview.document_stores.errors import MissingDocumentError, DuplicateDocumentError
+from haystack.preview.errors import FilterError
 
 
 class DocumentStoreBaseTests:

--- a/haystack/preview/utils/__init__.py
+++ b/haystack/preview/utils/__init__.py
@@ -1,2 +1,3 @@
 from haystack.preview.utils.expit import expit
 from haystack.preview.utils.requests_utils import request_with_retry
+from haystack.preview.utils.filters import document_matches_filter

--- a/haystack/preview/utils/filters.py
+++ b/haystack/preview/utils/filters.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List, Any, Union, Dict
 
 import numpy as np
 import pandas as pd
@@ -32,10 +32,10 @@ def and_operation(conditions: List[Any], document: Document, _current_key: str):
     :param _current_key: internal, don't use.
     :return: True if the document matches all the filters, False otherwise
     """
-    for condition in conditions:
-        if not document_matches_filter(conditions=condition, document=document, _current_key=_current_key):
-            return False
-    return True
+    return all(
+        document_matches_filter(conditions=condition, document=document, _current_key=_current_key)
+        for condition in conditions
+    )
 
 
 def or_operation(conditions: List[Any], document: Document, _current_key: str):
@@ -45,12 +45,12 @@ def or_operation(conditions: List[Any], document: Document, _current_key: str):
     :param conditions: the filters dictionary.
     :param document: the document to test.
     :param _current_key: internal, don't use.
-    :return: True if the document matches ano of the filters, False otherwise
+    :return: True if the document matches any of the filters, False otherwise
     """
-    for condition in conditions:
-        if document_matches_filter(conditions=condition, document=document, _current_key=_current_key):
-            return True
-    return False
+    return any(
+        document_matches_filter(conditions=condition, document=document, _current_key=_current_key)
+        for condition in conditions
+    )
 
 
 def _safe_eq(first: Any, second: Any) -> bool:
@@ -208,14 +208,17 @@ OPERATORS = {
 RESERVED_KEYS = [*LOGICAL_STATEMENTS.keys(), *OPERATORS.keys()]
 
 
-def document_matches_filter(conditions: Any, document: Document, _current_key=None):
+def document_matches_filter(conditions: Union[Dict, List], document: Document, _current_key=None):
     """
-    This method applies the filters to any given document and returns True when the documents
-    metadata matches the filters, False otherwise.
+    Check if a document's metadata matches the provided filter conditions.
 
-    :param conditions: the filters dictionary.
-    :param document: the document to test.
-    :return: True if the document matches the filters, False otherwise
+    This function evaluates the specified conditions against the metadata of the given document
+    and returns True if the conditions are met, otherwise it returns False.
+
+    :param conditions: A dictionary or list containing filter conditions to be applied to the document's metadata.
+    :param document: The document whose metadata will be evaluated against the conditions.
+    :param _current_key: internal parameter, don't use.
+    :return: True if the document's metadata matches the filter conditions, False otherwise.
     """
     if isinstance(conditions, dict):
         # Check for malformed filters, like {"name": {"year": "2020"}}


### PR DESCRIPTION
### Related Issues

- related to #5680 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR moves the filtering utilities from `preview/document_stores/memory/_filters.py` to `preview/filters/utils.py` as they are not only useful for the `MemoryDocumentStore`, but also for other components like the `MetadataRouter`.

With this refactoring `FilterError` isn't part of `preview/document_stores/memory/errors.py` anymore, but moved to `preview/errors.py`.
Also, I decided to rename the `match` method of `filters.py` to `document_matches_filter` to make it more descriptive. Let me know if we should keep the old name.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
