### PR TITLE
REST API - pin fastapi

### DIFF
--- a/rest_api/pyproject.toml
+++ b/rest_api/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "farm-haystack",
-    "fastapi<1",
+    "fastapi<0.104.0",  # https://github.com/deepset-ai/haystack/issues/6119
     "uvicorn<1",
     "python-multipart<1",  # optional FastAPI dependency for form data
     "pynvml",


### PR DESCRIPTION
### Related Issues

- related to #6119

### Proposed Changes:

Pin `fastapi<0.104.0`
It is a temporary workaround to make `farm-haystack[dev]` and REST API installable together and prevent failures like [this](https://github.com/deepset-ai/haystack/actions/runs/6572463510/job/17853669873).
Explained in depth in #6119.

### How did you test it?

Local test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
