### PR TITLE
refactor: Rename `Document`'s `metadata` field to `meta`

### DIFF
--- a/haystack/preview/components/audio/whisper_local.py
+++ b/haystack/preview/components/audio/whisper_local.py
@@ -110,7 +110,7 @@ class LocalWhisperTranscriber:
             content = transcript.pop("text")
             if not isinstance(audio, (str, Path)):
                 audio = "<<binary stream>>"
-            doc = Document(content=content, metadata={"audio_file": audio, **transcript})
+            doc = Document(content=content, meta={"audio_file": audio, **transcript})
             documents.append(doc)
         return documents
 

--- a/haystack/preview/components/audio/whisper_remote.py
+++ b/haystack/preview/components/audio/whisper_remote.py
@@ -92,7 +92,7 @@ class RemoteWhisperTranscriber:
             content = transcript.pop("text")
             if not isinstance(audio, (str, Path)):
                 audio = "<<binary stream>>"
-            doc = Document(content=content, metadata={"audio_file": audio, **transcript})
+            doc = Document(content=content, meta={"audio_file": audio, **transcript})
             documents.append(doc)
         return documents
 

--- a/haystack/preview/components/embedders/openai_document_embedder.py
+++ b/haystack/preview/components/embedders/openai_document_embedder.py
@@ -97,9 +97,9 @@ class OpenAIDocumentEmbedder:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.metadata[key])
+                str(doc.meta[key])
                 for key in self.metadata_fields_to_embed
-                if key in doc.metadata and doc.metadata[key] is not None
+                if key in doc.meta and doc.meta[key] is not None
             ]
 
             text_to_embed = (

--- a/haystack/preview/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/preview/components/embedders/sentence_transformers_document_embedder.py
@@ -109,9 +109,7 @@ class SentenceTransformersDocumentEmbedder:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.metadata[key])
-                for key in self.metadata_fields_to_embed
-                if key in doc.metadata and doc.metadata[key]
+                str(doc.meta[key]) for key in self.metadata_fields_to_embed if key in doc.meta and doc.meta[key]
             ]
             text_to_embed = (
                 self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix

--- a/haystack/preview/components/file_converters/txt.py
+++ b/haystack/preview/components/file_converters/txt.py
@@ -118,7 +118,7 @@ class TextFileToDocument:
                     valid_languages,
                 )
 
-            document = Document(content=text, metadata=meta)
+            document = Document(content=text, meta=meta)
             documents.append(document)
 
         return {"documents": documents}

--- a/haystack/preview/components/preprocessors/text_document_cleaner.py
+++ b/haystack/preview/components/preprocessors/text_document_cleaner.py
@@ -86,7 +86,7 @@ class DocumentCleaner:
             if self.remove_repeated_substrings:
                 text = self._remove_repeated_substrings(text)
 
-            cleaned_docs.append(Document(content=text, metadata=deepcopy(doc.metadata)))
+            cleaned_docs.append(Document(content=text, meta=deepcopy(doc.meta)))
 
         return {"documents": cleaned_docs}
 

--- a/haystack/preview/components/preprocessors/text_document_splitter.py
+++ b/haystack/preview/components/preprocessors/text_document_splitter.py
@@ -55,9 +55,9 @@ class TextDocumentSplitter:
                 )
             units = self._split_into_units(doc.content, self.split_by)
             text_splits = self._concatenate_units(units, self.split_length, self.split_overlap)
-            metadata = deepcopy(doc.metadata)
+            metadata = deepcopy(doc.meta)
             metadata["source_id"] = doc.id
-            split_docs += [Document(content=txt, metadata=metadata) for txt in text_splits]
+            split_docs += [Document(content=txt, meta=metadata) for txt in text_splits]
         return {"documents": split_docs}
 
     def _split_into_units(self, text: str, split_by: Literal["word", "sentence", "passage"]) -> List[str]:

