### PR TITLE
feat: Add TopPSampler Haystack 2.0 component

### DIFF
--- a/haystack/preview/components/samplers/__init__.py
+++ b/haystack/preview/components/samplers/__init__.py
@@ -1,0 +1,3 @@
+from haystack.preview.components.samplers.top_p import TopPSampler
+
+__all__ = ["TopPSampler"]

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -1,0 +1,142 @@
+import logging
+from typing import List, Optional, Dict, Any
+
+from haystack.preview import ComponentError
+
+from haystack.lazy_imports import LazyImport
+from haystack.preview import Document, component, default_from_dict, default_to_dict
+
+
+logger = logging.getLogger(__name__)
+
+
+with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]==4.32.1'") as torch_and_transformers_import:
+    import torch
+
+
+@component
+class TopPSampler:
+    """
+    Selects documents based on the cumulative probability of the Document similarity scores using top p (nucleus)
+    sampling.
+
+    Usage example:
+    ```
+    from haystack.preview import Document
+    from haystack.preview.components.samplers import TopPSampler
+
+    sampler = TopPSampler(top_p=0.95)
+    docs = [
+        Document(text="Berlin", metadata={"similarity_score": -10.6}),
+        Document(text="Belgrade", metadata={"similarity_score": -8.9}),
+        Document(text="Sarajevo", metadata={"similarity_score": -4.6}),
+    ]
+    query = "City in Bosnia and Herzegovina"
+    output = sampler.run(documents=docs)
+    docs = output["documents"]
+    assert len(docs) == 1
+    assert docs[0].text == "Sarajevo"
+    ```
+    """
+
+    def __init__(self, top_p: Optional[float] = 1.0, score_field: Optional[str] = "similarity_score"):
+        """
+        Creates an instance of TopPSampler.
+
+        :param top_p: Cumulative probability threshold for filtering the documents (usually between 0.9 and 0.99).
+        :param score_field: The name of the field that should be used to store the scores in a document's metadata.
+        """
+        torch_and_transformers_import.check()
+        super().__init__()
+
+        self.top_p = top_p
+        self.score_field = score_field
+        self.model = None
+        self.tokenizer = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        return default_to_dict(self, top_p=self.top_p, score_field=self.score_field)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TopPSampler":
+        """
+        Deserialize this component from a dictionary.
+        """
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(self, documents: List[Document], top_p: Optional[float] = None):
+        """
+        Returns a list of documents filtered using `top_p`, based on the similarity scores of the documents whose
+        cumulative probability is less than or equal to `top_p`.
+
+        :param documents: List of Documents.
+        :param top_p: Cumulative probability threshold for filtering the documents. If top_p is not provided at
+        initialization then top_p will default to 1.0
+        :return: List of Documents whose cumulative probability is less than or equal to `top_p`.
+        """
+        if not documents:
+            return {"documents": []}
+
+        top_p = top_p or self.top_p or 1.0  # default to 1.0 if both are None
+
+        if not 0 <= top_p <= 1:
+            raise ComponentError(f"top_p must be between 0 and 1. Got {top_p}.")
+
+        # If no model is provided, ensure documents have pre-computed scores
+        if not self._have_scores(documents):
+            raise ComponentError(
+                f"The component {self.__class__.__name__} requires similarity scores in the documents' metadata. "
+                "Either set 'model_name_or_path' to score documents or add scores to the documents."
+            )
+
+        similarity_scores = torch.tensor(self._collect_scores(documents), dtype=torch.float32)
+
+        # Apply softmax normalization to the similarity scores
+        probs = torch.exp(similarity_scores) / torch.sum(torch.exp(similarity_scores))
+
+        # Sort the probabilities and calculate their cumulative sum
+        sorted_probs, sorted_indices = torch.sort(probs, descending=True)
+        cumulative_probs = torch.cumsum(sorted_probs, dim=0)
+
+        # Find the indices with cumulative probabilities that exceed top_p
+        top_p_indices = torch.where(cumulative_probs <= top_p)[0]
+
+        # Map the selected indices back to their original indices
+        original_indices = sorted_indices[top_p_indices]
+        selected_docs = [documents[i.item()] for i in original_indices]
+
+        # If low p resulted in no documents being selected, then
+        # return at least one document
+        if not selected_docs:
+            highest_prob_indices = torch.argsort(probs, descending=True)
+            selected_docs = [documents[int(highest_prob_indices[0].item())]]
+
+        # Include prob scores in the results
+        if self.score_field:
+            for idx, doc in enumerate(selected_docs):
+                doc.metadata[self.score_field] = str(sorted_probs[idx].item())
+
+        return {"documents": selected_docs}
+
+    def _collect_scores(self, documents: List[Document]) -> List[float]:
+        """
+        Collect the scores from the documents' metadata.
+        :param documents: List of Documents.
+        :return: List of scores.
+        """
+        if not self.score_field:
+            raise ComponentError("Cannot collect document scores if score_field init parameter is not set.")
+
+        return [d.metadata[self.score_field] for d in documents]
+
+    def _have_scores(self, documents: List[Document]) -> bool:
+        """
+        Check if the documents have scores in their metadata.
+        :param documents: List of Documents.
+        :return: True if the documents have scores in their metadata, False otherwise.
+        """
+        return all(self.score_field in d.metadata for d in documents)

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -7,7 +7,7 @@ from haystack.preview.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]==4.32.1'") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install torch>=1.13'") as torch_import:
     import torch
 
 
