### PR TITLE
chore: pin `setuptools_scm` in the `metrics` extra only for Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ metrics = [  # for metrics
   "rapidfuzz>=2.0.15,<2.8.0",   # FIXME https://github.com/deepset-ai/haystack/pull/3199
   # Pin setuptools_scm to prevent errors in Windows tests while installing seqeval
   # https://github.com/deepset-ai/haystack/issues/5889
-  "setuptools_scm<8.0",
+  "setuptools_scm<8.0; platform_system == 'Windows'",
   "seqeval",
   "mlflow",
 ]


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/issues/5889

### Proposed Changes:

Pin `setuptools_scm` **only for Windows**, as suggested in https://github.com/deepset-ai/haystack/pull/5891#discussion_r1337392947


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
