### PR TITLE
refactor: Remove reimplementations of default `from_dict`/`to_dict` and corresponding tests in 2.0

### DIFF
--- a/haystack/preview/components/audio/whisper_local.py
+++ b/haystack/preview/components/audio/whisper_local.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Dict, Any, Union, BinaryIO, Literal, get_args
 import logging
 from pathlib import Path
 
-from haystack.preview import component, Document, default_to_dict, default_from_dict, ComponentError
+from haystack.preview import component, Document, default_to_dict, ComponentError
 from haystack.preview.lazy_imports import LazyImport
 
 with LazyImport("Run 'pip install openai-whisper'") as whisper_import:
@@ -65,13 +65,6 @@ class LocalWhisperTranscriber:
         return default_to_dict(
             self, model_name_or_path=self.model_name, device=str(self.device), whisper_params=self.whisper_params
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "LocalWhisperTranscriber":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, audio_files: List[Path], whisper_params: Optional[Dict[str, Any]] = None):

--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 
 from haystack.preview.utils import request_with_retry
-from haystack.preview import component, Document, default_to_dict, default_from_dict
+from haystack.preview import component, Document
 
 logger = logging.getLogger(__name__)
 
@@ -53,25 +53,6 @@ class RemoteWhisperTranscriber:
         self.api_key = api_key
         self.api_base = api_base
         self.whisper_params = whisper_params or {}
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(
-            self,
-            model_name=self.model_name,
-            api_key=self.api_key,
-            api_base=self.api_base,
-            whisper_params=self.whisper_params,
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "RemoteWhisperTranscriber":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, audio_files: List[Path], whisper_params: Optional[Dict[str, Any]] = None):

--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -5,6 +5,8 @@ import json
 import logging
 from pathlib import Path
 
+from canals.serialization import default_to_dict
+
 from haystack.preview.utils import request_with_retry
 from haystack.preview import component, Document
 
@@ -126,3 +128,12 @@ class RemoteWhisperTranscriber:
 
             transcriptions.append(transcription)
         return transcriptions
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        This method overrides the default serializer in order to avoid leaking the `api_key` value passed
+        to the constructor.
+        """
+        return default_to_dict(
+            self, model_name=self.model_name, api_base=self.api_base, whisper_params=self.whisper_params
+        )

--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -5,10 +5,8 @@ import json
 import logging
 from pathlib import Path
 
-from canals.serialization import default_to_dict
-
 from haystack.preview.utils import request_with_retry
-from haystack.preview import component, Document
+from haystack.preview import component, Document, default_to_dict
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/preview/components/builders/answer_builder.py
+++ b/haystack/preview/components/builders/answer_builder.py
@@ -107,19 +107,6 @@ class AnswerBuilder:
 
         return {"answers": all_answers}
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(self, pattern=self.pattern, reference_pattern=self.reference_pattern)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "AnswerBuilder":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
-
     @staticmethod
     def _extract_answer_string(reply: str, pattern: Optional[str] = None) -> str:
         """

--- a/haystack/preview/components/builders/answer_builder.py
+++ b/haystack/preview/components/builders/answer_builder.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import List, Dict, Any, Optional
 
-from haystack.preview import component, GeneratedAnswer, Document, default_to_dict, default_from_dict
+from haystack.preview import component, GeneratedAnswer, Document
 
 
 logger = logging.getLogger(__name__)

--- a/haystack/preview/components/builders/prompt_builder.py
+++ b/haystack/preview/components/builders/prompt_builder.py
@@ -3,7 +3,7 @@ from typing import Dict, Any
 from jinja2 import Template, meta
 
 from haystack.preview import component
-from haystack.preview import default_to_dict, default_from_dict
+from haystack.preview import default_to_dict
 
 
 @component

--- a/haystack/preview/components/builders/prompt_builder.py
+++ b/haystack/preview/components/builders/prompt_builder.py
@@ -36,10 +36,6 @@ class PromptBuilder:
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, template=self._template_string)
 
-    @classmethod
-    def from_dict(cls, data) -> "PromptBuilder":
-        return default_from_dict(cls, data)
-
     @component.output_types(prompt=str)
     def run(self, **kwargs):
         return {"prompt": self.template.render(kwargs)}

--- a/haystack/preview/components/embedders/openai_document_embedder.py
+++ b/haystack/preview/components/embedders/openai_document_embedder.py
@@ -5,7 +5,7 @@ import openai
 from tqdm import tqdm
 
 
-from haystack.preview import component, Document, default_to_dict, default_from_dict
+from haystack.preview import component, Document, default_to_dict
 
 
 @component
@@ -88,13 +88,6 @@ class OpenAIDocumentEmbedder:
             metadata_fields_to_embed=self.metadata_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "OpenAIDocumentEmbedder":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:
         """

--- a/haystack/preview/components/embedders/openai_text_embedder.py
+++ b/haystack/preview/components/embedders/openai_text_embedder.py
@@ -3,7 +3,7 @@ import os
 
 import openai
 
-from haystack.preview import component, default_to_dict, default_from_dict
+from haystack.preview import component, default_to_dict
 
 
 @component
@@ -65,13 +65,6 @@ class OpenAITextEmbedder:
         return default_to_dict(
             self, model_name=self.model_name, organization=self.organization, prefix=self.prefix, suffix=self.suffix
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "OpenAITextEmbedder":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(embedding=List[float], metadata=Dict[str, Any])
     def run(self, text: str):

--- a/haystack/preview/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/preview/components/embedders/sentence_transformers_document_embedder.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union, Dict, Any
 
-from haystack.preview import component, Document, default_to_dict, default_from_dict
+from haystack.preview import component, Document, default_to_dict
 from haystack.preview.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
@@ -80,13 +80,6 @@ class SentenceTransformersDocumentEmbedder:
             metadata_fields_to_embed=self.metadata_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SentenceTransformersDocumentEmbedder":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def warm_up(self):
         """

--- a/haystack/preview/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/preview/components/embedders/sentence_transformers_text_embedder.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union, Dict, Any
 
-from haystack.preview import component, default_to_dict, default_from_dict
+from haystack.preview import component, default_to_dict
 from haystack.preview.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
