### PR TITLE
feat: Update PromptBuilder to output `List[ChatMessage]` - Haystack 2.x

### DIFF
--- a/haystack/preview/components/builders/prompt_builder.py
+++ b/haystack/preview/components/builders/prompt_builder.py
@@ -10,77 +10,46 @@ from haystack.preview.dataclasses.chat_message import ChatMessage, ChatRole
 @component
 class PromptBuilder:
     """
-    A component for building prompts using template strings or template variables.
+    Constructs prompts for language models using a specified template or dynamic template variables.
 
-    The `PromptBuilder` can be initialized with a template string or template variables to dynamically build
-    a prompt. There are two distinct use cases:
+    This component operates in two modes:
 
-    1. **Static Template**: When initialized with a `template` string, the `PromptBuilder` will always use
-       this template for rendering prompts throughout its lifetime.
+    - **Static Template Mode**: Utilizes a single, fixed template for all prompts. This mode is ideal for
+      scenarios like non-chat language model (LLM) generation, where the prompt structure remains constant.
 
-    2. **Dynamic Templates**: When initialized with `template_variables` and receiving messages in
-       `ChatMessage` format, it allows for different templates for each message, enabling prompt templating
-       on a per-user message basis.
+    - **Dynamic Template Mode**: Applies a set of template variables to incoming `ChatMessage` objects.
+      This mode is tailored for interactive chat environments, allowing customization of each prompt based on user input.
 
-    :param template: (Optional) A template string to be rendered using Jinja2 syntax, e.g.,
-                     "What's the weather like in {{ location }}?". This template will be used for all
-                     prompts. Defaults to None.
-    :param template_variables: (Optional) A list of all template variables to be used as input.
-                              This parameter enables dynamic templating based on user messages. Defaults to None.
+    :param template: A Jinja2 template string for static templating. Defaults to None.
+    :param template_variables: A list of variable names for dynamic templating. Defaults to None.
 
-    :raises ValueError: If neither `template` nor `template_variables` are provided.
+    :raises ValueError: Raised if neither `template` nor `template_variables` are provided, or if both are simultaneously provided.
 
+    **Example Usage**:
 
-    Usage (static templating):
-
+    *Static Template Mode*:
     ```python
-    template = "Translate the following context to {{ target_language }}. Context: {{ snippet }}; Translation:"
+    template = "Translate '{{ snippet }}' to {{ target_language }}."
     builder = PromptBuilder(template=template)
-    builder.run(target_language="spanish", snippet="I can't speak spanish.")
+    prompt = builder.run(target_language="Spanish", snippet="Hello, world!")
     ```
 
-    The above template is used for all messages that are passed to the `PromptBuilder`.
-
-
-    Usage (dynamic templating):
+    *Dynamic Template Mode*:
     ```python
-
     from haystack.preview.dataclasses.chat_message import ChatMessage
-    template = "What's the weather like in {{ location }}?"
 
-    prompt_builder = PromptBuilder(template_variables=["location", "time"])
-    messages = [ChatMessage.from_system("Always start response to user with Herr Blagojevic.
-    Respond in German even if some input data is in other languages"),
-                ChatMessage.from_user(template)]
-
-    response = pipe.run(data={"prompt_builder": {"location": location, "messages": messages}})
+    builder = PromptBuilder(template_variables=["location"])
+    messages = [ChatMessage.from_user("What's the weather like in {{ location }}?")]
+    prompt = builder.run(messages=messages, location="Paris")
     ```
-
-    In this example, only the last user message is templated. The template_variables parameter in the PromptBuilder
-    initialization specifies all potential template variables, yet only the variables utilized in the template are
-    required in the run method. For instance, since the time variable isn't used in the template, it's not
-    necessary in the run method invocation above.
-
-
-    Note:
-        The behavior of `PromptBuilder` is determined by the initialization parameters. A static template
-        provides a consistent prompt structure, while template variables offer dynamic templating per user
-        message.
-
     """
 
     def __init__(self, template: Optional[str] = None, template_variables: Optional[List[str]] = None):
         """
-        Initialize the component with either a template string or template variables.
-        If template is given PromptBuilder will parse the template string and use the template variables
-        as input types. Conversely, if template_variables are given, PromptBuilder will directly use
-        them as input variables.
+        Initializes the `PromptBuilder`.
 
-        If neither template nor template_variables are provided, an error will be raised. If both are provided,
-        an error will be raised as well.
-
-        :param template: Template string to be rendered.
-        :param template_variables: List of template variables to be used as input types.
+        :param template: Jinja2 template string for static mode.
+        :param template_variables: Variable names for dynamic mode.
         """
         if template_variables and template:
             raise ValueError("template and template_variables cannot be provided at the same time.")
@@ -88,47 +57,62 @@ class PromptBuilder:
         # dynamic per-user message templating
         if template_variables:
             # treat vars as optional input slots
-            dynamic_input_slots = {var: Optional[Any] for var in template_variables}
+            input_slots = {var: Optional[Any] for var in template_variables}
             self.template = None
