### PR TITLE
feat: Add TextLanguageClassifier 2.0

### DIFF
--- a/haystack/preview/components/preprocessors/__init__.py
+++ b/haystack/preview/components/preprocessors/__init__.py
@@ -1,3 +1,4 @@
 from haystack.preview.components.preprocessors.text_document_splitter import TextDocumentSplitter
+from haystack.preview.components.preprocessors.text_language_classifier import TextLanguageClassifier
 
-__all__ = ["TextDocumentSplitter"]
+__all__ = ["TextDocumentSplitter", "TextLanguageClassifier"]

--- a/haystack/preview/components/preprocessors/text_language_classifier.py
+++ b/haystack/preview/components/preprocessors/text_language_classifier.py
@@ -19,12 +19,15 @@ class TextLanguageClassifier:
     For routing Documents based on their language use the related DocumentLanguageClassifier component.
 
     Example usage in a retrieval pipeline that passes only English language queries to the retriever:
+
+    ```python
     document_store = MemoryDocumentStore()
     p = Pipeline()
     p.add_component(instance=TextLanguageClassifier(), name="text_language_classifier")
     p.add_component(instance=MemoryBM25Retriever(document_store=document_store), name="retriever")
     p.connect("text_language_classifier.en", "retriever.query")
     p.run({"text_language_classifier": {"text": "What's your query?"}})
+    ```
     """
 
     def __init__(self, languages: Optional[List[str]] = None):

--- a/haystack/preview/components/preprocessors/text_language_classifier.py
+++ b/haystack/preview/components/preprocessors/text_language_classifier.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Dict, Any, Optional
 
-from haystack.preview import component, Document, default_from_dict, default_to_dict
+from haystack.preview import component, default_from_dict, default_to_dict
 from haystack.preview.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)

--- a/haystack/preview/components/preprocessors/text_language_classifier.py
+++ b/haystack/preview/components/preprocessors/text_language_classifier.py
@@ -37,7 +37,7 @@ class TextLanguageClassifier:
         self.languages = languages
         component.set_output_types(self, unmatched=str, **{language: str for language in languages})
 
-    def run(self, text: str):
+    def run(self, text: str) -> Dict[str, str]:
         """
         Run the TextLanguageClassifier. This method routes the text one of different edges based on its language.
         If the text does not match any of the languages specified at initialization, it is routed to
@@ -50,8 +50,7 @@ class TextLanguageClassifier:
                 "TextLanguageClassifier expects a str as input. In case you want to classify a document, please use the DocumentLanguageClassifier."
             )
 
-        output: Dict[str, str] = {language: None for language in self.languages}
-        output["unmatched"] = None
+        output: Dict[str, str] = {}
 
         detected_language = self.detect_language(text)
         if detected_language in self.languages:

--- a/haystack/preview/components/preprocessors/text_language_classifier.py
+++ b/haystack/preview/components/preprocessors/text_language_classifier.py
@@ -1,0 +1,68 @@
+from typing import List, Dict, Any, Optional
+
+from haystack.preview import component, Document, default_from_dict, default_to_dict
+
+
+@component
+class TextLanguageClassifier:
+    """
+    Routes text inputs onto different output connections depending on their language.
+    This is useful for routing queries to different models in a pipeline depending on their language.
+    The set of supported languages can be specified.
+    For routing Documents based on their language use the related DocumentLanguageClassifier component.
+    """
+
+    def __init__(self, languages: Optional[List[str]] = None):
+        """
+        :param languages: The languages that are supported as output edges. By default english is supported and texts of any other language are routed to "unmatched"
+        """
+        if not languages:
+            languages = ["english"]
+        self.languages = languages
+        component.set_output_types(self, unmatched=List[str], **{language: List[str] for language in languages})
+
+    def run(self, strings: List[str]):
+        """
+        Run the TextLanguageClassifier. This method routes the strings to different edges based on their language.
+        If a string does not match any of the languages specified at initialization, it is routed to
+        a connection named "unmatched".
+
+        :param strings: A list of strings to route to different edges.
+        """
+        if not isinstance(strings, list) or strings and not isinstance(strings[0], str):
+            raise TypeError(
+                "TextLanguageClassifier expects a list of str as input. In case you want to classify a document, please use the DocumentLanguageClassifier."
+            )
+
+        unmatched_strings = []
+        output: Dict[str, List[str]] = {language: [] for language in self.languages}
+
+        for string in strings:
+            cur_string_matched = False
+            for language in self.languages:
+                if self.string_matches_language(language, string):
+                    output[language].append(string)
+                    cur_string_matched = True
+                    break
+
+            if not cur_string_matched:
+                unmatched_strings.append(string)
+
+        output["unmatched"] = unmatched_strings
+        return output
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        return default_to_dict(self, languages=self.languages)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TextLanguageClassifier":
+        """
+        Deserialize this component from a dictionary.
+        """
+        return default_from_dict(cls, data)
+
+    def string_matches_language(self, language: str, string: str) -> bool:
+        return language == "english"

