### PR TITLE
ci: Add a workflow to verify haystack.preview doesn't import non preview modules

### DIFF
--- a/.github/workflows/preview_imports.yml
+++ b/.github/workflows/preview_imports.yml
@@ -1,0 +1,55 @@
+name: Verify preview imports only preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - "haystack/preview/**.py"
+
+jobs:
+  verify-imports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # With the default value of 1, there are corner cases where tj-actions/changed-files
+          # fails with a `no merge base` error
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: |
+            haystack/preview/**.py
+
+      - name: Check imports
+        shell: python
+        run: |
+          import re
+          regex = r"^(from haystack|import haystack)(?!\.preview| import preview)(.*)"
+
+          changed_files = "${{ steps.files.outputs.all_changed_files }}".split()
+          matches = {}
+          for path in changed_files:
+            with open(path, "r") as f:
+              file_matches = []
+              for line in f.readlines():
+                file_matches.extend(re.finditer(regex, line.strip()))
+              if file_matches:
+                matches[path] = file_matches
+
+          for path, match in matches.items():
+            print(f"Bad imports in file '{path}'")
+            for m in match:
+              print(m.group())
+            print()
+
+          if matches:
+            print("::error:: Imports in haystack.preview can only import from haystack.preview")
+            import sys; sys.exit(1)


### PR DESCRIPTION
### Proposed Changes:

I've noticed more and more occasions in `haystack.preview` imports to non preview `haystack`, that's an issue as we want to keep `haystack.preview` completely isolated and separated from old `haystack`.

This PR adds a workflow to verify that we don't actually add files in `haystack.preview` containing old `haystack` imports.

The workflow won't be required but at least will give a warning when creating PRs with bad imports.

### How did you test it?

I tested in an personal repo:
* [PR](https://github.com/silvanocerza/nodenode/pull/35)
* [Failing workflow](https://github.com/silvanocerza/nodenode/actions/runs/6524708624)

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
