### PR TITLE
fix: fix type hints on `DocumentStore` protocol

### DIFF
--- a/haystack/preview/document_stores/protocols.py
+++ b/haystack/preview/document_stores/protocols.py
@@ -29,17 +29,20 @@ class DocumentStore(Protocol):
         """
         Serializes this store to a dictionary.
         """
+        ...
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "DocumentStore":
         """
         Deserializes the store from a dictionary.
         """
+        ...
 
     def count_documents(self) -> int:
         """
         Returns the number of documents stored.
         """
+        ...
 
     def filter_documents(self, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         """
@@ -112,6 +115,7 @@ class DocumentStore(Protocol):
         :param filters: the filters to apply to the document list.
         :return: a list of Documents that match the given filters.
         """
+        ...
 
     def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> int:
         """
@@ -128,6 +132,7 @@ class DocumentStore(Protocol):
             If DuplicatePolicy.OVERWRITE is used, this number is always equal to the number of documents in input.
             If DuplicatePolicy.SKIP is used, this number can be lower than the number of documents in the input list.
         """
+        ...
 
     def delete_documents(self, document_ids: List[str]) -> None:
         """
@@ -136,3 +141,4 @@ class DocumentStore(Protocol):
 
         :param object_ids: the object_ids to delete
         """
+        ...

--- a/haystack/preview/document_stores/protocols.py
+++ b/haystack/preview/document_stores/protocols.py
@@ -5,6 +5,9 @@ from enum import Enum
 from haystack.preview.dataclasses import Document
 
 
+# Ellipsis are needed for the type checker, it's safe to disable module-wide
+# pylint: disable=unnecessary-ellipsis
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
### Related Issues

Pyright reporting 

> Function with declared return type "int" must return value on all code paths

on the protocol methods definitions

### Proposed Changes:

Use an ellipsis to signal the type checker that the method will be implemented eventually

### How did you test it?

Locally tested with pyright, mypy was already happy with the previous code

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