@@ -18,7 +18,8 @@ class TopPSampler:
     sampling.
 
     Usage example:
-    ```
+
+    ```python
     from haystack.preview import Document
     from haystack.preview.components.samplers import TopPSampler
 
@@ -45,7 +46,7 @@ class TopPSampler:
         If no score field is provided (default), the component will assume that the scores are stored in the Document
         score field.
         """
-        torch_and_transformers_import.check()
+        torch_import.check()
 
         self.top_p = top_p
         self.score_field = score_field

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -118,8 +118,8 @@ class TopPSampler:
         :return: List of scores.
         """
         if self.score_field:
-            have_scores = all(self.score_field in d.metadata for d in documents)
-            if not have_scores:
+            have_scores_in_metadata = all(self.score_field in d.metadata for d in documents)
+            if not have_scores_in_metadata:
                 raise ComponentError(
                     f"Score field '{self.score_field}' not found in metadata of all documents. "
                     f"Make sure that all documents have a score field '{self.score_field}' in their metadata."
@@ -127,4 +127,9 @@ class TopPSampler:
             return [d.metadata[self.score_field] for d in documents]
         else:
             # If no score field is provided, assume the scores are stored in the score
-            return [d.score for d in documents]
+            have_scores = all(d.score for d in documents)
+            if not have_scores:
+                raise ComponentError(
+                    "At least one Document score is None. Make sure all documents have a valid score value."
+                )
+            return [d.score for d in documents]  # type: ignore ## because Document score is Optional

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -104,7 +104,7 @@ class TopPSampler:
                 top_p,
             )
             highest_prob_indices = torch.argsort(probs, descending=True)
-            selected_docs = [documents[highest_prob_indices[0].item()]]
+            selected_docs = [documents[int(highest_prob_indices[0].item())]]
 
         return {"documents": selected_docs}
 

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -105,11 +105,6 @@ class TopPSampler:
             highest_prob_indices = torch.argsort(probs, descending=True)
             selected_docs = [documents[int(highest_prob_indices[0].item())]]
 
-        # Include prob scores in the results
-        if self.score_field:
-            for idx, doc in enumerate(selected_docs):
-                doc.metadata[self.score_field] = str(sorted_probs[idx].item())
-
         return {"documents": selected_docs}
 
     def _collect_scores(self, documents: List[Document]) -> List[float]:

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -99,8 +99,9 @@ class TopPSampler:
         # return at least one document
         if not selected_docs:
             logger.warning(
-                f"Top-p sampling with p={top_p} resulted in no documents being selected. "
-                f"Returning the document with the highest similarity score."
+                "Top-p sampling with p=%s resulted in no documents being selected. "
+                "Returning the document with the highest similarity score.",
+                top_p,
             )
             highest_prob_indices = torch.argsort(probs, descending=True)
             selected_docs = [documents[int(highest_prob_indices[0].item())]]

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -104,7 +104,7 @@ class TopPSampler:
                 top_p,
             )
             highest_prob_indices = torch.argsort(probs, descending=True)
-            selected_docs = [documents[int(highest_prob_indices[0].item())]]
+            selected_docs = [documents[highest_prob_indices[0].item()]]
 
         return {"documents": selected_docs}
 

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -79,6 +79,8 @@ class TopPSampler:
         if not 0 <= top_p <= 1:
             raise ComponentError(f"top_p must be between 0 and 1. Got {top_p}.")
 
+        epsilon = 1e-6  # account for floating-point precision issues
+
         similarity_scores = torch.tensor(self._collect_scores(documents), dtype=torch.float32)
 
         # Apply softmax normalization to the similarity scores
@@ -89,7 +91,7 @@ class TopPSampler:
         cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
 
         # Find the indices with cumulative probabilities that exceed top_p
