### PR TITLE
fix: Add meta to document created by PyPDFToDocument

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -82,6 +82,7 @@ class PyPDFToDocument:
             try:
                 pdf_reader = self._get_pdf_reader(source)
                 document = self._converter.convert(pdf_reader)
+                document.meta = source.metadata
             except Exception as e:
                 logger.warning("Could not read %s and convert it to Document, skipping. %s", source, e)
                 continue

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -82,7 +82,7 @@ class PyPDFToDocument:
             try:
                 pdf_reader = self._get_pdf_reader(source)
                 document = self._converter.convert(pdf_reader)
-                document.meta = source.metadata
+                document.meta = pdf_reader.metadata
             except Exception as e:
                 logger.warning("Could not read %s and convert it to Document, skipping. %s", source, e)
                 continue


### PR DESCRIPTION
### Proposed Changes:

I was running on an error:

```
haystack-api-1  |   File "/usr/local/lib/python3.10/site-packages/elasticsearch_haystack/document_store.py", line 238, in _serialize_document
haystack-api-1  |     res = {**doc.to_dict(), **doc.metadata}
haystack-api-1  | AttributeError: 'Document' object has no attribute 'metadata'
```

Then I saw that the PyPDFToDocument was not adding metadata to the document, so I read the docs from pypdf and saw that it is possible to use the metadata from the pdf reader.

### How did you test it?

When running the test I ran into another error:

```
haystack-api-1  |     raise PipelineRuntimeError(
haystack-api-1  | haystack.core.errors.PipelineRuntimeError: splitter raised 'ValueError: key must be PdfObject'
```

This error I could not solve.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
