### PR TITLE
fix: Add DocumentJoiner to routers' init

### DIFF
--- a/haystack/preview/components/routers/__init__.py
+++ b/haystack/preview/components/routers/__init__.py
@@ -1,5 +1,7 @@
+from haystack.preview.components.routers.document_joiner import DocumentJoiner
 from haystack.preview.components.routers.file_type_router import FileTypeRouter
 from haystack.preview.components.routers.metadata_router import MetadataRouter
 from haystack.preview.components.routers.text_language_router import TextLanguageRouter
 
-__all__ = ["FileTypeRouter", "MetadataRouter", "TextLanguageRouter"]
+
+__all__ = ["DocumentJoiner", "FileTypeRouter", "MetadataRouter", "TextLanguageRouter"]


### PR DESCRIPTION
### Related Issues

### Proposed Changes:

Add `DocumentJoiner` to routers' init to enable importing `from haystack.preview.components.routers import DocumentJoiner`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
