### PR TITLE
Fix wrong import in `cohere.py` and change `model` to `model_name` for consistency

### DIFF
--- a/haystack/preview/components/generators/cohere.py
+++ b/haystack/preview/components/generators/cohere.py
@@ -31,7 +31,7 @@ class CohereGenerator:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model: str = "command",
+        model_name: str = "command",
         streaming_callback: Optional[Callable] = None,
         api_base_url: str = COHERE_API_URL,
         **kwargs,
@@ -69,7 +69,7 @@ class CohereGenerator:
             )
 
         self.api_key = api_key
-        self.model = model
+        self.model_name = model_name
         self.streaming_callback = streaming_callback
         self.api_base_url = api_base_url
         self.model_parameters = kwargs
@@ -90,7 +90,7 @@ class CohereGenerator:
 
         return default_to_dict(
             self,
-            model=self.model,
+            model_name=self.model_name,
             streaming_callback=callback_name,
             api_base_url=self.api_base_url,
             **self.model_parameters,
@@ -123,7 +123,7 @@ class CohereGenerator:
         :param prompt: The prompt to be sent to the generative model.
         """
         response = self.client.generate(
-            model=self.model, prompt=prompt, stream=self.streaming_callback is not None, **self.model_parameters
+            model=self.model_name, prompt=prompt, stream=self.streaming_callback is not None, **self.model_parameters
         )
         if self.streaming_callback:
             metadata_dict: Dict[str, Any] = {}

--- a/haystack/preview/components/generators/cohere.py
+++ b/haystack/preview/components/generators/cohere.py
@@ -3,7 +3,7 @@ import os
 import sys
 from typing import Any, Callable, Dict, List, Optional
 
-from haystack.lazy_imports import LazyImport
+from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import DeserializationError, component, default_from_dict, default_to_dict
 
 with LazyImport(message="Run 'pip install cohere'") as cohere_import:

--- a/test/preview/components/generators/test_cohere_generators.py
+++ b/test/preview/components/generators/test_cohere_generators.py
@@ -54,7 +54,7 @@ class TestGPTGenerator:
     def test_to_dict_with_parameters(self):
         component = CohereGenerator(
             api_key="test-api-key",
-            momodel_namedel="command-light",
+            model_name="command-light",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=default_streaming_callback,

--- a/test/preview/components/generators/test_cohere_generators.py
+++ b/test/preview/components/generators/test_cohere_generators.py
@@ -140,7 +140,7 @@ class TestGPTGenerator:
     )
     @pytest.mark.integration
     def test_cohere_generator_run_wrong_model_name(self):
-        component = CohereGenerator(model="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY"))
+        component = CohereGenerator(model_name="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY"))
         with pytest.raises(
             cohere.CohereAPIError,
             match="model not found, make sure the correct model ID was used and that you have access to the model.",

--- a/test/preview/components/generators/test_cohere_generators.py
+++ b/test/preview/components/generators/test_cohere_generators.py
@@ -18,7 +18,7 @@ class TestGPTGenerator:
     def test_init_default(self):
         component = CohereGenerator(api_key="test-api-key")
         assert component.api_key == "test-api-key"
-        assert component.model == "command"
+        assert component.model_name == "command"
         assert component.streaming_callback is None
         assert component.api_base_url == cohere.COHERE_API_URL
         assert component.model_parameters == {}
@@ -27,14 +27,14 @@ class TestGPTGenerator:
         callback = lambda x: x
         component = CohereGenerator(
             api_key="test-api-key",
-            model="command-light",
+            model_name="command-light",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=callback,
             api_base_url="test-base-url",
         )
         assert component.api_key == "test-api-key"
-        assert component.model == "command-light"
+        assert component.model_name == "command-light"
         assert component.streaming_callback == callback
         assert component.api_base_url == "test-base-url"
         assert component.model_parameters == {"max_tokens": 10, "some_test_param": "test-params"}
@@ -44,13 +44,13 @@ class TestGPTGenerator:
         data = component.to_dict()
         assert data == {
             "type": "haystack.preview.components.generators.cohere.CohereGenerator",
-            "init_parameters": {"model": "command", "streaming_callback": None, "api_base_url": cohere.COHERE_API_URL},
+            "init_parameters": {"model_name": "command", "streaming_callback": None, "api_base_url": cohere.COHERE_API_URL},
         }
 
     def test_to_dict_with_parameters(self):
         component = CohereGenerator(
             api_key="test-api-key",
-            model="command-light",
+            momodel_namedel="command-light",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=default_streaming_callback,
@@ -60,7 +60,7 @@ class TestGPTGenerator:
         assert data == {
             "type": "haystack.preview.components.generators.cohere.CohereGenerator",
             "init_parameters": {
-                "model": "command-light",
+                "model_name": "command-light",
                 "max_tokens": 10,
                 "some_test_param": "test-params",
                 "api_base_url": "test-base-url",
@@ -71,7 +71,7 @@ class TestGPTGenerator:
     def test_to_dict_with_lambda_streaming_callback(self):
         component = CohereGenerator(
             api_key="test-api-key",
-            model="command",
+            model_name="command",
             max_tokens=10,
             some_test_param="test-params",
             streaming_callback=lambda x: x,
@@ -81,7 +81,7 @@ class TestGPTGenerator:
         assert data == {
             "type": "haystack.preview.components.generators.cohere.CohereGenerator",
             "init_parameters": {
-                "model": "command",
+                "model_name": "command",
                 "streaming_callback": "test_cohere_generators.<lambda>",
                 "api_base_url": "test-base-url",
                 "max_tokens": 10,
@@ -94,7 +94,7 @@ class TestGPTGenerator:
         data = {
             "type": "haystack.preview.components.generators.cohere.CohereGenerator",
             "init_parameters": {
-                "model": "command",
+                "model_name": "command",
                 "max_tokens": 10,
                 "some_test_param": "test-params",
                 "api_base_url": "test-base-url",
@@ -103,7 +103,7 @@ class TestGPTGenerator:
         }
         component = CohereGenerator.from_dict(data)
         assert component.api_key == "test-key"
-        assert component.model == "command"
+        assert component.model_name == "command"
         assert component.streaming_callback == default_streaming_callback
         assert component.api_base_url == "test-base-url"
         assert component.model_parameters == {"max_tokens": 10, "some_test_param": "test-params"}

--- a/test/preview/components/generators/test_cohere_generators.py
+++ b/test/preview/components/generators/test_cohere_generators.py
@@ -44,7 +44,11 @@ class TestGPTGenerator:
         data = component.to_dict()
         assert data == {
             "type": "haystack.preview.components.generators.cohere.CohereGenerator",
-            "init_parameters": {"model_name": "command", "streaming_callback": None, "api_base_url": cohere.COHERE_API_URL},
+            "init_parameters": {
+                "model_name": "command",
+                "streaming_callback": None,
+                "api_base_url": cohere.COHERE_API_URL,
+            },
         }
 
     def test_to_dict_with_parameters(self):


### PR DESCRIPTION
### Related Issues

- fixes failing import in `haystack-ai`

### Proposed Changes:

- `from haystack.lazy_import` --> `from haystack.preview.lazy_import` in `cohere.py` (the [recently introduced](https://github.com/deepset-ai/haystack/pull/6395) `CohereGenerator`)
- renames `model` to `model_name` for consistency

### How did you test it?

CI

### Notes for the reviewer

@bilgeyucel 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
