### PR TITLE
fix!: make `PyPDFToDocument` JSON-serializable

### DIFF
--- a/haystack/preview/components/converters/pypdf.py
+++ b/haystack/preview/components/converters/pypdf.py
@@ -55,9 +55,6 @@ class PyPDFToDocument:
         """
         pypdf_import.check()
 
-        if not isinstance(converter_name, str):
-            raise TypeError(f"converter_name must be a string, got {type(converter_name)}")
-        self.converter_name = converter_name
         try:
             converter = CONVERTERS_REGISTRY[converter_name]
         except KeyError:
@@ -65,6 +62,7 @@ class PyPDFToDocument:
                 f"Invalid converter_name: {converter_name}.\n Available converters: {list(CONVERTERS_REGISTRY.keys())}"
             )
             raise ValueError(msg) from KeyError
+        self.converter_name = converter_name
         self._converter: PyPDFConverter = converter
 
     def to_dict(self):

--- a/haystack/preview/components/converters/pypdf.py
+++ b/haystack/preview/components/converters/pypdf.py
@@ -54,8 +54,18 @@ class PyPDFToDocument:
             Defaults to 'default'.
         """
         pypdf_import.check()
+
+        if not isinstance(converter_name, str):
+            raise TypeError(f"converter_name must be a string, got {type(converter_name)}")
         self.converter_name = converter_name
-        self._converter: PyPDFConverter = CONVERTERS_REGISTRY[converter_name]
+        try:
+            converter = CONVERTERS_REGISTRY[converter_name]
+        except KeyError:
+            msg = (
+                f"Invalid converter_name: {converter_name}.\n Available converters: {list(CONVERTERS_REGISTRY.keys())}"
+            )
+            raise ValueError(msg) from KeyError
+        self._converter: PyPDFConverter = converter
 
     def to_dict(self):
         # do not serialize the _converter instance

--- a/haystack/preview/components/converters/pypdf.py
+++ b/haystack/preview/components/converters/pypdf.py
@@ -50,7 +50,7 @@ class PyPDFToDocument:
     def __init__(self, converter_name: str = "default"):
         """
         Initializes the PyPDFToDocument component with an optional custom converter.
-        :param converter_name: A converter name that is registered in the CONVERTER_REGISTRY.
+        :param converter_name: A converter name that is registered in the CONVERTERS_REGISTRY.
             Defaults to 'default'.
         """
         pypdf_import.check()

--- a/releasenotes/notes/fix-pypdf-serialization-93744fd01ef5b841.yaml
+++ b/releasenotes/notes/fix-pypdf-serialization-93744fd01ef5b841.yaml
@@ -1,0 +1,5 @@
+---
+preview:
+  - |
+    Make `PyPDFToDocument` accept a `converter_name` parameter instead of
+    a `converter` instance, to allow a smooth serialization of the component.

--- a/test/preview/components/converters/test_pypdf_to_document.py
+++ b/test/preview/components/converters/test_pypdf_to_document.py
@@ -4,6 +4,7 @@ from pypdf import PdfReader
 
 from haystack.preview import Document
 from haystack.preview.components.converters.pypdf import PyPDFToDocument
+from haystack.preview.components.converters.pypdf import CONVERTERS_REGISTRY
 from haystack.preview.dataclasses import ByteStream
 
 
@@ -58,7 +59,10 @@ class TestPyPDFToDocument:
             def convert(self, reader: PdfReader) -> Document:
                 return Document(content="I don't care about converting given pdfs, I always return this")
 
-        converter = PyPDFToDocument(converter=MyCustomConverter())
+        CONVERTERS_REGISTRY["custom"] = MyCustomConverter()
+
+        converter = PyPDFToDocument(converter_name="custom")
+        print(converter._converter)
         output = converter.run(sources=paths)
         docs = output["documents"]
         assert len(docs) == 1

--- a/test/preview/components/converters/test_pypdf_to_document.py
+++ b/test/preview/components/converters/test_pypdf_to_document.py
@@ -13,10 +13,6 @@ class TestPyPDFToDocument:
         assert component.converter_name == "default"
         assert hasattr(component, "_converter")
 
-    def test_init_fail_non_string_converter_name(self):
-        with pytest.raises(TypeError):
-            PyPDFToDocument(converter_name=[1, 2, 3])
-
     def test_init_fail_nonexisting_converter(self):
         with pytest.raises(ValueError):
             PyPDFToDocument(converter_name="non_existing_converter")

--- a/test/preview/components/converters/test_pypdf_to_document.py
+++ b/test/preview/components/converters/test_pypdf_to_document.py
@@ -3,12 +3,24 @@ import pytest
 from pypdf import PdfReader
 
 from haystack.preview import Document
-from haystack.preview.components.converters.pypdf import PyPDFToDocument
-from haystack.preview.components.converters.pypdf import CONVERTERS_REGISTRY
+from haystack.preview.components.converters.pypdf import PyPDFToDocument, CONVERTERS_REGISTRY
 from haystack.preview.dataclasses import ByteStream
 
 
 class TestPyPDFToDocument:
+    def test_init(self):
+        component = PyPDFToDocument()
+        assert component.converter_name == "default"
+        assert hasattr(component, "_converter")
+
+    def test_init_fail_non_string_converter_name(self):
+        with pytest.raises(TypeError):
+            PyPDFToDocument(converter_name=[1, 2, 3])
+
+    def test_init_fail_nonexisting_converter(self):
+        with pytest.raises(ValueError):
+            PyPDFToDocument(converter_name="non_existing_converter")
+
     @pytest.mark.unit
     def test_run(self, preview_samples_path):
         """

--- a/test/preview/components/converters/test_pypdf_to_document.py
+++ b/test/preview/components/converters/test_pypdf_to_document.py
@@ -70,7 +70,6 @@ class TestPyPDFToDocument:
         CONVERTERS_REGISTRY["custom"] = MyCustomConverter()
 
         converter = PyPDFToDocument(converter_name="custom")
-        print(converter._converter)
         output = converter.run(sources=paths)
         docs = output["documents"]
         assert len(docs) == 1


### PR DESCRIPTION
### Related Issues

- fixes #6388

### Proposed Changes:
The component accepted an object (`converter`) as an initialization parameter and this made the serialization/deserialization fail.

After discussing with @masci, we decided to:
- create a registry of available converters
- accept `converter_name` instead of `converter`

In the most common use case, we still use the same default converter.
The advanced user can insert its custom converter in the registry.

While not great from the UX perspective, it seems a good temporary solution that we can refine in the future.


### How did you test it?

CI, new test, manual tests based on #6388

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
