### PR TITLE
feat: add pipeline Yaml marshaller

### DIFF
--- a/haystack/preview/__init__.py
+++ b/haystack/preview/__init__.py
@@ -3,3 +3,17 @@ from canals.serialization import default_from_dict, default_to_dict
 from canals.errors import DeserializationError, ComponentError
 from haystack.preview.pipeline import Pipeline
 from haystack.preview.dataclasses import Document, Answer, GeneratedAnswer, ExtractedAnswer
+
+
+__all__ = [
+    "component",
+    "default_from_dict",
+    "default_to_dict",
+    "DeserializationError",
+    "ComponentError",
+    "Pipeline",
+    "Document",
+    "Answer",
+    "GeneratedAnswer",
+    "ExtractedAnswer",
+]

--- a/haystack/preview/marshal/__init__.py
+++ b/haystack/preview/marshal/__init__.py
@@ -1,0 +1,4 @@
+from haystack.preview.marshal.protocol import Marshaller
+from haystack.preview.marshal.yaml import YamlMarshaller
+
+__all__ = ["Marshaller", "YamlMarshaller"]

--- a/haystack/preview/marshal/protocol.py
+++ b/haystack/preview/marshal/protocol.py
@@ -1,0 +1,9 @@
+from typing import Protocol, Dict, Any, Union
+
+
+class Marshaller(Protocol):
+    def marshal(self, dict_: Dict[str, Any]) -> str:
+        ...
+
+    def unmarshal(self, data_: Union[str, bytes, bytearray]) -> Dict[str, Any]:
+        ...

--- a/haystack/preview/marshal/yaml.py
+++ b/haystack/preview/marshal/yaml.py
@@ -1,0 +1,11 @@
+from typing import Dict, Any, Union
+
+import yaml
+
+
+class YamlMarshaller:
+    def marshal(self, dict_: Dict[str, Any]) -> str:
+        return yaml.dump(dict_)
+
+    def unmarshal(self, data_: Union[str, bytes, bytearray]) -> Dict[str, Any]:
+        return yaml.safe_load(data_)

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -1,12 +1,14 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, TextIO
 from pathlib import Path
 import datetime
 import logging
 import canals
 
 from haystack.preview.telemetry import pipeline_running
+from haystack.preview.marshal import Marshaller, YamlMarshaller
 
 
+DEFAULT_MARSHALLER = YamlMarshaller()
 logger = logging.getLogger(__name__)
 
 
