### PR TITLE
refactor: Remove api_key from serialization of `AzureOCRDocumentConverter` and `SerperDevWebSearch`

### DIFF
--- a/haystack/preview/components/file_converters/azure.py
+++ b/haystack/preview/components/file_converters/azure.py
@@ -30,7 +30,7 @@ class AzureOCRDocumentConverter:
         :param endpoint: The endpoint of your Azure resource.
         :param api_key: The key of your Azure resource. It can be
         explicitly provided or automatically read from the
-        environment variable CORE_AZURE_CS_API_KEY (recommended).
+        environment variable AZURE_AI_API_KEY (recommended).
         :param model_id: The model ID of the model you want to use. Please refer to [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/choose-model-feature)
             for a list of available models. Default: `"prebuilt-read"`.
         """
@@ -38,11 +38,11 @@ class AzureOCRDocumentConverter:
 
         if api_key is None:
             try:
-                api_key = os.environ["CORE_AZURE_CS_API_KEY"]
+                api_key = os.environ["AZURE_AI_API_KEY"]
             except KeyError as e:
                 raise ValueError(
                     "AzureOCRDocumentConverter expects an Azure Credential key. "
-                    "Set the CORE_AZURE_CS_API_KEY environment variable (recommended) or pass it explicitly."
+                    "Set the AZURE_AI_API_KEY environment variable (recommended) or pass it explicitly."
                 ) from e
 
         self.api_key = api_key

--- a/haystack/preview/components/file_converters/azure.py
+++ b/haystack/preview/components/file_converters/azure.py
@@ -28,8 +28,9 @@ class AzureOCRDocumentConverter:
         Create an AzureOCRDocumentConverter component.
 
         :param endpoint: The endpoint of your Azure resource.
-        :param api_key: The key of your Azure resource. It can be explicitly provided or automatically read from the
-                        environment variable CORE_AZURE_CS_API_KEY (recommended).
+        :param api_key: The key of your Azure resource. It can be
+        explicitly provided or automatically read from the
+        environment variable CORE_AZURE_CS_API_KEY (recommended).
         :param model_id: The model ID of the model you want to use. Please refer to [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/choose-model-feature)
             for a list of available models. Default: `"prebuilt-read"`.
         """
@@ -44,6 +45,7 @@ class AzureOCRDocumentConverter:
                     "Set the CORE_AZURE_CS_API_KEY environment variable (recommended) or pass it explicitly."
                 ) from e
 
+        self.api_key = api_key
         self.document_analysis_client = DocumentAnalysisClient(
             endpoint=endpoint, credential=AzureKeyCredential(api_key)
         )

--- a/haystack/preview/components/websearch/serper_dev.py
+++ b/haystack/preview/components/websearch/serper_dev.py
@@ -1,4 +1,5 @@
 import json
+import os
 import logging
 from typing import Dict, List, Optional, Any
 
@@ -26,13 +27,15 @@ class SerperDevWebSearch:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: Optional[str] = None,
         top_k: Optional[int] = 10,
         allowed_domains: Optional[List[str]] = None,
         search_params: Optional[Dict[str, Any]] = None,
     ):
         """
-        :param api_key: API key for the SerperDev API.
+        :param api_key: API key for the SerperDev API.  It can be
+        explicitly provided or automatically read from the
+        environment variable SERPERDEV_API_KEY (recommended).
         :param top_k: Number of documents to return.
         :param allowed_domains: List of domains to limit the search to.
         :param search_params: Additional parameters passed to the SerperDev API.
@@ -40,6 +43,13 @@ class SerperDevWebSearch:
         See the [Serper Dev website](https://serper.dev/) for more details.
         """
         if api_key is None:
+            try:
+                api_key = os.environ["SERPERDEV_API_KEY"]
+            except KeyError as e:
+                raise ValueError(
+                    "SerperDevWebSearch expects an API key. "
+                    "Set the SERPERDEV_API_KEY environment variable (recommended) or pass it explicitly."
+                ) from e
             raise ValueError("API key for SerperDev API must be set.")
         self.api_key = api_key
         self.top_k = top_k
