### PR TITLE
feat: Add `ByteStream` metadata and other metadata to `Documents` created by `HTMLToDocument`  

### DIFF
--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -2,8 +2,6 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from tqdm import tqdm
-
 from haystack.preview import Document, component
 from haystack.preview.dataclasses import ByteStream
 from haystack.preview.lazy_imports import LazyImport
@@ -32,15 +30,11 @@ class HTMLToDocument:
 
     """
 
-    def __init__(self, progress_bar: bool = True):
+    def __init__(self):
         """
         Initializes the HTMLToDocument component.
-
-        :param progress_bar: Show a progress bar for the conversion. Defaults to True.
         """
         boilerpy3_import.check()
-
-        self.progress_bar = progress_bar
 
     @component.output_types(documents=List[Document])
     def run(self, sources: List[Union[str, Path, ByteStream]], meta: Optional[List[Dict[str, Any]]] = None):
@@ -61,12 +55,7 @@ class HTMLToDocument:
 
         extractor = extractors.ArticleExtractor(raise_on_failure=False)
 
-        for source, metadata in tqdm(
-            zip(sources, meta),
-            total=len(sources),
-            desc="Converting HTML files to Documents",
-            disable=not self.progress_bar,
-        ):
+        for source, metadata in zip(sources, meta):
             try:
                 file_content, extracted_meta = self._extract_content(source)
             except Exception as e:

--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -43,14 +43,17 @@ class HTMLToDocument:
 
         :param sources: List of HTML file paths or ByteStream objects.
         :param meta: Optional list of metadata to attach to the Documents.
-        The length of the list must match the number of paths. Defaults to `None`.
+        The length of the list must match the number of sources. Defaults to `None`.
         :return: List of converted Documents.
         """
 
         documents = []
 
         # Create metadata placeholders if not provided
-        if meta is None:
+        if meta is not None:
+            if len(sources) != len(meta):
+                raise ValueError("The length of the metadata list must match the number of sources.")
+        else:
             meta = [{}] * len(sources)
 
         extractor = extractors.ArticleExtractor(raise_on_failure=False)

--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -50,7 +50,7 @@ class HTMLToDocument:
         documents = []
 
         # Create metadata placeholders if not provided
-        if meta is not None:
+        if meta:
             if len(sources) != len(meta):
                 raise ValueError("The length of the metadata list must match the number of sources.")
         else:
@@ -71,7 +71,7 @@ class HTMLToDocument:
                 continue
 
             # Merge metadata received from ByteStream with supplied metadata
-            if extracted_meta is not None:
+            if extracted_meta:
                 # Supplied metadata overwrites metadata from ByteStream for overlapping keys.
                 metadata = {**extracted_meta, **metadata}
             document = Document(content=text, meta=metadata)

--- a/haystack/preview/components/file_converters/html.py
+++ b/haystack/preview/components/file_converters/html.py
@@ -1,6 +1,8 @@
 import logging
-from typing import List, Union
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from tqdm import tqdm
 
 from haystack.preview import Document, component
 from haystack.preview.dataclasses import ByteStream
@@ -16,27 +18,57 @@ with LazyImport("Run 'pip install boilerpy3'") as boilerpy3_import:
 class HTMLToDocument:
     """
     Converts an HTML file to a Document.
+
+    Usage example:
+    ```python
+    from haystack.preview.components.file_converters.html import HTMLToDocument
+
+    converter = HTMLToDocument()
+    results = converter.run(sources=["sample.html"])
+    documents = results["documents"]
+    print(documents[0].content)
+    # 'This is a text from the HTML file.'
+    ```
+
     """
 
-    def __init__(self):
+    def __init__(self, progress_bar: bool = True):
         """
         Initializes the HTMLToDocument component.
+
+        :param progress_bar: Show a progress bar for the conversion. Defaults to True.
         """
         boilerpy3_import.check()
 
+        self.progress_bar = progress_bar
+
     @component.output_types(documents=List[Document])
-    def run(self, sources: List[Union[str, Path, ByteStream]]):
+    def run(self, sources: List[Union[str, Path, ByteStream]], meta: Optional[List[Dict[str, Any]]] = None):
         """
         Converts a list of HTML files to Documents.
 
         :param sources: List of HTML file paths or ByteStream objects.
+        :param meta: Optional list of metadata to attach to the Documents.
+        The length of the list must match the number of paths. Defaults to `None`.
         :return: List of converted Documents.
         """
