### PR TITLE
feat: add support for async openai calls

### DIFF
--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -116,9 +116,9 @@ class PromptModel(BaseComponent):
         Drop-in replacement asyncio version of the `invoke` method, see there for documentation.
         """
         try:
-            return await self.model_invocation_layer.invoke(prompt=prompt, **kwargs)
-        except TypeError:
-            # The `invoke` method of the underlying invocation layer doesn't support asyncio
+            return await self.model_invocation_layer.ainvoke(prompt=prompt, **kwargs)
+        except AttributeError:
+            # The underlying invocation layer doesn't support asyncio
             return self.model_invocation_layer.invoke(prompt=prompt, **kwargs)
 
     @overload

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -115,11 +115,11 @@ class PromptModel(BaseComponent):
         """
         Drop-in replacement asyncio version of the `invoke` method, see there for documentation.
         """
-        try:
+        if hasattr(self.model_invocation_layer, "ainvoke"):
             return await self.model_invocation_layer.ainvoke(prompt=prompt, **kwargs)
-        except AttributeError:
-            # The underlying invocation layer doesn't support asyncio
-            return self.model_invocation_layer.invoke(prompt=prompt, **kwargs)
+
+        # The underlying invocation layer doesn't support asyncio
+        return self.model_invocation_layer.invoke(prompt=prompt, **kwargs)
 
     @overload
     def _ensure_token_limit(self, prompt: str) -> str:

--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -166,7 +166,7 @@ async def openai_async_request(
     """
     async with httpx.AsyncClient() as client:
         response = await client.request(
-            "POST", url, headers=headers, data=payload, timeout=cast(float, timeout), **kwargs
+            "POST", url, headers=headers, json=payload, timeout=cast(float, timeout), **kwargs
         )
 
     if read_response:

--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -157,7 +157,7 @@ async def openai_async_request(
     headers: Dict,
     payload: Dict,
     timeout: Union[float, Tuple[float, float]] = OPENAI_TIMEOUT,
-    read_response: Optional[bool] = True,
+    read_response: bool = True,
     **kwargs,
 ):
     """Make a request to the OpenAI API given a `url`, `headers`, `payload`, and `timeout`.

--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -3,7 +3,9 @@ import os
 import logging
 import platform
 import json
-from typing import Dict, Union, Tuple, Optional, List
+from typing import Dict, Union, Tuple, Optional, List, cast
+
+import httpx
 import requests
 import tenacity
 import tiktoken
@@ -143,6 +145,53 @@ def openai_request(
         return response
 
 
+@tenacity.retry(
+    reraise=True,
+    retry=tenacity.retry_if_exception_type(OpenAIError)
+    and tenacity.retry_if_not_exception_type(OpenAIUnauthorizedError),
+    wait=tenacity.wait_exponential(multiplier=OPENAI_BACKOFF),
+    stop=tenacity.stop_after_attempt(OPENAI_MAX_RETRIES),
+)
+async def openai_async_request(
+    url: str,
+    headers: Dict,
+    payload: Dict,
+    timeout: Union[float, Tuple[float, float]] = OPENAI_TIMEOUT,
+    read_response: Optional[bool] = True,
+    **kwargs,
+):
+    """Make a request to the OpenAI API given a `url`, `headers`, `payload`, and `timeout`.
+
+    See `openai_request`.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.request(
+            "POST", url, headers=headers, data=payload, timeout=cast(float, timeout), **kwargs
+        )
+
+    if read_response:
+        json_response = json.loads(response.text)
+
+    if response.status_code != 200:
+        openai_error: OpenAIError
+        if response.status_code == 429:
+            openai_error = OpenAIRateLimitError(f"API rate limit exceeded: {response.text}")
+        elif response.status_code == 401:
+            openai_error = OpenAIUnauthorizedError(f"API key is invalid: {response.text}")
+        else:
+            openai_error = OpenAIError(
+                f"OpenAI returned an error.\n"
+                f"Status code: {response.status_code}\n"
+                f"Response body: {response.text}",
+                status_code=response.status_code,
+            )
+        raise openai_error
+    if read_response:
+        return json_response
+    else:
+        return response
+
+
 def check_openai_policy_violation(input: Union[List[str], str], headers: Dict) -> bool:
     """
     Calls the moderation endpoint to check if the text(s) violate the policy.
@@ -150,6 +199,26 @@ def check_openai_policy_violation(input: Union[List[str], str], headers: Dict) -
     Returns true if any of the input is flagged as any of ['sexual', 'hate', 'violence', 'self-harm', 'sexual/minors', 'hate/threatening', 'violence/graphic'].
     """
     response = openai_request(url=OPENAI_MODERATION_URL, headers=headers, payload={"input": input})
