### PR TITLE
refactor: enabled user to pass in model name 

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -6,6 +6,11 @@ from haystack import component, default_to_dict
 from haystack.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
+model_name= input("Enter model's name. Else default model chosen")
+if model_name=="":
+    print("default model google/flan-t5-large chosen ")
+    model_name="google/flan-t5-large"
+
 
 SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
 
@@ -67,7 +72,7 @@ class HuggingFaceLocalGenerator:
     ```python
     from haystack.components.generators import HuggingFaceLocalGenerator
 
-    generator = HuggingFaceLocalGenerator(model_name_or_path="google/flan-t5-large",
+    generator = HuggingFaceLocalGenerator(model="google/flan-t5-large",
                                           task="text2text-generation",
                                           generation_kwargs={
                                             "max_new_tokens": 100,
@@ -81,7 +86,7 @@ class HuggingFaceLocalGenerator:
 
     def __init__(
         self,
-        model_name_or_path: str = "google/flan-t5-base",
+        model_name_or_path: str = model_name,
         task: Optional[Literal["text-generation", "text2text-generation"]] = None,
         device: Optional[str] = None,
         token: Optional[Union[str, bool]] = None,


### PR DESCRIPTION
### Related Issues

- none

### Proposed Changes:

Refactored the code so that user can give their own model name. The functionality does not change and only code has been refactored.

### How did you test it?

manually checked the code by locally running the changed files

### Notes for the reviewer

Added a model_name variable so the user can give their own model. If no name provided, the default google/flan-t5-large will be taken as the model after alerting the user.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
