### PR TITLE
refactor: Rework `Document.id` generation

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -133,9 +133,8 @@ class Document:
         blob = self.blob or None
         mime_type = self.mime_type or None
         metadata = self.metadata or {}
-        score = self.score if self.score is not None else None
         embedding = self.embedding.tolist() if self.embedding is not None else None
-        data = f"{text}{array}{dataframe}{blob}{mime_type}{metadata}{score}{embedding}"
+        data = f"{text}{array}{dataframe}{blob}{mime_type}{metadata}{embedding}"
         return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
     def to_dict(self):

--- a/releasenotes/notes/doc-id-rework-85e82b5359282f7e.yaml
+++ b/releasenotes/notes/doc-id-rework-85e82b5359282f7e.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Rework `Document.id` generation, if an `id` is not explicitly set it's generated
+    using all `Document` fields

--- a/releasenotes/notes/doc-id-rework-85e82b5359282f7e.yaml
+++ b/releasenotes/notes/doc-id-rework-85e82b5359282f7e.yaml
@@ -2,4 +2,4 @@
 preview:
   - |
     Rework `Document.id` generation, if an `id` is not explicitly set it's generated
-    using all `Document` fields
+    using all `Document` field' values, `score` and `id_hash_keys` are not used.

--- a/test/preview/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/preview/components/retrievers/test_in_memory_embedding_retriever.py
@@ -7,6 +7,7 @@ from haystack.preview.testing.factory import document_store_class
 from haystack.preview.components.retrievers.in_memory_embedding_retriever import InMemoryEmbeddingRetriever
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores import InMemoryDocumentStore
+import numpy as np
 
 
 class TestMemoryEmbeddingRetriever:
@@ -117,9 +118,9 @@ class TestMemoryEmbeddingRetriever:
         top_k = 3
         ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
         docs = [
-            Document(text="my document", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="another document", embedding=[1.0, 1.0, 1.0, 1.0]),
-            Document(text="third document", embedding=[0.5, 0.7, 0.5, 0.7]),
+            Document(text="my document", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
+            Document(text="another document", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
+            Document(text="third document", embedding=np.array([0.5, 0.7, 0.5, 0.7])),
         ]
         ds.write_documents(docs)
 
@@ -128,7 +129,7 @@ class TestMemoryEmbeddingRetriever:
 
         assert "documents" in result
         assert len(result["documents"]) == top_k
-        assert result["documents"][0].embedding == [1.0, 1.0, 1.0, 1.0]
+        assert (result["documents"][0].embedding == [1.0, 1.0, 1.0, 1.0]).all()
 
     @pytest.mark.unit
     def test_invalid_run_wrong_store_type(self):
@@ -141,9 +142,9 @@ class TestMemoryEmbeddingRetriever:
         ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
         top_k = 2
         docs = [
-            Document(text="my document", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="another document", embedding=[1.0, 1.0, 1.0, 1.0]),
-            Document(text="third document", embedding=[0.5, 0.7, 0.5, 0.7]),
+            Document(text="my document", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
+            Document(text="another document", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
+            Document(text="third document", embedding=np.array([0.5, 0.7, 0.5, 0.7])),
         ]
         ds.write_documents(docs)
         retriever = InMemoryEmbeddingRetriever(ds, top_k=top_k)

--- a/test/preview/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/preview/components/retrievers/test_in_memory_embedding_retriever.py
@@ -129,7 +129,7 @@ class TestMemoryEmbeddingRetriever:
 
         assert "documents" in result
         assert len(result["documents"]) == top_k
-        assert (result["documents"][0].embedding == [1.0, 1.0, 1.0, 1.0]).all()
+        assert np.array_equal(result["documents"][0].embedding, [1.0, 1.0, 1.0, 1.0])
 
     @pytest.mark.unit
     def test_invalid_run_wrong_store_type(self):
@@ -160,4 +160,4 @@ class TestMemoryEmbeddingRetriever:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert len(results_docs) == top_k
-        assert (results_docs[0].embedding == [1.0, 1.0, 1.0, 1.0]).all()
+        assert np.array_equal(results_docs[0].embedding, [1.0, 1.0, 1.0, 1.0])

--- a/test/preview/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/preview/components/retrievers/test_in_memory_embedding_retriever.py
@@ -152,7 +152,7 @@ class TestMemoryEmbeddingRetriever:
         pipeline = Pipeline()
         pipeline.add_component("retriever", retriever)
         result: Dict[str, Any] = pipeline.run(
-            data={"retriever": {"query_embedding": [0.1, 0.1, 0.1, 0.1], "return_embedding": True}}
+            data={"retriever": {"query_embedding": np.array([0.1, 0.1, 0.1, 0.1]), "return_embedding": True}}
         )
 
         assert result
@@ -160,4 +160,4 @@ class TestMemoryEmbeddingRetriever:
         results_docs = result["retriever"]["documents"]
         assert results_docs
         assert len(results_docs) == top_k
-        assert results_docs[0].embedding == [1.0, 1.0, 1.0, 1.0]
+        assert (results_docs[0].embedding == [1.0, 1.0, 1.0, 1.0]).all()

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -87,6 +87,7 @@ def test_empty_document_to_dict():
         "blob": None,
         "mime_type": "text/plain",
         "metadata": {},
+        "id_hash_keys": ["text", "array", "dataframe", "blob"],
         "score": None,
         "embedding": None,
     }
@@ -106,6 +107,7 @@ def test_full_document_to_dict():
         blob=b"some bytes",
         mime_type="application/pdf",
         metadata={"some": "values", "test": 10},
+        id_hash_keys=["text", "array", "dataframe", "blob"],
         score=0.99,
         embedding=np.zeros([10, 10]),
     )
@@ -128,6 +130,7 @@ def test_full_document_to_dict():
         "text": "test text",
         "mime_type": "application/pdf",
         "metadata": {"some": "values", "test": 10},
+        "id_hash_keys": ["text", "array", "dataframe", "blob"],
         "score": 0.99,
     }
 
@@ -169,6 +172,7 @@ def test_empty_document_to_json():
             "dataframe": None,
             "mime_type": "text/plain",
             "metadata": {},
+            "id_hash_keys": ["text", "array", "dataframe", "blob"],
             "score": None,
             "embedding": None,
         }
