### PR TITLE
chore: pin openai<1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ preview = [
   "posthog",  # telemetry
 
   "Jinja2",
-  "openai",
+  "openai<1.0.0",
   "pyyaml",
   "more-itertools",  # DocumentSplitter
 ]


### PR DESCRIPTION
### Related Issues

[OpenAI SDK 1.0.0 was recently released](https://pypi.org/project/openai/)
and some things are breaking: (e.g., https://github.com/deepset-ai/haystack/actions/runs/6773389495/job/18408515828)

### Proposed Changes:

- temporarily pin openai<1

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
