### PR TITLE
chore: remove `setuptools_scm` pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,9 +198,6 @@ onnx-gpu = [
 metrics = [  # for metrics
   "scipy>=1.3.2",
   "rapidfuzz>=2.0.15,<2.8.0",   # FIXME https://github.com/deepset-ai/haystack/pull/3199
-  # Pin setuptools_scm to prevent errors in Windows tests while installing seqeval
-  # https://github.com/deepset-ai/haystack/issues/5889
-  "setuptools_scm<8.0; platform_system == 'Windows'",
   "seqeval",
   "mlflow",
 ]


### PR DESCRIPTION
### Related Issues

- `setuptools_scm` pin was introduced to try to fix issue #5889, but it proved useless.
In fact, during the installation of `seqeval`, the latest version of this tool is always used.

- (the issue persists but was mitigated by a recent `setuptools_scm` release)

### Proposed Changes:
- remove the useless pin

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
