### PR TITLE
refactor: Rework `delete_documents` tests

### DIFF
--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -12,7 +12,7 @@ from haystack.preview.document_stores.decorator import document_store
 from haystack.preview.dataclasses import Document
 from haystack.preview.document_stores.protocols import DuplicatePolicy
 from haystack.preview.utils.filters import document_matches_filter
-from haystack.preview.document_stores.errors import DuplicateDocumentError, MissingDocumentError, DocumentStoreError
+from haystack.preview.document_stores.errors import DuplicateDocumentError, DocumentStoreError
 from haystack.preview.utils import expit
 
 logger = logging.getLogger(__name__)

--- a/haystack/preview/document_stores/in_memory/document_store.py
+++ b/haystack/preview/document_stores/in_memory/document_store.py
@@ -198,13 +198,11 @@ class InMemoryDocumentStore:
     def delete_documents(self, document_ids: List[str]) -> None:
         """
         Deletes all documents with matching document_ids from the DocumentStore.
-        Fails with `MissingDocumentError` if no document with this id is present in the DocumentStore.
-
         :param object_ids: The object_ids to delete.
         """
         for doc_id in document_ids:
             if doc_id not in self.storage.keys():
-                raise MissingDocumentError(f"ID '{doc_id}' not found, cannot delete it.")
+                continue
             del self.storage[doc_id]
 
     def bm25_retrieval(


### PR DESCRIPTION
### Related Issues

Related to #6284

### Proposed Changes:

Rework tests for `delete_documents()`.

This PR also changes the expected behaviour of `delete_document()` to not fail when the specified to delete doesn't exist. That's much more sensible and makes the method idempotent. 

### How did you test it?

Ran tests locally.

### Notes for the reviewer

This is part of a series of PRs, I'll update release notes at the end.
Depends on #6362

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
