### PR TITLE
test: Add langdetect installation to e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,7 +59,7 @@ jobs:
       run: docker run -d -p 8080:8080 --name haystack_test_weaviate --env AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED='true' --env PERSISTENCE_DATA_PATH='/var/lib/weaviate' --env ENABLE_EXPERIMENTAL_BM25='true' --env DISK_USE_READONLY_PERCENTAGE='95' semitechnologies/weaviate:1.17.2
 
     - name: Install Haystack
-      run: pip install -e .[inference,elasticsearch7,faiss,weaviate,opensearch,dev,pdf,preview]
+      run: pip install -e .[inference,elasticsearch7,faiss,weaviate,opensearch,dev,pdf,preview] langdetect
 
     # FIXME caching prevents PRs from running the e2e tests properly
 

--- a/e2e/preview/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/preview/pipelines/test_extractive_qa_pipeline.py
@@ -64,4 +64,5 @@ def test_extractive_qa_pipeline(tmp_path):
             assert hasattr(answer, "document")
             # the answer is extracted from the correct document
             if answer.document is not None:
-                assert answer.document == doc
+                assert answer.document.content == doc.content
+                assert answer.document.id == doc.id


### PR DESCRIPTION
### Related Issues

One of the e2e preview tests fails because of a missing dependency, langdetect: https://github.com/deepset-ai/haystack/actions/workflows/e2e.yml
`FAILED e2e/preview/pipelines/test_preprocessing_pipeline.py::test_preprocessing_pipeline - ImportError: Failed to import 'langdetect'. Run 'pip install langdetect'. Original error: No module named 'langdetect'`

### Proposed Changes:

- Install langdetect dependency
- Compare doc content and id only in test_extractive_qa_pipeline.py to account for changes to `Document.__eq__` in https://github.com/deepset-ai/haystack/pull/6323


### How did you test it?

e2e tests are passing: https://github.com/deepset-ai/haystack/actions/runs/6901284179

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
