### PR TITLE
refactor: Add new filters tests for Document Store testing

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -98,7 +98,7 @@ class InMemoryDocumentStore:
         :return: A list of Documents that match the given filters.
         """
         if filters:
-            if "operator" not in filters:
+            if "operator" not in filters and "conditions" not in filters:
                 filters = convert(filters)
             return [doc for doc in self.storage.values() if document_matches_filter(filters=filters, document=doc)]
         return list(self.storage.values())

--- a/releasenotes/notes/document-store-testing-c1a8050f06ff3e97.yaml
+++ b/releasenotes/notes/document-store-testing-c1a8050f06ff3e97.yaml
@@ -1,0 +1,25 @@
+---
+prelude: >
+  The `testing.DocumentStoreBaseTests` has been heavily overhauled.
+  It has been split into multiple classes so developers can gradually test their Document Store as they're implemented.
+  `DocumentStoreBaseTests` now inherits from this classes:
+  - `CountDocumentsTest`, to test `DocumentStore.count_documents()`
+  - `WriteDocumentsTest`, to test `DocumentStore.write_documents()`
+  - `DeleteDocumentsTest`, to test `DocumentStore.delete_documents()`
+  - `FilterDocumentsTest`, to test `DocumentStore.filter_documents()`
+
+  To use each class it's enough to inherit from it and define the `document_store` fixture to return an instance of the Document Store we're implementing.
+  ```python
+  class MyDocumentStoreCountDocumentTest(CountDocumentsTest):
+      @pytest.fixture
+      def document_store(self):
+          return MyDocumentStore()
+  ```
+
+  There's also another class that tests `DocumentStore.filter_documents()` using legacy filters.
+  This is not inherited by `DocumentStoreBaseTests` but can be added as a base class to verify the support of legacy filters.
+  - `LegacyFilterDocumentsTest`
+
+preview:
+  - |
+    Rework the `testing.DocumentStoreBaseTests` class to ease Document Stores development and testing


### PR DESCRIPTION
### Related Issues

- fixes #6284

### Proposed Changes:

Add `FilterDocumentsTest` to test Document Stores using new filters format.

### How did you test it?

I ran unit tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
