### PR TITLE
chore: add `PptxConverter` to pydoc configuration

### DIFF
--- a/docs/pydoc/config/file-converters.yml
+++ b/docs/pydoc/config/file-converters.yml
@@ -3,16 +3,17 @@ loaders:
     search_path: [../../../haystack/nodes/file_converter]
     modules:
       [
+        "azure",
         "csv",
         "docx",
         "image",
-        "markdown",
-        "pdf",
-        "parsr",
-        "azure",
-        "tika",
-        "txt",
         "json",
+        "markdown",
+        "parsr",
+        "pdf",
+        "pptx",
+        "tika",
+        "txt"
       ]
     ignore_when_discovered: ["__init__"]
 processors:


### PR DESCRIPTION
### Related Issues

- `PptxConverter` was introduced in #6399, but I forgot to to create an entry in pydoc config

### Proposed Changes:

- Add the entry to pydoc config
- (sort the entries in alphabetical order)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
