### PR TITLE
Feat: Create code snippets for each component

### DIFF
--- a/examples/preview/retrievers/in_memory_bm25_documentsearch.py
+++ b/examples/preview/retrievers/in_memory_bm25_documentsearch.py
@@ -1,0 +1,28 @@
+from haystack.preview import Document
+from haystack.preview.components.retrievers import InMemoryBM25Retriever
+from haystack.preview.document_stores import InMemoryDocumentStore
+from haystack.preview.pipeline import Pipeline
+
+# Create components and a query pipeline
+document_store = InMemoryDocumentStore()
+retriever = InMemoryBM25Retriever(document_store=document_store)
+
+pipeline = Pipeline()
+pipeline.add_component(instance=retriever, name="retriever")
+
+# Add Documents
+documents = [
+    Document(content="There are over 7,000 languages spoken around the world today."),
+    Document(
+        content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."
+    ),
+    Document(
+        content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves."
+    ),
+]
+document_store.write_documents(documents)
+
+# Run the pipeline
+result = pipeline.run(data={"retriever": {"query": "How many languages are there?"}})
+
+print(result["retriever"]["documents"][0])

--- a/examples/preview/retrievers/in_memory_bm25_rag.py
+++ b/examples/preview/retrievers/in_memory_bm25_rag.py
@@ -1,0 +1,53 @@
+import os
+
+from haystack.preview import Document
+from haystack.preview import Pipeline
+from haystack.preview.components.builders.answer_builder import AnswerBuilder
+from haystack.preview.components.builders.prompt_builder import PromptBuilder
+from haystack.preview.components.generators import GPTGenerator
+from haystack.preview.components.retrievers import InMemoryBM25Retriever
+from haystack.preview.document_stores import InMemoryDocumentStore
+
+# Create a RAG query pipeline
+prompt_template = """
+    Given these documents, answer the question.\nDocuments:
+    {% for doc in documents %}
+        {{ doc.content }}
+    {% endfor %}
+
+    \nQuestion: {{question}}
+    \nAnswer:
+    """
+
+rag_pipeline = Pipeline()
+rag_pipeline.add_component(instance=InMemoryBM25Retriever(document_store=InMemoryDocumentStore()), name="retriever")
+rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
+rag_pipeline.add_component(instance=GPTGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
+rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
+rag_pipeline.connect("retriever", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("llm.replies", "answer_builder.replies")
+rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
+rag_pipeline.connect("retriever", "answer_builder.documents")
+
+# Draw the pipeline
+rag_pipeline.draw("./rag_pipeline.png")
+
+# Add Documents
+documents = [
+    Document(content="There are over 7,000 languages spoken around the world today."),
+    Document(
+        content="Elephants have been observed to behave in a way that indicates a high level of self-awareness, such as recognizing themselves in mirrors."
+    ),
+    Document(
+        content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves."
+    ),
+]
+rag_pipeline.get_component("retriever").document_store.write_documents(documents)
+
+# Run the pipeline
+question = "How many languages are there?"
+result = rag_pipeline.run(
+    {"retriever": {"query": question}, "prompt_builder": {"question": question}, "answer_builder": {"query": question}}
+)
+print(result["answer_builder"]["answers"][0])


### PR DESCRIPTION
## Motivation
We want code snippets for each component. During user interviews, our outstanding documentation came up a lot. Users also love our code snippets and want even more of them. We should ensure that we have code snippets for each component and that those code snippets work.


## Code snippets
- will showcase simple usage of each component: usage of the component itself, within a pipeline, or both
- keep code snippets on GitHub and their usage inside documentation in sync (TBD how we sync with docs, for now documentation team will be notified of any changes to existing snippets, as well as when snippets fail to run)
- will be tested only if they run through (to be clear: there will be no assertions on code level) 
- constitute of one .py file per code snippet
- we have a folder structure similar to /haystack/preview/components
- will be named name_of_component + use case, e.g. there examples/preview/retrievers/in_memory_bm25_rag.py

## Additions in this PR 
This PR specifically adds the first code examples for BM25 retrievers
I chose to create folders, instead of py packages (containing __init__) because I do not see any value in being able to import those code snippets. That also means that we need to add folders on a case-by-case basis.
