### PR TITLE
ci: Change preview tests to run all tests except integration ones

### DIFF
--- a/.github/workflows/tests_preview.yml
+++ b/.github/workflows/tests_preview.yml
@@ -119,7 +119,7 @@ jobs:
         run: pip install .[dev,preview,audio] langdetect transformers[torch,sentencepiece]==4.34.1 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2'
 
       - name: Run
-        run: pytest -m "unit" test/preview
+        run: pytest -m "not integration" test/preview
 
       - name: Calculate alert data
         id: calculator
@@ -151,7 +151,6 @@ jobs:
                 - "workflow:${{ github.workflow }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
 
   integration-tests-linux:
     name: Integration / ubuntu-latest
@@ -211,13 +210,12 @@ jobs:
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-
   integration-tests-macos:
     name: Integration / macos-latest
     needs: unit-tests
     runs-on: macos-latest-xl
     env:
-      HAYSTACK_MPS_ENABLED : false
+      HAYSTACK_MPS_ENABLED: false
     steps:
       - uses: actions/checkout@v4
 
@@ -270,7 +268,6 @@ jobs:
                 - "workflow:${{ github.workflow }}"
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
 
   integration-tests-windows:
     name: Integration / windows-latest

--- a/test/preview/components/builders/test_answer_builder.py
+++ b/test/preview/components/builders/test_answer_builder.py
@@ -41,7 +41,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "Answer: AnswerString"
-        assert answers[0].meta == {}
+        assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -52,7 +52,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == {}
+        assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -63,7 +63,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "'AnswerString'"
-        assert answers[0].meta == {}
+        assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -80,7 +80,7 @@ class TestAnswerBuilder:
         answers = output["answers"]
         assert len(answers) == 1
         assert answers[0].data == "AnswerString"
-        assert answers[0].meta == {}
+        assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
@@ -99,8 +99,8 @@ class TestAnswerBuilder:
         assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 2
-        assert answers[0].documents[0].text == "test doc 1"
-        assert answers[0].documents[1].text == "test doc 2"
+        assert answers[0].documents[0].content == "test doc 1"
+        assert answers[0].documents[1].content == "test doc 2"
 
     def test_run_with_documents_with_reference_pattern(self):
         component = AnswerBuilder(reference_pattern="\\[(\\d+)\\]")
@@ -116,7 +116,7 @@ class TestAnswerBuilder:
         assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 1
-        assert answers[0].documents[0].text == "test doc 2"
+        assert answers[0].documents[0].content == "test doc 2"
 
     def test_run_with_documents_with_reference_pattern_and_no_match(self, caplog):
         component = AnswerBuilder(reference_pattern="\\[(\\d+)\\]")
@@ -150,5 +150,5 @@ class TestAnswerBuilder:
         assert answers[0].metadata == {}
         assert answers[0].query == "test query"
         assert len(answers[0].documents) == 2
-        assert answers[0].documents[0].text == "test doc 2"
-        assert answers[0].documents[1].text == "test doc 3"
+        assert answers[0].documents[0].content == "test doc 2"
+        assert answers[0].documents[1].content == "test doc 3"


### PR DESCRIPTION
### Proposed Changes:

Change CI for `preview` to run all tests not marked with `@pytest.mark.integration`.

I had to fix some tests as they weren't run with the current approach.

### How did you test it?

Run `pytest -m "not integration"  test/preview` locally.

### Notes for the reviewer

In a future PR I will remove all `@pytest.mark.unit` decorators from tests in `test/preview`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
