### PR TITLE
fix: `HuggingFaceLocalGenerator` - merge lazy import blocks

### DIFF
--- a/haystack/preview/components/generators/hugging_face_local.py
+++ b/haystack/preview/components/generators/hugging_face_local.py
@@ -9,12 +9,8 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
 
-with LazyImport(
-    message="PyTorch is needed to run this component. Please install it by following the instructions at https://pytorch.org/"
-) as torch_import:
+with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
     import torch
-
-with LazyImport(message="Run 'pip install transformers'") as transformers_import:
     from huggingface_hub import model_info
     from transformers import (
         pipeline,
@@ -127,8 +123,7 @@ class HuggingFaceLocalGenerator:
             For some chat models, the output includes both the new text and the original prompt.
             In these cases, it's important to make sure your prompt has no stop words.
         """
-        transformers_import.check()
-        torch_import.check()
+        torch_and_transformers_import.check()
 
         pipeline_kwargs = pipeline_kwargs or {}
         generation_kwargs = generation_kwargs or {}


### PR DESCRIPTION
### Related Issues

- fixes #6353 (added a comment to explain the bug)
 
### Proposed Changes:

- Merge the lazy import blocks of transformers and torch
- Make sure that the class `StopWordsCriteria` is contained in this block. It is required since it uses both transformers and torch.


### How did you test it?

Manual test on a fresh venv

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
