### PR TITLE
feat: Split linting preview into a separate file

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "**.py"
       - "**/pyproject.toml"
+      - "!haystack/preview/**/*.py"
+      - "!test/preview/**/*.py"
 
 env:
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/linting_preview.yml
+++ b/.github/workflows/linting_preview.yml
@@ -1,0 +1,80 @@
+# If you change this name also do it in linting-skipper.yml and ci_metrics.yml
+name: Linting (Preview)
+
+on:
+  pull_request:
+    paths:
+      - "haystack/preview/**/*.py"
+      - "test/preview/**/*.py"
+      - "**/pyproject.toml"
+
+env:
+  PYTHON_VERSION: "3.8"
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # With the default value of 1, there are corner cases where tj-actions/changed-files
+          # fails with a `no merge base` error
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: |
+            **/*.py
+          files_ignore: |
+            test/**
+            rest_api/test/**
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Haystack
+        run: pip install .[dev,preview] langdetect transformers[torch,sentencepiece]==4.32.1 'sentence-transformers>=2.2.0' pypdf openai-whisper tika 'azure-ai-formrecognizer>=3.2.0b2'
+
+      - name: Mypy
+        if: steps.files.outputs.any_changed == 'true'
+        run: |
+          mkdir .mypy_cache/
+          mypy --install-types --non-interactive ${{ steps.files.outputs.all_changed_files }} --exclude=rest_api/build/ --exclude=rest_api/test/
+
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # With the default value of 1, there are corner cases where tj-actions/changed-files
+          # fails with a `no merge base` error
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: |
+            **/*.py
+          files_ignore: |
+            test/**
+            rest_api/test/**
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Haystack
+        run: |
+          pip install .[dev,preview] langdetect transformers[torch,sentencepiece]==4.32.1 'sentence-transformers>=2.2.0' pypdf openai-whisper tika 'azure-ai-formrecognizer>=3.2.0b2'
+          pip install ./haystack-linter
+
+      - name: Pylint
+        if: steps.files.outputs.any_changed == 'true'
+        run: |
+          pylint -ry -j 0 ${{ steps.files.outputs.all_changed_files }}


### PR DESCRIPTION
We need to configure linting for preview in a separate file because we'll have different haystack install directives as we split from the old repo