### PR TITLE
fix: InMemoryDocumentStore - recreate Documents in the right way during embedding retrieval

### DIFF
--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -322,11 +322,10 @@ class InMemoryDocumentStore:
         # create Documents with the similarity score for the top k results
         top_documents = []
         for doc, score in sorted(zip(documents_with_embeddings, scores), key=lambda x: x[1], reverse=True)[:top_k]:
-            doc_fields = doc.to_dict()
-            doc_fields["score"] = score
+            doc.score = score
             if return_embedding is False:
-                doc_fields["embedding"] = None
-            top_documents.append(Document(**doc_fields))
+                doc.embedding = None
+            top_documents.append(doc)
 
         return top_documents
 

--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -1,4 +1,3 @@
-from copy import copy
 import re
 from typing import Literal, Any, Dict, List, Optional, Iterable
 
@@ -323,11 +322,11 @@ class InMemoryDocumentStore:
         # create Documents with the similarity score for the top k results
         top_documents = []
         for doc, score in sorted(zip(documents_with_embeddings, scores), key=lambda x: x[1], reverse=True)[:top_k]:
-            relevant_doc = copy(doc)
-            relevant_doc.score = score
+            relevant_doc_dict = doc.to_dict()
+            relevant_doc_dict["score"] = score
             if return_embedding is False:
-                relevant_doc.embedding = None
-            top_documents.append(relevant_doc)
+                relevant_doc_dict["embedding"] = None
+            top_documents.append(Document.from_dict(relevant_doc_dict))
 
         return top_documents
 

--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -322,11 +322,11 @@ class InMemoryDocumentStore:
         # create Documents with the similarity score for the top k results
         top_documents = []
         for doc, score in sorted(zip(documents_with_embeddings, scores), key=lambda x: x[1], reverse=True)[:top_k]:
-            relevant_doc_dict = doc.to_dict()
-            relevant_doc_dict["score"] = score
+            doc_fields = doc.to_dict()
+            doc_fields["score"] = score
             if return_embedding is False:
-                relevant_doc_dict["embedding"] = None
-            top_documents.append(Document.from_dict(relevant_doc_dict))
+                doc_fields["embedding"] = None
+            top_documents.append(Document.from_dict(doc_fields))
 
         return top_documents
 

--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -1,3 +1,4 @@
+from copy import copy
 import re
 from typing import Literal, Any, Dict, List, Optional, Iterable
 
@@ -322,10 +323,11 @@ class InMemoryDocumentStore:
         # create Documents with the similarity score for the top k results
         top_documents = []
         for doc, score in sorted(zip(documents_with_embeddings, scores), key=lambda x: x[1], reverse=True)[:top_k]:
-            doc.score = score
+            relevant_doc = copy(doc)
+            relevant_doc.score = score
             if return_embedding is False:
-                doc.embedding = None
-            top_documents.append(doc)
+                relevant_doc.embedding = None
+            top_documents.append(relevant_doc)
 
         return top_documents
 


### PR DESCRIPTION
### Related Issues

- fixes #6310

### Proposed Changes:

- The issue was related to recent refactorings of the Document class.
- To recreate the document from a dictionary, I correctly use `from_dict`

### How did you test it?

- CI
- [Colab example](https://colab.research.google.com/drive/17ZYL6MiohzSRHdJU_EJ5BQCzjQnOnQpf#scrollTo=XYuRkc7tljbK) is working

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
