### PR TITLE
feat: Add custom conversion callable to PyPDFToDocument - Haystack 2.x

### DIFF
--- a/haystack/preview/components/file_converters/pypdf.py
+++ b/haystack/preview/components/file_converters/pypdf.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import List, Union
+from typing import List, Union, Callable, Optional
 from pathlib import Path
 
 from haystack.preview.dataclasses import ByteStream
@@ -17,14 +17,24 @@ logger = logging.getLogger(__name__)
 @component
 class PyPDFToDocument:
     """
-    Converts a PDF file to a Document.
+    Converts a PDF file to a Document. By default, it extracts the text from the PDF file and creates a Document
+    instance with the extracted text. You can also pass a custom converter function to the component.
     """
 
-    def __init__(self):
+    def __init__(self, converter: Optional[Callable[[PdfReader], Document]] = None):
         """
-        Initializes the PyPDFToDocument component.
+        Initializes the PyPDFToDocument component with an optional custom converter.
         """
         pypdf_import.check()
+        if converter and not callable(converter):
+            raise ValueError("Converter must be a callable accepting a PdfReader object and returning a Document")
+        self.converter = (
+            converter
+            if converter
+            else lambda pdf_reader: Document(
+                content="".join(page.extract_text() for page in pdf_reader.pages if page.extract_text())
+            )
+        )
 
     @component.output_types(documents=List[Document])
     def run(self, sources: List[Union[str, Path, ByteStream]]):
@@ -36,29 +46,25 @@ class PyPDFToDocument:
         documents = []
         for source in sources:
             try:
-                text = self._read_pdf_file(source)
+                pdf_reader = self._get_pdf_reader(source)
+                document = self.converter(pdf_reader)
             except Exception as e:
-                logger.warning("Could not read %s. Skipping it. Error message: %s", source, e)
+                logger.warning("Could not read %s and convert it to Document, skipping. %s", source, e)
                 continue
-
-            document = Document(content=text)
             documents.append(document)
 
         return {"documents": documents}
 
-    def _read_pdf_file(self, source: Union[str, Path, ByteStream]) -> str:
+    def _get_pdf_reader(self, source: Union[str, Path, ByteStream]) -> PdfReader:
         """
-        Extracts content from the given PDF source.
-        :param source:  PDF file data source
-        :return: The extracted text.
+        Creates a PdfReader object from the given source.
+
+        :param source: PDF file data source
+        :return: PdfReader object
         """
         if isinstance(source, (str, Path)):
-            pdf_reader = PdfReader(str(source))
+            return PdfReader(str(source))
         elif isinstance(source, ByteStream):
-            pdf_reader = PdfReader(io.BytesIO(source.data))
+            return PdfReader(io.BytesIO(source.data))
         else:
             raise ValueError(f"Unsupported source type: {type(source)}")
-
-        text = "".join(extracted_text for page in pdf_reader.pages if (extracted_text := page.extract_text()))
-
-        return text

--- a/releasenotes/notes/add-custom-converter-hook-to-pypdf-cc7c333a6e7fc5f7.yaml
+++ b/releasenotes/notes/add-custom-converter-hook-to-pypdf-cc7c333a6e7fc5f7.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Add callable hook to PyPDFToDocument to enable easier customization of pdf to Document conversion.

--- a/test/preview/components/file_converters/test_pypdf_to_document.py
+++ b/test/preview/components/file_converters/test_pypdf_to_document.py
@@ -1,6 +1,4 @@
 import logging
-from typing import Callable
-
 import pytest
 from pypdf import PdfReader
 
@@ -56,20 +54,13 @@ class TestPyPDFToDocument:
         """
         paths = [preview_samples_path / "pdf" / "react_paper.pdf"]
 
-        custom_converter: Callable[[PdfReader], Document] = lambda pdf_reader: Document(
-            content="I don't care about converting given pdfs, I always return this"
-        )
-        converter = PyPDFToDocument(custom_converter)
+        class MyCustomConverter:
+            def convert(self, reader: PdfReader) -> Document:
+                return Document(content="I don't care about converting given pdfs, I always return this")
+
+        converter = PyPDFToDocument(converter=MyCustomConverter())
         output = converter.run(sources=paths)
         docs = output["documents"]
         assert len(docs) == 1
         assert "ReAct" not in docs[0].content
         assert "I don't care about converting given pdfs, I always return this" in docs[0].content
-
-    @pytest.mark.unit
-    def test_invalid_custom_converter(self):
-        """
-        Test if the component correctly handles invalid custom converters.
-        """
-        with pytest.raises(ValueError, match="Converter must be a callable accepting"):
-            PyPDFToDocument(converter="invalid_converter")

--- a/test/preview/components/file_converters/test_pypdf_to_document.py
+++ b/test/preview/components/file_converters/test_pypdf_to_document.py
@@ -49,6 +49,7 @@ class TestPyPDFToDocument:
         assert "ReAct" in docs[0].content
         assert "ReAct" in docs[1].content
 
+    @pytest.mark.unit
     def test_custom_converter(self, preview_samples_path):
         """
         Test if the component correctly handles custom converters.
@@ -64,3 +65,11 @@ class TestPyPDFToDocument:
         assert len(docs) == 1
         assert "ReAct" not in docs[0].content
         assert "I don't care about converting given pdfs, I always return this" in docs[0].content
+
+    @pytest.mark.unit
+    def test_invalid_custom_converter(self):
+        """
+        Test if the component correctly handles invalid custom converters.
+        """
+        with pytest.raises(ValueError, match="Converter must be a callable accepting"):
+            PyPDFToDocument(converter="invalid_converter")


### PR DESCRIPTION
#### Why:
Add support for a custom converter callable in PyPDFToDocument to enhance conversion flexibility and allow for more complex conversions tailored to specific use cases. This change was inspired by community discussions https://github.com/deepset-ai/haystack/discussions/4467 and https://github.com/deepset-ai/haystack/issues/5963

#### What:
We've added the ability to specify a custom converter function to the PyPDFToDocument component. This function takes a `PdfReader` object and returns a `Document` object, allowing for customized text extraction logic.

#### How can it be used:
You can now pass a custom converter to PyPDFToDocument like so:

```python
from pypdf import PdfReader
from haystack.preview.components.file_converters.pypdf import PyPDFToDocument
from haystack.preview.dataclasses import Document

# Custom converter function
def custom_converter(pdf_reader: PdfReader) -> Document:
    # Custom conversion logic
    return Document(content="Custom converted text")

# Using the custom converter
converter = PyPDFToDocument(converter=custom_converter)
```

### How did you test it:
Unit tests were added to ensure that the component can handle custom converters in `test/preview/components/file_converters/test_pypdf_to_document.py`

### Notes for reviewer:
This change introduces a new optional parameter converter to the PyPDFToDocument component, which should be fully backward compatible. The default behaviour remains unchanged if no custom converter is provided.
