### PR TITLE
feat: Update html and pdf converters to handle ByteStream(s)

### DIFF
--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -37,7 +37,7 @@ class HTMLToDocument:
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, paths: List[Union[str, Path]]):
+    def run(self, paths: List[Union[str, Path, ByteStream]]):
         """
         Converts a list of HTML files to Documents.
 

--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -2,69 +2,73 @@ import logging
 from typing import List, Optional, Dict, Any, Union
 from pathlib import Path
 
-from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import Document, component, default_to_dict, default_from_dict
+from haystack.preview.dataclasses import ByteStream
+from haystack.preview.lazy_imports import LazyImport
+
+logger = logging.getLogger(__name__)
 
 with LazyImport("Run 'pip install boilerpy3'") as boilerpy3_import:
     from boilerpy3 import extractors
 
 
-logger = logging.getLogger(__name__)
-
-
 @component
 class HTMLToDocument:
     """
-    A component for converting an HTML file to a Document.
+    Converts an HTML file to a Document.
     """
 
     def __init__(self, id_hash_keys: Optional[List[str]] = None):
         """
-        Create a HTMLToDocument component.
+        Initializes the HTMLToDocument component.
 
-        :param id_hash_keys: Generate the Document ID from a custom list of strings that refer to the Document's
-            attributes. Default: `None`
+        :param id_hash_keys: List of strings referencing the Document's attributes to generate its ID. Default: `None`
         """
         boilerpy3_import.check()
         self.id_hash_keys = id_hash_keys or []
 
     def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
+        """Serialize the component to a dictionary."""
         return default_to_dict(self, id_hash_keys=self.id_hash_keys)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "HTMLToDocument":
-        """
-        Deserialize this component from a dictionary.
-        """
+        """Deserialize the component from a dictionary."""
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, paths: List[Union[str, Path]]):
         """
-        Convert HTML files to Documents.
+        Converts a list of HTML files to Documents.
 
-        :param paths: A list of paths to HTML files.
-        :return: A list of Documents.
+        :param paths: Paths to HTML files.
+        :return: List of converted Documents.
         """
         documents = []
         extractor = extractors.ArticleExtractor(raise_on_failure=False)
         for path in paths:
             try:
-                file_content = extractor.read_from_file(path)
-            except Exception as e:
-                logger.warning("Could not read file %s. Skipping it. Error message: %s", path, e)
+                file_content = self._extract_content(path)
+            except IOError as e:
+                logger.warning("Could not read file %s. Skipping it. Error: %s", path, e)
                 continue
-            # although raise_on_failure is set to False, the extractor can still raise an exception
             try:
                 text = extractor.get_content(file_content)
-            except Exception as conversion_e:
-                logger.warning("Could not extract raw txt from %s. Skipping it. Error message: %s", path, conversion_e)
+            except Exception as conversion_e:  # Consider specifying the expected exception type(s) here
+                logger.warning("Failed to extract text from %s. Skipping it. Error: %s", path, conversion_e)
                 continue
 
             document = Document(text=text, id_hash_keys=self.id_hash_keys)
             documents.append(document)
 
         return {"documents": documents}
+
+    def _extract_content(self, path: Union[str, Path, ByteStream]) -> str:
+        """Extracts content from the given path or ByteStream."""
+        if isinstance(path, (str, Path)):
+            with open(path) as text_file:
+                return text_file.read()
+        if isinstance(path, ByteStream):
+            return path.data.decode("utf-8")
+
+        raise ValueError(f"Unsupported path type: {type(path)}")

--- a/haystack/preview/components/file_converters/pypdf.py
+++ b/haystack/preview/components/file_converters/pypdf.py
@@ -1,7 +1,9 @@
+import io
 import logging
 from typing import List, Optional, Dict, Any, Union
 from pathlib import Path
 
+from haystack.preview.dataclasses import ByteStream
 from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import Document, component, default_to_dict, default_from_dict
 
@@ -15,12 +17,12 @@ logger = logging.getLogger(__name__)
 @component
 class PyPDFToDocument:
     """
-    A component for converting a PDF file to a Document.
+    Converts a PDF file to a Document.
     """
 
     def __init__(self, id_hash_keys: Optional[List[str]] = None):
         """
-        Create a PyPDFToDocument component.
+        Initializes the PyPDFToDocument component.
 
         :param id_hash_keys: Generate the Document ID from a custom list of strings that refer to the Document's
             attributes. Default: `None`
@@ -31,6 +33,7 @@ class PyPDFToDocument:
     def to_dict(self) -> Dict[str, Any]:
         """
         Serialize this component to a dictionary.
+        :return: The dictionary containing the component's data.
         """
         return default_to_dict(self, id_hash_keys=self.id_hash_keys)
 
@@ -38,13 +41,15 @@ class PyPDFToDocument:
     def from_dict(cls, data: Dict[str, Any]) -> "PyPDFToDocument":
         """
         Deserialize this component from a dictionary.
+        :param data: The dictionary containing the component's data.
+        :return: The component instance.
         """
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
-    def run(self, paths: List[Union[str, Path]], id_hash_keys: Optional[List[str]] = None):
+    def run(self, paths: List[Union[str, Path, ByteStream]], id_hash_keys: Optional[List[str]] = None):
         """
-        Convert PDF files to Documents.
+        Converts PDF files to Documents.
 
         :param paths: A list of paths to PDF files.
         :param id_hash_keys: Generate the Document ID from a custom list of strings that refer to the Document's
@@ -56,7 +61,7 @@ class PyPDFToDocument:
             try:
                 text = self._read_pdf_file(path)
             except Exception as e:
-                logger.warning("Could not read file %s. Skipping it. Error message: %s", path, e)
+                logger.warning("Could not read %s. Skipping it. Error message: %s", path, e)
                 continue
 
             document = Document(text=text, id_hash_keys=id_hash_keys)
@@ -64,14 +69,19 @@ class PyPDFToDocument:
 
         return {"documents": documents}
 
-    def _read_pdf_file(self, path: Union[str, Path]) -> str:
+    def _read_pdf_file(self, path: Union[str, Path, ByteStream]) -> str:
         """
-        Read a PDF file and return its text content.
+        Extracts content from the given PDF path or ByteStream.
+        :param path: Path to a PDF file or a ByteStream containing a PDF file.
+        :return: The extracted text.
         """
-        pdf_reader = PdfReader(str(path))
-        text = ""
-        for page in pdf_reader.pages:
-            extracted_text = page.extract_text()
-            if extracted_text:
-                text += extracted_text
+        if isinstance(path, (str, Path)):
+            pdf_reader = PdfReader(str(path))
+        elif isinstance(path, ByteStream):
+            pdf_reader = PdfReader(io.BytesIO(path.data))
+        else:
+            raise ValueError(f"Unsupported path type: {type(path)}")
+
+        text = "".join(extracted_text for page in pdf_reader.pages if (extracted_text := page.extract_text()))
+
         return text


### PR DESCRIPTION
### Why:
Extend the input handling capabilities of `HTMLToDocument` and `PyPDFToDocument` to process `ByteStream` inputs, thus enhancing the flexibility and utility of these converters.

### What:
- Updated `HTMLToDocument` to handle `ByteStream` input.
- Updated `PyPDFToDocument` to handle `ByteStream` input.

### How Did You Test It:
Proper testing was performed including unit and integration tests to validate the functionality of the updated input handling mechanism. Manual testing was also conducted to ensure `ByteStream` inputs were processed accurately.

### Notes for Reviewer:
- Would appreciate a review on the updated input handling logic to ensure it aligns with project standards and efficiently handles `ByteStream` inputs without any glitches.
