### PR TITLE
fix: change pydoc configuration for `TextLanguageRouter`

### DIFF
--- a/docs/pydoc/config-preview/classifier.yml
+++ b/docs/pydoc/config-preview/classifier.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: loaders.CustomPythonLoader
     search_path: [../../../haystack/preview/components/classifiers]
-    modules: ["document_language_classifier", "text_language_classifier"]
+    modules: ["document_language_classifier"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter

--- a/docs/pydoc/config-preview/router.yml
+++ b/docs/pydoc/config-preview/router.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: loaders.CustomPythonLoader
     search_path: [../../../haystack/preview/components/routers]
-    modules: ["file_type_router", "metadata_router"]
+    modules: ["file_type_router", "metadata_router", "text_language_router"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter


### PR DESCRIPTION
### Related Issues

- related to #6226
- fixes errors like this: https://github.com/deepset-ai/haystack/actions/runs/6877253301/job/18704513358

### Proposed Changes:

- change pydoc configuration to reflect the changes in #6226

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
