### PR TITLE
refactor: improve Document representation

### DIFF
--- a/haystack/preview/dataclasses/document.py
+++ b/haystack/preview/dataclasses/document.py
@@ -65,9 +65,9 @@ class Document(metaclass=_BackwardCompatible):
     blob: Optional[ByteStream] = field(default=None)
     meta: Dict[str, Any] = field(default_factory=dict)
     score: Optional[float] = field(default=None)
-    embedding: Optional[List[float]] = field(default=None, repr=False)
+    embedding: Optional[List[float]] = field(default=None)
 
-    def __str__(self):
+    def __repr__(self):
         fields = []
         if self.content is not None:
             fields.append(
@@ -77,6 +77,12 @@ class Document(metaclass=_BackwardCompatible):
             fields.append(f"dataframe: {self.dataframe.shape}")
         if self.blob is not None:
             fields.append(f"blob: {len(self.blob.data)} bytes")
+        if len(self.meta) > 0:
+            fields.append(f"meta: {self.meta}")
+        if self.score is not None:
+            fields.append(f"score: {self.score}")
+        if self.embedding is not None:
+            fields.append(f"embedding: vector of size {len(self.embedding)}")
         fields_str = ", ".join(fields)
         return f"{self.__class__.__name__}(id={self.id}, {fields_str})"
 

--- a/releasenotes/notes/better-doc-repr-6d35de1cf4b25697.yaml
+++ b/releasenotes/notes/better-doc-repr-6d35de1cf4b25697.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Introduce a new Document representation, which includes meta, score and
+    embedding size.


### PR DESCRIPTION
### Related Issues

- fixes #6315

### Proposed Changes:

(Discussed with @masci)

- define a more descriptive `__repr__` for Document
- do not define `__str__` (`__repr__` will be used)

**Example**

`doc = Document(content="dfd", meta={"name": "test"}, score=0.9, embedding=[1, 2, 3])`
will have this representation:
`Document(id=0e2e032e0f638d798e971143e0a4439f606a46e304ed6c50a01501e820940e19, `
`content: 'dfd', meta: {'name': 'test'}, score: 0.9, embedding: vector of size 3)`

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
