### PR TITLE
feat: Update GPTGenerator to use ChatMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ First, run the minimal Haystack installation:
 pip install farm-haystack
 ```
 
-Then, index your data to the DocumentStore, build a RAG pipeline, and ask a question on your data: 
+Then, index your data to the DocumentStore, build a RAG pipeline, and ask a question on your data:
 
 ```python
 from haystack.document_stores import InMemoryDocumentStore

--- a/haystack/preview/dataclasses/chat_message.py
+++ b/haystack/preview/dataclasses/chat_message.py
@@ -38,14 +38,15 @@ class ChatMessage:
         return self.role == role
 
     @classmethod
-    def from_assistant(cls, content: str) -> "ChatMessage":
+    def from_assistant(cls, content: str, metadata: Optional[Dict[str, Any]] = None) -> "ChatMessage":
         """
         Create a message from the assistant.
 
         :param content: The text content of the message.
+        :param metadata: Additional metadata associated with the message.
         :return: A new ChatMessage instance.
         """
-        return cls(content, ChatRole.ASSISTANT, None)
+        return cls(content, ChatRole.ASSISTANT, None, metadata or {})
 
     @classmethod
     def from_user(cls, content: str) -> "ChatMessage":

--- a/releasenotes/notes/adapt-generator-for-chat-message-da24c312ee83cfbc.yaml
+++ b/releasenotes/notes/adapt-generator-for-chat-message-da24c312ee83cfbc.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Adapt GPTGenerator to use ChatMessage format for input and output.


### PR DESCRIPTION
### Why?

This PR comes from a need to standardize message handling across chat model components by utilizing `ChatMessage` data class. The modification will ensure that both `GPTGenerator` and `PromptBuilder` are aligned with this standard, which will, in turn, facilitate more consistent handling of chat messages within and across components.

### What?

~~1. **`PromptBuilder` Changes:**
    - Updates the initialization method to accept either a template string or template variables.
    - Incorporates `ChatMessage` data structure in the `run` method to handle messages.
    - Modifies the `to_dict` method to ensure proper serialization of `PromptBuilder`.
    - See this [colab](https://colab.research.google.com/drive/1cstp8EBBOfB3A_WGZS0k9iUuZiUy0xgd) to understand the change better~~
These changes ☝️ were handled in https://github.com/deepset-ai/haystack/pull/6161

2. **`GPTGenerator` Changes:**
    - Modifies the `run` method to utilize `ChatMessage` for handling prompts and replies.
    - Refactors existing methods and updates the test suite to reflect these changes.

3. **Dataclass `ChatMessage` Enhancements:**
    - Updates the `from_assistant` method to accept optional metadata.

4. **Test Coverage Improvements:**
    - Updates the tests in `test_gpt_generator.py` to reflect the utilization of `ChatMessage`.

### How can it be used?

The updated `GPTGenerator` and `PromptBuilder` components can now handle `ChatMessage` instances that standardize how messages are handled and passed around in the pipeline. Users can pass both `str` and `ChatMessage` instances to these components and expect consistent behaviour across different components in the system.

To notice the changes on a concrete example, please have a look at string message colab [notebok](https://colab.research.google.com/drive/1-gznXelh3cYE0Ny57aBR-23wvLhGmcSE#scrollTo=QJJ5AT3Z79e3) as well as the chat message approach in this [notebook](https://colab.research.google.com/drive/14_-4o2597r8n8b7_k1RVyVCReg4iIwEh)

### How did you test it?

The modifications have been tested by updating the existing test suite in `test_gpt_generator.py`. The tests now reflect the use of `ChatMessage` and ensure that the `GPTGenerator` and `PromptBuilder` components function as expected with these changes.


### Notice for Reviewer

- Yes, it would be nice to isolate PromptBuilder changes in another PR, but the use of `ChatMessage` requires adapting PromptBuilder. We can alternatively leave PromptBuilder as it is temporarily, knowing that it can't handle `ChatMessage`, and then briefly, after merging this PR, we can issue another PR related to PromptBuilder changes
