### PR TITLE
ci: Speed up tests.yml by caching dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,14 +97,9 @@ jobs:
       - name: Install Haystack and the dependencies needed for tests
         run: pip install -r test/test_requirements.txt
 
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
       - uses: actions/cache@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   unit-tests:
@@ -125,15 +120,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore pip cache
+      - name: Restore Python dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run
@@ -191,14 +181,10 @@ jobs:
           sudo apt update
           sudo apt install ffmpeg  # for local Whisper tests
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore pip cache
+      - name: Restore Python dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run
@@ -254,14 +240,10 @@ jobs:
           brew install docker
           colima start
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore pip cache
+      - name: Restore Python dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run Tika
@@ -312,15 +294,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Get pip cache dir
-        id: pip-cache
-        shell: bash
-        run: Write-Output "dir=$(pip cache dir)" >> "$Env:GITHUB_OUTPUT"
-
-      - name: Restore pip cache
+      - name: Restore Python dependencies
         uses: actions/cache/restore@v3
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,9 +79,36 @@ jobs:
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+  install-dependencies:
+    name: Install and cache ${{ matrix.os }} dependencies
+    needs: black
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Haystack and the dependencies needed for tests
+        run: pip install -r test/test_requirements.txt
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
   unit-tests:
     name: Unit / ${{ matrix.os }}
-    needs: black
+    needs: install-dependencies
     strategy:
       fail-fast: false
       matrix:
@@ -97,8 +124,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Haystack and the dependencies needed for tests
-        run: pip install -r test/test_requirements.txt
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run
         run: pytest -m "not integration" test
@@ -155,8 +189,15 @@ jobs:
           sudo apt update
           sudo apt install ffmpeg  # for local Whisper tests
 
-      - name: Install Haystack and the dependencies needed for tests
-        run: pip install -r test/test_requirements.txt
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test
@@ -211,8 +252,15 @@ jobs:
           brew install docker
           colima start
 
-      - name: Install Haystack and the dependencies needed for tests
-        run: pip install -r test/test_requirements.txt
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run Tika
         run: docker run -d -p 9998:9998 apache/tika:2.9.0.0
@@ -262,8 +310,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Haystack and the dependencies needed for tests
-        run: pip install -r test/test_requirements.txt
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test -k 'not tika'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pip cache
@@ -312,7 +313,8 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: Write-Output "dir=$(pip cache dir)" >> "$Env:GITHUB_OUTPUT"
 
       - name: Restore pip cache
         uses: actions/cache/restore@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pip cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -194,7 +194,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pip cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -257,7 +257,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pip cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -315,7 +315,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pip cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
-      - "!haystack/core/**/*.py"
+      - ci-speed-up
   pull_request:
     types:
       - opened

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ on:
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
-      - ci-speed-up
   pull_request:
     types:
       - opened


### PR DESCRIPTION
### Proposed Changes:

This PR should speed up `tests.yml` run time by leveraging the `cache` action to avoid installing Haystack `pip` dependencies multiple times but only once.

### How did you test it?

I didn't.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
