### PR TITLE
fix: remove `__future__` import from `pinecone.py`

### DIFF
--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import copy
 import json
 import logging

--- a/haystack/document_stores/pinecone.py
+++ b/haystack/document_stores/pinecone.py
@@ -200,7 +200,7 @@ class PineconeDocumentStore(BaseDocumentStore):
         shards: Optional[int] = 1,
         recreate_index: bool = False,
         metadata_config: Optional[Dict] = None,
-    ) -> pinecone.Index:
+    ) -> "pinecone.Index":
         """
         Create a new index for storing documents in case an index with the name
         doesn't exist already.


### PR DESCRIPTION
### Related Issues

- fixes failing Docker build

### Proposed Changes:

Removes `from __future__ import annotation` from `pinecone.py`, breaking the JSON schema generation.

### How did you test it?

CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
