### PR TITLE
ci: Add back workflow that runs in place of `linting.yml`

### DIFF
--- a/.github/workflows/linting_skipper.yml
+++ b/.github/workflows/linting_skipper.yml
@@ -1,0 +1,23 @@
+# If you change this name also do it in linting.yml and ci_metrics.yml
+name: Linting
+
+on:
+  pull_request:
+    paths-ignore:
+      - "haystack/preview/**/*.py"
+      - "test/preview/**/*.py"
+      - "e2e/preview/**/*.py"
+      - "**/pyproject.toml"
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip mypy
+        run: echo "Skipped mypy"
+
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip pylint
+        run: echo "Skipped pylint"


### PR DESCRIPTION
### Related Issues

Some PRs to `main` are currently block cause they're waiting for the required `mypy` and `pylint` jobs. 
These jobs are not run if not required, like when no Python file is edited. Before the branch off for 2.x we had a `linting_skipper.yml` workflow that run in place of the skipped `linting.yml`.

This PR brings back that workflow.

### Proposed Changes:


### How did you test it?

This PR.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