@@ -71,13 +71,6 @@ class SentenceTransformersTextEmbedder:
             progress_bar=self.progress_bar,
             normalize_embeddings=self.normalize_embeddings,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SentenceTransformersTextEmbedder":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def warm_up(self):
         """

--- a/haystack/preview/components/fetchers/link_content.py
+++ b/haystack/preview/components/fetchers/link_content.py
@@ -8,7 +8,7 @@ from requests import Response
 from requests.exceptions import HTTPError
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from haystack.preview import component, default_from_dict, default_to_dict
+from haystack.preview import component
 from haystack.preview.dataclasses import ByteStream
 from haystack.preview.version import __version__
 
@@ -94,25 +94,6 @@ class LinkContentFetcher:
             return response
 
         self._get_response: Callable = get_response
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(
-            self,
-            raise_on_failure=self.raise_on_failure,
-            user_agents=self.user_agents,
-            retry_attempts=self.retry_attempts,
-            timeout=self.timeout,
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "LinkContentFetcher":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(streams=List[ByteStream])
     def run(self, urls: List[str]):

--- a/haystack/preview/components/fetchers/link_content.py
+++ b/haystack/preview/components/fetchers/link_content.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import requests
 from requests import Response

--- a/haystack/preview/components/file_converters/azure.py
+++ b/haystack/preview/components/file_converters/azure.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import List, Union, Optional, Dict, Any
 
 from haystack.preview.lazy_imports import LazyImport
-from haystack.preview import component, Document, default_to_dict, default_from_dict
+from haystack.preview import component, Document, default_to_dict
 
 
 with LazyImport(message="Run 'pip install azure-ai-formrecognizer>=3.2.0b2'") as azure_import:
@@ -83,13 +83,6 @@ class AzureOCRDocumentConverter:
         return default_to_dict(
             self, endpoint=self.endpoint, api_key=self.api_key, model_id=self.model_id, id_hash_keys=self.id_hash_keys
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "AzureOCRDocumentConverter":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @staticmethod
     def _convert_azure_result_to_document(

--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -1,8 +1,8 @@
 import logging
-from typing import List, Optional, Dict, Any, Union
+from typing import List, Optional, Union
 from pathlib import Path
 
-from haystack.preview import Document, component, default_to_dict, default_from_dict
+from haystack.preview import Document, component
 from haystack.preview.dataclasses import ByteStream
 from haystack.preview.lazy_imports import LazyImport
 
@@ -26,15 +26,6 @@ class HTMLToDocument:
         """
         boilerpy3_import.check()
         self.id_hash_keys = id_hash_keys or []
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Serialize the component to a dictionary."""
-        return default_to_dict(self, id_hash_keys=self.id_hash_keys)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "HTMLToDocument":
-        """Deserialize the component from a dictionary."""
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, sources: List[Union[str, Path, ByteStream]]):

--- a/haystack/preview/components/file_converters/pypdf.py
+++ b/haystack/preview/components/file_converters/pypdf.py
@@ -1,11 +1,11 @@
 import io
 import logging
-from typing import List, Optional, Dict, Any, Union
+from typing import List, Optional, Union
 from pathlib import Path
 
 from haystack.preview.dataclasses import ByteStream
 from haystack.preview.lazy_imports import LazyImport
-from haystack.preview import Document, component, default_to_dict, default_from_dict
+from haystack.preview import Document, component
 
 with LazyImport("Run 'pip install pypdf'") as pypdf_import:
     from pypdf import PdfReader
@@ -29,22 +29,6 @@ class PyPDFToDocument:
         """
         pypdf_import.check()
         self.id_hash_keys = id_hash_keys or []
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        :return: The dictionary containing the component's data.
-        """
-        return default_to_dict(self, id_hash_keys=self.id_hash_keys)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PyPDFToDocument":
-        """
-        Deserialize this component from a dictionary.
-        :param data: The dictionary containing the component's data.
-        :return: The component instance.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, sources: List[Union[str, Path, ByteStream]], id_hash_keys: Optional[List[str]] = None):

--- a/haystack/preview/components/file_converters/tika.py
+++ b/haystack/preview/components/file_converters/tika.py
@@ -1,9 +1,9 @@
 import logging
 from pathlib import Path
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, List, Union
 
 from haystack.preview.lazy_imports import LazyImport
-from haystack.preview import component, Document, default_to_dict, default_from_dict
+from haystack.preview import component, Document
 
 
 with LazyImport("Run 'pip install tika'") as tika_import:
@@ -70,16 +70,3 @@ class TikaDocumentConverter:
                 logger.error("Could not convert file at '%s' to Document. Error: %s", str(path), e)
 
         return {"documents": documents}
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(self, tika_url=self.tika_url, id_hash_keys=self.id_hash_keys)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TikaDocumentConverter":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)

--- a/haystack/preview/components/file_converters/txt.py
+++ b/haystack/preview/components/file_converters/txt.py
@@ -1,12 +1,12 @@
 import logging
 from pathlib import Path
-from typing import Optional, List, Union, Dict, Any
+from typing import Optional, List, Union, Dict
 
 from canals.errors import PipelineRuntimeError
 from tqdm import tqdm
 
 from haystack.preview.lazy_imports import LazyImport
-from haystack.preview import Document, component, default_to_dict, default_from_dict
+from haystack.preview import Document, component
 
 with LazyImport("Run 'pip install langdetect'") as langdetect_import:
     import langdetect
