### PR TITLE
CI: make only `linting_preview` run on preview e2e tests

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,7 @@ on:
       - "**/pyproject.toml"
       - "!haystack/preview/**/*.py"
       - "!test/preview/**/*.py"
+      - "!e2e/preview/**/*.py"
 
 env:
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/linting_preview.yml
+++ b/.github/workflows/linting_preview.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "haystack/preview/**/*.py"
       - "test/preview/**/*.py"
+      - "e2e/preview/**/*.py"
       - "**/pyproject.toml"
 
 env:

--- a/.github/workflows/linting_skipper.yml
+++ b/.github/workflows/linting_skipper.yml
@@ -6,6 +6,9 @@ on:
     paths-ignore:
       - "**.py"
       - "**/pyproject.toml"
+      - "!haystack/preview/**/*.py"
+      - "!test/preview/**/*.py"
+      - "!e2e/preview/**/*.py"
 
 jobs:
   mypy:


### PR DESCRIPTION
### Related Issues

I discovered that when we modify preview e2e tests,
the workflow `linting` is running instead of `linting_preview`.

### Proposed Changes:
- `linting` will not run on preview e2e tests
- instead, `linting_preview` will run on them

### How did you test it?

I haven't tested it.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
