### PR TITLE
feat: `preview` extra

### DIFF
--- a/haystack/preview/components/audio/whisper_local.py
+++ b/haystack/preview/components/audio/whisper_local.py
@@ -4,9 +4,12 @@ import logging
 from pathlib import Path
 
 import torch
-import whisper
 
 from haystack.preview import component, Document, default_to_dict, default_from_dict, ComponentError
+from haystack.preview.lazy_imports import LazyImport
+
+with LazyImport("Run 'pip install openai-whisper'") as whisper_import:
+    import whisper
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +41,7 @@ class LocalWhisperTranscriber:
             - `large-v2`
         :param device: Name of the torch device to use for inference. If None, CPU is used.
         """
+        whisper_import.check()
         if model_name_or_path not in get_args(WhisperLocalModel):
             raise ValueError(
                 f"Model name '{model_name_or_path}' not recognized. Choose one among: "

--- a/haystack/preview/components/builders/prompt_builder.py
+++ b/haystack/preview/components/builders/prompt_builder.py
@@ -1,9 +1,11 @@
 from typing import Dict, Any
 
-from jinja2 import Template, meta
-
 from haystack.preview import component
 from haystack.preview import default_to_dict, default_from_dict
+from haystack.preview.lazy_imports import LazyImport
+
+with LazyImport("Run 'pip install jinja2'") as jinja_import:
+    from jinja2 import Template, meta
 
 
 @component
@@ -27,6 +29,7 @@ class PromptBuilder:
         :param template: Jinja2 template string, e.g. "Summarize this document: {documents}\nSummary:"
         :type template: str
         """
+        jinja_import.check()
         self._template_string = template
         self.template = Template(template)
         ast = self.template.environment.parse(template)

--- a/haystack/preview/components/file_converters/txt.py
+++ b/haystack/preview/components/file_converters/txt.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import Document, component, default_to_dict, default_from_dict
 
-with LazyImport("Run 'pip install farm-haystack[preprocessing]'") as langdetect_import:
+with LazyImport("Run 'pip install langdetect'") as langdetect_import:
     import langdetect
 
 

--- a/haystack/preview/components/generators/openai/gpt.py
+++ b/haystack/preview/components/generators/openai/gpt.py
@@ -5,9 +5,11 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, asdict
 
-import openai
-
 from haystack.preview import component, default_from_dict, default_to_dict, DeserializationError
+from haystack.preview.lazy_imports import LazyImport
+
+with LazyImport("Run 'pip install openai'") as openai_import:
+    import openai
 
 
 logger = logging.getLogger(__name__)
@@ -84,6 +86,7 @@ class GPTGenerator:
             - `logit_bias`: Add a logit bias to specific tokens. The keys of the dictionary are tokens and the
                 values are the bias to add to that token.
         """
+        openai_import.check()
         self.api_key = api_key
         self.model_name = model_name
         self.system_prompt = system_prompt

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -6,7 +6,9 @@ import warnings
 from haystack.preview import component, default_from_dict, default_to_dict, ComponentError, Document, ExtractedAnswer
 from haystack.preview.lazy_imports import LazyImport
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_and_transformers_import:
+with LazyImport(
+    "Run 'pip install transformers[torch,sentencepiece]==4.32.1 sentence-transformers>=2.2.0'"
+) as torch_and_transformers_import:
     from transformers import AutoModelForQuestionAnswering, AutoTokenizer
     from tokenizers import Encoding
     import torch

--- a/haystack/preview/embedding_backends/sentence_transformers_backend.py
+++ b/haystack/preview/embedding_backends/sentence_transformers_backend.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union, Dict
 
 from haystack.preview.lazy_imports import LazyImport
 
-with LazyImport(message="Run 'pip install farm-haystack[inference]'") as sentence_transformers_import:
+with LazyImport(message="Run 'pip install sentence-transformers>=2.2.0'") as sentence_transformers_import:
     from sentence_transformers import SentenceTransformer
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,13 +78,6 @@ dependencies = [
   # Schema validation
   "jsonschema",
 
-  # Preview
-  "canals==0.8.0",
-  "openai",
-  "Jinja2",
-  "openai-whisper",  # FIXME https://github.com/deepset-ai/haystack/issues/5731
-  "pypdf",
-
   # Agent events
   "events",
 
@@ -92,6 +85,20 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+preview = [
+  "canals==0.8.0",
+  "requests",  # needed by canals
+  "pandas",
+  "rank_bm25",
+  "tqdm",
+  "tenacity",
+  "lazy-imports",
+  "openai",
+  "Jinja2",
+  "openai-whisper",  # FIXME https://github.com/deepset-ai/haystack/issues/5731
+  "sentence-transformers>=2.2.0",  # FIXME should be an optional dependency listed in a specific subgroup
+  "pypdf", # FIXME should be an optional dependency listed in a specific subgroup
+]
 inference = [
   "transformers[torch,sentencepiece]==4.32.1",
   "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,17 +87,15 @@ dependencies = [
 [project.optional-dependencies]
 preview = [
   "canals==0.8.0",
-  "requests",  # needed by canals
+  "requests",
   "pandas",
   "rank_bm25",
   "tqdm",
   "tenacity",
   "lazy-imports",
-  "openai",
+
   "Jinja2",
-  "openai-whisper",  # FIXME https://github.com/deepset-ai/haystack/issues/5731
-  "sentence-transformers>=2.2.0",  # FIXME should be an optional dependency listed in a specific subgroup
-  "pypdf", # FIXME should be an optional dependency listed in a specific subgroup
+  "openai",
 ]
 inference = [
   "transformers[torch,sentencepiece]==4.32.1",


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/orgs/deepset-ai/projects/5/views/14?pane=issue&itemId=39359487

### Proposed Changes:

 - Moves Haystack's 2.0 dependencies from the core list of dependencies into a `preview` extra.
 - It's still recommended to use `haystack-ai` for trying out Haystack 2.0.

### How did you test it?

CI

### Notes for the reviewer
n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
