### PR TITLE
feat: Add `model_kwargs` to ExtractiveReader to impact model loading

### DIFF
--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -85,7 +85,7 @@ class ExtractiveReader:
         self.answers_per_seq = answers_per_seq
         self.no_answer = no_answer
         self.calibration_factor = calibration_factor
-        self.model_kwargs = model_kwargs
+        self.model_kwargs = model_kwargs or {}
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -126,14 +126,9 @@ class ExtractiveReader:
             else:
                 self.device = self.device or "cpu:0"
 
-            if self.model_kwargs:
-                kwargs = {"token": self.token, **self.model_kwargs}
-            else:
-                kwargs = {"token": self.token}
-
-            self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, **kwargs).to(
-                self.device
-            )
+            self.model = AutoModelForQuestionAnswering.from_pretrained(
+                self.model_name_or_path, token=self.token, **self.model_kwargs
+            ).to(self.device)
             self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=self.token)
 
     def _flatten_documents(

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -125,10 +125,12 @@ class ExtractiveReader:
                 self.device = self.device or "mps:0"
             else:
                 self.device = self.device or "cpu:0"
+
             if self.model_kwargs:
                 kwargs = {"token": self.token, **self.model_kwargs}
             else:
                 kwargs = {"token": self.token}
+
             self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, **kwargs).to(
                 self.device
             )

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -45,10 +45,11 @@ class ExtractiveReader:
         answers_per_seq: Optional[int] = None,
         no_answer: bool = True,
         calibration_factor: float = 0.1,
+        model_kwargs: Optional[dict] = None,
     ) -> None:
         """
         Creates an ExtractiveReader
-        :param model: A HuggingFace transformers question answering model.
+        :param model_name_or_path: A HuggingFace transformers question answering model.
             Can either be a path to a folder containing the model files or an identifier for the HF hub
             Default: `'deepset/roberta-base-squad2-distilled'`
         :param device: Pytorch device string. Uses GPU by default if available
@@ -68,6 +69,8 @@ class ExtractiveReader:
             This is relevant when a document has been split into multiple sequence due to max_seq_length.
         :param no_answer: Whether to return no answer scores
         :param calibration_factor: Factor used for calibrating confidence scores
+        :param model_kwargs: Additional keyword arguments passed to `AutoModelForQuestionAnswering.from_pretrained`
+            when loading the model specified in `model_name_or_path`.
         """
         torch_and_transformers_import.check()
         self.model_name_or_path = str(model_name_or_path)
@@ -82,6 +85,7 @@ class ExtractiveReader:
         self.answers_per_seq = answers_per_seq
         self.no_answer = no_answer
         self.calibration_factor = calibration_factor
+        self.model_kwargs = model_kwargs
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -106,6 +110,7 @@ class ExtractiveReader:
             answers_per_seq=self.answers_per_seq,
             no_answer=self.no_answer,
             calibration_factor=self.calibration_factor,
+            model_kwargs=self.model_kwargs,
         )
 
     def warm_up(self):
@@ -120,7 +125,8 @@ class ExtractiveReader:
                 self.device = self.device or "mps:0"
             else:
                 self.device = self.device or "cpu:0"
-            self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, token=self.token).to(
+            kwargs = {"token": self.token, **self.model_kwargs}
+            self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, **kwargs).to(
                 self.device
             )
             self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=self.token)

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -45,7 +45,7 @@ class ExtractiveReader:
         answers_per_seq: Optional[int] = None,
         no_answer: bool = True,
         calibration_factor: float = 0.1,
-        model_kwargs: Optional[dict] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Creates an ExtractiveReader

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -125,7 +125,10 @@ class ExtractiveReader:
                 self.device = self.device or "mps:0"
             else:
                 self.device = self.device or "cpu:0"
-            kwargs = {"token": self.token, **self.model_kwargs}
+            if self.model_kwargs:
+                kwargs = {"token": self.token, **self.model_kwargs}
+            else:
+                kwargs = {"token": self.token}
             self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, **kwargs).to(
                 self.device
             )

--- a/releasenotes/notes/add-model-kwargs-extractive-reader-c0b65ab34572408f.yaml
+++ b/releasenotes/notes/add-model-kwargs-extractive-reader-c0b65ab34572408f.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add new variable model_kwargs to the ExtractiveReader so we can pass different loading options supported by
+    HuggingFace.

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -89,7 +89,7 @@ example_documents = [
 
 @pytest.mark.unit
 def test_to_dict():
-    component = ExtractiveReader("my-model", token="secret-token")
+    component = ExtractiveReader("my-model", token="secret-token", model_kwargs={"torch_dtype": "auto"})
     data = component.to_dict()
 
     assert data == {
@@ -106,6 +106,7 @@ def test_to_dict():
             "answers_per_seq": None,
             "no_answer": True,
             "calibration_factor": 0.1,
+            "model_kwargs": {"torch_dtype": "auto"},
         },
     }
 

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -112,6 +112,30 @@ def test_to_dict():
 
 
 @pytest.mark.unit
+def test_to_dict_empty_model_kwargs():
+    component = ExtractiveReader("my-model", token="secret-token")
+    data = component.to_dict()
+
+    assert data == {
+        "type": "ExtractiveReader",
+        "init_parameters": {
+            "model_name_or_path": "my-model",
+            "device": None,
+            "token": None,  # don't serialize valid tokens
+            "top_k": 20,
+            "confidence_threshold": None,
+            "max_seq_length": 384,
+            "stride": 128,
+            "max_batch_size": None,
+            "answers_per_seq": None,
+            "no_answer": True,
+            "calibration_factor": 0.1,
+            "model_kwargs": {},
+        },
+    }
+
+
+@pytest.mark.unit
 def test_output(mock_reader: ExtractiveReader):
     answers = mock_reader.run(example_queries[0], example_documents[0], top_k=3)[
         "answers"


### PR DESCRIPTION
### Related Issues

- fixes #N/A

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Add new variable `model_kwargs` to the `ExtractiveReader` so we can pass different loading options supported by HuggingFace. This is similar to the `pipeline_kwargs` used by the HuggingFaceLocalGenerator to pass kwargs to the underlying HF pipeline. In this case I named the variable `model_kwargs` because we are loading the extractive QA model under-the-hood.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Updated unit test to check we are passing the kwargs properly.
- Also ran locally to check the passed model_kwargs impacted model loading.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
