### PR TITLE
feat: Use device_map when loading of ExtractiveReader

### DIFF
--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -135,9 +135,13 @@ class ExtractiveReader:
             else:
                 self.device = self.device or "cpu:0"
 
-            self.model = AutoModelForQuestionAnswering.from_pretrained(
-                self.model_name_or_path, token=self.token, **self.model_kwargs
-            ).to(self.device)
+            # Override model_kwargs if token and device are provided
+            kwargs = self.model_kwargs
+            if self.token:
+                kwargs["token"] = self.token
+            if self.device:
+                kwargs["device_map"] = self.device
+            self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, **kwargs)
             self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=self.token)
 
     def _flatten_documents(

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -137,10 +137,9 @@ class ExtractiveReader:
 
             # Override model_kwargs if token and device are provided
             kwargs = self.model_kwargs
+            kwargs["device_map"] = self.device
             if self.token:
                 kwargs["token"] = self.token
-            if self.device:
-                kwargs["device_map"] = self.device
             self.model = AutoModelForQuestionAnswering.from_pretrained(self.model_name_or_path, **kwargs)
             self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path, token=self.token)
 

--- a/releasenotes/notes/device-map-extractive-qa-49b00e9b44d118dc.yaml
+++ b/releasenotes/notes/device-map-extractive-qa-49b00e9b44d118dc.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Use device_map when loading the model for the ExtractiveReader. This enables more flexible model loading schemes by utilizng the transformers model loading.

--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -335,7 +335,7 @@ def test_missing_token_to_chars_values():
 
 @pytest.mark.integration
 def test_t5():
-    reader = ExtractiveReader("TARUNBHATT/flan-t5-small-finetuned-squad")
+    reader = ExtractiveReader("TARUNBHATT/flan-t5-small-finetuned-squad", device="auto")
     reader.warm_up()
     answers = reader.run(example_queries[0], example_documents[0], top_k=2)[
         "answers"


### PR DESCRIPTION
### Related Issues

- fixes N/A

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
When loading the AutoModelForQuestionAnswering used to power the ExtractiveReader we now use the device_map keyword instead of using the `to` function. This allows us to use the transformers model loading code which is necessary when using more exotic loading schemes like loading the model with the bitsandbytes library.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test and updated existing tests. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
