### PR TITLE
refactor: Move tests for `count_documents` from `DocumentStoreBaseTests` to separate class

### DIFF
--- a/haystack/preview/testing/document_store.py
+++ b/haystack/preview/testing/document_store.py
@@ -16,7 +16,34 @@ def _random_embeddings(n):
     return [random.random() for _ in range(n)]
 
 
-class DocumentStoreBaseTests:
+class CountDocumentsTest:
+    """
+    Utility class to test a Document Store `count_documents` method.
+
+    To use it create a custom test class and override the `docstore` fixture to return your Document Store.
+    Example usage:
+
+    ```python
+    class MyDocumentStoreTest(CountDocumentsTest):
+        @pytest.fixture
+        def docstore(self):
+            return MyDocumentStore()
+    ```
+    """
+
+    @pytest.mark.unit
+    def test_count_empty(self, docstore: DocumentStore):
+        assert docstore.count_documents() == 0
+
+    @pytest.mark.unit
+    def test_count_not_empty(self, docstore: DocumentStore):
+        docstore.write_documents(
+            [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
+        )
+        assert docstore.count_documents() == 3
+
+
+class DocumentStoreBaseTests(CountDocumentsTest):
     @pytest.fixture
     def docstore(self) -> DocumentStore:
         raise NotImplementedError()
@@ -63,17 +90,6 @@ class DocumentStoreBaseTests:
                 Document(content=f"Doc {i} with ones emb", meta={"name": "ones_doc"}, embedding=embedding_one)
             )
         return documents
-
-    @pytest.mark.unit
-    def test_count_empty(self, docstore: DocumentStore):
-        assert docstore.count_documents() == 0
-
-    @pytest.mark.unit
-    def test_count_not_empty(self, docstore: DocumentStore):
-        docstore.write_documents(
-            [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
-        )
-        assert docstore.count_documents() == 3
 
     @pytest.mark.unit
     def test_no_filter_empty(self, docstore: DocumentStore):


### PR DESCRIPTION
### Related Issues

Relates to #6284

### Proposed Changes:

Move `count_documents` tests from `DocumentStoreBaseTests` into `CountDocumentsTest` class.

`DocumentStoreBaseTests` now inherits `CountDocumentsTest`.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

Depends on #6324.

This is part of a series of PRs to split tests into different classes. I'll add release notes at the end.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
