### PR TITLE
feat: Convert OpenAI GPT function call JSON response to string

### DIFF
--- a/haystack/preview/components/generators/chat/openai.py
+++ b/haystack/preview/components/generators/chat/openai.py
@@ -236,7 +236,8 @@ class GPTChatGenerator:
         :return: The ChatMessage.
         """
         message: OpenAIObject = choice.message
-        content = message.function_call if choice.finish_reason == "function_call" else message.content
+        # message.content is str but message.function_call is OpenAIObject but JSON in fact, convert to str
+        content = str(message.function_call) if choice.finish_reason == "function_call" else message.content
         chat_message = ChatMessage.from_assistant(content)
         chat_message.metadata.update(
             {


### PR DESCRIPTION
### Why:
GPTChatGenerator, when doing function calling, returns a message.function_call, an OpenAIObject. This object wasn't converted to a string. This resulted in inconsistencies in message handling as the ChatMessage content field didn't contain a string.

### What:
I modified GPTChatGenerator to ensure that message.function_call, when received as an OpenAIObject, is converted to a string. This string can then be converted into JSON and processed further but it complies with our ChatMessage content field.

### How can it be used:
The modification allows GPTChatGenerator to handle function messages properly

### How did you test it:
Manually. I wanted to add a unit test, but I didn't for two reasons. These kinds of things can only be tested with a live call, and function calling has been [deprecated](https://platform.openai.com/docs/api-reference/chat/create#chat-create-function_call) in favour of tools, so we'll have to rename and adapt these soon anyways. We can add unit tests at that time. 