### PR TITLE
docs: Add readme sync for API docs 2.0

### DIFF
--- a/.github/utils/pydoc-markdown.sh
+++ b/.github/utils/pydoc-markdown.sh
@@ -9,3 +9,11 @@ for file in ../config/* ; do
     echo "Converting $file..."
     pydoc-markdown "$file"
 done
+# render preview markdown docs
+cd ..
+rm -rf temp-preview && mkdir temp-preview
+cd temp-preview
+for file in ../config-preview/* ; do
+    echo "Converting $file..."
+    pydoc-markdown "$file"
+done

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -54,9 +54,8 @@ jobs:
         with:
           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
 
-      - name: Sync preview docs with unstable release
-        # Instead of putting more logic into the previous step, let's just assume that commits on `main`
-        # will always be synced to the current `X.Y-unstable` version on Readme
+      - name: Sync preview docs
+        # Sync the preview docs to the `2.0` version on Readme
         id: sync-main-preview
         # if: github.ref_name == 'main' && github.event_name == 'push' # TODO reactivate
         uses: readmeio/rdme@8.3.1

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -9,7 +9,6 @@ on:
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
-      - readme-sync-api-2-0
 
 jobs:
   sync:
@@ -57,20 +56,20 @@ jobs:
       - name: Sync preview docs with 2.0
         # Sync the preview docs to the `2.0` version on Readme
         id: sync-main-preview
-        # if: github.ref_name == 'main' && github.event_name == 'push' # TODO reactivate
+        if: github.ref_name == 'main' && github.event_name == 'push'
         uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
         with:
           rdme: docs ./docs/pydoc/temp-preview --key="$README_API_KEY" --version=2.0
 
-#       - name: Sync docs with current release
-#         # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
-#         # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
-#         # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
-#         if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
-#         uses: readmeio/rdme@8.3.1
-#         env:
-#           README_API_KEY: ${{ secrets.README_API_KEY }}
-#         with:
-#           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}
+      - name: Sync docs with current release
+        # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
+        # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
+        # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
+        if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        with:
+          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
 
-      - name: Sync preview docs
+      - name: Sync preview docs with 2.0
         # Sync the preview docs to the `2.0` version on Readme
         id: sync-main-preview
         # if: github.ref_name == 'main' && github.event_name == 'push' # TODO reactivate
@@ -64,13 +64,13 @@ jobs:
         with:
           rdme: docs ./docs/pydoc/temp-preview --key="$README_API_KEY" --version=2.0
 
-      - name: Sync docs with current release
-        # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
-        # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
-        # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
-        if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
-        uses: readmeio/rdme@8.3.1
-        env:
-          README_API_KEY: ${{ secrets.README_API_KEY }}
-        with:
-          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}
+#       - name: Sync docs with current release
+#         # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
+#         # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
+#         # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
+#         if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
+#         uses: readmeio/rdme@8.3.1
+#         env:
+#           README_API_KEY: ${{ secrets.README_API_KEY }}
+#         with:
+#           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -1,6 +1,7 @@
 name: Sync docs with Readme
 
 on:
+  workflow_dispatch: # Activate this workflow manually
   pull_request:
     paths:
       - "docs/pydoc/**"
@@ -52,6 +53,19 @@ jobs:
           README_API_KEY: ${{ secrets.README_API_KEY }}
         with:
           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
+
+      - name: Sync preview docs with unstable release
+        # Instead of putting more logic into the previous step, let's just assume that commits on `main`
+        # will always be synced to the current `X.Y-unstable` version on Readme
+        id: sync-main-preview
+        # if: github.ref_name == 'main' && github.event_name == 'push' # TODO reactivate
+        if: github.ref_name == 'readme-sync-api-2-0' && github.event_name == 'push'
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        with:
+          rdme: docs ./docs/pydoc/temp-preview --key="$README_API_KEY" --version=2.0
+
 
       - name: Sync docs with current release
         # Mutually exclusive with the previous one, this step is supposed to only run on version branches.

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -43,16 +43,16 @@ jobs:
         # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
         run: echo "minor=$(cut -d "." -f 1,2 < VERSION.txt)" >> "$GITHUB_OUTPUT"
 
-      - name: Sync docs with unstable release
-        # Instead of putting more logic into the previous step, let's just assume that commits on `main`
-        # will always be synced to the current `X.Y-unstable` version on Readme
-        id: sync-main
-        if: github.ref_name == 'main' && github.event_name == 'push'
-        uses: readmeio/rdme@8.3.1
-        env:
-          README_API_KEY: ${{ secrets.README_API_KEY }}
-        with:
-          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
+#       - name: Sync docs with unstable release
+#         # Instead of putting more logic into the previous step, let's just assume that commits on `main`
+#         # will always be synced to the current `X.Y-unstable` version on Readme
+#         id: sync-main
+#         if: github.ref_name == 'main' && github.event_name == 'push'
+#         uses: readmeio/rdme@8.3.1
+#         env:
+#           README_API_KEY: ${{ secrets.README_API_KEY }}
+#         with:
+#           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
 
       - name: Sync preview docs with unstable release
         # Instead of putting more logic into the previous step, let's just assume that commits on `main`
@@ -66,14 +66,13 @@ jobs:
         with:
           rdme: docs ./docs/pydoc/temp-preview --key="$README_API_KEY" --version=2.0
 
-
-      - name: Sync docs with current release
-        # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
-        # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
-        # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
-        if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
-        uses: readmeio/rdme@8.3.1
-        env:
-          README_API_KEY: ${{ secrets.README_API_KEY }}
-        with:
-          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}
+#       - name: Sync docs with current release
+#         # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
+#         # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
+#         # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
+#         if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
+#         uses: readmeio/rdme@8.3.1
+#         env:
+#           README_API_KEY: ${{ secrets.README_API_KEY }}
+#         with:
+#           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -10,6 +10,7 @@ on:
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
+      - readme-sync-api-2-0
 
 jobs:
   sync:
@@ -59,7 +60,6 @@ jobs:
         # will always be synced to the current `X.Y-unstable` version on Readme
         id: sync-main-preview
         # if: github.ref_name == 'main' && github.event_name == 'push' # TODO reactivate
-        if: github.ref_name == 'readme-sync-api-2-0'
         uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -1,7 +1,6 @@
 name: Sync docs with Readme
 
 on:
-  workflow_dispatch: # Activate this workflow manually
   pull_request:
     paths:
       - "docs/pydoc/**"
@@ -44,16 +43,16 @@ jobs:
         # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
         run: echo "minor=$(cut -d "." -f 1,2 < VERSION.txt)" >> "$GITHUB_OUTPUT"
 
-#       - name: Sync docs with unstable release
-#         # Instead of putting more logic into the previous step, let's just assume that commits on `main`
-#         # will always be synced to the current `X.Y-unstable` version on Readme
-#         id: sync-main
-#         if: github.ref_name == 'main' && github.event_name == 'push'
-#         uses: readmeio/rdme@8.3.1
-#         env:
-#           README_API_KEY: ${{ secrets.README_API_KEY }}
-#         with:
-#           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
+      - name: Sync docs with unstable release
+        # Instead of putting more logic into the previous step, let's just assume that commits on `main`
+        # will always be synced to the current `X.Y-unstable` version on Readme
+        id: sync-main
+        if: github.ref_name == 'main' && github.event_name == 'push'
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        with:
+          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
 
       - name: Sync preview docs with unstable release
         # Instead of putting more logic into the previous step, let's just assume that commits on `main`
@@ -66,13 +65,13 @@ jobs:
         with:
           rdme: docs ./docs/pydoc/temp-preview --key="$README_API_KEY" --version=2.0
 
-#       - name: Sync docs with current release
-#         # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
-#         # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
-#         # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
-#         if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
-#         uses: readmeio/rdme@8.3.1
-#         env:
-#           README_API_KEY: ${{ secrets.README_API_KEY }}
-#         with:
-#           rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}
+      - name: Sync docs with current release
+        # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
+        # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
+        # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
+        if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        with:
+          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -59,7 +59,7 @@ jobs:
         # will always be synced to the current `X.Y-unstable` version on Readme
         id: sync-main-preview
         # if: github.ref_name == 'main' && github.event_name == 'push' # TODO reactivate
-        if: github.ref_name == 'readme-sync-api-2-0' && github.event_name == 'push'
+        if: github.ref_name == 'readme-sync-api-2-0'
         uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}

--- a/docs/pydoc/config-preview/audio.yml
+++ b/docs/pydoc/config-preview/audio.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: renderers.ReadmeRenderer
+  type: renderers.ReadmePreviewRenderer
   excerpt: LocalWhisperTranscriber transcribes audio files using OpenAI's Whisper's model on your local machine.
   category_slug: haystack-classes
   title: LocalWhisperTranscriber API

--- a/docs/pydoc/config-preview/audio.yml
+++ b/docs/pydoc/config-preview/audio.yml
@@ -1,0 +1,26 @@
+loaders:
+  - type: loaders.CustomPythonLoader
+    search_path: [../../../haystack/preview/components/audio]
+    modules: ["whisper_local"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: renderers.ReadmeRenderer
+  excerpt: LocalWhisperTranscriber transcribes audio files using OpenAI's Whisper's model on your local machine.
+  category_slug: haystack-classes
+  title: LocalWhisperTranscriber API
+  slug: local-whisper-transcriber-api
+  order: 10
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: local_whisper_transcriber_api.md

--- a/docs/pydoc/config-preview/audio.yml
+++ b/docs/pydoc/config-preview/audio.yml
@@ -13,7 +13,7 @@ processors:
   - type: crossref
 renderer:
   type: renderers.ReadmePreviewRenderer
-  excerpt: LocalWhisperTranscriber transcribes audio files using OpenAI's Whisper models on your local machine.
+  excerpt: LocalWhisperTranscriber transcribes audio files using OpenAI's Whisper models on your local machine
   category_slug: haystack-classes
   title: LocalWhisperTranscriber API
   slug: local-whisper-transcriber-api

--- a/docs/pydoc/config-preview/audio.yml
+++ b/docs/pydoc/config-preview/audio.yml
@@ -13,7 +13,7 @@ processors:
   - type: crossref
 renderer:
   type: renderers.ReadmePreviewRenderer
-  excerpt: LocalWhisperTranscriber transcribes audio files using OpenAI's Whisper's model on your local machine.
+  excerpt: LocalWhisperTranscriber transcribes audio files using OpenAI's Whisper models on your local machine.
   category_slug: haystack-classes
   title: LocalWhisperTranscriber API
   slug: local-whisper-transcriber-api

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -58,8 +58,7 @@ class ReadmeRenderer(Renderer):
 
     def init(self, context: Context) -> None:
         self.markdown.init(context)
-        # self.version = self._doc_version()
-        self.version = "v2.0"
+        self.version = self._doc_version()
         self.categories = self._readme_categories(self.version)
 
     def _doc_version(self) -> str:
@@ -134,3 +133,16 @@ class ReadmeRenderer(Renderer):
             slug=self.slug,
             order=self.order,
         )
+
+
+@dataclasses.dataclass
+class ReadmePreviewRenderer(ReadmeRenderer):
+    """
+    This custom Renderer behaves just like the ReadmeRenderer but renders docs with the hardcoded version 2.0 to generate correct category ids.
+    """
+
+    def _doc_version(self) -> str:
+        """
+        Returns the hardcoded docs version 2.0.
+        """
+        return "v2.0"

--- a/docs/pydoc/renderers.py
+++ b/docs/pydoc/renderers.py
@@ -58,7 +58,8 @@ class ReadmeRenderer(Renderer):
 
     def init(self, context: Context) -> None:
         self.markdown.init(context)
-        self.version = self._doc_version()
+        # self.version = self._doc_version()
+        self.version = "v2.0"
         self.categories = self._readme_categories(self.version)
 
     def _doc_version(self) -> str:


### PR DESCRIPTION
### Related Issues

- fixes #5883 

### Proposed Changes:

- Add step in the readme sync action to publish 2.0 docs
- Add rendering of markdown files for preview with a custom renderer
- Add example config yml for audio docs

### How did you test it?

- GitHub action: https://github.com/deepset-ai/haystack/actions/runs/6656706170/job/18089859339 for the commit [skip sync docs for current release for testing](https://github.com/deepset-ai/haystack/pull/6173/commits/20e7fd27e23972a7d6c5a161782591f6c8cf6e77) ran through and successfully uploaded https://docs.haystack.deepset.ai/v2.0/reference/local-whisper-transcriber-api
- Locally tested `./.github/utils/pydoc-markdown.sh`

### Notes for the reviewer

The last commit prepares the branch to be merged into main. Check the previous commit to see the action triggered.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
