### PR TITLE
chore: Fix deprecation warning when calling Document.from_dict()

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -1,3 +1,4 @@
+import io
 import hashlib
 import logging
 from dataclasses import asdict, dataclass, field, fields
@@ -145,7 +146,7 @@ class Document(metaclass=_BackwardCompatible):
         `dataframe` and `blob` fields are converted to their original types.
         """
         if (dataframe := data.get("dataframe")) is not None:
-            data["dataframe"] = pandas.read_json(dataframe)
+            data["dataframe"] = pandas.read_json(io.StringIO(dataframe))
         if blob := data.get("blob"):
             data["blob"] = ByteStream(data=bytes(blob["data"]), mime_type=blob["mime_type"])
         return cls(**data)


### PR DESCRIPTION
### Proposed Changes:

Wrap JSON string in `io.StringIO` when calling `pands.read_json()` as calling it with a JSON string is deprecated. See [official docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html#pandas-read-json).

### How did you test it?

Ran tests locally.

### Notes for the reviewer

The currently pinned version `2.0.3` of Pandas doesn't emit the warning since reading a JSON string directly as been deprecated only from `2.1.0`.

Still worth to fix this now to avoid future pains.

I omitted the release note as this doesn't change any public API or functionality.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
