### PR TITLE
ci: tag when branching off for a release

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -21,11 +21,14 @@ jobs:
           echo "current_release_minor=$(cut -d "." -f 1,2 < VERSION.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Create new version branch
+        # We tag the commit where we branch off as "<version>-rc0", so reno will know where to stop next
+        # time we generate release notes for "next minor".
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -m"v${{ steps.versions.outputs.current_release_minor }}.0-rc0" v${{ steps.versions.outputs.current_release_minor }}.0-rc0
           git checkout -b v${{ steps.versions.outputs.current_release_minor }}.x
-          git push -u origin v${{ steps.versions.outputs.current_release_minor }}.x
+          git push -u origin v${{ steps.versions.outputs.current_release_minor }}.x --tags
 
       - name: Bump version on main
         shell: bash

--- a/foo.html
+++ b/foo.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>v1.22.0-rc1</title>
+  <style>
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      background-color: #1a1a1a;
+      border: none;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: min(4vw, 1.5em);}
+    div.column{flex: auto; overflow-x: auto;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">v1.22.0-rc1</h1>
+</header>
+<h1 id="relnotes_v1.22.0-rc1_Upgrade Notes">Upgrade Notes</h1>
+<ul>
+<li>This update enables all Pinecone index types to be used, including
+Starter. Previously, Pinecone Starter index type couldn't be used as
+document store. Due to limitations of this index type (<a
+href="https://docs.pinecone.io/docs/starter-environment">https://docs.pinecone.io/docs/starter-environment</a>),
+in current implementation fetching documents is limited to Pinecone
+query vector limit (10000 vectors). Accordingly, if the number of
+documents in the index is above this limit, some of
+PineconeDocumentStore functions will be limited.</li>
+<li>Removes the <span class="title-ref">audio</span>, <span
+class="title-ref">ray</span>, <span class="title-ref">onnx</span> and
+<span class="title-ref">beir</span> extras from the extra group <span
+class="title-ref">all</span>.</li>
+</ul>
+<h1 id="relnotes_v1.22.0-rc1_New Features">New Features</h1>
+<ul>
+<li>Add experimental support for asynchronous <span
+class="title-ref">Pipeline</span> run</li>
+</ul>
+<h1 id="relnotes_v1.22.0-rc1_Enhancement Notes">Enhancement Notes</h1>
+<ul>
+<li>Added support for Apple Silicon GPU acceleration through "mps
+pytorch", enabling better performance on Apple M1 hardware.</li>
+<li>Document writer returns the number of documents written.</li>
+<li>added support for using <span
+class="title-ref">on_final_answer</span> trough <span
+class="title-ref">Agent</span> <span
+class="title-ref">callback_manager</span></li>
+<li>Add asyncio support to the OpenAI invocation layer.</li>
+<li>PromptNode can now be run asynchronously by calling the <span
+class="title-ref">arun</span> method.</li>
+<li>Add <span class="title-ref">search_engine_kwargs</span> param to
+WebRetriever so it can be propagated to WebSearch. This is useful, for
+example, to pass the engine id when using Google Custom Search.</li>
+<li>Upgrade Transformers to the latest version 4.34.1. This version adds
+support for the new Mistral, Persimmon, BROS, ViTMatte, and Nougat
+models.</li>
+<li>Make JoinDocuments return only the document with the highest score
+if there are duplicate documents in the list.</li>
+<li>Add <span class="title-ref">list_of_paths</span> argument to <span
+class="title-ref">utils.convert_files_to_docs</span> to allow input of
+list of file paths to be converted, instead of, or as well as, the
+current <span class="title-ref">dir_path</span> argument.</li>
+<li>Optimize particular methods from PineconeDocumentStore
+(delete_documents and _get_vector_count)</li>
+<li>Update the deepset Cloud SDK to the new endpoint format for new
+saving pipeline configs.</li>
+<li>Add alias names for Cohere embed models for an easier map between
+names</li>
+</ul>
+<h1 id="relnotes_v1.22.0-rc1_Deprecation Notes">Deprecation Notes</h1>
+<ul>
+<li>Deprecate <span class="title-ref">OpenAIAnswerGenerator</span> in
+favor of <span class="title-ref">PromptNode</span>. <span
+class="title-ref">OpenAIAnswerGenerator</span> will be removed in
+Haystack 1.23.</li>
+</ul>
+<h1 id="relnotes_v1.22.0-rc1_Bug Fixes">Bug Fixes</h1>
+<ul>
+<li>Fixed the bug that prevented the correct usage of ChatGPT invocation
+layer in 1.21.1. Added async support for ChatGPT invocation layer.</li>
+<li>Added documents_store.update_embeddings call to pipeline examples so
+that embeddings are calculated for newly added documents.</li>
+<li>Remove unsupported <span class="title-ref">medium</span> and <span
+class="title-ref">finance-sentiment</span> models from supported Cohere
+embed model list</li>
+</ul>
+<h1 id="relnotes_v1.22.0-rc1_Haystack 2.0 preview">Haystack 2.0
+preview</h1>
+<ul>
+<li>Add AzureOCRDocumentConverter to convert files of different types
+using Azure's Document Intelligence Service.</li>
+<li>Add ByteStream type to send binary raw data across components in a
+pipeline.</li>
+<li>Introduce ChatMessage data class to facilitate structured handling
+and processing of message content within LLM chat interactions.</li>
+<li>Adds <span class="title-ref">ChatMessage</span> templating in <span
+class="title-ref">PromptBuilder</span></li>
+<li>Adds HTMLToDocument component to convert HTML to a Document.</li>
+<li>Adds SimilarityRanker, a component that ranks a list of Documents
+based on their similarity to the query.</li>
+<li>Introduce the StreamingChunk dataclass for efficiently handling
+chunks of data streamed from a language model, encapsulating both the
+content and associated metadata for systematic processing.</li>
+<li>Adds TopPSampler, a component selects documents based on the
+cumulative probability of the Document scores using top p (nucleus)
+sampling.</li>
+<li>Add <span class="title-ref">dumps</span>, <span
+class="title-ref">dump</span>, <span class="title-ref">loads</span> and
+<span class="title-ref">load</span> methods to save and load pipelines
+in Yaml format.</li>
+<li>Adopt Hugging Face <span class="title-ref">token</span> instead of
+the deprecated <span class="title-ref">use_auth_token</span>. Add this
+parameter to <span class="title-ref">ExtractiveReader</span> and <span
+class="title-ref">SimilarityRanker</span> to allow loading private
+models. Proper handling of <span class="title-ref">token</span> during
+serialization: if it is a string (a possible valid token) it is not
+serialized.</li>
+<li>Add <span class="title-ref">mime_type</span> field to <span
+class="title-ref">ByteStream</span> dataclass.</li>
+<li>The Document dataclass checks if <span
+class="title-ref">id_hash_keys</span> is None or empty in __post_init__.
+If so, it uses the default factory to set a default valid value.</li>
+<li>Rework <span class="title-ref">Document.id</span> generation, if an
+<span class="title-ref">id</span> is not explicitly set it's generated
+using all <span class="title-ref">Document</span> field' values, <span
+class="title-ref">score</span> is not used.</li>
+<li>Change <span class="title-ref">Document</span>'s <span
+class="title-ref">embedding</span> field type from <span
+class="title-ref">numpy.ndarray</span> to <span
+class="title-ref">List[float]</span></li>
+<li>Fixed a bug that caused TextDocumentSplitter and DocumentCleaner to
+ignore id_hash_keys and create Documents with duplicate ids if the
+documents differed only in their metadata.</li>
+<li>Fix TextDocumentSplitter failing when run with an empty list</li>
+<li>Better management of API key in GPT Generator. The API key is never
+serialized. Make the <span class="title-ref">api_base_url</span>
+parameter really used (previously it was ignored).</li>
+<li>Add a minimal version of HuggingFaceLocalGenerator, a component that
+can run Hugging Face models locally to generate text.</li>
+<li>Migrate RemoteWhisperTranscriber to OpenAI SDK.</li>
+<li>Add OpenAI Document Embedder. It computes embeddings of Documents
+using OpenAI models. The embedding of each Document is stored in the
+<span class="title-ref">embedding</span> field of the Document.</li>
+<li>Add the <span class="title-ref">TextDocumentSplitter</span>
+component for Haystack 2.0 that splits a Document with long text into
+multiple Documents with shorter texts. Thereby the texts match the
+maximum length that the language models in Embedders or other components
+can process.</li>
+<li>Refactor OpenAIDocumentEmbedder to enrich documents with embeddings
+instead of recreating them.</li>
+<li>Refactor SentenceTransformersDocumentEmbedder to enrich documents
+with embeddings instead of recreating them.</li>
+<li>Remove "api_key" from serialization of AzureOCRDocumentConverter and
+SerperDevWebSearch.</li>
+<li>Removed implementations of from_dict and to_dict from all components
+where they had the same effect as the default implementation from
+Canals: <a
+href="https://github.com/deepset-ai/canals/blob/main/canals/serialization.py#L12-L13">https://github.com/deepset-ai/canals/blob/main/canals/serialization.py#L12-L13</a>
+This refactoring does not change the behavior of the components.</li>
+<li>Remove <span class="title-ref">array</span> field from <span
+class="title-ref">Document</span> dataclass.</li>
+<li>Remove <span class="title-ref">id_hash_keys</span> field from <span
+class="title-ref">Document</span> dataclass. <span
+class="title-ref">id_hash_keys</span> has been also removed from
+Components that were using it:
+<ul>
+<li><span class="title-ref">DocumentCleaner</span></li>
+<li><span class="title-ref">TextDocumentSplitter</span></li>
+<li><span class="title-ref">PyPDFToDocument</span></li>
+<li><span class="title-ref">AzureOCRDocumentConverter</span></li>
+<li><span class="title-ref">HTMLToDocument</span></li>
+<li><span class="title-ref">TextFileToDocument</span></li>
+<li><span class="title-ref">TikaDocumentConverter</span></li>
+</ul></li>
+<li>Enhanced file routing capabilities with the introduction of <span
+class="title-ref">ByteStream</span> handling, and improved clarity by
+renaming the router to <span
+class="title-ref">FileTypeRouter</span>.</li>
+<li>Rename <span class="title-ref">MemoryDocumentStore</span> to <span
+class="title-ref">InMemoryDocumentStore</span> Rename <span
+class="title-ref">MemoryBM25Retriever</span> to <span
+class="title-ref">InMemoryBM25Retriever</span> Rename <span
+class="title-ref">MemoryEmbeddingRetriever</span> to <span
+class="title-ref">InMemoryEmbeddingRetriever</span></li>
+<li>Renamed ExtractiveReader's input from <span
+class="title-ref">document</span> to <span
+class="title-ref">documents</span> to match its type
+List[Document].</li>
+<li>Rename <span class="title-ref">SimilarityRanker</span> to <span
+class="title-ref">TransformersSimilarityRanker</span>, as there will be
+more similarity rankers in the future.</li>
+<li>Allow specifying stopwords to stop text generation for <span
+class="title-ref">HuggingFaceLocalGenerator</span>.</li>
+<li>Add basic telemetry to Haystack 2.0 pipelines</li>
+<li>Added DocumentCleaner, which removes extra whitespace, empty lines,
+headers, etc. from Documents containing text. Useful as a preprocessing
+step before splitting into shorter text documents.</li>
+<li>Add TextLanguageClassifier component so that an input string, for
+example a query, can be routed to different components based on the
+detected language.</li>
+<li>Upgrade canals to 0.9.0 to support variadic inputs for Joiner
+components and "/" in connection names like "text/plain"</li>
+</ul>
+</body>
+</html>

--- a/foo.md
+++ b/foo.md
@@ -1,0 +1,186 @@
+# v1.22.0-rc1
+
+## Upgrade Notes
+
+-   This update enables all Pinecone index types to be used, including
+    Starter. Previously, Pinecone Starter index type couldn't be used as
+    document store. Due to limitations of this index type
+    (<https://docs.pinecone.io/docs/starter-environment>), in current
+    implementation fetching documents is limited to Pinecone query
+    vector limit (10000 vectors). Accordingly, if the number of
+    documents in the index is above this limit, some of
+    PineconeDocumentStore functions will be limited.
+-   Removes the <span class="title-ref">audio</span>,
+    <span class="title-ref">ray</span>,
+    <span class="title-ref">onnx</span> and
+    <span class="title-ref">beir</span> extras from the extra group
+    <span class="title-ref">all</span>.
+
+## New Features
+
+-   Add experimental support for asynchronous
+    <span class="title-ref">Pipeline</span> run
+
+## Enhancement Notes
+
+-   Added support for Apple Silicon GPU acceleration through "mps
+    pytorch", enabling better performance on Apple M1 hardware.
+-   Document writer returns the number of documents written.
+-   added support for using
+    <span class="title-ref">on_final_answer</span> trough
+    <span class="title-ref">Agent</span>
+    <span class="title-ref">callback_manager</span>
+-   Add asyncio support to the OpenAI invocation layer.
+-   PromptNode can now be run asynchronously by calling the
+    <span class="title-ref">arun</span> method.
+-   Add <span class="title-ref">search_engine_kwargs</span> param to
+    WebRetriever so it can be propagated to WebSearch. This is useful,
+    for example, to pass the engine id when using Google Custom Search.
+-   Upgrade Transformers to the latest version 4.34.1. This version adds
+    support for the new Mistral, Persimmon, BROS, ViTMatte, and Nougat
+    models.
+-   Make JoinDocuments return only the document with the highest score
+    if there are duplicate documents in the list.
+-   Add <span class="title-ref">list_of_paths</span> argument to
+    <span class="title-ref">utils.convert_files_to_docs</span> to allow
+    input of list of file paths to be converted, instead of, or as well
+    as, the current <span class="title-ref">dir_path</span> argument.
+-   Optimize particular methods from PineconeDocumentStore
+    (delete_documents and \_get_vector_count)
+-   Update the deepset Cloud SDK to the new endpoint format for new
+    saving pipeline configs.
+-   Add alias names for Cohere embed models for an easier map between
+    names
+
+## Deprecation Notes
+
+-   Deprecate <span class="title-ref">OpenAIAnswerGenerator</span> in
+    favor of <span class="title-ref">PromptNode</span>.
+    <span class="title-ref">OpenAIAnswerGenerator</span> will be removed
+    in Haystack 1.23.
+
+## Bug Fixes
+
+-   Fixed the bug that prevented the correct usage of ChatGPT invocation
+    layer in 1.21.1. Added async support for ChatGPT invocation layer.
+-   Added documents_store.update_embeddings call to pipeline examples so
+    that embeddings are calculated for newly added documents.
+-   Remove unsupported <span class="title-ref">medium</span> and
+    <span class="title-ref">finance-sentiment</span> models from
+    supported Cohere embed model list
+
+## Haystack 2.0 preview
+
+-   Add AzureOCRDocumentConverter to convert files of different types
+    using Azure's Document Intelligence Service.
+-   Add ByteStream type to send binary raw data across components in a
+    pipeline.
+-   Introduce ChatMessage data class to facilitate structured handling
+    and processing of message content within LLM chat interactions.
+-   Adds <span class="title-ref">ChatMessage</span> templating in
+    <span class="title-ref">PromptBuilder</span>
+-   Adds HTMLToDocument component to convert HTML to a Document.
+-   Adds SimilarityRanker, a component that ranks a list of Documents
+    based on their similarity to the query.
+-   Introduce the StreamingChunk dataclass for efficiently handling
+    chunks of data streamed from a language model, encapsulating both
+    the content and associated metadata for systematic processing.
+-   Adds TopPSampler, a component selects documents based on the
+    cumulative probability of the Document scores using top p (nucleus)
+    sampling.
+-   Add <span class="title-ref">dumps</span>,
+    <span class="title-ref">dump</span>,
+    <span class="title-ref">loads</span> and
+    <span class="title-ref">load</span> methods to save and load
+    pipelines in Yaml format.
+-   Adopt Hugging Face <span class="title-ref">token</span> instead of
+    the deprecated <span class="title-ref">use_auth_token</span>. Add
+    this parameter to <span class="title-ref">ExtractiveReader</span>
+    and <span class="title-ref">SimilarityRanker</span> to allow loading
+    private models. Proper handling of
+    <span class="title-ref">token</span> during serialization: if it is
+    a string (a possible valid token) it is not serialized.
+-   Add <span class="title-ref">mime_type</span> field to
+    <span class="title-ref">ByteStream</span> dataclass.
+-   The Document dataclass checks if
+    <span class="title-ref">id_hash_keys</span> is None or empty in
+    \_\_post_init\_\_. If so, it uses the default factory to set a
+    default valid value.
+-   Rework <span class="title-ref">Document.id</span> generation, if an
+    <span class="title-ref">id</span> is not explicitly set it's
+    generated using all <span class="title-ref">Document</span> field'
+    values, <span class="title-ref">score</span> is not used.
+-   Change <span class="title-ref">Document</span>'s
+    <span class="title-ref">embedding</span> field type from
+    <span class="title-ref">numpy.ndarray</span> to
+    <span class="title-ref">List\[float\]</span>
+-   Fixed a bug that caused TextDocumentSplitter and DocumentCleaner to
+    ignore id_hash_keys and create Documents with duplicate ids if the
+    documents differed only in their metadata.
+-   Fix TextDocumentSplitter failing when run with an empty list
+-   Better management of API key in GPT Generator. The API key is never
+    serialized. Make the <span class="title-ref">api_base_url</span>
+    parameter really used (previously it was ignored).
+-   Add a minimal version of HuggingFaceLocalGenerator, a component that
+    can run Hugging Face models locally to generate text.
+-   Migrate RemoteWhisperTranscriber to OpenAI SDK.
+-   Add OpenAI Document Embedder. It computes embeddings of Documents
+    using OpenAI models. The embedding of each Document is stored in the
+    <span class="title-ref">embedding</span> field of the Document.
+-   Add the <span class="title-ref">TextDocumentSplitter</span>
+    component for Haystack 2.0 that splits a Document with long text
+    into multiple Documents with shorter texts. Thereby the texts match
+    the maximum length that the language models in Embedders or other
+    components can process.
+-   Refactor OpenAIDocumentEmbedder to enrich documents with embeddings
+    instead of recreating them.
+-   Refactor SentenceTransformersDocumentEmbedder to enrich documents
+    with embeddings instead of recreating them.
+-   Remove "api_key" from serialization of AzureOCRDocumentConverter and
+    SerperDevWebSearch.
+-   Removed implementations of from_dict and to_dict from all components
+    where they had the same effect as the default implementation from
+    Canals:
+    <https://github.com/deepset-ai/canals/blob/main/canals/serialization.py#L12-L13>
+    This refactoring does not change the behavior of the components.
+-   Remove <span class="title-ref">array</span> field from
+    <span class="title-ref">Document</span> dataclass.
+-   Remove <span class="title-ref">id_hash_keys</span> field from
+    <span class="title-ref">Document</span> dataclass.
+    <span class="title-ref">id_hash_keys</span> has been also removed
+    from Components that were using it:
+    -   <span class="title-ref">DocumentCleaner</span>
+    -   <span class="title-ref">TextDocumentSplitter</span>
+    -   <span class="title-ref">PyPDFToDocument</span>
+    -   <span class="title-ref">AzureOCRDocumentConverter</span>
+    -   <span class="title-ref">HTMLToDocument</span>
+    -   <span class="title-ref">TextFileToDocument</span>
+    -   <span class="title-ref">TikaDocumentConverter</span>
+-   Enhanced file routing capabilities with the introduction of
+    <span class="title-ref">ByteStream</span> handling, and improved
+    clarity by renaming the router to
+    <span class="title-ref">FileTypeRouter</span>.
+-   Rename <span class="title-ref">MemoryDocumentStore</span> to
+    <span class="title-ref">InMemoryDocumentStore</span> Rename
+    <span class="title-ref">MemoryBM25Retriever</span> to
+    <span class="title-ref">InMemoryBM25Retriever</span> Rename
+    <span class="title-ref">MemoryEmbeddingRetriever</span> to
+    <span class="title-ref">InMemoryEmbeddingRetriever</span>
+-   Renamed ExtractiveReader's input from
+    <span class="title-ref">document</span> to
+    <span class="title-ref">documents</span> to match its type
+    List\[Document\].
+-   Rename <span class="title-ref">SimilarityRanker</span> to
+    <span class="title-ref">TransformersSimilarityRanker</span>, as
+    there will be more similarity rankers in the future.
+-   Allow specifying stopwords to stop text generation for
+    <span class="title-ref">HuggingFaceLocalGenerator</span>.
+-   Add basic telemetry to Haystack 2.0 pipelines
+-   Added DocumentCleaner, which removes extra whitespace, empty lines,
+    headers, etc. from Documents containing text. Useful as a
+    preprocessing step before splitting into shorter text documents.
+-   Add TextLanguageClassifier component so that an input string, for
+    example a query, can be routed to different components based on the
+    detected language.
+-   Upgrade canals to 0.9.0 to support variadic inputs for Joiner
+    components and "/" in connection names like "text/plain"

--- a/foo.rst
+++ b/foo.rst
@@ -1,0 +1,190 @@
+.. _relnotes_v1.22.0-rc1:
+
+v1.22.0-rc1
+===========
+
+.. _relnotes_v1.22.0-rc1_Upgrade Notes:
+
+Upgrade Notes
+-------------
+
+- This update enables all Pinecone index types to be used, including Starter.
+  Previously, Pinecone Starter index type couldn't be used as document store. Due to limitations of this index type
+  (https://docs.pinecone.io/docs/starter-environment), in current implementation fetching documents is limited to
+  Pinecone query vector limit (10000 vectors). Accordingly, if the number of documents in the index is above this limit,
+  some of PineconeDocumentStore functions will be limited.
+
+- Removes the `audio`, `ray`, `onnx` and `beir` extras from the extra group `all`.
+
+
+.. _relnotes_v1.22.0-rc1_New Features:
+
+New Features
+------------
+
+- Add experimental support for asynchronous `Pipeline` run
+
+
+.. _relnotes_v1.22.0-rc1_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- Added support for Apple Silicon GPU acceleration through "mps pytorch", enabling better performance on Apple M1 hardware.
+
+- Document writer returns the number of documents written.
+
+- added support for using `on_final_answer` trough `Agent` `callback_manager`
+
+- Add asyncio support to the OpenAI invocation layer.
+
+- PromptNode can now be run asynchronously by calling the `arun` method.
+
+- Add `search_engine_kwargs` param to WebRetriever so it can be propagated
+  to WebSearch. This is useful, for example, to pass the engine id when
+  using Google Custom Search.
+
+- Upgrade Transformers to the latest version 4.34.1.
+  This version adds support for the new Mistral, Persimmon, BROS, ViTMatte, and Nougat models.
+
+- Make JoinDocuments return only the document with the highest score if there are duplicate documents in the list.
+
+- Add `list_of_paths` argument to `utils.convert_files_to_docs` to allow 
+  input of list of file paths to be converted, instead of, or as well as, 
+  the current `dir_path` argument.
+
+- Optimize particular methods from PineconeDocumentStore (delete_documents and _get_vector_count)
+
+- Update the deepset Cloud SDK to the new endpoint format for new saving pipeline configs.
+
+- Add alias names for Cohere embed models for an easier map between names
+
+
+.. _relnotes_v1.22.0-rc1_Deprecation Notes:
+
+Deprecation Notes
+-----------------
+
+- Deprecate `OpenAIAnswerGenerator` in favor of `PromptNode`.
+  `OpenAIAnswerGenerator` will be removed in Haystack 1.23.
+
+
+.. _relnotes_v1.22.0-rc1_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Fixed the bug that prevented the correct usage of ChatGPT invocation layer
+  in 1.21.1.
+  Added async support for ChatGPT invocation layer.
+
+- Added documents_store.update_embeddings call to pipeline examples so that embeddings are calculated for newly added documents.
+
+- Remove unsupported `medium` and `finance-sentiment` models from supported Cohere embed model list
+
+
+.. _relnotes_v1.22.0-rc1_Haystack 2.0 preview:
+
+Haystack 2.0 preview
+--------------------
+
+- Add AzureOCRDocumentConverter to convert files of different types using Azure's Document Intelligence Service.
+
+- Add ByteStream type to send binary raw data across components
+  in a pipeline.
+
+- Introduce ChatMessage data class to facilitate structured handling and processing of message content
+  within LLM chat interactions.
+
+- Adds `ChatMessage` templating in `PromptBuilder`
+
+- Adds HTMLToDocument component to convert HTML to a Document.
+
+- Adds SimilarityRanker, a component that ranks a list of Documents based on their similarity to the query.
+
+- Introduce the StreamingChunk dataclass for efficiently handling chunks of data streamed from a language model,
+  encapsulating both the content and associated metadata for systematic processing.
+
+- Adds TopPSampler, a component selects documents based on the cumulative probability of the Document scores using top p (nucleus) sampling.
+
+- Add `dumps`, `dump`, `loads` and `load` methods to save
+  and load pipelines in Yaml format.
+
+- Adopt Hugging Face `token` instead of the deprecated `use_auth_token`.
+  Add this parameter to `ExtractiveReader` and `SimilarityRanker` to allow
+  loading private models.
+  Proper handling of `token` during serialization: if it is a string (a possible valid token)
+  it is not serialized.
+
+- Add `mime_type` field to `ByteStream` dataclass.
+
+- The Document dataclass checks if `id_hash_keys` is None or empty in
+  __post_init__. If so, it uses the default factory to set a default valid value.
+
+- Rework `Document.id` generation, if an `id` is not explicitly set it's generated
+  using all `Document` field' values, `score` is not used.
+
+- Change `Document`'s `embedding` field type from `numpy.ndarray` to `List[float]`
+
+- Fixed a bug that caused TextDocumentSplitter and DocumentCleaner to ignore id_hash_keys and create Documents with duplicate ids if the documents differed only in their metadata.
+
+- Fix TextDocumentSplitter failing when run with an empty list
+
+- Better management of API key in GPT Generator. The API key is never serialized.
+  Make the `api_base_url` parameter really used (previously it was ignored).
+
+- Add a minimal version of HuggingFaceLocalGenerator, a component that can run
+  Hugging Face models locally to generate text.
+
+- Migrate RemoteWhisperTranscriber to OpenAI SDK.
+
+- Add OpenAI Document Embedder.
+  It computes embeddings of Documents using OpenAI models.
+  The embedding of each Document is stored in the `embedding` field of the Document.
+
+- Add the `TextDocumentSplitter` component for Haystack 2.0 that splits a Document with long text into multiple Documents with shorter texts. Thereby the texts match the maximum length that the language models in Embedders or other components can process.
+
+- Refactor OpenAIDocumentEmbedder to enrich documents with embeddings instead of recreating them.
+
+- Refactor SentenceTransformersDocumentEmbedder to enrich documents with embeddings instead of recreating them.
+
+- Remove "api_key" from serialization of AzureOCRDocumentConverter and SerperDevWebSearch.
+
+- Removed implementations of from_dict and to_dict from all components where they had the same effect as the default implementation from Canals: https://github.com/deepset-ai/canals/blob/main/canals/serialization.py#L12-L13 This refactoring does not change the behavior of the components.
+
+- Remove `array` field from `Document` dataclass.
+
+- Remove `id_hash_keys` field from `Document` dataclass.
+  `id_hash_keys` has been also removed from Components that were using it:
+  * `DocumentCleaner`
+  * `TextDocumentSplitter`
+  * `PyPDFToDocument`
+  * `AzureOCRDocumentConverter`
+  * `HTMLToDocument`
+  * `TextFileToDocument`
+  * `TikaDocumentConverter`
+
+- Enhanced file routing capabilities with the introduction of `ByteStream` handling, and
+  improved clarity by renaming the router to `FileTypeRouter`.
+
+- Rename `MemoryDocumentStore` to `InMemoryDocumentStore`
+  Rename `MemoryBM25Retriever` to `InMemoryBM25Retriever`
+  Rename `MemoryEmbeddingRetriever` to `InMemoryEmbeddingRetriever`
+
+- Renamed ExtractiveReader's input from `document` to `documents` to match its type List[Document].
+
+- Rename `SimilarityRanker` to `TransformersSimilarityRanker`,
+  as there will be more similarity rankers in the future.
+
+- Allow specifying stopwords to stop text generation for `HuggingFaceLocalGenerator`.
+
+- Add basic telemetry to Haystack 2.0 pipelines
+
+- Added DocumentCleaner, which removes extra whitespace, empty lines, headers, etc. from Documents containing text.
+  Useful as a preprocessing step before splitting into shorter text documents.
+
+- Add TextLanguageClassifier component so that an input string, for example a query, can be routed to different components based on the detected language.
+
+- Upgrade canals to 0.9.0 to support variadic inputs for Joiner components and "/" in connection names like "text/plain"
+
+


### PR DESCRIPTION
### Related Issues

- fixes `reno report` execution on release branches

### Proposed Changes:

When we branch off in preparation of a release, say `git co -b v1.22.x` we also tag the same commit as `v1.22.0-rc0` so that when `reno` goes back the git history when generating the notes for a future `v1.23.0` will know where to stop collecting notes.

### How did you test it?

Manually tested the `reno report` command, didn't test the github workflow.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