@@ -60,27 +60,6 @@ class TextFileToDocument:
         self.valid_languages = valid_languages or []
         self.id_hash_keys = id_hash_keys or []
         self.progress_bar = progress_bar
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(
-            self,
-            encoding=self.encoding,
-            remove_numeric_tables=self.remove_numeric_tables,
-            numeric_row_threshold=self.numeric_row_threshold,
-            valid_languages=self.valid_languages,
-            id_hash_keys=self.id_hash_keys,
-            progress_bar=self.progress_bar,
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TextFileToDocument":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(

--- a/haystack/preview/components/generators/hugging_face/hugging_face_local.py
+++ b/haystack/preview/components/generators/hugging_face/hugging_face_local.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List, Literal, Optional, Union
 from copy import deepcopy
 
-from haystack.preview import component, default_from_dict, default_to_dict
+from haystack.preview import component, default_to_dict
 from haystack.preview.lazy_imports import LazyImport
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:
@@ -169,13 +169,6 @@ class HuggingFaceLocalGenerator:
             generation_kwargs=self.generation_kwargs,
             stop_words=self.stop_words,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "HuggingFaceLocalGenerator":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(replies=List[str])
     def run(self, prompt: str):

--- a/haystack/preview/components/preprocessors/text_document_cleaner.py
+++ b/haystack/preview/components/preprocessors/text_document_cleaner.py
@@ -3,9 +3,9 @@ import re
 from copy import deepcopy
 from functools import partial, reduce
 from itertools import chain
-from typing import Any, Dict, Generator, List, Optional, Set
+from typing import Generator, List, Optional, Set
 
-from haystack.preview import Document, component, default_from_dict, default_to_dict
+from haystack.preview import Document, component
 
 logger = logging.getLogger(__name__)
 
@@ -90,26 +90,6 @@ class DocumentCleaner:
             )
 
         return {"documents": cleaned_docs}
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(
-            self,
-            remove_empty_lines=self.remove_empty_lines,
-            remove_extra_whitespaces=self.remove_extra_whitespaces,
-            remove_repeated_substrings=self.remove_repeated_substrings,
-            remove_substrings=self.remove_substrings,
-            remove_regex=self.remove_regex,
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "DocumentCleaner":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def _remove_empty_lines(self, text: str) -> str:
         """

--- a/haystack/preview/components/preprocessors/text_document_splitter.py
+++ b/haystack/preview/components/preprocessors/text_document_splitter.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import List, Dict, Literal
+from typing import List, Literal
 
 from more_itertools import windowed
 

--- a/haystack/preview/components/preprocessors/text_document_splitter.py
+++ b/haystack/preview/components/preprocessors/text_document_splitter.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
-from typing import List, Dict, Any, Literal
+from typing import List, Dict, Literal
 
 from more_itertools import windowed
 
-from haystack.preview import component, Document, default_from_dict, default_to_dict
+from haystack.preview import component, Document
 
 
 @component
@@ -60,21 +60,6 @@ class TextDocumentSplitter:
             metadata["source_id"] = doc.id
             split_docs += [Document(text=txt, metadata=metadata, id_hash_keys=id_hash_keys) for txt in text_splits]
         return {"documents": split_docs}
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(
-            self, split_by=self.split_by, split_length=self.split_length, split_overlap=self.split_overlap
-        )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TextDocumentSplitter":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def _split_into_units(self, text: str, split_by: Literal["word", "sentence", "passage"]) -> List[str]:
         if split_by == "passage":

--- a/haystack/preview/components/preprocessors/text_language_classifier.py
+++ b/haystack/preview/components/preprocessors/text_language_classifier.py
@@ -1,7 +1,7 @@
 import logging
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 
-from haystack.preview import component, default_from_dict, default_to_dict
+from haystack.preview import component
 from haystack.preview.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
@@ -62,19 +62,6 @@ class TextLanguageClassifier:
             output["unmatched"] = text
 
         return output
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(self, languages=self.languages)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TextLanguageClassifier":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def detect_language(self, text: str) -> Optional[str]:
         try:

--- a/haystack/preview/components/rankers/similarity.py
+++ b/haystack/preview/components/rankers/similarity.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import List, Union, Dict, Any, Optional
 
-from haystack.preview import ComponentError, Document, component, default_from_dict, default_to_dict
+from haystack.preview import ComponentError, Document, component, default_to_dict
 from haystack.preview.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
@@ -88,13 +88,6 @@ class SimilarityRanker:
             token=self.token if not isinstance(self.token, str) else None,  # don't serialize valid tokens
             top_k=self.top_k,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SimilarityRanker":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, query: str, documents: List[Document], top_k: Optional[int] = None):

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import math
 import warnings
 
-from haystack.preview import component, default_from_dict, default_to_dict, ComponentError, Document, ExtractedAnswer
+from haystack.preview import component, default_to_dict, ComponentError, Document, ExtractedAnswer
 from haystack.preview.lazy_imports import LazyImport
 
 with LazyImport(
@@ -96,13 +96,6 @@ class ExtractiveReader:
             no_answer=self.no_answer,
             calibration_factor=self.calibration_factor,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ExtractiveReader":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def warm_up(self):
         if self.model is None:

--- a/haystack/preview/components/routers/file_type_router.py
+++ b/haystack/preview/components/routers/file_type_router.py
@@ -2,9 +2,9 @@ import logging
 import mimetypes
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Union, Optional, Dict, Any
+from typing import List, Union, Optional, Dict
 
-from haystack.preview import component, default_from_dict, default_to_dict
+from haystack.preview import component
 from haystack.preview.dataclasses import ByteStream
 
 logger = logging.getLogger(__name__)
@@ -41,19 +41,6 @@ class FileTypeRouter:
 
         component.set_output_types(self, unclassified=List[Path], **{mime_type: List[Path] for mime_type in mime_types})
         self.mime_types = mime_types
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(self, mime_types=self.mime_types)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "FileTypeRouter":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     def run(self, sources: List[Union[str, Path, ByteStream]]) -> Dict[str, List[Union[ByteStream, Path]]]:
         """

--- a/haystack/preview/components/routers/metadata_router.py
+++ b/haystack/preview/components/routers/metadata_router.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, List
+from typing import Dict, List
 
-from haystack.preview import component, default_from_dict, default_to_dict, Document
+from haystack.preview import component, Document
 from haystack.preview.utils.filters import document_matches_filter
 
 
@@ -52,16 +52,3 @@ class MetadataRouter:
 
         output["unmatched"] = unmatched_documents
         return output
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(self, rules=self.rules)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "MetadataRouter":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -1,7 +1,7 @@
 import logging
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 
-from haystack.preview import ComponentError, Document, component, default_from_dict, default_to_dict
+from haystack.preview import ComponentError, Document, component
 from haystack.preview.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
@@ -47,19 +47,6 @@ class TopPSampler:
 
         self.top_p = top_p
         self.score_field = score_field
-
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize this component to a dictionary.
-        """
-        return default_to_dict(self, top_p=self.top_p, score_field=self.score_field)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TopPSampler":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])
     def run(self, documents: List[Document], top_p: Optional[float] = None):

--- a/haystack/preview/components/websearch/serper_dev.py
+++ b/haystack/preview/components/websearch/serper_dev.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Any
 
 import requests
 
-from haystack.preview import Document, component, default_from_dict, default_to_dict, ComponentError
+from haystack.preview import Document, component, default_to_dict, ComponentError
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +57,6 @@ class SerperDevWebSearch:
             allowed_domains=self.allowed_domains,
             search_params=self.search_params,
         )
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SerperDevWebSearch":
-        """
-        Deserialize this component from a dictionary.
-        """
-        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document], links=List[str])
     def run(self, query: str):

--- a/releasenotes/notes/remove-default-from-dict-reimplementation-2db4c32153c1e7af.yaml
+++ b/releasenotes/notes/remove-default-from-dict-reimplementation-2db4c32153c1e7af.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Removed implementations of from_dict and to_dict from all components where they had the same effect as the default implementation from Canals: https://github.com/deepset-ai/canals/blob/main/canals/serialization.py#L12-L13 This refactoring does not change the behavior of the components.

--- a/test/preview/components/audio/test_whisper_local.py
+++ b/test/preview/components/audio/test_whisper_local.py
@@ -54,21 +54,6 @@ class TestLocalWhisperTranscriber:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "LocalWhisperTranscriber",
-            "init_parameters": {
-                "model_name_or_path": "tiny",
-                "device": "cuda",
-                "whisper_params": {"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
-            },
-        }
-        transcriber = LocalWhisperTranscriber.from_dict(data)
-        assert transcriber.model_name == "tiny"
-        assert transcriber.device == torch.device("cuda")
-        assert transcriber.whisper_params == {"return_segments": True, "temperature": [0.1, 0.6, 0.8]}
-
-    @pytest.mark.unit
     def test_warmup(self):
         with patch("haystack.preview.components.audio.whisper_local.whisper") as mocked_whisper:
             transcriber = LocalWhisperTranscriber(model_name_or_path="large-v2")

--- a/test/preview/components/audio/test_whisper_remote.py
+++ b/test/preview/components/audio/test_whisper_remote.py
@@ -26,6 +26,37 @@ class TestRemoteWhisperTranscriber:
             RemoteWhisperTranscriber(api_key=None)
 
     @pytest.mark.unit
+    def test_to_dict(self):
+        transcriber = RemoteWhisperTranscriber(api_key="test")
+        data = transcriber.to_dict()
+        assert data == {
+            "type": "RemoteWhisperTranscriber",
+            "init_parameters": {
+                "model_name": "whisper-1",
+                "api_base": "https://api.openai.com/v1",
+                "whisper_params": {},
+            },
+        }
+
+    @pytest.mark.unit
+    def test_to_dict_with_custom_init_parameters(self):
+        transcriber = RemoteWhisperTranscriber(
+            api_key="test",
+            model_name="whisper-1",
+            api_base="https://my.api.base/something_else/v3",
+            whisper_params={"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
+        )
+        data = transcriber.to_dict()
+        assert data == {
+            "type": "RemoteWhisperTranscriber",
+            "init_parameters": {
+                "model_name": "whisper-1",
+                "api_base": "https://my.api.base/something_else/v3",
+                "whisper_params": {"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
+            },
+        }
+
+    @pytest.mark.unit
     def test_run_with_path(self, preview_samples_path):
         mock_response = MagicMock()
         mock_response.status_code = 200

--- a/test/preview/components/audio/test_whisper_remote.py
+++ b/test/preview/components/audio/test_whisper_remote.py
@@ -26,56 +26,6 @@ class TestRemoteWhisperTranscriber:
             RemoteWhisperTranscriber(api_key=None)
 
     @pytest.mark.unit
-    def test_to_dict(self):
-        transcriber = RemoteWhisperTranscriber(api_key="test")
-        data = transcriber.to_dict()
-        assert data == {
-            "type": "RemoteWhisperTranscriber",
-            "init_parameters": {
-                "model_name": "whisper-1",
-                "api_key": "test",
-                "api_base": "https://api.openai.com/v1",
-                "whisper_params": {},
-            },
-        }
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        transcriber = RemoteWhisperTranscriber(
-            api_key="test",
-            model_name="whisper-1",
-            api_base="https://my.api.base/something_else/v3",
-            whisper_params={"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
-        )
-        data = transcriber.to_dict()
-        assert data == {
-            "type": "RemoteWhisperTranscriber",
-            "init_parameters": {
-                "model_name": "whisper-1",
-                "api_key": "test",
-                "api_base": "https://my.api.base/something_else/v3",
-                "whisper_params": {"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
-            },
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "RemoteWhisperTranscriber",
-            "init_parameters": {
-                "model_name": "whisper-1",
-                "api_key": "test",
-                "api_base": "https://my.api.base/something_else/v3",
-                "whisper_params": {"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
-            },
-        }
-        transcriber = RemoteWhisperTranscriber.from_dict(data)
-        assert transcriber.model_name == "whisper-1"
-        assert transcriber.api_key == "test"
-        assert transcriber.api_base == "https://my.api.base/something_else/v3"
-        assert transcriber.whisper_params == {"return_segments": True, "temperature": [0.1, 0.6, 0.8]}
-
-    @pytest.mark.unit
     def test_run_with_path(self, preview_samples_path):
         mock_response = MagicMock()
         mock_response.status_code = 200

--- a/test/preview/components/builders/test_answer_builder.py
+++ b/test/preview/components/builders/test_answer_builder.py
@@ -8,31 +8,6 @@ from haystack.preview.components.builders.answer_builder import AnswerBuilder
 
 class TestAnswerBuilder:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = AnswerBuilder()
-        data = component.to_dict()
-        assert data == {"type": "AnswerBuilder", "init_parameters": {"pattern": None, "reference_pattern": None}}
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        component = AnswerBuilder(pattern="pattern", reference_pattern="reference_pattern")
-        data = component.to_dict()
-        assert data == {
-            "type": "AnswerBuilder",
-            "init_parameters": {"pattern": "pattern", "reference_pattern": "reference_pattern"},
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "AnswerBuilder",
-            "init_parameters": {"pattern": "pattern", "reference_pattern": "reference_pattern"},
-        }
-        component = AnswerBuilder.from_dict(data)
-        assert component.pattern == "pattern"
-        assert component.reference_pattern == "reference_pattern"
-
-    @pytest.mark.unit
     def test_run_unmatching_input_len(self):
         component = AnswerBuilder()
         with pytest.raises(ValueError):

--- a/test/preview/components/builders/test_prompt_builder.py
+++ b/test/preview/components/builders/test_prompt_builder.py
@@ -17,13 +17,6 @@ def test_to_dict():
 
 
 @pytest.mark.unit
-def test_from_dict():
-    data = {"type": "PromptBuilder", "init_parameters": {"template": "This is a {{ variable }}"}}
-    builder = PromptBuilder.from_dict(data)
-    builder._template_string == "This is a {{ variable }}"
-
-
-@pytest.mark.unit
 def test_run():
     builder = PromptBuilder(template="This is a {{ variable }}")
     res = builder.run(variable="test")

--- a/test/preview/components/embedders/test_openai_document_embedder.py
+++ b/test/preview/components/embedders/test_openai_document_embedder.py
@@ -119,53 +119,6 @@ class TestOpenAIDocumentEmbedder:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
-        data = {
-            "type": "OpenAIDocumentEmbedder",
-            "init_parameters": {
-                "model_name": "model",
-                "organization": "my-org",
-                "prefix": "prefix",
-                "suffix": "suffix",
-                "batch_size": 64,
-                "progress_bar": False,
-                "metadata_fields_to_embed": ["test_field"],
-                "embedding_separator": " | ",
-            },
-        }
-        component = OpenAIDocumentEmbedder.from_dict(data)
-        assert openai.api_key == "fake-api-key"
-        assert component.model_name == "model"
-        assert component.organization == "my-org"
-        assert openai.organization == "my-org"
-        assert component.prefix == "prefix"
-        assert component.suffix == "suffix"
-        assert component.batch_size == 64
-        assert component.progress_bar is False
-        assert component.metadata_fields_to_embed == ["test_field"]
-        assert component.embedding_separator == " | "
-
-    @pytest.mark.unit
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        data = {
-            "type": "OpenAIDocumentEmbedder",
-            "init_parameters": {
-                "model_name": "model",
-                "organization": "my-org",
-                "prefix": "prefix",
-                "suffix": "suffix",
-                "batch_size": 64,
-                "progress_bar": False,
-                "metadata_fields_to_embed": ["test_field"],
-                "embedding_separator": " | ",
-            },
-        }
-        with pytest.raises(ValueError, match="OpenAIDocumentEmbedder expects an OpenAI API key"):
-            OpenAIDocumentEmbedder.from_dict(data)
-
-    @pytest.mark.unit
     def test_prepare_texts_to_embed_w_metadata(self):
         documents = [
             Document(text=f"document number {i}:\ncontent", metadata={"meta_field": f"meta_value {i}"})

--- a/test/preview/components/embedders/test_openai_text_embedder.py
+++ b/test/preview/components/embedders/test_openai_text_embedder.py
@@ -87,41 +87,6 @@ class TestOpenAITextEmbedder:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
-        data = {
-            "type": "OpenAITextEmbedder",
-            "init_parameters": {
-                "model_name": "model",
-                "organization": "fake-organization",
-                "prefix": "prefix",
-                "suffix": "suffix",
-            },
-        }
-        component = OpenAITextEmbedder.from_dict(data)
-        assert openai.api_key == "fake-api-key"
-        assert component.model_name == "model"
-        assert component.organization == "fake-organization"
-        assert openai.organization == "fake-organization"
-        assert component.prefix == "prefix"
-        assert component.suffix == "suffix"
-
-    @pytest.mark.unit
-    def test_from_dict_fail_wo_env_var(self, monkeypatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        data = {
-            "type": "OpenAITextEmbedder",
-            "init_parameters": {
-                "model_name": "model",
-                "organization": "fake-organization",
-                "prefix": "prefix",
-                "suffix": "suffix",
-            },
-        }
-        with pytest.raises(ValueError, match="OpenAITextEmbedder expects an OpenAI API key"):
-            OpenAITextEmbedder.from_dict(data)
-
-    @pytest.mark.unit
     def test_run(self):
         model = "text-similarity-ada-001"
 
@@ -138,7 +103,7 @@ class TestOpenAITextEmbedder:
             )
 
         assert len(result["embedding"]) == 1536
-        assert all([isinstance(x, float) for x in result["embedding"]])
+        assert all(isinstance(x, float) for x in result["embedding"])
         assert result["metadata"] == {"model": model, "usage": {"prompt_tokens": 4, "total_tokens": 4}}
 
     @pytest.mark.unit

--- a/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
@@ -101,35 +101,6 @@ class TestSentenceTransformersDocumentEmbedder:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "SentenceTransformersDocumentEmbedder",
-            "init_parameters": {
-                "model_name_or_path": "model",
-                "device": "cuda",
-                "token": None,
-                "prefix": "prefix",
-                "suffix": "suffix",
-                "batch_size": 64,
-                "progress_bar": False,
-                "normalize_embeddings": False,
-                "embedding_separator": " - ",
-                "metadata_fields_to_embed": ["meta_field"],
-            },
-        }
-        component = SentenceTransformersDocumentEmbedder.from_dict(data)
-        assert component.model_name_or_path == "model"
-        assert component.device == "cuda"
-        assert component.token is None
-        assert component.prefix == "prefix"
-        assert component.suffix == "suffix"
-        assert component.batch_size == 64
-        assert component.progress_bar is False
-        assert component.normalize_embeddings is False
-        assert component.metadata_fields_to_embed == ["meta_field"]
-        assert component.embedding_separator == " - "
-
-    @pytest.mark.unit
     @patch(
         "haystack.preview.components.embedders.sentence_transformers_document_embedder._SentenceTransformersEmbeddingBackendFactory"
     )

--- a/test/preview/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_text_embedder.py
@@ -104,31 +104,6 @@ class TestSentenceTransformersTextEmbedder:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "SentenceTransformersTextEmbedder",
-            "init_parameters": {
-                "model_name_or_path": "model",
-                "device": "cuda",
-                "token": True,
-                "prefix": "prefix",
-                "suffix": "suffix",
-                "batch_size": 64,
-                "progress_bar": False,
-                "normalize_embeddings": True,
-            },
-        }
-        component = SentenceTransformersTextEmbedder.from_dict(data)
-        assert component.model_name_or_path == "model"
-        assert component.device == "cuda"
-        assert component.token is True
-        assert component.prefix == "prefix"
-        assert component.suffix == "suffix"
-        assert component.batch_size == 64
-        assert component.progress_bar is False
-        assert component.normalize_embeddings is True
-
-    @pytest.mark.unit
     @patch(
         "haystack.preview.components.embedders.sentence_transformers_text_embedder._SentenceTransformersEmbeddingBackendFactory"
     )

--- a/test/preview/components/fetchers/test_link_content_fetcher.py
+++ b/test/preview/components/fetchers/test_link_content_fetcher.py
@@ -2,6 +2,7 @@ from unittest.mock import patch, Mock
 
 import pytest
 import requests
+from canals.serialization import component_to_dict
 
 from haystack.preview.components.fetchers.link_content import (
     LinkContentFetcher,
@@ -58,44 +59,6 @@ class TestLinkContentFetcher:
         assert fetcher.user_agents == ["test"]
         assert fetcher.retry_attempts == 1
         assert fetcher.timeout == 2
-
-    @pytest.mark.unit
-    def test_to_dict(self):
-        fetcher = LinkContentFetcher()
-        assert fetcher.to_dict() == {
-            "type": "LinkContentFetcher",
-            "init_parameters": {
-                "raise_on_failure": True,
-                "user_agents": [DEFAULT_USER_AGENT],
-                "retry_attempts": 2,
-                "timeout": 3,
-            },
-        }
-
-    @pytest.mark.unit
-    def test_to_dict_with_params(self):
-        fetcher = LinkContentFetcher(raise_on_failure=False, user_agents=["test"], retry_attempts=1, timeout=2)
-        assert fetcher.to_dict() == {
-            "type": "LinkContentFetcher",
-            "init_parameters": {"raise_on_failure": False, "user_agents": ["test"], "retry_attempts": 1, "timeout": 2},
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        fetcher = LinkContentFetcher.from_dict(
-            {
-                "type": "LinkContentFetcher",
-                "init_parameters": {
-                    "raise_on_failure": False,
-                    "user_agents": ["test"],
-                    "retry_attempts": 1,
-                    "timeout": 2,
-                },
-            }
-        )
-        assert fetcher.raise_on_failure is False
-        assert fetcher.user_agents == ["test"]
-        assert fetcher.retry_attempts == 1
 
     @pytest.mark.unit
     def test_run_text(self):

--- a/test/preview/components/fetchers/test_link_content_fetcher.py
+++ b/test/preview/components/fetchers/test_link_content_fetcher.py
@@ -2,7 +2,6 @@ from unittest.mock import patch, Mock
 
 import pytest
 import requests
-from canals.serialization import component_to_dict
 
 from haystack.preview.components.fetchers.link_content import (
     LinkContentFetcher,

--- a/test/preview/components/file_converters/test_azure_ocr_doc_converter.py
+++ b/test/preview/components/file_converters/test_azure_ocr_doc_converter.py
@@ -22,23 +22,6 @@ class TestAzureOCRDocumentConverter:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "AzureOCRDocumentConverter",
-            "init_parameters": {
-                "api_key": "test_credential_key",
-                "endpoint": "test_endpoint",
-                "id_hash_keys": [],
-                "model_id": "prebuilt-read",
-            },
-        }
-        component = AzureOCRDocumentConverter.from_dict(data)
-        assert component.endpoint == "test_endpoint"
-        assert component.api_key == "test_credential_key"
-        assert component.id_hash_keys == []
-        assert component.model_id == "prebuilt-read"
-
-    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         with patch("haystack.preview.components.file_converters.azure.DocumentAnalysisClient") as mock_azure_client:
             mock_result = Mock(pages=[Mock(lines=[Mock(content="mocked line 1"), Mock(content="mocked line 2")])])

--- a/test/preview/components/file_converters/test_html_to_document.py
+++ b/test/preview/components/file_converters/test_html_to_document.py
@@ -8,24 +8,6 @@ from haystack.preview.dataclasses import ByteStream
 
 class TestHTMLToDocument:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = HTMLToDocument()
-        data = component.to_dict()
-        assert data == {"type": "HTMLToDocument", "init_parameters": {"id_hash_keys": []}}
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        component = HTMLToDocument(id_hash_keys=["name"])
-        data = component.to_dict()
-        assert data == {"type": "HTMLToDocument", "init_parameters": {"id_hash_keys": ["name"]}}
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {"type": "HTMLToDocument", "init_parameters": {"id_hash_keys": ["name"]}}
-        component = HTMLToDocument.from_dict(data)
-        assert component.id_hash_keys == ["name"]
-
-    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly.

--- a/test/preview/components/file_converters/test_pypdf_to_document.py
+++ b/test/preview/components/file_converters/test_pypdf_to_document.py
@@ -8,24 +8,6 @@ from haystack.preview.dataclasses import ByteStream
 
 class TestPyPDFToDocument:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = PyPDFToDocument()
-        data = component.to_dict()
-        assert data == {"type": "PyPDFToDocument", "init_parameters": {"id_hash_keys": []}}
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        component = PyPDFToDocument(id_hash_keys=["name"])
-        data = component.to_dict()
-        assert data == {"type": "PyPDFToDocument", "init_parameters": {"id_hash_keys": ["name"]}}
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {"type": "PyPDFToDocument", "init_parameters": {"id_hash_keys": ["name"]}}
-        component = PyPDFToDocument.from_dict(data)
-        assert component.id_hash_keys == ["name"]
-
-    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly.

--- a/test/preview/components/file_converters/test_textfile_to_document.py
+++ b/test/preview/components/file_converters/test_textfile_to_document.py
@@ -12,66 +12,6 @@ from haystack.preview.components.file_converters.txt import TextFileToDocument
 
 class TestTextfileToDocument:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = TextFileToDocument()
-        data = component.to_dict()
-        assert data == {
-            "type": "TextFileToDocument",
-            "init_parameters": {
-                "encoding": "utf-8",
-                "remove_numeric_tables": False,
-                "numeric_row_threshold": 0.4,
-                "valid_languages": [],
-                "id_hash_keys": [],
-                "progress_bar": True,
-            },
-        }
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        component = TextFileToDocument(
-            encoding="latin-1",
-            remove_numeric_tables=True,
-            numeric_row_threshold=0.7,
-            valid_languages=["en", "de"],
-            id_hash_keys=["name"],
-            progress_bar=False,
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": "TextFileToDocument",
-            "init_parameters": {
-                "encoding": "latin-1",
-                "remove_numeric_tables": True,
-                "numeric_row_threshold": 0.7,
-                "valid_languages": ["en", "de"],
-                "id_hash_keys": ["name"],
-                "progress_bar": False,
-            },
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "TextFileToDocument",
-            "init_parameters": {
-                "encoding": "latin-1",
-                "remove_numeric_tables": True,
-                "numeric_row_threshold": 0.7,
-                "valid_languages": ["en", "de"],
-                "id_hash_keys": ["name"],
-                "progress_bar": False,
-            },
-        }
-        component = TextFileToDocument.from_dict(data)
-        assert component.encoding == "latin-1"
-        assert component.remove_numeric_tables
-        assert component.numeric_row_threshold == 0.7
-        assert component.valid_languages == ["en", "de"]
-        assert component.id_hash_keys == ["name"]
-        assert not component.progress_bar
-
-    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly.

--- a/test/preview/components/file_converters/test_tika_doc_converter.py
+++ b/test/preview/components/file_converters/test_tika_doc_converter.py
@@ -7,34 +7,6 @@ from haystack.preview.components.file_converters.tika import TikaDocumentConvert
 
 class TestTikaDocumentConverter:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = TikaDocumentConverter()
-        data = component.to_dict()
-        assert data == {
-            "type": "TikaDocumentConverter",
-            "init_parameters": {"tika_url": "http://localhost:9998/tika", "id_hash_keys": []},
-        }
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        component = TikaDocumentConverter(tika_url="http://localhost:1234/tika", id_hash_keys=["text", "category"])
-        data = component.to_dict()
-        assert data == {
-            "type": "TikaDocumentConverter",
-            "init_parameters": {"tika_url": "http://localhost:1234/tika", "id_hash_keys": ["text", "category"]},
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "TikaDocumentConverter",
-            "init_parameters": {"tika_url": "http://localhost:9998/tika", "id_hash_keys": ["text", "category"]},
-        }
-        component = TikaDocumentConverter.from_dict(data)
-        assert component.tika_url == "http://localhost:9998/tika"
-        assert component.id_hash_keys == ["text", "category"]
-
-    @pytest.mark.unit
     def test_run(self):
         component = TikaDocumentConverter()
         with patch("haystack.preview.components.file_converters.tika.tika_parser.from_file") as mock_tika_parser:

--- a/test/preview/components/generators/hugging_face/test_hugging_face_local_generator.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_local_generator.py
@@ -182,31 +182,6 @@ class TestHuggingFaceLocalGenerator:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "HuggingFaceLocalGenerator",
-            "init_parameters": {
-                "pipeline_kwargs": {
-                    "model": "gpt2",
-                    "task": "text-generation",
-                    "token": "test-token",
-                    "device": "cuda:0",
-                },
-                "generation_kwargs": {"max_new_tokens": 100, "return_full_text": False},
-            },
-        }
-
-        component = HuggingFaceLocalGenerator.from_dict(data)
-
-        assert component.pipeline_kwargs == {
-            "model": "gpt2",
-            "task": "text-generation",
-            "token": "test-token",
-            "device": "cuda:0",
-        }
-        assert component.generation_kwargs == {"max_new_tokens": 100, "return_full_text": False}
-
-    @pytest.mark.unit
     @patch("haystack.preview.components.generators.hugging_face.hugging_face_local.pipeline")
     def test_warm_up(self, pipeline_mock):
         generator = HuggingFaceLocalGenerator(

--- a/test/preview/components/preprocessors/test_text_document_cleaner.py
+++ b/test/preview/components/preprocessors/test_text_document_cleaner.py
@@ -17,61 +17,6 @@ class TestDocumentCleaner:
         assert cleaner.remove_regex is None
 
     @pytest.mark.unit
-    def test_to_dict(self):
-        cleaner = DocumentCleaner()
-        data = cleaner.to_dict()
-        assert data == {
-            "type": "DocumentCleaner",
-            "init_parameters": {
-                "remove_empty_lines": True,
-                "remove_extra_whitespaces": True,
-                "remove_repeated_substrings": False,
-                "remove_substrings": None,
-                "remove_regex": None,
-            },
-        }
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        cleaner = DocumentCleaner(
-            remove_empty_lines=False,
-            remove_extra_whitespaces=False,
-            remove_repeated_substrings=True,
-            remove_substrings=["a", "b"],
-            remove_regex=r"\s\s+",
-        )
-        data = cleaner.to_dict()
-        assert data == {
-            "type": "DocumentCleaner",
-            "init_parameters": {
-                "remove_empty_lines": False,
-                "remove_extra_whitespaces": False,
-                "remove_repeated_substrings": True,
-                "remove_substrings": ["a", "b"],
-                "remove_regex": r"\s\s+",
-            },
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "DocumentCleaner",
-            "init_parameters": {
-                "remove_empty_lines": False,
-                "remove_extra_whitespaces": False,
-                "remove_repeated_substrings": True,
-                "remove_substrings": ["a", "b"],
-                "remove_regex": r"\s\s+",
-            },
-        }
-        cleaner = DocumentCleaner.from_dict(data)
-        assert cleaner.remove_empty_lines == False
-        assert cleaner.remove_extra_whitespaces == False
-        assert cleaner.remove_repeated_substrings == True
-        assert cleaner.remove_substrings == ["a", "b"]
-        assert cleaner.remove_regex == r"\s\s+"
-
-    @pytest.mark.unit
     def test_non_text_document(self, caplog):
         with caplog.at_level(logging.WARNING):
             cleaner = DocumentCleaner()

--- a/test/preview/components/preprocessors/test_text_document_splitter.py
+++ b/test/preview/components/preprocessors/test_text_document_splitter.py
@@ -119,35 +119,6 @@ class TestTextDocumentSplitter:
         assert result["documents"][1].text == "is a second sentence. And there is a third sentence."
 
     @pytest.mark.unit
-    def test_to_dict(self):
-        splitter = TextDocumentSplitter()
-        data = splitter.to_dict()
-        assert data == {
-            "type": "TextDocumentSplitter",
-            "init_parameters": {"split_by": "word", "split_length": 200, "split_overlap": 0},
-        }
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        splitter = TextDocumentSplitter(split_by="passage", split_length=100, split_overlap=1)
-        data = splitter.to_dict()
-        assert data == {
-            "type": "TextDocumentSplitter",
-            "init_parameters": {"split_by": "passage", "split_length": 100, "split_overlap": 1},
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "TextDocumentSplitter",
-            "init_parameters": {"split_by": "passage", "split_length": 100, "split_overlap": 1},
-        }
-        splitter = TextDocumentSplitter.from_dict(data)
-        assert splitter.split_by == "passage"
-        assert splitter.split_length == 100
-        assert splitter.split_overlap == 1
-
-    @pytest.mark.unit
     def test_source_id_stored_in_metadata(self):
         splitter = TextDocumentSplitter(split_by="word", split_length=10)
         doc1 = Document(text="This is a text with some words.")

--- a/test/preview/components/preprocessors/test_text_language_classifier.py
+++ b/test/preview/components/preprocessors/test_text_language_classifier.py
@@ -7,18 +7,6 @@ from haystack.preview.components.preprocessors import TextLanguageClassifier
 
 class TestTextLanguageClassifier:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = TextLanguageClassifier(languages=["en", "de"])
-        data = component.to_dict()
-        assert data == {"type": "TextLanguageClassifier", "init_parameters": {"languages": ["en", "de"]}}
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {"type": "TextLanguageClassifier", "init_parameters": {"languages": ["en", "de"]}}
-        component = TextLanguageClassifier.from_dict(data)
-        assert component.languages == ["en", "de"]
-
-    @pytest.mark.unit
     def test_non_string_input(self):
         with pytest.raises(TypeError, match="TextLanguageClassifier expects a str as input."):
             classifier = TextLanguageClassifier()

--- a/test/preview/components/rankers/test_similarity.py
+++ b/test/preview/components/rankers/test_similarity.py
@@ -34,19 +34,6 @@ class TestSimilarityRanker:
         }
 
     @pytest.mark.integration
-    def test_from_dict(self):
-        data = {
-            "type": "SimilarityRanker",
-            "init_parameters": {
-                "device": "cpu",
-                "top_k": 10,
-                "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-            },
-        }
-        component = SimilarityRanker.from_dict(data)
-        assert component.model_name_or_path == "cross-encoder/ms-marco-MiniLM-L-6-v2"
-
-    @pytest.mark.integration
     @pytest.mark.parametrize(
         "query,docs_before_texts,expected_first_text",
         [

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -111,39 +111,6 @@ def test_to_dict():
 
 
 @pytest.mark.unit
-def test_from_dict():
-    data = {
-        "type": "ExtractiveReader",
-        "init_parameters": {
-            "model_name_or_path": "my-model",
-            "device": "cpu",
-            "token": None,
-            "top_k": 30,
-            "confidence_threshold": 0.5,
-            "max_seq_length": 300,
-            "stride": 100,
-            "max_batch_size": 20,
-            "answers_per_seq": 5,
-            "no_answer": False,
-            "calibration_factor": 0.5,
-        },
-    }
-
-    component = ExtractiveReader.from_dict(data)
-    assert component.model_name_or_path == "my-model"
-    assert component.device == "cpu"
-    assert component.token is None
-    assert component.top_k == 30
-    assert component.confidence_threshold == 0.5
-    assert component.max_seq_length == 300
-    assert component.stride == 100
-    assert component.max_batch_size == 20
-    assert component.answers_per_seq == 5
-    assert component.no_answer is False
-    assert component.calibration_factor == 0.5
-
-
-@pytest.mark.unit
 def test_output(mock_reader: ExtractiveReader):
     answers = mock_reader.run(example_queries[0], example_documents[0], top_k=3)[
         "answers"

--- a/test/preview/components/routers/test_file_router.py
+++ b/test/preview/components/routers/test_file_router.py
@@ -12,24 +12,6 @@ from haystack.preview.dataclasses import ByteStream
 )
 class TestFileTypeRouter:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
-        data = component.to_dict()
-        assert data == {
-            "type": "FileTypeRouter",
-            "init_parameters": {"mime_types": ["text/plain", "audio/x-wav", "image/jpeg"]},
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "FileTypeRouter",
-            "init_parameters": {"mime_types": ["text/plain", "audio/x-wav", "image/jpeg"]},
-        }
-        component = FileTypeRouter.from_dict(data)
-        assert component.mime_types == ["text/plain", "audio/x-wav", "image/jpeg"]
-
-    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly in the simplest happy path.

--- a/test/preview/components/routers/test_metadata_router.py
+++ b/test/preview/components/routers/test_metadata_router.py
@@ -6,24 +6,6 @@ from haystack.preview.components.routers.metadata_router import MetadataRouter
 
 class TestMetadataRouter:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = MetadataRouter(rules={"edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}}})
-        data = component.to_dict()
-        assert data == {
-            "type": "MetadataRouter",
-            "init_parameters": {"rules": {"edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}}}},
-        }
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "MetadataRouter",
-            "init_parameters": {"rules": {"edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}}}},
-        }
-        component = MetadataRouter.from_dict(data)
-        assert component.rules == {"edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}}}
-
-    @pytest.mark.unit
     def test_run(self):
         rules = {
             "edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}},

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -8,24 +8,6 @@ from haystack.preview.components.samplers.top_p import TopPSampler
 
 class TestTopPSampler:
     @pytest.mark.unit
-    def test_to_dict(self):
-        component = TopPSampler()
-        data = component.to_dict()
-        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 1.0, "score_field": None}}
-
-    @pytest.mark.unit
-    def test_to_dict_with_custom_init_parameters(self):
-        component = TopPSampler(top_p=0.92)
-        data = component.to_dict()
-        assert data == {"type": "TopPSampler", "init_parameters": {"top_p": 0.92, "score_field": None}}
-
-    @pytest.mark.unit
-    def test_from_dict(self):
-        data = {"type": "TopPSampler", "init_parameters": {"top_p": 0.9, "score_field": None}}
-        component = TopPSampler.from_dict(data)
-        assert component.top_p == 0.9
-
-    @pytest.mark.unit
     def test_run_scores_from_metadata(self):
         """
         Test if the component runs correctly with scores already in the metadata.

--- a/test/preview/components/websearch/test_serperdev.py
+++ b/test/preview/components/websearch/test_serperdev.py
@@ -125,23 +125,6 @@ class TestSerperDevSearchAPI:
         }
 
     @pytest.mark.unit
