### PR TITLE
feat: Add Haystack 2.x support for Text Generation Inference (TGI) models

### DIFF
--- a/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
+++ b/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
@@ -38,22 +38,24 @@ def check_generation_params(kwargs: Dict[str, Any], additional_accepted_params: 
             )
 
 
-def sanitize_generation_params(kwargs: Dict[str, Any]):
+def sanitize_generation_params(kwargs: Dict[str, Any]) -> List[str]:
     """
     Sanitize the provided generation parameters by removing any unknown parameters.
 
     :param kwargs: A dictionary containing the generation parameters.
     """
+    unknown_params: List[str] = []
     if kwargs:
         accepted_params = {
             param
             for param in inspect.signature(InferenceClient.text_generation).parameters.keys()
             if param not in ["self", "prompt"]
         }
-        unknown_params = set(kwargs.keys()) - accepted_params
+        unknown_params = list(set(kwargs.keys()) - accepted_params)
         if unknown_params:
             for param in unknown_params:
                 del kwargs[param]
+    return unknown_params
 
 
 def check_valid_model(model_id: str, token: Optional[str]) -> None:
@@ -101,7 +103,7 @@ class HuggingFaceRemoteGenerator:
         token: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         stop_words: Optional[List[str]] = None,
-        streaming_callback: Optional[Callable] = None,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
         Initialize the HuggingFaceRemoteGenerator instance.
@@ -252,7 +254,7 @@ class ChatHuggingFaceRemoteGenerator:
         token: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         stop_words: Optional[List[str]] = None,
-        streaming_callback: Optional[Callable] = None,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
         Initialize the ChatHuggingFaceRemoteGenerator instance.

