### PR TITLE
feat: Add posthog api key for telemetry

### DIFF
--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -43,6 +43,8 @@ class Telemetry:
         It also collects system information which cannot change across the lifecycle
         of the process (for example `is_containerized()`).
         """
+        posthog.api_key = "phc_C44vUK9R1J6HYVdfJarTEPqVAoRPJzMXzFcj8PIrJgP"
+        posthog.host = "https://eu.posthog.com"
 
         # disable posthog logging
         for module_name in ["posthog", "backoff"]:


### PR DESCRIPTION
### Related Issues

posthog not showing 2.0.0a3 or 2.0.0-beta.1 events

### Proposed Changes:

- Added posthog api key and host address

### How did you test it?
Ran `pip install git+https://github.com/deepset-ai/haystack.git@fix-telemetry-2.0#egg=haystack-ai`

And then 
from haystack.telemetry._telemetry import tutorial_running
tutorial_running("99")

And checked that the event is recorded in posthog.

### Notes for the reviewer


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
