### PR TITLE
feat: make `InMemoryDocumentStore` return the number of docs actually written

### DIFF
--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -163,7 +163,7 @@ class InMemoryDocumentStore:
             return [doc for doc in self.storage.values() if document_matches_filter(conditions=filters, document=doc)]
         return list(self.storage.values())
 
-    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> None:
+    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> int:
         """
         Writes (or overwrites) documents into the DocumentStore.
 
@@ -183,13 +183,16 @@ class InMemoryDocumentStore:
         ):
             raise ValueError("Please provide a list of Documents.")
 
+        written_documents = len(documents)
         for document in documents:
             if policy != DuplicatePolicy.OVERWRITE and document.id in self.storage.keys():
                 if policy == DuplicatePolicy.FAIL:
                     raise DuplicateDocumentError(f"ID '{document.id}' already exists.")
                 if policy == DuplicatePolicy.SKIP:
                     logger.warning("ID '%s' already exists", document.id)
+                    written_documents -= 1
             self.storage[document.id] = document
+        return written_documents
 
     def delete_documents(self, document_ids: List[str]) -> None:
         """

--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -191,6 +191,7 @@ class InMemoryDocumentStore:
                 if policy == DuplicatePolicy.SKIP:
                     logger.warning("ID '%s' already exists", document.id)
                     written_documents -= 1
+                    continue
             self.storage[document.id] = document
         return written_documents
 

--- a/releasenotes/notes/inmemory-return-written-documents-488b7f90df84bc59.yaml
+++ b/releasenotes/notes/inmemory-return-written-documents-488b7f90df84bc59.yaml
@@ -1,0 +1,2 @@
+preview:
+  - Make `InMemoryDocumentStore.write_documents()` return the number of docs actually written

--- a/test/preview/document_stores/test_in_memory.py
+++ b/test/preview/document_stores/test_in_memory.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from haystack.preview import Document
-from haystack.preview.document_stores import InMemoryDocumentStore, DocumentStoreError
+from haystack.preview.document_stores import InMemoryDocumentStore, DocumentStoreError, DuplicatePolicy
 
 
 from haystack.preview.testing.document_store import DocumentStoreBaseTests
@@ -69,6 +69,17 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert store.tokenizer
         assert store.bm25_algorithm.__name__ == "BM25Plus"
         assert store.bm25_parameters == {"key": "value"}
+
+    @pytest.mark.unit
+    def test_written_documents_count(self, docstore: InMemoryDocumentStore):
+        documents = [Document(content=f"Hello world #{i}") for i in range(10)]
+        docs_written = docstore.write_documents(documents[0:2])
+        assert docs_written == 2
+        assert docstore.filter_documents() == documents[0:2]
+
+        docs_written = docstore.write_documents(documents, DuplicatePolicy.SKIP)
+        assert docs_written == len(documents) - 2
+        assert docstore.filter_documents() == documents
 
     @pytest.mark.unit
     def test_bm25_retrieval(self, docstore: InMemoryDocumentStore):

--- a/test/preview/document_stores/test_in_memory.py
+++ b/test/preview/document_stores/test_in_memory.py
@@ -72,6 +72,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
 
     @pytest.mark.unit
     def test_written_documents_count(self, docstore: InMemoryDocumentStore):
+        # FIXME Remove after the document store base tests have been rewritten
         documents = [Document(content=f"Hello world #{i}") for i in range(10)]
         docs_written = docstore.write_documents(documents[0:2])
         assert docs_written == 2


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack/pull/6006

### Proposed Changes:

- Make `InMemoryDocumentStore` return the number of docs actually written

### How did you test it?

Unit test

### Notes for the reviewer

Should be merged after the related issue above

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
