### PR TITLE
chore: make preview integration tests reproducible

### DIFF
--- a/haystack/preview/testing/test_utils.py
+++ b/haystack/preview/testing/test_utils.py
@@ -1,11 +1,7 @@
 import os
 import random
 import numpy as np
-
-from haystack.preview.lazy_imports import LazyImport
-
-with LazyImport(message="Run 'pip install torch'") as torch_import:
-    import torch
+import torch
 
 
 def set_all_seeds(seed: int, deterministic_cudnn: bool = False) -> None:
@@ -18,8 +14,6 @@ def set_all_seeds(seed: int, deterministic_cudnn: bool = False) -> None:
     :param seed:number to use as seed
     :param deterministic_cudnn: Enable for full reproducibility when using CUDA. Caution: might slow down training.
     """
-    torch_import.check()
-
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/haystack/preview/utils/set_seeds.py
+++ b/haystack/preview/utils/set_seeds.py
@@ -1,0 +1,30 @@
+import os
+import random
+import numpy as np
+
+from haystack.preview.lazy_imports import LazyImport
+
+with LazyImport(message="Run 'pip install torch'") as torch_import:
+    import torch
+
+
+def set_all_seeds(seed: int, deterministic_cudnn: bool = False) -> None:
+    """
+    Setting multiple seeds to make runs reproducible.
+
+    Important: Enabling `deterministic_cudnn` gives you full reproducibility with CUDA,
+    but might slow down your training (see https://pytorch.org/docs/stable/notes/randomness.html#cudnn) !
+
+    :param seed:number to use as seed
+    :param deterministic_cudnn: Enable for full reproducibility when using CUDA. Caution: might slow down training.
+    """
+    torch_import.check()
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    torch.cuda.manual_seed_all(seed)
+    if deterministic_cudnn:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -262,7 +262,7 @@ def test_roberta():
 
 @pytest.mark.integration
 def test_matches_hf_pipeline():
-    reader = ExtractiveReader("deepset/tinyroberta-squad2")
+    reader = ExtractiveReader("deepset/tinyroberta-squad2", device="cpu")
     reader.warm_up()
     answers = reader.run(example_queries[0], [[example_documents[0][0]]][0], top_k=20, no_answer=False)[
         "answers"

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -217,11 +217,11 @@ def test_t5():
         "answers"
     ]  # remove indices when batching support is reintroduced
     assert answers[0].data == "Angela Merkel"
-    assert answers[0].probability == pytest.approx(0.7764519453048706)
+    assert answers[0].probability == pytest.approx(0.7764519453048706, abs=1e-4)
     assert answers[1].data == "Olaf Scholz"
-    assert answers[1].probability == pytest.approx(0.7703777551651001)
+    assert answers[1].probability == pytest.approx(0.7703777551651001, abs=1e-4)
     assert answers[2].data is None
-    assert answers[2].probability == pytest.approx(0.051331606147570596)
+    assert answers[2].probability == pytest.approx(0.051331606147570596, abs=1e-4)
     # Uncomment assertions below when batching is reintroduced
     # assert answers[0][2].probability == pytest.approx(0.051331606147570596)
     # assert answers[1][0].data == "Jerry"
@@ -240,11 +240,11 @@ def test_roberta():
         "answers"
     ]  # remove indices when batching is reintroduced
     assert answers[0].data == "Olaf Scholz"
-    assert answers[0].probability == pytest.approx(0.8614975214004517)
+    assert answers[0].probability == pytest.approx(0.8614975214004517, abs=1e-4)
     assert answers[1].data == "Angela Merkel"
-    assert answers[1].probability == pytest.approx(0.857952892780304)
+    assert answers[1].probability == pytest.approx(0.857952892780304, abs=1e-4)
     assert answers[2].data is None
-    assert answers[2].probability == pytest.approx(0.0196738764278237)
+    assert answers[2].probability == pytest.approx(0.0196738764278237, abs=1e-4)
     # uncomment assertions below when there is batching in v2
     # assert answers[0][0].data == "Olaf Scholz"
     # assert answers[0][0].probability == pytest.approx(0.8614975214004517)

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -217,11 +217,11 @@ def test_t5():
         "answers"
     ]  # remove indices when batching support is reintroduced
     assert answers[0].data == "Angela Merkel"
-    assert answers[0].probability == pytest.approx(0.7764519453048706, abs=1e-4)
+    assert answers[0].probability == pytest.approx(0.7764519453048706)
     assert answers[1].data == "Olaf Scholz"
-    assert answers[1].probability == pytest.approx(0.7703777551651001, abs=1e-4)
+    assert answers[1].probability == pytest.approx(0.7703777551651001)
     assert answers[2].data is None
-    assert answers[2].probability == pytest.approx(0.051331606147570596, abs=1e-4)
+    assert answers[2].probability == pytest.approx(0.051331606147570596)
     # Uncomment assertions below when batching is reintroduced
     # assert answers[0][2].probability == pytest.approx(0.051331606147570596)
     # assert answers[1][0].data == "Jerry"
@@ -240,11 +240,11 @@ def test_roberta():
         "answers"
     ]  # remove indices when batching is reintroduced
     assert answers[0].data == "Olaf Scholz"
-    assert answers[0].probability == pytest.approx(0.8614975214004517, abs=1e-4)
+    assert answers[0].probability == pytest.approx(0.8614975214004517)
     assert answers[1].data == "Angela Merkel"
-    assert answers[1].probability == pytest.approx(0.857952892780304, abs=1e-4)
+    assert answers[1].probability == pytest.approx(0.857952892780304)
     assert answers[2].data is None
-    assert answers[2].probability == pytest.approx(0.0196738764278237, abs=1e-4)
+    assert answers[2].probability == pytest.approx(0.019673851661650588)
     # uncomment assertions below when there is batching in v2
     # assert answers[0][0].data == "Olaf Scholz"
     # assert answers[0][0].probability == pytest.approx(0.8614975214004517)

--- a/test/preview/conftest.py
+++ b/test/preview/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import Mock
 import pytest
 
-from haystack.preview.utils.set_seeds import set_all_seeds
+from haystack.preview.testing.test_utils import set_all_seeds
 
 set_all_seeds(0)
 

--- a/test/preview/conftest.py
+++ b/test/preview/conftest.py
@@ -1,6 +1,10 @@
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 import pytest
+
+from haystack.preview.utils.set_seeds import set_all_seeds
+
+set_all_seeds(0)
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Related Issues
The Integration tests of the Extractive Reader are randomly failing ([see an example](https://github.com/deepset-ai/haystack/actions/runs/6297461927/job/17095016616))

### Proposed Changes:
- Add an absolute tolerance of 1e-4 to prevent groundless failures.
- (unrelated: force the reader to use the CPU in `test_matches_hf_pipeline`. Otherwise, in local environments where GPU is available, this test fails with `RuntimeError: Expected all tensors to be on the same device...`)

### How did you test it?
CI, local tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