-        top_p_indices = torch.where(cumulative_probs <= top_p)[0]
+        top_p_indices = torch.where(torch.BoolTensor(cumulative_probs <= (top_p + epsilon)))[0]
 
         # Map the selected indices back to their original indices
         original_indices = sorted_indices[top_p_indices]

--- a/releasenotes/notes/add-top-p-sampler-ad6e0f5d623a6bb5.yaml
+++ b/releasenotes/notes/add-top-p-sampler-ad6e0f5d623a6bb5.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Adds TopPSampler, a component selects documents based on the cumulative probability of the Document scores using top p (nucleus) sampling.

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -1,34 +1,34 @@
 import pytest
 
-from haystack.preview import Document
+from haystack.preview import Document, ComponentError
 from haystack.preview.components.samplers.top_p import TopPSampler
 
 
 class TestTopPSampler:
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_to_dict(self):
         component = TopPSampler()
         data = component.to_dict()
-        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 1.0, "score_field": "similarity_score"}}
+        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 1.0, "score_field": None}}
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = TopPSampler(top_p=0.92)
         data = component.to_dict()
-        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 0.92, "score_field": "similarity_score"}}
+        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 0.92, "score_field": None}}
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_from_dict(self):
-        data = {"type": "TopPSampler", "init_parameters": {"top_p": 0.9, "score_field": "similarity_score"}}
+        data = {"type": "TopPSampler", "init_parameters": {"top_p": 0.9, "score_field": None}}
         component = TopPSampler.from_dict(data)
         assert component.top_p == 0.9
 
-    @pytest.mark.integration
-    def test_run_scores(self):
+    @pytest.mark.unit
+    def test_run_scores_from_metadata(self):
         """
         Test if the component runs correctly with scores already in the metadata.
         """
-        sampler = TopPSampler(top_p=0.95)
+        sampler = TopPSampler(top_p=0.95, score_field="similarity_score")
         docs = [
             Document(text="Berlin", metadata={"similarity_score": -10.6}),
             Document(text="Belgrade", metadata={"similarity_score": -8.9}),
@@ -39,9 +39,40 @@ class TestTopPSampler:
         assert len(docs) == 1
         assert docs[0].text == "Sarajevo"
 
+    @pytest.mark.unit
+    def test_run_scores(self):
+        """
+        Test if the component runs correctly with scores in the Document score field.
+        """
+        sampler = TopPSampler(top_p=0.95)
+        docs = [
+            Document(text="Berlin", score=-10.6),
+            Document(text="Belgrade", score=-8.9),
+            Document(text="Sarajevo", score=-4.6),
+        ]
+        output = sampler.run(documents=docs)
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].text == "Sarajevo"
+
     #  Returns an empty list if no documents are provided
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_returns_empty_list_if_no_documents_are_provided(self):
         sampler = TopPSampler()
         output = sampler.run(documents=[])
         assert output["documents"] == []
+
+    @pytest.mark.unit
+    def test_run_scores_no_metadata_present(self):
+        """
+        Test if the component runs correctly with scores missing from the metadata yet being specified in the
+        score_field.
+        """
+        sampler = TopPSampler(top_p=0.95, score_field="similarity_score")
+        docs = [
+            Document(text="Berlin", score=-10.6),
+            Document(text="Belgrade", score=-8.9),
+            Document(text="Sarajevo", score=-4.6),
+        ]
+        with pytest.raises(ComponentError, match="Score field 'similarity_score' not found"):
+            sampler.run(documents=docs)

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -1,0 +1,47 @@
+import pytest
+
+from haystack.preview import Document
+from haystack.preview.components.samplers.top_p import TopPSampler
+
+
+class TestTopPSampler:
+    @pytest.mark.integration
+    def test_to_dict(self):
+        component = TopPSampler()
+        data = component.to_dict()
+        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 1.0, "score_field": "similarity_score"}}
+
+    @pytest.mark.integration
+    def test_to_dict_with_custom_init_parameters(self):
+        component = TopPSampler(top_p=0.92)
+        data = component.to_dict()
+        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 0.92, "score_field": "similarity_score"}}
+
+    @pytest.mark.integration
+    def test_from_dict(self):
+        data = {"type": "TopPSampler", "init_parameters": {"top_p": 0.9, "score_field": "similarity_score"}}
+        component = TopPSampler.from_dict(data)
+        assert component.top_p == 0.9
+
+    @pytest.mark.integration
+    def test_run_scores(self):
+        """
+        Test if the component runs correctly with scores already in the metadata.
+        """
+        sampler = TopPSampler(top_p=0.95)
+        docs = [
+            Document(text="Berlin", metadata={"similarity_score": -10.6}),
+            Document(text="Belgrade", metadata={"similarity_score": -8.9}),
+            Document(text="Sarajevo", metadata={"similarity_score": -4.6}),
+        ]
+        output = sampler.run(documents=docs)
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].text == "Sarajevo"
+
+    #  Returns an empty list if no documents are provided
+    @pytest.mark.integration
+    def test_returns_empty_list_if_no_documents_are_provided(self):
+        sampler = TopPSampler()
+        output = sampler.run(documents=[])
+        assert output["documents"] == []

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from haystack.preview import Document, ComponentError
@@ -44,16 +46,22 @@ class TestTopPSampler:
         """
         Test if the component runs correctly with scores in the Document score field.
         """