--- a/haystack/preview/components/samplers/top_p.py
+++ b/haystack/preview/components/samplers/top_p.py
@@ -108,7 +108,7 @@ class TopPSampler:
         :return: List of scores.
         """
         if self.score_field:
-            missing_scores_docs = [d for d in documents if self.score_field not in d.metadata]
+            missing_scores_docs = [d for d in documents if self.score_field not in d.meta]
             if missing_scores_docs:
                 missing_scores_docs_ids = [d.id for d in missing_scores_docs if d.id]
                 raise ComponentError(
@@ -116,7 +116,7 @@ class TopPSampler:
                     f"with IDs: {missing_scores_docs_ids}."
                     f"Make sure that all documents have a score field '{self.score_field}' in their metadata."
                 )
-            return [d.metadata[self.score_field] for d in documents]
+            return [d.meta[self.score_field] for d in documents]
         else:
             missing_scores_docs = [d for d in documents if d.score is None]
             if missing_scores_docs:

--- a/haystack/preview/components/websearch/serper_dev.py
+++ b/haystack/preview/components/websearch/serper_dev.py
@@ -92,7 +92,7 @@ class SerperDevWebSearch:
 
         # we get the snippet from the json result and put it in the content field of the document
         organic = [
-            Document(metadata={k: v for k, v in d.items() if k != "snippet"}, content=d["snippet"])
+            Document(meta={k: v for k, v in d.items() if k != "snippet"}, content=d["snippet"])
             for d in json_result["organic"]
         ]
 
@@ -116,7 +116,7 @@ class SerperDevWebSearch:
                 answer_box = [
                     Document(
                         content=answer_box_content,
-                        metadata={"title": answer_dict.get("title", ""), "link": answer_dict.get("link", "")},
+                        meta={"title": answer_dict.get("title", ""), "link": answer_dict.get("link", "")},
                     )
                 ]
 
@@ -128,7 +128,7 @@ class SerperDevWebSearch:
                 people_also_ask.append(
                     Document(
                         content=result["snippet"] if result.get("snippet") else title,
-                        metadata={"title": title, "link": result.get("link", None)},
+                        meta={"title": title, "link": result.get("link", None)},
                     )
                 )
 

--- a/haystack/preview/testing/document_store.py
+++ b/haystack/preview/testing/document_store.py
@@ -31,36 +31,36 @@ class DocumentStoreBaseTests:
             documents.append(
                 Document(
                     content=f"A Foo Document {i}",
-                    metadata={"name": f"name_{i}", "page": "100", "chapter": "intro", "number": 2},
+                    meta={"name": f"name_{i}", "page": "100", "chapter": "intro", "number": 2},
                     embedding=_random_embeddings(768),
                 )
             )
             documents.append(
                 Document(
                     content=f"A Bar Document {i}",
-                    metadata={"name": f"name_{i}", "page": "123", "chapter": "abstract", "number": -2},
+                    meta={"name": f"name_{i}", "page": "123", "chapter": "abstract", "number": -2},
                     embedding=_random_embeddings(768),
                 )
             )
             documents.append(
                 Document(
                     content=f"A Foobar Document {i}",
-                    metadata={"name": f"name_{i}", "page": "90", "chapter": "conclusion", "number": -10},
+                    meta={"name": f"name_{i}", "page": "90", "chapter": "conclusion", "number": -10},
                     embedding=_random_embeddings(768),
                 )
             )
             documents.append(
                 Document(
                     content=f"Document {i} without embedding",
-                    metadata={"name": f"name_{i}", "no_embedding": True, "chapter": "conclusion"},
+                    meta={"name": f"name_{i}", "no_embedding": True, "chapter": "conclusion"},
                 )
             )
-            documents.append(Document(dataframe=pd.DataFrame([i]), metadata={"name": f"table_doc_{i}"}))
+            documents.append(Document(dataframe=pd.DataFrame([i]), meta={"name": f"table_doc_{i}"}))
             documents.append(
-                Document(content=f"Doc {i} with zeros emb", metadata={"name": "zeros_doc"}, embedding=embedding_zero)
+                Document(content=f"Doc {i} with zeros emb", meta={"name": "zeros_doc"}, embedding=embedding_zero)
             )
             documents.append(
-                Document(content=f"Doc {i} with ones emb", metadata={"name": "ones_doc"}, embedding=embedding_one)
+                Document(content=f"Doc {i} with ones emb", meta={"name": "ones_doc"}, embedding=embedding_one)
             )
         return documents
 
@@ -101,13 +101,13 @@ class DocumentStoreBaseTests:
     def test_filter_simple_metadata_value(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": "100"})
-        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
+        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
     @pytest.mark.unit
     def test_filter_simple_list_single_element(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": ["100"]})
-        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
+        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
     @pytest.mark.unit
     def test_filter_document_content(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -128,14 +128,14 @@ class DocumentStoreBaseTests:
     def test_filter_simple_list_one_value(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": ["100"]})
-        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100"]])
+        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100"]])
 
     @pytest.mark.unit
     def test_filter_simple_list(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": ["100", "123"]})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100", "123"]]
+            result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100", "123"]]
         )
 
     @pytest.mark.unit
@@ -172,13 +172,13 @@ class DocumentStoreBaseTests:
     def test_eq_filter_explicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": {"$eq": "100"}})
-        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
+        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
     @pytest.mark.unit
     def test_eq_filter_implicit(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": "100"})
-        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") == "100"])
+        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
     @pytest.mark.unit
     def test_eq_filter_table(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -205,7 +205,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": {"$in": ["100", "123", "n.a."]}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100", "123"]]
+            result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100", "123"]]
         )
 
     @pytest.mark.unit
@@ -213,7 +213,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": ["100", "123", "n.a."]})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if doc.metadata.get("page") in ["100", "123"]]
+            result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100", "123"]]
         )
 
     @pytest.mark.unit
@@ -245,7 +245,7 @@ class DocumentStoreBaseTests:
     def test_ne_filter(self, docstore: DocumentStore, filterable_docs: List[Document]):
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": {"$ne": "100"}})
-        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.metadata.get("page") != "100"])
+        assert self.contains_same_docs(result, [doc for doc in filterable_docs if doc.meta.get("page") != "100"])
 
     @pytest.mark.unit
     def test_ne_filter_table(self, docstore: DocumentStore, filterable_docs: List[Document]):
@@ -308,7 +308,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"page": {"$nin": ["100", "123", "n.a."]}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if doc.metadata.get("page") not in ["100", "123"]]
+            result, [doc for doc in filterable_docs if doc.meta.get("page") not in ["100", "123"]]
         )
 
     @pytest.mark.unit
@@ -316,7 +316,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$gt": 0.0}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] > 0]
+            result, [doc for doc in filterable_docs if "number" in doc.meta and doc.meta["number"] > 0]
         )
 
     @pytest.mark.unit
@@ -343,7 +343,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$gte": -2}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] >= -2]
+            result, [doc for doc in filterable_docs if "number" in doc.meta and doc.meta["number"] >= -2]
         )
 
     @pytest.mark.unit
@@ -370,7 +370,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$lt": 0.0}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] < 0]
+            result, [doc for doc in filterable_docs if "number" in doc.meta and doc.meta["number"] < 0]
         )
 
     @pytest.mark.unit
@@ -397,7 +397,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$lte": 2.0}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if "number" in doc.metadata and doc.metadata["number"] <= 2.0]
+            result, [doc for doc in filterable_docs if "number" in doc.meta and doc.meta["number"] <= 2.0]
         )
 
     @pytest.mark.unit
@@ -430,7 +430,7 @@ class DocumentStoreBaseTests:
             [
                 doc
                 for doc in filterable_docs
-                if "number" in doc.metadata and doc.metadata["number"] >= 0.0 and doc.metadata["number"] <= 2.0
+                if "number" in doc.meta and doc.meta["number"] >= 0.0 and doc.meta["number"] <= 2.0
             ],
         )
 
@@ -441,7 +441,7 @@ class DocumentStoreBaseTests:
         docstore.write_documents(filterable_docs)
         result = docstore.filter_documents(filters={"number": {"$and": {"$gte": 0, "$lte": 2}}})
         assert self.contains_same_docs(
-            result, [doc for doc in filterable_docs if "number" in doc.metadata and 0 <= doc.metadata["number"] <= 2]
+            result, [doc for doc in filterable_docs if "number" in doc.meta and 0 <= doc.meta["number"] <= 2]
         )
 
     @pytest.mark.unit
@@ -453,7 +453,7 @@ class DocumentStoreBaseTests:
             [
                 doc
                 for doc in filterable_docs
-                if "number" in doc.metadata and doc.metadata["number"] <= 2.0 and doc.metadata["number"] >= 0.0
+                if "number" in doc.meta and doc.meta["number"] <= 2.0 and doc.meta["number"] >= 0.0
             ],
         )
 
@@ -466,7 +466,7 @@ class DocumentStoreBaseTests:
             [
                 doc
                 for doc in filterable_docs
-                if "number" in doc.metadata and doc.metadata["number"] <= 2.0 and doc.metadata["number"] >= 0.0
+                if "number" in doc.meta and doc.meta["number"] <= 2.0 and doc.meta["number"] >= 0.0
             ],
         )
 
@@ -481,10 +481,10 @@ class DocumentStoreBaseTests:
                 doc
                 for doc in filterable_docs
                 if (
-                    "number" in doc.metadata
-                    and doc.metadata["number"] >= 0
-                    and doc.metadata["number"] <= 2
-                    and doc.metadata["name"] in ["name_0", "name_1"]
+                    "number" in doc.meta
+                    and doc.meta["number"] >= 0
+                    and doc.meta["number"] <= 2
+                    and doc.meta["name"] in ["name_0", "name_1"]
                 )
             ],
         )
@@ -500,10 +500,10 @@ class DocumentStoreBaseTests:
                 doc
                 for doc in filterable_docs
                 if (
-                    "number" in doc.metadata
-                    and doc.metadata["number"] <= 2
-                    and doc.metadata["number"] >= 0
-                    and doc.metadata.get("name") in ["name_0", "name_1"]
+                    "number" in doc.meta
+                    and doc.meta["number"] <= 2
+                    and doc.meta["number"] >= 0
+                    and doc.meta.get("name") in ["name_0", "name_1"]
                 )
             ],
         )
@@ -518,10 +518,7 @@ class DocumentStoreBaseTests:
             [
                 doc
                 for doc in filterable_docs
-                if (
-                    ("number" in doc.metadata and doc.metadata["number"] < 1)
-                    or doc.metadata.get("name") in ["name_0", "name_1"]
-                )
+                if (("number" in doc.meta and doc.meta["number"] < 1) or doc.meta.get("name") in ["name_0", "name_1"])
             ],
         )
 
@@ -535,10 +532,7 @@ class DocumentStoreBaseTests:
             [
                 doc
                 for doc in filterable_docs
-                if (
-                    doc.metadata.get("name") in ["name_0", "name_1"]
-                    or ("number" in doc.metadata and doc.metadata["number"] < 1)
-                )
+                if (doc.meta.get("name") in ["name_0", "name_1"] or ("number" in doc.meta and doc.meta["number"] < 1))
             ],
         )
 
@@ -555,10 +549,10 @@ class DocumentStoreBaseTests:
                 doc
                 for doc in filterable_docs
                 if (
-                    doc.metadata.get("page") in ["123"]
+                    doc.meta.get("page") in ["123"]
                     and (
-                        doc.metadata.get("name") in ["name_0", "name_1"]
-                        or ("number" in doc.metadata and doc.metadata["number"] < 1)
+                        doc.meta.get("name") in ["name_0", "name_1"]
+                        or ("number" in doc.meta and doc.meta["number"] < 1)
                     )
                 )
             ],
@@ -578,10 +572,10 @@ class DocumentStoreBaseTests:
                 doc
                 for doc in filterable_docs
                 if (
-                    doc.metadata.get("page") in ["123"]
+                    doc.meta.get("page") in ["123"]
                     and (
-                        doc.metadata.get("name") in ["name_0", "name_1"]
-                        or ("number" in doc.metadata and doc.metadata["number"] < 1)
+                        doc.meta.get("name") in ["name_0", "name_1"]
+                        or ("number" in doc.meta and doc.meta["number"] < 1)
                     )
                 )
             ],
@@ -603,10 +597,10 @@ class DocumentStoreBaseTests:
                 doc
                 for doc in filterable_docs
                 if (
-                    ("number" in doc.metadata and doc.metadata["number"] < 1)
+                    ("number" in doc.meta and doc.meta["number"] < 1)
                     or (
-                        doc.metadata.get("name") in ["name_0", "name_1"]
-                        and ("chapter" in doc.metadata and doc.metadata["chapter"] != "intro")
+                        doc.meta.get("name") in ["name_0", "name_1"]
+                        and ("chapter" in doc.meta and doc.meta["chapter"] != "intro")
                     )
                 )
             ],
@@ -630,8 +624,8 @@ class DocumentStoreBaseTests:
                 doc
                 for doc in filterable_docs
                 if (
-                    (doc.metadata.get("name") in ["name_0", "name_1"] and doc.metadata.get("page") == "100")
-                    or (doc.metadata.get("chapter") in ["intro", "abstract"] and doc.metadata.get("page") == "123")
+                    (doc.meta.get("name") in ["name_0", "name_1"] and doc.meta.get("page") == "100")
+                    or (doc.meta.get("chapter") in ["intro", "abstract"] and doc.meta.get("page") == "123")
                 )
             ],
         )

--- a/proposals/text/5794-evaluation-haystack-2.py
+++ b/proposals/text/5794-evaluation-haystack-2.py
@@ -20,13 +20,11 @@ docstore = MemoryDocumentStore()
 # Write some fake documents
 docstore.write_documents(
     [
-        Document(content="This is not the answer you are looking for.", metadata={"name": "Obi-Wan Kenobi"}),
-        Document(content="This is the way.", metadata={"name": "Mandalorian"}),
-        Document(content="The answer to life, the universe and everything is 42.", metadata={"name": "Deep Thought"}),
-        Document(
-            content="When you play the game of thrones, you win or you die.", metadata={"name": "Cersei Lannister"}
-        ),
-        Document(content="Winter is coming.", metadata={"name": "Ned Stark"}),
+        Document(content="This is not the answer you are looking for.", meta={"name": "Obi-Wan Kenobi"}),
+        Document(content="This is the way.", meta={"name": "Mandalorian"}),
+        Document(content="The answer to life, the universe and everything is 42.", meta={"name": "Deep Thought"}),
+        Document(content="When you play the game of thrones, you win or you die.", meta={"name": "Cersei Lannister"}),
+        Document(content="Winter is coming.", meta={"name": "Ned Stark"}),
     ]
 )
 
@@ -92,13 +90,10 @@ expected_output = [
             "documents": [
                 [
                     Document(
-                        content="The answer to life, the universe and everything is 42.",
-                        metadata={"name": "Deep Thought"},
+                        content="The answer to life, the universe and everything is 42.", meta={"name": "Deep Thought"}
                     ),
-                    Document(
-                        content="This is not the answer you are looking for.", metadata={"name": "Obi-Wan Kenobi"}
-                    ),
-                    Document(content="This is the way.", metadata={"name": "Mandalorian"}),
+                    Document(content="This is not the answer you are looking for.", meta={"name": "Obi-Wan Kenobi"}),
+                    Document(content="This is the way.", meta={"name": "Mandalorian"}),
                 ]
             ]
         },
@@ -112,13 +107,10 @@ expected_output = [
             "documents": [
                 [
                     Document(
-                        content="The answer to life, the universe and everything is 42.",
-                        metadata={"name": "Deep Thought"},
+                        content="The answer to life, the universe and everything is 42.", meta={"name": "Deep Thought"}
                     ),
-                    Document(
-                        content="This is not the answer you are looking for.", metadata={"name": "Obi-Wan Kenobi"}
-                    ),
-                    Document(content="This is the way.", metadata={"name": "Mandalorian"}),
+                    Document(content="This is not the answer you are looking for.", meta={"name": "Obi-Wan Kenobi"}),
+                    Document(content="This is the way.", meta={"name": "Mandalorian"}),
                 ]
             ]
         },
@@ -130,13 +122,10 @@ expected_output = [
             "documents": [
                 [
                     Document(
-                        content="The answer to life, the universe and everything is 42.",
-                        metadata={"name": "Deep Thought"},
+                        content="The answer to life, the universe and everything is 42.", meta={"name": "Deep Thought"}
                     ),
-                    Document(
-                        content="This is not the answer you are looking for.", metadata={"name": "Obi-Wan Kenobi"}
-                    ),
-                    Document(content="This is the way.", metadata={"name": "Mandalorian"}),
+                    Document(content="This is not the answer you are looking for.", meta={"name": "Obi-Wan Kenobi"}),
+                    Document(content="This is the way.", meta={"name": "Mandalorian"}),
                 ]
             ]
         },

--- a/releasenotes/notes/document-metadata-to-meta-8564aa3c045bb526.yaml
+++ b/releasenotes/notes/document-metadata-to-meta-8564aa3c045bb526.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Rename `Document`'s `metadata` field to `meta` to enhance backward compatibility

--- a/test/preview/components/audio/test_whisper_local.py
+++ b/test/preview/components/audio/test_whisper_local.py
@@ -80,7 +80,7 @@ class TestLocalWhisperTranscriber:
         results = comp.run(audio_files=[SAMPLES_PATH / "audio" / "this is the content of the document.wav"])
         expected = Document(
             content="test transcription",
-            metadata={
+            meta={
                 "audio_file": SAMPLES_PATH / "audio" / "this is the content of the document.wav",
                 "other_metadata": ["other", "meta", "data"],
             },
@@ -100,7 +100,7 @@ class TestLocalWhisperTranscriber:
         )
         expected = Document(
             content="test transcription",
-            metadata={
+            meta={
                 "audio_file": str((SAMPLES_PATH / "audio" / "this is the content of the document.wav").absolute()),
                 "other_metadata": ["other", "meta", "data"],
             },
@@ -118,7 +118,7 @@ class TestLocalWhisperTranscriber:
         results = comp.transcribe(audio_files=[SAMPLES_PATH / "audio" / "this is the content of the document.wav"])
         expected = Document(
             content="test transcription",
-            metadata={
+            meta={
                 "audio_file": SAMPLES_PATH / "audio" / "this is the content of the document.wav",
                 "other_metadata": ["other", "meta", "data"],
             },
@@ -138,7 +138,7 @@ class TestLocalWhisperTranscriber:
         )
         expected = Document(
             content="test transcription",
-            metadata={"audio_file": "<<binary stream>>", "other_metadata": ["other", "meta", "data"]},
+            meta={"audio_file": "<<binary stream>>", "other_metadata": ["other", "meta", "data"]},
         )
         assert results == [expected]
 
@@ -158,15 +158,13 @@ class TestLocalWhisperTranscriber:
         assert len(docs) == 3
 
         assert docs[0].content.strip().lower() == "this is the content of the document."
-        assert (
-            preview_samples_path / "audio" / "this is the content of the document.wav" == docs[0].metadata["audio_file"]
-        )
+        assert preview_samples_path / "audio" / "this is the content of the document.wav" == docs[0].meta["audio_file"]
 
         assert docs[1].content.strip().lower() == "the context for this answer is here."
         assert (
             str((preview_samples_path / "audio" / "the context for this answer is here.wav").absolute())
-            == docs[1].metadata["audio_file"]
+            == docs[1].meta["audio_file"]
         )
 
         assert docs[2].content.strip().lower() == "answer."
-        assert docs[2].metadata["audio_file"] == "<<binary stream>>"
+        assert docs[2].meta["audio_file"] == "<<binary stream>>"

--- a/test/preview/components/audio/test_whisper_remote.py
+++ b/test/preview/components/audio/test_whisper_remote.py
@@ -69,7 +69,7 @@ class TestRemoteWhisperTranscriber:
             result = comp.run(audio_files=[preview_samples_path / "audio" / "this is the content of the document.wav"])
             expected = Document(
                 content="test transcription",
-                metadata={
+                meta={
                     "audio_file": preview_samples_path / "audio" / "this is the content of the document.wav",
                     "other_metadata": ["other", "meta", "data"],
                 },
@@ -93,7 +93,7 @@ class TestRemoteWhisperTranscriber:
             )
             expected = Document(
                 content="test transcription",
-                metadata={
+                meta={
                     "audio_file": str(
                         (preview_samples_path / "audio" / "this is the content of the document.wav").absolute()
                     ),
@@ -116,7 +116,7 @@ class TestRemoteWhisperTranscriber:
                 result = comp.transcribe(audio_files=[audio_stream])
                 expected = Document(
                     content="test transcription",
-                    metadata={"audio_file": "<<binary stream>>", "other_metadata": ["other", "meta", "data"]},
+                    meta={"audio_file": "<<binary stream>>", "other_metadata": ["other", "meta", "data"]},
                 )
                 assert result == [expected]
 
@@ -212,15 +212,13 @@ class TestRemoteWhisperTranscriber:
         assert len(docs) == 3
 
         assert docs[0].content.strip().lower() == "this is the content of the document."
-        assert (
-            preview_samples_path / "audio" / "this is the content of the document.wav" == docs[0].metadata["audio_file"]
-        )
+        assert preview_samples_path / "audio" / "this is the content of the document.wav" == docs[0].meta["audio_file"]
 
         assert docs[1].content.strip().lower() == "the context for this answer is here."
         assert (
             str((preview_samples_path / "audio" / "the context for this answer is here.wav").absolute())
-            == docs[1].metadata["audio_file"]
+            == docs[1].meta["audio_file"]
         )
 
         assert docs[2].content.strip().lower() == "answer."
-        assert docs[2].metadata["audio_file"] == "<<binary stream>>"
+        assert docs[2].meta["audio_file"] == "<<binary stream>>"

--- a/test/preview/components/builders/test_answer_builder.py
+++ b/test/preview/components/builders/test_answer_builder.py
@@ -41,7 +41,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString"
-        assert answers[0].metadata == {}
+        assert answers[0].meta == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -52,7 +52,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].metadata == {}
+        assert answers[0].meta == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -63,7 +63,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "'AnswerString'"
-        assert answers[0].metadata == {}
+        assert answers[0].meta == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -80,7 +80,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].metadata == {}
+        assert answers[0].meta == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)

--- a/test/preview/components/caching/test_url_cache_checker.py
+++ b/test/preview/components/caching/test_url_cache_checker.py
@@ -72,10 +72,10 @@ class TestUrlCacheChecker:
     def test_run(self):
         docstore = InMemoryDocumentStore()
         documents = [
-            Document(content="doc1", metadata={"url": "https://example.com/1"}),
-            Document(content="doc2", metadata={"url": "https://example.com/2"}),
-            Document(content="doc3", metadata={"url": "https://example.com/1"}),
-            Document(content="doc4", metadata={"url": "https://example.com/2"}),
+            Document(content="doc1", meta={"url": "https://example.com/1"}),
+            Document(content="doc2", meta={"url": "https://example.com/2"}),
+            Document(content="doc3", meta={"url": "https://example.com/1"}),
+            Document(content="doc4", meta={"url": "https://example.com/2"}),
         ]
         docstore.write_documents(documents)
         checker = UrlCacheChecker(docstore)

--- a/test/preview/components/embedders/test_openai_document_embedder.py
+++ b/test/preview/components/embedders/test_openai_document_embedder.py
@@ -123,8 +123,7 @@ class TestOpenAIDocumentEmbedder:
     @pytest.mark.unit
     def test_prepare_texts_to_embed_w_metadata(self):
         documents = [
-            Document(content=f"document number {i}:\ncontent", metadata={"meta_field": f"meta_value {i}"})
-            for i in range(5)
+            Document(content=f"document number {i}:\ncontent", meta={"meta_field": f"meta_value {i}"}) for i in range(5)
         ]
 
         embedder = OpenAIDocumentEmbedder(
@@ -185,8 +184,8 @@ class TestOpenAIDocumentEmbedder:
     @pytest.mark.unit
     def test_run(self):
         docs = [
-            Document(content="I love cheese", metadata={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", metadata={"topic": "ML"}),
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
 
         model = "text-similarity-ada-001"
@@ -227,8 +226,8 @@ class TestOpenAIDocumentEmbedder:
     @pytest.mark.unit
     def test_run_custom_batch_size(self):
         docs = [
-            Document(content="I love cheese", metadata={"topic": "Cuisine"}),
-            Document(content="A transformer is a deep learning architecture", metadata={"topic": "ML"}),
+            Document(content="I love cheese", meta={"topic": "Cuisine"}),
+            Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
 
         model = "text-similarity-ada-001"

--- a/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/preview/components/embedders/test_sentence_transformers_document_embedder.py
@@ -164,9 +164,7 @@ class TestSentenceTransformersDocumentEmbedder:
         )
         embedder.embedding_backend = MagicMock()
 
-        documents = [
-            Document(content=f"document number {i}", metadata={"meta_field": f"meta_value {i}"}) for i in range(5)
-        ]
+        documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 
         embedder.run(documents=documents)
 
@@ -194,9 +192,7 @@ class TestSentenceTransformersDocumentEmbedder:
         )
         embedder.embedding_backend = MagicMock()
 
-        documents = [
-            Document(content=f"document number {i}", metadata={"meta_field": f"meta_value {i}"}) for i in range(5)
-        ]
+        documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 
         embedder.run(documents=documents)
 

--- a/test/preview/components/file_converters/test_textfile_to_document.py
+++ b/test/preview/components/file_converters/test_textfile_to_document.py
@@ -23,8 +23,8 @@ class TestTextfileToDocument:
         assert len(docs) == 2
         assert docs[0].content == "Some text for testing.\nTwo lines in here."
         assert docs[1].content == "This is a test line.\n123 456 789\n987 654 321."
-        assert docs[0].metadata["file_path"] == str(paths[0])
-        assert docs[1].metadata["file_path"] == str(paths[1])
+        assert docs[0].meta["file_path"] == str(paths[0])
+        assert docs[1].meta["file_path"] == str(paths[1])
 
     @pytest.mark.unit
     def test_run_warning_for_invalid_language(self, preview_samples_path, caplog):
@@ -58,7 +58,7 @@ class TestTextfileToDocument:
             )
         docs = output["documents"]
         assert len(docs) == 1
-        assert docs[0].metadata["file_path"] == str(paths[0])
+        assert docs[0].meta["file_path"] == str(paths[0])
 
     @pytest.mark.unit
     def test_prepare_metadata_no_metadata(self):

--- a/test/preview/components/preprocessors/test_text_document_cleaner.py
+++ b/test/preview/components/preprocessors/test_text_document_cleaner.py
@@ -128,12 +128,12 @@ class TestDocumentCleaner:
     def test_copy_metadata(self):
         cleaner = DocumentCleaner()
         documents = [
-            Document(content="Text. ", metadata={"name": "doc 0"}),
-            Document(content="Text. ", metadata={"name": "doc 1"}),
+            Document(content="Text. ", meta={"name": "doc 0"}),
+            Document(content="Text. ", meta={"name": "doc 1"}),
         ]
         result = cleaner.run(documents=documents)
         assert len(result["documents"]) == 2
         assert result["documents"][0].id != result["documents"][1].id
         for doc, cleaned_doc in zip(documents, result["documents"]):
-            assert doc.metadata == cleaned_doc.metadata
+            assert doc.meta == cleaned_doc.meta
             assert cleaned_doc.content == "Text."

--- a/test/preview/components/preprocessors/test_text_document_splitter.py
+++ b/test/preview/components/preprocessors/test_text_document_splitter.py
@@ -124,19 +124,19 @@ class TestTextDocumentSplitter:
         doc1 = Document(content="This is a text with some words.")
         doc2 = Document(content="This is a different text with some words.")
         result = splitter.run(documents=[doc1, doc2])
-        assert result["documents"][0].metadata["source_id"] == doc1.id
-        assert result["documents"][1].metadata["source_id"] == doc2.id
+        assert result["documents"][0].meta["source_id"] == doc1.id
+        assert result["documents"][1].meta["source_id"] == doc2.id
 
     @pytest.mark.unit
     def test_copy_metadata(self):
         splitter = TextDocumentSplitter(split_by="word", split_length=10)
         documents = [
-            Document(content="Text.", metadata={"name": "doc 0"}),
-            Document(content="Text.", metadata={"name": "doc 1"}),
+            Document(content="Text.", meta={"name": "doc 0"}),
+            Document(content="Text.", meta={"name": "doc 1"}),
         ]
         result = splitter.run(documents=documents)
         assert len(result["documents"]) == 2
         assert result["documents"][0].id != result["documents"][1].id
         for doc, split_doc in zip(documents, result["documents"]):
-            assert doc.metadata.items() <= split_doc.metadata.items()
+            assert doc.meta.items() <= split_doc.meta.items()
             assert split_doc.content == "Text."

--- a/test/preview/components/routers/test_metadata_router.py
+++ b/test/preview/components/routers/test_metadata_router.py
@@ -13,11 +13,11 @@ class TestMetadataRouter:
         }
         router = MetadataRouter(rules=rules)
         documents = [
-            Document(metadata={"created_at": "2023-02-01"}),
-            Document(metadata={"created_at": "2023-05-01"}),
-            Document(metadata={"created_at": "2023-08-01"}),
+            Document(meta={"created_at": "2023-02-01"}),
+            Document(meta={"created_at": "2023-05-01"}),
+            Document(meta={"created_at": "2023-08-01"}),
         ]
         output = router.run(documents=documents)
-        assert output["edge_1"][0].metadata["created_at"] == "2023-02-01"
-        assert output["edge_2"][0].metadata["created_at"] == "2023-05-01"
-        assert output["unmatched"][0].metadata["created_at"] == "2023-08-01"
+        assert output["edge_1"][0].meta["created_at"] == "2023-02-01"
+        assert output["edge_2"][0].meta["created_at"] == "2023-05-01"
+        assert output["unmatched"][0].meta["created_at"] == "2023-08-01"

--- a/test/preview/components/samplers/test_top_p.py
+++ b/test/preview/components/samplers/test_top_p.py
@@ -14,9 +14,9 @@ class TestTopPSampler:
         """
         sampler = TopPSampler(top_p=0.95, score_field="similarity_score")
         docs = [
-            Document(content="Berlin", metadata={"similarity_score": -10.6}),
-            Document(content="Belgrade", metadata={"similarity_score": -8.9}),
-            Document(content="Sarajevo", metadata={"similarity_score": -4.6}),
+            Document(content="Berlin", meta={"similarity_score": -10.6}),
+            Document(content="Belgrade", meta={"similarity_score": -8.9}),
+            Document(content="Sarajevo", meta={"similarity_score": -4.6}),
         ]
         output = sampler.run(documents=docs)
         docs = output["documents"]

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -39,8 +39,7 @@ def test_init():
     assert doc.dataframe == None
     assert doc.blob == None
     assert doc.mime_type == "text/plain"
