### PR TITLE
feat: Use forward reference for AnalyzeResult

### DIFF
--- a/haystack/preview/components/file_converters/azure.py
+++ b/haystack/preview/components/file_converters/azure.py
@@ -92,7 +92,9 @@ class AzureOCRDocumentConverter:
         return default_from_dict(cls, data)
 
     @staticmethod
-    def _convert_azure_result_to_document(result: AnalyzeResult, id_hash_keys: List[str], file_suffix: str) -> Document:
+    def _convert_azure_result_to_document(
+        result: "AnalyzeResult", id_hash_keys: List[str], file_suffix: str
+    ) -> Document:
         """
         Convert the result of Azure OCR to a Haystack text Document.
         """


### PR DESCRIPTION
### Why
The static method `_convert_azure_result_to_document` in the `AzureOCRDocumentConverter` class was causing a `NameError` due to the direct use of `AnalyzeResult` from the `azure.ai.formrecognizer` package, which is an optional dependency. This PR addresses this issue to ensure smooth functionality even when the optional package isn't installed.

### What
The fix involves using a forward reference for `AnalyzeResult` in the method signature of `_convert_azure_result_to_document`.

### How Can It Be Used
After this fix, users won't get the `NameError` as before.  If they do have the package and want to utilize the full functionality, they can do so without any errors.


### How Did You Test It
1. Ran the code without the `azure.ai.formrecognizer` package installed to ensure no `NameError` is thrown.
2. Installed the `azure.ai.formrecognizer` package and tested the full functionality of the `AzureOCRDocumentConverter` class to ensure it works as expected.
