### PR TITLE
fix: fix contributing link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Then move into the cloned folder and install the project with `pip`, including t
 cd haystack && pip install -e '.[dev]'
 ```
 
-If you want to contribute to the Haystack repo, check our [Contributor Guidelines](#💙-contributing) first.
+If you want to contribute to the Haystack repo, check our [Contributor Guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) first.
 
 See the list of [dependencies](https://github.com/deepset-ai/haystack/blob/main/pyproject.toml) to check which ones you want to install (for example, `[all]`, `[dev]`, or other).
 


### PR DESCRIPTION
### Related Issues

- N/A

### Proposed Changes:

- The 💙 emoji in the anchor does not actually resolve. Should be `#contributing`.
- Fix broken contributor link. As this ultimately links to the actual contributing page, simply redirect to *CONTRIBUTING.md* instead of `#-contributing`

### How did you test it?

- Manually viewed preview

### Notes for the reviewer

- Single line documentation edit

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
