### PR TITLE
refactor: Remove `Document.__str__()`

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -70,17 +70,6 @@ class Document:
     score: Optional[float] = field(default=None)
     embedding: Optional[List[float]] = field(default=None, repr=False)
 
-    def __str__(self):
-        fields = [f"mimetype: '{self.mime_type}'"]
-        if self.text is not None:
-            fields.append(f"text: '{self.text}'" if len(self.text) < 100 else f"text: '{self.text[:100]}...'")
-        if self.dataframe is not None:
-            fields.append(f"dataframe: {self.dataframe.shape}")
-        if self.blob is not None:
-            fields.append(f"blob: {len(self.blob)} bytes")
-        fields_str = ", ".join(fields)
-        return f"{self.__class__.__name__}(id={self.id}, {fields_str})"
-
     def __eq__(self, other):
         """
         Compares documents for equality. Uses the id to check whether the documents are supposed to be the same.

--- a/releasenotes/notes/document-str-remove-e8dbfbc2fa709ade.yaml
+++ b/releasenotes/notes/document-str-remove-e8dbfbc2fa709ade.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Remove `Document.__str__()`

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -1,36 +1,11 @@
 import json
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import pytest
 
 from haystack.preview import Document
 from haystack.preview.dataclasses.document import DocumentDecoder, DocumentEncoder
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "doc,doc_str",
-    [
-        (Document(text="test text"), "text: 'test text'"),
-        (
-            Document(dataframe=pd.DataFrame([["John", 25], ["Martha", 34]], columns=["name", "age"])),
-            "dataframe: (2, 2)",
-        ),
-        (Document(blob=bytes("hello, test string".encode("utf-8"))), "blob: 18 bytes"),
-        (
-            Document(
-                text="test text",
-                dataframe=pd.DataFrame([["John", 25], ["Martha", 34]], columns=["name", "age"]),
-                blob=bytes("hello, test string".encode("utf-8")),
-            ),
-            "text: 'test text', dataframe: (2, 2), blob: 18 bytes",
-        ),
-    ],
-)
-def test_document_str(doc, doc_str):
-    assert f"Document(id={doc.id}, mimetype: 'text/plain', {doc_str})" == str(doc)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Proposed Changes:

Remove `Document.__str__()` as it's not necessary.

### How did you test it?

Ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
