### PR TITLE
docs: Add indexing example

### DIFF
--- a/examples/pipelines/indexing_pipeline.py
+++ b/examples/pipelines/indexing_pipeline.py
@@ -1,0 +1,35 @@
+from haystack import Pipeline
+from haystack.components.embedders import SentenceTransformersDocumentEmbedder
+from haystack.components.converters import PyPDFToDocument, TextFileToDocument
+from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
+from haystack.components.routers import FileTypeRouter, DocumentJoiner
+from haystack.components.writers import DocumentWriter
+from haystack.document_stores import InMemoryDocumentStore
+
+
+# Create components and an indexing pipeline that converts txt and pdf files to documents, cleans and splits them, and
+# indexes them for sparse and dense retrieval.
+p = Pipeline()
+p.add_component(instance=FileTypeRouter(mime_types=["text/plain", "application/pdf"]), name="file_type_router")
+p.add_component(instance=TextFileToDocument(), name="text_file_converter")
+p.add_component(instance=PyPDFToDocument(), name="pdf_file_converter")
+p.add_component(instance=DocumentJoiner(), name="joiner")
+p.add_component(instance=DocumentCleaner(), name="cleaner")
+p.add_component(instance=DocumentSplitter(split_by="sentence", split_length=250, split_overlap=30), name="splitter")
+p.add_component(
+    instance=SentenceTransformersDocumentEmbedder(model_name_or_path="sentence-transformers/all-MiniLM-L6-v2"),
+    name="embedder",
+)
+p.add_component(instance=DocumentWriter(document_store=InMemoryDocumentStore()), name="writer")
+
+p.connect("file_type_router.text/plain", "text_file_converter.sources")
+p.connect("file_type_router.application/pdf", "pdf_file_converter.sources")
+p.connect("text_file_converter.documents", "joiner.documents")
+p.connect("pdf_file_converter.documents", "joiner.documents")
+p.connect("joiner.documents", "cleaner.documents")
+p.connect("cleaner.documents", "splitter.documents")
+p.connect("splitter.documents", "embedder.documents")
+p.connect("embedder.documents", "writer.documents")
+
+# Take the current directory as input and run the pipeline
+result = p.run({"file_type_router": {"sources": list(".".iterdir())}})

--- a/examples/pipelines/indexing_pipeline.py
+++ b/examples/pipelines/indexing_pipeline.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from haystack import Pipeline
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder
 from haystack.components.converters import PyPDFToDocument, TextFileToDocument
@@ -32,4 +34,4 @@ p.connect("splitter.documents", "embedder.documents")
 p.connect("embedder.documents", "writer.documents")
 
 # Take the current directory as input and run the pipeline
-result = p.run({"file_type_router": {"sources": list(".".iterdir())}})
+result = p.run({"file_type_router": {"sources": list(Path(".").iterdir())}})


### PR DESCRIPTION
### Related Issues

- fixes #6014 

### Proposed Changes:

- Add example of an indexing pipeline that converts txt and pdf to documents, joins resulting lists, cleans and splits them, creates embeddings and then writes them to a document store.

### How did you test it?

Manually with and without a directory containing txt and pdf files. 
This code is also a subset of the code used in one of our e2e tests: https://github.com/deepset-ai/haystack/blob/main/e2e/pipelines/test_preprocessing_pipeline.py

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