@@ -193,6 +197,7 @@ def test_full_document_to_json(tmp_path):
         blob=b"some bytes",
         mime_type="application/pdf",
         metadata={"some object": TestClass(), "a path": tmp_path / "test.txt"},
+        id_hash_keys=["text", "array", "dataframe", "blob"],
         score=0.5,
         embedding=np.array([1, 2, 3, 4]),
     )
@@ -204,6 +209,7 @@ def test_full_document_to_json(tmp_path):
             "dataframe": '{"0":{"0":10,"1":20,"2":30}}',
             "mime_type": "application/pdf",
             "metadata": {"some object": "<the object>", "a path": str((tmp_path / "test.txt").absolute())},
+            "id_hash_keys": ["text", "array", "dataframe", "blob"],
             "score": 0.5,
             "embedding": [1, 2, 3, 4],
         }
@@ -267,6 +273,7 @@ def test_to_json_custom_encoder(tmp_path):
             "dataframe": None,
             "mime_type": "text/plain",
             "metadata": {"some object": "<<CUSTOM ENCODING>>"},
+            "id_hash_keys": ["text", "array", "dataframe", "blob"],
             "score": None,
             "embedding": None,
         },
@@ -322,6 +329,7 @@ def test_flatten_document_no_meta():
         "mime_type": "text/plain",
         "score": None,
         "embedding": None,
+        "id_hash_keys": ["text", "array", "dataframe", "blob"],
     }
 
 
@@ -339,6 +347,7 @@ def test_flatten_document_with_flat_meta():
         "embedding": None,
         "some-key": "a value",
         "another-key": "another value!",
+        "id_hash_keys": ["text", "array", "dataframe", "blob"],
     }
 
 
@@ -356,4 +365,5 @@ def test_flatten_document_with_nested_meta():
         "embedding": None,
         "some-key": "a value",
         "nested": {"key": 10, "key2": 50},
