### PR TITLE
feat: Change default `DuplicatePolicy` in `DocumentStore.write_documents()`

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -103,18 +103,11 @@ class InMemoryDocumentStore:
             return [doc for doc in self.storage.values() if document_matches_filter(filters=filters, document=doc)]
         return list(self.storage.values())
 
-    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> int:
+    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE) -> int:
         """
-        Writes (or overwrites) documents into the DocumentStore.
+        Refer to the DocumentStore.write_documents() protocol documentation.
 
-        :param documents: A list of documents.
-        :param policy: Documents with the same ID count as duplicates. When duplicates are met,
-            the DocumentStore can:
-             - skip: keep the existing document and ignore the new one.
-             - overwrite: remove the old document and write the new one.
-             - fail: an error is raised.
-        :raises DuplicateError: Exception trigger on duplicate document if `policy=DuplicatePolicy.FAIL`
-        :return: None
+        If `policy` is set to `DuplicatePolicy.NONE` defaults to `DuplicatePolicy.FAIL`.
         """
         if (
             not isinstance(documents, Iterable)
@@ -122,6 +115,9 @@ class InMemoryDocumentStore:
             or any(not isinstance(doc, Document) for doc in documents)
         ):
             raise ValueError("Please provide a list of Documents.")
+
+        if policy == DuplicatePolicy.NONE:
+            policy = DuplicatePolicy.FAIL
 
         written_documents = len(documents)
         for document in documents:

--- a/haystack/document_stores/protocols.py
+++ b/haystack/document_stores/protocols.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class DuplicatePolicy(Enum):
+    NONE = "none"
     SKIP = "skip"
     OVERWRITE = "overwrite"
     FAIL = "fail"
@@ -115,20 +116,20 @@ class DocumentStore(Protocol):
         """
         ...
 
-    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.FAIL) -> int:
+    def write_documents(self, documents: List[Document], policy: DuplicatePolicy = DuplicatePolicy.NONE) -> int:
         """
-        Writes (or overwrites) documents into the DocumentStore.
+        Writes Documents into the DocumentStore.
 
-        :param documents: a list of documents.
-        :param policy: documents with the same ID count as duplicates. When duplicates are met,
-            the DocumentStore can:
-             - skip: keep the existing document and ignore the new one.
-             - overwrite: remove the old document and write the new one.
-             - fail: an error is raised
-        :raises DuplicateError: Exception trigger on duplicate document if `policy=DuplicatePolicy.FAIL`
-        :return: The number of documents that was written.
-            If DuplicatePolicy.OVERWRITE is used, this number is always equal to the number of documents in input.
-            If DuplicatePolicy.SKIP is used, this number can be lower than the number of documents in the input list.
+        :param documents: a list of Document objects.
+        :param policy: the policy to apply when a Document with the same id already exists in the DocumentStore.
+            - `DuplicatePolicy.NONE`: Default policy, behaviour depends on the Document Store.
+            - `DuplicatePolicy.SKIP`: If a Document with the same id already exists, it is skipped and not written.
+            - `DuplicatePolicy.OVERWRITE`: If a Document with the same id already exists, it is overwritten.
+            - `DuplicatePolicy.FAIL`: If a Document with the same id already exists, an error is raised.
+        :raises DuplicateError: If `policy` is set to `DuplicatePolicy.FAIL` and a Document with the same id already exists.
+        :return: The number of Documents written.
+            If `DuplicatePolicy.OVERWRITE` is used, this number is always equal to the number of documents in input.
+            If `DuplicatePolicy.SKIP` is used, this number can be lower than the number of documents in the input list.
         """
         ...
 

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -70,11 +70,14 @@ class WriteDocumentsTest:
     @pytest.mark.unit
     def test_write_documents(self, document_store: DocumentStore):
         """
