### PR TITLE
chore: Fix preview module importing from old haystack

### DIFF
--- a/haystack/preview/__init__.py
+++ b/haystack/preview/__init__.py
@@ -1,19 +1,5 @@
-from importlib import metadata
-
 from canals import component
 from canals.serialization import default_from_dict, default_to_dict
 from canals.errors import DeserializationError, ComponentError
 from haystack.preview.pipeline import Pipeline
 from haystack.preview.dataclasses import Document, Answer, GeneratedAnswer, ExtractedAnswer
-
-# haystack.preview is distributed as a separate package called `haystack-ai`.
-# We want to keep all preview dependencies separate from the current Haystack version,
-# so imports in haystack.preview must only import from haystack.preview.
-# Since we need to access __version__ in haystack.preview without importing from
-# haystack we must set it here too.
-# When installing `haystack-ai` we want to use that package version though
-# as `farm-haystack` might not be installed and cause this to fail.
-try:
-    __version__: str = str(metadata.version("haystack-ai"))
-except metadata.PackageNotFoundError:
-    __version__: str = str(metadata.version("farm-haystack"))

--- a/haystack/preview/__init__.py
+++ b/haystack/preview/__init__.py
@@ -1,5 +1,19 @@
+from importlib import metadata
+
 from canals import component
 from canals.serialization import default_from_dict, default_to_dict
 from canals.errors import DeserializationError, ComponentError
 from haystack.preview.pipeline import Pipeline
 from haystack.preview.dataclasses import Document, Answer, GeneratedAnswer, ExtractedAnswer
+
+# haystack.preview is distributed as a separate package called `haystack-ai`.
+# We want to keep all preview dependencies separate from the current Haystack version,
+# so imports in haystack.preview must only import from haystack.preview.
+# Since we need to access __version__ in haystack.preview without importing from
+# haystack we must set it here too.
+# When installing `haystack-ai` we want to use that package version though
+# as `farm-haystack` might not be installed and cause this to fail.
+try:
+    __version__: str = str(metadata.version("haystack-ai"))
+except metadata.PackageNotFoundError:
+    __version__: str = str(metadata.version("farm-haystack"))

--- a/haystack/preview/components/fetchers/link_content.py
+++ b/haystack/preview/components/fetchers/link_content.py
@@ -8,9 +8,9 @@ from requests import Response
 from requests.exceptions import HTTPError
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from haystack.preview import __version__
 from haystack.preview import component, default_from_dict, default_to_dict
 from haystack.preview.dataclasses import ByteStream
+from haystack.preview.version import __version__
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/preview/components/fetchers/link_content.py
+++ b/haystack/preview/components/fetchers/link_content.py
@@ -8,7 +8,7 @@ from requests import Response
 from requests.exceptions import HTTPError
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from haystack import __version__
+from haystack.preview import __version__
 from haystack.preview import component, default_from_dict, default_to_dict
 from haystack.preview.dataclasses import ByteStream
 

--- a/haystack/preview/telemetry/_environment.py
+++ b/haystack/preview/telemetry/_environment.py
@@ -5,7 +5,7 @@ import platform
 import sys
 from typing import Optional, Dict, Any
 
-from haystack import __version__
+from haystack.preview import __version__
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/preview/telemetry/_environment.py
+++ b/haystack/preview/telemetry/_environment.py
@@ -5,7 +5,7 @@ import platform
 import sys
 from typing import Optional, Dict, Any
 
-from haystack.preview import __version__
+from haystack.preview.version import __version__
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/preview/version.py
+++ b/haystack/preview/version.py
@@ -8,6 +8,6 @@ from importlib import metadata
 # When installing `haystack-ai` we want to use that package version though
 # as `farm-haystack` might not be installed and cause this to fail.
 try:
-    __version__: str = str(metadata.version("haystack-ai"))
+    __version__ = str(metadata.version("haystack-ai"))
 except metadata.PackageNotFoundError:
-    __version__: str = str(metadata.version("farm-haystack"))
+    __version__ = str(metadata.version("farm-haystack"))

--- a/haystack/preview/version.py
+++ b/haystack/preview/version.py
@@ -1,0 +1,13 @@
+from importlib import metadata
+
+# haystack.preview is distributed as a separate package called `haystack-ai`.
+# We want to keep all preview dependencies separate from the current Haystack version,
+# so imports in haystack.preview must only import from haystack.preview.
+# Since we need to access __version__ in haystack.preview without importing from
+# haystack we must set it here too.
+# When installing `haystack-ai` we want to use that package version though
+# as `farm-haystack` might not be installed and cause this to fail.
+try:
+    __version__: str = str(metadata.version("haystack-ai"))
+except metadata.PackageNotFoundError:
+    __version__: str = str(metadata.version("farm-haystack"))


### PR DESCRIPTION
### Proposed Changes:

Fix `link_content.py` and `_environment.py` importing `__version__` from `haystack` instead of `haystack.preview` module.

### How did you test it?

Manually.

### Notes for the reviewer

I'll add a CI check to prevent this imports as I already caught some other occurences in past reviews.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
