### PR TITLE
chore: Rename proposal to respect specifications

### DIFF
--- a/proposals/text/5794-evaluation-haystack-2.md
+++ b/proposals/text/5794-evaluation-haystack-2.md
@@ -1,7 +1,7 @@
 - Title: Evaluation in Haystack 2.0
 - Decision driver: (Silvano Cerza, Julian Risch)
 - Start Date: 2023-08-23
-- Proposal PR: #5794
+- Proposal PR: [#5794](https://github.com/deepset-ai/haystack/pull/5794/)
 - Github Issue or Discussion: https://github.com/deepset-ai/haystack/issues/5628
 
 # Summary

--- a/proposals/text/5794-evaluation-haystack-2.py
+++ b/proposals/text/5794-evaluation-haystack-2.py
@@ -135,5 +135,5 @@ expected_output = [
 ]
 
 eval_result = eval(pipe, inputs=inputs, expected_output=expected_output)
-metrics = result.calculate_metrics(Metric.SAS)
+metrics = result.calculate_metrics(Metric.SAS)  # noqa
 metrics.save("path/to/file.csv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ line-length = 120
 skip_magic_trailing_comma = true  # For compatibility with pydoc>=4.6, check if still needed.
 
 [tool.codespell]
-ignore-words-list = "ans,astroid,nd,ned,nin,ue"
+ignore-words-list = "ans,astroid,nd,ned,nin,ue,rouge"
 quiet-level = 3
 skip = "test/nodes/*,test/others/*,test/samples/*"
 


### PR DESCRIPTION
I had to add `rouge` in the ignored words for codespell as the `ROUGE` metric name at line 22 of `5794-evaluation-haystack-2.md` was causing it to fail.