### PR TITLE
refactor: Change Document.blob type and remove mime_type field

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -65,7 +65,6 @@ class Document(metaclass=_BackwardCompatible):
     :param content: Text of the document, if the document contains text.
     :param dataframe: Pandas dataframe with the document's content, if the document contains tabular data.
     :param blob: Binary data associated with the document, if the document has any binary data associated with it.
-    :param mime_type: MIME type of the document. Defaults to "text/plain".
     :param meta: Additional custom metadata for the document. Must be JSON-serializable.
     :param score: Score of the document. Used for ranking, usually assigned by retrievers.
     :param embedding: Vector representation of the document.

--- a/releasenotes/notes/document-blob-ae28734c5be561d9.yaml
+++ b/releasenotes/notes/document-blob-ae28734c5be561d9.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Change `Document.blob` field type from `bytes` to `ByteStream` and remove `Document.mime_type` field.


### PR DESCRIPTION
### Proposed Changes:

This PR changes the type of the `blob` field in `Document` from `bytes` to `ByteStream`.
It also removes the `mime_type` field from `Document` as it's already present in `ByteStream`.

### How did you test it?

I updated tests and run unit tests locally.

### Notes for the reviewer

I also removed some `Document` unit tests that were outdated.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
