### PR TITLE
docs: Include TextEmbedder in DocumentJoiner usage example

### DIFF
--- a/haystack/preview/components/routers/document_joiner.py
+++ b/haystack/preview/components/routers/document_joiner.py
@@ -40,7 +40,7 @@ class DocumentJoiner:
     p.connect("embedding_retriever", "joiner")
     p.connect("text_embedder", "embedding_retriever")
     query = "What is the capital of France?"
-    p.run(data={"bm25_retriever": {"query": query}, 
+    p.run(data={"bm25_retriever": {"query": query},
                 "text_embedder": {"text": query}})
     ```
     """

--- a/haystack/preview/components/routers/document_joiner.py
+++ b/haystack/preview/components/routers/document_joiner.py
@@ -30,10 +30,18 @@ class DocumentJoiner:
     document_store = InMemoryDocumentStore()
     p = Pipeline()
     p.add_component(instance=InMemoryBM25Retriever(document_store=document_store), name="bm25_retriever")
+    p.add_component(
+            instance=SentenceTransformersTextEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
+            name="text_embedder",
+        )
     p.add_component(instance=InMemoryEmbeddingRetriever(document_store=document_store), name="embedding_retriever")
     p.add_component(instance=DocumentJoiner(), name="joiner")
     p.connect("bm25_retriever", "joiner")
     p.connect("embedding_retriever", "joiner")
+    p.connect("text_embedder", "embedding_retriever")
+    query = "What is the capital of France?"
+    p.run(data={"bm25_retriever": {"query": query}, 
+                "text_embedder": {"text": query}})
     ```
     """
 


### PR DESCRIPTION
### Related Issues

### Proposed Changes:

- Add TextEmbedder to DocumentJoiner usage example as the hybrid retrieval pipeline requires it

### How did you test it?

Ran the usage example manually

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
