### PR TITLE
chore: Add missing preview dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ preview = [
 
   "Jinja2",
   "openai",
+  "pyyaml"
 ]
 inference = [
   "transformers[torch,sentencepiece]==4.32.1",


### PR DESCRIPTION
`pyyaml` is a missing dependency of the preview package. I already added it in [deepset-ai/haystack-preview-package](https://github.com/deepset-ai/haystack-preview-package).