### PR TITLE
refactor: Remove `id_hash_keys` from `DocumentCleaner`

### DIFF
--- a/haystack/preview/components/preprocessors/text_document_cleaner.py
+++ b/haystack/preview/components/preprocessors/text_document_cleaner.py
@@ -59,7 +59,7 @@ class DocumentCleaner:
     def run(self, documents: List[Document]):
         """
         Run the DocumentCleaner on the given list of documents.
-        The documents' metadata and id_hash_keys remain unchanged.
+        The documents' metadata remain unchanged.
         """
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError("DocumentCleaner expects a List of Documents as input.")
@@ -85,9 +85,7 @@ class DocumentCleaner:
             if self.remove_repeated_substrings:
                 text = self._remove_repeated_substrings(text)
 
-            cleaned_docs.append(
-                Document(text=text, metadata=deepcopy(doc.metadata), id_hash_keys=deepcopy(doc.id_hash_keys))
-            )
+            cleaned_docs.append(Document(text=text, metadata=deepcopy(doc.metadata)))
 
         return {"documents": cleaned_docs}
 

--- a/test/preview/components/preprocessors/test_text_document_cleaner.py
+++ b/test/preview/components/preprocessors/test_text_document_cleaner.py
@@ -125,16 +125,15 @@ class TestDocumentCleaner:
         assert result["documents"][0].text == expected_text
 
     @pytest.mark.unit
-    def test_copy_id_hash_keys_and_metadata(self):
+    def test_copy_metadata(self):
         cleaner = DocumentCleaner()
         documents = [
-            Document(text="Text. ", metadata={"name": "doc 0"}, id_hash_keys=["name"]),
-            Document(text="Text. ", metadata={"name": "doc 1"}, id_hash_keys=["name"]),
+            Document(text="Text. ", metadata={"name": "doc 0"}),
+            Document(text="Text. ", metadata={"name": "doc 1"}),
         ]
         result = cleaner.run(documents=documents)
         assert len(result["documents"]) == 2
         assert result["documents"][0].id != result["documents"][1].id
         for doc, cleaned_doc in zip(documents, result["documents"]):
-            assert doc.id_hash_keys == cleaned_doc.id_hash_keys
             assert doc.metadata == cleaned_doc.metadata
             assert cleaned_doc.text == "Text."


### PR DESCRIPTION
### Proposed Changes:

This PR changes `DocumentCleaner` so it doesn't build `Document` with `id_hash_keys` anymore.

### How did you test it?

Ran unit tests locally.

### Notes for the reviewer

Depends on #6122.

Release notes will be updated at a later time in a separate following PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
