### PR TITLE
test: enhance e2e tests to also draw and serialize/deserialize the test pipelines

### DIFF
--- a/e2e/preview/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/preview/pipelines/test_extractive_qa_pipeline.py
@@ -22,6 +22,7 @@ def test_extractive_qa_pipeline(tmp_path):
 
     qa_pipeline.draw(tmp_path / "test_extractive_qa_pipeline.png")
 
+    # TODO write to JSON to make sure it's actually serializable
     serialized_pipeline = qa_pipeline.to_dict()
     qa_pipeline = Pipeline.from_dict(serialized_pipeline)
 

--- a/e2e/preview/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/preview/pipelines/test_extractive_qa_pipeline.py
@@ -4,7 +4,7 @@ from haystack.preview.components.retrievers import MemoryBM25Retriever
 from haystack.preview.components.readers import ExtractiveReader
 
 
-def test_extractive_qa_pipeline():
+def test_extractive_qa_pipeline(tmp_path):
     document_store = MemoryDocumentStore()
 
     documents = [
@@ -19,6 +19,11 @@ def test_extractive_qa_pipeline():
     qa_pipeline.add_component(instance=MemoryBM25Retriever(document_store=document_store), name="retriever")
     qa_pipeline.add_component(instance=ExtractiveReader(model_name_or_path="deepset/tinyroberta-squad2"), name="reader")
     qa_pipeline.connect("retriever", "reader")
+
+    qa_pipeline.draw(tmp_path / "test_extractive_qa_pipeline.png")
+
+    serialized_pipeline = qa_pipeline.to_dict()
+    qa_pipeline = Pipeline.from_dict(serialized_pipeline)
 
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]

--- a/e2e/preview/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/preview/pipelines/test_extractive_qa_pipeline.py
@@ -1,3 +1,5 @@
+import json
+
 from haystack.preview import Pipeline, Document
 from haystack.preview.document_stores import MemoryDocumentStore
 from haystack.preview.components.retrievers import MemoryBM25Retriever
@@ -5,17 +7,25 @@ from haystack.preview.components.readers import ExtractiveReader
 
 
 def test_extractive_qa_pipeline(tmp_path):
+    # Create the pipeline
     qa_pipeline = Pipeline()
     qa_pipeline.add_component(instance=MemoryBM25Retriever(document_store=MemoryDocumentStore()), name="retriever")
     qa_pipeline.add_component(instance=ExtractiveReader(model_name_or_path="deepset/tinyroberta-squad2"), name="reader")
     qa_pipeline.connect("retriever", "reader")
 
+    # Draw the pipeline
     qa_pipeline.draw(tmp_path / "test_extractive_qa_pipeline.png")
 
-    # TODO write to JSON to make sure it's actually serializable
-    serialized_pipeline = qa_pipeline.to_dict()
-    qa_pipeline = Pipeline.from_dict(serialized_pipeline)
+    # Serialize the pipeline to JSON
+    with open(tmp_path / "test_bm25_rag_pipeline.json", "w") as f:
+        print(json.dumps(qa_pipeline.to_dict(), indent=4))
+        json.dump(qa_pipeline.to_dict(), f)
 
+    # Load the pipeline back
+    with open(tmp_path / "test_bm25_rag_pipeline.json", "r") as f:
+        qa_pipeline = Pipeline.from_dict(json.load(f))
+
+    # Populate the document store
     documents = [
         Document(text="My name is Jean and I live in Paris."),
         Document(text="My name is Mark and I live in Berlin."),
@@ -23,6 +33,7 @@ def test_extractive_qa_pipeline(tmp_path):
     ]
     qa_pipeline.get_component("retriever").document_store.write_documents(documents)
 
+    # Query and assert
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]
 

--- a/e2e/preview/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/preview/pipelines/test_extractive_qa_pipeline.py
@@ -5,18 +5,8 @@ from haystack.preview.components.readers import ExtractiveReader
 
 
 def test_extractive_qa_pipeline(tmp_path):
-    document_store = MemoryDocumentStore()
-
-    documents = [
-        Document(text="My name is Jean and I live in Paris."),
-        Document(text="My name is Mark and I live in Berlin."),
-        Document(text="My name is Giorgio and I live in Rome."),
-    ]
-
-    document_store.write_documents(documents)
-
     qa_pipeline = Pipeline()
