### PR TITLE
fix: make `ExtractiveReader` handle situations where `token_to_chars` returns None instead of a (start, end) tuple

### DIFF
--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -222,7 +222,7 @@ class ExtractiveReader:
             [encoding.token_to_chars(start) for start in candidates]
             for candidates, encoding in zip(start_candidates, encodings)
         ]
-        if any(token_to_chars is None for token_to_chars in start_candidates_tokens_to_chars):
+        if any(any(pair is None for pair in token_to_chars) for token_to_chars in start_candidates_tokens_to_chars):
             logger.warning("Some starting tokens could not be found in the context.")
         start_candidates_char_indices = [
             [token_to_chars[0] if token_to_chars else None for token_to_chars in candidates]
@@ -233,7 +233,7 @@ class ExtractiveReader:
             [encoding.token_to_chars(end) for end in candidates]
             for candidates, encoding in zip(end_candidates, encodings)
         ]
-        if any(token_to_chars is None for token_to_chars in end_candidates_tokens_to_chars):
+        if any(any(pair is None for pair in token_to_chars) for token_to_chars in end_candidates_tokens_to_chars):
             logger.warning("Some end tokens could not be found in the context.")
         end_candidates_char_indices = [
             [token_to_chars[1] if token_to_chars else None for token_to_chars in candidates]

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -214,14 +214,24 @@ class ExtractiveReader:
         start_candidates = start_candidates.cpu()
         end_candidates = end_candidates.cpu()
 
-        start_candidates_char_indices = [
-            [encoding.token_to_chars(start)[0] for start in candidates]
+        start_candidates_tokens_to_chars = [
+            [encoding.token_to_chars(start) for start in candidates]
             for candidates, encoding in zip(start_candidates, encodings)
         ]
-        end_candidates_char_indices = [
-            [encoding.token_to_chars(end)[1] for end in candidates]
+        start_candidates_char_indices = [
+            [token_to_chars[0] if token_to_chars else None for token_to_chars in candidates]
+            for candidates in start_candidates_tokens_to_chars
+        ]
+
+        end_candidates_tokens_to_chars = [
+            [encoding.token_to_chars(end) for end in candidates]
             for candidates, encoding in zip(end_candidates, encodings)
         ]
+        end_candidates_char_indices = [
+            [token_to_chars[1] if token_to_chars else None for token_to_chars in candidates]
+            for candidates in end_candidates_tokens_to_chars
+        ]
+
         probabilities = candidates.values.cpu()
 
         return start_candidates_char_indices, end_candidates_char_indices, probabilities

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -222,8 +222,13 @@ class ExtractiveReader:
             [encoding.token_to_chars(start) for start in candidates]
             for candidates, encoding in zip(start_candidates, encodings)
         ]
-        if any(any(pair is None for pair in token_to_chars) for token_to_chars in start_candidates_tokens_to_chars):
-            logger.warning("Some starting tokens could not be found in the context.")
+        if missing_start_tokens := [
+            (batch, index)
+            for batch, token_to_chars in enumerate(start_candidates_tokens_to_chars)
+            for index, pair in enumerate(token_to_chars)
+            if pair is None
+        ]:
+            logger.warning("Some start tokens could not be found in the context: %s", missing_start_tokens)
         start_candidates_char_indices = [
             [token_to_chars[0] if token_to_chars else None for token_to_chars in candidates]
             for candidates in start_candidates_tokens_to_chars
@@ -233,8 +238,13 @@ class ExtractiveReader:
             [encoding.token_to_chars(end) for end in candidates]
             for candidates, encoding in zip(end_candidates, encodings)
         ]
-        if any(any(pair is None for pair in token_to_chars) for token_to_chars in end_candidates_tokens_to_chars):
-            logger.warning("Some end tokens could not be found in the context.")
+        if missing_end_tokens := [
+            (batch, index)
+            for batch, token_to_chars in enumerate(end_candidates_tokens_to_chars)
+            for index, pair in enumerate(token_to_chars)
+            if pair is None
+        ]:
+            logger.warning("Some end tokens could not be found in the context: %s", missing_end_tokens)
         end_candidates_char_indices = [
             [token_to_chars[1] if token_to_chars else None for token_to_chars in candidates]
             for candidates in end_candidates_tokens_to_chars

--- a/haystack/preview/components/readers/extractive.py
+++ b/haystack/preview/components/readers/extractive.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 import math
 import warnings
+import logging
 import os
 
 from haystack.preview import component, default_to_dict, ComponentError, Document, ExtractedAnswer
@@ -11,6 +12,9 @@ with LazyImport("Run 'pip install transformers[torch,sentencepiece]'") as torch_
     from transformers import AutoModelForQuestionAnswering, AutoTokenizer
     from tokenizers import Encoding
     import torch
+
+
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -218,6 +222,8 @@ class ExtractiveReader:
             [encoding.token_to_chars(start) for start in candidates]
             for candidates, encoding in zip(start_candidates, encodings)
         ]
+        if any(token_to_chars is None for token_to_chars in start_candidates_tokens_to_chars):
+            logger.warning("Some starting tokens could not be found in the context.")
         start_candidates_char_indices = [
             [token_to_chars[0] if token_to_chars else None for token_to_chars in candidates]
             for candidates in start_candidates_tokens_to_chars
@@ -227,6 +233,8 @@ class ExtractiveReader:
             [encoding.token_to_chars(end) for end in candidates]
             for candidates, encoding in zip(end_candidates, encodings)
         ]
+        if any(token_to_chars is None for token_to_chars in end_candidates_tokens_to_chars):
+            logger.warning("Some end tokens could not be found in the context.")
         end_candidates_char_indices = [
             [token_to_chars[1] if token_to_chars else None for token_to_chars in candidates]
             for candidates in end_candidates_tokens_to_chars

--- a/test/preview/components/readers/test_extractive.py
+++ b/test/preview/components/readers/test_extractive.py
@@ -269,6 +269,79 @@ def test_warm_up_use_hf_token(mocked_automodel, mocked_autotokenizer):
     mocked_autotokenizer.assert_called_once_with("deepset/roberta-base-squad2", token="fake-token")
 
 
+@pytest.mark.unit
+def test_missing_token_to_chars_values():
+    # See https://github.com/deepset-ai/haystack/issues/6098
+
+    def mock_tokenize(
+        texts: List[str],
+        text_pairs: List[str],
+        padding: bool,
+        truncation: bool,
+        max_length: int,
+        return_tensors: str,
+        return_overflowing_tokens: bool,
+        stride: int,
+    ):
+        assert padding
+        assert truncation
+        assert return_tensors == "pt"
+        assert return_overflowing_tokens
+
+        tokens = Mock()
+
+        num_splits = [ceil(len(text + pair) / max_length) for text, pair in zip(texts, text_pairs)]
+        tokens.overflow_to_sample_mapping = [i for i, num in enumerate(num_splits) for _ in range(num)]
+        num_samples = sum(num_splits)
+        tokens.encodings = [Mock() for _ in range(num_samples)]
+        sequence_ids = [0] * 16 + [1] * 16 + [None] * (max_length - 32)
+        for encoding in tokens.encodings:
+            encoding.sequence_ids = sequence_ids
+            encoding.token_to_chars = lambda i: None
+        tokens.input_ids = torch.zeros(num_samples, max_length, dtype=torch.int)
+        attention_mask = torch.zeros(num_samples, max_length, dtype=torch.int)
+        attention_mask[:32] = 1
+        tokens.attention_mask = attention_mask
+        return tokens
+
+    class MockModel(torch.nn.Module):
+        def to(self, device):
+            assert device == "cpu:0"
+            self.device_set = True
+            return self
+
+        def forward(self, input_ids, attention_mask, *args, **kwargs):
+            assert input_ids.device == torch.device("cpu")
+            assert attention_mask.device == torch.device("cpu")
+            assert self.device_set
+            start = torch.zeros(input_ids.shape[:2])
+            end = torch.zeros(input_ids.shape[:2])
+            start[:, 27] = 1
+            end[:, 31] = 1
+            end[:, 32] = 1
+            prediction = Mock()
+            prediction.start_logits = start
+            prediction.end_logits = end
+            return prediction
+
+    with patch("haystack.preview.components.readers.extractive.AutoTokenizer.from_pretrained") as tokenizer, patch(
+        "haystack.preview.components.readers.extractive.AutoModelForQuestionAnswering.from_pretrained"
+    ) as model:
+        tokenizer.return_value = mock_tokenize
+        model.return_value = MockModel()
+        reader = ExtractiveReader(model_name_or_path="mock-model", device="cpu:0")
+        reader.warm_up()
+
+        answers = reader.run(example_queries[0], example_documents[0], top_k=3)[
+            "answers"
+        ]  # [0] Uncomment and remove first two indices when batching support is reintroduced
+        for doc, answer in zip(example_documents[0], answers[:3]):
+            assert answer.start is None
+            assert answer.end is None
+            assert doc.content is not None
+            assert answer.data == doc.content
+
+
 @pytest.mark.integration
 def test_t5():
     reader = ExtractiveReader("TARUNBHATT/flan-t5-small-finetuned-squad")


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/6098

### Proposed Changes:

Some tokenizers seems to have their `token_to_chars` function returning None on some inputs, while the function should always return a tuple as long as the token is in the context, according to its own docstring. 

Considering that this is likely a bug of the tokenizer, and to prevent such issues from crashing the reader, I propose to use None as start/end positions when this bug occurs. This choice means that if the starting token points to position None, it will match the start of the document, and if the end token points to position None, it will match the end of the document. Such occurrences are logged.

Alternatively we could raise an error message, but the source of this behavior is unclear and likely tokenizer-dependent, see https://github.com/huggingface/transformers/issues/1662, https://github.com/huggingface/transformers/issues/8209.

### How did you test it?

Added a new unit test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
