### PR TITLE
feat: Add pipeline run with kwargs to Haystack 2.x

### DIFF
--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -93,7 +93,7 @@ class Pipeline(canals.Pipeline):
             pipeline_inputs, unresolved_inputs = self._prepare_pipeline_component_input_data(data)
             if unresolved_inputs:
                 logger.warning(
-                    "Inputs %s were not matched to any component inputs, please check your " "pipeline run parameters.",
+                    "Inputs %s were not matched to any component inputs, please check your run parameters.",
                     list(unresolved_inputs.keys()),
                 )
 

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -36,16 +36,16 @@ class Pipeline(canals.Pipeline):
 
     def run(self, data: Dict[str, Any], debug: bool = False) -> Dict[str, Any]:
         """
-        Runs the pipeline
+        Runs the pipeline with given input data.
 
-        :param data: the inputs to give to the input components of the Pipeline. data is a dictionary
-        where each key is a component name and each value is a dictionary of input parameter of that component.
-        :param debug: whether to collect and return debug information.
-        :return: A dictionary with the outputs of the Pipeline.
-        :raises PipelineRuntimeError: if any of the components fail or return unexpected output.
+        :param data: A dictionary of inputs for the pipeline's components. Each key is a component name
+        and its value is a dictionary of that component's input parameters.
+        :param debug: Set to True to collect and return debug information.
+        :return: A dictionary containing the pipeline's output.
+        :raises PipelineRuntimeError: If a component fails or returns unexpected output.
 
-        Here is an example using a simple Hello component having an input 'word', a string, and output
-        named 'output', also a string. The component just returns the input string with a greeting, i.e:
+        Example a - Using named components:
+        Consider a 'Hello' component that takes a 'word' input and outputs a greeting.
 
         ```python
         @component
@@ -55,31 +55,28 @@ class Pipeline(canals.Pipeline):
                 return {"output": f"Hello, {word}!"}
         ```
 
-        We can create a pipeline connecting two instances of this component together, and run it like so:
+        Create a pipeline with two 'Hello' components connected together:
 
         ```python
         pipeline = Pipeline()
         pipeline.add_component("hello", Hello())
         pipeline.add_component("hello2", Hello())
-
         pipeline.connect("hello.output", "hello2.word")
         result = pipeline.run(data={"hello": {"word": "world"}})
-        assert result == {'hello2': {'output': 'Hello, Hello, world!!'}}
         ```
 
-        Notice how run method takes a data dictionary with the inputs for each component. The keys of the
-        dictionary are the component names and the values are dictionaries with the input parameters of
-        that component.
+        This runs the pipeline with the specified input for 'hello', yielding
+        {'hello2': {'output': 'Hello, Hello, world!!'}}.
 
-        We can also run the pipeline by passing the inputs directly to the run method, omitting component names,
-        as in the following example:
+        Example b - Using flat inputs:
+        You can also pass inputs directly without specifying component names:
 
         ```python
         result = pipeline.run(data={"word": "world"})
-        assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
         ```
-        In this case, the pipeline will try to resolve the input parameters to the appropriate components and
-        if successful, it will run the pipeline and return the outputs.
+
+        The pipeline resolves inputs to the correct components, returning
+        {'hello2': {'output': 'Hello, Hello, world!!'}}.
         """
         # check whether the data is a nested dictionary of component inputs where each key is a component name
         # and each value is a dictionary of input parameters for that component

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Dict, Optional, Union, TextIO
+from typing import Any, Dict, Optional, Union, TextIO, Tuple
 from pathlib import Path
 import datetime
 import logging
@@ -87,7 +87,7 @@ class Pipeline(canals.Pipeline):
             # flat input, a dict where keys are input names and values are the corresponding values
             # we need to convert it to a nested dictionary of component inputs and then run the pipeline
             # just like in the previous case
