### PR TITLE
feature: Add `mime_type` field to `ByteStream`

### DIFF
--- a/haystack/preview/dataclasses/byte_stream.py
+++ b/haystack/preview/dataclasses/byte_stream.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Any
+from typing import Optional, Dict, Any
 
 
 @dataclass(frozen=True)
@@ -11,27 +11,28 @@ class ByteStream:
 
     data: bytes
     metadata: Dict[str, Any] = field(default_factory=dict, hash=False)
+    mime_type: Optional[str] = field(default=None)
 
     def to_file(self, destination_path: Path):
         with open(destination_path, "wb") as fd:
             fd.write(self.data)
 
     @classmethod
-    def from_file_path(cls, filepath: Path) -> "ByteStream":
+    def from_file_path(cls, filepath: Path, mime_type: Optional[str] = None) -> "ByteStream":
         """
         Create a ByteStream from the contents read from a file.
 
         :param filepath: A valid path to a file.
         """
         with open(filepath, "rb") as fd:
-            return cls(data=fd.read())
+            return cls(data=fd.read(), mime_type=mime_type)
 
     @classmethod
-    def from_string(cls, text: str, encoding: str = "utf-8") -> "ByteStream":
+    def from_string(cls, text: str, encoding: str = "utf-8", mime_type: Optional[str] = None) -> "ByteStream":
         """
         Create a ByteStream encoding a string.
 
         :param text: The string to encode
         :param encoding: The encoding used to convert the string into bytes
         """
-        return cls(data=text.encode(encoding))
+        return cls(data=text.encode(encoding), mime_type=mime_type)

--- a/releasenotes/notes/byte-stream-mime-type-b060e96791c4993a.yaml
+++ b/releasenotes/notes/byte-stream-mime-type-b060e96791c4993a.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Add `mime_type` field to `ByteStream` dataclass.

--- a/test/preview/dataclasses/test_byte_stream.py
+++ b/test/preview/dataclasses/test_byte_stream.py
@@ -14,6 +14,11 @@ def test_from_file_path(tmp_path, request):
 
     b = ByteStream.from_file_path(test_path)
     assert b.data == test_bytes
+    assert b.mime_type == None
+
+    b = ByteStream.from_file_path(test_path, mime_type="text/plain")
+    assert b.data == test_bytes
+    assert b.mime_type == "text/plain"
 
 
 @pytest.mark.unit
@@ -21,6 +26,11 @@ def test_from_string():
     test_string = "Hello, world!"
     b = ByteStream.from_string(test_string)
     assert b.data.decode() == test_string
+    assert b.mime_type == None
+
+    b = ByteStream.from_string(test_string, mime_type="text/plain")
+    assert b.data.decode() == test_string
+    assert b.mime_type == "text/plain"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Proposed Changes:

Add `mime_type` field to `ByteStream` dataclass.

### How did you test it?

Ran unit tests locally.

### Notes for the reviewer

We're going to remove `mime_type` in `Document` and change `blob` to `ByteStream` after this.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