+
         documents = []
+
+        # Create metadata placeholders if not provided
+        if meta is None:
+            meta = [{}] * len(sources)
+
         extractor = extractors.ArticleExtractor(raise_on_failure=False)
-        for source in sources:
+
+        for source, metadata in tqdm(
+            zip(sources, meta),
+            total=len(sources),
+            desc="Converting HTML files to Documents",
+            disable=not self.progress_bar,
+        ):
             try:
-                file_content = self._extract_content(source)
+                file_content, extracted_meta = self._extract_content(source)
             except Exception as e:
                 logger.warning("Could not read %s. Skipping it. Error: %s", source, e)
                 continue
@@ -46,21 +78,25 @@ class HTMLToDocument:
                 logger.warning("Failed to extract text from %s. Skipping it. Error: %s", source, conversion_e)
                 continue
 
-            document = Document(content=text)
+            # Merge metadata received from ByteStream with supplied metadata
+            if extracted_meta is not None:
+                # Supplied metadata overwrites metadata from ByteStream for overlapping keys.
+                metadata = {**extracted_meta, **metadata}
+            document = Document(content=text, meta=metadata)
             documents.append(document)
 
         return {"documents": documents}
 
-    def _extract_content(self, source: Union[str, Path, ByteStream]) -> str:
+    def _extract_content(self, source: Union[str, Path, ByteStream]) -> tuple:
         """
         Extracts content from the given data source
         :param source: The data source to extract content from.
-        :return: The extracted content.
+        :return: The extracted content and metadata.
         """
         if isinstance(source, (str, Path)):
             with open(source) as text_file:
-                return text_file.read()
+                return (text_file.read(), None)
         if isinstance(source, ByteStream):
-            return source.data.decode("utf-8")
+            return (source.data.decode("utf-8"), source.metadata)
 
         raise ValueError(f"Unsupported source type: {type(source)}")

--- a/releasenotes/notes/add-metadata-HTMLToDocument-42dbd074a46c979e.yaml
+++ b/releasenotes/notes/add-metadata-HTMLToDocument-42dbd074a46c979e.yaml
@@ -2,4 +2,3 @@
 preview:
   - |
     Adds support for adding additional metadata and utilizing metadata received from ByteStream sources when creating documents using HTMLToDocument.
-    Adds progress bar to HTMLToDocument.

--- a/releasenotes/notes/add-metadata-HTMLToDocument-42dbd074a46c979e.yaml
+++ b/releasenotes/notes/add-metadata-HTMLToDocument-42dbd074a46c979e.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Adds support for adding additional metadata and utilizing metadata received from ByteStream sources when creating documents using HTMLToDocument.
+    Adds progress bar to HTMLToDocument.

--- a/test/preview/components/file_converters/test_html_to_document.py
+++ b/test/preview/components/file_converters/test_html_to_document.py
@@ -49,7 +49,26 @@ class TestHTMLToDocument:
     @pytest.mark.integration
     def test_run_bytestream_metadata(self, preview_samples_path):
         """
-        Test if the component runs correctly when metadata is read from the received ByteStream object.
+        Test if the component runs correctly when metadata is read from the ByteStream object.
+        """
+        converter = HTMLToDocument()
+        with open(preview_samples_path / "html" / "what_is_haystack.html", "rb") as file:
+            byte_stream = file.read()
+            stream = ByteStream(byte_stream, metadata={"content_type": "text/html", "url": "test_url"})
+
+        results = converter.run(sources=[stream])
+        docs = results["documents"]
+
+        assert len(docs) == 1
+        assert "Haystack" in docs[0].content
+        assert docs[0].meta == {"content_type": "text/html", "url": "test_url"}
+
+    @pytest.mark.integration
+    def test_run_bytestream_and_doc_metadata(self, preview_samples_path):
+        """
+        Test if the component runs correctly when metadata is read from the ByteStream object and supplied by the user.
+
+        There is no overlap between the metadata received.
         """
         converter = HTMLToDocument()
         with open(preview_samples_path / "html" / "what_is_haystack.html", "rb") as file:
@@ -67,9 +86,11 @@ class TestHTMLToDocument:
     @pytest.mark.integration
     def test_run_bytestream_doc_overlapping_metadata(self, preview_samples_path):
         """
-        Test if the component runs correctly when metadata is read from the received ByteStream object and supplied by the user.
+        Test if the component runs correctly when metadata is read from the ByteStream object and supplied by the user.
 
-        The component will use the supplied metadata if there is an overlap between the keys.
+        There is an overlap between the metadata received.
+
+        The component should use the supplied metadata to overwrite the values if there is an overlap between the keys.
         """
         converter = HTMLToDocument()
         with open(preview_samples_path / "html" / "what_is_haystack.html", "rb") as file:

--- a/test/preview/components/file_converters/test_html_to_document.py
+++ b/test/preview/components/file_converters/test_html_to_document.py
@@ -7,19 +7,19 @@ from haystack.preview.dataclasses import ByteStream
 
 
 class TestHTMLToDocument:
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly.
         """
         sources = [preview_samples_path / "html" / "what_is_haystack.html"]
         converter = HTMLToDocument()
-        output = converter.run(sources=sources)
-        docs = output["documents"]
+        results = converter.run(sources=sources)
+        docs = results["documents"]
         assert len(docs) == 1
         assert "Haystack" in docs[0].content
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run_doc_metadata(self, preview_samples_path):
         """
         Test if the component runs correctly when metadata is supplied by the user.
@@ -34,7 +34,7 @@ class TestHTMLToDocument:
         assert "Haystack" in docs[0].content
         assert docs[0].meta == {"file_name": "what_is_haystack.html"}
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_incorrect_meta(self, preview_samples_path):
         """
         Test if the component raises an error when incorrect metadata is supplied by the user.
@@ -45,7 +45,7 @@ class TestHTMLToDocument:
         with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources."):
             converter.run(sources=sources, meta=metadata)
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run_bytestream_metadata(self, preview_samples_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object.
@@ -62,7 +62,7 @@ class TestHTMLToDocument:
         assert "Haystack" in docs[0].content
         assert docs[0].meta == {"content_type": "text/html", "url": "test_url"}
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run_bytestream_and_doc_metadata(self, preview_samples_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object and supplied by the user.
@@ -82,7 +82,7 @@ class TestHTMLToDocument:
         assert "Haystack" in docs[0].content
         assert docs[0].meta == {"file_name": "what_is_haystack.html", "content_type": "text/html", "url": "test_url"}
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run_bytestream_doc_overlapping_metadata(self, preview_samples_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object and supplied by the user.
@@ -110,7 +110,7 @@ class TestHTMLToDocument:
             "url": "test_url_new",
         }
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run_wrong_file_type(self, preview_samples_path, caplog):
         """
         Test if the component runs correctly when an input file is not of the expected type.
@@ -118,13 +118,12 @@ class TestHTMLToDocument:
         sources = [preview_samples_path / "audio" / "answer.wav"]
         converter = HTMLToDocument()
         with caplog.at_level(logging.WARNING):
-            output = converter.run(sources=sources)
+            results = converter.run(sources=sources)
             assert "codec can't decode byte" in caplog.text
 
-        docs = output["documents"]
-        assert not docs
+        assert results["documents"] == []
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_run_error_handling(self, caplog):
         """
         Test if the component correctly handles errors.
@@ -132,11 +131,11 @@ class TestHTMLToDocument:
         sources = ["non_existing_file.html"]
         converter = HTMLToDocument()
         with caplog.at_level(logging.WARNING):
-            result = converter.run(sources=sources)
+            results = converter.run(sources=sources)
             assert "Could not read non_existing_file.html" in caplog.text
-            assert not result["documents"]
+            assert results["documents"] == []
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_mixed_sources_run(self, preview_samples_path):
         """
         Test if the component runs correctly if the input is a mix of paths and ByteStreams.
@@ -150,8 +149,8 @@ class TestHTMLToDocument:
             sources.append(ByteStream(byte_stream))
 
         converter = HTMLToDocument()
-        output = converter.run(sources=sources)
-        docs = output["documents"]
+        results = converter.run(sources=sources)
+        docs = results["documents"]
         assert len(docs) == 3
         for doc in docs:
             assert "Haystack" in doc.content

--- a/test/preview/components/file_converters/test_html_to_document.py
+++ b/test/preview/components/file_converters/test_html_to_document.py
@@ -35,6 +35,17 @@ class TestHTMLToDocument:
         assert docs[0].meta == {"file_name": "what_is_haystack.html"}
 
     @pytest.mark.integration
