### PR TITLE
fix: Add new rankers to nodes __init__.py

### DIFF
--- a/haystack/nodes/__init__.py
+++ b/haystack/nodes/__init__.py
@@ -26,7 +26,14 @@ from haystack.nodes.prompt import PromptNode, PromptTemplate, PromptModel, BaseO
 from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
 from haystack.nodes.query_classifier import TransformersQueryClassifier
 from haystack.nodes.question_generator import QuestionGenerator
-from haystack.nodes.ranker import BaseRanker, SentenceTransformersRanker, CohereRanker
+from haystack.nodes.ranker import (
+    BaseRanker,
+    SentenceTransformersRanker,
+    CohereRanker,
+    LostInTheMiddleRanker,
+    DiversityRanker,
+    RecentnessRanker,
+)
 from haystack.nodes.reader import BaseReader, FARMReader, TransformersReader, TableReader, RCIReader
 from haystack.nodes.retriever import (
     BaseRetriever,

--- a/releasenotes/notes/add-new-rankers-schema-generation-7ad92fd5c5de8937.yaml
+++ b/releasenotes/notes/add-new-rankers-schema-generation-7ad92fd5c5de8937.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Adds LostInTheMiddleRanker, DiversityRanker, and RecentnessRanker to `haystack/nodes/__init__.py` and thus
+    ensures that they are included in JSON schema generation.


### PR DESCRIPTION
### Why:
The `LostInTheMiddleRanker`, `DiversityRanker`, and `RecentnessRanker` are not currently included in the `__init__.py` file of the haystack nodes directory (`haystack/nodes/__init__.py`), resulting in their omission from the generated JSON schema for Haystack pipelines. 

- fixes https://github.com/deepset-ai/haystack/issues/6213

### What:
- Added `LostInTheMiddleRanker`, `DiversityRanker`, and `RecentnessRanker` to `__init__.py` in the haystack nodes directory to ensure they are included in the JSON schema generation.

### How can it be used:
With these additions, users can now validate their pipeline configurations against the updated JSON schema which now includes definitions for `LostInTheMiddleRanker`, `DiversityRanker`, and `RecentnessRanker`.

### How did you test it:
- Generated the JSON schema post-modification to verify the inclusion of the missing rankers.


### Notes for reviewer:
While this is a straightforward addition to the `__init__.py` file to resolve the schema generation omission let's see if CI is ok with this change. 
