### PR TITLE
Enrich documents with embeddings for OpenAIDocumentEmbedder

### DIFF
--- a/haystack/preview/components/embedders/openai_document_embedder.py
+++ b/haystack/preview/components/embedders/openai_document_embedder.py
@@ -155,10 +155,7 @@ class OpenAIDocumentEmbedder:
 
         embeddings, metadata = self._embed_batch(texts_to_embed=texts_to_embed, batch_size=self.batch_size)
 
-        documents_with_embeddings = []
         for doc, emb in zip(documents, embeddings):
-            doc_as_dict = doc.to_dict()
-            doc_as_dict["embedding"] = emb
-            documents_with_embeddings.append(Document.from_dict(doc_as_dict))
+            doc.embedding = emb
 
-        return {"documents": documents_with_embeddings, "metadata": metadata}
+        return {"documents": documents, "metadata": metadata}

--- a/haystack/preview/components/embedders/openai_document_embedder.py
+++ b/haystack/preview/components/embedders/openai_document_embedder.py
@@ -112,7 +112,7 @@ class OpenAIDocumentEmbedder:
             texts_to_embed.append(text_to_embed)
         return texts_to_embed
 
-    def _embed_batch(self, texts_to_embed: List[str], batch_size: int) -> Tuple[List[str], Dict[str, Any]]:
+    def _embed_batch(self, texts_to_embed: List[str], batch_size: int) -> Tuple[List[List[float]], Dict[str, Any]]:
         """
         Embed a list of texts in batches.
         """

--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -86,7 +86,7 @@ class Document:
     metadata: Dict[str, Any] = field(default_factory=dict, hash=False)
     id_hash_keys: List[str] = field(default_factory=lambda: ["text", "array", "dataframe", "blob"], hash=False)
     score: Optional[float] = field(default=None, compare=False)
-    embedding: Optional[numpy.ndarray] = field(default=None, repr=False)
+    embedding: Optional[List[float]] = field(default=None, repr=False)
 
     def __str__(self):
         fields = [f"mimetype: '{self.mime_type}'"]

--- a/releasenotes/notes/refactor-openai-document-embedder.yaml
+++ b/releasenotes/notes/refactor-openai-document-embedder.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Refactor OpenAIDocumentEmbedder to enrich documents with embeddings instead of recreating them.


### PR DESCRIPTION
### Related Issues

- fixes a part of #6107 

Proposed Changes:
Enrich documents with embeddings instead of recreating documents for  OpenAIDocumentEmbedder.

Requesting Review:
@anakin87

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