-            pipeline_inputs, unresolved_inputs = self._prepare_pipeline_component_input_data(data)
+            pipeline_inputs, unresolved_inputs = self._prepare_component_input_data(data)
             if unresolved_inputs:
                 logger.warning(
                     "Inputs %s were not matched to any component inputs, please check your run parameters.",
@@ -161,17 +161,21 @@ class Pipeline(canals.Pipeline):
         """
         return cls.from_dict(marshaller.unmarshal(fp.read()))
 
-    def _prepare_pipeline_component_input_data(self, data: Dict[str, Any]):
+    def _prepare_component_input_data(self, data: Dict[str, Any]) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
         """
-        Prepares the input data for the pipeline components and identifies any unresolved parameters.
+        Organizes input data for pipeline components and identifies any inputs that are not matched to any
+        component's input slots.
 
-        This method organizes the inputs for each component in the pipeline based on the provided
-        data arguments. It also keeps track of any inputs that do not correspond to input slots of
-        any component.
+        This method processes a flat dictionary of input data, where each key-value pair represents an input name
+        and its corresponding value. It distributes these inputs to the appropriate pipeline components based on
+        their input requirements. Inputs that don't match any component's input slots are classified as unresolved.
 
-        :param data: flat dict of inputs where the keys are the input names and the values are the input values.
-        :return: A tuple containing the organized input data for the pipeline components (as a dictionary) and
-                 a dictionary of any unresolved keyword arguments.
+        :param data: A dictionary with input names as keys and input values as values.
+        :type data: Dict[str, Any]
+        :return: A tuple containing two elements:
+             1. A dictionary mapping component names to their respective matched inputs.
+             2. A dictionary of inputs that were not matched to any component, termed as unresolved keyword arguments.
+        :rtype: Tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]
         """
         pipeline_input_data: Dict[str, Dict[str, Any]] = defaultdict(dict)
         unresolved_kwargs = {}

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Union, TextIO
+from collections import defaultdict
+from typing import Any, Dict, Optional, Union, TextIO, overload
 from pathlib import Path
 import datetime
 import logging
@@ -33,7 +34,119 @@ class Pipeline(canals.Pipeline):
         self._last_telemetry_sent: Optional[datetime.datetime] = None
         super().__init__(metadata=metadata, max_loops_allowed=max_loops_allowed, debug_path=debug_path)
 
+    @overload
     def run(self, data: Dict[str, Any], debug: bool = False) -> Dict[str, Any]:
+        """
+        Runs the pipeline
+
+        :param data: the inputs to give to the input components of the Pipeline. data is a dictionary
+        where each key is a component name and each value is a dictionary of input parameter of that component.
+        :param debug: whether to collect and return debug information.
+        :return: A dictionary with the outputs of the Pipeline.
+        :raises PipelineRuntimeError: if any of the components fail or return unexpected output.
+
+        Here is an example using a simple Hello component having an input 'word', a string, and output
+        named 'output', also a string. The component just returns the input string with a greeting, i.e:
+
+        ```python
+        @component
+        class Hello:
+            @component.output_types(output=str)
+            def run(self, word: str):
+                return {"output": f"Hello, {word}!"}
+        ```
+
+        We can create a pipeline connecting two instances of this component together, and run it like so:
+
+        ```python
+        pipeline = Pipeline()
+        pipeline.add_component("hello", Hello())
+        pipeline.add_component("hello2", Hello())
+
+        pipeline.connect("hello.output", "hello2.word")
+        result = pipeline.run(data={"hello": {"word": "world"}})
+        assert result == {'hello2': {'output': 'Hello, Hello, world!!'}}
+        ```
+
+        Notice how run method takes a data dictionary with the inputs for each component. The keys of the
+        dictionary are the component names and the values are dictionaries with the input parameters of that component.
+        """
+
+    @overload
+    def run(self, **kwargs) -> Dict[str, Any]:
+        """
+        Runs the pipeline
+
+        :param kwargs: the inputs to give to the input components of the Pipeline. Each key in kwargs represents
+        an input parameter of some component in the pipeline and the value is the corresponding value to be passed.
+        The input name doesn't have to be fully qualified (no need to use 'component_name.input_name'), just having
+        input_name part is enough. If there are multiple components with the same input name, the pipeline input will be
+        passed to all of them (as long as the types match).
+
+        :return: A dictionary with the outputs of the Pipeline.
+        :raises PipelineRuntimeError: if any of the components fail or return unexpected output.
+
+        Here is an example using a simple Hello component having an input 'word', a string, and output
+        named 'output', also a string. The component just returns the input string with a greeting, i.e:
+
+        ```python
+        @component
+        class Hello:
+            @component.output_types(output=str)
+            def run(self, word: str):
+                return {"output": f"Hello, {word}!"}
+        ```
+
+        We can create a pipeline connecting two instances of this component together, and run it like so:
+
+        ```python
+        pipeline = Pipeline()
+        pipeline.add_component("hello", Hello())
+        pipeline.add_component("hello2", Hello())
+
+        pipeline.connect("hello.output", "hello2.word")
+        result = pipeline.run(word="world")
+        assert result == {'hello2': {'output': 'Hello, Hello, world!!'}}
+        ```
+        Notice how run method takes keyword arguments with the corresponding values. The pipeline will
+        automatically resolve the matching components and pass the input to them.
+        """
+
+    def run(self, *args, **kwargs) -> Dict[str, Any]:
+        """
+        Dispatches the execution to the appropriate overloaded run method based on the input arguments.
+
+        This method serves as an entry point to the pipeline execution process.
+
+        The selection of the appropriate method is based on the presence or absence of certain keywords or the
+        structure of the arguments. If the arguments match neither expected pattern, a TypeError is raised.
+
+        It is not meant to be called directly with arguments, but rather to be used by the class internally
+        to handle the variations in input that a user might provide when attempting to run the pipeline.
+
+        :param args: Positional arguments
+        :param kwargs: Keyword arguments
+        :return: A dictionary with the outputs of the pipeline if the dispatch was successful.
+        :raises TypeError: if the provided arguments do not match any expected signature for the overloaded run methods.
+        """
+        # Handling the original run signature with .run(data=...)
+        if "data" in kwargs and not args:
+            data = kwargs["data"]
+            debug = kwargs.get("debug", False)
+            return self._run_internal(data, debug)
+
+        # Handling the new run signature with keyword arguments only
+        if not args and kwargs:
+            pipeline_inputs, unresolved_inputs = self._prepare_pipeline_input_data(**kwargs)
+            if unresolved_inputs:
+                logger.warning("Inputs %s were not matched to any component", list(unresolved_inputs.keys()))
+            debug = kwargs.get("debug", False)
+            return self._run_internal(data=pipeline_inputs, debug=debug)
+
+        # Error if the signature does not match expected patterns
+        raise TypeError("Unsupported signature for 'run'")
+
+    def _run_internal(self, data: Dict[str, Any], debug: bool = False) -> Dict[str, Any]:
         """
         Runs the pipeline.
 