+        "id_hash_keys": ["text", "array", "dataframe", "blob"],
     }

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -36,76 +36,6 @@ def test_document_str(doc, doc_str):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "doc1_data,doc2_data",
-    [
-        [{"text": "test text"}, {"text": "test text", "mime_type": "text/plain"}],
-        [{"text": "test text", "mime_type": "text/html"}, {"text": "test text", "mime_type": "text/plain"}],
-        [{"text": "test text"}, {"text": "test text", "metadata": {"path": Path(__file__)}}],
-        [
-            {"text": "test text", "metadata": {"path": Path(__file__).parent}},
-            {"text": "test text", "metadata": {"path": Path(__file__)}},
-        ],
-        [{"text": "test text"}, {"text": "test text", "score": 200}],
-        [{"text": "test text", "score": 0}, {"text": "test text", "score": 200}],
-        [{"text": "test text"}, {"text": "test text", "embedding": np.array([1, 2, 3])}],
-        [
-            {"text": "test text", "embedding": np.array([100, 222, 345])},
-            {"text": "test text", "embedding": np.array([1, 2, 3])},
-        ],
-        [{"array": np.array(range(10))}, {"array": np.array(range(10))}],
-        [{"dataframe": pd.DataFrame([1, 2, 3])}, {"dataframe": pd.DataFrame([1, 2, 3])}],
-        [{"blob": b"some bytes"}, {"blob": b"some bytes"}],
-    ],
-)
-def test_id_hash_keys_default_fields_equal_id(doc1_data, doc2_data):
-    doc1 = Document.from_dict(doc1_data)
-    doc2 = Document.from_dict(doc2_data)
-    assert doc1.id == doc2.id
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "doc1_data,doc2_data",
-    [
-        [{"text": "test text"}, {"text": "test text "}],
-        [{"array": np.array(range(10))}, {"array": np.array(range(11))}],
-        [{"dataframe": pd.DataFrame([1, 2, 3])}, {"dataframe": pd.DataFrame([1, 2, 3, 4])}],
-        [{"blob": b"some bytes"}, {"blob": "something else".encode()}],
-    ],
-)
-def test_id_hash_keys_default_fields_different_ids(doc1_data, doc2_data):
-    doc1 = Document.from_dict(doc1_data)
-    doc2 = Document.from_dict(doc2_data)
-    assert doc1.id != doc2.id
-
-
-@pytest.mark.unit
-def test_id_hash_keys_changes_id():
-    doc1 = Document(text="test text", metadata={"some-value": "value"})
-    doc2 = Document(text="test text", metadata={"some-value": "value"}, id_hash_keys=["text", "some-value"])
-    assert doc1.id != doc2.id
-
-
-@pytest.mark.unit
-def test_id_hash_keys_field_may_be_missing(caplog):
-    doc1 = Document(text="test text", id_hash_keys=["something"])
-    doc2 = Document(text="test text", id_hash_keys=["something else"])
-    assert doc1.id == doc2.id
-    assert "is missing the following id_hash_keys: ['something']." in caplog.text
-    assert "is missing the following id_hash_keys: ['something else']." in caplog.text
-
-
-@pytest.mark.unit
-def test_id_hash_keys_is_set_to_default_if_invalid():
-    doc = Document(text="test text", id_hash_keys=None)
-    assert doc.id_hash_keys == ["text", "array", "dataframe", "blob"]
-
-    doc = Document(text="test text", id_hash_keys=[])
-    assert doc.id_hash_keys == ["text", "array", "dataframe", "blob"]
-
-
-@pytest.mark.unit
 def test_init_document_same_meta_as_main_fields():
     """
     This is forbidden to prevent later issues with `Document.flatten()`
@@ -140,12 +70,9 @@ def test_equality_with_metadata_with_objects():
             if type(self) == type(other):
                 return True
 
-    doc1 = Document(
-        text="test text", metadata={"value": np.array([0, 1, 2]), "path": Path(__file__), "obj": TestObject()}
-    )
-    doc2 = Document(
-        text="test text", metadata={"value": np.array([0, 1, 2]), "path": Path(__file__), "obj": TestObject()}
-    )
+    foo = TestObject()
+    doc1 = Document(text="test text", metadata={"value": np.array([0, 1, 2]), "path": Path("."), "obj": foo})
+    doc2 = Document(text="test text", metadata={"value": np.array([0, 1, 2]), "path": Path("."), "obj": foo})
     assert doc1 == doc2
 
 
@@ -160,7 +87,6 @@ def test_empty_document_to_dict():
         "blob": None,
         "mime_type": "text/plain",
         "metadata": {},
-        "id_hash_keys": ["text", "array", "dataframe", "blob"],
         "score": None,
         "embedding": None,
     }
@@ -180,7 +106,6 @@ def test_full_document_to_dict():
         blob=b"some bytes",
         mime_type="application/pdf",
         metadata={"some": "values", "test": 10},
-        id_hash_keys=["test"],
         score=0.99,
         embedding=np.zeros([10, 10]),
     )
@@ -203,7 +128,6 @@ def test_full_document_to_dict():
         "text": "test text",
         "mime_type": "application/pdf",
         "metadata": {"some": "values", "test": 10},
-        "id_hash_keys": ["test"],
         "score": 0.99,
     }
 
@@ -219,7 +143,6 @@ def test_document_with_most_attributes_from_dict():
             "blob": b"some bytes",
             "mime_type": "application/pdf",
             "metadata": {"some": "values", "test": 10},
-            "id_hash_keys": ["test"],
             "score": 0.99,
             "embedding": embedding,
         }
@@ -230,7 +153,6 @@ def test_document_with_most_attributes_from_dict():
         blob=b"some bytes",
         mime_type="application/pdf",
         metadata={"some": "values", "test": 10},
-        id_hash_keys=["test"],
         score=0.99,
         embedding=embedding,
     )
@@ -247,7 +169,6 @@ def test_empty_document_to_json():
             "dataframe": None,
             "mime_type": "text/plain",
             "metadata": {},
-            "id_hash_keys": ["text", "array", "dataframe", "blob"],
             "score": None,
             "embedding": None,
         }
@@ -272,7 +193,6 @@ def test_full_document_to_json(tmp_path):
         blob=b"some bytes",
         mime_type="application/pdf",
         metadata={"some object": TestClass(), "a path": tmp_path / "test.txt"},
-        id_hash_keys=["test"],
         score=0.5,
         embedding=np.array([1, 2, 3, 4]),
     )
@@ -284,7 +204,6 @@ def test_full_document_to_json(tmp_path):
             "dataframe": '{"0":{"0":10,"1":20,"2":30}}',
             "mime_type": "application/pdf",
             "metadata": {"some object": "<the object>", "a path": str((tmp_path / "test.txt").absolute())},
-            "id_hash_keys": ["test"],
             "score": 0.5,
             "embedding": [1, 2, 3, 4],
         }
@@ -308,7 +227,6 @@ def test_full_document_from_json(tmp_path):
                 "dataframe": '{"0":{"0":10,"1":20,"2":30}}',
                 "mime_type": "application/pdf",
                 "metadata": {"some object": "<the object>", "a path": str((tmp_path / "test.txt").absolute())},
-                "id_hash_keys": ["test"],
                 "score": 0.5,
                 "embedding": [1, 2, 3, 4],
             }
@@ -322,7 +240,6 @@ def test_full_document_from_json(tmp_path):
         mime_type="application/pdf",
         # Note the object serialization
         metadata={"some object": "<the object>", "a path": str((tmp_path / "test.txt").absolute())},
-        id_hash_keys=["test"],
         score=0.5,
         embedding=np.array([1, 2, 3, 4]),
     )
@@ -350,7 +267,6 @@ def test_to_json_custom_encoder(tmp_path):
             "dataframe": None,
             "mime_type": "text/plain",
             "metadata": {"some object": "<<CUSTOM ENCODING>>"},
-            "id_hash_keys": ["text", "array", "dataframe", "blob"],
             "score": None,
             "embedding": None,
         },
@@ -386,7 +302,6 @@ def test_from_json_custom_decoder():
                 "dataframe": None,
                 "mime_type": "text/plain",
                 "metadata": {"some object": "<<CUSTOM ENCODING>>"},
-                "id_hash_keys": ["text", "array", "dataframe", "blob"],
                 "score": None,
                 "embedding": None,
             }
@@ -405,7 +320,6 @@ def test_flatten_document_no_meta():
         "dataframe": None,
         "blob": None,
         "mime_type": "text/plain",
-        "id_hash_keys": ["text", "array", "dataframe", "blob"],
         "score": None,
         "embedding": None,
     }
@@ -421,7 +335,6 @@ def test_flatten_document_with_flat_meta():
         "dataframe": None,
         "blob": None,
         "mime_type": "text/plain",
-        "id_hash_keys": ["text", "array", "dataframe", "blob"],
         "score": None,
         "embedding": None,
         "some-key": "a value",
@@ -439,7 +352,6 @@ def test_flatten_document_with_nested_meta():
         "dataframe": None,
         "blob": None,
         "mime_type": "text/plain",
-        "id_hash_keys": ["text", "array", "dataframe", "blob"],
         "score": None,
         "embedding": None,
         "some-key": "a value",

--- a/test/preview/document_stores/test_in_memory.py
+++ b/test/preview/document_stores/test_in_memory.py
@@ -256,7 +256,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         # Tests if the embedding retrieval method returns the correct document based on the input query embedding.
         docs = [
-            Document(text="Hello world", embedding=np.array(np.array([0.1, 0.2, 0.3, 0.4]))),
+            Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
             Document(text="Haystack supports multiple languages", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
         ]
         docstore.write_documents(docs)

--- a/test/preview/document_stores/test_in_memory.py
+++ b/test/preview/document_stores/test_in_memory.py
@@ -256,12 +256,12 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         # Tests if the embedding retrieval method returns the correct document based on the input query embedding.
         docs = [
-            Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(text="Hello world", embedding=np.array(np.array([0.1, 0.2, 0.3, 0.4]))),
+            Document(text="Haystack supports multiple languages", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
         ]
         docstore.write_documents(docs)
         results = docstore.embedding_retrieval(
-            query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, filters={}, scale_score=False
+            query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=1, filters={}, scale_score=False
         )
         assert len(results) == 1
         assert results[0].text == "Haystack supports multiple languages"
@@ -280,7 +280,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         docstore = InMemoryDocumentStore()
         docs = [Document(text="Hello world"), Document(text="Haystack supports multiple languages")]
         docstore.write_documents(docs)
-        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
+        results = docstore.embedding_retrieval(query_embedding=np.array([0.1, 0.1, 0.1, 0.1]))
         assert len(results) == 0
         assert "No Documents found with embeddings. Returning empty list." in caplog.text
 
@@ -289,29 +289,29 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         caplog.set_level(logging.INFO)
         docstore = InMemoryDocumentStore()
         docs = [
-            Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
+            Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
             Document(text="Haystack supports multiple languages"),
         ]
         docstore.write_documents(docs)
-        docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
+        docstore.embedding_retrieval(query_embedding=np.array([0.1, 0.1, 0.1, 0.1]))
         assert "Skipping some Documents that don't have an embedding." in caplog.text
 
     @pytest.mark.unit
     def test_embedding_retrieval_documents_different_embedding_sizes(self):
         docstore = InMemoryDocumentStore()
         docs = [
-            Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="Haystack supports multiple languages", embedding=[1.0, 1.0]),
+            Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
+            Document(text="Haystack supports multiple languages", embedding=np.array([1.0, 1.0])),
         ]
         docstore.write_documents(docs)
 
         with pytest.raises(DocumentStoreError, match="The embedding size of all Documents should be the same."):
-            docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
+            docstore.embedding_retrieval(query_embedding=np.array([0.1, 0.1, 0.1, 0.1]))
 
     @pytest.mark.unit
     def test_embedding_retrieval_query_documents_different_embedding_sizes(self):
         docstore = InMemoryDocumentStore()
-        docs = [Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4])]
+        docs = [Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4]))]
         docstore.write_documents(docs)
 
         with pytest.raises(
@@ -324,61 +324,69 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
     def test_embedding_retrieval_with_different_top_k(self):
         docstore = InMemoryDocumentStore()
         docs = [
-            Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
-            Document(text="Python is a popular programming language", embedding=[0.5, 0.5, 0.5, 0.5]),
+            Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
+            Document(text="Haystack supports multiple languages", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
+            Document(text="Python is a popular programming language", embedding=np.array([0.5, 0.5, 0.5, 0.5])),
         ]
         docstore.write_documents(docs)
 
-        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=2)
+        results = docstore.embedding_retrieval(query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=2)
         assert len(results) == 2
 
-        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=3)
+        results = docstore.embedding_retrieval(query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=3)
         assert len(results) == 3
 
     @pytest.mark.unit
     def test_embedding_retrieval_with_scale_score(self):
         docstore = InMemoryDocumentStore()
         docs = [
-            Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
-            Document(text="Python is a popular programming language", embedding=[0.5, 0.5, 0.5, 0.5]),
+            Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
+            Document(text="Haystack supports multiple languages", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
+            Document(text="Python is a popular programming language", embedding=np.array([0.5, 0.5, 0.5, 0.5])),
         ]
         docstore.write_documents(docs)
 
-        results1 = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, scale_score=True)
+        results1 = docstore.embedding_retrieval(
+            query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=1, scale_score=True
+        )
         # Confirm that score is scaled between 0 and 1
         assert 0 <= results1[0].score <= 1
 
         # Same query, different scale, scores differ when not scaled
-        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, scale_score=False)
+        results = docstore.embedding_retrieval(
+            query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=1, scale_score=False
+        )
         assert results[0].score != results1[0].score
 
     @pytest.mark.unit
     def test_embedding_retrieval_return_embedding(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         docs = [
-            Document(text="Hello world", embedding=[0.1, 0.2, 0.3, 0.4]),
-            Document(text="Haystack supports multiple languages", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(text="Hello world", embedding=np.array([0.1, 0.2, 0.3, 0.4])),
+            Document(text="Haystack supports multiple languages", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
         ]
         docstore.write_documents(docs)
 
-        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, return_embedding=False)
+        results = docstore.embedding_retrieval(
+            query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=1, return_embedding=False
+        )
         assert results[0].embedding is None
 
-        results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, return_embedding=True)
-        assert results[0].embedding == [1.0, 1.0, 1.0, 1.0]
+        results = docstore.embedding_retrieval(
+            query_embedding=np.array([0.1, 0.1, 0.1, 0.1]), top_k=1, return_embedding=True
+        )
+        assert (results[0].embedding == np.array([1.0, 1.0, 1.0, 1.0])).all()
 
     @pytest.mark.unit
     def test_compute_cosine_similarity_scores(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         docs = [
-            Document(text="Document 1", embedding=[1.0, 0.0, 0.0, 0.0]),
-            Document(text="Document 2", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(text="Document 1", embedding=np.array([1.0, 0.0, 0.0, 0.0])),
+            Document(text="Document 2", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
         ]
 
         scores = docstore._compute_query_embedding_similarity_scores(
-            embedding=[0.1, 0.1, 0.1, 0.1], documents=docs, scale_score=False
+            embedding=np.array([0.1, 0.1, 0.1, 0.1]), documents=docs, scale_score=False
         )
         assert scores == [0.5, 1.0]
 
@@ -386,11 +394,11 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
     def test_compute_dot_product_similarity_scores(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="dot_product")
         docs = [
-            Document(text="Document 1", embedding=[1.0, 0.0, 0.0, 0.0]),
-            Document(text="Document 2", embedding=[1.0, 1.0, 1.0, 1.0]),
+            Document(text="Document 1", embedding=np.array([1.0, 0.0, 0.0, 0.0])),
+            Document(text="Document 2", embedding=np.array([1.0, 1.0, 1.0, 1.0])),
         ]
 
         scores = docstore._compute_query_embedding_similarity_scores(
-            embedding=[0.1, 0.1, 0.1, 0.1], documents=docs, scale_score=False
+            embedding=np.array([0.1, 0.1, 0.1, 0.1]), documents=docs, scale_score=False
         )
         assert scores == [0.1, 0.4]


### PR DESCRIPTION
### Proposed Changes:

Change how `Document.id` is generated when not explicitly set.
Now it uses all `Document` fields.

`Document.id_hash_keys` is not used anymore but it will removed in a later PR as there are several Components that sest it.

### How did you test it?

Ran unit tests.

### Notes for the reviewer

This is the first of a series of PRs to rework `Document`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
