### PR TITLE
feat: add tokenization details for gpt-4-1106-preview

### DIFF
--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -90,7 +90,7 @@ def _openai_text_completion_tokenization_details(model_name: str):
             max_tokens_limit = 32768  # tokens
             tokenizer_name = model_tokenizer
         elif model_name.startswith("gpt-4-1106-preview"):
-            max_tokens_limit = 131072  # tokens
+            max_tokens_limit = 128000  # tokens
             tokenizer_name = model_tokenizer
         elif model_name.startswith("gpt-4"):
             max_tokens_limit = 8192  # tokens

--- a/haystack/utils/openai_utils.py
+++ b/haystack/utils/openai_utils.py
@@ -89,6 +89,9 @@ def _openai_text_completion_tokenization_details(model_name: str):
         elif model_name.startswith("gpt-4-32k"):
             max_tokens_limit = 32768  # tokens
             tokenizer_name = model_tokenizer
+        elif model_name.startswith("gpt-4-1106-preview"):
+            max_tokens_limit = 131072  # tokens
+            tokenizer_name = model_tokenizer
         elif model_name.startswith("gpt-4"):
             max_tokens_limit = 8192  # tokens
             tokenizer_name = model_tokenizer

--- a/releasenotes/notes/support-gpt-4-1106-preview-ce8e551b11d96471.yaml
+++ b/releasenotes/notes/support-gpt-4-1106-preview-ce8e551b11d96471.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - Add new token limit for gpt-4-1106-preview model


### PR DESCRIPTION
### Related Issues

- fixes: n/a, no issue was created

### Proposed Changes:

On 6 November 2023, OpenAI released a preview model, `gpt-4-1106-preview`, with a 128K context length. This PR adds tokenizer configuration for this new model.

### How did you test it?

I did not see any relevant unit tests to update, but I did step through the code and observed that the token length was applied correctly. The errors about the prompt being too long were eliminated.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
