### PR TITLE
fix: load_from_deepset_cloud without name in yaml

### DIFF
--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -210,7 +210,7 @@ class Pipeline:
                     params["api_key"] = api_key
                 component_config["params"] = params
 
-        del pipeline_config["name"]  # Would fail validation otherwise
+        pipeline_config.pop("name", None)  # Would fail validation otherwise
         pipeline = cls.load_from_config(
             pipeline_config=pipeline_config,
             pipeline_name=pipeline_name,

--- a/releasenotes/notes/fix-load-from-deepset-cloud-8a86053ccb246494.yaml
+++ b/releasenotes/notes/fix-load-from-deepset-cloud-8a86053ccb246494.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `Pipeline.load_from_deepset_cloud` to work with the latest version of deepset Cloud.

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -858,12 +858,15 @@ def test_load_from_deepset_cloud_query(samples_path):
     assert prediction["documents"][0].id == "test_doc"
 
 
+@pytest.mark.parametrize("with_name", [True, False])
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
 @responses.activate
-def test_load_from_deepset_cloud_indexing(caplog, samples_path):
+def test_load_from_deepset_cloud_indexing(caplog, samples_path, with_name: bool):
     if MOCK_DC:
         with open(samples_path / "dc" / "pipeline_config.json", "r") as f:
             pipeline_config_yaml_response = json.load(f)
+            if not with_name:
+                del pipeline_config_yaml_response["name"]
 
         responses.add(
             method=responses.GET,

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -858,15 +858,12 @@ def test_load_from_deepset_cloud_query(samples_path):
     assert prediction["documents"][0].id == "test_doc"
 
 
-@pytest.mark.parametrize("with_name", [True, False])
 @pytest.mark.usefixtures(deepset_cloud_fixture.__name__)
 @responses.activate
-def test_load_from_deepset_cloud_indexing(caplog, samples_path, with_name: bool):
+def test_load_from_deepset_cloud_indexing(caplog, samples_path):
     if MOCK_DC:
         with open(samples_path / "dc" / "pipeline_config.json", "r") as f:
             pipeline_config_yaml_response = json.load(f)
-            if not with_name:
-                del pipeline_config_yaml_response["name"]
 
         responses.add(
             method=responses.GET,
@@ -1029,8 +1026,9 @@ def test_save_nonexisting_pipeline_to_deepset_cloud():
             matches = False
             reason = "No DeepsetCloudDocumentStore found."
             request_body = request.body or ""
-            json_body = yaml.safe_load(request_body)
-            components = json_body["components"]
+            json_body = json.loads(request_body)
+            config = yaml.safe_load(json_body["config"])
+            components = config["components"]
             for component in components:
                 if component["type"].endswith("DocumentStore"):
                     if component["type"] == "DeepsetCloudDocumentStore":


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/6469

### Proposed Changes:
- fix `Pipeline.load_from_deepset_cloud` if yaml does not contain `"name"`. This is the case for all newly created dC pipelines.

### How did you test it?
- ran existing sdk tests (They were actually catching the bug).

### Notes for the reviewer
- unfortunately the sdk tests are not run during CI. I ran them all locally and fixed where needed.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