--- a/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
+++ b/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
@@ -1,0 +1,304 @@
+import logging
+from dataclasses import fields, asdict
+from typing import Any, Dict, List, Optional, Union, Iterable, Callable
+from urllib.parse import urlparse
+
+from huggingface_hub import InferenceClient, HfApi
+from huggingface_hub.inference._text_generation import (
+    TextGenerationStreamResponse,
+    TextGenerationParameters,
+    TextGenerationResponse,
+    Token,
+)
+from huggingface_hub.utils import RepositoryNotFoundError
+from transformers import AutoTokenizer
+
+from haystack.preview import component, default_to_dict
+from haystack.preview.dataclasses import ChatMessage, StreamingChunk
+
+logger = logging.getLogger(__name__)
+
+
+def check_generation_params(kwargs: Dict[str, Any], additional_params: Optional[List[str]] = None):
+    """
+    Check the provided generation parameters for validity.
+
+    :param kwargs: A dictionary containing the generation parameters.
+    :param additional_params: An optional list of strings representing additional parameters.
+    :raises ValueError: If any unknown text generation parameters are provided.
+    """
+    if kwargs:
+        accepted_params = {field.name for field in fields(TextGenerationParameters)}
+        if additional_params:
+            accepted_params.update(additional_params)
+        unknown_params = set(kwargs.keys()) - accepted_params
+        if unknown_params:
+            raise ValueError(
+                f"Unknown text generation parameters: {unknown_params}, please provide {accepted_params} only."
+            )
+
+
+def check_valid_model(model_id: str, token: Optional[str]):
+    """
+    Check if the provided model ID corresponds to a valid model on HuggingFace Hub.
+    Also check if the model is a text generation model.
+
+    :param model_id: A string representing the HuggingFace model ID.
+    :param token: An optional string representing the authentication token.
+    :raises ValueError: If the model is not found or is not a text generation model.
+    """
+    api = HfApi()
+    try:
+        model_info = api.model_info(model_id, token=token)
+    except RepositoryNotFoundError as e:
+        raise ValueError(
+            f"Model {model_id} not found on HuggingFace Hub. Please provide a valid HuggingFace model_id."
+        ) from e
+
+    allowed_model = model_info.pipeline_tag in ["text-generation", "text2text-generation"]
+    if not allowed_model:
+        raise ValueError(f"Model {model_id} is not a text generation model. Please provide a text generation model.")
+
+
+def convert_to_chat_message(response: TextGenerationResponse, model_id: Optional[str] = None) -> ChatMessage:
+    """
+    Convert a TextGenerationResponse instance to a ChatMessage instance.
+
+    :param response: A TextGenerationResponse instance representing the text generation response.
+    :param model_id: An optional string representing the HuggingFace model ID.
+    :return: A ChatMessage instance representing the converted response.
+    """
+    message = ChatMessage.from_assistant(response.generated_text)
+    # TODO add token usage to metadata, it is in res.details.tokens
+    message.metadata.update(
+        {"finish_reason": response.details.finish_reason.value, "index": 0, "model": model_id or "unknown"}
+    )
+    return message
+
+
+@component
+class HuggingFaceRemoteGenerator:
+    """
+    HuggingFaceRemoteGenerator inferences remote Hugging Face models for text generation. It is designed to work
+    with any HuggingFace inference endpoint (https://huggingface.co/inference-endpoints) as well as models deployed
+    with the Text Generation Inference (TGI) framework (https://github.com/huggingface/text-generation-inference)
+    hosting non-chat models.
+
+    It can also use TGI based non-chat models on the rate-limited Inference API (https://huggingface.co/inference-api).
+    The list of available models can be viewed with the command:
+    ```
+    wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference
+    ```
+    HuggingFaceRemoteGenerator uses strings for both input and output.
+    """
+
+    def __init__(
+        self,
+        model: str = "HuggingFaceH4/zephyr-7b-alpha",
+        model_id: Optional[str] = None,
+        token: Optional[Union[str, bool]] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        stop_words: Optional[List[str]] = None,
+        streaming_callback: Optional[Callable] = None,
+    ):
+        """
+        Initialize the HuggingFaceRemoteGenerator instance.
+
+        :param model: A string representing the model path or URL. Default is "HuggingFaceH4/zephyr-7b-alpha".
+        :param model_id: An optional string representing the HuggingFace model ID.
+        :param token: An optional string or boolean representing the authentication token.
+        :param generation_kwargs: An optional dictionary containing generation parameters.
+        :param stop_words: An optional list of strings representing the stop words.
+        :param streaming_callback: An optional callable for handling streaming responses.
+        """
+        r = urlparse(model)
+        is_url = all([r.scheme in ["http", "https"], r.netloc])
+        if is_url:
+            if not model_id:
+                raise ValueError(
+                    "If model is a URL, you must provide a HuggingFace model_id (e.g.mistralai/Mistral-7B-v0.1)"
+                )
+            check_valid_model(model_id, token)
+        else:
+            check_valid_model(model, token)
+
+        generation_kwargs = generation_kwargs or {}
+        check_generation_params(generation_kwargs, ["n"])
+        generation_kwargs["stop_sequences"] = generation_kwargs.get("stop_sequences", []) + (stop_words or [])
+        self.generation_kwargs = generation_kwargs
+
+        self.client = InferenceClient(model, token=token)
+        self.streaming_callback = streaming_callback
+
+    def _get_telemetry_data(self) -> Dict[str, Any]:
+        """
+        Data that is sent to Posthog for usage analytics.
+        """
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        pass
+
+    @component.output_types(replies=List[str])
+    def run(self, prompt: str, **generation_kwargs):
+        """
+        Invoke the text generation inference for the given prompt and generation parameters.
+
+        :param prompt: A string representing the prompt.
+        :param generation_kwargs: Additional keyword arguments for text generation.
+        :return: A list containing the generated responses as ChatMessage instances.
+        """
+        num_responses = generation_kwargs.get("n", 1)
+
+        # check for unknown kwargs
+        check_generation_params(generation_kwargs, ["n"])
+
+        # update generation kwargs with invocation provided kwargs
+        generation_kwargs = {**self.generation_kwargs, **generation_kwargs}
+
+        if self.streaming_callback:
+            if num_responses > 1:
+                raise ValueError("Cannot stream multiple responses, please set n=1.")
+
+            res: Iterable[TextGenerationStreamResponse] = self.client.text_generation(
+                prompt, details=True, **generation_kwargs
+            )
+            chunks: List[ChatMessage] = []
+            for chunk in res:
+                token: Token = chunk.token
+                if token.special:
+                    continue
+                chunk_metadata = {**asdict(token), **(asdict(chunk.details) if chunk.details else {})}
+                chunk = StreamingChunk(token.text, chunk_metadata)
+                self.streaming_callback(chunk)
+            return {"replies": ["".join([chunk.content for chunk in chunks])]}
+        else:
+            responses: List[str] = []
+            for _i in range(num_responses):
+                res: TextGenerationResponse = self.client.text_generation(prompt, **generation_kwargs)
+                responses.append(res.generated_text)
+            return {"replies": [responses]}
+
+
+class ChatHuggingFaceRemoteGenerator:
+    """
+    ChatHuggingFaceRemoteGenerator inferences remote Hugging Face chat models for text generation. It is designed to work
+    with any HuggingFace inference endpoint (https://huggingface.co/inference-endpoints) as well as models deployed
+    with the Text Generation Inference (TGI) framework (https://github.com/huggingface/text-generation-inference).
+    It can also use TGI based models on the rate-limited tier called Inference API (https://huggingface.co/inference-api).
+    The list of available models can be viewed with the command:
+    ```
+    wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference | grep chat
+    ```
+    ChatHuggingFaceRemoteGenerator uses the ChatMessage format for both input and output, which is defined at
+    https://github.com/openai/openai-python/blob/main/chatml.md. This format facilitates the representation of chat
+    conversations in a structured manner, which is crucial for generating coherent and contextually relevant responses
+    in a chat-based text generation scenario.
+
+    """
+
+    def __init__(
+        self,
+        model: str = "meta-llama/Llama-2-13b-chat-hf",
+        model_id: Optional[str] = None,
+        token: Optional[Union[str, bool]] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        stop_words: Optional[List[str]] = None,
+        streaming_callback: Optional[Callable] = None,
+    ):
+        """
+        Initialize the ChatHuggingFaceRemoteGenerator instance.
+
+        :param model: A string representing the model path or URL. Default is "meta-llama/Llama-2-13b-chat-hf".
+        :param model_id: An optional string representing the HuggingFace model ID.
+        :param token: An optional string or boolean representing the authentication token.
+        :param generation_kwargs: An optional dictionary containing generation parameters.
+        :param stop_words: An optional list of strings representing the stop words.
+        :param streaming_callback: An optional callable for handling streaming responses.
+        """
+        r = urlparse(model)
+        is_url = all([r.scheme in ["http", "https"], r.netloc])
+        if is_url:
+            if not model_id:
+                raise ValueError(
+                    "If model is a URL, you must provide a HuggingFace model_id (e.g. meta-llama/Llama-2-7b-chat-hf)"
+                )
+            check_valid_model(model_id, token)
+            self.tokenizer = AutoTokenizer.from_pretrained(model_id, token=token)
+        else:
+            check_valid_model(model, token)
+            self.tokenizer = AutoTokenizer.from_pretrained(model, token=token)
+
+        generation_kwargs = generation_kwargs or {}
+        check_generation_params(generation_kwargs, ["n"])
+
+        generation_kwargs["stop_sequences"] = generation_kwargs.get("stop_sequences", []) + (stop_words or [])
+        self.generation_kwargs = generation_kwargs
+
+        self.client = InferenceClient(model, token=token)
+        self.streaming_callback = streaming_callback
+
+    def _get_telemetry_data(self) -> Dict[str, Any]:
+        """
+        Data that is sent to Posthog for usage analytics.
+
+        :return: A dictionary containing the telemetry data.
+        """
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :return: A dictionary representing the serialized component.
+        """
+        pass
+
+    @component.output_types(replies=List[ChatMessage])
+    def run(self, messages: List[ChatMessage], **generation_kwargs):
+        """
+        Invoke the text generation inference based on the provided messages and generation parameters.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param generation_kwargs: Additional keyword arguments for text generation.
+        :return: A list containing the generated responses as ChatMessage instances.
+        """
+        num_responses = generation_kwargs.get("n", 1)
+
+        # check for unknown kwargs
+        check_generation_params(generation_kwargs, ["n"])
+
+        # update generation kwargs with invocation provided kwargs
+        generation_kwargs = {**self.generation_kwargs, **generation_kwargs}
+
+        # apply chat template to messages to get string prompt
+        prepared_prompt: str = self.tokenizer.apply_chat_template(messages, tokenize=False)
+
+        if self.streaming_callback:
+            if num_responses > 1:
+                raise ValueError("Cannot stream multiple responses, please set n=1.")
+
+            res: Iterable[TextGenerationStreamResponse] = self.client.text_generation(
+                prepared_prompt, stream=True, details=True, **generation_kwargs
+            )
+            chunks: List[StreamingChunk] = []
+            for chunk in res:
+                token: Token = chunk.token
+                if token.special:
+                    continue
+                chunk_metadata = {**asdict(token), **(asdict(chunk.details) if chunk.details else {})}
+                chunk = StreamingChunk(token.text, chunk_metadata)
+                self.streaming_callback(chunk)
+                chunks.append(chunk)
+            return {"replies": [ChatMessage.from_assistant("".join([chunk.content for chunk in chunks]))]}
+        else:
+            chat_messages: List[ChatMessage] = []
+            for _i in range(num_responses):
+                res: TextGenerationResponse = self.client.text_generation(
+                    prepared_prompt, details=True, **generation_kwargs
+                )
+                chat_messages.append(convert_to_chat_message(res))
+            return {"replies": [chat_messages]}

--- a/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
+++ b/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
@@ -118,7 +118,7 @@ class HuggingFaceRemoteGenerator:
         self.streaming_callback = streaming_callback
         self.tokenizer = None
 
-    def warmup(self) -> None:
+    def warm_up(self) -> None:
         """
         Load the tokenizer
         """
@@ -280,7 +280,7 @@ class ChatHuggingFaceRemoteGenerator:
         self.streaming_callback = streaming_callback
         self.tokenizer = None
 
-    def warmup(self) -> None:
+    def warm_up(self) -> None:
         """
         Load the tokenizer
         """

--- a/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
+++ b/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
@@ -180,9 +180,9 @@ class HuggingFaceRemoteGenerator:
                 if token.special:
                     continue
                 chunk_metadata = {**asdict(token), **(asdict(chunk.details) if chunk.details else {})}
-                chunk = StreamingChunk(token.text, chunk_metadata)
-                chunks.append(chunk)
-                self.streaming_callback(chunk)
+                stream_chunk = StreamingChunk(token.text, chunk_metadata)
+                chunks.append(stream_chunk)
+                self.streaming_callback(stream_chunk)
             prompt_tokens_length = len(self.tokenizer.encode(prompt, add_special_tokens=False))
             metadata = {
                 "finish_reason": chunks[-1].metadata.get("finish_reason", None),
@@ -336,9 +336,9 @@ class ChatHuggingFaceRemoteGenerator:
                 if token.special:
                     continue
                 chunk_metadata = {**asdict(token), **(asdict(chunk.details) if chunk.details else {})}
-                chunk = StreamingChunk(token.text, chunk_metadata)
-                self.streaming_callback(chunk)
-                chunks.append(chunk)
+                stream_chunk = StreamingChunk(token.text, chunk_metadata)
+                self.streaming_callback(stream_chunk)
+                chunks.append(stream_chunk)
             prompt_tokens_length = len(self.tokenizer.encode(prepared_prompt, add_special_tokens=False))
             message = ChatMessage.from_assistant("".join([chunk.content for chunk in chunks]))
             message.metadata.update(

--- a/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
+++ b/haystack/preview/components/generators/hugging_face/hugging_face_remote.py
@@ -15,17 +15,6 @@ from haystack.preview.dataclasses import ChatMessage, StreamingChunk
 logger = logging.getLogger(__name__)
 
 
-def accepted_generation_params() -> Set[str]:
-    """
-    Return a set of accepted text generation parameters.
-    """
-    return {
-        param
-        for param in inspect.signature(InferenceClient.text_generation).parameters.keys()
-        if param not in ["self", "prompt"]
-    }
-
-
 def check_generation_params(kwargs: Dict[str, Any], additional_accepted_params: Optional[List[str]] = None):
     """
     Check the provided generation parameters for validity.
