### PR TITLE
chore: Remove classifiers directory from preview package

### DIFF
--- a/haystack/preview/components/classifiers/__init__.py
+++ b/haystack/preview/components/classifiers/__init__.py
@@ -1,3 +1,0 @@
-from haystack.preview.components.classifiers.file_classifier import FileExtensionClassifier
-
-__all__ = ["FileExtensionClassifier"]


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR removes the `classifiers` folder from the `preview` package. The `FileExtensionClassifier` has been renamed to `FileExtensionRouter` and moved to the `routers` folder in #5824.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