+    def test_incorrect_meta(self, preview_samples_path):
+        """
+        Test if the component raises an error when incorrect metadata is supplied by the user.
+        """
+        converter = HTMLToDocument()
+        sources = [preview_samples_path / "html" / "what_is_haystack.html"]
+        metadata = [{"file_name": "what_is_haystack.html"}, {"file_name": "haystack.html"}]
+        with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources."):
+            converter.run(sources=sources, meta=metadata)
+
+    @pytest.mark.integration
     def test_run_bytestream_metadata(self, preview_samples_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object.

--- a/test/preview/components/file_converters/test_html_to_document.py
+++ b/test/preview/components/file_converters/test_html_to_document.py
@@ -7,18 +7,6 @@ from haystack.preview.dataclasses import ByteStream
 
 
 class TestHTMLToDocument:
-    @pytest.mark.unit
-    def test_init_params_default(self):
-        """Test if the component sets default initialization parameters correctly."""
-        converter = HTMLToDocument()
-        assert converter.progress_bar is True
-
-    @pytest.mark.unit
-    def test_init_params_custom(self):
-        """Test if the component sets custom initialization parameters correctly."""
-        converter = HTMLToDocument(progress_bar=False)
-        assert converter.progress_bar is False
-
     @pytest.mark.integration
     def test_run(self, preview_samples_path):
         """
@@ -125,7 +113,7 @@ class TestHTMLToDocument:
         docs = output["documents"]
         assert not docs
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_run_error_handling(self, caplog):
         """
         Test if the component correctly handles errors.
@@ -137,7 +125,7 @@ class TestHTMLToDocument:
             assert "Could not read non_existing_file.html" in caplog.text
             assert not result["documents"]
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_mixed_sources_run(self, preview_samples_path):
         """
         Test if the component runs correctly if the input is a mix of paths and ByteStreams.

--- a/test/preview/components/file_converters/test_html_to_document.py
+++ b/test/preview/components/file_converters/test_html_to_document.py
@@ -8,56 +8,130 @@ from haystack.preview.dataclasses import ByteStream
 
 class TestHTMLToDocument:
     @pytest.mark.unit
+    def test_init_params_default(self):
+        """Test if the component sets default initialization parameters correctly."""
+        converter = HTMLToDocument()
+        assert converter.progress_bar is True
+
+    @pytest.mark.unit
+    def test_init_params_custom(self):
+        """Test if the component sets custom initialization parameters correctly."""
+        converter = HTMLToDocument(progress_bar=False)
+        assert converter.progress_bar is False
+
+    @pytest.mark.integration
     def test_run(self, preview_samples_path):
         """
         Test if the component runs correctly.
         """
-        paths = [preview_samples_path / "html" / "what_is_haystack.html"]
+        sources = [preview_samples_path / "html" / "what_is_haystack.html"]
         converter = HTMLToDocument()
-        output = converter.run(sources=paths)
+        output = converter.run(sources=sources)
         docs = output["documents"]
         assert len(docs) == 1
         assert "Haystack" in docs[0].content
 
-    @pytest.mark.unit
+    @pytest.mark.integration
+    def test_run_doc_metadata(self, preview_samples_path):
+        """
+        Test if the component runs correctly when metadata is supplied by the user.
+        """
+        converter = HTMLToDocument()
+        sources = [preview_samples_path / "html" / "what_is_haystack.html"]
+        metadata = [{"file_name": "what_is_haystack.html"}]
+        results = converter.run(sources=sources, meta=metadata)
+        docs = results["documents"]
+
+        assert len(docs) == 1
+        assert "Haystack" in docs[0].content
+        assert docs[0].meta == {"file_name": "what_is_haystack.html"}
+
+    @pytest.mark.integration
+    def test_run_bytestream_metadata(self, preview_samples_path):
+        """
+        Test if the component runs correctly when metadata is read from the received ByteStream object.
+        """
+        converter = HTMLToDocument()
+        with open(preview_samples_path / "html" / "what_is_haystack.html", "rb") as file:
+            byte_stream = file.read()
+            stream = ByteStream(byte_stream, metadata={"content_type": "text/html", "url": "test_url"})
+
+        metadata = [{"file_name": "what_is_haystack.html"}]
+        results = converter.run(sources=[stream], meta=metadata)
+        docs = results["documents"]
+
+        assert len(docs) == 1
+        assert "Haystack" in docs[0].content
+        assert docs[0].meta == {"file_name": "what_is_haystack.html", "content_type": "text/html", "url": "test_url"}
+
+    @pytest.mark.integration
+    def test_run_bytestream_doc_overlapping_metadata(self, preview_samples_path):
+        """
+        Test if the component runs correctly when metadata is read from the received ByteStream object and supplied by the user.
+
+        The component will use the supplied metadata if there is an overlap between the keys.
+        """
+        converter = HTMLToDocument()
+        with open(preview_samples_path / "html" / "what_is_haystack.html", "rb") as file:
+            byte_stream = file.read()
+            # ByteStream has "url" present in metadata
+            stream = ByteStream(byte_stream, metadata={"content_type": "text/html", "url": "test_url_correct"})
+
+        # "url" supplied by the user overwrites value present in metadata
+        metadata = [{"file_name": "what_is_haystack.html", "url": "test_url_new"}]
+        results = converter.run(sources=[stream], meta=metadata)
+        docs = results["documents"]
+
+        assert len(docs) == 1
+        assert "Haystack" in docs[0].content
+        assert docs[0].meta == {
+            "file_name": "what_is_haystack.html",
+            "content_type": "text/html",
+            "url": "test_url_new",
+        }
+
+    @pytest.mark.integration
     def test_run_wrong_file_type(self, preview_samples_path, caplog):
         """
         Test if the component runs correctly when an input file is not of the expected type.
         """
-        paths = [preview_samples_path / "audio" / "answer.wav"]
+        sources = [preview_samples_path / "audio" / "answer.wav"]
         converter = HTMLToDocument()
         with caplog.at_level(logging.WARNING):
-            output = converter.run(sources=paths)
+            output = converter.run(sources=sources)
             assert "codec can't decode byte" in caplog.text
 
         docs = output["documents"]
         assert not docs
 
     @pytest.mark.unit
-    def test_run_error_handling(self, preview_samples_path, caplog):
+    def test_run_error_handling(self, caplog):
         """
         Test if the component correctly handles errors.
         """
-        paths = ["non_existing_file.html"]
+        sources = ["non_existing_file.html"]
         converter = HTMLToDocument()
         with caplog.at_level(logging.WARNING):
-            result = converter.run(sources=paths)
+            result = converter.run(sources=sources)
             assert "Could not read non_existing_file.html" in caplog.text
             assert not result["documents"]
 
     @pytest.mark.unit
     def test_mixed_sources_run(self, preview_samples_path):
         """
-        Test if the component runs correctly if the input is a mix of paths and ByteStreams
+        Test if the component runs correctly if the input is a mix of paths and ByteStreams.
         """
-        paths = [preview_samples_path / "html" / "what_is_haystack.html"]
+        sources = [
+            preview_samples_path / "html" / "what_is_haystack.html",
+            str((preview_samples_path / "html" / "what_is_haystack.html").absolute()),
+        ]
         with open(preview_samples_path / "html" / "what_is_haystack.html", "rb") as f:
             byte_stream = f.read()
-            paths.append(ByteStream(byte_stream))
+            sources.append(ByteStream(byte_stream))
 
         converter = HTMLToDocument()
-        output = converter.run(sources=paths)
+        output = converter.run(sources=sources)
         docs = output["documents"]
-        assert len(docs) == 2
+        assert len(docs) == 3
         for doc in docs:
             assert "Haystack" in doc.content


### PR DESCRIPTION
### Related Issues

- fixes #6275 
- fixes a part of #6131 

### Proposed Changes:

- Adds `ByteStream` metadata to `Document` metadata on creation of documents.
- Adds an optional `meta` parameter in the `run()` method, that allows the users to pass additional metadata to the `Documents`.


### How did you test it?

Unit tests, Integration tests and manual verification.

### Notes for the reviewer

Usage examples showcasing the various methods for adding metadata to the documents can be viewed in this [Colab Notebook](https://colab.research.google.com/drive/1u7g0DzRg9OcgNWqoLQyvgjScb_PVIAbS?usp=sharing). It also has an example utilizing HTMLToDocument with LinkContentFetcher.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