-    def test_from_dict(self):
-        data = {
-            "type": "SerperDevWebSearch",
-            "init_parameters": {
-                "api_key": "test_key",
-                "top_k": 10,
-                "allowed_domains": ["test.com"],
-                "search_params": {"param": "test"},
-            },
-        }
-        component = SerperDevWebSearch.from_dict(data)
-        assert component.api_key == "test_key"
-        assert component.top_k == 10
-        assert component.allowed_domains == ["test.com"]
-        assert component.search_params == {"param": "test"}
-
-    @pytest.mark.unit
     @pytest.mark.parametrize("top_k", [1, 5, 7])
     def test_web_search_top_k(self, mock_serper_dev_search_result, top_k: int):
         ws = SerperDevWebSearch(api_key="some_invalid_key", top_k=top_k)


### PR DESCRIPTION
### Related Issues

- Topic came up in a PR review: https://github.com/deepset-ai/haystack/pull/6037#discussion_r1363702349

### Proposed Changes:

- Remove implementations of `from_dict` and `to_dict` from all components where it has the same effect as the default implementation from Canals: https://github.com/deepset-ai/canals/blob/main/canals/serialization.py#L12-L13

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

`AzureOCRDocumentConverter` serializes the api_key and needs to be changed. Same for `SerperDevWebSearch`. I didn't want to address it as part of this PR.
For `RemoteWhisperTranscriber` I removed the `api_key` from the `to_dict` implementation.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
