### PR TITLE
chore: pin `setuptools_scm` in the `metrics` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,9 @@ onnx-gpu = [
 metrics = [  # for metrics
   "scipy>=1.3.2",
   "rapidfuzz>=2.0.15,<2.8.0",   # FIXME https://github.com/deepset-ai/haystack/pull/3199
+  # Pin setuptools_scm to prevent errors in Windows tests while installing seqeval
+  # https://github.com/deepset-ai/haystack/issues/5889
+  "setuptools_scm<8.0",
   "seqeval",
   "mlflow",
 ]


### PR DESCRIPTION
### Related Issues

- trying to temporarily fix #5889 

### Proposed Changes:
Pin `setuptools_scm<8.0` in the `metrics` extra to avoid errors in Windows tests while installing `seqeval`

### How did you test it?

It is an attempt and I could not test it

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
