### PR TITLE
Change use_auth_token to token in TransformersDocumentClassifier

### DIFF
--- a/haystack/nodes/document_classifier/transformers.py
+++ b/haystack/nodes/document_classifier/transformers.py
@@ -149,7 +149,7 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
                 model=model_name_or_path,
                 tokenizer=tokenizer,
                 revision=model_version,
-                use_auth_token=use_auth_token,
+                token=use_auth_token,
                 device=resolved_devices[0],
             )
         elif task == "text-classification":
@@ -160,7 +160,7 @@ class TransformersDocumentClassifier(BaseDocumentClassifier):
                 device=resolved_devices[0],
                 revision=model_version,
                 top_k=top_k,
-                use_auth_token=use_auth_token,
+                token=use_auth_token,
             )
         self.top_k = top_k
         self.labels = labels


### PR DESCRIPTION
### Proposed Changes:

When I tried using the TransformersDocumentClassifier with the task 'text-classification' I always had an error because it used 'use_auth_token' in the creation of the pipeline, instead of 'token'.

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

Manual verification on the scrypt it was first intented to use it.

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