-        sampler = TopPSampler(top_p=0.95)
+        sampler = TopPSampler(top_p=0.99)
         docs = [
             Document(text="Berlin", score=-10.6),
             Document(text="Belgrade", score=-8.9),
             Document(text="Sarajevo", score=-4.6),
         ]
+
+        random.shuffle(docs)
+
         output = sampler.run(documents=docs)
         docs = output["documents"]
         assert len(docs) == 1
         assert docs[0].text == "Sarajevo"
+
+        sorted_scores = sorted([doc.score for doc in docs], reverse=True)
+        assert [doc.score for doc in docs] == sorted_scores
 
     #  Returns an empty list if no documents are provided
     @pytest.mark.unit

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -64,6 +64,26 @@ class TestTopPSampler:
 
         assert [doc.score for doc in docs_filtered] == sorted_scores[:1]
 
+    @pytest.mark.unit
+    def test_run_scores_top_p_1(self):
+        """
+        Test if the component runs correctly top_p=1.
+        """
+        sampler = TopPSampler(top_p=1.0)
+        docs = [
+            Document(text="Berlin", score=-10.6),
+            Document(text="Belgrade", score=-8.9),
+            Document(text="Sarajevo", score=-4.6),
+        ]
+
+        random.shuffle(docs)
+        output = sampler.run(documents=docs)
+        docs_filtered = output["documents"]
+        assert len(docs_filtered) == len(docs)
+        assert docs_filtered[0].text == "Sarajevo"
+
+        assert [doc.score for doc in docs_filtered] == sorted([doc.score for doc in docs], reverse=True)
+
     #  Returns an empty list if no documents are provided
     @pytest.mark.unit
     def test_returns_empty_list_if_no_documents_are_provided(self):

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -54,14 +54,15 @@ class TestTopPSampler:
         ]
 
         random.shuffle(docs)
-
-        output = sampler.run(documents=docs)
-        docs = output["documents"]
-        assert len(docs) == 1
-        assert docs[0].text == "Sarajevo"
-
         sorted_scores = sorted([doc.score for doc in docs], reverse=True)
-        assert [doc.score for doc in docs] == sorted_scores
+
+        # top_p = 0.99 will get the top 1 document
+        output = sampler.run(documents=docs)
+        docs_filtered = output["documents"]
+        assert len(docs_filtered) == 1
+        assert docs_filtered[0].text == "Sarajevo"
+
+        assert [doc.score for doc in docs_filtered] == sorted_scores[:1]
 
     #  Returns an empty list if no documents are provided
     @pytest.mark.unit


### PR DESCRIPTION
### Why:
In the realm of document sampling, we often need a mechanism that doesn't just pick the top-scoring documents but considers a range of high-scoring documents. Enter `TopPSampler`. This component leverages the concept of top p (nucleus) sampling, which selects documents based on the cumulative probability of their scores. It's a more dynamic approach compared to just picking the top N documents and can lead to more diverse and potentially insightful selections.

### What:
We're introducing the `TopPSampler` to our samplers package. This new sampler will allow users to harness the power of top p sampling in their document selection process.

### How can it be used:
Here's a quick example to get a feel for it:

```python
from haystack.preview import Document
from haystack.preview.components.sampler import TopPSampler

sampler = TopPSampler(top_p=0.95)
docs = [
    Document(text="Berlin", metadata={"similarity_score": -10.6}),
    Document(text="Belgrade", metadata={"similarity_score": -8.9}),
    Document(text="Sarajevo", metadata={"similarity_score": -4.6}),
]
output = sampler.run(documents=docs)
docs = output["documents"]
assert len(docs) == 1
assert docs[0].text == "Sarajevo"
```

### Testing:
Apart from the unit tests that have been added to ensure the functionality of `TopPSampler`, I've also run some manual tests (as shown in the code snippet above) to validate its behavior.

### Notes For Reviewer:
When you're diving into this, please ensure everything aligns with our standards and that I haven't missed any edge cases. 