### PR TITLE
refactor!: Remove routing from DocumentLanguageClassifier and rename TextLanguageClassifier

### DIFF
--- a/haystack/preview/components/classifiers/__init__.py
+++ b/haystack/preview/components/classifiers/__init__.py
@@ -1,4 +1,3 @@
 from haystack.preview.components.classifiers.document_language_classifier import DocumentLanguageClassifier
-from haystack.preview.components.classifiers.text_language_classifier import TextLanguageClassifier
 
-__all__ = ["DocumentLanguageClassifier", "TextLanguageClassifier"]
+__all__ = ["DocumentLanguageClassifier"]

--- a/haystack/preview/components/classifiers/document_language_classifier.py
+++ b/haystack/preview/components/classifiers/document_language_classifier.py
@@ -14,7 +14,7 @@ with LazyImport("Run 'pip install langdetect'") as langdetect_import:
 class DocumentLanguageClassifier:
     """
     Classify the language of documents and add the detected language to their metadata.
-    A MetaDataRouter can then route them onto different output connections depending on their language.
+    A MetadataRouter can then route them onto different output connections depending on their language.
     This is useful to route documents to different models in a pipeline depending on their language.
     The set of supported languages can be specified.
     For routing plain text using the same logic, use the related TextLanguageRouter component instead.
@@ -27,7 +27,7 @@ class DocumentLanguageClassifier:
     p = Pipeline()
     p.add_component(instance=TextFileToDocument(), name="text_file_converter")
     p.add_component(instance=DocumentLanguageClassifier(), name="language_classifier")
-    p.add_component(instance=MetaDataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router")
+    p.add_component(instance=MetadataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router")
     p.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
     p.connect("text_file_converter.documents", "language_classifier.documents")
     p.connect("language_classifier.documents", "router.documents")

--- a/haystack/preview/components/classifiers/document_language_classifier.py
+++ b/haystack/preview/components/classifiers/document_language_classifier.py
@@ -13,10 +13,11 @@ with LazyImport("Run 'pip install langdetect'") as langdetect_import:
 @component
 class DocumentLanguageClassifier:
     """
-    Routes documents onto different output connections depending on their language.
-    This is useful for routing documents to different models in a pipeline depending on their language.
+    Classify the language of documents and add the detected language to their metadata.
+    A MetaDataRouter can then route them onto different output connections depending on their language.
+    This is useful to route documents to different models in a pipeline depending on their language.
     The set of supported languages can be specified.
-    For routing plain text using the same logic, use the related TextLanguageClassifier component instead.
+    For routing plain text using the same logic, use the related TextLanguageRouter component instead.
 
     Example usage within an indexing pipeline, storing in a Document Store
     only documents written in English:
@@ -26,9 +27,11 @@ class DocumentLanguageClassifier:
     p = Pipeline()
     p.add_component(instance=TextFileToDocument(), name="text_file_converter")
     p.add_component(instance=DocumentLanguageClassifier(), name="language_classifier")
