### PR TITLE
docs: Add RAG pipeline example

### DIFF
--- a/examples/pipelines/rag_pipeline.py
+++ b/examples/pipelines/rag_pipeline.py
@@ -1,0 +1,51 @@
+import os
+from haystack import Pipeline, Document
+from haystack.document_stores import InMemoryDocumentStore
+from haystack.components.retrievers import InMemoryBM25Retriever
+from haystack.components.generators import GPTGenerator
+from haystack.components.builders.answer_builder import AnswerBuilder
+from haystack.components.builders.prompt_builder import PromptBuilder
+
+# We are model agnostic :) Here, we use OpenAI models and load an api key from environment variables.
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+
+# We support many different databases. Here we load a simple and lightweight in-memory document store.
+document_store = InMemoryDocumentStore()
+
+# Create some example documents and add them to the document store.
+documents = [
+    Document(content="My name is Jean and I live in Paris."),
+    Document(content="My name is Mark and I live in Berlin."),
+    Document(content="My name is Giorgio and I live in Rome."),
+]
+document_store.write_documents(documents)
+
+# Build a RAG pipeline with a Retriever to get relevant documents to the query and a GPTGenerator interacting with LLMs using a custom prompt.
+prompt_template = """
+Given these documents, answer the question.\nDocuments:
+{% for doc in documents %}
+    {{ doc.content }}
+{% endfor %}
+
+\nQuestion: {{question}}
+\nAnswer:
+"""
+rag_pipeline = Pipeline()
+rag_pipeline.add_component(instance=InMemoryBM25Retriever(document_store=document_store), name="retriever")
+rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
+rag_pipeline.add_component(instance=GPTGenerator(api_key=OPENAI_API_KEY), name="llm")
+rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
+rag_pipeline.connect("retriever", "prompt_builder.documents")
+rag_pipeline.connect("prompt_builder", "llm")
+rag_pipeline.connect("llm.replies", "answer_builder.replies")
+rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
+rag_pipeline.connect("retriever", "answer_builder.documents")
+
+# Ask a question on the data you just added.
+question = "Where does Mark live?"
+result = rag_pipeline.run(
+    {"retriever": {"query": question}, "prompt_builder": {"question": question}, "answer_builder": {"query": question}}
+)
+
+# For details, like which documents were used to generate the answer, look into the GeneratedAnswer object
+print(result["answer_builder"]["answers"])


### PR DESCRIPTION
### Related Issues

- Adding an example that can be used in the get started page for 2.0: https://docs.haystack.deepset.ai/v2.0/docs/get_started
@dfokina @Timoeller 

### Proposed Changes:

- Adding a RAG query pipeline example. No indexing is used. The RAG pipeline uses sparse retrieval for simplicity. 

### How did you test it?

Ran manually

### Notes for the reviewer

Once we have ready made pipelines https://github.com/deepset-ai/haystack/issues/5992, we can update this example. We can also simplify `rag_pipeline.run(...)` once simple input resolution is merged https://github.com/deepset-ai/haystack/pull/6413.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
