### PR TITLE
fix: Make `TransformersSimilarityRanker` run with single document list

### DIFF
--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -123,7 +123,7 @@ class TransformersSimilarityRanker:
             self.device
         )
         with torch.inference_mode():
-            similarity_scores = self.model(**features).logits.squeeze()  # type: ignore
+            similarity_scores = self.model(**features).logits.squeeze(dim=1)  # type: ignore
 
         _, sorted_indices = torch.sort(similarity_scores, descending=True)
         ranked_docs = []

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch, MagicMock
 
 from haystack import Document, ComponentError
 from haystack.components.rankers.transformers_similarity import TransformersSimilarityRanker
@@ -98,3 +99,16 @@ class TestSimilarityRanker:
 
         sorted_scores = sorted([doc.score for doc in docs_after], reverse=True)
         assert [doc.score for doc in docs_after] == sorted_scores
+
+    @pytest.mark.integration
+    def test_run_single_document(self):
+        """
+        Test if the component runs with a single document.
+        """
+        ranker = TransformersSimilarityRanker(model_name_or_path="cross-encoder/ms-marco-MiniLM-L-6-v2")
+        ranker.warm_up()
+        docs_before = [Document(content="Berlin")]
+        output = ranker.run(query="City in Germany", documents=docs_before)
+        docs_after = output["documents"]
+
+        assert len(docs_after) == 1


### PR DESCRIPTION
### Related Issues

- fixes #6499

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This PR fixes the `TransformersSimilarityRanker` by squeezing the resulting logits only on dimension 1. Without the change, if a list containing a single document is supplied to the ranker, a 0-dimensional tensor is produced for `similarity_scores`, as all dimensions are squeezed. This results in an error in the following for-loop because 0-d tensors are not iterable.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I added an integration test. (Because all of the tests not related to serialization for `TransformersSimilarityRanker` are integration tests. Let me know if I should write a unit test instead.)

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
