### PR TITLE
test: Add MetadataRouter to preprocessing pipeline in e2e test

### DIFF
--- a/e2e/preview/pipelines/test_preprocessing_pipeline.py
+++ b/e2e/preview/pipelines/test_preprocessing_pipeline.py
@@ -5,7 +5,7 @@ from haystack.preview.components.embedders import SentenceTransformersDocumentEm
 from haystack.preview.components.file_converters import TextFileToDocument
 from haystack.preview.components.preprocessors import DocumentSplitter, DocumentCleaner
 from haystack.preview.components.classifiers import DocumentLanguageClassifier
-from haystack.preview.components.routers import FileTypeRouter
+from haystack.preview.components.routers import FileTypeRouter, MetadataRouter
 from haystack.preview.components.writers import DocumentWriter
 from haystack.preview.document_stores import InMemoryDocumentStore
 
@@ -17,6 +17,9 @@ def test_preprocessing_pipeline(tmp_path):
     preprocessing_pipeline.add_component(instance=FileTypeRouter(mime_types=["text/plain"]), name="file_type_router")
     preprocessing_pipeline.add_component(instance=TextFileToDocument(), name="text_file_converter")
     preprocessing_pipeline.add_component(instance=DocumentLanguageClassifier(), name="language_classifier")
+    preprocessing_pipeline.add_component(
+        instance=MetadataRouter(rules={"en": {"language": {"$eq": "en"}}}), name="router"
+    )
     preprocessing_pipeline.add_component(instance=DocumentCleaner(), name="cleaner")
     preprocessing_pipeline.add_component(
         instance=DocumentSplitter(split_by="sentence", split_length=1), name="splitter"
@@ -28,7 +31,8 @@ def test_preprocessing_pipeline(tmp_path):
     preprocessing_pipeline.add_component(instance=DocumentWriter(document_store=document_store), name="writer")
     preprocessing_pipeline.connect("file_type_router.text/plain", "text_file_converter.paths")
     preprocessing_pipeline.connect("text_file_converter.documents", "language_classifier.documents")
-    preprocessing_pipeline.connect("language_classifier.en", "cleaner.documents")
+    preprocessing_pipeline.connect("language_classifier.documents", "router.documents")
+    preprocessing_pipeline.connect("router.en", "cleaner.documents")
     preprocessing_pipeline.connect("cleaner.documents", "splitter.documents")
     preprocessing_pipeline.connect("splitter.documents", "embedder.documents")
     preprocessing_pipeline.connect("embedder.documents", "writer.documents")

--- a/releasenotes/notes/fix-e2e-test-preprocessing-7b24f848e074c48a.yaml
+++ b/releasenotes/notes/fix-e2e-test-preprocessing-7b24f848e074c48a.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Updated end-to-end test to use the DocumentLanguageClassifier with a MetadataRouter in a preprocessing pipeline.


### PR DESCRIPTION
### Related Issues

`preprocessing_pipeline.connect("language_classifier.en", "cleaner.documents")` in the existing e2e test failed with
`canals.errors.PipelineConnectError: 'language_classifier.en does not exist. Output connections of language_classifier are: documents (type List[Document])` since we updated the DocumentLanguageClassifier to only update documents' metadata but not do any routing.

### Proposed Changes:

- Add MetadataRouter after the DocumentLanguageClassifier in the e2e test

### How did you test it?

Still pending

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
