### PR TITLE
docs: Reader returns top_k+1 answers if no_answer is enabled

### DIFF
--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -58,6 +58,7 @@ class ExtractiveReader:
             `transformers-cli login` (stored in ~/.huggingface) will be used.
         :param top_k: Number of answers to return per query.
             It is required even if confidence_threshold is set. Defaults to 20.
+            An additional answer is returned if no_answer is set to True (default).
         :param confidence_threshold: Answers with a confidence score below this value will not be returned
         :param max_seq_length: Maximum number of tokens.
             If exceeded by a sequence, the sequence will be split.
@@ -294,6 +295,7 @@ class ExtractiveReader:
         :param query: Query string.
         :param documents: List of Documents to search for an answer to the query.
         :param top_k: The maximum number of answers to return.
+            An additional answer is returned if no_answer is set to True (default).
         :return: List of ExtractedAnswers sorted by (desc.) answer score.
         """
         queries = [query]  # Temporary solution until we have decided what batching should look like in v2

--- a/releasenotes/notes/fix-reader-top-k-b4f7e29be5ba5ee1.yaml
+++ b/releasenotes/notes/fix-reader-top-k-b4f7e29be5ba5ee1.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Update Reader documentation to explain that top_k+1 answers are returned if no_answer is enabled (default).


### PR DESCRIPTION
### Related Issues

2.0 Reader returns top_k+1 answers if no_answer is enabled (default), while the documentation claims that top_k answers will be returned. For example, the following code returns two answers although top_k is set to 1. One answer is a the correct text answer and the other is a no_answer with no text and the probability that the other answer is incorrect.

```python
from haystack.preview import Document
from haystack.preview.components.readers import ExtractiveReader

docs = [Document(content="Paris is the capital of France."), Document(content="Berlin is the capital of Germany.")]

reader = ExtractiveReader()
reader.warm_up()

reader.run(query="What is the capital of France?", documents=docs, top_k=1)
```

### Proposed Changes:

- Updated the doc strings explaining that Reader returns top_k+1 answers if no_answer is True.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
