### PR TITLE
Revert "ci: added isort to pyproject.toml and pre-commit (#5933)"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,4 @@ repos:
   - id: actionlint-docker
     args: ["-ignore", "SC2102"]
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-    - id: isort
-      name: isort (python)
-
 # TODO we can make pylint run at this stage too, once their execution gets normalized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,6 @@ formatting = [
   # Version specified following Black stability policy:
   # https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy
   "black[jupyter]~=23.0",
-  "isort~=5.12"
 ]
 
 all = [
@@ -451,5 +450,3 @@ max-statements = 105  # Default is 50
 omit = [
     "haystack/testing/*",
 ]
-[tool.isort]
-profile = "black"


### PR DESCRIPTION
This PR reverts commit 64243540fb1f2cb6d4dfbb5b12db3aaf59a21b4a There is no easy way to make isort and black constantly overwrite each other. I tried this solution https://pycqa.github.io/isort/docs/configuration/black_compatibility.html but it didn't work. Let's find another one and in the meantime continue development unabated. 

