### PR TITLE
chore: ignore new mypy errors (due to 1.7 release)

### DIFF
--- a/examples/seq2seq_replacement.py
+++ b/examples/seq2seq_replacement.py
@@ -21,7 +21,7 @@ documents = [
 # query_and_docs = "question: {} context: {}".format(query, conditioned_doc)
 
 # Or use the PromptTemplate as shown here
-pt = PromptTemplate("lfqa", "question: {query} context: {join(documents, delimiter='<P>')}")
+pt = PromptTemplate("lfqa", "question: {query} context: {join(documents, delimiter='<P>')}")  # type: ignore [arg-type]
 
 res = p.prompt(prompt_template=pt, query=query, documents=[Document(d) for d in documents])
 

--- a/haystack/modeling/data_handler/data_silo.py
+++ b/haystack/modeling/data_handler/data_silo.py
@@ -819,12 +819,12 @@ class DistillationDataSilo(DataSilo):
                 corresponding_chunks.append(i)
                 if len(batch) == self.teacher_batch_size:
                     self._pass_batches(
-                        batch, corresponding_chunks, teacher_outputs, tensor_names
+                        batch, corresponding_chunks, teacher_outputs, tensor_names  # type: ignore [arg-type]
                     )  # doing forward pass on teacher model
                     batch = []
                     corresponding_chunks = []
         if batch:
-            self._pass_batches(batch, corresponding_chunks, teacher_outputs, tensor_names)
+            self._pass_batches(batch, corresponding_chunks, teacher_outputs, tensor_names)  # type: ignore [arg-type]
 
         # appending teacher outputs to original dataset
         for dataset, teacher_output in zip(concat_datasets.datasets, teacher_outputs):

--- a/haystack/utils/augment_squad.py
+++ b/haystack/utils/augment_squad.py
@@ -157,7 +157,7 @@ def get_replacements(
     for i, word in enumerate(words):
         if i in word_subword_mapping:  # word was not split into subwords so we can use MLM output
             subword_index = word_subword_mapping[i]
-            ranking = predictions[batch_index]
+            ranking = predictions[batch_index]  # type: ignore [assignment]
             possible_words_ = [word]
             for token in ranking:
                 word = tokenizer.convert_ids_to_tokens([token])[0]
@@ -172,8 +172,8 @@ def get_replacements(
             glove_vector = glove_vectors[word_id]
             with torch.inference_mode():
                 word_similarities = torch.mm(glove_vectors, glove_vector.unsqueeze(1)).squeeze(1)  # type: ignore [arg-type]
-                ranking = torch.argsort(word_similarities, descending=True)[: word_possibilities + 1]
-                possible_words.append([glove_id_word_mapping[int(id_)] for id_ in ranking.cpu()])
+                ranking = torch.argsort(word_similarities, descending=True)[: word_possibilities + 1]  # type: ignore [assignment]
+                possible_words.append([glove_id_word_mapping[int(id_)] for id_ in ranking.cpu()])  # type: ignore [attr-defined]
         else:  # word was not in glove either so we can't find any replacements
             possible_words.append([word])
 


### PR DESCRIPTION
### Related Issues

- since the release of mypy 1.7, we have seen errors like [this](https://github.com/deepset-ai/haystack/actions/runs/6826288135/job/18565889872?pr=6276)

### Proposed Changes:

- I ran mypy on the repository and I'm simply ignoring the specific types of errors raised by mypy

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
