### PR TITLE
docs: update anthropic doc link

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
+++ b/haystack/nodes/prompt/invocation_layer/anthropic_claude.py
@@ -41,7 +41,7 @@ class AnthropicClaudeInvocationLayer(PromptModelInvocationLayer):
         :param api_key: The Anthropic API key.
         :param kwargs: Additional keyword arguments passed to the underlying model. The list of Anthropic-relevant
         kwargs includes: stop_sequences, temperature, top_p, top_k, and stream. For more details about these kwargs,
-        see Anthropic's [documentation](https://console.anthropic.com/docs/api/reference).
+        see Anthropic's [documentation](https://docs.anthropic.com/claude/reference/complete_post).
         """
         super().__init__(model_name_or_path)
         if not isinstance(api_key, str) or len(api_key) == 0:


### PR DESCRIPTION
### Related Issues


### Proposed Changes:

Added a direct link to Anthropic kwagrs https://docs.anthropic.com/claude/reference/complete_post instead of general docs link.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
