### PR TITLE
chore: clean up `core` tests

### DIFF
--- a/test/core/pipeline/test_complex_pipeline.py
+++ b/test/core/pipeline/test_complex_pipeline.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
 import logging
 
 from haystack.core.pipeline import Pipeline
@@ -22,7 +20,7 @@ from haystack.testing.sample_components import (
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_complex_pipeline(tmp_path):
+def test_complex_pipeline():
     loop_merger = MergeLoop(expected_type=int, inputs=["in_1", "in_2"])
     summer = Sum()
 
@@ -81,11 +79,5 @@ def test_complex_pipeline(tmp_path):
     pipeline.connect("enumerate.first", "add_three.value")
     pipeline.connect("add_three", "sum.values")
 
-    pipeline.draw(tmp_path / "complex_pipeline.png")
-
     results = pipeline.run({"greet_first": {"value": 1}, "greet_enumerator": {"value": 1}})
     assert results == {"accumulate_3": {"value": -7}, "add_five": {"result": -6}}
-
-
-if __name__ == "__main__":
-    test_complex_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_default_value.py
+++ b/test/core/pipeline/test_default_value.py
@@ -2,11 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from pathlib import Path
-from pprint import pprint
 
 from haystack.core.component import component
 from haystack.core.pipeline import Pipeline
-from haystack.testing.sample_components import AddFixedValue, Sum
 
 import logging
 
@@ -27,14 +25,8 @@ def test_pipeline(tmp_path):
 
     # Pass all the inputs
     results = pipeline.run({"with_defaults": {"a": 40, "b": 30}})
-    pprint(results)
     assert results == {"with_defaults": {"c": 70}}
 
     # Rely on default value for 'b'
     results = pipeline.run({"with_defaults": {"a": 40}})
-    pprint(results)
     assert results == {"with_defaults": {"c": 42}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_distinct_loops_pipeline.py
+++ b/test/core/pipeline/test_distinct_loops_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, MergeLoop, Remainder, FirstIntSelector
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline_equally_long_branches(tmp_path):
+def test_pipeline_equally_long_branches():
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("merge", MergeLoop(expected_type=int, inputs=["in", "in_1", "in_2"]))
     pipeline.add_component("remainder", Remainder(divisor=3))
@@ -25,30 +22,23 @@ def test_pipeline_equally_long_branches(tmp_path):
     pipeline.connect("add_two", "merge.in_2")
     pipeline.connect("add_one", "merge.in_1")
 
-    pipeline.draw(tmp_path / "distinct_loops_pipeline_same_branches.png")
-
     results = pipeline.run({"merge": {"in": 0}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 0}}
 
     results = pipeline.run({"merge": {"in": 3}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 3}}
 
     results = pipeline.run({"merge": {"in": 4}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
     results = pipeline.run({"merge": {"in": 5}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
     results = pipeline.run({"merge": {"in": 6}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
 
-def test_pipeline_differing_branches(tmp_path):
+def test_pipeline_differing_branches():
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("merge", MergeLoop(expected_type=int, inputs=["in", "in_1", "in_2"]))
     pipeline.add_component("remainder", Remainder(divisor=3))
@@ -63,30 +53,23 @@ def test_pipeline_differing_branches(tmp_path):
     pipeline.connect("remainder.remainder_is_2", "add_one.value")
     pipeline.connect("add_one", "merge.in_1")
 
-    pipeline.draw(tmp_path / "distinct_loops_pipeline_different_branches.png")
-
     results = pipeline.run({"merge": {"in": 0}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 0}}
 
     results = pipeline.run({"merge": {"in": 3}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 3}}
 
     results = pipeline.run({"merge": {"in": 4}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
     results = pipeline.run({"merge": {"in": 5}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
     results = pipeline.run({"merge": {"in": 6}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
 
-def test_pipeline_differing_branches_variadic(tmp_path):
+def test_pipeline_differing_branches_variadic():
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("merge", FirstIntSelector())
     pipeline.add_component("remainder", Remainder(divisor=3))
@@ -101,30 +84,17 @@ def test_pipeline_differing_branches_variadic(tmp_path):
     pipeline.connect("remainder.remainder_is_2", "add_one.value")
     pipeline.connect("add_one", "merge.inputs")
 
-    pipeline.draw(tmp_path / "distinct_loops_pipeline_different_branches_variadic.png")
-
     results = pipeline.run({"merge": {"inputs": 0}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 0}}
 
     results = pipeline.run({"merge": {"inputs": 3}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 3}}
 
     results = pipeline.run({"merge": {"inputs": 4}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
     results = pipeline.run({"merge": {"inputs": 5}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
 
     results = pipeline.run({"merge": {"inputs": 6}})
-    pprint(results)
     assert results == {"remainder": {"remainder_is_0": 6}}
-
-
-if __name__ == "__main__":
-    test_pipeline_equally_long_branches(Path(__file__).parent)
-    test_pipeline_differing_branches(Path(__file__).parent)
-    test_pipeline_differing_branches_variadic(Path(__file__).parent)

--- a/test/core/pipeline/test_double_loop_pipeline.py
+++ b/test/core/pipeline/test_double_loop_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import Accumulate, AddFixedValue, Threshold, MergeLoop
 
@@ -36,12 +33,6 @@ def test_pipeline(tmp_path):
     pipeline.draw(tmp_path / "double_loop_pipeline.png")
 
     results = pipeline.run({"add_one": {"value": 3}})
-    pprint(results)
-    print("accumulator: ", accumulator.state)
 
     assert results == {"add_two": {"result": 13}}
     assert accumulator.state == 8
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_dynamic_inputs_pipeline.py
+++ b/test/core/pipeline/test_dynamic_inputs_pipeline.py
@@ -1,9 +1,8 @@
-from pathlib import Path
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import FString, Hello, TextSplitter
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("hello", Hello())
     pipeline.add_component("fstring", FString(template="This is the greeting: {greeting}!", variables=["greeting"]))
@@ -11,14 +10,8 @@ def test_pipeline(tmp_path):
     pipeline.connect("hello.output", "fstring.greeting")
     pipeline.connect("fstring.string", "splitter.sentence")
 
-    pipeline.draw(tmp_path / "dynamic_inputs_pipeline.png")
-
     output = pipeline.run({"hello": {"word": "Alice"}})
     assert output == {"splitter": {"output": ["This", "is", "the", "greeting:", "Hello,", "Alice!!"]}}
 
     output = pipeline.run({"hello": {"word": "Alice"}, "fstring": {"template": "Received: {greeting}"}})
     assert output == {"splitter": {"output": ["Received:", "Hello,", "Alice!"]}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_fixed_decision_and_merge_pipeline.py
+++ b/test/core/pipeline/test_fixed_decision_and_merge_pipeline.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from pathlib import Path
-from pprint import pprint
 
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Parity, Double, Subtract
@@ -11,7 +10,7 @@ from haystack.testing.sample_components import AddFixedValue, Parity, Double, Su
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("add_one", AddFixedValue())
     pipeline.add_component("parity", Parity())
@@ -31,18 +30,8 @@ def test_pipeline(tmp_path):
     pipeline.connect("add_four.result", "add_two.value")
     pipeline.connect("add_four.result", "add_two_as_well.value")
 
-    pipeline.draw(tmp_path / "fixed_decision_and_merge_pipeline.png")
-
     results = pipeline.run({"add_one": {"value": 1}, "add_two": {"add": 2}, "add_two_as_well": {"add": 2}})
-    pprint(results)
-
-    results == {"add_two": {"result": 8}}
+    assert results == {"add_two": {"result": 8}, "add_two_as_well": {"result": 8}}
 
     results = pipeline.run({"add_one": {"value": 2}, "add_two": {"add": 2}, "add_two_as_well": {"add": 2}})
-    pprint(results)
-
-    results == {"diff": {"difference": 7}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)
+    assert results == {"diff": {"difference": 7}}

--- a/test/core/pipeline/test_fixed_decision_pipeline.py
+++ b/test/core/pipeline/test_fixed_decision_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Parity, Double
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("parity", Parity())
@@ -25,16 +22,8 @@ def test_pipeline(tmp_path):
     pipeline.connect("parity.odd", "double.value")
     pipeline.connect("add_ten.result", "add_three.value")
 
-    pipeline.draw(tmp_path / "fixed_decision_pipeline.png")
-
     results = pipeline.run({"add_one": {"value": 1}})
-    pprint(results)
     assert results == {"add_three": {"result": 15}}
 
     results = pipeline.run({"add_one": {"value": 2}})
-    pprint(results)
     assert results == {"double": {"value": 6}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_fixed_merging_pipeline.py
+++ b/test/core/pipeline/test_fixed_merging_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Subtract
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue(add=2))
@@ -25,13 +22,5 @@ def test_pipeline(tmp_path):
     pipeline.connect("third_addition.result", "diff.second_value")
     pipeline.connect("diff", "fourth_addition.value")
 
-    pipeline.draw(tmp_path / "fixed_merging_pipeline.png")
-
     results = pipeline.run({"first_addition": {"value": 1}, "third_addition": {"value": 1}})
-    pprint(results)
-
     assert results == {"fourth_addition": {"result": 3}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_joiners.py
+++ b/test/core/pipeline/test_joiners.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import StringJoiner, StringListJoiner, Hello, TextSplitter
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_joiner(tmp_path):
+def test_joiner():
     pipeline = Pipeline()
     pipeline.add_component("hello_one", Hello())
     pipeline.add_component("hello_two", Hello())
@@ -23,13 +20,11 @@ def test_joiner(tmp_path):
     pipeline.connect("hello_two", "joiner")
     pipeline.connect("hello_three", "joiner")
 
-    pipeline.draw(tmp_path / "joiner_pipeline.png")
-
     results = pipeline.run({"hello_one": {"word": "world"}, "hello_three": {"word": "my friend"}})
     assert results == {"joiner": {"output": "Hello, my friend! Hello, Hello, world!!"}}
 
 
-def test_joiner_with_lists(tmp_path):
+def test_joiner_with_lists():
     pipeline = Pipeline()
     pipeline.add_component("first", TextSplitter())
     pipeline.add_component("second", TextSplitter())
@@ -38,25 +33,15 @@ def test_joiner_with_lists(tmp_path):
     pipeline.connect("first", "joiner")
     pipeline.connect("second", "joiner")
 
-    pipeline.draw(tmp_path / "joiner_list_pipeline.png")
-
     results = pipeline.run({"first": {"sentence": "Hello world!"}, "second": {"sentence": "How are you?"}})
     assert results == {"joiner": {"output": ["Hello", "world!", "How", "are", "you?"]}}
 
 
-def test_joiner_with_pipeline_run(tmp_path):
+def test_joiner_with_pipeline_run():
     pipeline = Pipeline()
     pipeline.add_component("hello", Hello())
     pipeline.add_component("joiner", StringJoiner())
     pipeline.connect("hello", "joiner")
 
-    pipeline.draw(tmp_path / "joiner_with_pipeline_run.png")
-
     results = pipeline.run({"hello": {"word": "world"}, "joiner": {"input_str": "another string!"}})
     assert results == {"joiner": {"output": "another string! Hello, world!"}}
-
-
-if __name__ == "__main__":
-    test_joiner(Path(__file__).parent)
-    test_joiner_with_lists(Path(__file__).parent)
-    test_joiner_with_pipeline_run(Path(__file__).parent)

--- a/test/core/pipeline/test_linear_pipeline.py
+++ b/test/core/pipeline/test_linear_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Double
 
@@ -23,10 +20,4 @@ def test_pipeline(tmp_path):
     pipeline.draw(tmp_path / "linear_pipeline.png")
 
     results = pipeline.run({"first_addition": {"value": 1}})
-    pprint(results)
-
     assert results == {"second_addition": {"result": 7}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_looping_and_merge_pipeline.py
+++ b/test/core/pipeline/test_looping_and_merge_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import Accumulate, AddFixedValue, Threshold, Sum, FirstIntSelector, MergeLoop
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline_fixed(tmp_path):
+def test_pipeline_fixed():
     accumulator = Accumulate()
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("add_zero", AddFixedValue(add=0))
@@ -31,17 +28,12 @@ def test_pipeline_fixed(tmp_path):
     pipeline.connect("below_10.above", "add_two.value")
     pipeline.connect("add_two.result", "sum.values")
 
-    pipeline.draw(tmp_path / "looping_and_fixed_merge_pipeline.png")
-
     results = pipeline.run({"add_zero": {"value": 8}, "sum": {"values": 2}})
-    pprint(results)
-    print("accumulate: ", accumulator.state)
-
     assert results == {"sum": {"total": 23}}
     assert accumulator.state == 19
 
 
-def test_pipeline_variadic(tmp_path):
+def test_pipeline_variadic():
     accumulator = Accumulate()
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("add_zero", AddFixedValue(add=0))
@@ -60,16 +52,6 @@ def test_pipeline_variadic(tmp_path):
     pipeline.connect("below_10.above", "add_two.value")
     pipeline.connect("add_two.result", "sum.values")
 
-    pipeline.draw(tmp_path / "looping_and_variadic_merge_pipeline.png")
-
     results = pipeline.run({"add_zero": {"value": 8}, "sum": {"values": 2}})
-    pprint(results)
-    print("accumulate: ", accumulator.state)
-
     assert results == {"sum": {"total": 23}}
     assert accumulator.state == 19
-
-
-if __name__ == "__main__":
-    test_pipeline_fixed(Path(__file__).parent)
-    test_pipeline_variadic(Path(__file__).parent)

--- a/test/core/pipeline/test_looping_pipeline.py
+++ b/test/core/pipeline/test_looping_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import Accumulate, AddFixedValue, Threshold, MergeLoop, FirstIntSelector
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     accumulator = Accumulate()
 
     pipeline = Pipeline(max_loops_allowed=10)
@@ -28,16 +25,12 @@ def test_pipeline(tmp_path):
     pipeline.connect("accumulator.value", "merge.in_2")
     pipeline.connect("below_10.above", "add_two.value")
 
-    pipeline.draw(tmp_path / "looping_pipeline.png")
-
     results = pipeline.run({"add_one": {"value": 3}})
-    pprint(results)
-
     assert results == {"add_two": {"result": 18}}
     assert accumulator.state == 16
 
 
-def test_pipeline_direct_io_loop(tmp_path):
+def test_pipeline_direct_io_loop():
     accumulator = Accumulate()
 
     pipeline = Pipeline(max_loops_allowed=10)
@@ -49,16 +42,12 @@ def test_pipeline_direct_io_loop(tmp_path):
     pipeline.connect("below_10.below", "accumulator.value")
     pipeline.connect("accumulator.value", "merge.in_2")
 
-    pipeline.draw(tmp_path / "looping_pipeline_direct_io_loop.png")
-
     results = pipeline.run({"merge": {"in_1": 4}})
-    pprint(results)
-
     assert results == {"below_10": {"above": 16}}
     assert accumulator.state == 16
 
 
-def test_pipeline_fixed_merger_input(tmp_path):
+def test_pipeline_fixed_merger_input():
     accumulator = Accumulate()
 
     pipeline = Pipeline(max_loops_allowed=10)
@@ -72,17 +61,12 @@ def test_pipeline_fixed_merger_input(tmp_path):
     pipeline.connect("accumulator.value", "merge.in_2")
     pipeline.connect("below_10.above", "add_two.value")
 
-    pipeline.draw(tmp_path / "looping_pipeline_fixed_merger_input.png")
-
     results = pipeline.run({"merge": {"in_1": 4}})
-    pprint(results)
-    print("accumulator: ", accumulator.state)
-
     assert results == {"add_two": {"result": 18}}
     assert accumulator.state == 16
 
 
-def test_pipeline_variadic_merger_input(tmp_path):
+def test_pipeline_variadic_merger_input():
     accumulator = Accumulate()
 
     pipeline = Pipeline(max_loops_allowed=10)
@@ -96,17 +80,6 @@ def test_pipeline_variadic_merger_input(tmp_path):
     pipeline.connect("accumulator.value", "merge.inputs")
     pipeline.connect("below_10.above", "add_two.value")
 
-    pipeline.draw(tmp_path / "looping_pipeline_variadic_merger_input.png")
-
     results = pipeline.run({"merge": {"inputs": 4}})
-    pprint(results)
-
     assert results == {"add_two": {"result": 18}}
     assert accumulator.state == 16
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)
-    test_pipeline_direct_io_loop(Path(__file__).parent)
-    test_pipeline_fixed_merger_input(Path(__file__).parent)
-    test_pipeline_variadic_merger_input(Path(__file__).parent)

--- a/test/core/pipeline/test_mutable_inputs.py
+++ b/test/core/pipeline/test_mutable_inputs.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 from haystack.core.pipeline import Pipeline

--- a/test/core/pipeline/test_parallel_branches_pipeline.py
+++ b/test/core/pipeline/test_parallel_branches_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Repeat, Double
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("repeat", Repeat(outputs=["first", "second"]))
@@ -27,13 +24,5 @@ def test_pipeline(tmp_path):
     pipeline.connect("repeat.second", "add_three.value")
     pipeline.connect("add_three.result", "add_one_again.value")
 
-    pipeline.draw(tmp_path / "parallel_branches_pipeline.png")
-
     results = pipeline.run({"add_one": {"value": 1}})
-    pprint(results)
-
     assert results == {"add_one_again": {"result": 6}, "add_ten": {"result": 12}, "double": {"value": 4}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_self_loop.py
+++ b/test/core/pipeline/test_self_loop.py
@@ -1,10 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.component import component
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, SelfLoop
@@ -14,20 +10,16 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline_one_node(tmp_path):
+def test_pipeline_one_node():
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("self_loop", SelfLoop())
     pipeline.connect("self_loop.current_value", "self_loop.values")
 
-    pipeline.draw(tmp_path / "self_looping_pipeline_one_node.png")
-
     results = pipeline.run({"self_loop": {"values": 5}})
-    pprint(results)
-
     assert results["self_loop"]["final_result"] == 0
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("add_1", AddFixedValue())
     pipeline.add_component("self_loop", SelfLoop())
@@ -36,14 +28,5 @@ def test_pipeline(tmp_path):
     pipeline.connect("self_loop.current_value", "self_loop.values")
     pipeline.connect("self_loop.final_result", "add_2.value")
 
-    pipeline.draw(tmp_path / "self_looping_pipeline.png")
-
     results = pipeline.run({"add_1": {"value": 5}})
-    pprint(results)
-
     assert results["add_2"]["result"] == 1
-
-
-if __name__ == "__main__":
-    test_pipeline_one_node(Path(__file__).parent)
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_validation_pipeline_io.py
+++ b/test/core/pipeline/test_validation_pipeline_io.py
@@ -1,7 +1,9 @@
+# SPDX-FileCopyrightText: 2023-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 
 import pytest
-import inspect
 
 from haystack.core.pipeline import Pipeline
 from haystack.core.component.types import Variadic

--- a/test/core/pipeline/test_variable_decision_and_merge_pipeline.py
+++ b/test/core/pipeline/test_variable_decision_and_merge_pipeline.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from pathlib import Path
-from pprint import pprint
 
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Remainder, Double, Sum
@@ -11,7 +9,7 @@ from haystack.testing.sample_components import AddFixedValue, Remainder, Double,
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("add_one", AddFixedValue())
     pipeline.add_component("parity", Remainder(divisor=2))
@@ -31,16 +29,8 @@ def test_pipeline(tmp_path):
     pipeline.connect("add_four.result", "add_one_again.value")
     pipeline.connect("add_one_again.result", "sum.values")
 
-    pipeline.draw(tmp_path / "variable_decision_and_merge_pipeline.png")
-
     results = pipeline.run({"add_one": {"value": 1}})
-    pprint(results)
     assert results == {"sum": {"total": 14}}
 
     results = pipeline.run({"add_one": {"value": 2}})
-    pprint(results)
     assert results == {"sum": {"total": 17}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_variable_decision_pipeline.py
+++ b/test/core/pipeline/test_variable_decision_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Remainder, Double
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("remainder", Remainder(divisor=3))
@@ -27,13 +24,5 @@ def test_pipeline(tmp_path):
     pipeline.connect("remainder.remainder_is_2", "add_three.value")
     pipeline.connect("add_three.result", "add_one_again.value")
 
-    pipeline.draw(tmp_path / "variable_decision_pipeline.png")
-
     results = pipeline.run({"add_one": {"value": 1}})
-    pprint(results)
-
     assert results == {"add_one_again": {"result": 6}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)

--- a/test/core/pipeline/test_variable_merging_pipeline.py
+++ b/test/core/pipeline/test_variable_merging_pipeline.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from pathlib import Path
-from pprint import pprint
-
 from haystack.core.pipeline import Pipeline
 from haystack.testing.sample_components import AddFixedValue, Sum
 
@@ -12,7 +9,7 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-def test_pipeline(tmp_path):
+def test_pipeline():
     pipeline = Pipeline()
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue(add=2))
@@ -26,13 +23,5 @@ def test_pipeline(tmp_path):
     pipeline.connect("third_addition.result", "sum.values")
     pipeline.connect("sum.total", "fourth_addition.value")
 
-    pipeline.draw(tmp_path / "variable_merging_pipeline.png")
-
     results = pipeline.run({"first_addition": {"value": 1}, "third_addition": {"value": 1}})
-    pprint(results)
-
     assert results == {"fourth_addition": {"result": 12}}
-
-
-if __name__ == "__main__":
-    test_pipeline(Path(__file__).parent)


### PR DESCRIPTION
### Proposed Changes:

Remove leftovers from canals migration:
- Remove prints
- Remove calls to `draw()`
- Remove `__main__` entrypoint

### How did you test it?

`pytest -m"not integration" test/core/pipeline`

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
