### PR TITLE
chore: remove unit marker

### DIFF
--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -51,11 +51,9 @@ class CountDocumentsTest:
     ```
     """
 
-    @pytest.mark.unit
     def test_count_empty(self, document_store: DocumentStore):
         assert document_store.count_documents() == 0
 
-    @pytest.mark.unit
     def test_count_not_empty(self, document_store: DocumentStore):
         document_store.write_documents(
             [Document(content="test doc 1"), Document(content="test doc 2"), Document(content="test doc 3")]
@@ -80,7 +78,6 @@ class WriteDocumentsTest(AssertDocumentsEqualMixin):
     ```
     """
 
-    @pytest.mark.unit
     def test_write_documents(self, document_store: DocumentStore):
         """
         Test write_documents() default behaviour.
@@ -92,7 +89,6 @@ class WriteDocumentsTest(AssertDocumentsEqualMixin):
         )
         raise NotImplementedError(msg)
 
-    @pytest.mark.unit
     def test_write_documents_duplicate_fail(self, document_store: DocumentStore):
         """
         Test write_documents() fails when trying to write Document with same id
@@ -104,7 +100,6 @@ class WriteDocumentsTest(AssertDocumentsEqualMixin):
             document_store.write_documents(documents=[doc], policy=DuplicatePolicy.FAIL)
         self.assert_documents_are_equal(document_store.filter_documents(), [doc])
 
-    @pytest.mark.unit
     def test_write_documents_duplicate_skip(self, document_store: DocumentStore):
         """
         Test write_documents() skips Document when trying to write one with same id
@@ -114,7 +109,6 @@ class WriteDocumentsTest(AssertDocumentsEqualMixin):
         assert document_store.write_documents([doc], policy=DuplicatePolicy.SKIP) == 1
         assert document_store.write_documents(documents=[doc], policy=DuplicatePolicy.SKIP) == 0
 
-    @pytest.mark.unit
     def test_write_documents_duplicate_overwrite(self, document_store: DocumentStore):
         """
         Test write_documents() overwrites stored Document when trying to write one with same id
@@ -128,7 +122,6 @@ class WriteDocumentsTest(AssertDocumentsEqualMixin):
         assert document_store.write_documents(documents=[doc1], policy=DuplicatePolicy.OVERWRITE) == 1
         self.assert_documents_are_equal(document_store.filter_documents(), [doc1])
 
-    @pytest.mark.unit
     def test_write_documents_invalid_input(self, document_store: DocumentStore):
         """
         Test write_documents() fails when providing unexpected input.
@@ -155,7 +148,6 @@ class DeleteDocumentsTest:
     ```
     """
 
-    @pytest.mark.unit
     def test_delete_documents(self, document_store: DocumentStore):
         """
         Test delete_documents() normal behaviour.
@@ -167,14 +159,12 @@ class DeleteDocumentsTest:
         document_store.delete_documents([doc.id])
         assert document_store.count_documents() == 0
 
-    @pytest.mark.unit
     def test_delete_documents_empty_document_store(self, document_store: DocumentStore):
         """
         Test delete_documents() doesn't fail when called using an empty Document Store.
         """
         document_store.delete_documents(["non_existing_id"])
 
-    @pytest.mark.unit
     def test_delete_documents_non_existing_document(self, document_store: DocumentStore):
         """
         Test delete_documents() doesn't delete any Document when called with non existing id.
@@ -268,19 +258,16 @@ class LegacyFilterDocumentsInvalidFiltersTest(AssertDocumentsEqualMixin, Filtera
     ```
     """
 
-    @pytest.mark.unit
     def test_incorrect_filter_type(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(ValueError):
             document_store.filter_documents(filters="something odd")  # type: ignore
 
-    @pytest.mark.unit
     def test_incorrect_filter_nesting(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"number": {"page": "100"}})
 
-    @pytest.mark.unit
     def test_deeper_incorrect_filter_nesting(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
@@ -302,19 +289,16 @@ class LegacyFilterDocumentsEqualTest(AssertDocumentsEqualMixin, FilterableDocsFi
     ```
     """
 
-    @pytest.mark.unit
     def test_filter_document_content(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"content": "A Foo Document 1"})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.content == "A Foo Document 1"])
 
-    @pytest.mark.unit
     def test_filter_simple_metadata_value(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": "100"})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
-    @pytest.mark.unit
     def test_filter_document_dataframe(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"dataframe": pd.DataFrame([1])})
@@ -323,19 +307,16 @@ class LegacyFilterDocumentsEqualTest(AssertDocumentsEqualMixin, FilterableDocsFi
             [doc for doc in filterable_docs if doc.dataframe is not None and doc.dataframe.equals(pd.DataFrame([1]))],
         )
 
-    @pytest.mark.unit
     def test_eq_filter_explicit(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": {"$eq": "100"}})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
-    @pytest.mark.unit
     def test_eq_filter_implicit(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": "100"})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
-    @pytest.mark.unit
     def test_eq_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"dataframe": pd.DataFrame([1])})
@@ -348,7 +329,6 @@ class LegacyFilterDocumentsEqualTest(AssertDocumentsEqualMixin, FilterableDocsFi
             ],
         )
 
-    @pytest.mark.unit
     def test_eq_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         embedding = [0.0] * 768
@@ -371,13 +351,11 @@ class LegacyFilterDocumentsNotEqualTest(AssertDocumentsEqualMixin, FilterableDoc
     ```
     """
 
-    @pytest.mark.unit
     def test_ne_filter(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": {"$ne": "100"}})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.meta.get("page") != "100"])
 
-    @pytest.mark.unit
     def test_ne_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"dataframe": {"$ne": pd.DataFrame([1])}})
@@ -390,7 +368,6 @@ class LegacyFilterDocumentsNotEqualTest(AssertDocumentsEqualMixin, FilterableDoc
             ],
         )
 
-    @pytest.mark.unit
     def test_ne_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"embedding": {"$ne": TEST_EMBEDDING_1}})
@@ -412,19 +389,16 @@ class LegacyFilterDocumentsInTest(AssertDocumentsEqualMixin, FilterableDocsFixtu
     ```
     """
 
-    @pytest.mark.unit
     def test_filter_simple_list_single_element(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": ["100"]})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.meta.get("page") == "100"])
 
-    @pytest.mark.unit
     def test_filter_simple_list_one_value(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": ["100"]})
         self.assert_documents_are_equal(result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100"]])
 
-    @pytest.mark.unit
     def test_filter_simple_list(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": ["100", "123"]})
@@ -432,19 +406,16 @@ class LegacyFilterDocumentsInTest(AssertDocumentsEqualMixin, FilterableDocsFixtu
             result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100", "123"]]
         )
 
-    @pytest.mark.unit
     def test_incorrect_filter_name(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"non_existing_meta_field": ["whatever"]})
         self.assert_documents_are_equal(result, [])
 
-    @pytest.mark.unit
     def test_incorrect_filter_value(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": ["nope"]})
         self.assert_documents_are_equal(result, [])
 
-    @pytest.mark.unit
     def test_in_filter_explicit(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": {"$in": ["100", "123", "n.a."]}})
@@ -452,7 +423,6 @@ class LegacyFilterDocumentsInTest(AssertDocumentsEqualMixin, FilterableDocsFixtu
             result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100", "123"]]
         )
 
-    @pytest.mark.unit
     def test_in_filter_implicit(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": ["100", "123", "n.a."]})
@@ -460,7 +430,6 @@ class LegacyFilterDocumentsInTest(AssertDocumentsEqualMixin, FilterableDocsFixtu
             result, [doc for doc in filterable_docs if doc.meta.get("page") in ["100", "123"]]
         )
 
-    @pytest.mark.unit
     def test_in_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"dataframe": {"$in": [pd.DataFrame([1]), pd.DataFrame([2])]}})
@@ -474,7 +443,6 @@ class LegacyFilterDocumentsInTest(AssertDocumentsEqualMixin, FilterableDocsFixtu
             ],
         )
 
-    @pytest.mark.unit
     def test_in_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         embedding_zero = [0.0] * 768
@@ -501,7 +469,6 @@ class LegacyFilterDocumentsNotInTest(AssertDocumentsEqualMixin, FilterableDocsFi
     ```
     """
 
-    @pytest.mark.unit
     def test_nin_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(
@@ -517,7 +484,6 @@ class LegacyFilterDocumentsNotInTest(AssertDocumentsEqualMixin, FilterableDocsFi
             ],
         )
 
-    @pytest.mark.unit
     def test_nin_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"embedding": {"$nin": [TEST_EMBEDDING_1, TEST_EMBEDDING_2]}})
@@ -525,7 +491,6 @@ class LegacyFilterDocumentsNotInTest(AssertDocumentsEqualMixin, FilterableDocsFi
             result, [doc for doc in filterable_docs if doc.embedding not in [TEST_EMBEDDING_1, TEST_EMBEDDING_2]]
         )
 
-    @pytest.mark.unit
     def test_nin_filter(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"page": {"$nin": ["100", "123", "n.a."]}})
@@ -549,7 +514,6 @@ class LegacyFilterDocumentsGreaterThanTest(AssertDocumentsEqualMixin, Filterable
     ```
     """
 
-    @pytest.mark.unit
     def test_gt_filter(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"number": {"$gt": 0.0}})
@@ -557,19 +521,16 @@ class LegacyFilterDocumentsGreaterThanTest(AssertDocumentsEqualMixin, Filterable
             result, [doc for doc in filterable_docs if "number" in doc.meta and doc.meta["number"] > 0]
         )
 
-    @pytest.mark.unit
     def test_gt_filter_non_numeric(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"page": {"$gt": "100"}})
 
-    @pytest.mark.unit
     def test_gt_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"dataframe": {"$gt": pd.DataFrame([[1, 2, 3], [-1, -2, -3]])}})
 
-    @pytest.mark.unit
     def test_gt_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
@@ -591,7 +552,6 @@ class LegacyFilterDocumentsGreaterThanEqualTest(AssertDocumentsEqualMixin, Filte
     ```
     """
 
-    @pytest.mark.unit
     def test_gte_filter(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"number": {"$gte": -2}})
@@ -599,19 +559,16 @@ class LegacyFilterDocumentsGreaterThanEqualTest(AssertDocumentsEqualMixin, Filte
             result, [doc for doc in filterable_docs if "number" in doc.meta and doc.meta["number"] >= -2]
         )
 
-    @pytest.mark.unit
     def test_gte_filter_non_numeric(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"page": {"$gte": "100"}})
 
-    @pytest.mark.unit
     def test_gte_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"dataframe": {"$gte": pd.DataFrame([[1, 2, 3], [-1, -2, -3]])}})
 
-    @pytest.mark.unit
     def test_gte_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
@@ -633,7 +590,6 @@ class LegacyFilterDocumentsLessThanTest(AssertDocumentsEqualMixin, FilterableDoc
     ```
     """
 
-    @pytest.mark.unit
     def test_lt_filter(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"number": {"$lt": 0.0}})
@@ -641,19 +597,16 @@ class LegacyFilterDocumentsLessThanTest(AssertDocumentsEqualMixin, FilterableDoc
             result, [doc for doc in filterable_docs if doc.meta.get("number") is not None and doc.meta["number"] < 0]
         )
 
-    @pytest.mark.unit
     def test_lt_filter_non_numeric(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"page": {"$lt": "100"}})
 
-    @pytest.mark.unit
     def test_lt_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"dataframe": {"$lt": pd.DataFrame([[1, 2, 3], [-1, -2, -3]])}})
 
-    @pytest.mark.unit
     def test_lt_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
