### PR TITLE
feat: Ready-made RAG pipeline

### DIFF
--- a/haystack/preview/ready_made_pipelines/__init__.py
+++ b/haystack/preview/ready_made_pipelines/__init__.py
@@ -1,0 +1,3 @@
+from haystack.preview.ready_made_pipelines.rag import RAGPipeline
+
+__all__ = ["RAGPipeline"]

--- a/haystack/preview/ready_made_pipelines/rag.py
+++ b/haystack/preview/ready_made_pipelines/rag.py
@@ -1,0 +1,97 @@
+from typing import Optional, List
+
+from haystack.preview import Pipeline
+from haystack.preview.dataclasses import Answer
+from haystack.preview.document_stores import InMemoryDocumentStore
+from haystack.preview.components.retrievers import InMemoryBM25Retriever, InMemoryEmbeddingRetriever
+from haystack.preview.components.embedders import SentenceTransformersTextEmbedder
+from haystack.preview.components.generators import GPTGenerator
+from haystack.preview.components.builders.answer_builder import AnswerBuilder
+from haystack.preview.components.builders.prompt_builder import PromptBuilder
+
+
+class RAGPipeline(Pipeline):
+    """
+    A simple ready-made pipeline for RAG. It requires a populated document store.
+
+    If an embedding model is given, it uses embedding retrieval. Otherwise it falls back to BM25 retrieval.
+
+    Example usage:
+
+    ```python
+    rag_pipe = RAGPipeline(document_store=InMemoryDocumentStore())
+    answers = rag_pipe.run(query="Who lives in Rome?", top_k=2)
+    >>> [Answer(data="Giorgio"), Answer(data="Giorgio lives in Rome")]
+    ```
+
+    """
+
+    def __init__(
+        self,
+        document_store: InMemoryDocumentStore,
+        generation_model: str = "gpt-3.5-turbo",
+        prompt_template: Optional[str] = None,
+        embedding_model: Optional[str] = None,
+    ):
+        """
+        :param document_store: An instance of a DocumentStore to retrieve documents from.
+        :param generation_model: The name of the model to use for generation.
+        :param prompt_template: The template to use for the prompt. If not given, a default template is used.
+        :param embedding_model: The name of the model to use for embedding. If not given, BM25 is used.
+        """
+        prompt_template = (
+            prompt_template
+            or """
+        Given these documents, answer the question.
+
+        Documents:
+        {% for doc in documents %}
+            {{ doc.content }}
+        {% endfor %}
+
+        Question: {{question}}
+
+        Answer:
+        """
+        )
+        if not isinstance(document_store, InMemoryDocumentStore):
+            raise ValueError("RAGPipeline only works with an InMemoryDocumentStore.")
+
+        self.pipeline = Pipeline()
+
+        if embedding_model:
+            self.pipeline.add_component(
+                instance=SentenceTransformersTextEmbedder(model_name_or_path=embedding_model), name="text_embedder"
+            )
+            self.pipeline.add_component(
+                instance=InMemoryEmbeddingRetriever(document_store=InMemoryDocumentStore()), name="retriever"
+            )
+            self.pipeline.connect("text_embedder", "retriever")
+        else:
+            self.pipeline.add_component(
+                instance=InMemoryBM25Retriever(document_store=InMemoryDocumentStore()), name="retriever"
+            )
+
+        self.pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
+        self.pipeline.add_component(instance=GPTGenerator(model_name=generation_model), name="llm")
+        self.pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
+        self.pipeline.connect("retriever", "prompt_builder.documents")
+        self.pipeline.connect("prompt_builder.prompt", "llm.prompt")
+        self.pipeline.connect("llm.replies", "answer_builder.replies")
+        self.pipeline.connect("llm.metadata", "answer_builder.metadata")
+        self.pipeline.connect("retriever", "answer_builder.documents")
+
+    def run(self, query: str) -> Answer:
+        """
+        Performs RAG using the given query.
+
+        :param query: The query to ask.
+        :return: A Answer object.
+        """
+        run_values = {"prompt_builder": {"question": query}, "answer_builder": {"query": query}}
+        if self.pipeline.graph.nodes.get("text_embedder"):
+            run_values["text_embedder"] = {"query": query}
+        else:
+            run_values["retriever"] = {"query": query}
+
+        return self.pipeline.run(run_values)["answer_builder"]["answers"][0]