+            component.set_output_types(self, prompt=List[ChatMessage])
 
         # static templating
         else:
-            if not template:
-                raise ValueError("Either template or template_variables must be provided.")
             self.template = Template(template)
             ast = self.template.environment.parse(template)
             static_template_variables = meta.find_undeclared_variables(ast)
             # treat vars as required input slots - as per design
-            dynamic_input_slots = {var: Any for var in static_template_variables}
+            input_slots = {var: Any for var in static_template_variables}
+            component.set_output_types(self, prompt=str)
 
         # always provide all serialized vars, so we can serialize
         # the component regardless of the initialization method (static vs. dynamic)
-        self.template_variables = template_variables
         self._template_string = template
 
-        optional_input_slots = {"messages": Optional[List[ChatMessage]]}
-        component.set_input_types(self, **optional_input_slots, **dynamic_input_slots)
+        optional_input_slots = {"messages": Optional[List[ChatMessage]], "template_variables": Optional[List[str]]}
+        component.set_input_types(self, **optional_input_slots, **input_slots)
 
     def to_dict(self) -> Dict[str, Any]:
-        return default_to_dict(self, template=self._template_string, template_variables=self.template_variables)
+        return default_to_dict(self, template=self._template_string)
 
-    @component.output_types(prompt=str)
-    def run(self, messages: Optional[List[ChatMessage]] = None, **kwargs):
+    def run(
+        self,
+        messages: Optional[List[ChatMessage]] = None,
+        template_variables: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
         """
-        Build and return the prompt based on the provided messages and template or template variables.
-        If `messages` are provided, the template will be applied to the last user message.
+        Generates a prompt based on the provided messages and template variables.
 
-        :param messages: (Optional) List of `ChatMessage` instances, used for dynamic templating
-        when `template_variables` are provided.
-        :param kwargs: Additional keyword arguments representing template variables.
+        If `messages` are not provided, the method uses the static template defined during initialization,
+        populating it with `kwargs` to generate a prompt string.
+
+        If `messages` are provided (List[ChatMessage]), the last user message is templated. Besides the initial
+        template variables (resolved automatically), additional variables can optionally be provided through
+        `template_variables`.
+
+        :param messages: List of `ChatMessage` instances for dynamic mode.
+        :param template_variables: Dictionary of additional variables for dynamic mode.
+        :return: Generated prompt (str) or list of `ChatMessage` instances.
         """
-
         if messages:
             # apply the template to the last user message only
             last_message: ChatMessage = messages[-1]
             if last_message.is_from(ChatRole.USER):
                 template = Template(last_message.content)
-                return {"prompt": messages[:-1] + [ChatMessage.from_user(template.render(kwargs))]}
+                if template_variables or kwargs:
+                    # merge template_variables and kwargs
+                    template_variables_final = {**(kwargs or {}), **(template_variables or {})}
+                    templated_user_message = ChatMessage.from_user(template.render(template_variables_final))
+                    # return all previous messages + templated user message
+                    new_messages = messages[:-1] + [templated_user_message]
+                    return {"prompt": new_messages}
+                return {"prompt": messages}
             else:
                 return {"prompt": messages}
         else:


### PR DESCRIPTION
### Why:
The `PromptBuilder` component in our framework was previously limited to outputting only strings. However, with the introduction of the `ChatMessage` data type and chat models, there's a need to expand the capabilities of `PromptBuilder` to handle lists of `ChatMessage` objects. 

### What:
This PR introduces an update to the `PromptBuilder` component, allowing it to produce `List[ChatMessage]` as an output type in addition to strings. 

### How can it be used:
With this improvement, `PromptBuilder` can now be used in scenarios where chat-based interactions are processed or generated. 

Example usage:

```python
from haystack.preview.components.builders.prompt_builder import PromptBuilder
from haystack.preview.components.generators.chat import GPTChatGenerator
from haystack.preview.dataclasses.chat_message import ChatMessage
from haystack.preview import Pipeline


prompt_builder = PromptBuilder(template_variables=["location"])
llm = GPTChatGenerator(api_key=llm_api_key, model_name="gpt-3.5-turbo")

pipe = Pipeline()
pipe.add_component("prompt_builder", prompt_builder)
pipe.add_component("llm", llm)
pipe.connect("prompt_builder.prompt", "llm.messages")

template = "Tell me more about {{ location }}?"
messages = [ChatMessage.from_system("Always respond in German even if some input data is in other languages"),
            ChatMessage.from_user(template)]

response = pipe.run(data={"prompt_builder": {"location": "Berlin", "messages": messages}})
print(response)

>>{'llm': {'replies': [ChatMessage(content="Berlin ist ...")]}}
```

### How did you test it:

This new functionality has been tested manually. 

Unit tests have been previously added to `test/preview/components/builders/test_prompt_builder.py` but now we've removed `prompt: Union[str, List[ChatMessage]]` from GPTGenerator run method, and we need to adjust PrompBuilder output types accordingly. 

### Notes for reviewer:
Note how, in PromptBuilder, we now dynamically set the output based on the input parameters. Is there a better way to do this?