### PR TITLE
ci: skip mandatory release notes check when not needed

### DIFF
--- a/.github/workflows/release_notes_skipper.yml
+++ b/.github/workflows/release_notes_skipper.yml
@@ -1,0 +1,23 @@
+name: Check Release Notes
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+    paths-ignore:
+      - "**.py"
+      - "pyproject.toml"
+      - "!.github/**/*.py"
+      - "!rest_api/**/*.py"
+
+jobs:
+  reno:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip mandatory job
+        run: echo "Skipped!"


### PR DESCRIPTION
### Proposed Changes:

Release note check was made mandatory, but certain PRs don't run it at all so I'm adding a job skipper worfklow similar to the one we have for tests