### PR TITLE
chore: remove matrix from Linux CI

### DIFF
--- a/.github/workflows/tests_preview.yml
+++ b/.github/workflows/tests_preview.yml
@@ -154,14 +154,9 @@ jobs:
 
 
   integration-tests-linux:
-    name: Integration / ubuntu-latest
+    name: Integration / Linux
     needs: unit-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     services:
       tika:
         image: apache/tika:2.9.0.0
@@ -218,7 +213,7 @@ jobs:
 
 
   integration-tests-macos:
-    name: Integration / macos-latest
+    name: Integration / MacOS
     needs: unit-tests
     runs-on: macos-latest
     steps:
@@ -276,7 +271,7 @@ jobs:
 
 
   integration-tests-windows:
-    name: Integration / windows-latest
+    name: Integration / Windows
     needs: unit-tests
     runs-on: windows-latest
     steps:

--- a/.github/workflows/tests_preview.yml
+++ b/.github/workflows/tests_preview.yml
@@ -154,7 +154,7 @@ jobs:
 
 
   integration-tests-linux:
-    name: Integration / Linux
+    name: Integration / ubuntu-latest
     needs: unit-tests
     runs-on: ubuntu-latest
     services:
@@ -213,7 +213,7 @@ jobs:
 
 
   integration-tests-macos:
-    name: Integration / MacOS
+    name: Integration / macos-latest
     needs: unit-tests
     runs-on: macos-latest
     steps:
@@ -271,7 +271,7 @@ jobs:
 
 
   integration-tests-windows:
-    name: Integration / Windows
+    name: Integration / windows-latest
     needs: unit-tests
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
### Proposed Changes:

- During the CI split for v2 I accidentally left over a matrix for the Linux CI. This PR removes it.

### How did you test it?

CI

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
