### PR TITLE
fix: fix ChatGPT invocation layer (and add async support)

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -1,10 +1,17 @@
 import logging
-from typing import Optional, List, Dict, Union, Any
+from typing import Any, Dict, List, Optional, Union
 
 from haystack.nodes.prompt.invocation_layer.handlers import DefaultTokenStreamingHandler, TokenStreamingHandler
 from haystack.nodes.prompt.invocation_layer.open_ai import OpenAIInvocationLayer
 from haystack.nodes.prompt.invocation_layer.utils import has_azure_parameters
-from haystack.utils.openai_utils import openai_request, _check_openai_finish_reason, count_openai_tokens_messages
+from haystack.utils.openai_utils import (
+    _check_openai_finish_reason,
+    check_openai_async_policy_violation,
+    check_openai_policy_violation,
+    count_openai_tokens_messages,
+    openai_async_request,
+    openai_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,45 +49,6 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
         if set. If the input or answers are flagged, an empty list is returned in place of the answers.
         """
         super().__init__(api_key, model_name_or_path, max_length, api_base=api_base, **kwargs)
-
-    def _execute_openai_request(
-        self, prompt: Union[str, List[Dict]], base_payload: Dict, kwargs_with_defaults: Dict, stream: bool
-    ):
-        """
-        For more details, see [OpenAI ChatGPT API reference](https://platform.openai.com/docs/api-reference/chat).
-        """
-        if isinstance(prompt, str):
-            messages = [{"role": "user", "content": prompt}]
-        elif isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], dict):
-            messages = prompt
-        else:
-            raise ValueError(
-                f"The prompt format is different than what the model expects. "
-                f"The model {self.model_name_or_path} requires either a string or messages in the ChatML format. "
-                f"For more details, see this [GitHub discussion](https://github.com/openai/openai-python/blob/main/chatml.md)."
-            )
-        extra_payload = {"messages": messages}
-        payload = {**base_payload, **extra_payload}
-        if not stream:
-            response = openai_request(url=self.url, headers=self.headers, payload=payload)
-            _check_openai_finish_reason(result=response, payload=payload)
-            assistant_response = [choice["message"]["content"].strip() for choice in response["choices"]]
-        else:
-            response = openai_request(
-                url=self.url, headers=self.headers, payload=payload, read_response=False, stream=True
-            )
-            handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", DefaultTokenStreamingHandler())
-            assistant_response = self._process_streaming_response(response=response, stream_handler=handler)
-
-        # Although ChatGPT generates text until stop words are encountered, unfortunately it includes the stop word
-        # We want to exclude it to be consistent with other invocation layers
-        if "stop" in kwargs_with_defaults and kwargs_with_defaults["stop"] is not None:
-            stop_words = kwargs_with_defaults["stop"]
-            for idx, _ in enumerate(assistant_response):
-                for stop_word in stop_words:
-                    assistant_response[idx] = assistant_response[idx].replace(stop_word, "").strip()
-
-        return assistant_response
 
     def _extract_token(self, event_data: Dict[str, Any]):
         delta = event_data["choices"][0]["delta"]
@@ -141,3 +109,109 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
             and not "gpt-3.5-turbo-instruct" in model_name_or_path
         )
         return valid_model and not has_azure_parameters(**kwargs)
+
+    async def ainvoke(self, *args, **kwargs):
+        """
+        Invokes a prompt on the model. Based on the model, it takes in a prompt (or either a prompt or a list of messages)
+        and returns a list of responses using a REST invocation.
+
+        :return: The responses are being returned.
+
+        Note: Only kwargs relevant to OpenAI are passed to OpenAI rest API. Others kwargs are ignored.
+        For more details, see OpenAI [documentation](https://platform.openai.com/docs/api-reference/completions/create).
+        """
+        prompt, base_payload, kwargs_with_defaults, stream, moderation = self._prepare_invoke(*args, **kwargs)
+
+        if moderation and await check_openai_async_policy_violation(input=prompt, headers=self.headers):
+            logger.info("Prompt '%s' will not be sent to OpenAI due to potential policy violation.", prompt)
+            return []
+
+        if isinstance(prompt, str):
+            messages = [{"role": "user", "content": prompt}]
+        elif isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], dict):
+            messages = prompt
+        else:
+            raise ValueError(
+                f"The prompt format is different than what the model expects. "
+                f"The model {self.model_name_or_path} requires either a string or messages in the ChatML format. "
+                f"For more details, see this [GitHub discussion](https://github.com/openai/openai-python/blob/main/chatml.md)."
+            )
+        extra_payload = {"messages": messages}
+        payload = {**base_payload, **extra_payload}
+        if not stream:
+            response = await openai_async_request(url=self.url, headers=self.headers, payload=payload)
+            _check_openai_finish_reason(result=response, payload=payload)
+            assistant_response = [choice["message"]["content"].strip() for choice in response["choices"]]
+        else:
+            response = await openai_async_request(
+                url=self.url, headers=self.headers, payload=payload, read_response=False, stream=True
+            )
+            handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", DefaultTokenStreamingHandler())
+            assistant_response = self._process_streaming_response(response=response, stream_handler=handler)
+
+        # Although ChatGPT generates text until stop words are encountered, unfortunately it includes the stop word
+        # We want to exclude it to be consistent with other invocation layers
+        if "stop" in kwargs_with_defaults and kwargs_with_defaults["stop"] is not None:
+            stop_words = kwargs_with_defaults["stop"]
+            for idx, _ in enumerate(assistant_response):
+                for stop_word in stop_words:
+                    assistant_response[idx] = assistant_response[idx].replace(stop_word, "").strip()
+
+        if moderation and await check_openai_async_policy_violation(input=assistant_response, headers=self.headers):
+            logger.info("Response '%s' will not be returned due to potential policy violation.", assistant_response)
+            return []
+
+        return assistant_response
+
+    def invoke(self, *args, **kwargs):
+        """
+        Invokes a prompt on the model. Based on the model, it takes in a prompt (or either a prompt or a list of messages)
+        and returns a list of responses using a REST invocation.
+
+        :return: The responses are being returned.
+
+        Note: Only kwargs relevant to OpenAI are passed to OpenAI rest API. Others kwargs are ignored.
+        For more details, see OpenAI [documentation](https://platform.openai.com/docs/api-reference/completions/create).
+        """
+        prompt, base_payload, kwargs_with_defaults, stream, moderation = self._prepare_invoke(*args, **kwargs)
+
+        if moderation and check_openai_policy_violation(input=prompt, headers=self.headers):
+            logger.info("Prompt '%s' will not be sent to OpenAI due to potential policy violation.", prompt)
+            return []
+
+        if isinstance(prompt, str):
+            messages = [{"role": "user", "content": prompt}]
+        elif isinstance(prompt, list) and len(prompt) > 0 and isinstance(prompt[0], dict):
+            messages = prompt
+        else:
+            raise ValueError(
+                f"The prompt format is different than what the model expects. "
+                f"The model {self.model_name_or_path} requires either a string or messages in the ChatML format. "
+                f"For more details, see this [GitHub discussion](https://github.com/openai/openai-python/blob/main/chatml.md)."
+            )
+        extra_payload = {"messages": messages}
+        payload = {**base_payload, **extra_payload}
+        if not stream:
+            response = openai_request(url=self.url, headers=self.headers, payload=payload)
+            _check_openai_finish_reason(result=response, payload=payload)
+            assistant_response = [choice["message"]["content"].strip() for choice in response["choices"]]
+        else:
+            response = openai_request(
+                url=self.url, headers=self.headers, payload=payload, read_response=False, stream=True
+            )
+            handler: TokenStreamingHandler = kwargs_with_defaults.pop("stream_handler", DefaultTokenStreamingHandler())
+            assistant_response = self._process_streaming_response(response=response, stream_handler=handler)
+
+        # Although ChatGPT generates text until stop words are encountered, unfortunately it includes the stop word
+        # We want to exclude it to be consistent with other invocation layers
+        if "stop" in kwargs_with_defaults and kwargs_with_defaults["stop"] is not None:
+            stop_words = kwargs_with_defaults["stop"]
+            for idx, _ in enumerate(assistant_response):
+                for stop_word in stop_words:
+                    assistant_response[idx] = assistant_response[idx].replace(stop_word, "").strip()
+
+        if moderation and check_openai_policy_violation(input=assistant_response, headers=self.headers):
+            logger.info("Response '%s' will not be returned due to potential policy violation.", assistant_response)
+            return []
+
+        return assistant_response

--- a/releasenotes/notes/fix-chatgpt-invocation-layer-bc25d0ea5f77f05c.yaml
+++ b/releasenotes/notes/fix-chatgpt-invocation-layer-bc25d0ea5f77f05c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the bug that prevented the correct usage of ChatGPT invocation layer
+    in 1.21.1.
+    Added async support for ChatGPT invocation layer.

--- a/test/prompt/invocation_layer/test_chatgpt.py
+++ b/test/prompt/invocation_layer/test_chatgpt.py
@@ -1,13 +1,13 @@
+import logging
 from unittest.mock import patch
 
-import logging
 import pytest
 
 from haystack.nodes.prompt.invocation_layer import ChatGPTInvocationLayer
 
 
 @pytest.mark.unit
-@patch("haystack.nodes.prompt.invocation_layer.open_ai.openai_request")
+@patch("haystack.nodes.prompt.invocation_layer.chatgpt.openai_request")
 def test_default_api_base(mock_request):
     with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer"):
         invocation_layer = ChatGPTInvocationLayer(api_key="fake_api_key")
@@ -19,7 +19,7 @@ def test_default_api_base(mock_request):
 
 
 @pytest.mark.unit
-@patch("haystack.nodes.prompt.invocation_layer.open_ai.openai_request")
+@patch("haystack.nodes.prompt.invocation_layer.chatgpt.openai_request")
 def test_custom_api_base(mock_request):
     with patch("haystack.nodes.prompt.invocation_layer.open_ai.load_openai_tokenizer"):
         invocation_layer = ChatGPTInvocationLayer(api_key="fake_api_key", api_base="https://fake_api_base.com")


### PR DESCRIPTION
### Related Issues

- failing examples tests: https://github.com/deepset-ai/haystack/actions/runs/6415666359/job/17417960613
- https://github.com/deepset-ai/haystack/pull/5946/files#r1347216493

`ChatGPTInvocationLayer` inherits from `OpenAIInvocationLayer` and has its own custom method `_execute_openai_request` that also creates requests with `messages` field (required in models such as `gpt-3.5-turbo`).

After #5946, this method was no longer called and requests with the wrong format were created.

### Proposed Changes:
- include the logic of the old method  `_execute_openai_request` in synchronous and asynchronous invocation methods.

### How did you test it?

CI. Manual tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
