### PR TITLE
feat: Add general and HF util methods

### DIFF
--- a/haystack/preview/components/generators/hf_utils.py
+++ b/haystack/preview/components/generators/hf_utils.py
@@ -24,7 +24,7 @@ def check_generation_params(kwargs: Dict[str, Any], additional_accepted_params: 
         unknown_params = set(kwargs.keys()) - accepted_params
         if unknown_params:
             raise ValueError(
-                f"Unknown text generation parameters: {unknown_params}, please provide {accepted_params} only."
+                f"Unknown text generation parameters: {unknown_params}. The valid parameters are: {accepted_params}."
             )
 
 

--- a/haystack/preview/components/generators/hf_utils.py
+++ b/haystack/preview/components/generators/hf_utils.py
@@ -1,0 +1,50 @@
+import inspect
+from typing import Any, Dict, List, Optional
+
+from huggingface_hub import InferenceClient, HfApi
+from huggingface_hub.utils import RepositoryNotFoundError
+
+
+def check_generation_params(kwargs: Dict[str, Any], additional_accepted_params: Optional[List[str]] = None):
+    """
+    Check the provided generation parameters for validity.
+
+    :param kwargs: A dictionary containing the generation parameters.
+    :param additional_accepted_params: An optional list of strings representing additional accepted parameters.
+    :raises ValueError: If any unknown text generation parameters are provided.
+    """
+    if kwargs:
+        accepted_params = {
+            param
+            for param in inspect.signature(InferenceClient.text_generation).parameters.keys()
+            if param not in ["self", "prompt"]
+        }
+        if additional_accepted_params:
+            accepted_params.update(additional_accepted_params)
+        unknown_params = set(kwargs.keys()) - accepted_params
+        if unknown_params:
+            raise ValueError(
+                f"Unknown text generation parameters: {unknown_params}, please provide {accepted_params} only."
+            )
+
+
+def check_valid_model(model_id: str, token: Optional[str]) -> None:
+    """
+    Check if the provided model ID corresponds to a valid model on HuggingFace Hub.
+    Also check if the model is a text generation model.
+
+    :param model_id: A string representing the HuggingFace model ID.
+    :param token: An optional string representing the authentication token.
+    :raises ValueError: If the model is not found or is not a text generation model.
+    """
+    api = HfApi()
+    try:
+        model_info = api.model_info(model_id, token=token)
+    except RepositoryNotFoundError as e:
+        raise ValueError(
+            f"Model {model_id} not found on HuggingFace Hub. Please provide a valid HuggingFace model_id."
+        ) from e
+
+    allowed_model = model_info.pipeline_tag in ["text-generation", "text2text-generation"]
+    if not allowed_model:
+        raise ValueError(f"Model {model_id} is not a text generation model. Please provide a text generation model.")

--- a/haystack/preview/components/generators/utils.py
+++ b/haystack/preview/components/generators/utils.py
@@ -1,0 +1,41 @@
+import inspect
+import sys
+from typing import Optional, Callable
+
+from haystack.preview import DeserializationError
+from haystack.preview.dataclasses import StreamingChunk
+
+
+def serialize_callback_handler(streaming_callback: Callable[[StreamingChunk], None]) -> str:
+    """
+    Serializes the streaming callback handler.
+    :param streaming_callback: The streaming callback handler function
+    :return: The full path of the streaming callback handler function
+    """
+    module = inspect.getmodule(streaming_callback)
+
+    # Get the full package path of the function
+    if module is not None:
+        full_path = f"{module.__name__}.{streaming_callback.__name__}"
+    else:
+        full_path = streaming_callback.__name__
+    return full_path
+
+
+def deserialize_callback_handler(callback_name: str) -> Optional[Callable[[StreamingChunk], None]]:
+    """
+    Deserializes the streaming callback handler.
+    :param callback_name: The full path of the streaming callback handler function
+    :return: The streaming callback handler function
+    :raises DeserializationError: If the streaming callback handler function cannot be found
+    """
+    parts = callback_name.split(".")
+    module_name = ".".join(parts[:-1])
+    function_name = parts[-1]
+    module = sys.modules.get(module_name, None)
+    if not module:
+        raise DeserializationError(f"Could not locate the module of the streaming callback: {module_name}")
+    streaming_callback = getattr(module, function_name, None)
+    if not streaming_callback:
+        raise DeserializationError(f"Could not locate the streaming callback: {function_name}")
+    return streaming_callback

--- a/test/preview/components/generators/test_hf_utils.py
+++ b/test/preview/components/generators/test_hf_utils.py
@@ -43,8 +43,8 @@ def test_additional_accepted_params_known_parameter():
 
 @pytest.mark.unit
 def test_additional_accepted_params_unknown_parameter():
-    kwargs = {"temperature": 0.8}
-    additional_accepted_params = ["valid_param"]
-    # Although valid_param is not generation param the check_generation_params
-    # does not raise exception because valid_param is passed as additional_accepted_params
+    kwargs = {"strange_param": "value"}
+    additional_accepted_params = ["strange_param"]
+    # Although strange_param is not generation param the check_generation_params
+    # does not raise exception because strange_param is passed as additional_accepted_params
     check_generation_params(kwargs, additional_accepted_params)

--- a/test/preview/components/generators/test_hf_utils.py
+++ b/test/preview/components/generators/test_hf_utils.py
@@ -1,0 +1,49 @@
+import pytest
+
+from haystack.preview.components.generators.hf_utils import check_generation_params
+
+
+@pytest.mark.unit
+def test_empty_dictionary():
+    # no exception raised
+    check_generation_params({})
+
+
+@pytest.mark.unit
+def test_valid_generation_parameters():
+    # these are valid parameters
+    kwargs = {"max_new_tokens": 100, "temperature": 0.8}
+    additional_accepted_params = None
+    check_generation_params(kwargs, additional_accepted_params)
+
+
+@pytest.mark.unit
+def test_invalid_generation_parameters():
+    # these are invalid parameters
+    kwargs = {"invalid_param": "value"}
+    additional_accepted_params = None
+    with pytest.raises(ValueError):
+        check_generation_params(kwargs, additional_accepted_params)
+
+
+@pytest.mark.unit
+def test_additional_accepted_params_empty_list():
+    kwargs = {"temperature": 0.8}
+    additional_accepted_params = []
+    check_generation_params(kwargs, additional_accepted_params)
+
+
+@pytest.mark.unit
+def test_additional_accepted_params_non_empty_list():
+    # both are valid parameters
+    kwargs = {"temperature": 0.8}
+    additional_accepted_params = ["max_new_tokens"]
+    check_generation_params(kwargs, additional_accepted_params)
+
+
+@pytest.mark.unit
+def test_additional_accepted_params_valid_invalid():
+    kwargs = {"temperature": 0.8}
+    additional_accepted_params = ["valid_param"]
+    # does not raise exception because valid_param is in additional_accepted_params
+    check_generation_params(kwargs, additional_accepted_params)

--- a/test/preview/components/generators/test_hf_utils.py
+++ b/test/preview/components/generators/test_hf_utils.py
@@ -34,7 +34,7 @@ def test_additional_accepted_params_empty_list():
 
 
 @pytest.mark.unit
-def test_additional_accepted_params_non_empty_list():
+def test_additional_accepted_params_known_parameter():
     # both are valid parameters
     kwargs = {"temperature": 0.8}
     additional_accepted_params = ["max_new_tokens"]
@@ -42,8 +42,9 @@ def test_additional_accepted_params_non_empty_list():
 
 
 @pytest.mark.unit
-def test_additional_accepted_params_valid_invalid():
+def test_additional_accepted_params_unknown_parameter():
     kwargs = {"temperature": 0.8}
     additional_accepted_params = ["valid_param"]
-    # does not raise exception because valid_param is in additional_accepted_params
+    # Although valid_param is not generation param the check_generation_params
+    # does not raise exception because valid_param is passed as additional_accepted_params
     check_generation_params(kwargs, additional_accepted_params)

--- a/test/preview/components/generators/test_utils.py
+++ b/test/preview/components/generators/test_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from haystack.preview.components.generators.openai.gpt import default_streaming_callback
+from haystack.preview.components.generators.utils import serialize_callback_handler, deserialize_callback_handler
+
+
+# streaming callback needs to be on module level
+def streaming_callback(chunk):
+    pass
+
+
+@pytest.mark.unit
+def test_callback_handler_serialization():
+    result = serialize_callback_handler(streaming_callback)
+    assert result == "test_utils.streaming_callback"
+
+
+@pytest.mark.unit
+def test_callback_handler_serialization_non_local():
+    result = serialize_callback_handler(default_streaming_callback)
+    assert result == "haystack.preview.components.generators.openai.gpt.default_streaming_callback"
+
+
+@pytest.mark.unit
+def test_callback_handler_deserialization():
+    result = serialize_callback_handler(streaming_callback)
+    fn = deserialize_callback_handler(result)
+
+    assert fn == streaming_callback
+
+
+@pytest.mark.unit
+def test_callback_handler_deserialization_non_local():
+    result = serialize_callback_handler(default_streaming_callback)
+    fn = deserialize_callback_handler(result)
+
+    assert fn == default_streaming_callback

--- a/test/preview/components/generators/test_utils.py
+++ b/test/preview/components/generators/test_utils.py
@@ -26,7 +26,7 @@ def test_callback_handler_deserialization():
     result = serialize_callback_handler(streaming_callback)
     fn = deserialize_callback_handler(result)
 
-    assert fn == streaming_callback
+    assert fn is streaming_callback
 
 
 @pytest.mark.unit
@@ -34,4 +34,4 @@ def test_callback_handler_deserialization_non_local():
     result = serialize_callback_handler(default_streaming_callback)
     fn = deserialize_callback_handler(result)
 
-    assert fn == default_streaming_callback
+    assert fn is default_streaming_callback


### PR DESCRIPTION
### Why:

The general utility methods are aimed at serializing and deserializing callback handlers which are crucial for managing streaming responses. 
HuggingFace specific utility methods provide robust checking mechanisms for generation parameters and model validation against the HuggingFace Hub. These utility methods enhance code robustness, readability, and maintainability.

### What:

This PR introduces two sets of utility methods:

#### General Utility Methods:
`serialize_callback_handler`: Serializes the streaming callback handler function to a string representing its full path.
`deserialize_callback_handler`: Deserializes the string representing the full path of the streaming callback handler function to the actual function object. Raises a DeserializationError if the function cannot be found.

#### HuggingFace Specific Utility Methods:
`check_generation_params`: Validates the provided generation parameters against the accepted parameters of the InferenceClient.text_generation method, and optionally against an additional list of accepted parameters.
`check_valid_model`: Validates the provided HuggingFace model ID against the HuggingFace Hub to ensure it corresponds to a valid text generation model.

### How can it be used:
The general utility methods can be used for serializing and deserializing callback handlers systematically and reliably, which is particularly useful when handling streaming responses across all LLM components.

The HuggingFace-specific utility methods can be used to validate generation parameters and model IDs before invoking text generation, ensuring that only valid input is processed. 

### How did you test it: 
Unit tests were added in `test/preview/components/generators/test_hf_utils.py` and `test/preview/components/generators/test_utils.py`

 ### Notes for reviewer:
 None