@@ -675,7 +628,6 @@ class LegacyFilterDocumentsLessThanEqualTest(AssertDocumentsEqualMixin, Filterab
     ```
     """
 
-    @pytest.mark.unit
     def test_lte_filter(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"number": {"$lte": 2.0}})
@@ -683,19 +635,16 @@ class LegacyFilterDocumentsLessThanEqualTest(AssertDocumentsEqualMixin, Filterab
             result, [doc for doc in filterable_docs if doc.meta.get("number") is not None and doc.meta["number"] <= 2.0]
         )
 
-    @pytest.mark.unit
     def test_lte_filter_non_numeric(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"page": {"$lte": "100"}})
 
-    @pytest.mark.unit
     def test_lte_filter_table(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
             document_store.filter_documents(filters={"dataframe": {"$lte": pd.DataFrame([[1, 2, 3], [-1, -2, -3]])}})
 
-    @pytest.mark.unit
     def test_lte_filter_embedding(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         with pytest.raises(FilterError):
@@ -717,7 +666,6 @@ class LegacyFilterDocumentsSimpleLogicalTest(AssertDocumentsEqualMixin, Filterab
     ```
     """
 
-    @pytest.mark.unit
     def test_filter_simple_or(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         filters = {"$or": {"name": {"$in": ["name_0", "name_1"]}, "number": {"$lt": 1.0}}}
@@ -732,7 +680,6 @@ class LegacyFilterDocumentsSimpleLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_simple_implicit_and_with_multi_key_dict(
         self, document_store: DocumentStore, filterable_docs: List[Document]
     ):
@@ -747,7 +694,6 @@ class LegacyFilterDocumentsSimpleLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_simple_explicit_and_with_list(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"number": {"$and": [{"$lte": 2}, {"$gte": 0}]}})
@@ -760,7 +706,6 @@ class LegacyFilterDocumentsSimpleLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_simple_implicit_and(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         result = document_store.filter_documents(filters={"number": {"$lte": 2.0, "$gte": 0}})
@@ -789,7 +734,6 @@ class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, Filterab
     ```
     """
 
-    @pytest.mark.unit
     def test_filter_nested_implicit_and(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         filters_simplified = {"number": {"$lte": 2, "$gte": 0}, "name": ["name_0", "name_1"]}
@@ -808,7 +752,6 @@ class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_nested_or(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         filters = {"$or": {"name": {"$or": [{"$eq": "name_0"}, {"$eq": "name_1"}]}, "number": {"$lt": 1.0}}}
@@ -825,7 +768,6 @@ class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_nested_and_or_explicit(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         filters_simplified = {
@@ -847,7 +789,6 @@ class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_nested_and_or_implicit(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         filters_simplified = {
@@ -870,7 +811,6 @@ class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_nested_or_and(self, document_store: DocumentStore, filterable_docs: List[Document]):
         document_store.write_documents(filterable_docs)
         filters_simplified = {
@@ -892,7 +832,6 @@ class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, Filterab
             ],
         )
 
-    @pytest.mark.unit
     def test_filter_nested_multiple_identical_operators_same_level(
         self, document_store: DocumentStore, filterable_docs: List[Document]
     ):
@@ -944,12 +883,10 @@ class LegacyFilterDocumentsTest(  # pylint: disable=too-many-ancestors
     ```
     """
 
-    @pytest.mark.unit
     def test_no_filter_empty(self, document_store: DocumentStore):
         assert document_store.filter_documents() == []
         assert document_store.filter_documents(filters={}) == []
 
-    @pytest.mark.unit
     def test_no_filter_not_empty(self, document_store: DocumentStore):
         docs = [Document(content="test doc")]
         document_store.write_documents(docs)

--- a/test/components/audio/test_whisper_local.py
+++ b/test/components/audio/test_whisper_local.py
@@ -13,7 +13,6 @@ SAMPLES_PATH = Path(__file__).parent.parent.parent / "test_files"
 
 
 class TestLocalWhisperTranscriber:
-    @pytest.mark.unit
     def test_init(self):
         transcriber = LocalWhisperTranscriber(
             model_name_or_path="large-v2"
@@ -22,12 +21,10 @@ class TestLocalWhisperTranscriber:
         assert transcriber.device == torch.device("cpu")
         assert transcriber._model is None
 
-    @pytest.mark.unit
     def test_init_wrong_model(self):
         with pytest.raises(ValueError, match="Model name 'whisper-1' not recognized"):
             LocalWhisperTranscriber(model_name_or_path="whisper-1")
 
-    @pytest.mark.unit
     def test_to_dict(self):
         transcriber = LocalWhisperTranscriber()
         data = transcriber.to_dict()
@@ -36,7 +33,6 @@ class TestLocalWhisperTranscriber:
             "init_parameters": {"model_name_or_path": "large", "device": "cpu", "whisper_params": {}},
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         transcriber = LocalWhisperTranscriber(
             model_name_or_path="tiny",
@@ -53,7 +49,6 @@ class TestLocalWhisperTranscriber:
             },
         }
 
-    @pytest.mark.unit
     def test_warmup(self):
         with patch("haystack.components.audio.whisper_local.whisper") as mocked_whisper:
             transcriber = LocalWhisperTranscriber(model_name_or_path="large-v2")
@@ -61,7 +56,6 @@ class TestLocalWhisperTranscriber:
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once_with("large-v2", device=torch.device(type="cpu"))
 
-    @pytest.mark.unit
     def test_warmup_doesnt_reload(self):
         with patch("haystack.components.audio.whisper_local.whisper") as mocked_whisper:
             transcriber = LocalWhisperTranscriber(model_name_or_path="large-v2")
@@ -69,7 +63,6 @@ class TestLocalWhisperTranscriber:
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once()
 
-    @pytest.mark.unit
     def test_run_with_path(self):
         comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
         comp._model = MagicMock()
@@ -87,7 +80,6 @@ class TestLocalWhisperTranscriber:
         )
         assert results["documents"] == [expected]
 
-    @pytest.mark.unit
     def test_run_with_str(self):
         comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
         comp._model = MagicMock()
@@ -107,7 +99,6 @@ class TestLocalWhisperTranscriber:
         )
         assert results["documents"] == [expected]
 
-    @pytest.mark.unit
     def test_transcribe(self):
         comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
         comp._model = MagicMock()
@@ -125,7 +116,6 @@ class TestLocalWhisperTranscriber:
         )
         assert results == [expected]
 
-    @pytest.mark.unit
     def test_transcribe_stream(self):
         comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
         comp._model = MagicMock()

--- a/test/components/audio/test_whisper_remote.py
+++ b/test/components/audio/test_whisper_remote.py
@@ -21,7 +21,6 @@ def mock_openai_response(response_format="json", **kwargs) -> openai.openai_obje
 
 
 class TestRemoteWhisperTranscriber:
-    @pytest.mark.unit
     def test_init_no_key(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -42,7 +41,6 @@ class TestRemoteWhisperTranscriber:
         # The module global variable takes preference
         assert openai.api_key == "test_api_key_1"
 
-    @pytest.mark.unit
     def test_init_default(self):
         transcriber = RemoteWhisperTranscriber(api_key="test_api_key")
 
@@ -52,7 +50,6 @@ class TestRemoteWhisperTranscriber:
         assert transcriber.api_base_url == "https://api.openai.com/v1"
         assert transcriber.whisper_params == {"response_format": "json"}
 
-    @pytest.mark.unit
     def test_init_custom_parameters(self):
         transcriber = RemoteWhisperTranscriber(
             api_key="test_api_key",
@@ -76,7 +73,6 @@ class TestRemoteWhisperTranscriber:
             "temperature": "0.5",
         }
 
-    @pytest.mark.unit
     def test_to_dict_default_parameters(self):
         transcriber = RemoteWhisperTranscriber(api_key="test_api_key")
         data = transcriber.to_dict()
@@ -90,7 +86,6 @@ class TestRemoteWhisperTranscriber:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         transcriber = RemoteWhisperTranscriber(
             api_key="test_api_key",
@@ -182,7 +177,6 @@ class TestRemoteWhisperTranscriber:
         with pytest.raises(ValueError, match="RemoteWhisperTranscriber expects an OpenAI API key."):
             RemoteWhisperTranscriber.from_dict(data)
 
-    @pytest.mark.unit
     def test_run_str(self, test_files_path):
         with patch("haystack.components.audio.whisper_remote.openai.Audio") as openai_audio_patch:
             model = "whisper-1"
@@ -195,7 +189,6 @@ class TestRemoteWhisperTranscriber:
             assert result["documents"][0].content == "test transcription"
             assert result["documents"][0].meta["file_path"] == file_path
 
-    @pytest.mark.unit
     def test_run_path(self, test_files_path):
         with patch("haystack.components.audio.whisper_remote.openai.Audio") as openai_audio_patch:
             model = "whisper-1"
@@ -208,7 +201,6 @@ class TestRemoteWhisperTranscriber:
             assert result["documents"][0].content == "test transcription"
             assert result["documents"][0].meta["file_path"] == file_path
 
-    @pytest.mark.unit
     def test_run_bytestream(self, test_files_path):
         with patch("haystack.components.audio.whisper_remote.openai.Audio") as openai_audio_patch:
             model = "whisper-1"

--- a/test/components/builders/test_answer_builder.py
+++ b/test/components/builders/test_answer_builder.py
@@ -7,13 +7,11 @@ from haystack.components.builders.answer_builder import AnswerBuilder
 
 
 class TestAnswerBuilder:
-    @pytest.mark.unit
     def test_run_unmatching_input_len(self):
         component = AnswerBuilder()
         with pytest.raises(ValueError):
             component.run(query="query", replies=["reply1"], metadata=[{"test": "meta"}, {"test": "meta2"}])
 
-    @pytest.mark.unit
     def test_run_without_meta(self):
         component = AnswerBuilder()
         output = component.run(query="query", replies=["reply1"])
@@ -24,7 +22,6 @@ class TestAnswerBuilder:
         assert answers[0].documents == []
         assert isinstance(answers[0], GeneratedAnswer)
 
-    @pytest.mark.unit
     def test_run_meta_is_an_empty_list(self):
         component = AnswerBuilder()
         output = component.run(query="query", replies=["reply1"], metadata=[])

--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -3,13 +3,11 @@ import pytest
 from haystack.components.builders.prompt_builder import PromptBuilder
 
 
-@pytest.mark.unit
 def test_init():
     builder = PromptBuilder(template="This is a {{ variable }}")
     assert builder._template_string == "This is a {{ variable }}"
 
 
-@pytest.mark.unit
 def test_to_dict():
     builder = PromptBuilder(template="This is a {{ variable }}")
     res = builder.to_dict()
@@ -19,21 +17,18 @@ def test_to_dict():
     }
 
 
-@pytest.mark.unit
 def test_run():
     builder = PromptBuilder(template="This is a {{ variable }}")
     res = builder.run(variable="test")
     assert res == {"prompt": "This is a test"}
 
 
-@pytest.mark.unit
 def test_run_without_input():
     builder = PromptBuilder(template="This is a template without input")
     res = builder.run()
     assert res == {"prompt": "This is a template without input"}
 
 
-@pytest.mark.unit
 def test_run_with_missing_input():
     builder = PromptBuilder(template="This is a {{ variable }}")
     res = builder.run()

--- a/test/components/caching/test_url_cache_checker.py
+++ b/test/components/caching/test_url_cache_checker.py
@@ -7,7 +7,6 @@ from haystack.components.caching.url_cache_checker import UrlCacheChecker
 
 
 class TestUrlCacheChecker:
-    @pytest.mark.unit
     def test_to_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         component = UrlCacheChecker(document_store=mocked_docstore_class())
@@ -20,7 +19,6 @@ class TestUrlCacheChecker:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         component = UrlCacheChecker(document_store=mocked_docstore_class(), url_field="my_url_field")
@@ -33,7 +31,6 @@ class TestUrlCacheChecker:
             },
         }
 
-    @pytest.mark.unit
     def test_from_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         data = {
@@ -47,13 +44,11 @@ class TestUrlCacheChecker:
         assert isinstance(component.document_store, mocked_docstore_class)
         assert component.url_field == "my_url_field"
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore(self):
         data = {"type": "haystack.components.caching.url_cache_checker.UrlCacheChecker", "init_parameters": {}}
         with pytest.raises(DeserializationError, match="Missing 'document_store' in serialization data"):
             UrlCacheChecker.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore_type(self):
         data = {
             "type": "haystack.components.caching.url_cache_checker.UrlCacheChecker",
@@ -62,7 +57,6 @@ class TestUrlCacheChecker:
         with pytest.raises(DeserializationError, match="Missing 'type' in document store's serialization data"):
             UrlCacheChecker.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_nonexisting_docstore(self):
         data = {
             "type": "haystack.components.caching.url_cache_checker.UrlCacheChecker",
@@ -71,7 +65,6 @@ class TestUrlCacheChecker:
         with pytest.raises(DeserializationError, match="DocumentStore of type 'NonexistingDocumentStore' not found."):
             UrlCacheChecker.from_dict(data)
 
-    @pytest.mark.unit
     def test_run(self):
         docstore = InMemoryDocumentStore()
         documents = [

--- a/test/components/classifiers/test_document_language_classifier.py
+++ b/test/components/classifiers/test_document_language_classifier.py
@@ -6,36 +6,30 @@ from haystack.components.classifiers import DocumentLanguageClassifier
 
 
 class TestDocumentLanguageClassifier:
-    @pytest.mark.unit
     def test_init(self):
         component = DocumentLanguageClassifier()
         assert component.languages == ["en"]
 
-    @pytest.mark.unit
     def test_non_document_input(self):
         with pytest.raises(TypeError, match="DocumentLanguageClassifier expects a list of Document as input."):
             classifier = DocumentLanguageClassifier()
             classifier.run(documents="This is an english sentence.")
 
-    @pytest.mark.unit
     def test_single_document(self):
         with pytest.raises(TypeError, match="DocumentLanguageClassifier expects a list of Document as input."):
             classifier = DocumentLanguageClassifier()
             classifier.run(documents=Document(content="This is an english sentence."))
 
-    @pytest.mark.unit
     def test_empty_list(self):
         classifier = DocumentLanguageClassifier()
         result = classifier.run(documents=[])
         assert result == {"documents": []}
 
-    @pytest.mark.unit
     def test_detect_language(self):
         classifier = DocumentLanguageClassifier()
         detected_language = classifier.detect_language(Document(content="This is an english sentence."))
         assert detected_language == "en"
 
-    @pytest.mark.unit
     def test_classify_as_en_and_unmatched(self):
         classifier = DocumentLanguageClassifier()
         english_document = Document(content="This is an english sentence.")
@@ -44,7 +38,6 @@ class TestDocumentLanguageClassifier:
         assert result["documents"][0].meta["language"] == "en"
         assert result["documents"][1].meta["language"] == "unmatched"
 
-    @pytest.mark.unit
     def test_warning_if_no_language_detected(self, caplog):
         with caplog.at_level(logging.WARNING):
             classifier = DocumentLanguageClassifier()

--- a/test/components/converters/test_azure_ocr_doc_converter.py
+++ b/test/components/converters/test_azure_ocr_doc_converter.py
@@ -7,13 +7,11 @@ from haystack.components.converters.azure import AzureOCRDocumentConverter
 
 
 class TestAzureOCRDocumentConverter:
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("AZURE_AI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="AzureOCRDocumentConverter expects an Azure Credential key"):
             AzureOCRDocumentConverter(endpoint="test_endpoint")
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
         data = component.to_dict()
@@ -22,7 +20,6 @@ class TestAzureOCRDocumentConverter:
             "init_parameters": {"endpoint": "test_endpoint", "model_id": "prebuilt-read"},
         }
 
-    @pytest.mark.unit
     def test_run(self, test_files_path):
         with patch("haystack.components.converters.azure.DocumentAnalysisClient") as mock_azure_client:
             mock_result = Mock(pages=[Mock(lines=[Mock(content="mocked line 1"), Mock(content="mocked line 2")])])

--- a/test/components/converters/test_html_to_document.py
+++ b/test/components/converters/test_html_to_document.py
@@ -7,7 +7,6 @@ from haystack.dataclasses import ByteStream
 
 
 class TestHTMLToDocument:
-    @pytest.mark.unit
     def test_run(self, test_files_path):
         """
         Test if the component runs correctly.
@@ -19,7 +18,6 @@ class TestHTMLToDocument:
         assert len(docs) == 1
         assert "Haystack" in docs[0].content
 
-    @pytest.mark.unit
     def test_run_doc_metadata(self, test_files_path):
         """
         Test if the component runs correctly when metadata is supplied by the user.
@@ -34,7 +32,6 @@ class TestHTMLToDocument:
         assert "Haystack" in docs[0].content
         assert docs[0].meta == {"file_name": "what_is_haystack.html"}
 
-    @pytest.mark.unit
     def test_incorrect_meta(self, test_files_path):
         """
         Test if the component raises an error when incorrect metadata is supplied by the user.
@@ -45,7 +42,6 @@ class TestHTMLToDocument:
         with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources."):
             converter.run(sources=sources, meta=metadata)
 
-    @pytest.mark.unit
     def test_run_bytestream_metadata(self, test_files_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object.
@@ -62,7 +58,6 @@ class TestHTMLToDocument:
         assert "Haystack" in docs[0].content
         assert docs[0].meta == {"content_type": "text/html", "url": "test_url"}
 
-    @pytest.mark.unit
     def test_run_bytestream_and_doc_metadata(self, test_files_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object and supplied by the user.
@@ -82,7 +77,6 @@ class TestHTMLToDocument:
         assert "Haystack" in docs[0].content
         assert docs[0].meta == {"file_name": "what_is_haystack.html", "content_type": "text/html", "url": "test_url"}
 
-    @pytest.mark.unit
     def test_run_bytestream_doc_overlapping_metadata(self, test_files_path):
         """
         Test if the component runs correctly when metadata is read from the ByteStream object and supplied by the user.
@@ -110,7 +104,6 @@ class TestHTMLToDocument:
             "url": "test_url_new",
         }
 
-    @pytest.mark.unit
     def test_run_wrong_file_type(self, test_files_path, caplog):
         """
         Test if the component runs correctly when an input file is not of the expected type.
@@ -123,7 +116,6 @@ class TestHTMLToDocument:
 
         assert results["documents"] == []
 
-    @pytest.mark.unit
     def test_run_error_handling(self, caplog):
         """
         Test if the component correctly handles errors.
@@ -135,7 +127,6 @@ class TestHTMLToDocument:
             assert "Could not read non_existing_file.html" in caplog.text
             assert results["documents"] == []
 
-    @pytest.mark.unit
     def test_mixed_sources_run(self, test_files_path):
         """
         Test if the component runs correctly if the input is a mix of paths and ByteStreams.

--- a/test/components/converters/test_markdown_to_document.py
+++ b/test/components/converters/test_markdown_to_document.py
@@ -6,14 +6,13 @@ from haystack.components.converters.markdown import MarkdownToDocument
 from haystack.dataclasses import ByteStream
 
 
+@pytest.mark.integration
 class TestMarkdownToDocument:
-    @pytest.mark.unit
     def test_init_params_default(self):
         converter = MarkdownToDocument()
         assert converter.table_to_single_line is False
         assert converter.progress_bar is True
 
-    @pytest.mark.unit
     def test_init_params_custom(self):
         converter = MarkdownToDocument(table_to_single_line=True, progress_bar=False)
         assert converter.table_to_single_line is True
@@ -71,7 +70,6 @@ class TestMarkdownToDocument:
             assert "Could not read non_existing_file.md" in caplog.text
             assert not result["documents"]
 
-    @pytest.mark.unit
     def test_mixed_sources_run(self, test_files_path):
         """
         Test if the component runs correctly if the input is a mix of strings, paths and ByteStreams.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -1,12 +1,12 @@
 import logging
 import pytest
-from pypdf import PdfReader
 
 from haystack import Document
 from haystack.components.converters.pypdf import PyPDFToDocument, CONVERTERS_REGISTRY
 from haystack.dataclasses import ByteStream
 
 
+@pytest.mark.integration
 class TestPyPDFToDocument:
     def test_init(self):
         component = PyPDFToDocument()
@@ -17,7 +17,6 @@ class TestPyPDFToDocument:
         with pytest.raises(ValueError):
             PyPDFToDocument(converter_name="non_existing_converter")
 
-    @pytest.mark.unit
     def test_run(self, test_files_path):
         """
         Test if the component runs correctly.
@@ -29,7 +28,6 @@ class TestPyPDFToDocument:
         assert len(docs) == 1
         assert "ReAct" in docs[0].content
 
-    @pytest.mark.unit
     def test_run_error_handling(self, test_files_path, caplog):
         """
         Test if the component correctly handles errors.
@@ -40,7 +38,6 @@ class TestPyPDFToDocument:
             converter.run(sources=paths)
             assert "Could not read non_existing_file.pdf" in caplog.text
 
-    @pytest.mark.unit
     def test_mixed_sources_run(self, test_files_path):
         """
         Test if the component runs correctly when mixed sources are provided.
@@ -56,11 +53,12 @@ class TestPyPDFToDocument:
         assert "ReAct" in docs[0].content
         assert "ReAct" in docs[1].content
 
-    @pytest.mark.unit
     def test_custom_converter(self, test_files_path):
         """
         Test if the component correctly handles custom converters.
         """
+        from pypdf import PdfReader
+
         paths = [test_files_path / "pdf" / "react_paper.pdf"]
 
         class MyCustomConverter:

--- a/test/components/converters/test_textfile_to_document.py
+++ b/test/components/converters/test_textfile_to_document.py
@@ -9,7 +9,6 @@ from haystack.components.converters.txt import TextFileToDocument
 
 
 class TestTextfileToDocument:
-    @pytest.mark.unit
     def test_run(self, test_files_path):
         """
         Test if the component runs correctly.
@@ -29,7 +28,6 @@ class TestTextfileToDocument:
         assert docs[1].meta["file_path"] == str(files[1])
         assert docs[2].meta == bytestream.metadata
 
-    @pytest.mark.unit
     def test_run_error_handling(self, test_files_path, caplog):
         """
         Test if the component correctly handles errors.
@@ -44,7 +42,6 @@ class TestTextfileToDocument:
         assert docs[0].meta["file_path"] == str(paths[0])
         assert docs[1].meta["file_path"] == str(paths[2])
 
-    @pytest.mark.unit
     def test_encoding_override(self, test_files_path):
         """
         Test if the encoding metadata field is used properly

--- a/test/components/converters/test_tika_doc_converter.py
+++ b/test/components/converters/test_tika_doc_converter.py
@@ -6,7 +6,6 @@ from haystack.components.converters.tika import TikaDocumentConverter
 
 
 class TestTikaDocumentConverter:
-    @pytest.mark.unit
     def test_run(self):
         component = TikaDocumentConverter()
         with patch("haystack.components.converters.tika.tika_parser.from_file") as mock_tika_parser:
@@ -16,7 +15,6 @@ class TestTikaDocumentConverter:
         assert len(documents) == 1
         assert documents[0].content == "Content of mock_file.pdf"
 
-    @pytest.mark.unit
     def test_run_logs_warning_if_content_empty(self, caplog):
         component = TikaDocumentConverter()
         with patch("haystack.components.converters.tika.tika_parser.from_file") as mock_tika_parser:
@@ -25,7 +23,6 @@ class TestTikaDocumentConverter:
                 component.run(paths=["mock_file.pdf"])
                 assert "Skipping file at 'mock_file.pdf' as Tika was not able to extract any content." in caplog.text
 
-    @pytest.mark.unit
     def test_run_logs_error(self, caplog):
         component = TikaDocumentConverter()
         with patch("haystack.components.converters.tika.tika_parser.from_file") as mock_tika_parser:

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -25,7 +25,6 @@ def mock_openai_response(input: List[str], model: str = "text-embedding-ada-002"
 
 
 class TestOpenAIDocumentEmbedder:
-    @pytest.mark.unit
     def test_init_default(self, monkeypatch):
         openai.api_key = None
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
@@ -42,7 +41,6 @@ class TestOpenAIDocumentEmbedder:
         assert embedder.metadata_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         embedder = OpenAIDocumentEmbedder(
             api_key="fake-api-key",
@@ -67,14 +65,12 @@ class TestOpenAIDocumentEmbedder:
         assert embedder.metadata_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="OpenAIDocumentEmbedder expects an OpenAI API key"):
             OpenAIDocumentEmbedder()
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = OpenAIDocumentEmbedder(api_key="fake-api-key")
         data = component.to_dict()
@@ -92,7 +88,6 @@ class TestOpenAIDocumentEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = OpenAIDocumentEmbedder(
             api_key="fake-api-key",
@@ -120,7 +115,6 @@ class TestOpenAIDocumentEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_prepare_texts_to_embed_w_metadata(self):
         documents = [
             Document(content=f"document number {i}:\ncontent", meta={"meta_field": f"meta_value {i}"}) for i in range(5)
@@ -141,7 +135,6 @@ class TestOpenAIDocumentEmbedder:
             "meta_value 4 | document number 4: content",
         ]
 
-    @pytest.mark.unit
     def test_prepare_texts_to_embed_w_suffix(self):
         documents = [Document(content=f"document number {i}") for i in range(5)]
 
@@ -157,7 +150,6 @@ class TestOpenAIDocumentEmbedder:
             "my_prefix document number 4 my_suffix",
         ]
 
-    @pytest.mark.unit
     def test_embed_batch(self):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
 
@@ -179,7 +171,6 @@ class TestOpenAIDocumentEmbedder:
         # openai.Embedding.create is called 3 times
         assert metadata == {"model": "model", "usage": {"prompt_tokens": 3 * 4, "total_tokens": 3 * 4}}
 
-    @pytest.mark.unit
     def test_run(self):
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
@@ -219,7 +210,6 @@ class TestOpenAIDocumentEmbedder:
             assert all(isinstance(x, float) for x in doc.embedding)
         assert metadata == {"model": model, "usage": {"prompt_tokens": 4, "total_tokens": 4}}
 
-    @pytest.mark.unit
     def test_run_custom_batch_size(self):
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),
@@ -257,7 +247,6 @@ class TestOpenAIDocumentEmbedder:
         # openai.Embedding.create is called 2 times
         assert metadata == {"model": model, "usage": {"prompt_tokens": 2 * 4, "total_tokens": 2 * 4}}
 
-    @pytest.mark.unit
     def test_run_wrong_input_format(self):
         embedder = OpenAIDocumentEmbedder(api_key="fake-api-key")
 
@@ -271,7 +260,6 @@ class TestOpenAIDocumentEmbedder:
         with pytest.raises(TypeError, match="OpenAIDocumentEmbedder expects a list of Documents as input"):
             embedder.run(documents=list_integers_input)
 
-    @pytest.mark.unit
     def test_run_on_empty_list(self):
         embedder = OpenAIDocumentEmbedder(api_key="fake-api-key")
 

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -19,7 +19,6 @@ def mock_openai_response(model: str = "text-embedding-ada-002", **kwargs) -> ope
 
 
 class TestOpenAITextEmbedder:
-    @pytest.mark.unit
     def test_init_default(self, monkeypatch):
         openai.api_key = None
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
@@ -31,7 +30,6 @@ class TestOpenAITextEmbedder:
         assert embedder.prefix == ""
         assert embedder.suffix == ""
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         embedder = OpenAITextEmbedder(
             api_key="fake-api-key",
@@ -47,14 +45,12 @@ class TestOpenAITextEmbedder:
         assert embedder.prefix == "prefix"
         assert embedder.suffix == "suffix"
 
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="OpenAITextEmbedder expects an OpenAI API key"):
             OpenAITextEmbedder()
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = OpenAITextEmbedder(api_key="fake-api-key")
         data = component.to_dict()
@@ -68,7 +64,6 @@ class TestOpenAITextEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = OpenAITextEmbedder(
             api_key="fake-api-key",
@@ -88,7 +83,6 @@ class TestOpenAITextEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_run(self):
         model = "text-similarity-ada-001"
 
@@ -106,7 +100,6 @@ class TestOpenAITextEmbedder:
         assert all(isinstance(x, float) for x in result["embedding"])
         assert result["metadata"] == {"model": model, "usage": {"prompt_tokens": 4, "total_tokens": 4}}
 
-    @pytest.mark.unit
     def test_run_wrong_input_format(self):
         embedder = OpenAITextEmbedder(api_key="fake-api-key")
 

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -7,7 +7,6 @@ from haystack.components.embedders.sentence_transformers_document_embedder impor
 
 
 class TestSentenceTransformersDocumentEmbedder:
-    @pytest.mark.unit
     def test_init_default(self):
         embedder = SentenceTransformersDocumentEmbedder(model_name_or_path="model")
         assert embedder.model_name_or_path == "model"
@@ -21,7 +20,6 @@ class TestSentenceTransformersDocumentEmbedder:
         assert embedder.metadata_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         embedder = SentenceTransformersDocumentEmbedder(
             model_name_or_path="model",
@@ -46,7 +44,6 @@ class TestSentenceTransformersDocumentEmbedder:
         assert embedder.metadata_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = SentenceTransformersDocumentEmbedder(model_name_or_path="model")
         data = component.to_dict()
@@ -66,7 +63,6 @@ class TestSentenceTransformersDocumentEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = SentenceTransformersDocumentEmbedder(
             model_name_or_path="model",
@@ -98,7 +94,6 @@ class TestSentenceTransformersDocumentEmbedder:
             },
         }
 
-    @pytest.mark.unit
     @patch(
         "haystack.components.embedders.sentence_transformers_document_embedder._SentenceTransformersEmbeddingBackendFactory"
     )
@@ -110,7 +105,6 @@ class TestSentenceTransformersDocumentEmbedder:
             model_name_or_path="model", device="cpu", use_auth_token=None
         )
 
-    @pytest.mark.unit
     @patch(
         "haystack.components.embedders.sentence_transformers_document_embedder._SentenceTransformersEmbeddingBackendFactory"
     )
@@ -121,7 +115,6 @@ class TestSentenceTransformersDocumentEmbedder:
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once()
 
-    @pytest.mark.unit
     def test_run(self):
         embedder = SentenceTransformersDocumentEmbedder(model_name_or_path="model")
         embedder.embedding_backend = MagicMock()
@@ -138,7 +131,6 @@ class TestSentenceTransformersDocumentEmbedder:
             assert isinstance(doc.embedding, list)
             assert isinstance(doc.embedding[0], float)
 
-    @pytest.mark.unit
     def test_run_wrong_input_format(self):
         embedder = SentenceTransformersDocumentEmbedder(model_name_or_path="model")
 
@@ -155,7 +147,6 @@ class TestSentenceTransformersDocumentEmbedder:
         ):
             embedder.run(documents=list_integers_input)
 
-    @pytest.mark.unit
     def test_embed_metadata(self):
         embedder = SentenceTransformersDocumentEmbedder(
             model_name_or_path="model", metadata_fields_to_embed=["meta_field"], embedding_separator="\n"
@@ -179,7 +170,6 @@ class TestSentenceTransformersDocumentEmbedder:
             normalize_embeddings=False,
         )
 
-    @pytest.mark.unit
     def test_prefix_suffix(self):
         embedder = SentenceTransformersDocumentEmbedder(
             model_name_or_path="model",

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -5,7 +5,6 @@ from haystack.components.embedders.backends.sentence_transformers_backend import
 )
 
 
-@pytest.mark.unit
 @patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
 def test_factory_behavior(mock_sentence_transformer):
     embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
@@ -20,7 +19,6 @@ def test_factory_behavior(mock_sentence_transformer):
     assert another_embedding_backend is not embedding_backend
 
 
-@pytest.mark.unit
 @patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
 def test_model_initialization(mock_sentence_transformer):
     _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
@@ -31,7 +29,6 @@ def test_model_initialization(mock_sentence_transformer):
     )
 
 
-@pytest.mark.unit
 @patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
 def test_embedding_function_with_kwargs(mock_sentence_transformer):
     embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(model_name_or_path="model")

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -7,7 +7,6 @@ from haystack.components.embedders.sentence_transformers_text_embedder import Se
 
 
 class TestSentenceTransformersTextEmbedder:
-    @pytest.mark.unit
     def test_init_default(self):
         embedder = SentenceTransformersTextEmbedder(model_name_or_path="model")
         assert embedder.model_name_or_path == "model"
@@ -19,7 +18,6 @@ class TestSentenceTransformersTextEmbedder:
         assert embedder.progress_bar is True
         assert embedder.normalize_embeddings is False
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         embedder = SentenceTransformersTextEmbedder(
             model_name_or_path="model",
@@ -40,7 +38,6 @@ class TestSentenceTransformersTextEmbedder:
         assert embedder.progress_bar is False
         assert embedder.normalize_embeddings is True
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = SentenceTransformersTextEmbedder(model_name_or_path="model")
         data = component.to_dict()
@@ -58,7 +55,6 @@ class TestSentenceTransformersTextEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = SentenceTransformersTextEmbedder(
             model_name_or_path="model",
@@ -85,7 +81,6 @@ class TestSentenceTransformersTextEmbedder:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_not_serialize_token(self):
         component = SentenceTransformersTextEmbedder(model_name_or_path="model", token="awesome-token")
         data = component.to_dict()
@@ -103,7 +98,6 @@ class TestSentenceTransformersTextEmbedder:
             },
         }
 
-    @pytest.mark.unit
     @patch(
         "haystack.components.embedders.sentence_transformers_text_embedder._SentenceTransformersEmbeddingBackendFactory"
     )
@@ -115,7 +109,6 @@ class TestSentenceTransformersTextEmbedder:
             model_name_or_path="model", device="cpu", use_auth_token=None
         )
 
-    @pytest.mark.unit
     @patch(
         "haystack.components.embedders.sentence_transformers_text_embedder._SentenceTransformersEmbeddingBackendFactory"
     )
@@ -126,7 +119,6 @@ class TestSentenceTransformersTextEmbedder:
         embedder.warm_up()
         mocked_factory.get_embedding_backend.assert_called_once()
 
-    @pytest.mark.unit
     def test_run(self):
         embedder = SentenceTransformersTextEmbedder(model_name_or_path="model")
         embedder.embedding_backend = MagicMock()
@@ -140,7 +132,6 @@ class TestSentenceTransformersTextEmbedder:
         assert isinstance(embedding, list)
         assert all(isinstance(el, float) for el in embedding)
 
-    @pytest.mark.unit
     def test_run_wrong_input_format(self):
         embedder = SentenceTransformersTextEmbedder(model_name_or_path="model")
         embedder.embedding_backend = MagicMock()

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -36,7 +36,6 @@ def mock_get_link_content(test_files_path):
 
 
 class TestLinkContentFetcher:
-    @pytest.mark.unit
     def test_init(self):
         fetcher = LinkContentFetcher()
         assert fetcher.raise_on_failure is True
@@ -51,7 +50,6 @@ class TestLinkContentFetcher:
         }
         assert hasattr(fetcher, "_get_response")
 
-    @pytest.mark.unit
     def test_init_with_params(self):
         fetcher = LinkContentFetcher(raise_on_failure=False, user_agents=["test"], retry_attempts=1, timeout=2)
         assert fetcher.raise_on_failure is False
@@ -59,7 +57,6 @@ class TestLinkContentFetcher:
         assert fetcher.retry_attempts == 1
         assert fetcher.timeout == 2
 
-    @pytest.mark.unit
     def test_run_text(self):
         correct_response = b"Example test response"
         with patch("haystack.components.fetchers.link_content.requests") as mock_run:
@@ -72,7 +69,6 @@ class TestLinkContentFetcher:
             assert first_stream.data == correct_response
             assert first_stream.metadata["content_type"] == "text/plain"
 
-    @pytest.mark.unit
     def test_run_html(self):
         correct_response = b"<h1>Example test response</h1>"
         with patch("haystack.components.fetchers.link_content.requests") as mock_run:
@@ -85,7 +81,6 @@ class TestLinkContentFetcher:
             assert first_stream.data == correct_response
             assert first_stream.metadata["content_type"] == "text/html"
 
-    @pytest.mark.unit
     def test_run_binary(self, test_files_path):
         file_bytes = open(test_files_path / "pdf" / "sample_pdf_1.pdf", "rb").read()
         with patch("haystack.components.fetchers.link_content.requests") as mock_run:
@@ -98,7 +93,6 @@ class TestLinkContentFetcher:
             assert first_stream.data == file_bytes
             assert first_stream.metadata["content_type"] == "application/pdf"
 
-    @pytest.mark.unit
     def test_run_bad_status_code(self):
         empty_byte_stream = b""
         fetcher = LinkContentFetcher(raise_on_failure=False)

--- a/test/components/generators/chat/test_hugging_face_tgi.py
+++ b/test/components/generators/chat/test_hugging_face_tgi.py
@@ -36,7 +36,6 @@ def streaming_callback_handler(x):
 
 
 class TestHuggingFaceTGIChatGenerator:
-    @pytest.mark.unit
     def test_initialize_with_valid_model_and_generation_parameters(self, mock_check_valid_model, mock_auto_tokenizer):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"n": 1}
@@ -56,7 +55,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert generator.client is not None
         assert generator.streaming_callback == streaming_callback
 
-    @pytest.mark.unit
     def test_to_dict(self, mock_check_valid_model):
         # Initialize the HuggingFaceTGIChatGenerator object with valid parameters
         generator = HuggingFaceTGIChatGenerator(
@@ -76,7 +74,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert init_params["token"] is None
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
 
-    @pytest.mark.unit
     def test_from_dict(self, mock_check_valid_model):
         generator = HuggingFaceTGIChatGenerator(
             model="NousResearch/Llama-2-7b-chat-hf",
@@ -92,7 +89,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert generator_2.generation_kwargs == {"n": 5, "stop_sequences": ["stop", "words"]}
         assert generator_2.streaming_callback is streaming_callback_handler
 
-    @pytest.mark.unit
     def test_warm_up(self, mock_check_valid_model, mock_auto_tokenizer):
         generator = HuggingFaceTGIChatGenerator()
         generator.warm_up()
@@ -100,7 +96,6 @@ class TestHuggingFaceTGIChatGenerator:
         # Assert that the tokenizer is now initialized
         assert generator.tokenizer is not None
 
-    @pytest.mark.unit
     def test_warm_up_no_chat_template(self, mock_check_valid_model, mock_auto_tokenizer, caplog):
         generator = HuggingFaceTGIChatGenerator(model="meta-llama/Llama-2-13b-chat-hf")
 
@@ -111,7 +106,6 @@ class TestHuggingFaceTGIChatGenerator:
         # warning message should be logged
         assert "The model 'meta-llama/Llama-2-13b-chat-hf' doesn't have a default chat_template" in caplog.text
 
-    @pytest.mark.unit
     def test_custom_chat_template(
         self, chat_messages, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
@@ -132,7 +126,6 @@ class TestHuggingFaceTGIChatGenerator:
         _, kwargs = mock_auto_tokenizer.apply_chat_template.call_args
         assert kwargs["chat_template"] == custom_chat_template
 
-    @pytest.mark.unit
     def test_initialize_with_invalid_model_path_or_url(self, mock_check_valid_model):
         model = "invalid_model"
         generation_kwargs = {"n": 1}
@@ -149,19 +142,16 @@ class TestHuggingFaceTGIChatGenerator:
                 streaming_callback=streaming_callback,
             )
 
-    @pytest.mark.unit
     def test_initialize_with_invalid_url(self, mock_check_valid_model):
         with pytest.raises(ValueError):
             HuggingFaceTGIChatGenerator(model="NousResearch/Llama-2-7b-chat-hf", url="invalid_url")
 
-    @pytest.mark.unit
     def test_initialize_with_url_but_invalid_model(self, mock_check_valid_model):
         # When custom TGI endpoint is used via URL, model must be provided and valid HuggingFace Hub model id
         mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id")
         with pytest.raises(RepositoryNotFoundError):
             HuggingFaceTGIChatGenerator(model="invalid_model_id", url="https://some_chat_model.com")
 
-    @pytest.mark.unit
     def test_generate_text_response_with_valid_prompt_and_generation_parameters(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation, chat_messages
     ):
@@ -191,7 +181,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_generate_multiple_text_responses_with_valid_prompt_and_generation_parameters(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation, chat_messages
     ):
@@ -223,7 +212,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert len(response["replies"]) == 3
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_generate_text_with_stop_words(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation, chat_messages
     ):
@@ -246,7 +234,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert len(response["replies"]) > 0
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_generate_text_with_custom_generation_parameters(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation, chat_messages
     ):
@@ -269,7 +256,6 @@ class TestHuggingFaceTGIChatGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
         assert response["replies"][0].content == "I'm fine, thanks."
 
-    @pytest.mark.unit
     def test_generate_text_with_streaming_callback(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation, chat_messages
     ):

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -66,7 +66,6 @@ def chat_messages():
 
 
 class TestGPTChatGenerator:
-    @pytest.mark.unit
     def test_init_default(self):
         component = GPTChatGenerator(api_key="test-api-key")
         assert openai.api_key == "test-api-key"
@@ -76,14 +75,12 @@ class TestGPTChatGenerator:
         assert openai.api_base == "https://api.openai.com/v1"
         assert not component.generation_kwargs
 
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="GPTChatGenerator expects an OpenAI API key"):
             GPTChatGenerator()
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         component = GPTChatGenerator(
             api_key="test-api-key",
@@ -99,7 +96,6 @@ class TestGPTChatGenerator:
         assert openai.api_base == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    @pytest.mark.unit
     def test_to_dict_default(self):
         component = GPTChatGenerator(api_key="test-api-key")
         data = component.to_dict()
@@ -113,7 +109,6 @@ class TestGPTChatGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_parameters(self):
         component = GPTChatGenerator(
             api_key="test-api-key",
@@ -133,7 +128,6 @@ class TestGPTChatGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_lambda_streaming_callback(self):
         component = GPTChatGenerator(
             api_key="test-api-key",
@@ -153,7 +147,6 @@ class TestGPTChatGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
         data = {
@@ -171,7 +164,6 @@ class TestGPTChatGenerator:
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    @pytest.mark.unit
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -187,7 +179,6 @@ class TestGPTChatGenerator:
         with pytest.raises(ValueError, match="GPTChatGenerator expects an OpenAI API key"):
             GPTChatGenerator.from_dict(data)
 
-    @pytest.mark.unit
     def test_run(self, chat_messages, mock_chat_completion):
         component = GPTChatGenerator(api_key="test-api-key")
         response = component.run(chat_messages)
@@ -199,7 +190,6 @@ class TestGPTChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_run_with_params(self, chat_messages, mock_chat_completion):
         component = GPTChatGenerator(api_key="test-api-key", generation_kwargs={"max_tokens": 10, "temperature": 0.5})
         response = component.run(chat_messages)
@@ -216,7 +206,6 @@ class TestGPTChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_run_streaming(self, chat_messages, mock_chat_completion):
         streaming_call_count = 0
 
@@ -248,7 +237,6 @@ class TestGPTChatGenerator:
         assert len(response["replies"]) > 0
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_check_abnormal_completions(self, caplog):
         component = GPTChatGenerator(api_key="test-api-key")
         messages = [

--- a/test/components/generators/test_cohere_generators.py
+++ b/test/components/generators/test_cohere_generators.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-import cohere
 
 from haystack.components.generators import CohereGenerator
 
@@ -14,8 +13,11 @@ def default_streaming_callback(chunk):
     print(chunk.text, flush=True, end="")
 
 
-class TestGPTGenerator:
+@pytest.mark.integration
+class TestCohereGenerator:
     def test_init_default(self):
+        import cohere
+
         component = CohereGenerator(api_key="test-api-key")
         assert component.api_key == "test-api-key"
         assert component.model_name == "command"
@@ -40,6 +42,8 @@ class TestGPTGenerator:
         assert component.model_parameters == {"max_tokens": 10, "some_test_param": "test-params"}
 
     def test_to_dict_default(self):
+        import cohere
+
         component = CohereGenerator(api_key="test-api-key")
         data = component.to_dict()
         assert data == {
@@ -140,6 +144,8 @@ class TestGPTGenerator:
     )
     @pytest.mark.integration
     def test_cohere_generator_run_wrong_model_name(self):
+        import cohere
+
         component = CohereGenerator(model_name="something-obviously-wrong", api_key=os.environ.get("COHERE_API_KEY"))
         with pytest.raises(
             cohere.CohereAPIError,

--- a/test/components/generators/test_hf_utils.py
+++ b/test/components/generators/test_hf_utils.py
@@ -3,13 +3,11 @@ import pytest
 from haystack.components.generators.hf_utils import check_generation_params
 
 
-@pytest.mark.unit
 def test_empty_dictionary():
     # no exception raised
     check_generation_params({})
 
 
-@pytest.mark.unit
 def test_valid_generation_parameters():
     # these are valid parameters
     kwargs = {"max_new_tokens": 100, "temperature": 0.8}
@@ -17,7 +15,6 @@ def test_valid_generation_parameters():
     check_generation_params(kwargs, additional_accepted_params)
 
 
-@pytest.mark.unit
 def test_invalid_generation_parameters():
     # these are invalid parameters
     kwargs = {"invalid_param": "value"}
@@ -26,14 +23,12 @@ def test_invalid_generation_parameters():
         check_generation_params(kwargs, additional_accepted_params)
 
 
-@pytest.mark.unit
 def test_additional_accepted_params_empty_list():
     kwargs = {"temperature": 0.8}
     additional_accepted_params = []
     check_generation_params(kwargs, additional_accepted_params)
 
 
-@pytest.mark.unit
 def test_additional_accepted_params_known_parameter():
     # both are valid parameters
     kwargs = {"temperature": 0.8}
@@ -41,7 +36,6 @@ def test_additional_accepted_params_known_parameter():
     check_generation_params(kwargs, additional_accepted_params)
 
 
-@pytest.mark.unit
 def test_additional_accepted_params_unknown_parameter():
     kwargs = {"strange_param": "value"}
     additional_accepted_params = ["strange_param"]

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -8,7 +8,6 @@ from haystack.components.generators.hugging_face_local import HuggingFaceLocalGe
 
 
 class TestHuggingFaceLocalGenerator:
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.model_info")
     def test_init_default(self, model_info_mock):
         model_info_mock.return_value.pipeline_tag = "text2text-generation"
@@ -22,7 +21,6 @@ class TestHuggingFaceLocalGenerator:
         assert generator.generation_kwargs == {}
         assert generator.pipeline is None
 
-    @pytest.mark.unit
     def test_init_custom_token(self):
         generator = HuggingFaceLocalGenerator(
             model_name_or_path="google/flan-t5-base", task="text2text-generation", token="test-token"
@@ -34,7 +32,6 @@ class TestHuggingFaceLocalGenerator:
             "token": "test-token",
         }
 
-    @pytest.mark.unit
     def test_init_custom_device(self):
         generator = HuggingFaceLocalGenerator(
             model_name_or_path="google/flan-t5-base", task="text2text-generation", device="cuda:0"
@@ -47,7 +44,6 @@ class TestHuggingFaceLocalGenerator:
             "device": "cuda:0",
         }
 
-    @pytest.mark.unit
     def test_init_task_parameter(self):
         generator = HuggingFaceLocalGenerator(task="text2text-generation")
 
@@ -57,7 +53,6 @@ class TestHuggingFaceLocalGenerator:
             "token": None,
         }
 
-    @pytest.mark.unit
     def test_init_task_in_huggingface_pipeline_kwargs(self):
         generator = HuggingFaceLocalGenerator(huggingface_pipeline_kwargs={"task": "text2text-generation"})
 
@@ -67,7 +62,6 @@ class TestHuggingFaceLocalGenerator:
             "token": None,
         }
 
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.model_info")
     def test_init_task_inferred_from_model_name(self, model_info_mock):
         model_info_mock.return_value.pipeline_tag = "text2text-generation"
@@ -79,12 +73,10 @@ class TestHuggingFaceLocalGenerator:
             "token": None,
         }
 
-    @pytest.mark.unit
     def test_init_invalid_task(self):
         with pytest.raises(ValueError, match="is not supported."):
             HuggingFaceLocalGenerator(task="text-classification")
 
-    @pytest.mark.unit
     def test_init_huggingface_pipeline_kwargs_override_other_parameters(self):
         """
         huggingface_pipeline_kwargs represent the main configuration of this component.
@@ -108,13 +100,11 @@ class TestHuggingFaceLocalGenerator:
 
         assert generator.huggingface_pipeline_kwargs == huggingface_pipeline_kwargs
 
-    @pytest.mark.unit
     def test_init_generation_kwargs(self):
         generator = HuggingFaceLocalGenerator(task="text2text-generation", generation_kwargs={"max_new_tokens": 100})
 
         assert generator.generation_kwargs == {"max_new_tokens": 100}
 
-    @pytest.mark.unit
     def test_init_set_return_full_text(self):
         """
         if not specified, return_full_text is set to False for text-generation task
@@ -124,7 +114,6 @@ class TestHuggingFaceLocalGenerator:
 
         assert generator.generation_kwargs == {"return_full_text": False}
 
-    @pytest.mark.unit
     def test_init_fails_with_both_stopwords_and_stoppingcriteria(self):
         with pytest.raises(
             ValueError,
@@ -136,7 +125,6 @@ class TestHuggingFaceLocalGenerator:
                 generation_kwargs={"stopping_criteria": "fake-stopping-criteria"},
             )
 
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.model_info")
     def test_to_dict_default(self, model_info_mock):
         model_info_mock.return_value.pipeline_tag = "text2text-generation"
@@ -157,7 +145,6 @@ class TestHuggingFaceLocalGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_parameters(self):
         component = HuggingFaceLocalGenerator(
             model_name_or_path="gpt2",
@@ -183,7 +170,6 @@ class TestHuggingFaceLocalGenerator:
             },
         }
 
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.pipeline")
     def test_warm_up(self, pipeline_mock):
         generator = HuggingFaceLocalGenerator(
@@ -197,7 +183,6 @@ class TestHuggingFaceLocalGenerator:
             model="google/flan-t5-base", task="text2text-generation", token="test-token"
         )
 
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.pipeline")
     def test_warm_up_doesn_reload(self, pipeline_mock):
         generator = HuggingFaceLocalGenerator(
@@ -211,7 +196,6 @@ class TestHuggingFaceLocalGenerator:
 
         pipeline_mock.assert_called_once()
 
-    @pytest.mark.unit
     def test_run(self):
         generator = HuggingFaceLocalGenerator(
             model_name_or_path="google/flan-t5-base",
@@ -229,7 +213,6 @@ class TestHuggingFaceLocalGenerator:
         )
         assert results == {"replies": ["Rome"]}
 
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.pipeline")
     def test_run_empty_prompt(self, pipeline_mock):
         generator = HuggingFaceLocalGenerator(
@@ -244,7 +227,6 @@ class TestHuggingFaceLocalGenerator:
 
         assert results == {"replies": []}
 
-    @pytest.mark.unit
     def test_run_with_generation_kwargs(self):
         generator = HuggingFaceLocalGenerator(
             model_name_or_path="google/flan-t5-base",
@@ -261,7 +243,6 @@ class TestHuggingFaceLocalGenerator:
             "irrelevant", max_new_tokens=200, temperature=0.5, stopping_criteria=None
         )
 
-    @pytest.mark.unit
     def test_run_fails_without_warm_up(self):
         generator = HuggingFaceLocalGenerator(
             model_name_or_path="google/flan-t5-base",
@@ -272,7 +253,6 @@ class TestHuggingFaceLocalGenerator:
         with pytest.raises(RuntimeError, match="The generation model has not been loaded."):
             generator.run(prompt="irrelevant")
 
-    @pytest.mark.unit
     def test_stop_words_criteria(self):
         """
         Test that StopWordsCriteria will check stop word tokens in a continuous and sequential order
@@ -309,7 +289,6 @@ class TestHuggingFaceLocalGenerator:
         present_and_continuous = stop_words_criteria(input_ids2, scores=None)
         assert present_and_continuous
 
-    @pytest.mark.unit
     @patch("haystack.components.generators.hugging_face_local.pipeline")
     @patch("haystack.components.generators.hugging_face_local.StopWordsCriteria")
     @patch("haystack.components.generators.hugging_face_local.StoppingCriteriaList")
@@ -331,7 +310,6 @@ class TestHuggingFaceLocalGenerator:
 
         assert hasattr(generator, "stopping_criteria_list")
 
-    @pytest.mark.unit
     def test_run_stop_words_removal(self):
         """
         Test that stop words are removed from the generated text

--- a/test/components/generators/test_hugging_face_tgi.py
+++ b/test/components/generators/test_hugging_face_tgi.py
@@ -35,7 +35,6 @@ def streaming_callback_handler(x):
 
 
 class TestHuggingFaceTGIGenerator:
-    @pytest.mark.unit
     def test_initialize_with_valid_model_and_generation_parameters(self, mock_check_valid_model):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"n": 1}
@@ -57,7 +56,6 @@ class TestHuggingFaceTGIGenerator:
         assert generator.client is not None
         assert generator.streaming_callback == streaming_callback
 
-    @pytest.mark.unit
     def test_to_dict(self, mock_check_valid_model):
         # Initialize the HuggingFaceRemoteGenerator object with valid parameters
         generator = HuggingFaceTGIGenerator(
@@ -73,7 +71,6 @@ class TestHuggingFaceTGIGenerator:
         assert not init_params["token"]
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
 
-    @pytest.mark.unit
     def test_from_dict(self, mock_check_valid_model):
         generator = HuggingFaceTGIGenerator(
             model="mistralai/Mistral-7B-v0.1",
@@ -90,19 +87,16 @@ class TestHuggingFaceTGIGenerator:
         assert generator_2.generation_kwargs == {"n": 5, "stop_sequences": ["stop", "words"]}
         assert generator_2.streaming_callback is streaming_callback_handler
 
-    @pytest.mark.unit
     def test_initialize_with_invalid_url(self, mock_check_valid_model):
         with pytest.raises(ValueError):
             HuggingFaceTGIGenerator(model="mistralai/Mistral-7B-v0.1", url="invalid_url")
 
-    @pytest.mark.unit
     def test_initialize_with_url_but_invalid_model(self, mock_check_valid_model):
         # When custom TGI endpoint is used via URL, model must be provided and valid HuggingFace Hub model id
         mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id")
         with pytest.raises(RepositoryNotFoundError):
             HuggingFaceTGIGenerator(model="invalid_model_id", url="https://some_chat_model.com")
 
-    @pytest.mark.unit
     def test_generate_text_response_with_valid_prompt_and_generation_parameters(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
@@ -137,7 +131,6 @@ class TestHuggingFaceTGIGenerator:
         assert len(response["metadata"]) == 1
         assert [isinstance(reply, str) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_generate_multiple_text_responses_with_valid_prompt_and_generation_parameters(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
@@ -173,7 +166,6 @@ class TestHuggingFaceTGIGenerator:
         assert len(response["metadata"]) == 3
         assert [isinstance(reply, dict) for reply in response["metadata"]]
 
-    @pytest.mark.unit
     def test_initialize_with_invalid_model(self, mock_check_valid_model):
         model = "invalid_model"
         generation_kwargs = {"n": 1}
@@ -190,7 +182,6 @@ class TestHuggingFaceTGIGenerator:
                 streaming_callback=streaming_callback,
             )
 
-    @pytest.mark.unit
     def test_generate_text_with_stop_words(self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation):
         generator = HuggingFaceTGIGenerator()
         generator.warm_up()
@@ -214,7 +205,6 @@ class TestHuggingFaceTGIGenerator:
         assert len(response["metadata"]) > 0
         assert [isinstance(reply, dict) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_generate_text_with_custom_generation_parameters(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):
@@ -241,7 +231,6 @@ class TestHuggingFaceTGIGenerator:
         assert len(response["metadata"]) > 0
         assert [isinstance(reply, str) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_generate_text_with_streaming_callback(
         self, mock_check_valid_model, mock_auto_tokenizer, mock_text_generation
     ):

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -59,7 +59,6 @@ def streaming_chunk(content: str):
 
 
 class TestGPTGenerator:
-    @pytest.mark.unit
     def test_init_default(self):
         component = GPTGenerator(api_key="test-api-key")
         assert openai.api_key == "test-api-key"
@@ -69,14 +68,12 @@ class TestGPTGenerator:
         assert openai.api_base == "https://api.openai.com/v1"
         assert not component.generation_kwargs
 
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="GPTGenerator expects an OpenAI API key"):
             GPTGenerator()
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         component = GPTGenerator(
             api_key="test-api-key",
@@ -92,7 +89,6 @@ class TestGPTGenerator:
         assert openai.api_base == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    @pytest.mark.unit
     def test_to_dict_default(self):
         component = GPTGenerator(api_key="test-api-key")
         data = component.to_dict()
@@ -107,7 +103,6 @@ class TestGPTGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_parameters(self):
         component = GPTGenerator(
             api_key="test-api-key",
@@ -128,7 +123,6 @@ class TestGPTGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_lambda_streaming_callback(self):
         component = GPTGenerator(
             api_key="test-api-key",
@@ -149,7 +143,6 @@ class TestGPTGenerator:
             },
         }
 
-    @pytest.mark.unit
     def test_from_dict(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
         data = {
@@ -168,7 +161,6 @@ class TestGPTGenerator:
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    @pytest.mark.unit
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         openai.api_key = None
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -184,7 +176,6 @@ class TestGPTGenerator:
         with pytest.raises(ValueError, match="GPTGenerator expects an OpenAI API key"):
             GPTGenerator.from_dict(data)
 
-    @pytest.mark.unit
     def test_run(self, mock_chat_completion):
         component = GPTGenerator(api_key="test-api-key")
         response = component.run("What's Natural Language Processing?")
@@ -196,7 +187,6 @@ class TestGPTGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, str) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_run_with_params(self, mock_chat_completion):
         component = GPTGenerator(api_key="test-api-key", generation_kwargs={"max_tokens": 10, "temperature": 0.5})
         response = component.run("What's Natural Language Processing?")
@@ -213,7 +203,6 @@ class TestGPTGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, str) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_run_streaming(self, mock_chat_completion):
         streaming_call_count = 0
 
@@ -245,7 +234,6 @@ class TestGPTGenerator:
         assert len(response["replies"]) > 0
         assert [isinstance(reply, str) for reply in response["replies"]]
 
-    @pytest.mark.unit
     def test_check_abnormal_completions(self, caplog):
         component = GPTGenerator(api_key="test-api-key")
 

--- a/test/components/generators/test_utils.py
+++ b/test/components/generators/test_utils.py
@@ -9,19 +9,16 @@ def streaming_callback(chunk):
     pass
 
 
-@pytest.mark.unit
 def test_callback_handler_serialization():
     result = serialize_callback_handler(streaming_callback)
     assert result == "test_utils.streaming_callback"
 
 
-@pytest.mark.unit
 def test_callback_handler_serialization_non_local():
     result = serialize_callback_handler(default_streaming_callback)
     assert result == "haystack.components.generators.utils.default_streaming_callback"
 
 
-@pytest.mark.unit
 def test_callback_handler_deserialization():
     result = serialize_callback_handler(streaming_callback)
     fn = deserialize_callback_handler(result)
@@ -29,7 +26,6 @@ def test_callback_handler_deserialization():
     assert fn is streaming_callback
 
 
-@pytest.mark.unit
 def test_callback_handler_deserialization_non_local():
     result = serialize_callback_handler(default_streaming_callback)
     fn = deserialize_callback_handler(result)

--- a/test/components/preprocessors/test_document_cleaner.py
+++ b/test/components/preprocessors/test_document_cleaner.py
@@ -7,7 +7,6 @@ from haystack.components.preprocessors import DocumentCleaner
 
 
 class TestDocumentCleaner:
-    @pytest.mark.unit
     def test_init(self):
         cleaner = DocumentCleaner()
         assert cleaner.remove_empty_lines is True
@@ -16,26 +15,22 @@ class TestDocumentCleaner:
         assert cleaner.remove_substrings is None
         assert cleaner.remove_regex is None
 
-    @pytest.mark.unit
     def test_non_text_document(self, caplog):
         with caplog.at_level(logging.WARNING):
             cleaner = DocumentCleaner()
             cleaner.run(documents=[Document()])
             assert "DocumentCleaner only cleans text documents but document.content for document ID" in caplog.text
 
-    @pytest.mark.unit
     def test_single_document(self):
         with pytest.raises(TypeError, match="DocumentCleaner expects a List of Documents as input."):
             cleaner = DocumentCleaner()
             cleaner.run(documents=Document())
 
-    @pytest.mark.unit
     def test_empty_list(self):
         cleaner = DocumentCleaner()
         result = cleaner.run(documents=[])
         assert result == {"documents": []}
 
-    @pytest.mark.unit
     def test_remove_empty_lines(self):
         cleaner = DocumentCleaner(remove_extra_whitespaces=False)
         result = cleaner.run(
@@ -55,7 +50,6 @@ class TestDocumentCleaner:
             == "This is a text with some words. There is a second sentence. And there is a third sentence."
         )
 
-    @pytest.mark.unit
     def test_remove_whitespaces(self):
         cleaner = DocumentCleaner(remove_empty_lines=False)
         result = cleaner.run(
@@ -74,21 +68,18 @@ class TestDocumentCleaner:
             "This is a text with some words. " "" "There is a second sentence. " "" "And there is a third sentence."
         )
 
-    @pytest.mark.unit
     def test_remove_substrings(self):
         cleaner = DocumentCleaner(remove_substrings=["This", "A", "words", "🪲"])
         result = cleaner.run(documents=[Document(content="This is a text with some words.🪲")])
         assert len(result["documents"]) == 1
         assert result["documents"][0].content == " is a text with some ."
 
-    @pytest.mark.unit
     def test_remove_regex(self):
         cleaner = DocumentCleaner(remove_regex=r"\s\s+")
         result = cleaner.run(documents=[Document(content="This is a  text with   some words.")])
         assert len(result["documents"]) == 1
         assert result["documents"][0].content == "This is a text with some words."
 
-    @pytest.mark.unit
     def test_remove_repeated_substrings(self):
         cleaner = DocumentCleaner(
             remove_empty_lines=False, remove_extra_whitespaces=False, remove_repeated_substrings=True
@@ -124,7 +115,6 @@ class TestDocumentCleaner:
         result = cleaner.run(documents=[Document(content=text)])
         assert result["documents"][0].content == expected_text
 
-    @pytest.mark.unit
     def test_copy_metadata(self):
         cleaner = DocumentCleaner()
         documents = [

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -5,7 +5,6 @@ from haystack.components.preprocessors import DocumentSplitter
 
 
 class TestDocumentSplitter:
-    @pytest.mark.unit
     def test_non_text_document(self):
         with pytest.raises(
             ValueError, match="DocumentSplitter only works with text documents but document.content for document ID"
@@ -13,34 +12,28 @@ class TestDocumentSplitter:
             splitter = DocumentSplitter()
             splitter.run(documents=[Document()])
 
-    @pytest.mark.unit
     def test_single_doc(self):
         with pytest.raises(TypeError, match="DocumentSplitter expects a List of Documents as input."):
             splitter = DocumentSplitter()
             splitter.run(documents=Document())
 
-    @pytest.mark.unit
     def test_empty_list(self):
         splitter = DocumentSplitter()
         res = splitter.run(documents=[])
         assert res == {"documents": []}
 
-    @pytest.mark.unit
     def test_unsupported_split_by(self):
         with pytest.raises(ValueError, match="split_by must be one of 'word', 'sentence' or 'passage'."):
             DocumentSplitter(split_by="unsupported")
 
-    @pytest.mark.unit
     def test_unsupported_split_length(self):
         with pytest.raises(ValueError, match="split_length must be greater than 0."):
             DocumentSplitter(split_length=0)
 
-    @pytest.mark.unit
     def test_unsupported_split_overlap(self):
         with pytest.raises(ValueError, match="split_overlap must be greater than or equal to 0."):
             DocumentSplitter(split_overlap=-1)
 
-    @pytest.mark.unit
     def test_split_by_word(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         result = splitter.run(
@@ -54,7 +47,6 @@ class TestDocumentSplitter:
         assert result["documents"][0].content == "This is a text with some words. There is a "
         assert result["documents"][1].content == "second sentence. And there is a third sentence."
 
-    @pytest.mark.unit
     def test_split_by_word_multiple_input_docs(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         result = splitter.run(
@@ -74,7 +66,6 @@ class TestDocumentSplitter:
         assert result["documents"][3].content == "a second sentence. And there is a third sentence. And "
         assert result["documents"][4].content == "there is a fourth sentence."
 
-    @pytest.mark.unit
     def test_split_by_sentence(self):
         splitter = DocumentSplitter(split_by="sentence", split_length=1)
         result = splitter.run(
@@ -89,7 +80,6 @@ class TestDocumentSplitter:
         assert result["documents"][1].content == " There is a second sentence."
         assert result["documents"][2].content == " And there is a third sentence."
 
-    @pytest.mark.unit
     def test_split_by_passage(self):
         splitter = DocumentSplitter(split_by="passage", split_length=1)
         result = splitter.run(
@@ -104,7 +94,6 @@ class TestDocumentSplitter:
         assert result["documents"][1].content == "And there is a third sentence.\n\n"
         assert result["documents"][2].content == " And another passage."
 
-    @pytest.mark.unit
     def test_split_by_word_with_overlap(self):
         splitter = DocumentSplitter(split_by="word", split_length=10, split_overlap=2)
         result = splitter.run(
@@ -118,7 +107,6 @@ class TestDocumentSplitter:
         assert result["documents"][0].content == "This is a text with some words. There is a "
         assert result["documents"][1].content == "is a second sentence. And there is a third sentence."
 
-    @pytest.mark.unit
     def test_source_id_stored_in_metadata(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         doc1 = Document(content="This is a text with some words.")
@@ -127,7 +115,6 @@ class TestDocumentSplitter:
         assert result["documents"][0].meta["source_id"] == doc1.id
         assert result["documents"][1].meta["source_id"] == doc2.id
 
-    @pytest.mark.unit
     def test_copy_metadata(self):
         splitter = DocumentSplitter(split_by="word", split_length=10)
         documents = [

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -5,7 +5,6 @@ from haystack.components.rankers.meta_field import MetaFieldRanker
 
 
 class TestMetaFieldRanker:
-    @pytest.mark.unit
     def test_to_dict(self):
         component = MetaFieldRanker(metadata_field="rating")
         data = component.to_dict()
@@ -19,7 +18,6 @@ class TestMetaFieldRanker:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = MetaFieldRanker(metadata_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score")
         data = component.to_dict()

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -5,7 +5,6 @@ from haystack.components.rankers.transformers_similarity import TransformersSimi
 
 
 class TestSimilarityRanker:
-    @pytest.mark.unit
     def test_to_dict(self):
         component = TransformersSimilarityRanker()
         data = component.to_dict()
@@ -19,7 +18,6 @@ class TestSimilarityRanker:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         component = TransformersSimilarityRanker(
             model_name_or_path="my_model", device="cuda", token="my_token", top_k=5

--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -87,7 +87,6 @@ example_documents = [
 ] * 2
 
 
-@pytest.mark.unit
 def test_to_dict():
     component = ExtractiveReader("my-model", token="secret-token", model_kwargs={"torch_dtype": "auto"})
     data = component.to_dict()
@@ -111,7 +110,6 @@ def test_to_dict():
     }
 
 
-@pytest.mark.unit
 def test_to_dict_empty_model_kwargs():
     component = ExtractiveReader("my-model", token="secret-token")
     data = component.to_dict()
@@ -135,7 +133,6 @@ def test_to_dict_empty_model_kwargs():
     }
 
 
-@pytest.mark.unit
 def test_output(mock_reader: ExtractiveReader):
     answers = mock_reader.run(example_queries[0], example_documents[0], top_k=3)[
         "answers"
@@ -154,7 +151,6 @@ def test_output(mock_reader: ExtractiveReader):
     assert answers[-1].probability == pytest.approx(no_answer_prob)
 
 
-@pytest.mark.unit
 def test_flatten_documents(mock_reader: ExtractiveReader):
     queries, docs, query_ids = mock_reader._flatten_documents(example_queries, example_documents)
     i = 0
@@ -167,7 +163,6 @@ def test_flatten_documents(mock_reader: ExtractiveReader):
     assert len(docs) == len(queries) == len(query_ids) == i
 
 
-@pytest.mark.unit
 def test_preprocess(mock_reader: ExtractiveReader):
     _, _, seq_ids, _, query_ids, doc_ids = mock_reader._preprocess(
         example_queries * 3, example_documents[0], 384, [1, 1, 1], 0
@@ -189,7 +184,6 @@ def test_preprocess_splitting(mock_reader: ExtractiveReader):
     assert doc_ids == [0, 1, 2, 3, 3]
 
 
-@pytest.mark.unit
 def test_postprocess(mock_reader: ExtractiveReader):
     start = torch.zeros((2, 8))
     start[0, 3] = 4
@@ -231,7 +225,6 @@ def test_postprocess(mock_reader: ExtractiveReader):
     assert probs[1][0] == pytest.approx(1 / 2)
 
 
-@pytest.mark.unit
 def test_nest_answers(mock_reader: ExtractiveReader):
     start = list(range(5))
     end = [i + 5 for i in start]
@@ -258,7 +251,6 @@ def test_nest_answers(mock_reader: ExtractiveReader):
         assert no_answer.probability == pytest.approx(expected_no_answer)
 
 
-@pytest.mark.unit
 @patch("haystack.components.readers.extractive.AutoTokenizer.from_pretrained")
 @patch("haystack.components.readers.extractive.AutoModelForQuestionAnswering.from_pretrained")
 def test_warm_up_use_hf_token(mocked_automodel, mocked_autotokenizer):
@@ -269,7 +261,6 @@ def test_warm_up_use_hf_token(mocked_automodel, mocked_autotokenizer):
     mocked_autotokenizer.assert_called_once_with("deepset/roberta-base-squad2", token="fake-token")
 
 
-@pytest.mark.unit
 def test_missing_token_to_chars_values():
     # See https://github.com/deepset-ai/haystack/issues/6098
 

--- a/test/components/retrievers/test_in_memory_bm25_retriever.py
+++ b/test/components/retrievers/test_in_memory_bm25_retriever.py
@@ -21,14 +21,12 @@ def mock_docs():
 
 
 class TestMemoryBM25Retriever:
-    @pytest.mark.unit
     def test_init_default(self):
         retriever = InMemoryBM25Retriever(InMemoryDocumentStore())
         assert retriever.filters is None
         assert retriever.top_k == 10
         assert retriever.scale_score is False
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         retriever = InMemoryBM25Retriever(
             InMemoryDocumentStore(), filters={"name": "test.txt"}, top_k=5, scale_score=True
@@ -37,12 +35,10 @@ class TestMemoryBM25Retriever:
         assert retriever.top_k == 5
         assert retriever.scale_score
 
-    @pytest.mark.unit
     def test_init_with_invalid_top_k_parameter(self):
         with pytest.raises(ValueError):
             InMemoryBM25Retriever(InMemoryDocumentStore(), top_k=-2)
 
-    @pytest.mark.unit
     def test_to_dict(self):
         MyFakeStore = document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         document_store = MyFakeStore()
@@ -60,7 +56,6 @@ class TestMemoryBM25Retriever:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         MyFakeStore = document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         document_store = MyFakeStore()
@@ -79,7 +74,6 @@ class TestMemoryBM25Retriever:
             },
         }
 
-    @pytest.mark.unit
     def test_from_dict(self):
         document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         data = {
@@ -96,19 +90,16 @@ class TestMemoryBM25Retriever:
         assert component.top_k == 5
         assert component.scale_score is False
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore(self):
         data = {"type": "InMemoryBM25Retriever", "init_parameters": {}}
         with pytest.raises(DeserializationError, match="Missing 'document_store' in serialization data"):
             InMemoryBM25Retriever.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore_type(self):
         data = {"type": "InMemoryBM25Retriever", "init_parameters": {"document_store": {"init_parameters": {}}}}
         with pytest.raises(DeserializationError, match="Missing 'type' in document store's serialization data"):
             InMemoryBM25Retriever.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_nonexisting_docstore(self):
         data = {
             "type": "haystack.components.retrievers.in_memory_bm25_retriever.InMemoryBM25Retriever",
@@ -117,7 +108,6 @@ class TestMemoryBM25Retriever:
         with pytest.raises(DeserializationError, match="DocumentStore type 'NonexistingDocstore' not found"):
             InMemoryBM25Retriever.from_dict(data)
 
-    @pytest.mark.unit
     def test_retriever_valid_run(self, mock_docs):
         top_k = 5
         ds = InMemoryDocumentStore()
@@ -130,7 +120,6 @@ class TestMemoryBM25Retriever:
         assert len(result["documents"]) == top_k
         assert result["documents"][0].content == "PHP is a popular programming language"
 
-    @pytest.mark.unit
     def test_invalid_run_wrong_store_type(self):
         SomeOtherDocumentStore = document_store_class("SomeOtherDocumentStore")
         with pytest.raises(ValueError, match="document_store must be an instance of InMemoryDocumentStore"):

--- a/test/components/retrievers/test_in_memory_embedding_retriever.py
+++ b/test/components/retrievers/test_in_memory_embedding_retriever.py
@@ -11,14 +11,12 @@ from haystack.document_stores import InMemoryDocumentStore
 
 
 class TestMemoryEmbeddingRetriever:
-    @pytest.mark.unit
     def test_init_default(self):
         retriever = InMemoryEmbeddingRetriever(InMemoryDocumentStore())
         assert retriever.filters is None
         assert retriever.top_k == 10
         assert retriever.scale_score is False
 
-    @pytest.mark.unit
     def test_init_with_parameters(self):
         retriever = InMemoryEmbeddingRetriever(
             InMemoryDocumentStore(), filters={"name": "test.txt"}, top_k=5, scale_score=True
@@ -27,12 +25,10 @@ class TestMemoryEmbeddingRetriever:
         assert retriever.top_k == 5
         assert retriever.scale_score
 
-    @pytest.mark.unit
     def test_init_with_invalid_top_k_parameter(self):
         with pytest.raises(ValueError):
             InMemoryEmbeddingRetriever(InMemoryDocumentStore(), top_k=-2)
 
-    @pytest.mark.unit
     def test_to_dict(self):
         MyFakeStore = document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         document_store = MyFakeStore()
@@ -51,7 +47,6 @@ class TestMemoryEmbeddingRetriever:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         MyFakeStore = document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         document_store = MyFakeStore()
@@ -75,7 +70,6 @@ class TestMemoryEmbeddingRetriever:
             },
         }
 
-    @pytest.mark.unit
     def test_from_dict(self):
         document_store_class("MyFakeStore", bases=(InMemoryDocumentStore,))
         data = {
@@ -92,7 +86,6 @@ class TestMemoryEmbeddingRetriever:
         assert component.top_k == 5
         assert component.scale_score is False
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore(self):
         data = {
             "type": "haystack.components.retrievers.in_memory_embedding_retriever.InMemoryEmbeddingRetriever",
@@ -101,7 +94,6 @@ class TestMemoryEmbeddingRetriever:
         with pytest.raises(DeserializationError, match="Missing 'document_store' in serialization data"):
             InMemoryEmbeddingRetriever.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore_type(self):
         data = {
             "type": "haystack.components.retrievers.in_memory_embedding_retriever.InMemoryEmbeddingRetriever",
@@ -110,7 +102,6 @@ class TestMemoryEmbeddingRetriever:
         with pytest.raises(DeserializationError, match="Missing 'type' in document store's serialization data"):
             InMemoryEmbeddingRetriever.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_nonexisting_docstore(self):
         data = {
             "type": "haystack.components.retrievers.in_memory_embedding_retriever.InMemoryEmbeddingRetriever",
@@ -119,7 +110,6 @@ class TestMemoryEmbeddingRetriever:
         with pytest.raises(DeserializationError, match="DocumentStore type 'NonexistingDocstore' not found"):
             InMemoryEmbeddingRetriever.from_dict(data)
 
-    @pytest.mark.unit
     def test_valid_run(self):
         top_k = 3
         ds = InMemoryDocumentStore(embedding_similarity_function="cosine")
@@ -137,7 +127,6 @@ class TestMemoryEmbeddingRetriever:
         assert len(result["documents"]) == top_k
         assert np.array_equal(result["documents"][0].embedding, [1.0, 1.0, 1.0, 1.0])
 
-    @pytest.mark.unit
     def test_invalid_run_wrong_store_type(self):
         SomeOtherDocumentStore = document_store_class("SomeOtherDocumentStore")
         with pytest.raises(ValueError, match="document_store must be an instance of InMemoryDocumentStore"):

--- a/test/components/routers/test_document_joiner.py
+++ b/test/components/routers/test_document_joiner.py
@@ -7,7 +7,6 @@ from haystack.components.routers.document_joiner import DocumentJoiner
 
 
 class TestDocumentJoiner:
-    @pytest.mark.unit
     def test_init(self):
         joiner = DocumentJoiner()
         assert joiner.join_mode == "concatenate"
@@ -15,7 +14,6 @@ class TestDocumentJoiner:
         assert joiner.top_k is None
         assert joiner.sort_by_score
 
-    @pytest.mark.unit
     def test_init_with_custom_parameters(self):
         joiner = DocumentJoiner(join_mode="merge", weights=[0.4, 0.6], top_k=5, sort_by_score=False)
         assert joiner.join_mode == "merge"
@@ -23,31 +21,26 @@ class TestDocumentJoiner:
         assert joiner.top_k == 5
         assert not joiner.sort_by_score
 
-    @pytest.mark.unit
     def test_empty_list(self):
         joiner = DocumentJoiner()
         result = joiner.run([])
         assert result == {"documents": []}
 
-    @pytest.mark.unit
     def test_list_of_empty_lists(self):
         joiner = DocumentJoiner()
         result = joiner.run([[], []])
         assert result == {"documents": []}
 
-    @pytest.mark.unit
     def test_list_with_one_empty_list(self):
         joiner = DocumentJoiner()
         documents = [Document(content="a"), Document(content="b"), Document(content="c")]
         result = joiner.run([[], documents])
         assert result == {"documents": documents}
 
-    @pytest.mark.unit
     def test_unsupported_join_mode(self):
         with pytest.raises(ValueError, match="DocumentJoiner component does not support 'unsupported_mode' join_mode."):
             DocumentJoiner(join_mode="unsupported_mode")
 
-    @pytest.mark.unit
     def test_run_with_concatenate_join_mode_and_top_k(self):
         joiner = DocumentJoiner(top_k=6)
         documents_1 = [Document(content="a"), Document(content="b"), Document(content="c")]
@@ -63,7 +56,6 @@ class TestDocumentJoiner:
             output["documents"], key=lambda d: d.id
         )
 
-    @pytest.mark.unit
     def test_run_with_concatenate_join_mode_and_duplicate_documents(self):
         joiner = DocumentJoiner()
         documents_1 = [Document(content="a", score=0.3), Document(content="b"), Document(content="c")]
@@ -78,7 +70,6 @@ class TestDocumentJoiner:
             output["documents"], key=lambda d: d.id
         )
 
-    @pytest.mark.unit
     def test_run_with_merge_join_mode(self):
         joiner = DocumentJoiner(join_mode="merge", weights=[1.5, 0.5])
         documents_1 = [Document(content="a", score=1.0), Document(content="b", score=2.0)]
@@ -99,7 +90,6 @@ class TestDocumentJoiner:
         ]
         assert all(doc.id in expected_document_ids for doc in output["documents"])
 
-    @pytest.mark.unit
     def test_run_with_reciprocal_rank_fusion_join_mode(self):
         joiner = DocumentJoiner(join_mode="reciprocal_rank_fusion")
         documents_1 = [Document(content="a"), Document(content="b"), Document(content="c")]
@@ -122,7 +112,6 @@ class TestDocumentJoiner:
         ]
         assert all(doc.id in expected_document_ids for doc in output["documents"])
 
-    @pytest.mark.unit
     def test_sort_by_score_without_scores(self, caplog):
         joiner = DocumentJoiner()
         with caplog.at_level(logging.INFO):
@@ -131,7 +120,6 @@ class TestDocumentJoiner:
             assert "those with score=None were sorted as if they had a score of -infinity" in caplog.text
             assert output["documents"] == documents[::-1]
 
-    @pytest.mark.unit
     def test_output_documents_not_sorted_by_score(self):
         joiner = DocumentJoiner(sort_by_score=False)
         documents_1 = [Document(content="a", score=0.1)]

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -11,7 +11,6 @@ from haystack.dataclasses import ByteStream
     reason="Can't run on Windows Github CI, need access to registry to get mime types",
 )
 class TestFileTypeRouter:
-    @pytest.mark.unit
     def test_run(self, test_files_path):
         """
         Test if the component runs correctly in the simplest happy path.
@@ -31,7 +30,6 @@ class TestFileTypeRouter:
         assert len(output["image/jpeg"]) == 1
         assert not output["unclassified"]
 
-    @pytest.mark.unit
     def test_run_with_bytestreams(self, test_files_path):
         """
         Test if the component runs correctly with ByteStream inputs.
@@ -65,7 +63,6 @@ class TestFileTypeRouter:
         assert len(output["image/jpeg"]) == 1
         assert len(output.get("unclassified")) == 1
 
-    @pytest.mark.unit
     def test_run_with_bytestreams_and_file_paths(self, test_files_path):
         file_paths = [
             test_files_path / "txt" / "doc_1.txt",
@@ -88,7 +85,6 @@ class TestFileTypeRouter:
         assert len(output["audio/x-wav"]) == 1
         assert len(output["image/jpeg"]) == 1
 
-    @pytest.mark.unit
     def test_no_files(self):
         """
         Test that the component runs correctly when no files are provided.
@@ -97,7 +93,6 @@ class TestFileTypeRouter:
         output = router.run(sources=[])
         assert not output
 
-    @pytest.mark.unit
     def test_unlisted_extensions(self, test_files_path):
         """
         Test that the component correctly handles files with non specified mime types.
@@ -115,7 +110,6 @@ class TestFileTypeRouter:
         assert str(output["unclassified"][0]).endswith("ignored.mp3")
         assert str(output["unclassified"][1]).endswith("this is the content of the document.wav")
 
-    @pytest.mark.unit
     def test_no_extension(self, test_files_path):
         """
         Test that the component ignores files with no extension.
@@ -130,7 +124,6 @@ class TestFileTypeRouter:
         assert len(output["text/plain"]) == 2
         assert len(output["unclassified"]) == 1
 
-    @pytest.mark.unit
     def test_unknown_mime_type(self):
         """
         Test that the component handles files with unknown mime types.

--- a/test/components/routers/test_metadata_router.py
+++ b/test/components/routers/test_metadata_router.py
@@ -5,7 +5,6 @@ from haystack.components.routers.metadata_router import MetadataRouter
 
 
 class TestMetadataRouter:
-    @pytest.mark.unit
     def test_run(self):
         rules = {
             "edge_1": {

--- a/test/components/routers/test_text_language_router.py
+++ b/test/components/routers/test_text_language_router.py
@@ -6,45 +6,38 @@ from haystack.components.routers import TextLanguageRouter
 
 
 class TestTextLanguageRouter:
-    @pytest.mark.unit
     def test_non_string_input(self):
         with pytest.raises(TypeError, match="TextLanguageRouter expects a str as input."):
             classifier = TextLanguageRouter()
             classifier.run(text=Document(content="This is an english sentence."))
 
-    @pytest.mark.unit
     def test_list_of_string(self):
         with pytest.raises(TypeError, match="TextLanguageRouter expects a str as input."):
             classifier = TextLanguageRouter()
             classifier.run(text=["This is an english sentence."])
 
-    @pytest.mark.unit
     def test_empty_string(self):
         classifier = TextLanguageRouter()
         result = classifier.run(text="")
         assert result == {"unmatched": ""}
 
-    @pytest.mark.unit
     def test_detect_language(self):
         classifier = TextLanguageRouter()
         detected_language = classifier.detect_language("This is an english sentence.")
         assert detected_language == "en"
 
-    @pytest.mark.unit
     def test_route_to_en(self):
         classifier = TextLanguageRouter()
         english_sentence = "This is an english sentence."
         result = classifier.run(text=english_sentence)
         assert result == {"en": english_sentence}
 
-    @pytest.mark.unit
     def test_route_to_unmatched(self):
         classifier = TextLanguageRouter()
         german_sentence = "Ein deutscher Satz ohne Verb."
         result = classifier.run(text=german_sentence)
         assert result == {"unmatched": german_sentence}
 
-    @pytest.mark.unit
     def test_warning_if_no_language_detected(self, caplog):
         with caplog.at_level(logging.WARNING):
             classifier = TextLanguageRouter()

--- a/test/components/samplers/test_top_p.py
+++ b/test/components/samplers/test_top_p.py
@@ -7,7 +7,6 @@ from haystack.components.samplers.top_p import TopPSampler
 
 
 class TestTopPSampler:
-    @pytest.mark.unit
     def test_run_scores_from_metadata(self):
         """
         Test if the component runs correctly with scores already in the metadata.
@@ -23,7 +22,6 @@ class TestTopPSampler:
         assert len(docs) == 1
         assert docs[0].content == "Sarajevo"
 
-    @pytest.mark.unit
     def test_run_scores(self):
         """
         Test if the component runs correctly with scores in the Document score field.
@@ -46,7 +44,6 @@ class TestTopPSampler:
 
         assert [doc.score for doc in docs_filtered] == sorted_scores[:1]
 
-    @pytest.mark.unit
     def test_run_scores_top_p_1(self):
         """
         Test if the component runs correctly top_p=1.
@@ -67,13 +64,12 @@ class TestTopPSampler:
         assert [doc.score for doc in docs_filtered] == sorted([doc.score for doc in docs], reverse=True)
 
     #  Returns an empty list if no documents are provided
-    @pytest.mark.unit
+
     def test_returns_empty_list_if_no_documents_are_provided(self):
         sampler = TopPSampler()
         output = sampler.run(documents=[])
         assert output["documents"] == []
 
-    @pytest.mark.unit
     def test_run_scores_no_metadata_present(self):
         """
         Test if the component runs correctly with scores missing from the metadata yet being specified in the

--- a/test/components/websearch/test_searchapi.py
+++ b/test/components/websearch/test_searchapi.py
@@ -367,13 +367,11 @@ def mock_searchapi_search_result():
 
 
 class TestSearchApiSearchAPI:
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("SEARCHAPI_API_KEY", raising=False)
         with pytest.raises(ValueError, match="SearchApiWebSearch expects an API key"):
             SearchApiWebSearch()
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = SearchApiWebSearch(
             api_key="api_key", top_k=10, allowed_domains=["testdomain.com"], search_params={"param": "test params"}
@@ -388,7 +386,6 @@ class TestSearchApiSearchAPI:
             },
         }
 
-    @pytest.mark.unit
     @pytest.mark.parametrize("top_k", [1, 5, 7])
     def test_web_search_top_k(self, mock_searchapi_search_result, top_k: int):
         ws = SearchApiWebSearch(api_key="api_key", top_k=top_k)
@@ -400,7 +397,6 @@ class TestSearchApiSearchAPI:
         assert all(isinstance(link, str) for link in links)
         assert all(link.startswith("http") for link in links)
 
-    @pytest.mark.unit
     @patch("requests.get")
     def test_timeout_error(self, mock_get):
         mock_get.side_effect = Timeout
@@ -409,7 +405,6 @@ class TestSearchApiSearchAPI:
         with pytest.raises(TimeoutError):
             ws.run(query="Who is CEO of Microsoft?")
 
-    @pytest.mark.unit
     @patch("requests.get")
     def test_request_exception(self, mock_get):
         mock_get.side_effect = RequestException
@@ -418,7 +413,6 @@ class TestSearchApiSearchAPI:
         with pytest.raises(SearchApiError):
             ws.run(query="Who is CEO of Microsoft?")
 
-    @pytest.mark.unit
     @patch("requests.get")
     def test_bad_response_code(self, mock_get):
         mock_response = mock_get.return_value

--- a/test/components/websearch/test_serperdev.py
+++ b/test/components/websearch/test_serperdev.py
@@ -108,13 +108,11 @@ def mock_serper_dev_search_result():
 
 
 class TestSerperDevSearchAPI:
-    @pytest.mark.unit
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("SERPERDEV_API_KEY", raising=False)
         with pytest.raises(ValueError, match="SerperDevWebSearch expects an API key"):
             SerperDevWebSearch()
 
-    @pytest.mark.unit
     def test_to_dict(self):
         component = SerperDevWebSearch(
             api_key="test_key", top_k=10, allowed_domains=["test.com"], search_params={"param": "test"}
@@ -125,7 +123,6 @@ class TestSerperDevSearchAPI:
             "init_parameters": {"top_k": 10, "allowed_domains": ["test.com"], "search_params": {"param": "test"}},
         }
 
-    @pytest.mark.unit
     @pytest.mark.parametrize("top_k", [1, 5, 7])
     def test_web_search_top_k(self, mock_serper_dev_search_result, top_k: int):
         ws = SerperDevWebSearch(api_key="some_invalid_key", top_k=top_k)
@@ -137,7 +134,6 @@ class TestSerperDevSearchAPI:
         assert all(isinstance(link, str) for link in links)
         assert all(link.startswith("http") for link in links)
 
-    @pytest.mark.unit
     @patch("requests.post")
     def test_timeout_error(self, mock_post):
         mock_post.side_effect = Timeout
@@ -146,7 +142,6 @@ class TestSerperDevSearchAPI:
         with pytest.raises(TimeoutError):
             ws.run(query="Who is the boyfriend of Olivia Wilde?")
 
-    @pytest.mark.unit
     @patch("requests.post")
     def test_request_exception(self, mock_post):
         mock_post.side_effect = RequestException
@@ -155,7 +150,6 @@ class TestSerperDevSearchAPI:
         with pytest.raises(SerperDevError):
             ws.run(query="Who is the boyfriend of Olivia Wilde?")
 
-    @pytest.mark.unit
     @patch("requests.post")
     def test_bad_response_code(self, mock_post):
         mock_response = mock_post.return_value

--- a/test/components/writers/test_document_writer.py
+++ b/test/components/writers/test_document_writer.py
@@ -8,7 +8,6 @@ from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 
 class TestDocumentWriter:
-    @pytest.mark.unit
     def test_to_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         component = DocumentWriter(document_store=mocked_docstore_class())
@@ -21,7 +20,6 @@ class TestDocumentWriter:
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         component = DocumentWriter(document_store=mocked_docstore_class(), policy=DuplicatePolicy.SKIP)
@@ -34,7 +32,6 @@ class TestDocumentWriter:
             },
         }
 
-    @pytest.mark.unit
     def test_from_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
         data = {
@@ -48,19 +45,16 @@ class TestDocumentWriter:
         assert isinstance(component.document_store, mocked_docstore_class)
         assert component.policy == DuplicatePolicy.SKIP
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore(self):
         data = {"type": "DocumentWriter", "init_parameters": {}}
         with pytest.raises(DeserializationError, match="Missing 'document_store' in serialization data"):
             DocumentWriter.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_without_docstore_type(self):
         data = {"type": "DocumentWriter", "init_parameters": {"document_store": {"init_parameters": {}}}}
         with pytest.raises(DeserializationError, match="Missing 'type' in document store's serialization data"):
             DocumentWriter.from_dict(data)
 
-    @pytest.mark.unit
     def test_from_dict_nonexisting_docstore(self):
         data = {
             "type": "DocumentWriter",
@@ -69,7 +63,6 @@ class TestDocumentWriter:
         with pytest.raises(DeserializationError, match="DocumentStore of type 'NonexistingDocumentStore' not found."):
             DocumentWriter.from_dict(data)
 
-    @pytest.mark.unit
     def test_run(self):
         document_store = InMemoryDocumentStore()
         writer = DocumentWriter(document_store)
@@ -81,7 +74,6 @@ class TestDocumentWriter:
         result = writer.run(documents=documents)
         assert result["documents_written"] == 2
 
-    @pytest.mark.unit
     def test_run_skip_policy(self):
         document_store = InMemoryDocumentStore()
         writer = DocumentWriter(document_store, policy=DuplicatePolicy.SKIP)

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -5,7 +5,6 @@ from haystack.dataclasses import ByteStream
 import pytest
 
 
-@pytest.mark.unit
 def test_from_file_path(tmp_path, request):
     test_bytes = "Hello, world!\n".encode()
     test_path = tmp_path / request.node.name
@@ -21,7 +20,6 @@ def test_from_file_path(tmp_path, request):
     assert b.mime_type == "text/plain"
 
 
-@pytest.mark.unit
 def test_from_string():
     test_string = "Hello, world!"
     b = ByteStream.from_string(test_string)
@@ -33,7 +31,6 @@ def test_from_string():
     assert b.mime_type == "text/plain"
 
 
-@pytest.mark.unit
 def test_to_file(tmp_path, request):
     test_str = "Hello, world!\n"
     test_path = tmp_path / request.node.name

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -4,7 +4,6 @@ from transformers import AutoTokenizer
 from haystack.dataclasses import ChatMessage, ChatRole
 
 
-@pytest.mark.unit
 def test_from_assistant_with_valid_content():
     content = "Hello, how can I assist you?"
     message = ChatMessage.from_assistant(content)
@@ -12,7 +11,6 @@ def test_from_assistant_with_valid_content():
     assert message.role == ChatRole.ASSISTANT
 
 
-@pytest.mark.unit
 def test_from_user_with_valid_content():
     content = "I have a question."
     message = ChatMessage.from_user(content)
@@ -20,7 +18,6 @@ def test_from_user_with_valid_content():
     assert message.role == ChatRole.USER
 
 
-@pytest.mark.unit
 def test_from_system_with_valid_content():
     content = "System message."
     message = ChatMessage.from_system(content)
@@ -28,13 +25,11 @@ def test_from_system_with_valid_content():
     assert message.role == ChatRole.SYSTEM
 
 
-@pytest.mark.unit
 def test_with_empty_content():
     message = ChatMessage.from_user("")
     assert message.content == ""
 
 
-@pytest.mark.unit
 def test_from_function_with_empty_name():
     content = "Function call"
     message = ChatMessage.from_function(content, "")

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -7,7 +7,6 @@ from haystack import Document
 from haystack.dataclasses.byte_stream import ByteStream
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     "doc,doc_str",
     [
@@ -31,7 +30,6 @@ def test_document_str(doc, doc_str):
     assert f"Document(id={doc.id}, {doc_str})" == str(doc)
 
 
-@pytest.mark.unit
 def test_init():
     doc = Document()
     assert doc.id == "d4675c57fcfe114db0b95f1da46eea3c5d6f5729c17d01fb5251ae19830a3455"
@@ -43,13 +41,11 @@ def test_init():
     assert doc.embedding == None
 
 
-@pytest.mark.unit
 def test_init_with_wrong_parameters():
     with pytest.raises(TypeError):
         Document(text="")
 
 
-@pytest.mark.unit
 def test_init_with_parameters():
     blob_data = b"some bytes"
     doc = Document(
@@ -71,7 +67,6 @@ def test_init_with_parameters():
     assert doc.embedding == [0.1, 0.2, 0.3]
 
 
-@pytest.mark.unit
 def test_init_with_legacy_fields():
     doc = Document(
         content="test text", content_type="text", id_hash_keys=["content"], score=0.812, embedding=[0.1, 0.2, 0.3]  # type: ignore
@@ -85,7 +80,6 @@ def test_init_with_legacy_fields():
     assert doc.embedding == [0.1, 0.2, 0.3]
 
 
-@pytest.mark.unit
 def test_init_with_legacy_field():
     doc = Document(
         content="test text",
@@ -103,13 +97,11 @@ def test_init_with_legacy_field():
     assert doc.embedding == [0.1, 0.2, 0.3]
 
 
-@pytest.mark.unit
 def test_basic_equality_type_mismatch():
     doc = Document(content="test text")
     assert doc != "test text"
 
 
-@pytest.mark.unit
 def test_basic_equality_id():
     doc1 = Document(content="test text")
     doc2 = Document(content="test text")
@@ -122,7 +114,6 @@ def test_basic_equality_id():
     assert doc1 != doc2
 
 
-@pytest.mark.unit
 def test_to_dict():
     doc = Document()
     assert doc.to_dict() == {
@@ -135,7 +126,6 @@ def test_to_dict():
     }
 
 
-@pytest.mark.unit
 def test_to_dict_without_flattening():
     doc = Document()
     assert doc.to_dict(flatten=False) == {
@@ -149,7 +139,6 @@ def test_to_dict_without_flattening():
     }
 
 
-@pytest.mark.unit
 def test_to_dict_with_custom_parameters():
     doc = Document(
         content="test text",
@@ -172,7 +161,6 @@ def test_to_dict_with_custom_parameters():
     }
 
 
-@pytest.mark.unit
 def test_to_dict_with_custom_parameters_without_flattening():
     doc = Document(
         content="test text",
@@ -194,12 +182,10 @@ def test_to_dict_with_custom_parameters_without_flattening():
     }
 
 
-@pytest.mark.unit
 def test_from_dict():
     assert Document.from_dict({}) == Document()
 
 
-@pytest.mark.unit
 def from_from_dict_with_parameters():
     blob_data = b"some bytes"
     assert Document.from_dict(
@@ -221,7 +207,6 @@ def from_from_dict_with_parameters():
     )
 
 
-@pytest.mark.unit
 def test_from_dict_with_legacy_fields():
     assert Document.from_dict(
         {
@@ -257,7 +242,6 @@ def test_from_dict_with_legacy_field_and_flat_meta():
     )
 
 
-@pytest.mark.unit
 def test_from_dict_with_flat_meta():
     blob_data = b"some bytes"
     assert Document.from_dict(
@@ -280,7 +264,6 @@ def test_from_dict_with_flat_meta():
     )
 
 
-@pytest.mark.unit
 def test_from_dict_with_flat_and_non_flat_meta():
     with pytest.raises(ValueError, match="Pass either the 'meta' parameter or flattened metadata keys"):
         Document.from_dict(
@@ -297,7 +280,6 @@ def test_from_dict_with_flat_and_non_flat_meta():
         )
 
 
-@pytest.mark.unit
 def test_content_type():
     assert Document(content="text").content_type == "text"
     assert Document(dataframe=pd.DataFrame([0])).content_type == "table"

--- a/test/dataclasses/test_streaming_chunk.py
+++ b/test/dataclasses/test_streaming_chunk.py
@@ -3,7 +3,6 @@ import pytest
 from haystack.dataclasses import StreamingChunk
 
 
-@pytest.mark.unit
 def test_create_chunk_with_content_and_metadata():
     chunk = StreamingChunk(content="Test content", metadata={"key": "value"})
 
@@ -11,7 +10,6 @@ def test_create_chunk_with_content_and_metadata():
     assert chunk.metadata == {"key": "value"}
 
 
-@pytest.mark.unit
 def test_create_chunk_with_only_content():
     chunk = StreamingChunk(content="Test content")
 
@@ -19,13 +17,11 @@ def test_create_chunk_with_only_content():
     assert chunk.metadata == {}
 
 
-@pytest.mark.unit
 def test_access_content():
     chunk = StreamingChunk(content="Test content", metadata={"key": "value"})
     assert chunk.content == "Test content"
 
 
-@pytest.mark.unit
 def test_create_chunk_with_empty_content():
     chunk = StreamingChunk(content="")
     assert chunk.content == ""

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -20,7 +20,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
     def document_store(self) -> InMemoryDocumentStore:
         return InMemoryDocumentStore()
 
-    @pytest.mark.unit
     def test_to_dict(self):
         store = InMemoryDocumentStore()
         data = store.to_dict()
@@ -34,7 +33,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
             },
         }
 
-    @pytest.mark.unit
     def test_to_dict_with_custom_init_parameters(self):
         store = InMemoryDocumentStore(
             bm25_tokenization_regex="custom_regex",
@@ -53,7 +51,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
             },
         }
 
-    @pytest.mark.unit
     @patch("haystack.document_stores.in_memory.document_store.re")
     def test_from_dict(self, mock_regex):
         data = {
@@ -76,7 +73,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         with pytest.raises(DuplicateDocumentError):
             document_store.write_documents(docs)
 
-    @pytest.mark.unit
     def test_bm25_retrieval(self, document_store: InMemoryDocumentStore):
         document_store = InMemoryDocumentStore()
         # Tests if the bm25_retrieval method returns the correct document based on the input query.
@@ -86,7 +82,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 1
         assert results[0].content == "Haystack supports multiple languages"
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_empty_document_store(self, document_store: InMemoryDocumentStore, caplog):
         caplog.set_level(logging.INFO)
         # Tests if the bm25_retrieval method correctly returns an empty list when there are no documents in the DocumentStore.
@@ -94,7 +89,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 0
         assert "No documents found for BM25 retrieval. Returning empty list." in caplog.text
 
-    @pytest.mark.unit
     def test_bm25_retrieval_empty_query(self, document_store: InMemoryDocumentStore):
         # Tests if the bm25_retrieval method returns a document when the query is an empty string.
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
@@ -102,7 +96,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         with pytest.raises(ValueError, match="Query should be a non-empty string"):
             document_store.bm25_retrieval(query="", top_k=1)
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_different_top_k(self, document_store: InMemoryDocumentStore):
         # Tests if the bm25_retrieval method correctly changes the number of returned documents
         # based on the top_k parameter.
@@ -122,7 +115,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 3
 
     # Test two queries and make sure the results are different
-    @pytest.mark.unit
+
     def test_bm25_retrieval_with_two_queries(self, document_store: InMemoryDocumentStore):
         # Tests if the bm25_retrieval method returns different documents for different queries.
         docs = [
@@ -141,7 +134,7 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert results[0].content == "Python is a popular programming language"
 
     # Test a query, add a new document and make sure results are appropriately updated
-    @pytest.mark.unit
+
     def test_bm25_retrieval_with_updated_docs(self, document_store: InMemoryDocumentStore):
         # Tests if the bm25_retrieval method correctly updates the retrieved documents when new
         # documents are added to the DocumentStore.
@@ -161,7 +154,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 1
         assert results[0].content == "Python is a popular programming language"
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_scale_score(self, document_store: InMemoryDocumentStore):
         docs = [Document(content="Python programming"), Document(content="Java programming")]
         document_store.write_documents(docs)
@@ -175,7 +167,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         results = document_store.bm25_retrieval(query="Python", top_k=1, scale_score=False)
         assert results[0].score != results1[0].score
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_table_content(self, document_store: InMemoryDocumentStore):
         # Tests if the bm25_retrieval method correctly returns a dataframe when the content_type is table.
         table_content = pd.DataFrame({"language": ["Python", "Java"], "use": ["Data Science", "Web Development"]})
@@ -188,7 +179,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert isinstance(df, pd.DataFrame)
         assert df.equals(table_content)
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_text_and_table_content(self, document_store: InMemoryDocumentStore, caplog):
         table_content = pd.DataFrame({"language": ["Python", "Java"], "use": ["Data Science", "Web Development"]})
         document = Document(content="Gardening", dataframe=table_content)
@@ -206,14 +196,12 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         results = document_store.bm25_retrieval(query="Python", top_k=2)
         assert document.id not in [d.id for d in results]
 
-    @pytest.mark.unit
     def test_bm25_retrieval_default_filter_for_text_and_dataframes(self, document_store: InMemoryDocumentStore):
         docs = [Document(), Document(content="Gardening"), Document(content="Bird watching")]
         document_store.write_documents(docs)
         results = document_store.bm25_retrieval(query="doesn't matter, top_k is 10", top_k=10)
         assert len(results) == 2
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_filters(self, document_store: InMemoryDocumentStore):
         selected_document = Document(content="Gardening", meta={"selected": True})
         docs = [Document(), selected_document, Document(content="Bird watching")]
@@ -222,14 +210,12 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 1
         assert results[0].id == selected_document.id
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_filters_keeps_default_filters(self, document_store: InMemoryDocumentStore):
         docs = [Document(meta={"selected": True}), Document(content="Gardening"), Document(content="Bird watching")]
         document_store.write_documents(docs)
         results = document_store.bm25_retrieval(query="Java", top_k=10, filters={"selected": True})
         assert len(results) == 0
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_filters_on_text_or_dataframe(self, document_store: InMemoryDocumentStore):
         document = Document(dataframe=pd.DataFrame({"language": ["Python", "Java"], "use": ["Data Science", "Web"]}))
         docs = [Document(), Document(content="Gardening"), Document(content="Bird watching"), document]
@@ -238,7 +224,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 1
         assert results[0].id == document.id
 
-    @pytest.mark.unit
     def test_bm25_retrieval_with_documents_with_mixed_content(self, document_store: InMemoryDocumentStore):
         double_document = Document(content="Gardening", embedding=[1.0, 2.0, 3.0])
         docs = [Document(embedding=[1.0, 2.0, 3.0]), double_document, Document(content="Bird watching")]
@@ -247,7 +232,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 1
         assert results[0].id == double_document.id
 
-    @pytest.mark.unit
     def test_embedding_retrieval(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         # Tests if the embedding retrieval method returns the correct document based on the input query embedding.
@@ -262,7 +246,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 1
         assert results[0].content == "Haystack supports multiple languages"
 
-    @pytest.mark.unit
     def test_embedding_retrieval_invalid_query(self):
         docstore = InMemoryDocumentStore()
         with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
@@ -270,7 +253,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         with pytest.raises(ValueError, match="query_embedding should be a non-empty list of floats"):
             docstore.embedding_retrieval(query_embedding=["invalid", "list", "of", "strings"])  # type: ignore
 
-    @pytest.mark.unit
     def test_embedding_retrieval_no_embeddings(self, caplog):
         caplog.set_level(logging.WARNING)
         docstore = InMemoryDocumentStore()
@@ -280,7 +262,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert len(results) == 0
         assert "No Documents found with embeddings. Returning empty list." in caplog.text
 
-    @pytest.mark.unit
     def test_embedding_retrieval_some_documents_wo_embeddings(self, caplog):
         caplog.set_level(logging.INFO)
         docstore = InMemoryDocumentStore()
@@ -292,7 +273,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
         assert "Skipping some Documents that don't have an embedding." in caplog.text
 
-    @pytest.mark.unit
     def test_embedding_retrieval_documents_different_embedding_sizes(self):
         docstore = InMemoryDocumentStore()
         docs = [
@@ -304,7 +284,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         with pytest.raises(DocumentStoreError, match="The embedding size of all Documents should be the same."):
             docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1])
 
-    @pytest.mark.unit
     def test_embedding_retrieval_query_documents_different_embedding_sizes(self):
         docstore = InMemoryDocumentStore()
         docs = [Document(content="Hello world", embedding=[0.1, 0.2, 0.3, 0.4])]
@@ -316,7 +295,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         ):
             docstore.embedding_retrieval(query_embedding=[0.1, 0.1])
 
-    @pytest.mark.unit
     def test_embedding_retrieval_with_different_top_k(self):
         docstore = InMemoryDocumentStore()
         docs = [
@@ -332,7 +310,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=3)
         assert len(results) == 3
 
-    @pytest.mark.unit
     def test_embedding_retrieval_with_scale_score(self):
         docstore = InMemoryDocumentStore()
         docs = [
@@ -351,7 +328,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, scale_score=False)
         assert results[0].score != results1[0].score
 
-    @pytest.mark.unit
     def test_embedding_retrieval_return_embedding(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         docs = [
@@ -366,7 +342,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         results = docstore.embedding_retrieval(query_embedding=[0.1, 0.1, 0.1, 0.1], top_k=1, return_embedding=True)
         assert results[0].embedding == [1.0, 1.0, 1.0, 1.0]
 
-    @pytest.mark.unit
     def test_compute_cosine_similarity_scores(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="cosine")
         docs = [
@@ -379,7 +354,6 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         )
         assert scores == [0.5, 1.0]
 
-    @pytest.mark.unit
     def test_compute_dot_product_similarity_scores(self):
         docstore = InMemoryDocumentStore(embedding_similarity_function="dot_product")
         docs = [

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -20,7 +20,6 @@ def pipeline():
     return Pipeline()
 
 
-@pytest.mark.unit
 def test_pipeline_dumps(pipeline, test_files_path):
     pipeline.add_component("Comp1", TestComponent("Foo"))
     pipeline.add_component("Comp2", TestComponent())
@@ -31,7 +30,6 @@ def test_pipeline_dumps(pipeline, test_files_path):
         assert f.read() == result
 
 
-@pytest.mark.unit
 def test_pipeline_loads(test_files_path):
     with open(f"{test_files_path}/yaml/test_pipeline.yaml", "r") as f:
         pipeline = Pipeline.loads(f.read())
@@ -40,7 +38,6 @@ def test_pipeline_loads(test_files_path):
         assert isinstance(pipeline.get_component("Comp2"), TestComponent)
 
 
-@pytest.mark.unit
 def test_pipeline_dump(pipeline, test_files_path, tmp_path):
     pipeline.add_component("Comp1", TestComponent("Foo"))
     pipeline.add_component("Comp2", TestComponent())
@@ -53,7 +50,6 @@ def test_pipeline_dump(pipeline, test_files_path, tmp_path):
         assert f.read() == test_f.read()
 
 
-@pytest.mark.unit
 def test_pipeline_load(test_files_path):
     with open(f"{test_files_path}/yaml/test_pipeline.yaml", "r") as f:
         pipeline = Pipeline.load(f)

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -6,7 +6,6 @@ from haystack import Pipeline, component
 from haystack.telemetry._telemetry import pipeline_running
 
 
-@pytest.mark.unit
 @patch("haystack.telemetry._telemetry.telemetry")
 def test_pipeline_running(telemetry):
     telemetry.send_event = Mock()

--- a/test/testing/test_factory.py
+++ b/test/testing/test_factory.py
@@ -6,7 +6,6 @@ from haystack.document_stores.decorator import document_store
 from haystack.core.component import component
 
 
-@pytest.mark.unit
 def test_document_store_class_default():
     MyStore = document_store_class("MyStore")
     store = MyStore()
@@ -17,7 +16,6 @@ def test_document_store_class_default():
     assert store.to_dict() == {"type": "haystack.testing.factory.MyStore", "init_parameters": {}}
 
 
-@pytest.mark.unit
 def test_document_store_from_dict():
     MyStore = document_store_class("MyStore")
 
@@ -25,13 +23,11 @@ def test_document_store_from_dict():
     assert isinstance(store, MyStore)
 
 
-@pytest.mark.unit
 def test_document_store_class_is_registered():
     MyStore = document_store_class("MyStore")
     assert document_store.registry["haystack.testing.factory.MyStore"] == MyStore
 
 
-@pytest.mark.unit
 def test_document_store_class_with_documents():
     doc = Document(id="fake_id", content="This is a document")
     MyStore = document_store_class("MyStore", documents=[doc])
@@ -40,7 +36,6 @@ def test_document_store_class_with_documents():
     assert store.filter_documents() == [doc]
 
 
-@pytest.mark.unit
 def test_document_store_class_with_documents_count():
     MyStore = document_store_class("MyStore", documents_count=100)
     store = MyStore()
@@ -48,7 +43,6 @@ def test_document_store_class_with_documents_count():
     assert store.filter_documents() == []
 
 
-@pytest.mark.unit
 def test_document_store_class_with_documents_and_documents_count():
     doc = Document(id="fake_id", content="This is a document")
     MyStore = document_store_class("MyStore", documents=[doc], documents_count=100)
@@ -57,14 +51,12 @@ def test_document_store_class_with_documents_and_documents_count():
     assert store.filter_documents() == [doc]
 
 
-@pytest.mark.unit
 def test_document_store_class_with_bases():
     MyStore = document_store_class("MyStore", bases=(Exception,))
     store = MyStore()
     assert isinstance(store, Exception)
 
 
-@pytest.mark.unit
 def test_document_store_class_with_extra_fields():
     MyStore = document_store_class("MyStore", extra_fields={"my_field": 10})
     store = MyStore()


### PR DESCRIPTION
### Related Issues

We don't use the `unit` marker anymore, let's remove dead code.

### Notes for the reviewer

Part of this PR consists of marking tests that require external dependencies as integration. To be reviewed if they can be converted to unit by mocking or rearranging the imports.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