@@ -44,3 +46,17 @@ class Pipeline(canals.Pipeline):
         """
         pipeline_running(self)
         return super().run(data=data, debug=debug)
+
+    def dumps(self, marshaller: Marshaller = DEFAULT_MARSHALLER) -> str:
+        return marshaller.marshal(self.to_dict())
+
+    def dump(self, fp: TextIO, marshaller: Marshaller = DEFAULT_MARSHALLER):
+        fp.write(marshaller.marshal(self.to_dict()))
+
+    @classmethod
+    def loads(cls, data: Union[str, bytes, bytearray], marshaller: Marshaller = DEFAULT_MARSHALLER) -> "Pipeline":
+        return cls.from_dict(marshaller.unmarshal(data))
+
+    @classmethod
+    def load(cls, data: bytes, fp: TextIO, marshaller: Marshaller = DEFAULT_MARSHALLER) -> "Pipeline":
+        return cls.from_dict(marshaller.unmarshal(data))

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -48,15 +48,52 @@ class Pipeline(canals.Pipeline):
         return super().run(data=data, debug=debug)
 
     def dumps(self, marshaller: Marshaller = DEFAULT_MARSHALLER) -> str:
+        """
+        Returns the string representation of this pipeline according to the
+        format dictated by the `Marshaller` in use.
+
+        :params marshaller: The Marshaller used to create the string representation. Defaults to
+                            `YamlMarshaller`
+
+        :returns: A string representing the pipeline.
+        """
         return marshaller.marshal(self.to_dict())
 
     def dump(self, fp: TextIO, marshaller: Marshaller = DEFAULT_MARSHALLER):
+        """
+        Writes the string representation of this pipeline to the file-like object
+        passed in the `fp` argument.
+
+        :params fp: A file-like object ready to be written to.
+        :params marshaller: The Marshaller used to create the string representation. Defaults to
+                            `YamlMarshaller`.
+        """
         fp.write(marshaller.marshal(self.to_dict()))
 
     @classmethod
     def loads(cls, data: Union[str, bytes, bytearray], marshaller: Marshaller = DEFAULT_MARSHALLER) -> "Pipeline":
+        """
+        Creates a `Pipeline` object from the string representation passed in the `data` argument.
+
+        :params data: The string representation of the pipeline, can be `str`, `bytes` or `bytearray`.
+        :params marshaller: the Marshaller used to create the string representation. Defaults to
+                            `YamlMarshaller`
+
+        :returns: A `Pipeline` object.
+        """
         return cls.from_dict(marshaller.unmarshal(data))
 
     @classmethod
-    def load(cls, data: bytes, fp: TextIO, marshaller: Marshaller = DEFAULT_MARSHALLER) -> "Pipeline":
-        return cls.from_dict(marshaller.unmarshal(data))
+    def load(cls, fp: TextIO, marshaller: Marshaller = DEFAULT_MARSHALLER) -> "Pipeline":
+        """
+        Creates a `Pipeline` object from the string representation read from the file-like
+        object passed in the `fp` argument.
+
+        :params data: The string representation of the pipeline, can be `str`, `bytes` or `bytearray`.
+        :params fp: A file-like object ready to be read from.
+        :params marshaller: the Marshaller used to create the string representation. Defaults to
+                            `YamlMarshaller`
+
+        :returns: A `Pipeline` object.
+        """
+        return cls.from_dict(marshaller.unmarshal(fp.read()))

--- a/releasenotes/notes/add-yaml-marshaller-030e889f46484573.yaml
+++ b/releasenotes/notes/add-yaml-marshaller-030e889f46484573.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Add `dumps`, `dump`, `loads` and `load` methods to save
+    and load pipelines in Yaml format.

--- a/test/preview/test_files/yaml/test_pipeline.yaml
+++ b/test/preview/test_files/yaml/test_pipeline.yaml
@@ -1,0 +1,14 @@
+components:
+  Comp1:
+    init_parameters:
+      an_init_param: null
+    type: TestComponent
+  Comp2:
+    init_parameters:
+      an_init_param: null
+    type: TestComponent
+connections:
+- receiver: Comp2.input_
+  sender: Comp1.value
+max_loops_allowed: 99
+metadata: {}

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -38,3 +38,25 @@ def test_pipeline_loads(test_files_path):
         assert pipeline.max_loops_allowed == 99
         assert isinstance(pipeline.get_component("Comp1"), TestComponent)
         assert isinstance(pipeline.get_component("Comp2"), TestComponent)
+
+
+@pytest.mark.unit
+def test_pipeline_dump(pipeline, test_files_path, tmp_path):
+    pipeline.add_component("Comp1", TestComponent("Foo"))
+    pipeline.add_component("Comp2", TestComponent())
+    pipeline.connect("Comp1.value", "Comp2.input_")
+    pipeline.max_loops_allowed = 99
+    with open(tmp_path / "out.yaml", "w") as f:
+        pipeline.dump(f)
+    # re-open and ensure it's the same data as the test file
+    with open(f"{test_files_path}/yaml/test_pipeline.yaml", "r") as test_f, open(tmp_path / "out.yaml", "r") as f:
+        assert f.read() == test_f.read()
+
+
+@pytest.mark.unit
+def test_pipeline_load(test_files_path):
+    with open(f"{test_files_path}/yaml/test_pipeline.yaml", "r") as f:
+        pipeline = Pipeline.load(f)
+        assert pipeline.max_loops_allowed == 99
+        assert isinstance(pipeline.get_component("Comp1"), TestComponent)
+        assert isinstance(pipeline.get_component("Comp2"), TestComponent)

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+import pytest
+
+from haystack.preview import Pipeline, component
+
+
+@component
+class TestComponent:
+    def __init__(self, an_init_param: Optional[str] = None):
+        pass
+
+    @component.output_types(value=str)
+    def run(self, input_: str):
+        return {"value": input_}
+
+
+@pytest.fixture
+def pipeline():
+    return Pipeline()
+
+
+@pytest.mark.unit
+def test_pipeline_dumps(pipeline, test_files_path):
+    pipeline.add_component("Comp1", TestComponent("Foo"))
+    pipeline.add_component("Comp2", TestComponent())
+    pipeline.connect("Comp1.value", "Comp2.input_")
+    pipeline.max_loops_allowed = 99
+    result = pipeline.dumps()
+    with open(f"{test_files_path}/yaml/test_pipeline.yaml", "r") as f:
+        assert f.read() == result
+
+
+@pytest.mark.unit
+def test_pipeline_loads(test_files_path):
+    with open(f"{test_files_path}/yaml/test_pipeline.yaml", "r") as f:
+        pipeline = Pipeline.loads(f.read())
+        assert pipeline.max_loops_allowed == 99
+        assert isinstance(pipeline.get_component("Comp1"), TestComponent)
+        assert isinstance(pipeline.get_component("Comp2"), TestComponent)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/6010

### Proposed Changes:

We add the following methods to the `Pipeline` class:
- `dumps` to return its string representation
- `dump` to write its string representation to a file-like object passed to the method
- `loads` to return a `Pipeline` instance from its string representation
- `load` to return a `Pipeline` instance reading its string representation from a file-like object

All the methods can be invoked passing a `Marshaller` object that will determine what's the string representation format, defaulting to Yaml (the only format available at the moment).

### How did you test it?

Unit tests covering the default marshaller.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