-    qa_pipeline.add_component(instance=MemoryBM25Retriever(document_store=document_store), name="retriever")
+    qa_pipeline.add_component(instance=MemoryBM25Retriever(document_store=MemoryDocumentStore()), name="retriever")
     qa_pipeline.add_component(instance=ExtractiveReader(model_name_or_path="deepset/tinyroberta-squad2"), name="reader")
     qa_pipeline.connect("retriever", "reader")
 
@@ -25,6 +15,13 @@ def test_extractive_qa_pipeline(tmp_path):
     # TODO write to JSON to make sure it's actually serializable
     serialized_pipeline = qa_pipeline.to_dict()
     qa_pipeline = Pipeline.from_dict(serialized_pipeline)
+
+    documents = [
+        Document(text="My name is Jean and I live in Paris."),
+        Document(text="My name is Mark and I live in Berlin."),
+        Document(text="My name is Giorgio and I live in Rome."),
+    ]
+    qa_pipeline.get_component("retriever").document_store.write_documents(documents)
 
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]

--- a/e2e/preview/pipelines/test_rag_pipelines.py
+++ b/e2e/preview/pipelines/test_rag_pipelines.py
@@ -49,6 +49,7 @@ def test_bm25_rag_pipeline(tmp_path):
 
     rag_pipeline.draw(tmp_path / "test_bm25_rag_pipeline.png")
 
+    # TODO write to JSON to make sure it's actually serializable
     serialized_pipeline = rag_pipeline.to_dict()
     rag_pipeline = Pipeline.from_dict(serialized_pipeline)
 
@@ -122,6 +123,7 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
 
     rag_pipeline.draw(tmp_path / "test_embedding_rag_pipeline.png")
 
+    # TODO write to JSON to make sure it's actually serializable
     serialized_pipeline = rag_pipeline.to_dict()
     rag_pipeline = Pipeline.from_dict(serialized_pipeline)
 

--- a/e2e/preview/pipelines/test_rag_pipelines.py
+++ b/e2e/preview/pipelines/test_rag_pipelines.py
@@ -95,7 +95,7 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
     """
     rag_pipeline = Pipeline()
     rag_pipeline.add_component(
-        instance=SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-mpnet-base-v2"),
+        instance=SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
         name="text_embedder",
     )
     rag_pipeline.add_component(
@@ -131,7 +131,7 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
     document_store = rag_pipeline.get_component("retriever").document_store
     indexing_pipeline = Pipeline()
     indexing_pipeline.add_component(
-        instance=SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-mpnet-base-v2"),
+        instance=SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
         name="document_embedder",
     )
     indexing_pipeline.add_component(instance=DocumentWriter(document_store=document_store), name="document_writer")
@@ -153,7 +153,6 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
 
         assert len(result["answer_builder"]["answers"]) == 1
         generated_answer = result["answer_builder"]["answers"][0]
-        print(generated_answer)
         assert spyword in generated_answer.data
         assert generated_answer.query == question
         assert hasattr(generated_answer, "documents")

--- a/e2e/preview/pipelines/test_rag_pipelines.py
+++ b/e2e/preview/pipelines/test_rag_pipelines.py
@@ -15,7 +15,7 @@ from haystack.preview.components.builders.prompt_builder import PromptBuilder
     not os.environ.get("OPENAI_API_KEY", None),
     reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
-def test_bm25_rag_pipeline():
+def test_bm25_rag_pipeline(tmp_path):
     document_store = MemoryDocumentStore()
 
     documents = [
@@ -47,6 +47,11 @@ def test_bm25_rag_pipeline():
     rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
     rag_pipeline.connect("retriever", "answer_builder.documents")
 
+    rag_pipeline.draw(tmp_path / "test_bm25_rag_pipeline.png")
+
+    serialized_pipeline = rag_pipeline.to_dict()
+    rag_pipeline = Pipeline.from_dict(serialized_pipeline)
+
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]
 
@@ -71,7 +76,7 @@ def test_bm25_rag_pipeline():
     not os.environ.get("OPENAI_API_KEY", None),
     reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
-def test_embedding_retrieval_rag_pipeline():
+def test_embedding_retrieval_rag_pipeline(tmp_path):
     document_store = MemoryDocumentStore()
 
     documents = [
@@ -114,6 +119,11 @@ def test_embedding_retrieval_rag_pipeline():
     rag_pipeline.connect("llm.replies", "answer_builder.replies")
     rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
     rag_pipeline.connect("retriever", "answer_builder.documents")
+
+    rag_pipeline.draw(tmp_path / "test_embedding_rag_pipeline.png")
+
+    serialized_pipeline = rag_pipeline.to_dict()
+    rag_pipeline = Pipeline.from_dict(serialized_pipeline)
 
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]

--- a/e2e/preview/pipelines/test_rag_pipelines.py
+++ b/e2e/preview/pipelines/test_rag_pipelines.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pytest
 
 from haystack.preview import Pipeline, Document
@@ -16,6 +17,7 @@ from haystack.preview.components.builders.prompt_builder import PromptBuilder
     reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
 def test_bm25_rag_pipeline(tmp_path):
+    # Create the RAG pipeline
     prompt_template = """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
