### PR TITLE
feat: Make `metadata` optional in AnswerBuilder

### DIFF
--- a/haystack/preview/components/builders/answer_builder.py
+++ b/haystack/preview/components/builders/answer_builder.py
@@ -42,7 +42,7 @@ class AnswerBuilder:
         self,
         query: str,
         replies: List[str],
-        metadata: List[Dict[str, Any]],
+        metadata: Optional[List[Dict[str, Any]]] = None,
         documents: Optional[List[Document]] = None,
         pattern: Optional[str] = None,
         reference_pattern: Optional[str] = None,
@@ -73,8 +73,11 @@ class AnswerBuilder:
                                   If not specified, no parsing is done, and all documents are referenced.
                                   Default: `None`.
         """
-        if len(replies) != len(metadata):
+        if not metadata:
+            metadata = [{}] * len(replies)
+        elif len(replies) != len(metadata):
             raise ValueError(f"Number of replies ({len(replies)}), and metadata ({len(metadata)}) must match.")
+
         if pattern:
             AnswerBuilder._check_num_groups_in_regex(pattern)
 

--- a/haystack/preview/components/builders/answer_builder.py
+++ b/haystack/preview/components/builders/answer_builder.py
@@ -52,7 +52,8 @@ class AnswerBuilder:
 
         :param query: The query used in the prompts for the Generator. A strings.
         :param replies: The output of the Generator. A list of strings.
-        :param metadata: The metadata returned by the Generator. A list of dictionaries.
+        :param metadata: The metadata returned by the Generator. An optional list of dictionaries. If not specified,
+                            the generated answer will contain no metadata.
         :param documents: The documents used as input to the Generator. A list of `Document` objects. If
                           `documents` are specified, they are added to the `Answer` objects.
                           If both `documents` and `reference_pattern` are specified, the documents referenced in the

--- a/test/preview/components/builders/test_answer_builder.py
+++ b/test/preview/components/builders/test_answer_builder.py
@@ -36,7 +36,29 @@ class TestAnswerBuilder:
     def test_run_unmatching_input_len(self):
         component = AnswerBuilder()
         with pytest.raises(ValueError):
-            component.run(query="query", replies=["reply1", "reply2"], metadata=[])
+            component.run(query="query", replies=["reply1"], metadata=[{"test": "meta"}, {"test": "meta2"}])
+
+    @pytest.mark.unit
+    def test_run_without_meta(self):
+        component = AnswerBuilder()
+        output = component.run(query="query", replies=["reply1"])
+        answers = output["answers"]
+        assert answers[0].data == "reply1"
+        assert answers[0].metadata == {}
+        assert answers[0].query == "query"
+        assert answers[0].documents == []
+        assert isinstance(answers[0], GeneratedAnswer)
+
+    @pytest.mark.unit
+    def test_run_meta_is_an_empty_list(self):
+        component = AnswerBuilder()
+        output = component.run(query="query", replies=["reply1"], metadata=[])
+        answers = output["answers"]
+        assert answers[0].data == "reply1"
+        assert answers[0].metadata == {}
+        assert answers[0].query == "query"
+        assert answers[0].documents == []
+        assert isinstance(answers[0], GeneratedAnswer)
 
     def test_run_without_pattern(self):
         component = AnswerBuilder()


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

- For small demos I found that passing the metadata makes the pipeline definition a bit more noisy than necessary.
- Metadata is not an optional field
- Tests have been added

### How did you test it?

- Local unit tests run

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
