### PR TITLE
ci: pre-commit - move `ruff` after `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,15 +16,15 @@ repos:
     - id: trailing-whitespace  # trims trailing whitespace
       args: [--markdown-linebreak-ext=md]
 
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.289
-  hooks:
-  - id: ruff
-
 - repo: https://github.com/psf/black
   rev: 23.9.1
   hooks:
   - id: black-jupyter
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.289
+  hooks:
+  - id: ruff  
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5


### PR DESCRIPTION
### Related Issues

I have been encountering some issues with `ruff` pre-commit hook: it raises "line too long (E501)."

`line-length` is quite high
https://github.com/deepset-ai/haystack/blob/cab21da87be6560977d6d604ae3867aa64696202/pyproject.toml#L405
but it is not correctly working.
(I also tried with a clean Haystack installation)

Possible reason: [`line-length` is not consistent between `ruff` and `black`](https://beta.ruff.rs/docs/faq/#is-ruff-compatible-with-black)

Then, I also found that [**Ruff's pre-commit hook should be placed after other formatting tools, such as Black and isort**](https://beta.ruff.rs/docs/usage/#pre-commit).

### Proposed Changes:

Move `ruff` pre-commit hook after `black` hook

### How did you test it?

Local run.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
