### PR TITLE
fix: Cohere - better handling of `COHERE_API_URL`

### DIFF
--- a/haystack/preview/components/generators/cohere.py
+++ b/haystack/preview/components/generators/cohere.py
@@ -7,9 +7,12 @@ from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import DeserializationError, component, default_from_dict, default_to_dict
 
 with LazyImport(message="Run 'pip install cohere'") as cohere_import:
-    from cohere import Client, COHERE_API_URL
+    from cohere import Client
 
 logger = logging.getLogger(__name__)
+
+
+COHERE_API_URL = "https://api.cohere.ai"
 
 
 @component

--- a/haystack/preview/components/generators/cohere.py
+++ b/haystack/preview/components/generators/cohere.py
@@ -7,12 +7,9 @@ from haystack.preview.lazy_imports import LazyImport
 from haystack.preview import DeserializationError, component, default_from_dict, default_to_dict
 
 with LazyImport(message="Run 'pip install cohere'") as cohere_import:
-    from cohere import Client
+    from cohere import Client, COHERE_API_URL
 
 logger = logging.getLogger(__name__)
-
-
-COHERE_API_URL = "https://api.cohere.ai"
 
 
 @component
@@ -36,7 +33,7 @@ class CohereGenerator:
         api_key: Optional[str] = None,
         model_name: str = "command",
         streaming_callback: Optional[Callable] = None,
-        api_base_url: str = COHERE_API_URL,
+        api_base_url: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -64,12 +61,17 @@ class CohereGenerator:
                           The format is {token_id: bias} where bias is a float between -10 and 10.
 
         """
+        cohere_import.check()
+
         if not api_key:
             api_key = os.environ.get("COHERE_API_KEY")
         if not api_key:
             raise ValueError(
                 "CohereGenerator needs an API key to run. Either provide it as init parameter or set the env var COHERE_API_KEY."
             )
+
+        if not api_base_url:
+            api_base_url = COHERE_API_URL
 
         self.api_key = api_key
         self.model_name = model_name


### PR DESCRIPTION
### Related Issues

`from haystack.preview.components.generators import GPTGenerator`

fails:

```
NameError                                 Traceback (most recent call last)
[<ipython-input-7-eb9e460423a2>](https://localhost:8080/#) in <cell line: 3>()
      1 from haystack.preview import Pipeline
      2 from haystack.preview.components.builders.prompt_builder import PromptBuilder
----> 3 from haystack.preview.components.generators import GPTGenerator
      4 
      5 prompt_template = """

2 frames
[/usr/local/lib/python3.10/dist-packages/haystack/preview/components/generators/__init__.py](https://localhost:8080/#) in <module>
----> 1 from haystack.preview.components.generators.cohere import CohereGenerator
      2 from haystack.preview.components.generators.hugging_face_local import HuggingFaceLocalGenerator
      3 from haystack.preview.components.generators.hugging_face_tgi import HuggingFaceTGIGenerator
      4 from haystack.preview.components.generators.openai import GPTGenerator
      5 

[/usr/local/lib/python3.10/dist-packages/haystack/preview/components/generators/cohere.py](https://localhost:8080/#) in <module>
     14 
     15 @component
---> 16 class CohereGenerator:
     17     """LLM Generator compatible with Cohere's generate endpoint.
     18 

[/usr/local/lib/python3.10/dist-packages/haystack/preview/components/generators/cohere.py](https://localhost:8080/#) in CohereGenerator()
     34         model_name: str = "command",
     35         streaming_callback: Optional[Callable] = None,
---> 36         api_base_url: str = COHERE_API_URL,
     37         **kwargs,
     38     ):


NameError: name 'COHERE_API_URL' is not defined
```

### Proposed Changes:

Extract `COHERE_API_URL` from the lazy import block and assign a default value.
(Not so nice, but I haven't found a better quick solution).


### How did you test it?

Local test, CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