@@ -42,7 +155,7 @@ class Pipeline(canals.Pipeline):
 
         :returns: A dictionary with the outputs of the output components of the Pipeline.
 
-        :raises PipelineRuntimeError: if the any of the components fail or return unexpected output.
+        :raises PipelineRuntimeError: if any of the components fail or return unexpected output.
         """
         pipeline_running(self)
         return super().run(data=data, debug=debug)
@@ -97,3 +210,37 @@ class Pipeline(canals.Pipeline):
         :returns: A `Pipeline` object.
         """
         return cls.from_dict(marshaller.unmarshal(fp.read()))
+
+    def _prepare_pipeline_input_data(self, **kwargs):
+        """
+        Prepares the input data for the pipeline components and identifies any unresolved parameters.
+
+        This method organizes the inputs for each component in the pipeline based on the provided
+        keyword arguments (kwargs).
+        It also keeps track of any kwargs that do not correspond to input slots of any component.
+
+        :param kwargs: Arbitrary keyword arguments that are inputs to the components of the pipeline.
+        :return: A tuple containing the organized input data for the pipeline components (as a dictionary) and
+                 a dictionary of any unresolved keyword arguments.
+        """
+        pipeline_input_data: Dict[str, Dict[str, Any]] = defaultdict(dict)
+        unresolved_kwargs = {}
+
+        # Retrieve the input slots for each component in the pipeline
+        available_inputs: Dict[str, Dict[str, Any]] = self.inputs()
+
+        # Go through all provided kwargs to distribute them to the appropriate component inputs
+        for input_name, input_value in kwargs.items():
+            resolved_at_least_once = False
+
+            # Check each component to see if it has a slot for the current kwarg
+            for component_name, component_inputs in available_inputs.items():
+                if input_name in component_inputs:
+                    # If a match is found, add the kwarg to the component's input data
+                    pipeline_input_data[component_name][input_name] = input_value
+                    resolved_at_least_once = True
+
+            if not resolved_at_least_once:
+                unresolved_kwargs[input_name] = input_value
+
+        return pipeline_input_data, unresolved_kwargs

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -72,46 +72,6 @@ class Pipeline(canals.Pipeline):
         dictionary are the component names and the values are dictionaries with the input parameters of that component.
         """
 
-    @overload
-    def run(self, **kwargs) -> Dict[str, Any]:
-        """
-        Runs the pipeline
-
-        :param kwargs: the inputs to give to the input components of the Pipeline. Each key in kwargs represents
-        an input parameter of some component in the pipeline and the value is the corresponding value to be passed.
-        The input name doesn't have to be fully qualified (no need to use 'component_name.input_name'), just having
-        input_name part is enough. If there are multiple components with the same input name, the pipeline input will be
-        passed to all of them (as long as the types match).
-
-        :return: A dictionary with the outputs of the Pipeline.
-        :raises PipelineRuntimeError: if any of the components fail or return unexpected output.
-
-        Here is an example using a simple Hello component having an input 'word', a string, and output
-        named 'output', also a string. The component just returns the input string with a greeting, i.e:
-
-        ```python
-        @component
-        class Hello:
-            @component.output_types(output=str)
-            def run(self, word: str):
-                return {"output": f"Hello, {word}!"}
-        ```
-
-        We can create a pipeline connecting two instances of this component together, and run it like so:
-
-        ```python
-        pipeline = Pipeline()
-        pipeline.add_component("hello", Hello())
-        pipeline.add_component("hello2", Hello())
-
-        pipeline.connect("hello.output", "hello2.word")
-        result = pipeline.run(word="world")
-        assert result == {'hello2': {'output': 'Hello, Hello, world!!'}}
-        ```
-        Notice how run method takes keyword arguments with the corresponding values. The pipeline will
-        automatically resolve the matching components and pass the input to them.
-        """
-
     def run(self, *args, **kwargs) -> Dict[str, Any]:
         """
         Dispatches the execution to the appropriate overloaded run method based on the input arguments.

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -70,7 +70,28 @@ class Pipeline(canals.Pipeline):
 
         Notice how run method takes a data dictionary with the inputs for each component. The keys of the
         dictionary are the component names and the values are dictionaries with the input parameters of that component.
