### PR TITLE
feat: Change type of PromptModel invocation_layer_class init param

### DIFF
--- a/releasenotes/notes/prompt-model-invocation-layer-e7a69a3ac3beb5a7.yaml
+++ b/releasenotes/notes/prompt-model-invocation-layer-e7a69a3ac3beb5a7.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Change `PromptModel` constructor parameter `invocation_layer_class` to accept a `str` too.
+    If a `str` is used the invocation layer class will be imported and used.
+    This should ease serialisation to YAML when using `invocation_layer_class` with `PromptModel`.

--- a/test/prompt/test_prompt_model.py
+++ b/test/prompt/test_prompt_model.py
@@ -39,6 +39,16 @@ def test_constructor_with_no_supported_model():
         PromptModel("some-random-model")
 
 
+@pytest.mark.unit
+def test_constructor_with_invocation_layer_class_string():
+    model = PromptModel(
+        invocation_layer_class="haystack.nodes.prompt.invocation_layer.CohereInvocationLayer", api_key="fake_api_key"
+    )
+    from haystack.nodes.prompt.invocation_layer import CohereInvocationLayer
+
+    assert isinstance(model.model_invocation_layer, CohereInvocationLayer)
+
+
 @pytest.mark.asyncio
 async def test_ainvoke():
     def async_return(result):


### PR DESCRIPTION
### Related Issues

- fixes #6495

### Proposed Changes:

This PR changes `PromptModel` `invocation_layer_class` init parameter type. Now it can either be a `PromptModelInvocationLayer` class or `str` pointing to the invocation layer class.

If `str` is used the class module will be imported automatically.

Example usage:

```
model = PromptModel(
    invocation_layer_class="haystack.nodes.prompt.invocation_layer.CohereInvocationLayer", api_key="fake_api_key"
)
```

### How did you test it?

I added a unit test and tested serialisation manually.

### Notes for the reviewer

This is not a complete fix to the serialisation issue but at least it makes possible to set a custom `invocation_layer_class` in YAML.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
