### PR TITLE
fix: Load additional fields from SQUAD-format file to meta field for labels #5978

### DIFF
--- a/haystack/document_stores/utils.py
+++ b/haystack/document_stores/utils.py
@@ -172,6 +172,9 @@ def _extract_docs_and_labels_from_dict(
 
         ## Assign Labels to corresponding documents
         for qa in paragraph["qas"]:
+            meta_qa = {
+                k: v for k, v in qa.items() if k not in ("is_impossible", "answers", "question", "id", "missing")
+            }
             if not qa.get("is_impossible", False):
                 for answer in qa["answers"]:
                     ans = answer["text"]
@@ -191,6 +194,7 @@ def _extract_docs_and_labels_from_dict(
                             is_correct_answer=True,
                             is_correct_document=True,
                             origin="gold-label",
+                            meta=meta_qa,
                         )
                         labels.append(label)
                     else:
@@ -234,6 +238,7 @@ def _extract_docs_and_labels_from_dict(
                             is_correct_answer=True,
                             is_correct_document=True,
                             origin="gold-label",
+                            meta=meta_qa,
                         )
                         labels.append(label)
             else:
@@ -252,6 +257,7 @@ def _extract_docs_and_labels_from_dict(
                         is_correct_answer=True,
                         is_correct_document=True,
                         origin="gold-label",
+                        meta=meta_qa,
                     )
 
                     labels.append(label)

--- a/releasenotes/notes/metadata_enhancement_for_SQuAD_files-2247c72f07760465.yaml
+++ b/releasenotes/notes/metadata_enhancement_for_SQuAD_files-2247c72f07760465.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Load additional fields from SQUAD-format file into the meta field for Labels, addressing issue #5978

--- a/releasenotes/notes/metadata_enhancement_for_SQuAD_files-2247c72f07760465.yaml
+++ b/releasenotes/notes/metadata_enhancement_for_SQuAD_files-2247c72f07760465.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Load additional fields from SQUAD-format file into the meta field for Labels, addressing issue #5978
+    Make it possible to load additional fields from the SQUAD format file into the meta field of the Labels

--- a/test/others/test_eval_data_from_json.py
+++ b/test/others/test_eval_data_from_json.py
@@ -1,0 +1,76 @@
+import unittest
+import json
+from haystack.document_stores import eval_data_from_json
+
+
+class TestEvalDataFromJSON(unittest.TestCase):
+    def test_eval_data_from_json(self):
+        # Create a temporary SQuAD-style JSON file for testing
+        temp_filename = "temp_squad_file.json"
+        with open(temp_filename, "w", encoding="utf-8") as temp_file:
+            # Use the provided example JSON data
+            json.dump(
+                {
+                    "metadata": {
+                        "dataset_version": "1.0",
+                        "description": "This dataset contains questions and answers related to...",
+                        "other_metadata_field": "value",
+                    },
+                    "data": [
+                        {
+                            "title": "Article Title",
+                            "paragraphs": [
+                                {
+                                    "context": "This is the context of the article.",
+                                    "qas": [
+                                        {
+                                            "question": "What is the SQuAD dataset?",
+                                            "id": 0,
+                                            "answers": [{"text": "This is the context", "answer_start": 0}],
+                                            "annotator": "annotator0",
+                                            "date": "2023-11-07",
+                                        },
+                                        {
+                                            "question": "Another question?",
+                                            "id": 1,
+                                            "answers": [
+                                                {"text": "This is the context of the article", "answer_start": 0}
+                                            ],
+                                            "annotator": "annotator1",
+                                            "date": "2023-12-09",
+                                        },
+                                    ],
+                                }
+                            ],
+                            "author": "Your Name",
+                            "creation_date": "2023-11-14",
+                        }
+                    ],
+                },
+                temp_file,
+                indent=2,  # Adjust indentation for readability
+            )
+
+        # Call the function with the temporary file
+        docs, labels = eval_data_from_json(temp_filename)
+
+        # Add your assertions based on the structure of your data
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(len(labels), 2)
+
+        # Assuming that your Document and Label classes have attributes like 'text', 'question', 'answer', etc.
+        self.assertEqual(docs[0].content, "This is the context of the article.")
+        self.assertEqual(labels[0].query, "What is the SQuAD dataset?")
+        self.assertEqual(labels[0].meta, {"annotator": "annotator0", "date": "2023-11-07"})
+
+        self.assertEqual(labels[1].query, "Another question?")
+        self.assertEqual(labels[1].meta, {"annotator": "annotator1", "date": "2023-12-09"})
+
+        # Clean up: Remove the temporary file
+        import os
+
+        os.remove(temp_filename)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/others/test_eval_data_from_json.py
+++ b/test/others/test_eval_data_from_json.py
@@ -1,76 +1,70 @@
-import unittest
 import json
+import os
+import pytest
 from haystack.document_stores import eval_data_from_json
 
 
-class TestEvalDataFromJSON(unittest.TestCase):
-    def test_eval_data_from_json(self):
-        # Create a temporary SQuAD-style JSON file for testing
-        temp_filename = "temp_squad_file.json"
-        with open(temp_filename, "w", encoding="utf-8") as temp_file:
-            # Use the provided example JSON data
-            json.dump(
-                {
-                    "metadata": {
-                        "dataset_version": "1.0",
-                        "description": "This dataset contains questions and answers related to...",
-                        "other_metadata_field": "value",
-                    },
-                    "data": [
-                        {
-                            "title": "Article Title",
-                            "paragraphs": [
-                                {
-                                    "context": "This is the context of the article.",
-                                    "qas": [
-                                        {
-                                            "question": "What is the SQuAD dataset?",
-                                            "id": 0,
-                                            "answers": [{"text": "This is the context", "answer_start": 0}],
-                                            "annotator": "annotator0",
-                                            "date": "2023-11-07",
-                                        },
-                                        {
-                                            "question": "Another question?",
-                                            "id": 1,
-                                            "answers": [
-                                                {"text": "This is the context of the article", "answer_start": 0}
-                                            ],
-                                            "annotator": "annotator1",
-                                            "date": "2023-12-09",
-                                        },
-                                    ],
-                                }
-                            ],
-                            "author": "Your Name",
-                            "creation_date": "2023-11-14",
-                        }
-                    ],
+@pytest.fixture
+def temp_squad_file(tmp_path):
+    temp_filename = tmp_path / "temp_squad_file.json"
+    with open(temp_filename, "w", encoding="utf-8") as temp_file:
+        json.dump(
+            {
+                "metadata": {
+                    "dataset_version": "1.0",
+                    "description": "This dataset contains questions and answers related to...",
+                    "other_metadata_field": "value",
                 },
-                temp_file,
-                indent=2,  # Adjust indentation for readability
-            )
+                "data": [
+                    {
+                        "title": "Article Title",
+                        "paragraphs": [
+                            {
+                                "context": "This is the context of the article.",
+                                "qas": [
+                                    {
+                                        "question": "What is the SQuAD dataset?",
+                                        "id": 0,
+                                        "answers": [{"text": "This is the context", "answer_start": 0}],
+                                        "annotator": "annotator0",
+                                        "date": "2023-11-07",
+                                    },
+                                    {
+                                        "question": "Another question?",
+                                        "id": 1,
+                                        "answers": [{"text": "This is the context of the article", "answer_start": 0}],
+                                        "annotator": "annotator1",
+                                        "date": "2023-12-09",
+                                    },
+                                ],
+                            }
+                        ],
+                        "author": "Your Name",
+                        "creation_date": "2023-11-14",
+                    }
+                ],
+            },
+            temp_file,
+            indent=2,
+        )
+    return temp_filename
 
-        # Call the function with the temporary file
-        docs, labels = eval_data_from_json(temp_filename)
 
-        # Add your assertions based on the structure of your data
-        self.assertEqual(len(docs), 1)
-        self.assertEqual(len(labels), 2)
+def test_eval_data_from_json(temp_squad_file):
+    # Call the function with the temporary file
+    docs, labels = eval_data_from_json(temp_squad_file)
 
-        # Assuming that your Document and Label classes have attributes like 'text', 'question', 'answer', etc.
-        self.assertEqual(docs[0].content, "This is the context of the article.")
-        self.assertEqual(labels[0].query, "What is the SQuAD dataset?")
-        self.assertEqual(labels[0].meta, {"annotator": "annotator0", "date": "2023-11-07"})
+    # Add your assertions based on the structure of your data
+    assert len(docs) == 1
+    assert len(labels) == 2
 
-        self.assertEqual(labels[1].query, "Another question?")
-        self.assertEqual(labels[1].meta, {"annotator": "annotator1", "date": "2023-12-09"})
+    # Assuming that your Document and Label classes have attributes like 'text', 'question', 'answer', etc.
+    assert docs[0].content == "This is the context of the article."
+    assert labels[0].query == "What is the SQuAD dataset?"
+    assert labels[0].meta == {"annotator": "annotator0", "date": "2023-11-07"}
 
-        # Clean up: Remove the temporary file
-        import os
+    assert labels[1].query == "Another question?"
+    assert labels[1].meta == {"annotator": "annotator1", "date": "2023-12-09"}
 
-        os.remove(temp_filename)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    # Clean up: Remove the temporary file
+    os.remove(temp_squad_file)

--- a/test/others/test_eval_data_from_json.py
+++ b/test/others/test_eval_data_from_json.py
@@ -54,17 +54,12 @@ def test_eval_data_from_json(temp_squad_file):
     # Call the function with the temporary file
     docs, labels = eval_data_from_json(temp_squad_file)
 
-    # Add your assertions based on the structure of your data
     assert len(docs) == 1
     assert len(labels) == 2
 
-    # Assuming that your Document and Label classes have attributes like 'text', 'question', 'answer', etc.
     assert docs[0].content == "This is the context of the article."
     assert labels[0].query == "What is the SQuAD dataset?"
     assert labels[0].meta == {"annotator": "annotator0", "date": "2023-11-07"}
 
     assert labels[1].query == "Another question?"
     assert labels[1].meta == {"annotator": "annotator1", "date": "2023-12-09"}
-
-    # Clean up: Remove the temporary file
-    os.remove(temp_squad_file)


### PR DESCRIPTION
### Related Issues

- Fixes #5978

### Proposed Changes:

Load additional fields from SQUAD-format file to meta field for labels. This change ensures that `eval_data_from_json` loads additional fields for Labels into the `meta` field, analogous to how it's done for Documents.

### How did you test it?

I added new unit tests to cover the changes, ensuring that the loading of additional fields for Labels functions as expected. Additionally, I performed manual verification by running the modified `eval_data_from_json` function on a SQUAD-format file with additional fields for Labels.

### Notes for the Reviewer

I've followed the structure of `eval_data_from_json` for Documents and extended it to support Labels. 

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issues

