### PR TITLE
feat: `DocumentWriter` returns number of documents written

### DIFF
--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -58,4 +58,4 @@ class DocumentWriter:
             policy = self.policy
 
         self.document_store.write_documents(documents=documents, policy=policy)
-        return len(documents) + 1
+        return len(documents)

--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -44,6 +44,7 @@ class DocumentWriter:
         data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
         return default_from_dict(cls, data)
 
+    @component.output_types(documents_written=int)
     def run(self, documents: List[Document], policy: Optional[DuplicatePolicy] = None):
         """
         Run DocumentWriter on the given input data.
@@ -58,4 +59,4 @@ class DocumentWriter:
             policy = self.policy
 
         self.document_store.write_documents(documents=documents, policy=policy)
-        return len(documents)
+        return {"documents_written": len(documents)}

--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -50,7 +50,7 @@ class DocumentWriter:
 
         :param documents: A list of documents to write to the store.
         :param policy: The policy to use when encountering duplicate documents.
-        :return: None
+        :return: Number of documents written
 
         :raises ValueError: If the specified document store is not found.
         """
@@ -58,4 +58,4 @@ class DocumentWriter:
             policy = self.policy
 
         self.document_store.write_documents(documents=documents, policy=policy)
-        return {}
+        return len(documents) + 1

--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -50,7 +50,7 @@ class DocumentWriter:
 
         :param documents: A list of documents to write to the store.
         :param policy: The policy to use when encountering duplicate documents.
-        :return: Number of documents written
+        :return: None
 
         :raises ValueError: If the specified document store is not found.
         """
@@ -58,4 +58,4 @@ class DocumentWriter:
             policy = self.policy
 
         self.document_store.write_documents(documents=documents, policy=policy)
-        return len(documents)+1
+        return {}

--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -50,7 +50,7 @@ class DocumentWriter:
 
         :param documents: A list of documents to write to the store.
         :param policy: The policy to use when encountering duplicate documents.
-        :return: None
+        :return: Number of documents written
 
         :raises ValueError: If the specified document store is not found.
         """
@@ -58,4 +58,4 @@ class DocumentWriter:
             policy = self.policy
 
         self.document_store.write_documents(documents=documents, policy=policy)
-        return {}
+        return len(documents)+1

--- a/releasenotes/notes/add-document-writer-number-of-documents-written-2c57f3a5d6ae2131.yaml
+++ b/releasenotes/notes/add-document-writer-number-of-documents-written-2c57f3a5d6ae2131.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Document writer returns the number of documents written.


### PR DESCRIPTION
### Related Issues

- fixes #5780 

### Proposed Changes:

Document writer now returns number of documents written.

### How did you test it?

Automated CI tests

### Notes for the reviewer


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue