### PR TITLE
Fix: torch type hints put into quotes

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -36,20 +36,20 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
             self,
             tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
             stop_words: List[str],
-            device: Union[str, torch.device] = "cpu",
+            device: Union[str, "torch.device"] = "cpu",
         ):
             super().__init__()
             encoded_stop_words = tokenizer(stop_words, add_special_tokens=False, padding=True, return_tensors="pt")
             self.stop_ids = encoded_stop_words.input_ids.to(device)
 
-        def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        def __call__(self, input_ids: "torch.LongTensor", scores: "torch.FloatTensor", **kwargs) -> bool:
             for stop_id in self.stop_ids:
                 found_stop_word = self.is_stop_word_found(input_ids, stop_id)
                 if found_stop_word:
                     return True
             return False
 
-        def is_stop_word_found(self, generated_text_ids: torch.Tensor, stop_id: torch.Tensor) -> bool:
+        def is_stop_word_found(self, generated_text_ids: "torch.Tensor", stop_id: "torch.Tensor") -> bool:
             generated_text_ids = generated_text_ids[-1]
             len_generated_text_ids = generated_text_ids.size(0)
             len_stop_id = stop_id.size(0)

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -153,7 +153,7 @@ class ExtractiveReader:
 
     def _preprocess(
         self, queries: List[str], documents: List[Document], max_seq_length: int, query_ids: List[int], stride: int
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[Encoding], List[int], List[int]]:
+    ) -> Tuple["torch.Tensor", "torch.Tensor", "torch.Tensor", List["Encoding"], List[int], List[int]]:
         """
         Split and tokenize Documents and preserve structures by returning mappings to query and Document IDs.
         """
@@ -194,13 +194,13 @@ class ExtractiveReader:
 
     def _postprocess(
         self,
-        start: torch.Tensor,
-        end: torch.Tensor,
-        sequence_ids: torch.Tensor,
-        attention_mask: torch.Tensor,
+        start: "torch.Tensor",
+        end: "torch.Tensor",
+        sequence_ids: "torch.Tensor",
+        attention_mask: "torch.Tensor",
         answers_per_seq: int,
-        encodings: List[Encoding],
-    ) -> Tuple[List[List[int]], List[List[int]], torch.Tensor]:
+        encodings: List["Encoding"],
+    ) -> Tuple[List[List[int]], List[List[int]], "torch.Tensor"]:
         """
         Turn start and end logits into probability scores for each answer span. Unlike most other
         implementations, it doesn't normalize the scores to make them easier to compare across different
@@ -267,7 +267,7 @@ class ExtractiveReader:
         self,
         start: List[List[int]],
         end: List[List[int]],
-        probabilities: torch.Tensor,
+        probabilities: "torch.Tensor",
         flattened_documents: List[Document],
         queries: List[str],
         answers_per_seq: int,


### PR DESCRIPTION
### Related Issues

- fixes N/A

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add quotes around type hints for optional dependencies. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Locally tested by trying to import ExtractiveReader when torch isn't installed.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