-        Test write_documents() normal behaviour.
+        Test write_documents() default behaviour.
         """
-        doc = Document(content="test doc")
-        assert document_store.write_documents([doc]) == 1
-        assert document_store.filter_documents() == [doc]
+        msg = (
+            "Default write_documents() behaviour depends on the Document Store implementantion, "
+            "as we don't enforce a default behaviour when no policy is set. "
+            "Override this test in your custom test class."
+        )
+        raise NotImplementedError(msg)
 
     @pytest.mark.unit
     def test_write_documents_duplicate_fail(self, document_store: DocumentStore):
@@ -83,7 +86,7 @@ class WriteDocumentsTest:
         using DuplicatePolicy.FAIL.
         """
         doc = Document(content="test doc")
-        assert document_store.write_documents([doc]) == 1
+        assert document_store.write_documents([doc], policy=DuplicatePolicy.FAIL) == 1
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(documents=[doc], policy=DuplicatePolicy.FAIL)
         assert document_store.filter_documents() == [doc]
@@ -95,7 +98,7 @@ class WriteDocumentsTest:
         using DuplicatePolicy.SKIP.
         """
         doc = Document(content="test doc")
-        assert document_store.write_documents([doc]) == 1
+        assert document_store.write_documents([doc], policy=DuplicatePolicy.SKIP) == 1
         assert document_store.write_documents(documents=[doc], policy=DuplicatePolicy.SKIP) == 0
 
     @pytest.mark.unit
@@ -107,7 +110,7 @@ class WriteDocumentsTest:
         doc1 = Document(id="1", content="test doc 1")
         doc2 = Document(id="1", content="test doc 2")
 
-        assert document_store.write_documents([doc2]) == 1
+        assert document_store.write_documents([doc2], policy=DuplicatePolicy.OVERWRITE) == 1
         assert document_store.filter_documents() == [doc2]
         assert document_store.write_documents(documents=[doc1], policy=DuplicatePolicy.OVERWRITE) == 1
         assert document_store.filter_documents() == [doc1]

--- a/releasenotes/notes/default-write-documents-policy-95afe5fb34fc73ad.yaml
+++ b/releasenotes/notes/default-write-documents-policy-95afe5fb34fc73ad.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Change the default `DuplicatePolicy` for the `DocumentStore.write_documents()` protocol from `DuplicatePolicy.FAIL` to `DuplicatePolicy.NONE`.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from haystack import Document
-from haystack.document_stores import InMemoryDocumentStore, DocumentStoreError, DuplicatePolicy
+from haystack.document_stores import InMemoryDocumentStore, DocumentStoreError, DuplicatePolicy, DuplicateDocumentError
 
 
 from haystack.testing.document_store import DocumentStoreBaseTests
@@ -70,17 +70,11 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert store.bm25_algorithm.__name__ == "BM25Plus"
         assert store.bm25_parameters == {"key": "value"}
 
-    @pytest.mark.unit
-    def test_written_documents_count(self, document_store: InMemoryDocumentStore):
-        # FIXME Remove after the document store base tests have been rewritten
-        documents = [Document(content=f"Hello world #{i}") for i in range(10)]
-        docs_written = document_store.write_documents(documents[0:2])
-        assert docs_written == 2
-        assert document_store.filter_documents() == documents[0:2]
-
-        docs_written = document_store.write_documents(documents, DuplicatePolicy.SKIP)
-        assert docs_written == len(documents) - 2
-        assert document_store.filter_documents() == documents
+    def test_write_documents(self, document_store):
+        docs = [Document(id="1")]
+        assert document_store.write_documents(docs) == 1
+        with pytest.raises(DuplicateDocumentError):
+            document_store.write_documents(docs)
 
     @pytest.mark.unit
     def test_bm25_retrieval(self, document_store: InMemoryDocumentStore):


### PR DESCRIPTION
### Related Issues

- fixes #6430

### Proposed Changes:

Change the default `DuplicatePolicy` for the `DocumentStore.write_documents()` protocol from `DuplicatePolicy.FAIL` to `DuplicatePolicy.NONE`.

This way Document Stores implementers will be able to choose their own default policy instead of being forced to use `DuplicatePolicy.FAIL`.

This PR also changes the `WriteDocumentsTest` class to raise when testing the default behaviour of `DocumentStore.write_documents`. This is done so we don't enforce a default behaviour again and so that the implementer is aware it should handle the default policy.

I also had to update the tests for `InMemoryDocumentStore`.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
