### PR TITLE
refactor: `Document` serialization to json

### DIFF
--- a/haystack/preview/components/caching/url_cache_checker.py
+++ b/haystack/preview/components/caching/url_cache_checker.py
@@ -11,7 +11,7 @@ class UrlCacheChecker:
     implement caching functionality within web retrieval pipelines that use a Document Store.
     """
 
-    def __init__(self, document_store: DocumentStore, url_field: str = "url"):
+    def __init__(self, document_store: DocumentStore, url_field: str = "metadata.url"):
         """
         Create a UrlCacheChecker component.
         """

--- a/haystack/preview/components/routers/metadata_router.py
+++ b/haystack/preview/components/routers/metadata_router.py
@@ -19,10 +19,10 @@ class MetadataRouter:
                       follow the format of filtering expressions in Haystack. For example:
                       ```python
                       {
-                            "edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}},
-                            "edge_2": {"created_at": {"$gte": "2023-04-01", "$lt": "2023-07-01"}},
-                            "edge_3": {"created_at": {"$gte": "2023-07-01", "$lt": "2023-10-01"}},
-                            "edge_4": {"created_at": {"$gte": "2023-10-01", "$lt": "2024-01-01"}},
+                            "edge_1": {"metadata.created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}},
+                            "edge_2": {"metadata.created_at": {"$gte": "2023-04-01", "$lt": "2023-07-01"}},
+                            "edge_3": {"metadata.created_at": {"$gte": "2023-07-01", "$lt": "2023-10-01"}},
+                            "edge_4": {"metadata.created_at": {"$gte": "2023-10-01", "$lt": "2024-01-01"}},
                       }
                       ```
         """

--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -1,47 +1,12 @@
 import hashlib
 import json
 import logging
-from dataclasses import asdict, dataclass, field, fields
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Type
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
 
-import numpy
 import pandas
 
 logger = logging.getLogger(__name__)
-
-
-class DocumentEncoder(json.JSONEncoder):
-    """
-    Encodes more exotic datatypes like pandas dataframes or file paths.
-    """
-
-    def default(self, obj):
-        if isinstance(obj, numpy.ndarray):
-            return obj.tolist()
-        if isinstance(obj, pandas.DataFrame):
-            return obj.to_json()
-        if isinstance(obj, Path):
-            return str(obj.absolute())
-        try:
-            return json.JSONEncoder.default(self, obj)
-        except TypeError:
-            return str(obj)
-
-
-class DocumentDecoder(json.JSONDecoder):
-    """
-    Decodes more exotic datatypes like pandas dataframes or file paths.
-    """
-
-    def __init__(self, *_, object_hook=None, **__):
-        super().__init__(object_hook=object_hook or self.document_decoder)
-
-    def document_decoder(self, dictionary):
-        if "dataframe" in dictionary and dictionary.get("dataframe"):
-            dictionary["dataframe"] = pandas.read_json(dictionary.get("dataframe", None))
-
-        return dictionary
 
 
 @dataclass
@@ -56,7 +21,7 @@ class Document:
     :param dataframe: Pandas dataframe with the document's content, if the document contains tabular data.
     :param blob: Binary data associated with the document, if the document has any binary data associated with it.
     :param mime_type: MIME type of the document. Defaults to "text/plain".
-    :param metadata: Additional custom metadata for the document.
+    :param metadata: Additional custom metadata for the document. Must be JSON serializable.
     :param score: Score of the document. Used for ranking, usually assigned by retrievers.
     :param embedding: Vector representation of the document.
     """
@@ -93,11 +58,6 @@ class Document:
         """
         Generate the ID based on the init parameters.
         """
-        # Validate metadata
-        for key in self.metadata:
-            if key in [field.name for field in fields(self)]:
-                raise ValueError(f"Cannot name metadata fields as top-level document fields, like '{key}'.")
-
         # Generate an id only if not explicitly set
         self.id = self.id or self._create_id()
 
@@ -114,41 +74,38 @@ class Document:
         data = f"{text}{dataframe}{blob}{mime_type}{metadata}{embedding}"
         return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """
-        Saves the Document into a dictionary.
+        Converts Document into a dictionary.
         """
         return asdict(self)
 
-    def to_json(self, json_encoder: Optional[Type[DocumentEncoder]] = None, **json_kwargs):
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Document":
         """