-    assert doc.metadata == {}
-    assert doc.metadata == {}
+    assert doc.meta == {}
     assert doc.score == None
     assert doc.embedding == None
 
@@ -53,7 +52,7 @@ def test_init_with_parameters():
         dataframe=pd.DataFrame([0]),
         blob=blob,
         mime_type="text/markdown",
-        metadata={"text": "test text"},
+        meta={"text": "test text"},
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
     )
@@ -62,7 +61,7 @@ def test_init_with_parameters():
     assert doc.dataframe.equals(pd.DataFrame([0]))
     assert doc.blob == blob
     assert doc.mime_type == "text/markdown"
-    assert doc.metadata == {"text": "test text"}
+    assert doc.meta == {"text": "test text"}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
 
@@ -77,13 +76,13 @@ def test_init_with_legacy_fields():
     assert doc.dataframe == None
     assert doc.blob == None
     assert doc.mime_type == "text/plain"
-    assert doc.metadata == {}
+    assert doc.meta == {}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
 
 
 @pytest.mark.unit
-def test_init_with_legacy_field_and_flat_metadata():
+def test_init_with_legacy_field_and_flat_meta():
     doc = Document(
         content="test text",
         content_type="text",
@@ -98,13 +97,13 @@ def test_init_with_legacy_field_and_flat_metadata():
     assert doc.dataframe == None
     assert doc.blob == None
     assert doc.mime_type == "text/plain"
-    assert doc.metadata == {"date": "10-10-2023", "type": "article"}
+    assert doc.meta == {"date": "10-10-2023", "type": "article"}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
 
 
 @pytest.mark.unit
-def test_init_with_flat_metadata():
+def test_init_with_flat_meta():
     blob = b"some bytes"
     doc = Document(
         content="test text",
@@ -121,13 +120,13 @@ def test_init_with_flat_metadata():
     assert doc.dataframe.equals(pd.DataFrame([0]))
     assert doc.blob == blob
     assert doc.mime_type == "text/markdown"
-    assert doc.metadata == {"date": "10-10-2023", "type": "article"}
+    assert doc.meta == {"date": "10-10-2023", "type": "article"}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
 
 
 @pytest.mark.unit
-def test_init_with_flat_and_non_flat_metadata():
+def test_init_with_flat_and_non_flat_meta():
     with pytest.raises(TypeError):
         Document(
             content="test text",
@@ -135,7 +134,7 @@ def test_init_with_flat_and_non_flat_metadata():
             blob=b"some bytes",
             mime_type="text/markdown",
             score=0.812,
-            metadata={"test": 10},
+            meta={"test": 10},
             embedding=[0.1, 0.2, 0.3],
             date="10-10-2023",
             type="article",
@@ -162,15 +161,15 @@ def test_basic_equality_id():
 
 
 @pytest.mark.unit
-def test_equality_with_metadata_with_objects():
+def test_equality_with_meta_with_objects():
     class TestObject:
         def __eq__(self, other):
             if type(self) == type(other):
                 return True
 
     foo = TestObject()
-    doc1 = Document(content="test text", metadata={"value": [0, 1, 2], "path": Path("."), "obj": foo})
-    doc2 = Document(content="test text", metadata={"value": [0, 1, 2], "path": Path("."), "obj": foo})
+    doc1 = Document(content="test text", meta={"value": [0, 1, 2], "path": Path("."), "obj": foo})
+    doc2 = Document(content="test text", meta={"value": [0, 1, 2], "path": Path("."), "obj": foo})
     assert doc1 == doc2
 
 
@@ -197,7 +196,7 @@ def test_to_dict_without_flattening():
         "dataframe": None,
         "blob": None,
         "mime_type": "text/plain",
-        "metadata": {},
+        "meta": {},
         "score": None,
         "embedding": None,
     }
@@ -210,7 +209,7 @@ def test_to_dict_with_custom_parameters():
         dataframe=pd.DataFrame([10, 20, 30]),
         blob=b"some bytes",
         mime_type="application/pdf",
-        metadata={"some": "values", "test": 10},
+        meta={"some": "values", "test": 10},
         score=0.99,
         embedding=[10, 10],
     )
@@ -235,7 +234,7 @@ def test_to_dict_with_custom_parameters_without_flattening():
         dataframe=pd.DataFrame([10, 20, 30]),
         blob=b"some bytes",
         mime_type="application/pdf",
-        metadata={"some": "values", "test": 10},
+        meta={"some": "values", "test": 10},
         score=0.99,
         embedding=[10, 10],
     )
