### PR TITLE
feat: Made DocumentWriter return the number of documents it wrote

### DIFF
--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -50,7 +50,7 @@ class DocumentWriter:
 
         :param documents: A list of documents to write to the store.
         :param policy: The policy to use when encountering duplicate documents.
-        :return: None
+        :return: Number of documents written.
 
         :raises ValueError: If the specified document store is not found.
         """
@@ -58,4 +58,4 @@ class DocumentWriter:
             policy = self.policy
 
         self.document_store.write_documents(documents=documents, policy=policy)
-        return {}
+        return len(documents)


### PR DESCRIPTION
### Related Issues

- fixes #5780

### Proposed Changes:
 <!--- In case of a feature: Describe what did you add and how it works -->
DocumentWriter returns the number of documents it wrote to help users make sure that the Pipeline actually worked  

### How did you test it?
Tried running pytest : Interrupted 19 errors during collection 
```
the errors were like ERROR collecting test/preview/components/generators/openai/test_gpt_generator.py
ModuleNotFoundError: No module named 'openai'
```
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

**Follow-up Question**: There are other files where write_documents method is defined in their description we have return None, do we need to change them as well?
<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
