### PR TITLE
ci: Speed up pylint GitHub Action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -68,10 +68,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Haystack
+      - name: Install Pylint and Haystack Linter
         run: |
-          pip install ".[all,dev]"
-          pip install ./haystack-linter
+          pip install pylint ./haystack-linter
 
       - name: Pylint
         if: steps.files.outputs.any_changed == 'true'


### PR DESCRIPTION
### Related Issues

- fixes #5782

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
As discussed at https://github.com/deepset-ai/haystack/pull/5771#issuecomment-1714833290 the current pylint GitHub Action builds all haystack which is not required for lining with pylint.  This pull request eliminates unneeded steps so that pylint results are returned in seconds (14 sec. for 50+ Python files modified), instead of [7 to 11 minutes](https://github.com/deepset-ai/haystack/actions/workflows/linting.yml). 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

Run `ruff --select=UP --fix .` to modify 50+ Python files and ensure pylint runs correctly.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