--- a/haystack/preview/components/preprocessors/text_language_classifier.py
+++ b/haystack/preview/components/preprocessors/text_language_classifier.py
@@ -71,6 +71,6 @@ class TextLanguageClassifier:
         try:
             language = langdetect.detect(string)
         except langdetect.LangDetectException:
-            logger.debug("Langdetect cannot detect the language of text: %s", string)
+            logger.warning("Langdetect cannot detect the language of text: %s", string)
             language = None
         return language

--- a/releasenotes/notes/text-language-classifier-0d1e1a97f1bb8ac6.yaml
+++ b/releasenotes/notes/text-language-classifier-0d1e1a97f1bb8ac6.yaml
@@ -1,4 +1,4 @@
 ---
 preview:
   - |
-    Add TextLanguageClassifier component so that input strings, for example queries, can be routed to different components based on the detected language.
+    Add TextLanguageClassifier component so that an input string, for example a query, can be routed to different components based on the detected language.

--- a/releasenotes/notes/text-language-classifier-0d1e1a97f1bb8ac6.yaml
+++ b/releasenotes/notes/text-language-classifier-0d1e1a97f1bb8ac6.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Add TextLanguageClassifier component so that input strings, for example queries, can be routed to different components based on the detected language.

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -1,0 +1,24 @@
+import pytest
+
+from haystack.preview import Document
+from haystack.preview.components.preprocessors import TextLanguageClassifier
+
+
+class TestTextLanguageClassifier:
+    @pytest.mark.unit
+    def test_non_string_input(self):
+        with pytest.raises(TypeError, match="TextLanguageClassifier expects a list of str as input."):
+            classifier = TextLanguageClassifier()
+            classifier.run(strings=Document(text="This is an english sentence."))
+
+    @pytest.mark.unit
+    def test_single_string(self):
+        with pytest.raises(TypeError, match="TextLanguageClassifier expects a list of str as input."):
+            classifier = TextLanguageClassifier()
+            classifier.run(strings="This is an english sentence.")
+
+    @pytest.mark.unit
+    def test_empty_list(self):
+        classifier = TextLanguageClassifier()
+        result = classifier.run(strings=[])
+        assert result == {"english": [], "unmatched": []}

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -22,7 +22,7 @@ class TestTextLanguageClassifier:
     def test_empty_string(self):
         classifier = TextLanguageClassifier()
         result = classifier.run(text="")
-        assert result == {"en": None, "unmatched": ""}
+        assert result == {"unmatched": ""}
 
     @pytest.mark.unit
     def test_detect_language(self):
@@ -35,14 +35,14 @@ class TestTextLanguageClassifier:
         classifier = TextLanguageClassifier()
         english_sentence = "This is an english sentence."
         result = classifier.run(text=english_sentence)
-        assert result == {"en": english_sentence, "unmatched": None}
+        assert result == {"en": english_sentence}
 
     @pytest.mark.unit
     def test_route_to_unmatched(self):
         classifier = TextLanguageClassifier()
         german_sentence = "Ein deutscher Satz ohne Verb."
         result = classifier.run(text=german_sentence)
-        assert result == {"en": None, "unmatched": german_sentence}
+        assert result == {"unmatched": german_sentence}
 
     @pytest.mark.unit
     def test_warning_if_no_language_detected(self, caplog):

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -7,6 +7,18 @@ from haystack.preview.components.preprocessors import TextLanguageClassifier
 
 class TestTextLanguageClassifier:
     @pytest.mark.unit
+    def test_to_dict(self):
+        component = TextLanguageClassifier(languages=["en", "de"])
+        data = component.to_dict()
+        assert data == {"type": "TextLanguageClassifier", "init_parameters": {"languages": ["en", "de"]}}
+
+    @pytest.mark.unit
+    def test_from_dict(self):
+        data = {"type": "TextLanguageClassifier", "init_parameters": {"languages": ["en", "de"]}}
+        component = TextLanguageClassifier.from_dict(data)
+        assert component.languages == ["en", "de"]
+
+    @pytest.mark.unit
     def test_non_string_input(self):
         with pytest.raises(TypeError, match="TextLanguageClassifier expects a str as input."):
             classifier = TextLanguageClassifier()

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from haystack.preview import Document
 from haystack.preview.components.preprocessors import TextLanguageClassifier
@@ -36,3 +37,10 @@ class TestTextLanguageClassifier:
         german_setence = "Ein deutscher Satz ohne Verb."
         result = classifier.run(strings=[english_sentence, german_setence])
         assert result == {"en": [english_sentence], "unmatched": [german_setence]}
