### PR TITLE
fix: Fix TextDocumentSplitter failing if run with empty list

### DIFF
--- a/haystack/preview/components/preprocessors/text_document_splitter.py
+++ b/haystack/preview/components/preprocessors/text_document_splitter.py
@@ -43,8 +43,9 @@ class TextDocumentSplitter:
         :return: A list of documents with the split texts.
         """
 
-        if not documents or not isinstance(documents, list) or not isinstance(documents[0], Document):
+        if not isinstance(documents, list) or (len(documents) > 0 and not isinstance(documents[0], Document)):
             raise TypeError("TextDocumentSplitter expects a List of Documents as input.")
+
         split_docs = []
         for doc in documents:
             if doc.text is None:

--- a/haystack/preview/components/preprocessors/text_document_splitter.py
+++ b/haystack/preview/components/preprocessors/text_document_splitter.py
@@ -43,7 +43,7 @@ class TextDocumentSplitter:
         :return: A list of documents with the split texts.
         """
 
-        if not isinstance(documents, list) or (len(documents) > 0 and not isinstance(documents[0], Document)):
+        if not isinstance(documents, list) or (documents and not isinstance(documents[0], Document)):
             raise TypeError("TextDocumentSplitter expects a List of Documents as input.")
 
         split_docs = []

--- a/releasenotes/notes/fix-text-splitter-65870db474338749.yaml
+++ b/releasenotes/notes/fix-text-splitter-65870db474338749.yaml
@@ -1,0 +1,3 @@
+---
+preview:
+  - Fix TextDocumentSplitter failing when run with an empty list

--- a/test/preview/components/preprocessors/test_text_document_splitter.py
+++ b/test/preview/components/preprocessors/test_text_document_splitter.py
@@ -22,7 +22,8 @@ class TestTextDocumentSplitter:
     @pytest.mark.unit
     def test_empty_list(self):
         splitter = TextDocumentSplitter()
-        splitter.run(documents=[])
+        res = splitter.run(documents=[])
+        assert res == {"documents": []}
 
     @pytest.mark.unit
     def test_unsupported_split_by(self):

--- a/test/preview/components/preprocessors/test_text_document_splitter.py
+++ b/test/preview/components/preprocessors/test_text_document_splitter.py
@@ -21,9 +21,8 @@ class TestTextDocumentSplitter:
 
     @pytest.mark.unit
     def test_empty_list(self):
-        with pytest.raises(TypeError, match="TextDocumentSplitter expects a List of Documents as input."):
-            splitter = TextDocumentSplitter()
-            splitter.run(documents=[])
+        splitter = TextDocumentSplitter()
+        splitter.run(documents=[])
 
     @pytest.mark.unit
     def test_unsupported_split_by(self):


### PR DESCRIPTION
### Proposed Changes:

`TextDocumentSplitter` right now fails if run with an empty list, the error message is also quite confusing.
This PR changes the behaviour so it doesn't fail when an empty list is use as input.

### How did you test it?

I ran `TextDocumentSplitter` tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