-        Saves the Document into a JSON string that can be later loaded back. Drops all binary data from the blob field.
+        Creates a new Document object from a dictionary.
         """
-        dictionary = self.to_dict()
-        del dictionary["blob"]
-        return json.dumps(dictionary, cls=json_encoder or DocumentEncoder, **json_kwargs)
+        return cls(**data)
+
+    def to_json(self) -> str:
+        """
+        Converts Document into a JSON string.
+        """
+        data = self.to_dict()
+        if (dataframe := data.get("dataframe", None)) is not None:
+            data["dataframe"] = dataframe.to_json()
+        if blob := data.get("blob", None):
+            data["blob"] = list(blob)
+        return json.dumps(data)
 
     @classmethod
-    def from_dict(cls, dictionary):
-        """
-        Creates a new Document object from a dictionary of its fields.
-        """
-        return cls(**dictionary)
-
-    @classmethod
-    def from_json(cls, data, json_decoder: Optional[Type[DocumentDecoder]] = None, **json_kwargs):
+    def from_json(cls, data: str) -> "Document":
         """
         Creates a new Document object from a JSON string.
         """
-        dictionary = json.loads(data, cls=json_decoder or DocumentDecoder, **json_kwargs)
-        return cls.from_dict(dictionary=dictionary)
-
-    def flatten(self) -> Dict[str, Any]:
-        """
-        Returns a dictionary with all the fields of the document and the metadata on the same level.
-        This allows filtering by all document fields, not only the metadata.
-        """
-        dictionary = self.to_dict()
-        metadata = dictionary.pop("metadata", {})
-        dictionary = {**dictionary, **metadata}
-        return dictionary
+        loaded = json.loads(data)
+        if dataframe := loaded.get("dataframe", None):
+            loaded["dataframe"] = pandas.read_json(dataframe)
+        if blob := loaded.get("blob", None):
+            loaded["blob"] = bytes(blob)
+        return cls.from_dict(data=loaded)

--- a/haystack/preview/testing/document_store.py
+++ b/haystack/preview/testing/document_store.py
@@ -100,13 +100,13 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_simple_metadata_value(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": "100"})
+        result = docstore.filter_documents(filters={"metadata.page": "100"})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
 
     @pytest.mark.unit
     def test_filter_simple_list_single_element(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": ["100"]})
+        result = docstore.filter_documents(filters={"metadata.page": ["100"]})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
 
     @pytest.mark.unit
@@ -127,13 +127,13 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_simple_list_one_value(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": ["100"]})
+        result = docstore.filter_documents(filters={"metadata.page": ["100"]})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100"]])
 
     @pytest.mark.unit
     def test_filter_simple_list(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": ["100", "123"]})
+        result = docstore.filter_documents(filters={"metadata.page": ["100", "123"]})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100", "123"]]
         )
@@ -171,13 +171,13 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_eq_filter_explicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": {"$eq": "100"}})
+        result = docstore.filter_documents(filters={"metadata.page": {"$eq": "100"}})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
 
     @pytest.mark.unit
     def test_eq_filter_implicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": "100"})
+        result = docstore.filter_documents(filters={"metadata.page": "100"})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
 
     @pytest.mark.unit
@@ -203,7 +203,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_in_filter_explicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": {"$in": ["100", "123", "n.a."]}})
+        result = docstore.filter_documents(filters={"metadata.page": {"$in": ["100", "123", "n.a."]}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100", "123"]]
         )
@@ -211,7 +211,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_in_filter_implicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": ["100", "123", "n.a."]})
+        result = docstore.filter_documents(filters={"metadata.page": ["100", "123", "n.a."]})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100", "123"]]
         )
@@ -244,7 +244,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_ne_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": {"$ne": "100"}})
+        result = docstore.filter_documents(filters={"metadata.page": {"$ne": "100"}})
         assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") != "100"])
 
     @pytest.mark.unit
@@ -306,7 +306,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_nin_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"page": {"$nin": ["100", "123", "n.a."]}})
+        result = docstore.filter_documents(filters={"metadata.page": {"$nin": ["100", "123", "n.a."]}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if doc.metadata.get("page") not in ["100", "123"]]
         )
@@ -314,7 +314,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_gt_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$gt": 0.0}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$gt": 0.0}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] > 0]
         )
@@ -323,7 +323,7 @@ class DocumentStoreBaseTests:
     def test_gt_filter_non_numeric(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         with pytest.raises(FilterError):
-            docstore.filter_documents(filters={"page": {"$gt": "100"}})
+            docstore.filter_documents(filters={"metadata.page": {"$gt": "100"}})
 
     @pytest.mark.unit
     def test_gt_filter_table(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -341,7 +341,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_gte_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$gte": -2}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$gte": -2}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] >= -2]
         )
@@ -350,7 +350,7 @@ class DocumentStoreBaseTests:
     def test_gte_filter_non_numeric(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         with pytest.raises(FilterError):
-            docstore.filter_documents(filters={"page": {"$gte": "100"}})
+            docstore.filter_documents(filters={"metadata.page": {"$gte": "100"}})
 
     @pytest.mark.unit
     def test_gte_filter_table(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -368,7 +368,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_lt_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$lt": 0.0}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$lt": 0.0}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] < 0]
         )
@@ -377,7 +377,7 @@ class DocumentStoreBaseTests:
     def test_lt_filter_non_numeric(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         with pytest.raises(FilterError):
-            docstore.filter_documents(filters={"page": {"$lt": "100"}})
+            docstore.filter_documents(filters={"metadata.page": {"$lt": "100"}})
 
     @pytest.mark.unit
     def test_lt_filter_table(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -395,7 +395,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_lte_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$lte": 2.0}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$lte": 2.0}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] <= 2.0]
         )
@@ -404,7 +404,7 @@ class DocumentStoreBaseTests:
     def test_lte_filter_non_numeric(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         with pytest.raises(FilterError):
-            docstore.filter_documents(filters={"page": {"$lte": "100"}})
+            docstore.filter_documents(filters={"metadata.page": {"$lte": "100"}})
 
     @pytest.mark.unit
     def test_lte_filter_table(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -424,7 +424,7 @@ class DocumentStoreBaseTests:
         self, docstore: DocumentStore, filterable_docs: List[Document]
     ):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$lte": 2.0, "$gte": 0.0}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$lte": 2.0, "$gte": 0.0}})
         assert self.contains_same_docs(
             result,
             [
@@ -439,7 +439,7 @@ class DocumentStoreBaseTests:
         self, docstore: DocumentStore, filterable_docs: List[Document]
     ):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$and": {"$gte": 0, "$lte": 2}}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$and": {"$gte": 0, "$lte": 2}}})
         assert self.contains_same_docs(
             result, [doc for doc in filterable_docs if "number" in doc.metadata and 0 <= doc.metadata["number"] <= 2]
         )
@@ -447,7 +447,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_simple_explicit_and_with_list(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$and": [{"$lte": 2}, {"$gte": 0}]}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$and": [{"$lte": 2}, {"$gte": 0}]}})
         assert self.contains_same_docs(
             result,
             [
@@ -460,7 +460,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_simple_implicit_and(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        result = docstore.filter_documents(filters={"number": {"$lte": 2.0, "$gte": 0}})
+        result = docstore.filter_documents(filters={"metadata.number": {"$lte": 2.0, "$gte": 0}})
         assert self.contains_same_docs(
             result,
             [
@@ -473,7 +473,12 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_nested_explicit_and(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        filters = {"$and": {"number": {"$and": {"$lte": 2, "$gte": 0}}, "name": {"$in": ["name_0", "name_1"]}}}
+        filters = {
+            "$and": {
+                "metadata.number": {"$and": {"$lte": 2, "$gte": 0}},
+                "metadata.name": {"$in": ["name_0", "name_1"]},
+            }
+        }
         result = docstore.filter_documents(filters=filters)
         assert self.contains_same_docs(
             result,
@@ -492,7 +497,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_nested_implicit_and(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        filters_simplified = {"number": {"$lte": 2, "$gte": 0}, "name": ["name_0", "name_1"]}
+        filters_simplified = {"metadata.number": {"$lte": 2, "$gte": 0}, "metadata.name": ["name_0", "name_1"]}
         result = docstore.filter_documents(filters=filters_simplified)
         assert self.contains_same_docs(
             result,
@@ -511,7 +516,7 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_simple_or(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        filters = {"$or": {"name": {"$in": ["name_0", "name_1"]}, "number": {"$lt": 1.0}}}
+        filters = {"$or": {"metadata.name": {"$in": ["name_0", "name_1"]}, "metadata.number": {"$lt": 1.0}}}
         result = docstore.filter_documents(filters=filters)
         assert self.contains_same_docs(
             result,
@@ -528,7 +533,9 @@ class DocumentStoreBaseTests:
     @pytest.mark.unit
     def test_filter_nested_or(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
-        filters = {"$or": {"name": {"$or": [{"$eq": "name_0"}, {"$eq": "name_1"}]}, "number": {"$lt": 1.0}}}
+        filters = {
+            "$or": {"metadata.name": {"$or": [{"$eq": "name_0"}, {"$eq": "name_1"}]}, "metadata.number": {"$lt": 1.0}}
+        }
         result = docstore.filter_documents(filters=filters)
         assert self.contains_same_docs(
             result,
@@ -546,7 +553,10 @@ class DocumentStoreBaseTests:
     def test_filter_nested_and_or_explicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         filters_simplified = {
-            "$and": {"page": {"$eq": "123"}, "$or": {"name": {"$in": ["name_0", "name_1"]}, "number": {"$lt": 1.0}}}
+            "$and": {
+                "metadata.page": {"$eq": "123"},
+                "$or": {"metadata.name": {"$in": ["name_0", "name_1"]}, "metadata.number": {"$lt": 1.0}},
+            }
         }
         result = docstore.filter_documents(filters=filters_simplified)
         assert self.contains_same_docs(
@@ -568,8 +578,8 @@ class DocumentStoreBaseTests:
     def test_filter_nested_and_or_implicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         filters_simplified = {
-            "page": {"$eq": "123"},
-            "$or": {"name": {"$in": ["name_0", "name_1"]}, "number": {"$lt": 1.0}},
+            "metadata.page": {"$eq": "123"},
+            "$or": {"metadata.name": {"$in": ["name_0", "name_1"]}, "metadata.number": {"$lt": 1.0}},
         }
         result = docstore.filter_documents(filters=filters_simplified)
         assert self.contains_same_docs(
@@ -592,8 +602,11 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         filters_simplified = {
             "$or": {
-                "number": {"$lt": 1},
-                "$and": {"name": {"$in": ["name_0", "name_1"]}, "$not": {"chapter": {"$eq": "intro"}}},
+                "metadata.number": {"$lt": 1},
+                "$and": {
+                    "metadata.name": {"$in": ["name_0", "name_1"]},
+                    "$not": {"metadata.chapter": {"$eq": "intro"}},
+                },
             }
         }
         result = docstore.filter_documents(filters=filters_simplified)
@@ -619,8 +632,8 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         filters = {
             "$or": [
-                {"$and": {"name": {"$in": ["name_0", "name_1"]}, "page": "100"}},
-                {"$and": {"chapter": {"$in": ["intro", "abstract"]}, "page": "123"}},
+                {"$and": {"metadata.name": {"$in": ["name_0", "name_1"]}, "metadata.page": "100"}},
+                {"$and": {"metadata.chapter": {"$in": ["intro", "abstract"]}, "metadata.page": "123"}},
             ]
         }
         result = docstore.filter_documents(filters=filters)

--- a/releasenotes/notes/document-serialisation-rework-713031a64368aa1a.yaml
+++ b/releasenotes/notes/document-serialisation-rework-713031a64368aa1a.yaml
@@ -1,0 +1,27 @@
+---
+prelude: >
+  The `Document` serialisation has been changed quite a bit, this will make it easier to implement
+  new Document Stores. But it will also change how filters must be declared and how certain Components work.
+
+  The most notable change is that the `Document.flatten()` method has been removed as it was deemed dangerous.
+  Since it could overwrite a `Document` field if `metadata` contained a key with the same name.
+  Now `metadata` is not flattened anymore but it's stored as a `metadata` field.
+
+  Conversion to JSON has also been simplified. Previous implementation handled custom types in metadata by
+  giving the possibility to provide custom encoders and decoders to could handle whatever types.
+  This has now changed so `metadata` must only contain primitives that can be serialised to JSON with
+  no custom encoders. If any Document Store needs custom serialisation they can implement their own logic.
+
+  `dataframe` and `blob` field serialisation is handled internally by `Document`.
+
+  We also changed how Document Store's filters must be declared when filtering `metadata`.
+  The user must now set filters using the `metadata.` prefix. The filter can be nested multiple times.
+  e.g `metadata.person.age`, `metadata.create_date`
+
+  `UrlCacheChecker` default `url_field` has been changed from `url` to `metadata.url`.
+
+  The `DocumentStoreBaseTests` utility class to test Document Stores has been changed too to handle
+  the filters changes.
+preview:
+  - |
+    Refactor Document JSON serialisation

--- a/test/preview/components/caching/test_url_cache_checker.py
+++ b/test/preview/components/caching/test_url_cache_checker.py
@@ -16,7 +16,7 @@ class TestUrlCacheChecker:
             "type": "UrlCacheChecker",
             "init_parameters": {
                 "document_store": {"type": "MockedDocumentStore", "init_parameters": {}},
-                "url_field": "url",
+                "url_field": "metadata.url",
             },
         }
 

--- a/test/preview/components/routers/test_metadata_router.py
+++ b/test/preview/components/routers/test_metadata_router.py
@@ -8,8 +8,8 @@ class TestMetadataRouter:
     @pytest.mark.unit
     def test_run(self):
         rules = {
-            "edge_1": {"created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}},
-            "edge_2": {"created_at": {"$gte": "2023-04-01", "$lt": "2023-07-01"}},
+            "edge_1": {"metadata.created_at": {"$gte": "2023-01-01", "$lt": "2023-04-01"}},
+            "edge_2": {"metadata.created_at": {"$gte": "2023-04-01", "$lt": "2023-07-01"}},
         }
         router = MetadataRouter(rules=rules)
         documents = [

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -31,15 +31,38 @@ def test_document_str(doc, doc_str):
     assert f"Document(id={doc.id}, mimetype: 'text/plain', {doc_str})" == str(doc)
 
 
-def test_init():
-    doc = Document(text="test text", metadata={"text": "test text"})
-    assert doc.text == "test text"
+@pytest.mark.unit
+def test_init_with_default_parameters():
+    doc = Document()
+    assert doc.id == "eaefbcfb6d4274ef83b7b4726d5df854060b6079d12bac65e8ed3feb99d9f69e"
+    assert doc.text == None
     assert doc.dataframe == None
     assert doc.blob == None
     assert doc.mime_type == "text/plain"
-    assert doc.metadata == {"text": "test text"}
+    assert doc.metadata == {}
     assert doc.score == None
     assert doc.embedding == None
+
+
+@pytest.mark.unit
+def test_init_with_custom_parameters():
+    doc = Document(
+        text="test text",
+        dataframe=pd.DataFrame([0]),
+        blob=b"some bytes",
+        mime_type="text/markdown",
+        metadata={"text": "test text"},
+        score=0.812,
+        embedding=[0.1, 0.2, 0.3],
+    )
+    assert doc.id == "ec92455f3f4576d40031163c89b1b4210b34ea1426ee0ff68ebed86cb7ba13f8"
+    assert doc.text == "test text"
+    assert doc.dataframe.equals(pd.DataFrame([0]))
+    assert doc.blob == bytes("some bytes")
+    assert doc.mime_type == "text/markdown"
+    assert doc.metadata == {"text": "test text"}
+    assert doc.score == 0.812
+    assert doc.embedding == [0.1, 0.2, 0.3]
 
 
 @pytest.mark.unit

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -46,10 +46,11 @@ def test_init_with_default_parameters():
 
 @pytest.mark.unit
 def test_init_with_custom_parameters():
+    some_bytes = b"some bytes"
     doc = Document(
         text="test text",
         dataframe=pd.DataFrame([0]),
-        blob=b"some bytes",
+        blob=some_bytes,
         mime_type="text/markdown",
         metadata={"text": "test text"},
         score=0.812,
@@ -58,7 +59,7 @@ def test_init_with_custom_parameters():
     assert doc.id == "ec92455f3f4576d40031163c89b1b4210b34ea1426ee0ff68ebed86cb7ba13f8"
     assert doc.text == "test text"
     assert doc.dataframe.equals(pd.DataFrame([0]))
-    assert doc.blob == bytes("some bytes")
+    assert doc.blob == some_bytes
     assert doc.mime_type == "text/markdown"
     assert doc.metadata == {"text": "test text"}
     assert doc.score == 0.812

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -31,6 +31,17 @@ def test_document_str(doc, doc_str):
     assert f"Document(id={doc.id}, mimetype: 'text/plain', {doc_str})" == str(doc)
 
 
+def test_init():
+    doc = Document(text="test text", metadata={"text": "test text"})
+    assert doc.text == "test text"
+    assert doc.dataframe == None
+    assert doc.blob == None
+    assert doc.mime_type == "text/plain"
+    assert doc.metadata == {"text": "test text"}
+    assert doc.score == None
+    assert doc.embedding == None
+
+
 @pytest.mark.unit
 def test_basic_equality_type_mismatch():
     doc = Document(text="test text")
@@ -192,6 +203,7 @@ def test_full_document_from_json():
             {
                 "text": "test text",
                 "dataframe": '{"0":{"0":10,"1":20,"2":30}}',
+                "blob": [115, 111, 109, 101, 32, 98, 121, 116, 101, 115],
                 "mime_type": "application/pdf",
                 "metadata": {"create_date": -14186580},
                 "score": 0.5,
@@ -202,7 +214,7 @@ def test_full_document_from_json():
     assert doc == Document(
         text="test text",
         dataframe=pd.DataFrame([10, 20, 30]),
-        blob=None,
+        blob=b"some bytes",
         mime_type="application/pdf",
         metadata={"create_date": -14186580},
         score=0.5,

--- a/test/preview/document_stores/test_in_memory.py
+++ b/test/preview/document_stores/test_in_memory.py
@@ -216,7 +216,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
         selected_document = Document(text="Gardening", metadata={"selected": True})
         docs = [Document(), selected_document, Document(text="Bird watching")]
         docstore.write_documents(docs)
-        results = docstore.bm25_retrieval(query="Java", top_k=10, filters={"selected": True})
+        results = docstore.bm25_retrieval(query="Java", top_k=10, filters={"metadata.selected": True})
         assert results == [selected_document]
 
     @pytest.mark.unit

--- a/test/preview/utils/test_filters.py
+++ b/test/preview/utils/test_filters.py
@@ -4,274 +4,282 @@ import numpy as np
 
 from haystack.preview import Document
 from haystack.preview.errors import FilterError
-from haystack.preview.utils.filters import document_matches_filter
+from haystack.preview.utils.filters import document_matches_filter, _find_nested_value
 
 
 class TestFilterUtils:
     @pytest.mark.unit
+    def test_find_nested_value(self):
+        assert _find_nested_value({"a": {"b": 1}}, "a.b") == 1
+        with pytest.raises(ValueError):
+            assert _find_nested_value({"a": {"b": 1}}, "a.c") == None
+        with pytest.raises(ValueError):
+            assert _find_nested_value({"a": [1]}, "a.b") == None
+
+    @pytest.mark.unit
     def test_eq_match(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": "test"}
+        filter = {"metadata.name": "test"}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_no_match(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": "test1"}
+        filter = {"metadata.name": "test1"}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_no_match_missing_key(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name1": "test"}
+        filter = {"metadata.name1": "test"}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_explicit_eq(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$eq": "test"}}
+        filter = {"metadata.name": {"$eq": "test"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_different_types(self):
         document = Document(metadata={"name": 1})
-        filter = {"name": "1"}
+        filter = {"metadata.name": "1"}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_dataframes(self):
         document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
-        filter = {"name": pd.DataFrame({"a": [1, 2, 3]})}
+        filter = {"metadata.name": pd.DataFrame({"a": [1, 2, 3]})}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_dataframes_no_match(self):
         document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
-        filter = {"name": pd.DataFrame({"a": [1, 2, 4]})}
+        filter = {"metadata.name": pd.DataFrame({"a": [1, 2, 4]})}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_np_arrays(self):
         document = Document(metadata={"name": np.array([1, 2, 3])})
-        filter = {"name": np.array([1, 2, 3])}
+        filter = {"metadata.name": np.array([1, 2, 3])}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_np_arrays_no_match(self):
         document = Document(metadata={"name": np.array([1, 2, 3])})
-        filter = {"name": np.array([1, 2, 4])}
+        filter = {"metadata.name": np.array([1, 2, 4])}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_match(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$ne": "test1"}}
+        filter = {"metadata.name": {"$ne": "test1"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_no_match(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$ne": "test"}}
+        filter = {"metadata.name": {"$ne": "test"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_no_match_missing_key(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name1": {"$ne": "test"}}
+        filter = {"metadata.name1": {"$ne": "test"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_different_types(self):
         document = Document(metadata={"name": 1})
-        filter = {"name": {"$ne": "1"}}
+        filter = {"metadata.name": {"$ne": "1"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_dataframes(self):
         document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
-        filter = {"name": {"$ne": pd.DataFrame({"a": [1, 2, 4]})}}
+        filter = {"metadata.name": {"$ne": pd.DataFrame({"a": [1, 2, 4]})}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_dataframes_no_match(self):
         document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
-        filter = {"name": {"$ne": pd.DataFrame({"a": [1, 2, 3]})}}
+        filter = {"metadata.name": {"$ne": pd.DataFrame({"a": [1, 2, 3]})}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_np_arrays(self):
         document = Document(metadata={"name": np.array([1, 2, 3])})
-        filter = {"name": {"$ne": np.array([1, 2, 4])}}
+        filter = {"metadata.name": {"$ne": np.array([1, 2, 4])}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_np_arrays_no_match(self):
         document = Document(metadata={"name": np.array([1, 2, 3])})
-        filter = {"name": {"$ne": np.array([1, 2, 3])}}
+        filter = {"metadata.name": {"$ne": np.array([1, 2, 3])}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_match_list(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": ["test", "test1"]}}
+        filter = {"metadata.name": {"$in": ["test", "test1"]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_list(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": ["test2", "test3"]}}
+        filter = {"metadata.name": {"$in": ["test2", "test3"]}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_implicit(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": ["test", "test1"]}
+        filter = {"metadata.name": ["test", "test1"]}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_match_set(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": {"test", "test1"}}}
+        filter = {"metadata.name": {"$in": {"test", "test1"}}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_set(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": {"test2", "test3"}}}
+        filter = {"metadata.name": {"$in": {"test2", "test3"}}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_match_tuple(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": ("test", "test1")}}
+        filter = {"metadata.name": {"$in": ("test", "test1")}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_tuple(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": ("test2", "test3")}}
+        filter = {"metadata.name": {"$in": ("test2", "test3")}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_missing_key(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name1": {"$in": ["test", "test1"]}}
+        filter = {"metadata.name1": {"$in": ["test", "test1"]}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_unsupported_type(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$in": "unsupported"}}
+        filter = {"metadata.name": {"$in": "unsupported"}}
         with pytest.raises(FilterError, match=r"\$in accepts only iterable values like lists, sets and tuples"):
             document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_match_list(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": ["test1", "test2"]}}
+        filter = {"metadata.name": {"$nin": ["test1", "test2"]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_list(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": ["test", "test1"]}}
+        filter = {"metadata.name": {"$nin": ["test", "test1"]}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_match_set(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": {"test1", "test2"}}}
+        filter = {"metadata.name": {"$nin": {"test1", "test2"}}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_set(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": {"test", "test1"}}}
+        filter = {"metadata.name": {"$nin": {"test", "test1"}}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_match_tuple(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": ("test1", "test2")}}
+        filter = {"metadata.name": {"$nin": ("test1", "test2")}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_tuple(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": ("test", "test1")}}
+        filter = {"metadata.name": {"$nin": ("test", "test1")}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_missing_key(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name1": {"$nin": ["test", "test1"]}}
+        filter = {"metadata.name1": {"$nin": ["test", "test1"]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_unsupported_type(self):
         document = Document(metadata={"name": "test"})
-        filter = {"name": {"$nin": "unsupported"}}
+        filter = {"metadata.name": {"$nin": "unsupported"}}
         with pytest.raises(FilterError, match=r"\$in accepts only iterable values like lists, sets and tuples"):
             document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_int(self):
         document = Document(metadata={"age": 21})
-        filter = {"age": {"$gt": 20}}
+        filter = {"metadata.age": {"$gt": 20}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_int(self):
         document = Document(metadata={"age": 19})
-        filter = {"age": {"$gt": 20}}
+        filter = {"metadata.age": {"$gt": 20}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_float(self):
         document = Document(metadata={"number": 90.5})
-        filter = {"number": {"$gt": 90.0}}
+        filter = {"metadata.number": {"$gt": 90.0}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_float(self):
         document = Document(metadata={"number": 89.5})
-        filter = {"number": {"$gt": 90.0}}
+        filter = {"metadata.number": {"$gt": 90.0}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_np_number(self):
         document = Document(metadata={"value": np.float64(7.5)})
-        filter = {"value": {"$gt": np.float64(7.0)}}
+        filter = {"metadata.value": {"$gt": np.float64(7.0)}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_np_number(self):
         document = Document(metadata={"value": np.float64(6.5)})
-        filter = {"value": {"$gt": np.float64(7.0)}}
+        filter = {"metadata.value": {"$gt": np.float64(7.0)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_date_string(self):
         document = Document(metadata={"date": "2022-01-02"})
-        filter = {"date": {"$gt": "2022-01-01"}}
+        filter = {"metadata.date": {"$gt": "2022-01-01"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_date_string(self):
         document = Document(metadata={"date": "2022-01-01"})
-        filter = {"date": {"$gt": "2022-01-01"}}
+        filter = {"metadata.date": {"$gt": "2022-01-01"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_missing_key(self):
         document = Document(metadata={"age": 21})
-        filter = {"age1": {"$gt": 20}}
+        filter = {"metadata.age1": {"$gt": 20}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_unsupported_type(self):
         document = Document(metadata={"age": 21})
-        filter = {"age": {"$gt": "unsupported"}}
+        filter = {"metadata.age": {"$gt": "unsupported"}}
         with pytest.raises(
             FilterError,
             match=(
@@ -284,63 +292,63 @@ class TestFilterUtils:
     @pytest.mark.unit
     def test_gte_match_int(self):
         document = Document(metadata={"age": 21})
-        filter_1 = {"age": {"$gte": 21}}
-        filter_2 = {"age": {"$gte": 20}}
+        filter_1 = {"metadata.age": {"$gte": 21}}
+        filter_2 = {"metadata.age": {"$gte": 20}}
         assert document_matches_filter(filter_1, document)
         assert document_matches_filter(filter_2, document)
 
     @pytest.mark.unit
     def test_gte_no_match_int(self):
         document = Document(metadata={"age": 20})
-        filter = {"age": {"$gte": 21}}
+        filter = {"metadata.age": {"$gte": 21}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_match_float(self):
         document = Document(metadata={"number": 90.5})
-        filter_1 = {"number": {"$gte": 90.5}}
-        filter_2 = {"number": {"$gte": 90.4}}
+        filter_1 = {"metadata.number": {"$gte": 90.5}}
+        filter_2 = {"metadata.number": {"$gte": 90.4}}
         assert document_matches_filter(filter_1, document)
         assert document_matches_filter(filter_2, document)
 
     @pytest.mark.unit
     def test_gte_no_match_float(self):
         document = Document(metadata={"number": 90.4})
-        filter = {"number": {"$gte": 90.5}}
+        filter = {"metadata.number": {"$gte": 90.5}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_match_np_number(self):
         document = Document(metadata={"value": np.float64(7.5)})
-        filter_1 = {"value": {"$gte": np.float64(7.5)}}
-        filter_2 = {"value": {"$gte": np.float64(7.4)}}
+        filter_1 = {"metadata.value": {"$gte": np.float64(7.5)}}
+        filter_2 = {"metadata.value": {"$gte": np.float64(7.4)}}
         assert document_matches_filter(filter_1, document)
         assert document_matches_filter(filter_2, document)
 
     @pytest.mark.unit
     def test_gte_no_match_np_number(self):
         document = Document(metadata={"value": np.float64(7.4)})
-        filter = {"value": {"$gte": np.float64(7.5)}}
+        filter = {"metadata.value": {"$gte": np.float64(7.5)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_match_date_string(self):
         document = Document(metadata={"date": "2022-01-02"})
-        filter_1 = {"date": {"$gte": "2022-01-02"}}
-        filter_2 = {"date": {"$gte": "2022-01-01"}}
+        filter_1 = {"metadata.date": {"$gte": "2022-01-02"}}
+        filter_2 = {"metadata.date": {"$gte": "2022-01-01"}}
         assert document_matches_filter(filter_1, document)
         assert document_matches_filter(filter_2, document)
 
     @pytest.mark.unit
     def test_gte_no_match_date_string(self):
         document = Document(metadata={"date": "2022-01-01"})
-        filter = {"date": {"$gte": "2022-01-02"}}
+        filter = {"metadata.date": {"$gte": "2022-01-02"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_unsupported_type(self):
         document = Document(metadata={"age": 21})
-        filter = {"age": {"$gte": "unsupported"}}
+        filter = {"metadata.age": {"$gte": "unsupported"}}
         with pytest.raises(
             FilterError,
             match=(
@@ -353,55 +361,55 @@ class TestFilterUtils:
     @pytest.mark.unit
     def test_lt_match_int(self):
         document = Document(metadata={"age": 19})
-        filter = {"age": {"$lt": 20}}
+        filter = {"metadata.age": {"$lt": 20}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_int(self):
         document = Document(metadata={"age": 20})
-        filter = {"age": {"$lt": 20}}
+        filter = {"metadata.age": {"$lt": 20}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_match_float(self):
         document = Document(metadata={"number": 89.9})
-        filter = {"number": {"$lt": 90.0}}
+        filter = {"metadata.number": {"$lt": 90.0}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_float(self):
         document = Document(metadata={"number": 90.0})
-        filter = {"number": {"$lt": 90.0}}
+        filter = {"metadata.number": {"$lt": 90.0}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_match_np_number(self):
         document = Document(metadata={"value": np.float64(6.9)})
-        filter = {"value": {"$lt": np.float64(7.0)}}
+        filter = {"metadata.value": {"$lt": np.float64(7.0)}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_np_number(self):
         document = Document(metadata={"value": np.float64(7.0)})
-        filter = {"value": {"$lt": np.float64(7.0)}}
+        filter = {"metadata.value": {"$lt": np.float64(7.0)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_match_date_string(self):
         document = Document(metadata={"date": "2022-01-01"})
-        filter = {"date": {"$lt": "2022-01-02"}}
+        filter = {"metadata.date": {"$lt": "2022-01-02"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_date_string(self):
         document = Document(metadata={"date": "2022-01-02"})
-        filter = {"date": {"$lt": "2022-01-02"}}
+        filter = {"metadata.date": {"$lt": "2022-01-02"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_unsupported_type(self):
         document = Document(metadata={"age": 21})
-        filter = {"age": {"$lt": "unsupported"}}
+        filter = {"metadata.age": {"$lt": "unsupported"}}
         with pytest.raises(
             FilterError,
             match=(
@@ -414,63 +422,63 @@ class TestFilterUtils:
     @pytest.mark.unit
     def test_lte_match_int(self):
         document = Document(metadata={"age": 21})
-        filter_1 = {"age": {"$lte": 21}}
-        filter_2 = {"age": {"$lte": 20}}
+        filter_1 = {"metadata.age": {"$lte": 21}}
+        filter_2 = {"metadata.age": {"$lte": 20}}
         assert not document_matches_filter(filter_2, document)
         assert document_matches_filter(filter_1, document)
 
     @pytest.mark.unit
     def test_lte_no_match_int(self):
         document = Document(metadata={"age": 22})
-        filter = {"age": {"$lte": 21}}
+        filter = {"metadata.age": {"$lte": 21}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_match_float(self):
         document = Document(metadata={"number": 90.5})
-        filter_1 = {"number": {"$lte": 90.5}}
-        filter_2 = {"number": {"$lte": 90.4}}
+        filter_1 = {"metadata.number": {"$lte": 90.5}}
+        filter_2 = {"metadata.number": {"$lte": 90.4}}
         assert not document_matches_filter(filter_2, document)
         assert document_matches_filter(filter_1, document)
 
     @pytest.mark.unit
     def test_lte_no_match_float(self):
         document = Document(metadata={"number": 90.6})
-        filter = {"number": {"$lte": 90.5}}
+        filter = {"metadata.number": {"$lte": 90.5}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_match_np_number(self):
         document = Document(metadata={"value": np.float64(7.5)})
-        filter_1 = {"value": {"$lte": np.float64(7.5)}}
-        filter_2 = {"value": {"$lte": np.float64(7.4)}}
+        filter_1 = {"metadata.value": {"$lte": np.float64(7.5)}}
+        filter_2 = {"metadata.value": {"$lte": np.float64(7.4)}}
         assert not document_matches_filter(filter_2, document)
         assert document_matches_filter(filter_1, document)
 
     @pytest.mark.unit
     def test_lte_no_match_np_number(self):
         document = Document(metadata={"value": np.float64(7.6)})
-        filter = {"value": {"$lte": np.float64(7.5)}}
+        filter = {"metadata.value": {"$lte": np.float64(7.5)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_match_date_string(self):
         document = Document(metadata={"date": "2022-01-02"})
-        filter_1 = {"date": {"$lte": "2022-01-02"}}
-        filter_2 = {"date": {"$lte": "2022-01-01"}}
+        filter_1 = {"metadata.date": {"$lte": "2022-01-02"}}
+        filter_2 = {"metadata.date": {"$lte": "2022-01-01"}}
         assert not document_matches_filter(filter_2, document)
         assert document_matches_filter(filter_1, document)
 
     @pytest.mark.unit
     def test_lte_no_match_date_string(self):
         document = Document(metadata={"date": "2022-01-03"})
-        filter = {"date": {"$lte": "2022-01-02"}}
+        filter = {"metadata.date": {"$lte": "2022-01-02"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_unsupported_type(self):
         document = Document(metadata={"age": 21})
-        filter = {"age": {"$lte": "unsupported"}}
+        filter = {"metadata.age": {"$lte": "unsupported"}}
         with pytest.raises(
             FilterError,
             match=(
@@ -483,23 +491,23 @@ class TestFilterUtils:
     @pytest.mark.unit
     def test_implicit_and(self):
         document = Document(metadata={"age": 21, "name": "John"})
-        filter = {"age": {"$gt": 18}, "name": "John"}
+        filter = {"metadata.age": {"$gt": 18}, "metadata.name": "John"}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_explicit_and(self):
         document = Document(metadata={"age": 21})
-        filter = {"age": {"$and": {"$gt": 18}, "$lt": 25}}
+        filter = {"metadata.age": {"$and": {"$gt": 18}, "$lt": 25}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_or(self):
         document = Document(metadata={"age": 26})
-        filter = {"age": {"$or": [{"$gt": 18}, {"$lt": 25}]}}
+        filter = {"metadata.age": {"$or": [{"$gt": 18}, {"$lt": 25}]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_not(self):
         document = Document(metadata={"age": 17})
-        filter = {"age": {"$not": {"$gt": 18}}}
+        filter = {"metadata.age": {"$not": {"$gt": 18}}}
         assert document_matches_filter(filter, document)

--- a/test/preview/utils/test_filters.py
+++ b/test/preview/utils/test_filters.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from haystack.preview import Document
 from haystack.preview.errors import FilterError
-from haystack.preview.utils.filters import document_matches_filter, _find_nested_value
+from haystack.preview.utils.filters import document_matches_filter, _find_nested_value, _get_field_value
 
 
 class TestFilterUtils:
@@ -12,9 +12,18 @@ class TestFilterUtils:
     def test_find_nested_value(self):
         assert _find_nested_value({"a": {"b": 1}}, "a.b") == 1
         with pytest.raises(ValueError):
-            assert _find_nested_value({"a": {"b": 1}}, "a.c") == None
+            _find_nested_value({"a": {"b": 1}}, "a.c")
         with pytest.raises(ValueError):
-            assert _find_nested_value({"a": [1]}, "a.b") == None
+            _find_nested_value({"a": [1]}, "a.b")
+
+    @pytest.mark.unit
+    def test_get_field_value(self):
+        assert _get_field_value({"a": {"b": 1}}, "a") == {"b": 1}
+        assert _get_field_value({"a": {"b": 1}}, "a.b") == 1
+        with pytest.raises(ValueError):
+            _get_field_value({"a": {"b": 1}}, "a.c")
+        with pytest.raises(ValueError):
+            _get_field_value({"a": {"b": 1}}, "c")
 
     @pytest.mark.unit
     def test_eq_match(self):


### PR DESCRIPTION
### Proposed Changes:

This PR changes `Document` serialisation to ease storaging in most DBs. 

Most notable change is the removal of `Document.flatten()` as it was deemed too dangerous. Users could lose data if `metadata` contained a key with the same name as a `Document` field. That would have also prevented fields to be added in the future.

Given that `metadata` is not flattened anymore the user must set filters using the `metadata.` prefix to specify a filter that compares `metadata`. The filter can be nested multiple times. e.g `metadata.person.age`, `metadata.create_date`

Another big change is how a `Document` is serialized to JSON. Previous implementation handled custom types in `metadata` by giving the possibility to provide custom encoders and decoders to could handle whatever types. This has now changed so `metadata` must only contain primitives that can be serialised to JSON with no custom encoders. If any Document Store needs custom serialisation they can implement their own.

`dataframe` and `blob` fields are handled directly by the `Document` class as it knows its fields. `dataframe` is simply converted to JSON using `DataFrame.to_json()`, and `blob` is converted to a list of ints.

The above serialisation change led to changes also in the following Components:
* `UrlCacheChecker`, default `url_field` changed to `metadata.url`
* `MetadataRouter`, docstring changes

It also led changes in the serialisation logic of `InMemoryDocumenStore` that is mostly contained in `haystack/preview/utils/filters.py`. I tried to keep the filtering changes at a minimum.

Tests have been updated accordingly.

`haystack/preview/testing/document_store.py` had to be changed too as most of the filters where filtering `metadata`.

This is a huge change that will break also some external integration like `MarqoDocumentStore`, `ChromaDocumentStore` and others.

I'll take care of updating all the Document Stores that need to be updated to keep them compatible. I won't do it right after this PR as there are other changes following this though.

### How did you test it?

I ran unit tests locally and updated them according to the changes.

### Notes for the reviewer

Sorry this is a huge PR but changing `Document` serialisation influenced ton of different parts of `preview`.

Splitting is not easily feasible as all these changes are interlocked and would require either skipping tests or making the change retrocompatible.

I found two bugs in the filtering logic of `InMemoryDocumentStore` while working on this.
I created two related issues for each: #6153 and #6160

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
