### PR TITLE
feat: Add `StreamingChunk` dataclass to Haystack 2.x

### DIFF
--- a/haystack/preview/dataclasses/__init__.py
+++ b/haystack/preview/dataclasses/__init__.py
@@ -3,5 +3,15 @@ from haystack.preview.dataclasses.answer import ExtractedAnswer, GeneratedAnswer
 from haystack.preview.dataclasses.byte_stream import ByteStream
 from haystack.preview.dataclasses.chat_message import ChatMessage
 from haystack.preview.dataclasses.chat_message import ChatRole
+from haystack.preview.dataclasses.streaming_chunk import StreamingChunk
 
-__all__ = ["Document", "ExtractedAnswer", "GeneratedAnswer", "Answer", "ByteStream", "ChatMessage", "ChatRole"]
+__all__ = [
+    "Document",
+    "ExtractedAnswer",
+    "GeneratedAnswer",
+    "Answer",
+    "ByteStream",
+    "ChatMessage",
+    "ChatRole",
+    "StreamingChunk",
+]

--- a/haystack/preview/dataclasses/streaming_chunk.py
+++ b/haystack/preview/dataclasses/streaming_chunk.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class StreamingChunk:
+    """
+    The StreamingChunk class encapsulates a segment of streamed content along with
+    associated metadata. This structure facilitates the handling and processing of
+    streamed data in a systematic manner.
+
+    :param content: The content of the message chunk as a string.
+    :param metadata: A dictionary containing metadata related to the message chunk.
+    """
+
+    content: str
+    metadata: Dict[str, Any]

--- a/haystack/preview/dataclasses/streaming_chunk.py
+++ b/haystack/preview/dataclasses/streaming_chunk.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Any
 
 
@@ -14,4 +14,4 @@ class StreamingChunk:
     """
 
     content: str
-    metadata: Dict[str, Any]
+    metadata: Dict[str, Any] = field(default_factory=dict, hash=False)

--- a/releasenotes/notes/add-streaming-chunk-67897d7cb2c0d7c0.yaml
+++ b/releasenotes/notes/add-streaming-chunk-67897d7cb2c0d7c0.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Introduce the StreamingChunk dataclass for efficiently handling chunks of data streamed from a language model,
+    encapsulating both the content and associated metadata for systematic processing.


### PR DESCRIPTION
### Why
The introduction of the `StreamingChunk` class is aimed at providing a structured way to handle and process chunks of data streamed from a language model. `StreamingChunk` will serve both chat and non-chat models but the instances might have different metadata. 

### What
We have introduced a new dataclass, `StreamingChunk`, to encapsulate a segment of streamed content along with associated metadata. The class is defined as follows:

### How can it be used
The `StreamingChunk` class can be utilized whenever there is a need to process streamed data from a language model. It will be mostly used in callback handlers.

Example:

```python
def handle_streaming_chunk(chunk: StreamingChunk):
    print(chunk.content, flush=True, end="")
```

### How did you test it
No tests were added by design as the class is a data class and has two simple fields. 

### Notes for reviewer
None