+
+    @pytest.mark.unit
+    def test_warning_if_no_language_detected(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            classifier = TextLanguageClassifier()
+            classifier.run(strings=["."])
+            assert "Langdetect cannot detect the language of text: ." in caplog.text

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -21,4 +21,18 @@ class TestTextLanguageClassifier:
     def test_empty_list(self):
         classifier = TextLanguageClassifier()
         result = classifier.run(strings=[])
-        assert result == {"english": [], "unmatched": []}
+        assert result == {"en": [], "unmatched": []}
+
+    @pytest.mark.unit
+    def test_detect_language(self):
+        classifier = TextLanguageClassifier()
+        detected_language = classifier.detect_language("This is an english sentence.")
+        assert detected_language == "en"
+
+    @pytest.mark.unit
+    def test_route_to_en_and_unmatched(self):
+        classifier = TextLanguageClassifier()
+        english_sentence = "This is an english sentence."
+        german_setence = "Ein deutscher Satz ohne Verb."
+        result = classifier.run(strings=[english_sentence, german_setence])
+        assert result == {"en": [english_sentence], "unmatched": [german_setence]}

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -1,5 +1,5 @@
-import pytest
 import logging
+import pytest
 
 from haystack.preview import Document
 from haystack.preview.components.preprocessors import TextLanguageClassifier
@@ -8,21 +8,21 @@ from haystack.preview.components.preprocessors import TextLanguageClassifier
 class TestTextLanguageClassifier:
     @pytest.mark.unit
     def test_non_string_input(self):
-        with pytest.raises(TypeError, match="TextLanguageClassifier expects a list of str as input."):
+        with pytest.raises(TypeError, match="TextLanguageClassifier expects a str as input."):
             classifier = TextLanguageClassifier()
-            classifier.run(strings=Document(text="This is an english sentence."))
+            classifier.run(text=Document(text="This is an english sentence."))
 
     @pytest.mark.unit
-    def test_single_string(self):
-        with pytest.raises(TypeError, match="TextLanguageClassifier expects a list of str as input."):
+    def test_list_of_string(self):
+        with pytest.raises(TypeError, match="TextLanguageClassifier expects a str as input."):
             classifier = TextLanguageClassifier()
-            classifier.run(strings="This is an english sentence.")
+            classifier.run(text=["This is an english sentence."])
 
     @pytest.mark.unit
-    def test_empty_list(self):
+    def test_empty_string(self):
         classifier = TextLanguageClassifier()
-        result = classifier.run(strings=[])
-        assert result == {"en": [], "unmatched": []}
+        result = classifier.run(text="")
+        assert result == {"en": None, "unmatched": ""}
 
     @pytest.mark.unit
     def test_detect_language(self):
@@ -31,16 +31,22 @@ class TestTextLanguageClassifier:
         assert detected_language == "en"
 
     @pytest.mark.unit
-    def test_route_to_en_and_unmatched(self):
+    def test_route_to_en(self):
         classifier = TextLanguageClassifier()
         english_sentence = "This is an english sentence."
-        german_setence = "Ein deutscher Satz ohne Verb."
-        result = classifier.run(strings=[english_sentence, german_setence])
-        assert result == {"en": [english_sentence], "unmatched": [german_setence]}
+        result = classifier.run(text=english_sentence)
+        assert result == {"en": english_sentence, "unmatched": None}
+
+    @pytest.mark.unit
+    def test_route_to_unmatched(self):
+        classifier = TextLanguageClassifier()
+        german_sentence = "Ein deutscher Satz ohne Verb."
+        result = classifier.run(text=german_sentence)
+        assert result == {"en": None, "unmatched": german_sentence}
 
     @pytest.mark.unit
     def test_warning_if_no_language_detected(self, caplog):
         with caplog.at_level(logging.WARNING):
             classifier = TextLanguageClassifier()
-            classifier.run(strings=["."])
+            classifier.run(text=".")
             assert "Langdetect cannot detect the language of text: ." in caplog.text


### PR DESCRIPTION
### Related Issues

- First part of https://github.com/deepset-ai/haystack/issues/5677

### Proposed Changes:

Add TextLanguageClassifier component that takes list of string as input and routes to different output connections based on detected language. LangDetect is used for language detection.

### How did you test it?

Newly added unit tests and manually with the following code snippet:
```python
def test_pipe(self):
    document_store = MemoryDocumentStore()
    document_store.write_documents(documents=[Document(text="Emma lives in Berlin.")])
    p = Pipeline()
    p.add_component(instance=TextLanguageClassifier(), name="text_language_classifier")
    p.add_component(instance=MemoryBM25Retriever(document_store=document_store), name="retriever")
    p.connect("text_language_classifier.en", "retriever.query")
    result = p.run({"text_language_classifier": {"text": "Who lives in Berlin?"}})
    assert "Emma" in result["retriever"]["documents"][0].text
    result = p.run({"text_language_classifier": {"text": "Wer lebt in Berlin?"}})
    assert result == {}
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