+    p.add_component(instance=MetaDataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router")
     p.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
     p.connect("text_file_converter.documents", "language_classifier.documents")
-    p.connect("language_classifier.en", "writer.documents")
+    p.connect("language_classifier.documents", "router.documents")
+    p.connect("router.en", "writer.documents")
     ```
     """
 
@@ -42,17 +45,15 @@ class DocumentLanguageClassifier:
         if not languages:
             languages = ["en"]
         self.languages = languages
-        component.set_output_types(
-            self, unmatched=List[Document], **{language: List[Document] for language in languages}
-        )
 
+    @component.output_types(documents=List[Document])
     def run(self, documents: List[Document]):
         """
-        Run the DocumentLanguageClassifier. This method routes the documents to different edges based on their language.
-        If a Document's text does not match any of the languages specified at initialization, it is routed to
-        a connection named "unmatched".
+        Run the DocumentLanguageClassifier. This method classifies the documents' language and adds it to their metadata.
+        If a Document's text does not match any of the languages specified at initialization, the metadata value "unmatched" will be stored.
 
-        :param documents: A list of documents to route to different edges.
+        :param documents: A list of documents to classify their language.
+        :return: List of Documents with an added metadata field called language.
         """
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError(
@@ -66,11 +67,11 @@ class DocumentLanguageClassifier:
         for document in documents:
             detected_language = self.detect_language(document)
             if detected_language in self.languages:
-                output[detected_language].append(document)
+                document.meta["language"] = detected_language
             else:
-                output["unmatched"].append(document)
+                document.meta["language"] = "unmatched"
 
-        return output
+        return {"documents": documents}
 
     def detect_language(self, document: Document) -> Optional[str]:
         try:

--- a/haystack/preview/components/routers/__init__.py
+++ b/haystack/preview/components/routers/__init__.py
@@ -1,4 +1,5 @@
 from haystack.preview.components.routers.file_type_router import FileTypeRouter
 from haystack.preview.components.routers.metadata_router import MetadataRouter
+from haystack.preview.components.routers.text_language_router import TextLanguageRouter
 
-__all__ = ["FileTypeRouter", "MetadataRouter"]
+__all__ = ["FileTypeRouter", "MetadataRouter", "TextLanguageRouter"]

--- a/haystack/preview/components/routers/text_language_router.py
+++ b/haystack/preview/components/routers/text_language_router.py
@@ -11,22 +11,23 @@ with LazyImport("Run 'pip install langdetect'") as langdetect_import:
 
 
 @component
-class TextLanguageClassifier:
+class TextLanguageRouter:
     """
     Routes a text input onto one of different output connections depending on its language.
     This is useful for routing queries to different models in a pipeline depending on their language.
     The set of supported languages can be specified.
-    For routing Documents based on their language use the related DocumentLanguageClassifier component.
+    For routing Documents based on their language use the related DocumentLanguageClassifier component to first
+    classify the documents and then the MetaDataRouter to route them.
 
     Example usage in a retrieval pipeline that passes only English language queries to the retriever:
 
     ```python
     document_store = InMemoryDocumentStore()
     p = Pipeline()
-    p.add_component(instance=TextLanguageClassifier(), name="text_language_classifier")
+    p.add_component(instance=TextLanguageRouter(), name="text_language_router")
     p.add_component(instance=InMemoryBM25Retriever(document_store=document_store), name="retriever")
-    p.connect("text_language_classifier.en", "retriever.query")
-    p.run({"text_language_classifier": {"text": "What's your query?"}})
+    p.connect("text_language_router.en", "retriever.query")
+    p.run({"text_language_router": {"text": "What's your query?"}})
     ```
     """
 
@@ -42,7 +43,7 @@ class TextLanguageClassifier:
 
     def run(self, text: str) -> Dict[str, str]:
         """
-        Run the TextLanguageClassifier. This method routes the text one of different edges based on its language.
+        Run the TextLanguageRouter. This method routes the text one of different edges based on its language.
         If the text does not match any of the languages specified at initialization, it is routed to
         a connection named "unmatched".
 
@@ -50,7 +51,7 @@ class TextLanguageClassifier:
         """
         if not isinstance(text, str):
             raise TypeError(
-                "TextLanguageClassifier expects a str as input. In case you want to classify a document, please use the DocumentLanguageClassifier."
+                "TextLanguageRouter expects a str as input. In case you want to classify a document, please use the DocumentLanguageClassifier and MetaDataRouter."
             )
 
         output: Dict[str, str] = {}

--- a/releasenotes/notes/separate-classifiers-from-routers-96a37c76820385d6.yaml
+++ b/releasenotes/notes/separate-classifiers-from-routers-96a37c76820385d6.yaml
@@ -1,0 +1,6 @@
+---
+preview:
+  - |
+    Remove routing functionality from DocumentLanguageClassifier and rename TextLanguageClassifer to TextLanguageRouter.
+    Classifiers in Haystack 2.x change metadata values but do not route inputs to multiple outputs. The latter is reserved for routers.
+    Use DocumentLanguageClassifier in combination with MetaDataRouter to classify and route documents in indexing pipelines.

--- a/test/preview/components/classifiers/test_document_language_classifier.py
+++ b/test/preview/components/classifiers/test_document_language_classifier.py
@@ -27,7 +27,7 @@ class TestDocumentLanguageClassifier:
     def test_empty_list(self):
         classifier = DocumentLanguageClassifier()
         result = classifier.run(documents=[])
-        assert result == {"en": [], "unmatched": []}
+        assert result == {"documents": []}
 
     @pytest.mark.unit
     def test_detect_language(self):
@@ -36,12 +36,13 @@ class TestDocumentLanguageClassifier:
         assert detected_language == "en"
 
     @pytest.mark.unit
-    def test_route_to_en_and_unmatched(self):
+    def test_classify_as_en_and_unmatched(self):
         classifier = DocumentLanguageClassifier()
         english_document = Document(content="This is an english sentence.")
         german_document = Document(content="Ein deutscher Satz ohne Verb.")
         result = classifier.run(documents=[english_document, german_document])
-        assert result == {"en": [english_document], "unmatched": [german_document]}
+        assert result["documents"][0].meta["language"] == "en"
+        assert result["documents"][1].meta["language"] == "unmatched"
 
     @pytest.mark.unit
     def test_warning_if_no_language_detected(self, caplog):

--- a/test/preview/components/routers/test_text_language_router.py
+++ b/test/preview/components/routers/test_text_language_router.py
@@ -2,44 +2,44 @@ import logging
 import pytest
 
 from haystack.preview import Document
-from haystack.preview.components.classifiers import TextLanguageClassifier
+from haystack.preview.components.routers import TextLanguageRouter
 
 
-class TestTextLanguageClassifier:
+class TestTextLanguageRouter:
     @pytest.mark.unit
     def test_non_string_input(self):
-        with pytest.raises(TypeError, match="TextLanguageClassifier expects a str as input."):
-            classifier = TextLanguageClassifier()
+        with pytest.raises(TypeError, match="TextLanguageRouter expects a str as input."):
+            classifier = TextLanguageRouter()
             classifier.run(text=Document(content="This is an english sentence."))
 
     @pytest.mark.unit
     def test_list_of_string(self):
-        with pytest.raises(TypeError, match="TextLanguageClassifier expects a str as input."):
-            classifier = TextLanguageClassifier()
+        with pytest.raises(TypeError, match="TextLanguageRouter expects a str as input."):
+            classifier = TextLanguageRouter()
             classifier.run(text=["This is an english sentence."])
 
     @pytest.mark.unit
     def test_empty_string(self):
-        classifier = TextLanguageClassifier()
+        classifier = TextLanguageRouter()
         result = classifier.run(text="")
         assert result == {"unmatched": ""}
 
     @pytest.mark.unit
     def test_detect_language(self):
-        classifier = TextLanguageClassifier()
+        classifier = TextLanguageRouter()
         detected_language = classifier.detect_language("This is an english sentence.")
         assert detected_language == "en"
 
     @pytest.mark.unit
     def test_route_to_en(self):
-        classifier = TextLanguageClassifier()
+        classifier = TextLanguageRouter()
         english_sentence = "This is an english sentence."
         result = classifier.run(text=english_sentence)
         assert result == {"en": english_sentence}
 
     @pytest.mark.unit
     def test_route_to_unmatched(self):
-        classifier = TextLanguageClassifier()
+        classifier = TextLanguageRouter()
         german_sentence = "Ein deutscher Satz ohne Verb."
         result = classifier.run(text=german_sentence)
         assert result == {"unmatched": german_sentence}
@@ -47,6 +47,6 @@ class TestTextLanguageClassifier:
     @pytest.mark.unit
     def test_warning_if_no_language_detected(self, caplog):
         with caplog.at_level(logging.WARNING):
-            classifier = TextLanguageClassifier()
+            classifier = TextLanguageRouter()
             classifier.run(text=".")
             assert "Langdetect cannot detect the language of text: ." in caplog.text


### PR DESCRIPTION
### Related Issues

There was an open discussion about how to separate classifiers from routers. @silvanocerza @anakin87 and I made the following decision: 
- Classifiers should not do routing, which is reserved to routers. 
- Classifiers only change metadata. Thus the inputs to classifiers should be objects with metadata, such as Documents or Answers. Afterward, a MetadataRouter can be used in a pipeline
- TextLanguageClassifier works on strings and thus cannot edit metadata. Therefore we rename it to TextLanguageRouter.
- Any component classifying strings will be a router, for example the 1.x QueryClassifier would become a QueryRouter.

### Proposed Changes:

- Remove routing functionality from DocumentLanguageClassifier
- Rename TextLanguageClassifier to TextLanguageRouter and move to routers module
- Adjust unit tests

### How did you test it?
```python
from haystack.preview import Pipeline
from haystack.preview.document_stores import InMemoryDocumentStore
from haystack.preview.components.file_converters import TextFileToDocument
from haystack.preview.components.classifiers import DocumentLanguageClassifier
from haystack.preview.components.routers import MetadataRouter
from haystack.preview.components.writers import DocumentWriter

document_store = InMemoryDocumentStore()
p = Pipeline()
p.add_component(instance=TextFileToDocument(), name="text_file_converter")
p.add_component(instance=DocumentLanguageClassifier(), name="language_classifier")
p.add_component(instance=MetadataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router")
p.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
p.connect("text_file_converter.documents", "language_classifier.documents")
p.connect("language_classifier.documents", "router.documents")
p.connect("router.en", "writer.documents")

p.run({"text_file_converter": {"paths": ["your-file-here.txt"]}})
```
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
