### PR TITLE
test: Prevent `pytest_generate_tests` from polluting `preview` tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,9 @@ def pytest_addoption(parser):
 
 
 def pytest_generate_tests(metafunc):
+    # Ugly hack to avoid polluting preview tests this with unwanted fixtures
+    if "test/preview" in metafunc.module.__file__ or "test\\preview" in metafunc.module.__file__:
+        return
     # Get selected docstores from CLI arg
     document_store_type = metafunc.config.option.document_store_type
     selected_doc_stores = [item.strip() for item in document_store_type.split(",")]


### PR DESCRIPTION
### Proposed Changes:

Make a small change in `pytest_generate_tests` to skip polluting `preview` tests with unwanted, hard to debug hidden parametrization.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

I discovered this after #6360. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
