### PR TITLE
feat: Add SimilarityRanker to Haystack 2.0

### DIFF
--- a/haystack/preview/components/rankers/__init__.py
+++ b/haystack/preview/components/rankers/__init__.py
@@ -1,0 +1,3 @@
+from haystack.preview.components.rankers.similarity import SimilarityRanker
+
+__all__ = ["SimilarityRanker"]

--- a/haystack/preview/components/rankers/similarity.py
+++ b/haystack/preview/components/rankers/similarity.py
@@ -24,14 +24,14 @@ class SimilarityRanker:
     Usage example:
     ```
     from haystack.preview import Document
-    from haystack.preview.components.samplers import SimilarityRanker
+    from haystack.preview.components.rankers import SimilarityRanker
 
-    sampler = SimilarityRanker(top_p=0.95)
+    sampler = SimilarityRanker()
     docs = [Document(text="Paris"), Document(text="Berlin")]
     query = "City in Germany"
     output = sampler.run(query=query, documents=docs)
     docs = output["documents"]
-    assert len(docs) == 1
+    assert len(docs) == 2
     assert docs[0].text == "Berlin"
     ```
     """
@@ -39,23 +39,18 @@ class SimilarityRanker:
     def __init__(
         self,
         model_name_or_path: Union[str, Path] = "cross-encoder/ms-marco-MiniLM-L-6-v2",
-        score_field: Optional[str] = "similarity_score",
         device: Optional[str] = "cpu",
     ):
         """
         Creates an instance of SimilarityRanker.
 