@@ -36,12 +38,18 @@ def test_bm25_rag_pipeline(tmp_path):
     rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
     rag_pipeline.connect("retriever", "answer_builder.documents")
 
+    # Draw the pipeline
     rag_pipeline.draw(tmp_path / "test_bm25_rag_pipeline.png")
 
-    # TODO write to JSON to make sure it's actually serializable
-    serialized_pipeline = rag_pipeline.to_dict()
-    rag_pipeline = Pipeline.from_dict(serialized_pipeline)
+    # Serialize the pipeline to JSON
+    with open(tmp_path / "test_bm25_rag_pipeline.json", "w") as f:
+        json.dump(rag_pipeline.to_dict(), f)
 
+    # Load the pipeline back
+    with open(tmp_path / "test_bm25_rag_pipeline.json", "r") as f:
+        rag_pipeline = Pipeline.from_dict(json.load(f))
+
+    # Populate the document store
     documents = [
         Document(text="My name is Jean and I live in Paris."),
         Document(text="My name is Mark and I live in Berlin."),
@@ -49,6 +57,7 @@ def test_bm25_rag_pipeline(tmp_path):
     ]
     rag_pipeline.get_component("retriever").document_store.write_documents(documents)
 
+    # Query and assert
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]
 
@@ -74,6 +83,7 @@ def test_bm25_rag_pipeline(tmp_path):
     reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
 )
 def test_embedding_retrieval_rag_pipeline(tmp_path):
+    # Create the RAG pipeline
     prompt_template = """
     Given these documents, answer the question.\nDocuments:
     {% for doc in documents %}
@@ -101,12 +111,18 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
     rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
     rag_pipeline.connect("retriever", "answer_builder.documents")
 
+    # Draw the pipeline
     rag_pipeline.draw(tmp_path / "test_embedding_rag_pipeline.png")
 
-    # TODO write to JSON to make sure it's actually serializable
-    serialized_pipeline = rag_pipeline.to_dict()
-    rag_pipeline = Pipeline.from_dict(serialized_pipeline)
+    # Serialize the pipeline to JSON
+    with open(tmp_path / "test_bm25_rag_pipeline.json", "w") as f:
+        json.dump(rag_pipeline.to_dict(), f)
 
+    # Load the pipeline back
+    with open(tmp_path / "test_bm25_rag_pipeline.json", "r") as f:
+        rag_pipeline = Pipeline.from_dict(json.load(f))
+
+    # Populate the document store
     documents = [
         Document(text="My name is Jean and I live in Paris."),
         Document(text="My name is Mark and I live in Berlin."),
@@ -122,6 +138,7 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
     indexing_pipeline.connect("document_embedder", "document_writer")
     indexing_pipeline.run({"document_embedder": {"documents": documents}})
 
+    # Query and assert
     questions = ["Who lives in Paris?", "Who lives in Berlin?", "Who lives in Rome?"]
     answers_spywords = ["Jean", "Mark", "Giorgio"]
 

--- a/haystack/preview/components/generators/openai/gpt.py
+++ b/haystack/preview/components/generators/openai/gpt.py
@@ -121,7 +121,7 @@ class GPTGenerator:
         """
         init_params = data.get("init_parameters", {})
         streaming_callback = None
-        if "streaming_callback" in init_params:
+        if "streaming_callback" in init_params and init_params["streaming_callback"]:
             parts = init_params["streaming_callback"].split(".")
             module_name = ".".join(parts[:-1])
             function_name = parts[-1]


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/canals/issues/108

### Proposed Changes:

-  Enhance e2e tests to also draw and serialize/deserialize all the test pipelines under `e2e/preview/pipelines`.

### How did you test it?

- CI

### Notes for the reviewer

Bugs that are discovered should be fixed in parallel PRs before merging this one

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