+
+        We can also run the pipeline by passing the inputs directly to the run method like so:
+
+        ```python
+        result = pipeline.run(data={"word": "world"})
+        assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
+        ```
+        In this case, the pipeline will try to resolve the input parameters to the appropriate components and
+        if successful, it will run the pipeline and return the outputs.
         """
+        pass
+
+    @overload
+    def run(self, **kwargs) -> Dict[str, Any]:
+        """
+        Runs the pipeline
+
+        **Note**: This method is part of an evolving interface and may be subject to changes in future releases.
+        We recommend using the more stable 'run(data: Dict[str, Any], debug: bool = False)' method for
+        regular use. Please keep this in mind when developing against this API.
+        """
+        pass
 
     def run(self, *args, **kwargs) -> Dict[str, Any]:
         """
@@ -78,15 +99,14 @@ class Pipeline(canals.Pipeline):
 
         This method serves as an entry point to the pipeline execution process.
 
-        **Note**: This method is part of an evolving interface and may be subject to changes in future releases.
-        We recommend using the more stable 'run(data: Dict[str, Any], debug: bool = False)' method for
-        regular use. Please keep this in mind when developing against this API.
-
         :param args: Positional arguments
         :param kwargs: Keyword arguments
         :return: A dictionary with the outputs of the pipeline if the dispatch was successful.
         :raises TypeError: if the provided arguments do not match any expected signature for the overloaded run methods.
         """
+        if args:
+            raise TypeError("Unsupported signature for 'run'")
+
         if "data" in kwargs:
             data = kwargs.pop("data")
             debug = kwargs.pop("debug", False)

--- a/haystack/preview/pipeline.py
+++ b/haystack/preview/pipeline.py
@@ -78,12 +78,11 @@ class Pipeline(canals.Pipeline):
 
         This method serves as an entry point to the pipeline execution process.
 
-        The selection of the appropriate method is based on the presence or absence of certain keywords or the
-        structure of the arguments. If the arguments match neither expected pattern, a TypeError is raised.
+        **Note**: This method is part of an evolving interface and may be subject to changes in future releases.
+        We recommend using the more stable 'run(data: Dict[str, Any], debug: bool = False)' method for
+        regular use. Please keep this in mind when developing against this API.
 
-        It is not meant to be called directly with arguments, but rather to be used by the class internally
-        to handle the variations in input that a user might provide when attempting to run the pipeline.
-
+        :param args: Positional arguments
         :param kwargs: Keyword arguments
         :return: A dictionary with the outputs of the pipeline if the dispatch was successful.
         :raises TypeError: if the provided arguments do not match any expected signature for the overloaded run methods.

--- a/releasenotes/notes/allow-simplified-pipeline-run-input-e3dd98ff38f0bc01.yaml
+++ b/releasenotes/notes/allow-simplified-pipeline-run-input-e3dd98ff38f0bc01.yaml
@@ -1,0 +1,6 @@
+---
+preview:
+  - |
+    Adds option to run pipelines without specifying component inputs and their corresponding key/value pairs. Instead,
+    provide the input keys/values directly, and the pipeline's internal mechanisms will automatically determine the
+    appropriate components.

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -63,7 +63,7 @@ def test_pipeline_load(test_files_path):
 
 
 @pytest.mark.unit
-def test_pipeline_input_resolution():
+def test_pipeline_resolution_simple_input():
     @component
     class Hello:
         @component.output_types(output=str)
@@ -84,3 +84,65 @@ def test_pipeline_input_resolution():
 
     result = pipeline.run(data={"word": "world"})
     assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
+
+
+def test_pipeline_resolution_wrong_input_name(caplog):
+    @component
+    class Hello:
+        @component.output_types(output=str)
+        def run(self, who: str):
+            """
+            Takes a string in input and returns "Hello, <string>!"
+            in output.
+            """
+            return {"output": f"Hello, {who}!"}
+
+    pipeline = Pipeline()
+    pipeline.add_component("hello", Hello())
+    pipeline.add_component("hello2", Hello())
+
+    pipeline.connect("hello.output", "hello2.who")
+
+    # test case with nested component inputs
+    with pytest.raises(ValueError):
+        pipeline.run(data={"hello": {"non_existing_input": "world"}})
+
+    # test case with flat component inputs
+    with pytest.raises(ValueError):
+        pipeline.run(data={"non_existing_input": "world"})
+
+    # important to check that the warning is logged for UX purposes, leave it here
+    assert "were not matched to any component" in caplog.text
+
+
+def test_pipeline_resolution_with_mixed_correct_and_incorrect_input_names(caplog):
+    @component
+    class Hello:
+        @component.output_types(output=str)
+        def run(self, who: str):
+            """
+            Takes a string in input and returns "Hello, <string>!"
+            in output.
+            """
+            return {"output": f"Hello, {who}!"}
+
+    pipeline = Pipeline()
+    pipeline.add_component("hello", Hello())
+    pipeline.add_component("hello2", Hello())
+
+    pipeline.connect("hello.output", "hello2.who")
+
+    # test case with nested component inputs
+    # this will raise ValueError because hello component does not have an input named "non_existing_input"
+    # even though it has an input named "who"
+    with pytest.raises(ValueError):
+        pipeline.run(data={"hello": {"non_existing_input": "world", "who": "world"}})
+
+    # test case with flat component inputs
+    # this will not raise ValueError because the input "who" will be resolved to the correct component
+    # and we'll log a warning for the input "non_existing_input" which was not resolved
+    result = pipeline.run(data={"non_existing_input": "world", "who": "world"})
+    assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
+
+    # important to check that the warning is logged for UX purposes, leave it here
+    assert "were not matched to any component" in caplog.text

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -164,7 +164,7 @@ def test_pipeline_resolution_duplicate_input_names_across_components():
     result = pipe.run(data={"what": "Haystack", "who": "world"})
     assert result == {"hello2": {"output": "Hello Hello world Haystack! Haystack!"}}
 
-    resolved, _ = pipe._prepare_pipeline_component_input_data(data={"what": "Haystack", "who": "world"})
+    resolved, _ = pipe._prepare_component_input_data(data={"what": "Haystack", "who": "world"})
 
     # why does hello2 have only one input? Because who of hello2 is inserted from hello.output
     assert resolved == {"hello": {"what": "Haystack", "who": "world"}, "hello2": {"what": "Haystack"}}

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -84,6 +84,3 @@ def test_pipeline_input_resolution():
 
     result = pipeline.run(data={"word": "world"})
     assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
-
-    result = pipeline.run(word="world")
-    assert result == {"hello2": {"output": "Hello, Hello, world!!"}}

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -60,3 +60,27 @@ def test_pipeline_load(test_files_path):
         assert pipeline.max_loops_allowed == 99
         assert isinstance(pipeline.get_component("Comp1"), TestComponent)
         assert isinstance(pipeline.get_component("Comp2"), TestComponent)
+
+
+@pytest.mark.unit
+def test_pipeline_input_resolution():
+    @component
+    class Hello:
+        @component.output_types(output=str)
+        def run(self, word: str):
+            """
+            Takes a string in input and returns "Hello, <string>!"
+            in output.
+            """
+            return {"output": f"Hello, {word}!"}
+
+    pipeline = Pipeline()
+    pipeline.add_component("hello", Hello())
+    pipeline.add_component("hello2", Hello())
+
+    pipeline.connect("hello.output", "hello2.word")
+    result = pipeline.run(data={"hello": {"word": "world"}})
+    assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
+
+    result = pipeline.run(word="world")
+    assert result == {"hello2": {"output": "Hello, Hello, world!!"}}

--- a/test/preview/test_pipeline.py
+++ b/test/preview/test_pipeline.py
@@ -82,5 +82,8 @@ def test_pipeline_input_resolution():
     result = pipeline.run(data={"hello": {"word": "world"}})
     assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
 
+    result = pipeline.run(data={"word": "world"})
+    assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
+
     result = pipeline.run(word="world")
     assert result == {"hello2": {"output": "Hello, Hello, world!!"}}


### PR DESCRIPTION
### Why:
The current implementation of Haystack 2.x pipelines requires users to explicitly map input data to specific components, which can be cumbersome and error-prone, especially as the complexity of the pipeline grows.

- fixes https://github.com/deepset-ai/haystack/issues/6101

### What:
We've streamlined the process of feeding inputs into the pipeline by allowing users to pass kwargs directly. The pipeline can now intelligently resolve which components can utilize the provided inputs, simplifying the interface and reducing the likelihood of user errors.

#### How can it be used:
With this enhancement, running a pipeline becomes more intuitive. Users can provide the inputs without specifying the components they correspond to:

```python
@component
class Hello:
    @component.output_types(output=str)
    def run(self, word: str):
        """
        Takes a string in input and returns "Hello, <string>!"
        in output.
        """
        return {"output": f"Hello, {word}!"}

pipeline = Pipeline()
pipeline.add_component("hello", Hello())
pipeline.add_component("hello2", Hello())
pipeline.connect("hello.output", "hello2.word")

# current approach
result = pipeline.run(data={"hello": {"word": "world"}})
assert result == {"hello2": {"output": "Hello, Hello, world!!"}}

# new simplified input resolution approach
result = pipeline.run(word="world")
assert result == {"hello2": {"output": "Hello, Hello, world!!"}}
```

### How did you test it:
This is a work in progress as we await a release of the latest canals with supporting methods for component input that this PR relies on. The unit tests will be in `test/preview/test_pipeline.py`

### Notes for reviewer:
This is a draft for now so we can discuss the approach early. We are still awaiting the new release of canals.
DO NOT INTEGRATE
