### PR TITLE
chore: add posthog to the dependencies of preview extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ preview = [
   "tqdm",
   "tenacity",
   "lazy-imports",
+  "posthog",  # telemetry
 
   "Jinja2",
   "openai",


### PR DESCRIPTION
### Related Issues

- twin PR of https://github.com/deepset-ai/haystack-preview-package/pull/9

We want to keep the effective dependencies of the preview package up to date.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
