### PR TITLE
chore: deprecate `OpenAIAnswerGenerator`

### DIFF
--- a/haystack/nodes/answer_generator/openai.py
+++ b/haystack/nodes/answer_generator/openai.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import List, Optional, Tuple, Union
+import warnings
 
 from haystack import Document
 from haystack.environment import HAYSTACK_REMOTE_API_TIMEOUT_SEC
@@ -21,6 +22,10 @@ OPENAI_TIMEOUT = float(os.environ.get(HAYSTACK_REMOTE_API_TIMEOUT_SEC, 30))
 
 class OpenAIAnswerGenerator(BaseGenerator):
     """
+    This component is now deprecated and will be removed in future versions.
+    Use `PromptNode` instead of `OpenAIAnswerGenerator`,
+    as explained in https://haystack.deepset.ai/tutorials/22_pipeline_with_promptnode.
+
     Uses the GPT-3 models from the OpenAI API to generate Answers based on the Documents it receives.
     The Documents can come from a Retriever or you can supply them manually.
 
@@ -109,6 +114,12 @@ class OpenAIAnswerGenerator(BaseGenerator):
         :param openai_organization: The OpenAI-Organization ID, defaults to `None`. For more details, see see OpenAI
         [documentation](https://platform.openai.com/docs/api-reference/requesting-organization).
         """
+        warnings.warn(
+            "`OpenAIAnswerGenerator component is deprecated and will be removed in future versions. Use `PromptNode` "
+            "instead of `OpenAIAnswerGenerator`.",
+            category=DeprecationWarning,
+        )
+
         super().__init__(progress_bar=progress_bar)
         if (examples is None and examples_context is not None) or (examples is not None and examples_context is None):
             logger.warning(

--- a/releasenotes/notes/deprecate-openai-answergenerator-537266612ba1ffff.yaml
+++ b/releasenotes/notes/deprecate-openai-answergenerator-537266612ba1ffff.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Deprecate `OpenAIAnswerGenerator` in favor of `PromptNode`.
+    `OpenAIAnswerGenerator` will be removed in Haystack 1.23.

--- a/test/nodes/test_generator.py
+++ b/test/nodes/test_generator.py
@@ -6,7 +6,17 @@ from haystack.schema import Document, Answer
 from haystack.nodes.answer_generator import OpenAIAnswerGenerator
 from haystack.nodes import PromptTemplate
 
+from ..conftest import fail_at_version
+
 import logging
+
+
+@pytest.mark.unit
+@fail_at_version(1, 23)
+@patch("haystack.nodes.answer_generator.openai.load_openai_tokenizer")
+def test_openaianswergenerator_deprecation(mock_load_tokenizer):
+    with pytest.warns(DeprecationWarning):
+        OpenAIAnswerGenerator(api_key="fake_api_key")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- fixes #5349

### Proposed Changes:

Deprecate this component in favor of `PromptNode`.

As discussed internally, if we release this deprecation with Haystack 1.21.1,
we can remove this component in 1.23.

### How did you test it?

CI. Added deprecation test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
