### PR TITLE
feat: make `DocumentWriter` return the actual number of documents written

### DIFF
--- a/haystack/preview/components/writers/document_writer.py
+++ b/haystack/preview/components/writers/document_writer.py
@@ -64,5 +64,5 @@ class DocumentWriter:
         if policy is None:
             policy = self.policy
 
-        self.document_store.write_documents(documents=documents, policy=policy)
-        return {"documents_written": len(documents)}
+        documents_written = self.document_store.write_documents(documents=documents, policy=policy)
+        return {"documents_written": documents_written}


### PR DESCRIPTION
### Related Issues

- #6362 requires the `write_documents` method of Document Stores to return the number of Documents actually written
- for the `InMemoryDocumentStore`, this was implemented in #6006

### Proposed Changes:

- align the Document Writer component with the `write_documents` method, making it return the actual number of Documents written (instead of the initial number of docs)

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