--- a/haystack/preview/ready_made_pipelines/rag.py
+++ b/haystack/preview/ready_made_pipelines/rag.py
@@ -20,8 +20,8 @@ class RAGPipeline(Pipeline):
 
     ```python
     rag_pipe = RAGPipeline(document_store=InMemoryDocumentStore())
-    answers = rag_pipe.run(query="Who lives in Rome?", top_k=2)
-    >>> [Answer(data="Giorgio"), Answer(data="Giorgio lives in Rome")]
+    answers = rag_pipe.run(query="Who lives in Rome?")
+    >>> Answer(data="Giorgio")
     ```
 
     """

--- a/haystack/preview/ready_made_pipelines/rag.py
+++ b/haystack/preview/ready_made_pipelines/rag.py
@@ -10,7 +10,7 @@ from haystack.preview.components.builders.answer_builder import AnswerBuilder
 from haystack.preview.components.builders.prompt_builder import PromptBuilder
 
 
-class RAGPipeline(Pipeline):
+class RAGPipeline:
     """
     A simple ready-made pipeline for RAG. It requires a populated document store.
 

--- a/releasenotes/notes/ready-made-rag-pipeline-f0726624d3db4449.yaml
+++ b/releasenotes/notes/ready-made-rag-pipeline-f0726624d3db4449.yaml
@@ -1,0 +1,2 @@
+preview:
+  - Introduce RAGPipeline

--- a/test/preview/ready_made_pipelines/test_rag.py
+++ b/test/preview/ready_made_pipelines/test_rag.py
@@ -39,8 +39,8 @@ def mock_chat_completion():
 
 def test_rag_pipeline(mock_chat_completion):
     rag_pipe = RAGPipeline(document_store=InMemoryDocumentStore())
-    answers = rag_pipe.run(query="question")
-    assert isinstance(answers[0], Answer)
+    answer = rag_pipe.run(query="question")
+    assert isinstance(answer, Answer)
 
 
 def test_rag_pipeline_other_docstore():

--- a/test/preview/ready_made_pipelines/test_rag.py
+++ b/test/preview/ready_made_pipelines/test_rag.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch, Mock
+import pytest
+
+from haystack.preview.dataclasses import Answer
+from haystack.preview.testing.factory import document_store_class
+from haystack.preview.document_stores import InMemoryDocumentStore
+from haystack.preview.ready_made_pipelines.rag import RAGPipeline
+
+
+@pytest.fixture
+def mock_chat_completion():
+    """
+    Mock the OpenAI API completion response and reuse it for tests
+    """
+    with patch("openai.ChatCompletion.create", autospec=True) as mock_chat_completion_create:
+        # mimic the response from the OpenAI API
+        mock_choice = Mock()
+        mock_choice.index = 0
+        mock_choice.finish_reason = "stop"
+
+        mock_message = Mock()
+        mock_message.content = "I'm fine, thanks. How are you?"
+        mock_message.role = "user"
+
+        mock_choice.message = mock_message
+
+        mock_response = Mock()
+        mock_response.model = "gpt-3.5-turbo"
+        mock_response.usage = Mock()
+        mock_response.usage.items.return_value = [
+            ("prompt_tokens", 57),
+            ("completion_tokens", 40),
+            ("total_tokens", 97),
+        ]
+        mock_response.choices = [mock_choice]
+        mock_chat_completion_create.return_value = mock_response
+        yield mock_chat_completion_create
+
+
+def test_rag_pipeline(mock_chat_completion):
+    rag_pipe = RAGPipeline(document_store=InMemoryDocumentStore())
+    answers = rag_pipe.run(query="question")
+    assert isinstance(answers[0], Answer)
+
+
+def test_rag_pipeline_other_docstore():
+    FakeStore = document_store_class("FakeStore")
+    with pytest.raises(ValueError, match="InMemoryDocumentStore"):
+        assert RAGPipeline(document_store=FakeStore())
+
+
+def test_rag_pipeline_no_embedder_if_no_model():
+    rag_pipe = RAGPipeline(document_store=InMemoryDocumentStore())
+    assert "text_embedder" not in rag_pipe.pipeline.graph.nodes
+
+
+def test_rag_pipeline_embedder_exist_if_model_is_given():
+    rag_pipe = RAGPipeline(
+        document_store=InMemoryDocumentStore(), embedding_model="sentence-transformers/all-mpnet-base-v2"
+    )
+    assert "text_embedder" in rag_pipe.pipeline.graph.nodes


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/5992

### Proposed Changes:

 Adds a very simple wrapper over Pipeline, called RAGPipeline, that performs RAG. Allows for minimal customizations at the moment.

### How did you test it?

New test suite.

### Notes for the reviewer

See related issue.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
