### PR TITLE
ci: reintroduce readme_sync workflow

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -1,0 +1,65 @@
+name: Sync docs with Readme
+
+on:
+  pull_request:
+    paths:
+      - "docs/pydoc/**"
+  push:
+    branches:
+      - main
+      # release branches have the form v1.9.x
+      - "v[0-9].*[0-9].x"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/pydoc/requirements.txt
+
+      - name: Generate API docs
+        env:
+          # This is necessary to fetch the documentation categories
+          # from Readme.io as we need them to associate the slug
+          # in config files with their id.
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        run: ./.github/utils/pydoc-markdown.sh
+
+      - name: Get current version
+        id: current-version
+        if: github.event_name == 'push'
+        shell: bash
+        # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
+        run: echo "minor=$(cut -d "." -f 1,2 < VERSION.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Sync docs with unstable release
+        # Instead of putting more logic into the previous step, let's just assume that commits on `main`
+        # will always be synced to the current `X.Y-unstable` version on Readme
+        id: sync-main
+        if: github.ref_name == 'main' && github.event_name == 'push'
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        with:
+          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
+
+      - name: Sync docs with current release
+        # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
+        # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
+        # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
+        if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
+        uses: readmeio/rdme@8.3.1
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+        with:
+          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Sync preview docs with 2.0
         # Sync the preview docs to the `2.0` version on Readme
-        id: sync-main-preview
+        id: sync-main
         if: github.ref_name == 'main' && github.event_name == 'push'
         uses: readmeio/rdme@8.3.1
         env:

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      # release branches have the form v1.9.x
-      - "v[0-9].*[0-9].x"
 
 jobs:
   sync:

--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -35,31 +35,12 @@ jobs:
           README_API_KEY: ${{ secrets.README_API_KEY }}
         run: ./.github/utils/pydoc-markdown.sh
 
-      - name: Get current version
-        id: current-version
-        if: github.event_name == 'push'
-        shell: bash
-        # We only need `major.minor` in Readme so we cut the full version string to the first two tokens
-        run: echo "minor=$(cut -d "." -f 1,2 < VERSION.txt)" >> "$GITHUB_OUTPUT"
-
-      - name: Sync docs with unstable release
-        # Instead of putting more logic into the previous step, let's just assume that commits on `main`
-        # will always be synced to the current `X.Y-unstable` version on Readme
-        id: sync-main
+      - name: Sync preview docs with 2.0
+        # Sync the preview docs to the `2.0` version on Readme
+        id: sync-main-preview
         if: github.ref_name == 'main' && github.event_name == 'push'
         uses: readmeio/rdme@8.3.1
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
         with:
-          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}-unstable
-
-      - name: Sync docs with current release
-        # Mutually exclusive with the previous one, this step is supposed to only run on version branches.
-        # Sync the current Haystack version `X.Y.Z` with its corresponding Readme version `X.Y`.
-        # See https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context for the condition used
-        if: steps.sync-main.outcome == 'skipped' && github.event_name == 'push'
-        uses: readmeio/rdme@8.3.1
-        env:
-          README_API_KEY: ${{ secrets.README_API_KEY }}
-        with:
-          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=${{ steps.current-version.outputs.minor }}
+          rdme: docs ./docs/pydoc/temp --key="$README_API_KEY" --version=2.0


### PR DESCRIPTION
### Related Issues

- API Reference is not currently updated on changes

### Proposed Changes:

Reintroduce a minimal readme_sync workflow, that only pushes changes on main to the 2.0 API reference

### Notes for the reviewer

I need help to configure the workflow right

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