-        :param model_name_or_path: Path to a pre-trained sentence-transformers model. If not specified, no document
-        scoring will be performed, and it is assumed that documents already have scores in the metadata specified under
-        the `score_field` key.
-        :param score_field: The name of the field that should be used to store the scores in a document's metadata.
+        :param model_name_or_path: Path to a pre-trained sentence-transformers model.
         :param device: torch device (for example, cuda:0, cpu, mps) to limit model inference to a specific device.
         """
         torch_and_transformers_import.check()
         super().__init__()
 
         self.model_name_or_path = model_name_or_path
-        self.score_field = score_field
         self.device = device
         self.model = None
         self.tokenizer = None
@@ -74,9 +69,7 @@ class SimilarityRanker:
         """
         Serialize this component to a dictionary.
         """
-        return default_to_dict(
-            self, score_field=self.score_field, device=self.device, model_name_or_path=self.model_name_or_path
-        )
+        return default_to_dict(self, device=self.device, model_name_or_path=self.model_name_or_path)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SimilarityRanker":

--- a/haystack/preview/components/rankers/similarity.py
+++ b/haystack/preview/components/rankers/similarity.py
@@ -1,0 +1,117 @@
+import logging
+from pathlib import Path
+from typing import List, Optional, Union, Dict, Any
+
+from haystack.preview import ComponentError
+
+from haystack.lazy_imports import LazyImport
+from haystack.preview import Document, component, default_from_dict, default_to_dict
+
+
+logger = logging.getLogger(__name__)
+
+
+with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]==4.32.1'") as torch_and_transformers_import:
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+
+@component
+class SimilarityRanker:
+    """
+    Ranks documents based on query similarity.
+
+    Usage example:
+    ```
+    from haystack.preview import Document
+    from haystack.preview.components.samplers import SimilarityRanker
+
+    sampler = SimilarityRanker(top_p=0.95)
+    docs = [Document(text="Paris"), Document(text="Berlin")]
+    query = "City in Germany"
+    output = sampler.run(query=query, documents=docs)
+    docs = output["documents"]
+    assert len(docs) == 1
+    assert docs[0].text == "Berlin"
+    ```
+    """
+
+    def __init__(
+        self,
+        model_name_or_path: Union[str, Path] = "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        score_field: Optional[str] = "similarity_score",
+        device: Optional[str] = "cpu",
+    ):
+        """
+        Creates an instance of SimilarityRanker.
+
+        :param model_name_or_path: Path to a pre-trained sentence-transformers model. If not specified, no document
+        scoring will be performed, and it is assumed that documents already have scores in the metadata specified under
+        the `score_field` key.
+        :param score_field: The name of the field that should be used to store the scores in a document's metadata.
+        :param device: torch device (for example, cuda:0, cpu, mps) to limit model inference to a specific device.
+        """
+        torch_and_transformers_import.check()
+        super().__init__()
+
+        self.model_name_or_path = model_name_or_path
+        self.score_field = score_field
+        self.device = device
+        self.model = None
+        self.tokenizer = None
+
+    def warm_up(self):
+        """
+        Warm up the model and tokenizer used in scoring the documents.
+        """
+        if self.model_name_or_path and not self.model:
+            self.model = AutoModelForSequenceClassification.from_pretrained(self.model_name_or_path)
+            self.model = self.model.to(self.device)
+            self.model.eval()
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        return default_to_dict(
+            self, score_field=self.score_field, device=self.device, model_name_or_path=self.model_name_or_path
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SimilarityRanker":
+        """
+        Deserialize this component from a dictionary.
+        """
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(self, query: str, documents: List[Document]):
+        """
+        Returns a list of documents ranked by their similarity to the given query
+
+        :param query: Query string.
+        :param documents: List of Documents.
+        :return: List of Documents sorted by (desc.) similarity with the query.
+        """
+        if not documents:
+            return {"documents": []}
+
+        # If a model path is provided but the model isn't loaded
+        if self.model_name_or_path and not self.model:
+            raise ComponentError(
+                f"The component {self.__class__.__name__} not warmed up. Run 'warm_up()' before calling 'run()'."
+            )
+
+        query_doc_pairs = [[query, doc.text] for doc in documents]
+        features = self.tokenizer(
+            query_doc_pairs, padding=True, truncation=True, return_tensors="pt"
+        ).to(  # type: ignore
+            self.device
+        )
+        with torch.inference_mode():
+            similarity_scores = self.model(**features).logits.squeeze()  # type: ignore
+
+        sorted_probs, sorted_indices = torch.sort(similarity_scores, descending=True)
+        ranked_docs = [documents[i] for i in sorted_indices]
+        return {"documents": ranked_docs}

--- a/releasenotes/notes/add-similarity-ranker-401bf595cea7318a.yaml
+++ b/releasenotes/notes/add-similarity-ranker-401bf595cea7318a.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Adds SimilarityRanker, a component that ranks a list of Documents based on their similarity to the query.

--- a/test/preview/components/rankers/test_similarity.py
+++ b/test/preview/components/rankers/test_similarity.py
@@ -1,0 +1,83 @@
+import pytest
+
+from haystack.preview import Document, ComponentError
+from haystack.preview.components.rankers.similarity import SimilarityRanker
+
+
+class TestSimilarityRanker:
+    @pytest.mark.integration
+    def test_to_dict(self):
+        component = SimilarityRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-6-v2")
+        data = component.to_dict()
+        assert data == {
+            "type": "SimilarityRanker",
+            "init_parameters": {
+                "score_field": "similarity_score",
+                "device": "cpu",
+                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+            },
+        }
+
+    @pytest.mark.integration
+    def test_to_dict_with_custom_init_parameters(self):
+        component = SimilarityRanker()
+        data = component.to_dict()
+        assert data == {
+            "type": "SimilarityRanker",
+            "init_parameters": {
+                "score_field": "similarity_score",
+                "device": "cpu",
+                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+            },
+        }
+
+    @pytest.mark.integration
+    def test_from_dict(self):
+        data = {
+            "type": "SimilarityRanker",
+            "init_parameters": {
+                "score_field": "similarity_score",
+                "device": "cpu",
+                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+            },
+        }
+        component = SimilarityRanker.from_dict(data)
+        assert component.model_name_or_path == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+    @pytest.mark.integration
+    def test_run(self):
+        """
+        Test if the component runs correctly.
+        """
+        sampler = SimilarityRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-6-v2")
+        sampler.warm_up()
+        docs = [Document(text="Berlin"), Document(text="Belgrade"), Document(text="Sarajevo")]
+        query = "City in Bosnia and Herzegovina"
+        output = sampler.run(query=query, documents=docs)
+        docs = output["documents"]
+        assert len(docs) == 3
+        assert docs[0].text == "Sarajevo"
+
+        # another test to make sure the first one was not a fluke
+        docs = [Document(text="Python"), Document(text="Bakery in Paris"), Document(text="Tesla Giga Berlin")]
+        query = "Programming language usually used for machine learning?"
+        output = sampler.run(query=query, documents=docs)
+        docs = output["documents"]
+        assert len(docs) == 3
+        assert docs[0].text == "Python"
+
+    #  Returns an empty list if no documents are provided
+    @pytest.mark.integration
+    def test_returns_empty_list_if_no_documents_are_provided(self):
+        sampler = SimilarityRanker()
+        sampler.warm_up()
+        output = sampler.run(query="City in Germany", documents=[])
+        assert output["documents"] == []
+
+    #  Raises ComponentError if model is not warmed up
+    @pytest.mark.integration
+    def test_raises_component_error_if_model_not_warmed_up(self):
+        sampler = SimilarityRanker()
+
+        with pytest.raises(ComponentError):
+            sampler.run(query="query", documents=[Document(text="document")])

--- a/test/preview/components/rankers/test_similarity.py
+++ b/test/preview/components/rankers/test_similarity.py
@@ -11,11 +11,7 @@ class TestSimilarityRanker:
         data = component.to_dict()
         assert data == {
             "type": "SimilarityRanker",
-            "init_parameters": {
-                "score_field": "similarity_score",
-                "device": "cpu",
-                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-            },
+            "init_parameters": {"device": "cpu", "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2"},
         }
 
     @pytest.mark.integration
@@ -24,22 +20,14 @@ class TestSimilarityRanker:
         data = component.to_dict()
         assert data == {
             "type": "SimilarityRanker",
-            "init_parameters": {
-                "score_field": "similarity_score",
-                "device": "cpu",
-                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-            },
+            "init_parameters": {"device": "cpu", "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2"},
         }
 
     @pytest.mark.integration
     def test_from_dict(self):
         data = {
             "type": "SimilarityRanker",
-            "init_parameters": {
-                "score_field": "similarity_score",
-                "device": "cpu",
-                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-            },
+            "init_parameters": {"device": "cpu", "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2"},
         }
         component = SimilarityRanker.from_dict(data)
         assert component.model_name_or_path == "cross-encoder/ms-marco-MiniLM-L-6-v2"


### PR DESCRIPTION
### **Why**:
Ranking by similarity to a query is essential. Enter `SimilarityRanker`.

### **What**:
Added `SimilarityRanker` to the `rankers` package. It's all about evaluating document relevance based on similarity.

### **How can it be used**:
Here's a quick dive into its usage:

```python
from haystack.preview import Document
from haystack.preview.components.rankers import SimilarityRanker

ranker = SimilarityRanker()
docs = [Document(text="Sarajevo"), Document(text="Berlin")]
query = "City in Bosnia and Herzegovina"
output = ranker.run(query=query, documents=docs)
docs = output["documents"]

assert len(docs) == 2
assert docs[0].text == "Sarajevo"
```

### **How did you test it**:
Unit tests are in place. Also, ran the above snippet. Worked as expected.

### **Notes For Reviewer**:
Reviewer, please do a deep dive into the similarity metrics and integration. Let's ensure this fits seamlessly into Haystack's architecture.