@@ -246,7 +245,7 @@ def test_to_dict_with_custom_parameters_without_flattening():
         "dataframe": pd.DataFrame([10, 20, 30]).to_json(),
         "blob": list(doc.blob),
         "mime_type": "application/pdf",
-        "metadata": {"some": "values", "test": 10},
+        "meta": {"some": "values", "test": 10},
         "score": 0.99,
         "embedding": [10, 10],
     }
@@ -266,7 +265,7 @@ def from_from_dict_with_parameters():
             "dataframe": pd.DataFrame([0]).to_json(),
             "blob": blob,
             "mime_type": "text/markdown",
-            "metadata": {"text": "test text"},
+            "meta": {"text": "test text"},
             "score": 0.812,
             "embedding": [0.1, 0.2, 0.3],
         }
@@ -275,7 +274,7 @@ def from_from_dict_with_parameters():
         dataframe=pd.DataFrame([0]),
         blob=blob,
         mime_type="text/markdown",
-        metadata={"text": "test text"},
+        meta={"text": "test text"},
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
     )
@@ -296,7 +295,7 @@ def test_from_dict_with_legacy_fields():
     )
 
 
-def test_from_dict_with_legacy_field_and_flat_metadata():
+def test_from_dict_with_legacy_field_and_flat_meta():
     assert Document.from_dict(
         {
             "content": "test text",
@@ -319,7 +318,7 @@ def test_from_dict_with_legacy_field_and_flat_metadata():
 
 
 @pytest.mark.unit
-def test_from_dict_with_flat_metadata():
+def test_from_dict_with_flat_meta():
     blob = b"some bytes"
     assert Document.from_dict(
         {
@@ -339,12 +338,12 @@ def test_from_dict_with_flat_metadata():
         mime_type="text/markdown",
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
-        metadata={"date": "10-10-2023", "type": "article"},
+        meta={"date": "10-10-2023", "type": "article"},
     )
 
 
 @pytest.mark.unit
-def test_from_dict_with_flat_and_non_flat_metadata():
+def test_from_dict_with_flat_and_non_flat_meta():
     with pytest.raises(TypeError):
         Document.from_dict(
             {
@@ -353,7 +352,7 @@ def test_from_dict_with_flat_and_non_flat_metadata():
                 "blob": b"some bytes",
                 "mime_type": "text/markdown",
                 "score": 0.812,
-                "metadata": {"test": 10},
+                "meta": {"test": 10},
                 "embedding": [0.1, 0.2, 0.3],
                 "date": "10-10-2023",
                 "type": "article",

--- a/test/preview/document_stores/test_in_memory.py
+++ b/test/preview/document_stores/test_in_memory.py
@@ -213,7 +213,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
 
     @pytest.mark.unit
     def test_bm25_retrieval_with_filters(self, docstore: DocumentStore):
-        selected_document = Document(content="Gardening", metadata={"selected": True})
+        selected_document = Document(content="Gardening", meta={"selected": True})
         docs = [Document(), selected_document, Document(content="Bird watching")]
         docstore.write_documents(docs)
         results = docstore.bm25_retrieval(query="Java", top_k=10, filters={"selected": True})
@@ -221,7 +221,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):
 
     @pytest.mark.unit
     def test_bm25_retrieval_with_filters_keeps_default_filters(self, docstore: DocumentStore):
-        docs = [Document(metadata={"selected": True}), Document(content="Gardening"), Document(content="Bird watching")]
+        docs = [Document(meta={"selected": True}), Document(content="Gardening"), Document(content="Bird watching")]
         docstore.write_documents(docs)
         results = docstore.bm25_retrieval(query="Java", top_k=10, filters={"selected": True})
         assert not len(results)

--- a/test/preview/utils/test_filters.py
+++ b/test/preview/utils/test_filters.py
@@ -10,267 +10,267 @@ from haystack.preview.utils.filters import document_matches_filter
 class TestFilterUtils:
     @pytest.mark.unit
     def test_eq_match(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": "test"}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_no_match(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": "test1"}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_no_match_missing_key(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name1": "test"}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_explicit_eq(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$eq": "test"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_different_types(self):
-        document = Document(metadata={"name": 1})
+        document = Document(meta={"name": 1})
         filter = {"name": "1"}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_dataframes(self):
-        document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
+        document = Document(meta={"name": pd.DataFrame({"a": [1, 2, 3]})})
         filter = {"name": pd.DataFrame({"a": [1, 2, 3]})}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_dataframes_no_match(self):
-        document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
+        document = Document(meta={"name": pd.DataFrame({"a": [1, 2, 3]})})
         filter = {"name": pd.DataFrame({"a": [1, 2, 4]})}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_np_arrays(self):
-        document = Document(metadata={"name": np.array([1, 2, 3])})
+        document = Document(meta={"name": np.array([1, 2, 3])})
         filter = {"name": np.array([1, 2, 3])}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_eq_np_arrays_no_match(self):
-        document = Document(metadata={"name": np.array([1, 2, 3])})
+        document = Document(meta={"name": np.array([1, 2, 3])})
         filter = {"name": np.array([1, 2, 4])}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_match(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$ne": "test1"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_no_match(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$ne": "test"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_no_match_missing_key(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name1": {"$ne": "test"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_different_types(self):
-        document = Document(metadata={"name": 1})
+        document = Document(meta={"name": 1})
         filter = {"name": {"$ne": "1"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_dataframes(self):
-        document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
+        document = Document(meta={"name": pd.DataFrame({"a": [1, 2, 3]})})
         filter = {"name": {"$ne": pd.DataFrame({"a": [1, 2, 4]})}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_dataframes_no_match(self):
-        document = Document(metadata={"name": pd.DataFrame({"a": [1, 2, 3]})})
+        document = Document(meta={"name": pd.DataFrame({"a": [1, 2, 3]})})
         filter = {"name": {"$ne": pd.DataFrame({"a": [1, 2, 3]})}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_np_arrays(self):
-        document = Document(metadata={"name": np.array([1, 2, 3])})
+        document = Document(meta={"name": np.array([1, 2, 3])})
         filter = {"name": {"$ne": np.array([1, 2, 4])}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_ne_np_arrays_no_match(self):
-        document = Document(metadata={"name": np.array([1, 2, 3])})
+        document = Document(meta={"name": np.array([1, 2, 3])})
         filter = {"name": {"$ne": np.array([1, 2, 3])}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_match_list(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": ["test", "test1"]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_list(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": ["test2", "test3"]}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_implicit(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": ["test", "test1"]}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_match_set(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": {"test", "test1"}}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_set(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": {"test2", "test3"}}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_match_tuple(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": ("test", "test1")}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_tuple(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": ("test2", "test3")}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_no_match_missing_key(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name1": {"$in": ["test", "test1"]}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_in_unsupported_type(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$in": "unsupported"}}
         with pytest.raises(FilterError, match=r"\$in accepts only iterable values like lists, sets and tuples"):
             document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_match_list(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": ["test1", "test2"]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_list(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": ["test", "test1"]}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_match_set(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": {"test1", "test2"}}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_set(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": {"test", "test1"}}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_match_tuple(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": ("test1", "test2")}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_tuple(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": ("test", "test1")}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_no_match_missing_key(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name1": {"$nin": ["test", "test1"]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_nin_unsupported_type(self):
-        document = Document(metadata={"name": "test"})
+        document = Document(meta={"name": "test"})
         filter = {"name": {"$nin": "unsupported"}}
         with pytest.raises(FilterError, match=r"\$in accepts only iterable values like lists, sets and tuples"):
             document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_int(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age": {"$gt": 20}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_int(self):
-        document = Document(metadata={"age": 19})
+        document = Document(meta={"age": 19})
         filter = {"age": {"$gt": 20}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_float(self):
-        document = Document(metadata={"number": 90.5})
+        document = Document(meta={"number": 90.5})
         filter = {"number": {"$gt": 90.0}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_float(self):
-        document = Document(metadata={"number": 89.5})
+        document = Document(meta={"number": 89.5})
         filter = {"number": {"$gt": 90.0}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_np_number(self):
-        document = Document(metadata={"value": np.float64(7.5)})
+        document = Document(meta={"value": np.float64(7.5)})
         filter = {"value": {"$gt": np.float64(7.0)}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_np_number(self):
-        document = Document(metadata={"value": np.float64(6.5)})
+        document = Document(meta={"value": np.float64(6.5)})
         filter = {"value": {"$gt": np.float64(7.0)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-02"})
+        document = Document(meta={"date": "2022-01-02"})
         filter = {"date": {"$gt": "2022-01-01"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-01"})
+        document = Document(meta={"date": "2022-01-01"})
         filter = {"date": {"$gt": "2022-01-01"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_no_match_missing_key(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age1": {"$gt": 20}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gt_unsupported_type(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age": {"$gt": "unsupported"}}
         with pytest.raises(
             FilterError,
@@ -283,7 +283,7 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_gte_match_int(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter_1 = {"age": {"$gte": 21}}
         filter_2 = {"age": {"$gte": 20}}
         assert document_matches_filter(filter_1, document)
@@ -291,13 +291,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_gte_no_match_int(self):
-        document = Document(metadata={"age": 20})
+        document = Document(meta={"age": 20})
         filter = {"age": {"$gte": 21}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_match_float(self):
-        document = Document(metadata={"number": 90.5})
+        document = Document(meta={"number": 90.5})
         filter_1 = {"number": {"$gte": 90.5}}
         filter_2 = {"number": {"$gte": 90.4}}
         assert document_matches_filter(filter_1, document)
@@ -305,13 +305,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_gte_no_match_float(self):
-        document = Document(metadata={"number": 90.4})
+        document = Document(meta={"number": 90.4})
         filter = {"number": {"$gte": 90.5}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_match_np_number(self):
-        document = Document(metadata={"value": np.float64(7.5)})
+        document = Document(meta={"value": np.float64(7.5)})
         filter_1 = {"value": {"$gte": np.float64(7.5)}}
         filter_2 = {"value": {"$gte": np.float64(7.4)}}
         assert document_matches_filter(filter_1, document)
@@ -319,13 +319,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_gte_no_match_np_number(self):
-        document = Document(metadata={"value": np.float64(7.4)})
+        document = Document(meta={"value": np.float64(7.4)})
         filter = {"value": {"$gte": np.float64(7.5)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-02"})
+        document = Document(meta={"date": "2022-01-02"})
         filter_1 = {"date": {"$gte": "2022-01-02"}}
         filter_2 = {"date": {"$gte": "2022-01-01"}}
         assert document_matches_filter(filter_1, document)
@@ -333,13 +333,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_gte_no_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-01"})
+        document = Document(meta={"date": "2022-01-01"})
         filter = {"date": {"$gte": "2022-01-02"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_gte_unsupported_type(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age": {"$gte": "unsupported"}}
         with pytest.raises(
             FilterError,
@@ -352,55 +352,55 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_lt_match_int(self):
-        document = Document(metadata={"age": 19})
+        document = Document(meta={"age": 19})
         filter = {"age": {"$lt": 20}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_int(self):
-        document = Document(metadata={"age": 20})
+        document = Document(meta={"age": 20})
         filter = {"age": {"$lt": 20}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_match_float(self):
-        document = Document(metadata={"number": 89.9})
+        document = Document(meta={"number": 89.9})
         filter = {"number": {"$lt": 90.0}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_float(self):
-        document = Document(metadata={"number": 90.0})
+        document = Document(meta={"number": 90.0})
         filter = {"number": {"$lt": 90.0}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_match_np_number(self):
-        document = Document(metadata={"value": np.float64(6.9)})
+        document = Document(meta={"value": np.float64(6.9)})
         filter = {"value": {"$lt": np.float64(7.0)}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_np_number(self):
-        document = Document(metadata={"value": np.float64(7.0)})
+        document = Document(meta={"value": np.float64(7.0)})
         filter = {"value": {"$lt": np.float64(7.0)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-01"})
+        document = Document(meta={"date": "2022-01-01"})
         filter = {"date": {"$lt": "2022-01-02"}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_no_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-02"})
+        document = Document(meta={"date": "2022-01-02"})
         filter = {"date": {"$lt": "2022-01-02"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lt_unsupported_type(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age": {"$lt": "unsupported"}}
         with pytest.raises(
             FilterError,
@@ -413,7 +413,7 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_lte_match_int(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter_1 = {"age": {"$lte": 21}}
         filter_2 = {"age": {"$lte": 20}}
         assert not document_matches_filter(filter_2, document)
@@ -421,13 +421,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_lte_no_match_int(self):
-        document = Document(metadata={"age": 22})
+        document = Document(meta={"age": 22})
         filter = {"age": {"$lte": 21}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_match_float(self):
-        document = Document(metadata={"number": 90.5})
+        document = Document(meta={"number": 90.5})
         filter_1 = {"number": {"$lte": 90.5}}
         filter_2 = {"number": {"$lte": 90.4}}
         assert not document_matches_filter(filter_2, document)
@@ -435,13 +435,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_lte_no_match_float(self):
-        document = Document(metadata={"number": 90.6})
+        document = Document(meta={"number": 90.6})
         filter = {"number": {"$lte": 90.5}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_match_np_number(self):
-        document = Document(metadata={"value": np.float64(7.5)})
+        document = Document(meta={"value": np.float64(7.5)})
         filter_1 = {"value": {"$lte": np.float64(7.5)}}
         filter_2 = {"value": {"$lte": np.float64(7.4)}}
         assert not document_matches_filter(filter_2, document)
@@ -449,13 +449,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_lte_no_match_np_number(self):
-        document = Document(metadata={"value": np.float64(7.6)})
+        document = Document(meta={"value": np.float64(7.6)})
         filter = {"value": {"$lte": np.float64(7.5)}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-02"})
+        document = Document(meta={"date": "2022-01-02"})
         filter_1 = {"date": {"$lte": "2022-01-02"}}
         filter_2 = {"date": {"$lte": "2022-01-01"}}
         assert not document_matches_filter(filter_2, document)
@@ -463,13 +463,13 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_lte_no_match_date_string(self):
-        document = Document(metadata={"date": "2022-01-03"})
+        document = Document(meta={"date": "2022-01-03"})
         filter = {"date": {"$lte": "2022-01-02"}}
         assert not document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_lte_unsupported_type(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age": {"$lte": "unsupported"}}
         with pytest.raises(
             FilterError,
@@ -482,24 +482,24 @@ class TestFilterUtils:
 
     @pytest.mark.unit
     def test_implicit_and(self):
-        document = Document(metadata={"age": 21, "name": "John"})
+        document = Document(meta={"age": 21, "name": "John"})
         filter = {"age": {"$gt": 18}, "name": "John"}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_explicit_and(self):
-        document = Document(metadata={"age": 21})
+        document = Document(meta={"age": 21})
         filter = {"age": {"$and": {"$gt": 18}, "$lt": 25}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_or(self):
-        document = Document(metadata={"age": 26})
+        document = Document(meta={"age": 26})
         filter = {"age": {"$or": [{"$gt": 18}, {"$lt": 25}]}}
         assert document_matches_filter(filter, document)
 
     @pytest.mark.unit
     def test_not(self):
-        document = Document(metadata={"age": 17})
+        document = Document(meta={"age": 17})
         filter = {"age": {"$not": {"$gt": 18}}}
         assert document_matches_filter(filter, document)


### PR DESCRIPTION
### Proposed Changes:


This PR renames all occurences of `Document`'s `metadata` field to `meta` to enhance backward compatbility.

### How did you test it?

Ran unit tests locally.

### Notes for the reviewer

This depends on #6181.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
