### PR TITLE
chore: Remove `pydoc-markdown` from dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,6 @@ dev = [
   "pylint",
   "farm-haystack[formatting]",
   # Documentation
-  "pydoc-markdown",
   "toml",
   "reno",
   # dulwich is a reno dependency, they pin it at >=0.15.0 so pip takes ton of time to resolve the dependency tree.

--- a/rest_api/pyproject.toml
+++ b/rest_api/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "farm-haystack",
-    "fastapi<0.104.0",  # https://github.com/deepset-ai/haystack/issues/6119
+    "fastapi",
     "uvicorn<1",
     "python-multipart<1",  # optional FastAPI dependency for form data
     "pynvml",


### PR DESCRIPTION
### Related Issues

Fixed #6119

### Proposed Changes:

Remove `pydoc-markdown` dependency from `dev` extra.

`pydoc-markdown` is only used in `readme_sync.yml` workflow and is also installed via `docs/pydoc/requirements.txt` ignoring Haystack `pyproject.toml`.

So it's safe to remove.

This also unpins `fastapi` version in `rest_api`.

### How did you test it?

There's nothing much to test really.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
