### PR TITLE
refactor: Remove `id_hash_keys` from `TextDocumentSplitter`

### DIFF
--- a/haystack/preview/components/preprocessors/text_document_cleaner.py
+++ b/haystack/preview/components/preprocessors/text_document_cleaner.py
@@ -59,7 +59,7 @@ class DocumentCleaner:
     def run(self, documents: List[Document]):
         """
         Run the DocumentCleaner on the given list of documents.
-        The documents' metadata and id_hash_keys remain unchanged.
+        The documents' metadata remain unchanged.
         """
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError("DocumentCleaner expects a List of Documents as input.")
@@ -85,9 +85,7 @@ class DocumentCleaner:
             if self.remove_repeated_substrings:
                 text = self._remove_repeated_substrings(text)
 
-            cleaned_docs.append(
-                Document(text=text, metadata=deepcopy(doc.metadata), id_hash_keys=deepcopy(doc.id_hash_keys))
-            )
+            cleaned_docs.append(Document(text=text, metadata=deepcopy(doc.metadata)))
 
         return {"documents": cleaned_docs}
 

--- a/haystack/preview/components/preprocessors/text_document_splitter.py
+++ b/haystack/preview/components/preprocessors/text_document_splitter.py
@@ -39,7 +39,7 @@ class TextDocumentSplitter:
         Splits the documents by split_by after split_length units with an overlap of split_overlap units.
         Returns a list of documents with the split texts.
         A metadata field "source_id" is added to each document to keep track of the original document that was split.
-        Other metadata and id_hash_keys are copied from the original document.
+        Other metadata are copied from the original document.
         :param documents: The documents to split.
         :return: A list of documents with the split texts.
         """
@@ -56,9 +56,8 @@ class TextDocumentSplitter:
             units = self._split_into_units(doc.text, self.split_by)
             text_splits = self._concatenate_units(units, self.split_length, self.split_overlap)
             metadata = deepcopy(doc.metadata)
-            id_hash_keys = deepcopy(doc.id_hash_keys)
             metadata["source_id"] = doc.id
-            split_docs += [Document(text=txt, metadata=metadata, id_hash_keys=id_hash_keys) for txt in text_splits]
+            split_docs += [Document(text=txt, metadata=metadata) for txt in text_splits]
         return {"documents": split_docs}
 
     def _split_into_units(self, text: str, split_by: Literal["word", "sentence", "passage"]) -> List[str]:

--- a/test/preview/components/preprocessors/test_text_document_cleaner.py
+++ b/test/preview/components/preprocessors/test_text_document_cleaner.py
@@ -125,16 +125,15 @@ class TestDocumentCleaner:
         assert result["documents"][0].text == expected_text
 
     @pytest.mark.unit
-    def test_copy_id_hash_keys_and_metadata(self):
+    def test_copy_metadata(self):
         cleaner = DocumentCleaner()
         documents = [
-            Document(text="Text. ", metadata={"name": "doc 0"}, id_hash_keys=["name"]),
-            Document(text="Text. ", metadata={"name": "doc 1"}, id_hash_keys=["name"]),
+            Document(text="Text. ", metadata={"name": "doc 0"}),
+            Document(text="Text. ", metadata={"name": "doc 1"}),
         ]
         result = cleaner.run(documents=documents)
         assert len(result["documents"]) == 2
         assert result["documents"][0].id != result["documents"][1].id
         for doc, cleaned_doc in zip(documents, result["documents"]):
-            assert doc.id_hash_keys == cleaned_doc.id_hash_keys
             assert doc.metadata == cleaned_doc.metadata
             assert cleaned_doc.text == "Text."

--- a/test/preview/components/preprocessors/test_text_document_splitter.py
+++ b/test/preview/components/preprocessors/test_text_document_splitter.py
@@ -128,16 +128,15 @@ class TestTextDocumentSplitter:
         assert result["documents"][1].metadata["source_id"] == doc2.id
 
     @pytest.mark.unit
-    def test_copy_id_hash_keys_and_metadata(self):
+    def test_copy_metadata(self):
         splitter = TextDocumentSplitter(split_by="word", split_length=10)
         documents = [
-            Document(text="Text.", metadata={"name": "doc 0"}, id_hash_keys=["name"]),
-            Document(text="Text.", metadata={"name": "doc 1"}, id_hash_keys=["name"]),
+            Document(text="Text.", metadata={"name": "doc 0"}),
+            Document(text="Text.", metadata={"name": "doc 1"}),
         ]
         result = splitter.run(documents=documents)
         assert len(result["documents"]) == 2
         assert result["documents"][0].id != result["documents"][1].id
         for doc, split_doc in zip(documents, result["documents"]):
-            assert doc.id_hash_keys == split_doc.id_hash_keys
             assert doc.metadata.items() <= split_doc.metadata.items()
             assert split_doc.text == "Text."


### PR DESCRIPTION
### Proposed Changes:

This PR changes `TextDocumentSplitter` so it doesn't build `Document` with `id_hash_keys` anymore.

### How did you test it?

Ran unit tests locally.

### Notes for the reviewer

Depends on #6123.

Release notes will be updated at a later time in a separate following PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
