### PR TITLE
test: Utility to compare two lists of documents for equality

### DIFF
--- a/haystack/preview/testing/document_store.py
+++ b/haystack/preview/testing/document_store.py
@@ -62,12 +62,12 @@ class DocumentStoreBaseTests:
 
     def contains_same_docs(self, first_list: List[Document], second_list: List[Document]) -> bool:
         """
-        Utility to compare two lists of documents for equality regardless of the order od the documents.
+        Utility to compare two lists of documents for equality regardless of the order of the documents.
         """
         return (
             len(first_list) > 0
             and len(second_list) > 0
-            and first_list.sort(key=lambda d: d.id) == second_list.sort(key=lambda d: d.id)
+            and sorted(first_list, key=lambda d: d.id) == sorted(second_list, key=lambda d: d.id)
         )
 
     @pytest.mark.unit

--- a/haystack/preview/testing/document_store.py
+++ b/haystack/preview/testing/document_store.py
@@ -361,9 +361,9 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_gte_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$gte": -2.0}})
+        result = docstore.filter_documents(filters={"number": {"$gte": -2}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] >= -2.0]
+            result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] >= -2]
         )
 
     @pytest.mark.unit
@@ -459,14 +459,9 @@ class DocumentStoreBaseTests:
         self, docstore: DocumentStore, filterable_docs: List[Document]
     ):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$and": {"$lte": 0, "$gte": -2}}})
+        result = docstore.filter_documents(filters={"number": {"$and": {"$gte": 0, "$lte": 2}}})
         assert self.contains_same_docs(
-            result,
-            [
-                doc
-                for doc in filterable_docs
-                if "number" in doc.metadata and doc.metadata["number"] >= 0.0 and doc.metadata["number"] <= 2.0
-            ],
+            result, [doc for doc in filterable_docs if "number" in doc.metadata and 0 <= doc.metadata["number"] <= 2]
         )
 
     @pytest.mark.unit
@@ -617,7 +612,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         filters_simplified = {
             "$or": {
-                "number": {"$lt": 1.0},
+                "number": {"$lt": 1},
                 "$and": {"name": {"$in": ["name_0", "name_1"]}, "$not": {"chapter": {"$eq": "intro"}}},
             }
         }
@@ -631,7 +626,7 @@ class DocumentStoreBaseTests:
                     ("number" in doc.metadata and doc.metadata["number"] < 1)
                     or (
                         doc.metadata.get("name") in ["name_0", "name_1"]
-                        or ("chapter" in doc.metadata and doc.metadata["chapter"] != "intro")
+                        and ("chapter" in doc.metadata and doc.metadata["chapter"] != "intro")
                     )
                 )
             ],
@@ -656,7 +651,7 @@ class DocumentStoreBaseTests:
                 for doc in filterable_docs
                 if (
                     (doc.metadata.get("name") in ["name_0", "name_1"] and doc.metadata.get("page") == "100")
-                    or (doc.metadata.get("chapter") in ["intro", "abstract"] and doc.metadata.get("page") == "100")
+                    or (doc.metadata.get("chapter") in ["intro", "abstract"] and doc.metadata.get("page") == "123")
                 )
             ],
         )


### PR DESCRIPTION
### Related Issues

`contains_same_docs` always returned `True` if the two input lists of documents had the same length. This happened because the implementation uses the return value of `sort` instead of `sorted`.
Four tests using the utility were actually broken due to issues in the implementation of the tests.

### Proposed Changes:

* Use `sorted` instead of `sort`, which returns the sorted list so that it can be compared to the other sorted list of documents.
* Fix four broken tests that used the utility. Three of them contained just small mistakes. One had a problem comparing int `-2` and float `-2.0` for equality.

### How did you test it?

Manual tests for the `contains_same_docs`. It's a small utility function of `DocumentStoreBaseTests` and I didn't want to add tests for it.
Updated unit tests.

### Notes for the reviewer


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
