### PR TITLE
fix: make types work without installing pypdf

### DIFF
--- a/haystack/preview/components/file_converters/pypdf.py
+++ b/haystack/preview/components/file_converters/pypdf.py
@@ -20,7 +20,6 @@ class PyPDFConverter(Protocol):
     """
 
     def convert(self, reader: "PdfReader") -> Document:
-        """Convert a PdfReader instance to a Document instance."""
         ...
 
 

--- a/haystack/preview/components/file_converters/pypdf.py
+++ b/haystack/preview/components/file_converters/pypdf.py
@@ -19,8 +19,9 @@ class PyPDFConverter(Protocol):
     A protocol that defines a converter which takes a PdfReader object and converts it into a Document object.
     """
 
-    def convert(self, reader: PdfReader) -> Document:
+    def convert(self, reader: "PdfReader") -> Document:
         """Convert a PdfReader instance to a Document instance."""
+        ...
 
 
 class DefaultConverter:
@@ -28,7 +29,7 @@ class DefaultConverter:
     The default converter class that extracts text from a PdfReader object's pages and returns a Document.
     """
 
-    def convert(self, reader: PdfReader) -> Document:
+    def convert(self, reader: "PdfReader") -> Document:
         """Extract text from the PDF and return a Document object with the text content."""
         text = "".join(page.extract_text() for page in reader.pages if page.extract_text())
         return Document(content=text)
@@ -71,7 +72,7 @@ class PyPDFToDocument:
 
         return {"documents": documents}
 
-    def _get_pdf_reader(self, source: Union[str, Path, ByteStream]) -> PdfReader:
+    def _get_pdf_reader(self, source: Union[str, Path, ByteStream]) -> "PdfReader":
         """
         Creates a PdfReader object from a given source, which can be a file path or a ByteStream object.
 


### PR DESCRIPTION
### Related Issues

- fixes: using the `PdfReader` symbol when `pypdf` is not installed

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
