### PR TITLE
feat: Add support for OpenAI's `gpt-3.5-turbo-instruct` model

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -136,5 +136,8 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        valid_model = any(m for m in ["gpt-3.5-turbo", "gpt-4"] if m in model_name_or_path)
+        valid_model = (
+            any(m for m in ["gpt-3.5-turbo", "gpt-4"] if m in model_name_or_path)
+            and not "gpt-3.5-turbo-instruct" in model_name_or_path
+        )
         return valid_model and not has_azure_parameters(**kwargs)

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -231,7 +231,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
 
     @classmethod
     def supports(cls, model_name_or_path: str, **kwargs) -> bool:
-        valid_model = model_name_or_path in ["ada", "babbage", "davinci", "curie"] or any(
+        valid_model = model_name_or_path in ["ada", "babbage", "davinci", "curie", "gpt-3.5-turbo-instruct"] or any(
             m in model_name_or_path for m in ["-ada-", "-babbage-", "-davinci-", "-curie-"]
         )
         return valid_model and not has_azure_parameters(**kwargs)

--- a/releasenotes/notes/support-gpt-3.5-turbo-instruct-79236835a8be143c.yaml
+++ b/releasenotes/notes/support-gpt-3.5-turbo-instruct-79236835a8be143c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Support OpenAI's new `gpt-3.5-turbo-instruct` model

--- a/test/prompt/invocation_layer/test_chatgpt.py
+++ b/test/prompt/invocation_layer/test_chatgpt.py
@@ -38,7 +38,7 @@ def test_supports_correct_model_names():
 
 @pytest.mark.unit
 def test_does_not_support_wrong_model_names():
-    for model_name in ["got-3.5-turbo", "wrong_model_name"]:
+    for model_name in ["got-3.5-turbo", "wrong_model_name", "gpt-3.5-turbo-instruct"]:
         assert not ChatGPTInvocationLayer.supports(model_name)
 
 

--- a/test/prompt/invocation_layer/test_openai.py
+++ b/test/prompt/invocation_layer/test_openai.py
@@ -132,6 +132,7 @@ def test_supports(load_openai_tokenizer):
     assert layer.supports("davinci")
     assert layer.supports("text-ada-001")
     assert layer.supports("text-davinci-002")
+    assert layer.supports("gpt-3.5-turbo-instruct")
 
     # the following model contains "ada" in the name, but it's not from OpenAI
     assert not layer.supports("ybelkada/mpt-7b-bf16-sharded")


### PR DESCRIPTION
### Related Issues

Let's add support for the very recently released model gpt-3.5.-turbo-instruct (see [HN](https://news.ycombinator.com/item?id=37558911))

### Proposed Changes:
As this is an instruction model (not a chat model), it is implemented in OpenAI's legacy completion API endpoint.
Therefore, I am adding the support in the `OpenAIInvocationlayer` (and not `ChatGPTInvocationLayer`)

### How did you test it?
- Validated manually that OpenAI really uses the legacy completions endpoint for it
- Extended the unit tests for supported model names

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