@@ -35,7 +24,11 @@ def check_generation_params(kwargs: Dict[str, Any], additional_accepted_params: 
     :raises ValueError: If any unknown text generation parameters are provided.
     """
     if kwargs:
-        accepted_params = accepted_generation_params()
+        accepted_params = {
+            param
+            for param in inspect.signature(InferenceClient.text_generation).parameters.keys()
+            if param not in ["self", "prompt"]
+        }
         if additional_accepted_params:
             accepted_params.update(additional_accepted_params)
         unknown_params = set(kwargs.keys()) - accepted_params

--- a/releasenotes/notes/add-huggingface-remote-inferencing-5dc9b644835721db.yaml
+++ b/releasenotes/notes/add-huggingface-remote-inferencing-5dc9b644835721db.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Introducing `HuggingFaceRemoteGenerator` and `ChatHuggingFaceRemoteGenerator` for text and chat generation.
+    These components support remote inferencing with Hugging Face models via text-generation-inference (TGI) protocol.

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -76,7 +76,7 @@ class TestHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
-        generator.warmup()
+        generator.warm_up()
 
         prompt = "Hello, how are you?"
         response = generator.run(prompt)
@@ -114,7 +114,7 @@ class TestHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
-        generator.warmup()
+        generator.warm_up()
 
         prompt = "Hello, how are you?"
         response = generator.run(prompt)
@@ -159,7 +159,7 @@ class TestHuggingFaceRemoteGenerator:
     @pytest.mark.unit
     def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
         generator = HuggingFaceRemoteGenerator()
-        generator.warmup()
+        generator.warm_up()
 
         stop_words = ["stop", "words"]
 
@@ -187,7 +187,7 @@ class TestHuggingFaceRemoteGenerator:
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
         generator = HuggingFaceRemoteGenerator()
-        generator.warmup()
+        generator.warm_up()
 
         generation_kwargs = {"temperature": 0.8, "max_new_tokens": 100}
         response = generator.run("How are you?", **generation_kwargs)
@@ -223,7 +223,7 @@ class TestHuggingFaceRemoteGenerator:
 
         # Create an instance of HuggingFaceRemoteGenerator
         generator = HuggingFaceRemoteGenerator(streaming_callback=streaming_callback_fn)
-        generator.warmup()
+        generator.warm_up()
 
         # Create a fake streamed response
         def mock_iter(self):
@@ -286,7 +286,7 @@ class TestChatHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
-        generator.warmup()
+        generator.warm_up()
 
         assert generator.model_id == model
         assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
@@ -313,7 +313,7 @@ class TestChatHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
-        generator.warmup()
+        generator.warm_up()
 
         response = generator.run(messages=chat_messages)
 
@@ -347,7 +347,7 @@ class TestChatHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
-        generator.warmup()
+        generator.warm_up()
 
         response = generator.run(chat_messages)
 
@@ -386,7 +386,7 @@ class TestChatHuggingFaceRemoteGenerator:
     @pytest.mark.unit
     def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
         generator = ChatHuggingFaceRemoteGenerator()
-        generator.warmup()
+        generator.warm_up()
 
         stop_words = ["stop", "words"]
 
@@ -408,7 +408,7 @@ class TestChatHuggingFaceRemoteGenerator:
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
         generator = ChatHuggingFaceRemoteGenerator()
-        generator.warmup()
+        generator.warm_up()
 
         generation_kwargs = {"temperature": 0.8, "max_new_tokens": 100}
         response = generator.run(chat_messages, **generation_kwargs)
@@ -438,7 +438,7 @@ class TestChatHuggingFaceRemoteGenerator:
 
         # Create an instance of HuggingFaceRemoteGenerator
         generator = ChatHuggingFaceRemoteGenerator(streaming_callback=streaming_callback_fn)
-        generator.warmup()
+        generator.warm_up()
 
         # Create a fake streamed response
         def mock_iter(self):

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -1,8 +1,13 @@
 from unittest.mock import patch, MagicMock, Mock
 
 import pytest
+from huggingface_hub.inference._text_generation import TextGenerationStreamResponse, Token, StreamDetails, FinishReason
 
-from haystack.preview.components.generators.hugging_face.hugging_face_remote import HuggingFaceRemoteGenerator
+from haystack.preview.components.generators.hugging_face.hugging_face_remote import (
+    HuggingFaceRemoteGenerator,
+    ChatHuggingFaceRemoteGenerator,
+)
+from haystack.preview.dataclasses import StreamingChunk, ChatMessage
 
 
 @pytest.fixture
@@ -190,22 +195,44 @@ class TestHuggingFaceRemoteGenerator:
         assert isinstance(response["metadata"], list)
         assert len(response["metadata"]) > 0
 
-    @pytest.mark.skip(reason="Need to implement stream mocking")
+    @pytest.mark.integration
     def test_generate_text_with_streaming_callback(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
-        # Create an instance of HuggingFaceRemoteGenerator
-        generator = HuggingFaceRemoteGenerator()
+        streaming_call_count = 0
 
         # Define the streaming callback function
-        def streaming_callback(chunk):
-            print(chunk.content)
+        def streaming_callback_fn(chunk: StreamingChunk):
+            nonlocal streaming_call_count
+            streaming_call_count += 1
+            assert isinstance(chunk, StreamingChunk)
 
-        # Set the streaming callback function
-        generator.streaming_callback = streaming_callback
+        # Create an instance of HuggingFaceRemoteGenerator
+        generator = HuggingFaceRemoteGenerator(streaming_callback=streaming_callback_fn)
+
+        # Create a fake streamed response
+        def mock_iter(self):
+            yield TextGenerationStreamResponse(
+                generated_text=None, token=Token(id=1, text="I'm fine, thanks.", logprob=0.0, special=False)
+            )
+            yield TextGenerationStreamResponse(
+                generated_text=None,
+                token=Token(id=1, text="Ok bye", logprob=0.0, special=False),
+                details=StreamDetails(finish_reason=FinishReason.Length, generated_tokens=5),
+            )
+
+        mock_response = Mock(**{"__iter__": mock_iter})
+        mock_text_generation.return_value = mock_response
 
         # Generate text response with streaming callback
         response = generator.run("prompt")
+
+        # check kwargs passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": [], "stream": True}
+
+        # Assert that the streaming callback was called twice
+        assert streaming_call_count == 2
 
         # Assert that the response contains the generated replies
         assert "replies" in response
@@ -216,3 +243,204 @@ class TestHuggingFaceRemoteGenerator:
         assert "metadata" in response
         assert isinstance(response["metadata"], list)
         assert len(response["metadata"]) > 0
+
+
+chat_messages = [
+    ChatMessage.from_system("You are a helpful assistant speaking on A2 level of English"),
+    ChatMessage.from_user("Tell me about Berlin"),
+]
+
+
+class TestChatHuggingFaceRemoteGenerator:
+    @pytest.mark.unit
+    def test_initialize_with_valid_model_and_generation_parameters(self, mock_check_valid_model, mock_auto_tokenizer):
+        model = "HuggingFaceH4/zephyr-7b-alpha"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = ChatHuggingFaceRemoteGenerator(
+            model=model,
+            model_id=model_id,
+            token=token,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        assert generator.model_id == model_id
+        assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
+        assert generator.tokenizer is not None
+        assert generator.client is not None
+        assert generator.streaming_callback == streaming_callback
+
+    @pytest.mark.unit
+    def test_generate_text_response_with_valid_prompt_and_generation_parameters(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        model = "meta-llama/Llama-2-13b-chat-hf"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = ChatHuggingFaceRemoteGenerator(
+            model=model,
+            model_id=model_id,
+            token=token,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        response = generator.run(messages=chat_messages)
+
+        # check kwargs passed to text_generation
+        # note how n was not passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": ["stop"]}
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.unit
+    def test_generate_multiple_text_responses_with_valid_prompt_and_generation_parameters(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        model = "meta-llama/Llama-2-13b-chat-hf"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 3}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = ChatHuggingFaceRemoteGenerator(
+            model=model,
+            model_id=model_id,
+            token=token,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        response = generator.run(chat_messages)
+
+        # check kwargs passed to text_generation
+        # note how n was not passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": ["stop"]}
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 3
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.unit
+    def test_initialize_with_invalid_model_path_or_url(self, mock_check_valid_model):
+        model = "invalid_model"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        mock_check_valid_model.side_effect = ValueError("Invalid model path or url")
+
+        with pytest.raises(ValueError):
+            ChatHuggingFaceRemoteGenerator(
+                model=model,
+                model_id=model_id,
+                token=token,
+                generation_kwargs=generation_kwargs,
+                stop_words=stop_words,
+                streaming_callback=streaming_callback,
+            )
+
+    @pytest.mark.unit
+    def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
+        generator = ChatHuggingFaceRemoteGenerator()
+        stop_words = ["stop", "words"]
+
+        # Generate text response with stop words
+        response = generator.run(chat_messages, stop_words=stop_words)
+
+        # check kwargs passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": ["stop", "words"]}
+
+        # Assert that the response contains the generated replies
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.unit
+    def test_generate_text_with_custom_generation_parameters(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        generator = ChatHuggingFaceRemoteGenerator()
+        generation_kwargs = {"temperature": 0.8, "max_new_tokens": 100}
+        response = generator.run(chat_messages, **generation_kwargs)
+
+        # check kwargs passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "max_new_tokens": 100, "stop_sequences": [], "temperature": 0.8}
+
+        # Assert that the response contains the generated replies and the right response
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert response["replies"][0].content == "I'm fine, thanks."
+
+    @pytest.mark.integration
+    def test_generate_text_with_streaming_callback(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        streaming_call_count = 0
+
+        # Define the streaming callback function
+        def streaming_callback_fn(chunk: StreamingChunk):
+            nonlocal streaming_call_count
+            streaming_call_count += 1
+            assert isinstance(chunk, StreamingChunk)
+
+        # Create an instance of HuggingFaceRemoteGenerator
+        generator = ChatHuggingFaceRemoteGenerator(streaming_callback=streaming_callback_fn)
+
+        # Create a fake streamed response
+        def mock_iter(self):
+            yield TextGenerationStreamResponse(
+                generated_text=None, token=Token(id=1, text="I'm fine, thanks.", logprob=0.0, special=False)
+            )
+            yield TextGenerationStreamResponse(
+                generated_text=None,
+                token=Token(id=1, text="Ok bye", logprob=0.0, special=False),
+                details=StreamDetails(finish_reason=FinishReason.Length, generated_tokens=5),
+            )
+
+        mock_response = Mock(**{"__iter__": mock_iter})
+        mock_text_generation.return_value = mock_response
+
+        # Generate text response with streaming callback
+        response = generator.run(chat_messages)
+
+        # check kwargs passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": [], "stream": True}
+
+        # Assert that the streaming callback was called twice
+        assert streaming_call_count == 2
+
+        # Assert that the response contains the generated replies
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -92,6 +92,7 @@ class TestHuggingFaceRemoteGenerator:
         assert isinstance(response["metadata"], list)
         assert len(response["replies"]) == 1
         assert len(response["metadata"]) == 1
+        assert [isinstance(reply, str) for reply in response["replies"]]
 
     @pytest.mark.unit
     def test_generate_multiple_text_responses_with_valid_prompt_and_generation_parameters(
@@ -125,9 +126,12 @@ class TestHuggingFaceRemoteGenerator:
         assert "replies" in response
         assert "metadata" in response
         assert isinstance(response["replies"], list)
+        assert [isinstance(reply, str) for reply in response["replies"]]
+
         assert isinstance(response["metadata"], list)
         assert len(response["replies"]) == 3
         assert len(response["metadata"]) == 3
+        assert [isinstance(reply, dict) for reply in response["metadata"]]
 
     @pytest.mark.unit
     def test_initialize_with_invalid_model_path_or_url(self, mock_check_valid_model):
@@ -166,11 +170,13 @@ class TestHuggingFaceRemoteGenerator:
         assert "replies" in response
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
+        assert [isinstance(reply, str) for reply in response["replies"]]
 
         # Assert that the response contains the metadata
         assert "metadata" in response
         assert isinstance(response["metadata"], list)
         assert len(response["metadata"]) > 0
+        assert [isinstance(reply, dict) for reply in response["replies"]]
 
     @pytest.mark.unit
     def test_generate_text_with_custom_generation_parameters(
@@ -188,14 +194,16 @@ class TestHuggingFaceRemoteGenerator:
         assert "replies" in response
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
+        assert [isinstance(reply, str) for reply in response["replies"]]
         assert response["replies"][0] == "I'm fine, thanks."
 
         # Assert that the response contains the metadata
         assert "metadata" in response
         assert isinstance(response["metadata"], list)
         assert len(response["metadata"]) > 0
+        assert [isinstance(reply, str) for reply in response["replies"]]
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_generate_text_with_streaming_callback(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
@@ -238,11 +246,13 @@ class TestHuggingFaceRemoteGenerator:
         assert "replies" in response
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
+        assert [isinstance(reply, str) for reply in response["replies"]]
 
         # Assert that the response contains the metadata
         assert "metadata" in response
         assert isinstance(response["metadata"], list)
         assert len(response["metadata"]) > 0
+        assert [isinstance(reply, dict) for reply in response["replies"]]
 
 
 chat_messages = [
@@ -400,7 +410,7 @@ class TestChatHuggingFaceRemoteGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
         assert response["replies"][0].content == "I'm fine, thanks."
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_generate_text_with_streaming_callback(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -34,7 +34,7 @@ def mock_text_generation():
 
 
 # used to test serialization of streaming_callback
-def testing_streaming_callback(x):
+def streaming_callback_handler(x):
     return x
 
 
@@ -92,7 +92,7 @@ class TestHuggingFaceRemoteGenerator:
             model_id="HuggingFaceH4/zephyr-7b-alpha",
             generation_kwargs={"n": 5},
             stop_words=["stop", "words"],
-            streaming_callback=testing_streaming_callback,
+            streaming_callback=streaming_callback_handler,
         )
         # Call the to_dict method
         result = generator.to_dict()
@@ -100,7 +100,7 @@ class TestHuggingFaceRemoteGenerator:
         generator_2 = HuggingFaceRemoteGenerator.from_dict(result)
         assert generator_2.model_id == "HuggingFaceH4/zephyr-7b-alpha"
         assert generator_2.generation_kwargs == {"n": 5, "stop_sequences": ["stop", "words"]}
-        assert generator_2.streaming_callback == testing_streaming_callback
+        assert generator_2.streaming_callback == streaming_callback_handler
 
     @pytest.mark.unit
     def test_initialize_with_url_for_model_without_model_id(self, mock_check_valid_model):
@@ -371,7 +371,6 @@ class TestChatHuggingFaceRemoteGenerator:
         # Assert that the init_params dictionary contains the expected keys and values
         assert init_params["model"] == "NousResearch/Llama-2-7b-chat-hf"
         assert init_params["model_id"] == "NousResearch/Llama-2-7b-chat-hf"
-        assert init_params["stop_words"] == ["stop", "words"]
         assert init_params["token"] is None
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
 
@@ -382,7 +381,7 @@ class TestChatHuggingFaceRemoteGenerator:
             model_id="HuggingFaceH4/zephyr-7b-alpha",
             generation_kwargs={"n": 5},
             stop_words=["stop", "words"],
-            streaming_callback=testing_streaming_callback,
+            streaming_callback=streaming_callback_handler,
         )
         # Call the to_dict method
         result = generator.to_dict()
@@ -390,7 +389,7 @@ class TestChatHuggingFaceRemoteGenerator:
         generator_2 = ChatHuggingFaceRemoteGenerator.from_dict(result)
         assert generator_2.model_id == "HuggingFaceH4/zephyr-7b-alpha"
         assert generator_2.generation_kwargs == {"n": 5, "stop_sequences": ["stop", "words"]}
-        assert generator_2.streaming_callback == testing_streaming_callback
+        assert generator_2.streaming_callback == streaming_callback_handler
 
     @pytest.mark.unit
     def test_initialize_with_url_for_model_without_model_id(self, mock_check_valid_model):

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -33,6 +33,11 @@ def mock_text_generation():
         yield mock_from_pretrained
 
 
+# used to test serialization of streaming_callback
+def testing_streaming_callback(x):
+    return x
+
+
 class TestHuggingFaceRemoteGenerator:
     @pytest.mark.unit
     def test_initialize_with_valid_model_and_generation_parameters(self, mock_check_valid_model, mock_auto_tokenizer):
@@ -80,6 +85,23 @@ class TestHuggingFaceRemoteGenerator:
         assert init_params["stop_words"] == ["stop", "words"]
         assert init_params["token"] is None
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
+
+    @pytest.mark.unit
+    def test_serialize_and_deserialize(self, mock_check_valid_model, mock_auto_tokenizer):
+        generator = HuggingFaceRemoteGenerator(
+            model="HuggingFaceH4/zephyr-7b-alpha",
+            model_id="HuggingFaceH4/zephyr-7b-alpha",
+            generation_kwargs={"n": 5},
+            stop_words=["stop", "words"],
+            streaming_callback=testing_streaming_callback,
+        )
+        # Call the to_dict method
+        result = generator.to_dict()
+
+        generator_2 = HuggingFaceRemoteGenerator.from_dict(result)
+        assert generator_2.model_id == "HuggingFaceH4/zephyr-7b-alpha"
+        assert generator_2.generation_kwargs == {"n": 5, "stop_sequences": ["stop", "words"]}
+        assert generator_2.streaming_callback == testing_streaming_callback
 
     @pytest.mark.unit
     def test_initialize_with_url_for_model_without_model_id(self, mock_check_valid_model):
@@ -353,6 +375,23 @@ class TestChatHuggingFaceRemoteGenerator:
         assert init_params["stop_words"] == ["stop", "words"]
         assert init_params["token"] is None
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
+
+    @pytest.mark.unit
+    def test_serialize_and_deserialize(self, mock_check_valid_model, mock_auto_tokenizer):
+        generator = ChatHuggingFaceRemoteGenerator(
+            model="HuggingFaceH4/zephyr-7b-alpha",
+            model_id="HuggingFaceH4/zephyr-7b-alpha",
+            generation_kwargs={"n": 5},
+            stop_words=["stop", "words"],
+            streaming_callback=testing_streaming_callback,
+        )
+        # Call the to_dict method
+        result = generator.to_dict()
+
+        generator_2 = ChatHuggingFaceRemoteGenerator.from_dict(result)
+        assert generator_2.model_id == "HuggingFaceH4/zephyr-7b-alpha"
+        assert generator_2.generation_kwargs == {"n": 5, "stop_sequences": ["stop", "words"]}
+        assert generator_2.streaming_callback == testing_streaming_callback
 
     @pytest.mark.unit
     def test_initialize_with_url_for_model_without_model_id(self, mock_check_valid_model):

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -51,9 +51,9 @@ class TestHuggingFaceRemoteGenerator:
             streaming_callback=streaming_callback,
         )
 
-        assert generator.model_id == model_id
+        assert generator.model_id == model
         assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
-        assert generator.tokenizer is not None
+        assert generator.tokenizer is None
         assert generator.client is not None
         assert generator.streaming_callback == streaming_callback
 
@@ -76,6 +76,7 @@ class TestHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
+        generator.warmup()
 
         prompt = "Hello, how are you?"
         response = generator.run(prompt)
@@ -113,6 +114,7 @@ class TestHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
+        generator.warmup()
 
         prompt = "Hello, how are you?"
         response = generator.run(prompt)
@@ -157,6 +159,8 @@ class TestHuggingFaceRemoteGenerator:
     @pytest.mark.unit
     def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
         generator = HuggingFaceRemoteGenerator()
+        generator.warmup()
+
         stop_words = ["stop", "words"]
 
         # Generate text response with stop words
@@ -183,6 +187,8 @@ class TestHuggingFaceRemoteGenerator:
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
         generator = HuggingFaceRemoteGenerator()
+        generator.warmup()
+
         generation_kwargs = {"temperature": 0.8, "max_new_tokens": 100}
         response = generator.run("How are you?", **generation_kwargs)
 
@@ -217,6 +223,7 @@ class TestHuggingFaceRemoteGenerator:
 
         # Create an instance of HuggingFaceRemoteGenerator
         generator = HuggingFaceRemoteGenerator(streaming_callback=streaming_callback_fn)
+        generator.warmup()
 
         # Create a fake streamed response
         def mock_iter(self):
@@ -279,8 +286,9 @@ class TestChatHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
+        generator.warmup()
 
-        assert generator.model_id == model_id
+        assert generator.model_id == model
         assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
         assert generator.tokenizer is not None
         assert generator.client is not None
@@ -305,6 +313,7 @@ class TestChatHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
+        generator.warmup()
 
         response = generator.run(messages=chat_messages)
 
@@ -338,6 +347,7 @@ class TestChatHuggingFaceRemoteGenerator:
             stop_words=stop_words,
             streaming_callback=streaming_callback,
         )
+        generator.warmup()
 
         response = generator.run(chat_messages)
 
@@ -376,6 +386,8 @@ class TestChatHuggingFaceRemoteGenerator:
     @pytest.mark.unit
     def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
         generator = ChatHuggingFaceRemoteGenerator()
+        generator.warmup()
+
         stop_words = ["stop", "words"]
 
         # Generate text response with stop words
@@ -396,6 +408,8 @@ class TestChatHuggingFaceRemoteGenerator:
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
         generator = ChatHuggingFaceRemoteGenerator()
+        generator.warmup()
+
         generation_kwargs = {"temperature": 0.8, "max_new_tokens": 100}
         response = generator.run(chat_messages, **generation_kwargs)
 
@@ -424,6 +438,7 @@ class TestChatHuggingFaceRemoteGenerator:
 
         # Create an instance of HuggingFaceRemoteGenerator
         generator = ChatHuggingFaceRemoteGenerator(streaming_callback=streaming_callback_fn)
+        generator.warmup()
 
         # Create a fake streamed response
         def mock_iter(self):

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -14,7 +14,7 @@ from haystack.preview.dataclasses import StreamingChunk, ChatMessage
 @pytest.fixture
 def mock_check_valid_model():
     with patch(
-        "haystack.preview.components.generators.hugging_face.hugging_face_remote.check_valid_model",
+        "haystack.preview.components.generators.hugging_face.hugging_face_remote._check_valid_model",
         MagicMock(return_value=None),
     ) as mock:
         yield mock
@@ -82,7 +82,6 @@ class TestHuggingFaceRemoteGenerator:
         # Assert that the init_params dictionary contains the expected keys and values
         assert init_params["model"] == "HuggingFaceH4/zephyr-7b-alpha"
         assert init_params["model_id"] == "HuggingFaceH4/zephyr-7b-alpha"
-        assert init_params["stop_words"] == ["stop", "words"]
         assert init_params["token"] is None
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
 

--- a/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
+++ b/test/preview/components/generators/hugging_face/test_hugging_face_remote.py
@@ -1,0 +1,218 @@
+from unittest.mock import patch, MagicMock, Mock
+
+import pytest
+
+from haystack.preview.components.generators.hugging_face.hugging_face_remote import HuggingFaceRemoteGenerator
+
+
+@pytest.fixture
+def mock_check_valid_model():
+    with patch(
+        "haystack.preview.components.generators.hugging_face.hugging_face_remote.check_valid_model",
+        MagicMock(return_value=None),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_text_generation():
+    with patch("huggingface_hub.InferenceClient.text_generation", autospec=True) as mock_from_pretrained:
+        mock_response = Mock()
+        mock_response.generated_text = "I'm fine, thanks."
+        details = Mock()
+        details.finish_reason = MagicMock(field1="value")
+        details.tokens = [1, 2, 3]
+        mock_response.details = details
+        mock_from_pretrained.return_value = mock_response
+        yield mock_from_pretrained
+
+
+class TestHuggingFaceRemoteGenerator:
+    @pytest.mark.unit
+    def test_initialize_with_valid_model_and_generation_parameters(self, mock_check_valid_model, mock_auto_tokenizer):
+        model = "HuggingFaceH4/zephyr-7b-alpha"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = HuggingFaceRemoteGenerator(
+            model=model,
+            model_id=model_id,
+            token=token,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        assert generator.model_id == model_id
+        assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
+        assert generator.tokenizer is not None
+        assert generator.client is not None
+        assert generator.streaming_callback == streaming_callback
+
+    @pytest.mark.unit
+    def test_generate_text_response_with_valid_prompt_and_generation_parameters(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        model = "HuggingFaceH4/zephyr-7b-alpha"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = HuggingFaceRemoteGenerator(
+            model=model,
+            model_id=model_id,
+            token=token,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        prompt = "Hello, how are you?"
+        response = generator.run(prompt)
+
+        # check kwargs passed to text_generation
+        # note how n was not passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": ["stop"]}
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert "metadata" in response
+        assert isinstance(response["replies"], list)
+        assert isinstance(response["metadata"], list)
+        assert len(response["replies"]) == 1
+        assert len(response["metadata"]) == 1
+
+    @pytest.mark.unit
+    def test_generate_multiple_text_responses_with_valid_prompt_and_generation_parameters(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        model = "HuggingFaceH4/zephyr-7b-alpha"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 3}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = HuggingFaceRemoteGenerator(
+            model=model,
+            model_id=model_id,
+            token=token,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        prompt = "Hello, how are you?"
+        response = generator.run(prompt)
+
+        # check kwargs passed to text_generation
+        # note how n was not passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": ["stop"]}
+
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert "metadata" in response
+        assert isinstance(response["replies"], list)
+        assert isinstance(response["metadata"], list)
+        assert len(response["replies"]) == 3
+        assert len(response["metadata"]) == 3
+
+    @pytest.mark.unit
+    def test_initialize_with_invalid_model_path_or_url(self, mock_check_valid_model):
+        model = "invalid_model"
+        model_id = None
+        token = None
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        mock_check_valid_model.side_effect = ValueError("Invalid model path or url")
+
+        with pytest.raises(ValueError):
+            HuggingFaceRemoteGenerator(
+                model=model,
+                model_id=model_id,
+                token=token,
+                generation_kwargs=generation_kwargs,
+                stop_words=stop_words,
+                streaming_callback=streaming_callback,
+            )
+
+    @pytest.mark.unit
+    def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
+        generator = HuggingFaceRemoteGenerator()
+        stop_words = ["stop", "words"]
+
+        # Generate text response with stop words
+        response = generator.run("How are you?", stop_words=stop_words)
+
+        # check kwargs passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "stop_sequences": ["stop", "words"]}
+
+        # Assert that the response contains the generated replies
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+
+        # Assert that the response contains the metadata
+        assert "metadata" in response
+        assert isinstance(response["metadata"], list)
+        assert len(response["metadata"]) > 0
+
+    @pytest.mark.unit
+    def test_generate_text_with_custom_generation_parameters(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        generator = HuggingFaceRemoteGenerator()
+        generation_kwargs = {"temperature": 0.8, "max_new_tokens": 100}
+        response = generator.run("How are you?", **generation_kwargs)
+
+        # check kwargs passed to text_generation
+        args, kwargs = mock_text_generation.call_args
+        assert kwargs == {"details": True, "max_new_tokens": 100, "stop_sequences": [], "temperature": 0.8}
+
+        # Assert that the response contains the generated replies and the right response
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert response["replies"][0] == "I'm fine, thanks."
+
+        # Assert that the response contains the metadata
+        assert "metadata" in response
+        assert isinstance(response["metadata"], list)
+        assert len(response["metadata"]) > 0
+
+    @pytest.mark.skip(reason="Need to implement stream mocking")
+    def test_generate_text_with_streaming_callback(
+        self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
+    ):
+        # Create an instance of HuggingFaceRemoteGenerator
+        generator = HuggingFaceRemoteGenerator()
+
+        # Define the streaming callback function
+        def streaming_callback(chunk):
+            print(chunk.content)
+
+        # Set the streaming callback function
+        generator.streaming_callback = streaming_callback
+
+        # Generate text response with streaming callback
+        response = generator.run("prompt")
+
+        # Assert that the response contains the generated replies
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+
+        # Assert that the response contains the metadata
+        assert "metadata" in response
+        assert isinstance(response["metadata"], list)
+        assert len(response["metadata"]) > 0


### PR DESCRIPTION
### Why:
- To enable remote Hugging Face models inference for text generation, facilitating both chat and non-chat use models while providing flexibility for streaming responses. These components are compatible with any Text Generation Inference (TGI) deployed model. 

### What:
- Two new classes, `HuggingFaceRemoteGenerator` and `ChatHuggingFaceRemoteGenerator`, have been introduced. They are designed to work with any HuggingFace inference endpoint or models deployed with the Text Generation Inference (TGI) framework.

### How can it be used:
```python
from haystack.preview.components.generators.hugging_face.hugging_face_remote import ChatHuggingFaceRemoteGenerator, HuggingFaceRemoteGenerator
from haystack.preview.dataclasses import ChatMessage

# For chat-based text generation:
messages = [ChatMessage.from_system("You are a helpful assistant speaking on A2 level of English"),
            ChatMessage.from_user("Tell me about Belgrade")]

chat_client = ChatHuggingFaceRemoteGenerator(model="meta-llama/Llama-2-70b-chat-hf", token="<your-hf-token-here>")
chat_client.warm_up()

chat_response = chat_client.run(messages, max_new_tokens=120)
print(chat_response)

# For streaming chat responses:
chat_client = ChatHuggingFaceRemoteGenerator(model="meta-llama/Llama-2-70b-chat-hf",
                                        token="<your-hf-token-here>",
                                        streaming_callback=lambda x: print(x.content, flush=True, end=""))
chat_client.warm_up()

streaming_result = client.run(messages, max_new_tokens=120)


# For non-chat text generation:
non_chat_client = HuggingFaceRemoteGenerator(model="HuggingFaceH4/zephyr-7b-alpha", token="<your-hf-token-here>")
non_chat_client.warm_up()

non_chat_result = non_chat_client.run("Tell me about Berlin", max_new_tokens=120)
print(non_chat_result)

# For streaming non-chat responses:
streaming_client = HuggingFaceRemoteGenerator(model="HuggingFaceH4/zephyr-7b-alpha", token="<your-hf-token-here>",
                                              streaming_callback=lambda x: print(x.content, flush=True, end=""))
streaming_client.warm_up()

streaming_result = streaming_client.run("Tell me about Berlin", max_new_tokens=120)
```
These examples demonstrate how users can leverage remote Hugging Face models for generating text responses in both chat and non-chat contexts, with an additional example showcasing the streaming capability for handling responses in real-time.

### How did you test it:
Only manually for now. See examples above. ~~Will add unit tests once @anakin87 and I are synced around the final APIs~~
Added unit tests in `test/preview/components/generators/hugging_face/test_hugging_face_remote.py`

### Notes for reviewer:
Ready for review
