### PR TITLE
Add `more-itertools` to preview dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ preview = [
 
   "Jinja2",
   "openai",
-  "pyyaml"
+  "pyyaml",
+  "more-itertools",  # TextDocumentSplitter
 ]
 inference = [
   "transformers[torch,sentencepiece]==4.32.1",


### PR DESCRIPTION
### Related Issues

Twin PR in the preview package: https://github.com/deepset-ai/haystack-preview-package/pull/10

`more-itertools` is a lightweight dependency needed by `TextDocumentSplitter`.

In most environments (e.g. Colab), it is already installed by other libraries, so it is difficult to notice its absence.

### Proposed Changes:

Add `more-itertools` to `preview` extra.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