+    results = response["results"]
+    flagged = any(res["flagged"] for res in results)
+    if flagged:
+        for result in results:
+            if result["flagged"]:
+                logger.debug(
+                    "OpenAI Moderation API flagged the text '%s' as a potential policy violation of the following categories: %s",
+                    input,
+                    result["categories"],
+                )
+    return flagged
+
+
+async def check_openai_async_policy_violation(input: Union[List[str], str], headers: Dict) -> bool:
+    """
+    Calls the moderation endpoint to check if the text(s) violate the policy.
+    See [OpenAI Moderation API](https://platform.openai.com/docs/guides/moderation) for more details.
+    Returns true if any of the input is flagged as any of ['sexual', 'hate', 'violence', 'self-harm', 'sexual/minors', 'hate/threatening', 'violence/graphic'].
+    """
+    response = await openai_async_request(url=OPENAI_MODERATION_URL, headers=headers, payload={"input": input})
     results = response["results"]
     flagged = any(res["flagged"] for res in results)
     if flagged:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ classifiers = [
 ]
 dependencies = [
   "requests",
+  "httpx",
   "pydantic<2",
   "transformers==4.32.1",
   "pandas",

--- a/releasenotes/notes/add-openai-async-1f65701142f77181.yaml
+++ b/releasenotes/notes/add-openai-async-1f65701142f77181.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add asyncio support to the OpenAI invocation layer.

--- a/test/prompt/invocation_layer/test_chatgpt.py
+++ b/test/prompt/invocation_layer/test_chatgpt.py
@@ -7,7 +7,7 @@ from haystack.nodes.prompt.invocation_layer import ChatGPTInvocationLayer
 
 
 @pytest.mark.unit
-@patch("haystack.nodes.prompt.invocation_layer.chatgpt.openai_request")
+@patch("haystack.nodes.prompt.invocation_layer.open_ai.openai_request")
 def test_default_api_base(mock_request):
     with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer"):
         invocation_layer = ChatGPTInvocationLayer(api_key="fake_api_key")
@@ -19,7 +19,7 @@ def test_default_api_base(mock_request):
 
 
 @pytest.mark.unit
-@patch("haystack.nodes.prompt.invocation_layer.chatgpt.openai_request")
+@patch("haystack.nodes.prompt.invocation_layer.open_ai.openai_request")
 def test_custom_api_base(mock_request):
     with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer"):
         invocation_layer = ChatGPTInvocationLayer(api_key="fake_api_key", api_base="https://fake_api_base.com")

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -1046,36 +1046,59 @@ def test_chatgpt_direct_prompting_w_messages(chatgpt_prompt_model):
 @pytest.mark.unit
 @patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer", lambda tokenizer_name: None)
 @patch("haystack.nodes.prompt.prompt_model.PromptModel._ensure_token_limit", lambda self, prompt: prompt)
-def test_content_moderation_gpt_3_and_gpt_3_5():
+def test_content_moderation_gpt_3():
     """
-    Check all possible cases of the moderation checks passing / failing in a PromptNode call
-    for both ChatGPTInvocationLayer and OpenAIInvocationLayer.
+    Check all possible cases of the moderation checks passing / failing in a PromptNode uses
+    OpenAIInvocationLayer.
     """
-    prompt_node_gpt_3_5 = PromptNode(
-        model_name_or_path="gpt-3.5-turbo", api_key="key", model_kwargs={"moderate_content": True}
-    )
-    prompt_node_gpt_3 = PromptNode(
+    prompt_node = PromptNode(
         model_name_or_path="text-davinci-003", api_key="key", model_kwargs={"moderate_content": True}
     )
     with patch("haystack.nodes.prompt.invocation_layer.open_ai.check_openai_policy_violation") as mock_check, patch(
-        "haystack.nodes.prompt.invocation_layer.chatgpt.ChatGPTInvocationLayer._execute_openai_request"
-    ) as mock_execute_gpt_3_5, patch(
-        "haystack.nodes.prompt.invocation_layer.open_ai.OpenAIInvocationLayer._execute_openai_request"
-    ) as mock_execute_gpt_3:
+        "haystack.nodes.prompt.invocation_layer.open_ai.openai_request"
+    ) as mock_request:
         VIOLENT_TEXT = "some violent text"
         mock_check.side_effect = lambda input, headers: input == VIOLENT_TEXT or input == [VIOLENT_TEXT]
         # case 1: prompt fails the moderation check
         # prompt should not be sent to OpenAi & function should return an empty list
         mock_check.return_value = True
-        assert prompt_node_gpt_3_5(VIOLENT_TEXT) == prompt_node_gpt_3(VIOLENT_TEXT) == []
+        assert prompt_node(VIOLENT_TEXT) == []
         # case 2: prompt passes the moderation check but the generated output fails the check
         # function should also return an empty list
-        mock_execute_gpt_3_5.return_value = mock_execute_gpt_3.return_value = [VIOLENT_TEXT]
-        assert prompt_node_gpt_3_5("normal prompt") == prompt_node_gpt_3("normal prompt") == []
+        mock_request.return_value = {"choices": [{"text": VIOLENT_TEXT, "finish_reason": ""}]}
+        assert prompt_node("normal prompt") == []
         # case 3: both prompt and output pass the moderation check
         # function should return the output
-        mock_execute_gpt_3_5.return_value = mock_execute_gpt_3.return_value = ["normal output"]
-        assert prompt_node_gpt_3_5("normal prompt") == prompt_node_gpt_3("normal prompt") == ["normal output"]
+        mock_request.return_value = {"choices": [{"text": "normal output", "finish_reason": ""}]}
+        assert prompt_node("normal prompt") == ["normal output"]
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer", lambda tokenizer_name: None)
+@patch("haystack.nodes.prompt.prompt_model.PromptModel._ensure_token_limit", lambda self, prompt: prompt)
+def test_content_moderation_gpt_35():
+    """
+    Check all possible cases of the moderation checks passing / failing in a PromptNode uses
+    ChatGPTInvocationLayer.
+    """
+    prompt_node = PromptNode(model_name_or_path="gpt-3.5-turbo", api_key="key", model_kwargs={"moderate_content": True})
+    with patch("haystack.nodes.prompt.invocation_layer.open_ai.check_openai_policy_violation") as mock_check, patch(
+        "haystack.nodes.prompt.invocation_layer.open_ai.openai_request"
+    ) as mock_request:
+        VIOLENT_TEXT = "some violent text"
+        mock_check.side_effect = lambda input, headers: input == VIOLENT_TEXT or input == [VIOLENT_TEXT]
+        # case 1: prompt fails the moderation check
+        # prompt should not be sent to OpenAi & function should return an empty list
+        mock_check.return_value = True
+        assert prompt_node(VIOLENT_TEXT) == []
+        # case 2: prompt passes the moderation check but the generated output fails the check
+        # function should also return an empty list
+        mock_request.return_value = {"choices": [{"text": VIOLENT_TEXT, "finish_reason": ""}]}
+        assert prompt_node("normal prompt") == []
+        # case 3: both prompt and output pass the moderation check
+        # function should return the output
+        mock_request.return_value = {"choices": [{"text": "normal output", "finish_reason": ""}]}
+        assert prompt_node("normal prompt") == ["normal output"]
 
 
 @patch("haystack.nodes.prompt.prompt_node.PromptModel")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- add a secondary, async api `ainvoke` to the OpenAI invocation layer.

### How did you test it?

Code was manually tested with the following snippet:
```py
import asyncio
import os
from haystack.pipelines import Pipeline
from haystack.nodes import PromptNode, PromptTemplate, AnswerParser
from haystack.schema import Document

# Let's create a custom LFQA prompt using PromptTemplate
lfqa_prompt = PromptTemplate(
    prompt="""Synthesize a comprehensive answer from the following topk most relevant paragraphs and the given question.
                             Provide a clear and concise response that summarizes the key points and information presented in the paragraphs.
                             Your answer should be in your own words and be no longer than 50 words.
                             \n\n Paragraphs: {join(documents)} \n\n Question: {query} \n\n Answer:""",
    output_parser=AnswerParser(),
)

# These docs could also come from a retriever
# Here we explicitly specify them to avoid the setup steps for Retriever and DocumentStore
doc_1 = "Contrails are a manmade type of cirrus cloud formed when water vapor from the exhaust of a jet engine condenses on particles, which come from either the surrounding air or the exhaust itself, and freezes, leaving behind a visible trail. The exhaust can also trigger the formation of cirrus by providing ice nuclei when there is an insufficient naturally-occurring supply in the atmosphere. One of the environmental impacts of aviation is that persistent contrails can form into large mats of cirrus, and increased air traffic has been implicated as one possible cause of the increasing frequency and amount of cirrus in Earth's atmosphere."
doc_2 = "Because the aviation industry is especially sensitive to the weather, accurate weather forecasting is essential. Fog or exceptionally low ceilings can prevent many aircraft from landing and taking off. Turbulence and icing are also significant in-flight hazards. Thunderstorms are a problem for all aircraft because of severe turbulence due to their updrafts and outflow boundaries, icing due to the heavy precipitation, as well as large hail, strong winds, and lightning, all of which can cause severe damage to an aircraft in flight. Volcanic ash is also a significant problem for aviation, as aircraft can lose engine power within ash clouds. On a day-to-day basis airliners are routed to take advantage of the jet stream tailwind to improve fuel efficiency. Aircrews are briefed prior to takeoff on the conditions to expect en route and at their destination. Additionally, airports often change which runway is being used to take advantage of a headwind. This reduces the distance required for takeoff, and eliminates potential crosswinds."


# Let's initiate the PromptNode
node = PromptNode("text-davinci-003", default_prompt_template=lfqa_prompt, api_key=os.environ.get("OPENAI_API_KEY"))

pipe = Pipeline()
pipe.add_node(component=node, name="prompt_node", inputs=["Query"])


async def main():
    output = await pipe._arun(
        query="Why do airplanes leave contrails in the sky?", documents=[Document(doc_1), Document(doc_2)]
    )
    for a in output["answers"]:
        print(a.answer)


if __name__ == "__main__":
    loop = asyncio.get_event_loop()
    loop.run_until_complete(main())
```

### Notes for the reviewer

- I couldn't get away with just defining `async def invoke()` because of the invocation layers class hierarchy 🙈 
- As much as I dislike duplicating code, I think that's the best course of action to introduce the `httpx` version of the two methods `check_openai_async_policy_violation` and `openai_async_request`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
