### PR TITLE
fix: fix un-flattening of metadata

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -158,7 +158,7 @@ class Document(metaclass=_BackwardCompatible):
             )
 
         # Finally put back all the metadata
-        return cls(**data, meta=meta | flatten_meta)
+        return cls(**data, meta={**meta, **flatten_meta})
 
     @property
     def content_type(self):

--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -154,7 +154,8 @@ class Document(metaclass=_BackwardCompatible):
         # We don't support passing both flatten keys and the `meta` keyword parameter
         if meta and flatten_meta:
             raise ValueError(
-                "Passing the 'meta' parameter together with flatten metadata keys as keyword arguments is not supported."
+                "You can pass either the 'meta' parameter or flattened metadata keys as keyword arguments, "
+                "but currently you're passing both. Pass either the 'meta' parameter or flattened metadata keys."
             )
 
         # Finally put back all the metadata

--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -142,7 +142,7 @@ class Document(metaclass=_BackwardCompatible):
         # ValueError later if this is the case.
         meta = data.pop("meta", {})
         # Unflatten metadata if it was flattened. We assume any keyword argument that's not
-        # a document field as a metadata key. We treat legacy fields as document fields
+        # a document field is a metadata key. We treat legacy fields as document fields
         # for backward compatibility.
         flatten_meta = {}
         legacy_fields = ["content_type", "id_hash_keys"]

--- a/releasenotes/notes/fix-document-flatten-metadata-ef61dbbae08b1db7.yaml
+++ b/releasenotes/notes/fix-document-flatten-metadata-ef61dbbae08b1db7.yaml
@@ -1,0 +1,6 @@
+---
+
+preview:
+  - |
+    Fix a failure that occurred when creating a document passing the 'meta' keyword 
+    to the constructor.

--- a/releasenotes/notes/fix-document-flatten-metadata-ef61dbbae08b1db7.yaml
+++ b/releasenotes/notes/fix-document-flatten-metadata-ef61dbbae08b1db7.yaml
@@ -2,5 +2,7 @@
 
 preview:
   - |
-    Fix a failure that occurred when creating a document passing the 'meta' keyword 
-    to the constructor.
+    Fix a failure that occurred when creating a document passing the 'meta' keyword
+    to the constructor. Raise a specific ValueError if the 'meta' keyword is passed
+    along with metadata as keyword arguments, the two options are mutually exclusive
+    now.

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -282,18 +282,22 @@ def test_from_dict_with_flat_meta():
 
 @pytest.mark.unit
 def test_from_dict_with_flat_and_non_flat_meta():
-    Document.from_dict(
-        {
-            "content": "test text",
-            "dataframe": pd.DataFrame([0]).to_json(),
-            "blob": {"data": list(b"some bytes"), "mime_type": "text/markdown"},
-            "score": 0.812,
-            "meta": {"test": 10},
-            "embedding": [0.1, 0.2, 0.3],
-            "date": "10-10-2023",
-            "type": "article",
-        }
-    )
+    with pytest.raises(
+        ValueError,
+        match="Passing the 'meta' parameter together with flatten metadata keys as keyword arguments is not supported",
+    ):
+        Document.from_dict(
+            {
+                "content": "test text",
+                "dataframe": pd.DataFrame([0]).to_json(),
+                "blob": {"data": list(b"some bytes"), "mime_type": "text/markdown"},
+                "score": 0.812,
+                "meta": {"test": 10},
+                "embedding": [0.1, 0.2, 0.3],
+                "date": "10-10-2023",
+                "type": "article",
+            }
+        )
 
 
 @pytest.mark.unit

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -282,10 +282,7 @@ def test_from_dict_with_flat_meta():
 
 @pytest.mark.unit
 def test_from_dict_with_flat_and_non_flat_meta():
-    with pytest.raises(
-        ValueError,
-        match="Passing the 'meta' parameter together with flatten metadata keys as keyword arguments is not supported",
-    ):
+    with pytest.raises(ValueError, match="Pass either the 'meta' parameter or flattened metadata keys"):
         Document.from_dict(
             {
                 "content": "test text",

--- a/test/preview/dataclasses/test_document.py
+++ b/test/preview/dataclasses/test_document.py
@@ -282,19 +282,18 @@ def test_from_dict_with_flat_meta():
 
 @pytest.mark.unit
 def test_from_dict_with_flat_and_non_flat_meta():
-    with pytest.raises(TypeError):
-        Document.from_dict(
-            {
-                "content": "test text",
-                "dataframe": pd.DataFrame([0]).to_json(),
-                "blob": {"data": list(b"some bytes"), "mime_type": "text/markdown"},
-                "score": 0.812,
-                "meta": {"test": 10},
-                "embedding": [0.1, 0.2, 0.3],
-                "date": "10-10-2023",
-                "type": "article",
-            }
-        )
+    Document.from_dict(
+        {
+            "content": "test text",
+            "dataframe": pd.DataFrame([0]).to_json(),
+            "blob": {"data": list(b"some bytes"), "mime_type": "text/markdown"},
+            "score": 0.812,
+            "meta": {"test": 10},
+            "embedding": [0.1, 0.2, 0.3],
+            "date": "10-10-2023",
+            "type": "article",
+        }
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- follow-up of #6286

After #6286, creating a document with `Document(meta={"key": "value"})` would fail with:

`TypeError: haystack.preview.dataclasses.document.Document() got multiple values for keyword argument 'meta'`

### Proposed Changes:

- Remove the `meta` key from the `data` dictionary while we iterate the fields to unflatten meta

### How did you test it?

- This change fixes https://github.com/deepset-ai/haystack-core-integrations/actions/runs/6884405007/job/18726839670
- Unit tests

### Notes for the reviewer

I don't think we'll have a case where we receive both `meta=` and flatten keywords, but the current logic accounts for that.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