@@ -51,11 +61,7 @@ class SerperDevWebSearch:
         Serialize this component to a dictionary.
         """
         return default_to_dict(
-            self,
-            api_key=self.api_key,
-            top_k=self.top_k,
-            allowed_domains=self.allowed_domains,
-            search_params=self.search_params,
+            self, top_k=self.top_k, allowed_domains=self.allowed_domains, search_params=self.search_params
         )
 
     @component.output_types(documents=List[Document], links=List[str])

--- a/releasenotes/notes/remove-api-key-from-serialization-2474a1539b86e233.yaml
+++ b/releasenotes/notes/remove-api-key-from-serialization-2474a1539b86e233.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Remove "api_key" from serialization of AzureOCRDocumentConverter and SerperDevWebSearch.

--- a/test/preview/components/file_converters/test_azure_ocr_doc_converter.py
+++ b/test/preview/components/file_converters/test_azure_ocr_doc_converter.py
@@ -8,16 +8,18 @@ from haystack.preview.components.file_converters.azure import AzureOCRDocumentCo
 
 class TestAzureOCRDocumentConverter:
     @pytest.mark.unit
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv("CORE_AZURE_CS_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="AzureOCRDocumentConverter expects an Azure Credential key"):
+            AzureOCRDocumentConverter(endpoint="test_endpoint")
+
+    @pytest.mark.unit
     def test_to_dict(self):
         component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
         data = component.to_dict()
         assert data == {
             "type": "AzureOCRDocumentConverter",
-            "init_parameters": {
-                "api_key": "test_credential_key",
-                "endpoint": "test_endpoint",
-                "model_id": "prebuilt-read",
-            },
+            "init_parameters": {"endpoint": "test_endpoint", "model_id": "prebuilt-read"},
         }
 
     @pytest.mark.unit

--- a/test/preview/components/file_converters/test_azure_ocr_doc_converter.py
+++ b/test/preview/components/file_converters/test_azure_ocr_doc_converter.py
@@ -9,7 +9,7 @@ from haystack.preview.components.file_converters.azure import AzureOCRDocumentCo
 class TestAzureOCRDocumentConverter:
     @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
-        monkeypatch.delenv("CORE_AZURE_CS_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_AI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="AzureOCRDocumentConverter expects an Azure Credential key"):
             AzureOCRDocumentConverter(endpoint="test_endpoint")
 

--- a/test/preview/components/websearch/test_serperdev.py
+++ b/test/preview/components/websearch/test_serperdev.py
@@ -116,12 +116,7 @@ class TestSerperDevSearchAPI:
         data = component.to_dict()
         assert data == {
             "type": "SerperDevWebSearch",
-            "init_parameters": {
-                "api_key": "test_key",
-                "top_k": 10,
-                "allowed_domains": ["test.com"],
-                "search_params": {"param": "test"},
-            },
+            "init_parameters": {"top_k": 10, "allowed_domains": ["test.com"], "search_params": {"param": "test"}},
         }
 
     @pytest.mark.unit

--- a/test/preview/components/websearch/test_serperdev.py
+++ b/test/preview/components/websearch/test_serperdev.py
@@ -109,6 +109,12 @@ def mock_serper_dev_search_result():
 
 class TestSerperDevSearchAPI:
     @pytest.mark.unit
+    def test_init_fail_wo_api_key(self, monkeypatch):
+        monkeypatch.delenv("SERPERDEV_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="SerperDevWebSearch expects an API key"):
+            SerperDevWebSearch()
+
+    @pytest.mark.unit
     def test_to_dict(self):
         component = SerperDevWebSearch(
             api_key="test_key", top_k=10, allowed_domains=["test.com"], search_params={"param": "test"}


### PR DESCRIPTION
### Related Issues

- fixes #6116 

### Proposed Changes:

Remove `api_key` from serialization of `AzureOCRDocumentConverter` and `SerperDevWebSearch`

### How did you test it?

Unit Tests have been updated to test the serialization without `api_key`.

### Notes for the reviewer

I have opened a PR (https://github.com/deepset-ai/haystack/pull/6149) for migrating `RemoteWhisperTranscriber` to the OpenAI SDK. The `RemoteWhisperTranscriber` implementation in that PR does not serialize the `api_key` and is fixed as part of that PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
