### PR TITLE
Fix Document init when passing non existing fields

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -2,7 +2,7 @@ import io
 import hashlib
 import logging
 from dataclasses import asdict, dataclass, field, fields
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Any, Dict, List, Optional
 
 import numpy
 import pandas

--- a/releasenotes/notes/fix-document-init-09c1cbb14202be7d.yaml
+++ b/releasenotes/notes/fix-document-init-09c1cbb14202be7d.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Fix Document init when passing non existing fields.

--- a/releasenotes/notes/fix-document-init-09c1cbb14202be7d.yaml
+++ b/releasenotes/notes/fix-document-init-09c1cbb14202be7d.yaml
@@ -1,4 +1,4 @@
 ---
 preview:
   - |
-    Fix Document init when passing non existing fields.
+    Make Document's constructor fail when is passed fields that are not present in the dataclass. An exception is made for  "content_type" and "id_hash_keys": they are accepted in order to keep backward compatibility.

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -44,6 +44,12 @@ def test_init():
 
 
 @pytest.mark.unit
+def test_init_with_wrong_parameters():
+    with pytest.raises(TypeError):
+        Document(text="")
+
+
+@pytest.mark.unit
 def test_init_with_parameters():
     blob_data = b"some bytes"
     doc = Document(
@@ -80,15 +86,14 @@ def test_init_with_legacy_fields():
 
 
 @pytest.mark.unit
-def test_init_with_legacy_field_and_flat_meta():
+def test_init_with_legacy_field():
     doc = Document(
         content="test text",
         content_type="text",  # type: ignore
         id_hash_keys=["content"],  # type: ignore
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
-        date="10-10-2023",  # type: ignore
-        type="article",  # type: ignore
+        meta={"date": "10-10-2023", "type": "article"},
     )
     assert doc.id == "a2c0321b34430cc675294611e55529fceb56140ca3202f1c59a43a8cecac1f43"
     assert doc.content == "test text"
@@ -96,44 +101,6 @@ def test_init_with_legacy_field_and_flat_meta():
     assert doc.meta == {"date": "10-10-2023", "type": "article"}
     assert doc.score == 0.812
     assert doc.embedding == [0.1, 0.2, 0.3]
-
-
-@pytest.mark.unit
-def test_init_with_flat_meta():
-    blob_data = b"some bytes"
-    doc = Document(
-        content="test text",
-        dataframe=pd.DataFrame([0]),
-        blob=ByteStream(data=blob_data, mime_type="text/markdown"),
-        score=0.812,
-        embedding=[0.1, 0.2, 0.3],
-        date="10-10-2023",  # type: ignore
-        type="article",  # type: ignore
-    )
-    assert doc.id == "c6212ad7bb513c572367e11dd12fd671911a1a5499e3d31e4fe3bda7e87c0641"
-    assert doc.content == "test text"
-    assert doc.dataframe is not None
-    assert doc.dataframe.equals(pd.DataFrame([0]))
-    assert doc.blob.data == blob_data
-    assert doc.blob.mime_type == "text/markdown"
-    assert doc.meta == {"date": "10-10-2023", "type": "article"}
-    assert doc.score == 0.812
-    assert doc.embedding == [0.1, 0.2, 0.3]
-
-
-@pytest.mark.unit
-def test_init_with_flat_and_non_flat_meta():
-    with pytest.raises(TypeError):
-        Document(
-            content="test text",
-            dataframe=pd.DataFrame([0]),
-            blob=ByteStream(data=b"some bytes", mime_type="text/markdown"),
-            score=0.812,
-            meta={"test": 10},
-            embedding=[0.1, 0.2, 0.3],
-            date="10-10-2023",  # type: ignore
-            type="article",  # type: ignore
-        )
 
 
 @pytest.mark.unit
@@ -286,8 +253,7 @@ def test_from_dict_with_legacy_field_and_flat_meta():
         id_hash_keys=["content"],  # type: ignore
         score=0.812,
         embedding=[0.1, 0.2, 0.3],
-        date="10-10-2023",  # type: ignore
-        type="article",  # type: ignore
+        meta={"date": "10-10-2023", "type": "article"},
     )
 
 


### PR DESCRIPTION
### Related Issues

- fixes #6259 

### Proposed Changes:

The `_BackwardCompatible` metaclass made it possible to create a `Document` by passing any parameter to it.
This parameters would end up in the `meta` field.

This PR fixes that so that only legacy and new fields can be used to build a `Document`.
`from_dict` has been updated accordingly to handle flattened dictionaries.

### How did you test it?

Updated unit tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
