### PR TITLE
fix: fix typo in pydoc config

### DIFF
--- a/docs/pydoc/config/dataclass.yml
+++ b/docs/pydoc/config/dataclass.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: loaders.CustomPythonLoader
     search_path: [../../../haystack/dataclasses]
-    modules: ["answer", "byte_steam", "chat_message", "document", "streaming_chunk"]
+    modules: ["answer", "byte_stream", "chat_message", "document", "streaming_chunk"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -14,7 +14,7 @@ processors:
 renderer:
   type: renderers.ReadmePreviewRenderer
   excerpt: Core classes that carry data through the system.
-  category_slug: data-classes
+  category_slug: haystack-classes
   title: Data Classes API
   slug: data-classes-api
   order: 30


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/actions/runs/7114326817

### Proposed Changes:

Fix typo

### How did you test it?

Run locally ./.github/utils/pydoc-markdown.sh

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
