### PR TITLE
feat: Add to_dict() and from_dict() methods to Answer, ExtractedAnswer and GeneratedAnswer

### DIFF
--- a/haystack/dataclasses/answer.py
+++ b/haystack/dataclasses/answer.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, fields
 from haystack.dataclasses.document import Document
 
 
@@ -8,6 +8,46 @@ class Answer:
     data: Any
     query: str
     metadata: Dict[str, Any]
+
+    def to_dict(self, flatten=True) -> Dict[str, Any]:
+        """
+        Converts Answer into a dictionary.
+
+        :param flatten: Whether to flatten `metadata` field or not. Defaults to `True`.
+        """
+        data = asdict(self)
+        if flatten:
+            meta = data.pop("metadata")
+            return {**data, **meta}
+        return data
+
+    @classmethod
+    def from_dict(cls, data_dict: Dict[str, Any]) -> "Answer":
+        """
+        Creates a new Answer object from a dictionary.
+        """
+        # Store metadata for a moment while we try un-flattening allegedly flatten metadata.
+        # We don't expect both a `metadata=` keyword and flatten metadata keys so we'll raise a
+        # ValueError later if this is the case.
+        meta = data_dict.pop("metadata", {})
+
+        # Unflatten metadata if it was flattened. We assume any keyword argument that's not
+        # a document field is a metadata key.
+        flatten_meta = {}
+        answer_fields = [f.name for f in fields(cls)]
+        for key in list(data_dict.keys()):
+            if key not in answer_fields:
+                flatten_meta[key] = data_dict.pop(key)
+
+        # We don't support passing both flatten keys and the `metadata` keyword parameter
+        if meta and flatten_meta:
+            raise ValueError(
+                "You can pass either the 'metadata' parameter or flattened metadata keys as keyword arguments, "
+                "but currently you're passing both. Pass either the 'metadata' parameter or flattened metadata keys."
+            )
+
+        # Finally put back all the metadata
+        return cls(**data_dict, metadata={**meta, **flatten_meta})
 
 
 @dataclass(frozen=True)
@@ -18,8 +58,94 @@ class ExtractedAnswer(Answer):
     start: Optional[int] = None
     end: Optional[int] = None
 
+    def to_dict(self, flatten=True) -> Dict[str, Any]:
+        """
+        Converts ExtractedAnswer into a dictionary.
+
+        :param flatten: Whether to flatten `metadata` field or not. Defaults to `True`.
+        """
+        data = super().to_dict(flatten)
+        if self.document:
+            data["document"] = self.document.to_dict(flatten)
+        return data
+
+    @classmethod
+    def from_dict(cls, data_dict: Dict[str, Any]) -> "ExtractedAnswer":
+        """
+        Creates a new ExtractedAnswer object from a dictionary.
+        """
+        # Convert document to dictionary, if present
+        if data_dict["document"]:
+            doc = data_dict.pop("document")
+            data_dict["document"] = Document.from_dict(doc)
+
+        # Store metadata for a moment while we try un-flattening allegedly flatten metadata.
+        # We don't expect both a `metadata=` keyword and flatten metadata keys so we'll raise a
+        # ValueError later if this is the case.
+        meta = data_dict.pop("metadata", {})
+
+        # Unflatten metadata if it was flattened. We assume any keyword argument that's not
+        # a document field is a metadata key.
+        flatten_meta = {}
+        answer_fields = [f.name for f in fields(cls)]
+        for key in list(data_dict.keys()):
+            if key not in answer_fields:
+                flatten_meta[key] = data_dict.pop(key)
+
+        # We don't support passing both flatten keys and the `metadata` keyword parameter
+        if meta and flatten_meta:
+            raise ValueError(
+                "You can pass either the 'metadata' parameter or flattened metadata keys as keyword arguments, "
+                "but currently you're passing both. Pass either the 'metadata' parameter or flattened metadata keys."
+            )
+
+        # Finally put back all the metadata
+        return cls(**data_dict, metadata={**meta, **flatten_meta})
+
 
 @dataclass(frozen=True)
 class GeneratedAnswer(Answer):
     data: str
     documents: List[Document]
+
+    def to_dict(self, flatten=True) -> Dict[str, Any]:
+        """
+        Converts GeneratedAnswer into a dictionary.
+
+        :param flatten: Whether to flatten `metadata` field or not. Defaults to `True`.
+        """
+        data = super().to_dict(flatten)
+        data["documents"] = [doc.to_dict(flatten) for doc in self.documents]
+        return data
+
+    @classmethod
+    def from_dict(cls, data_dict: Dict[str, Any]) -> "GeneratedAnswer":
+        """
+        Creates a new GeneratedAnswer object from a dictionary.
+        """
+        # Convert Documents to dictionaries
+        documents = data_dict.pop("documents", {})
+        data_dict["documents"] = [Document.from_dict(doc) for doc in documents]
+
+        # Store metadata for a moment while we try un-flattening allegedly flatten metadata.
+        # We don't expect both a `metadata=` keyword and flatten metadata keys so we'll raise a
+        # ValueError later if this is the case.
+        meta = data_dict.pop("metadata", {})
+
+        # Unflatten metadata if it was flattened. We assume any keyword argument that's not
+        # a document field is a metadata key.
+        flatten_meta = {}
+        answer_fields = [f.name for f in fields(cls)]
+        for key in list(data_dict.keys()):
+            if key not in answer_fields:
+                flatten_meta[key] = data_dict.pop(key)
+
+        # We don't support passing both flatten keys and the `metadata` keyword parameter
+        if meta and flatten_meta:
+            raise ValueError(
+                "You can pass either the 'metadata' parameter or flattened metadata keys as keyword arguments, "
+                "but currently you're passing both. Pass either the 'metadata' parameter or flattened metadata keys."
+            )
+
+        # Finally put back all the metadata
+        return cls(**data_dict, metadata={**meta, **flatten_meta})

--- a/releasenotes/notes/add-serialization-to-dict-answer-ce17fdf5996fbfb5.yaml
+++ b/releasenotes/notes/add-serialization-to-dict-answer-ce17fdf5996fbfb5.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Add to_dict() and from_dict() for serialization to dictionary for Answer, ExtractedAnswer and GeneratedAnswer.

--- a/test/dataclasses/test_answer.py
+++ b/test/dataclasses/test_answer.py
@@ -1,0 +1,480 @@
+import pytest
+
+from haystack import Document, Answer, ExtractedAnswer, GeneratedAnswer
+
+
+def test_answer_to_dict():
+    answer = Answer(data="Giorgio and I", query="Who lives in Rome?", metadata={"text": "test metadata"})
+
+    assert answer.to_dict() == {"data": "Giorgio and I", "query": "Who lives in Rome?", "text": "test metadata"}
+
+
+def test_answer_to_dict_without_flattening():
+    answer = Answer(data="Giorgio and I", query="Who lives in Rome?", metadata={"text": "test metadata"})
+
+    assert answer.to_dict(flatten=False) == {
+        "data": "Giorgio and I",
+        "query": "Who lives in Rome?",
+        "metadata": {"text": "test metadata"},
+    }
+
+
+def test_answer_from_dict():
+    data = {"data": "Giorgio and I", "query": "Who lives in Rome?", "text": "test metadata"}
+
+    assert Answer.from_dict(data) == Answer(
+        data="Giorgio and I", query="Who lives in Rome?", metadata={"text": "test metadata"}
+    )
+
+
+def test_answer_from_dict_without_flattening():
+    data = {"data": "Giorgio and I", "query": "Who lives in Rome?", "metadata": {"text": "test metadata"}}
+
+    assert Answer.from_dict(data) == Answer(
+        data="Giorgio and I", query="Who lives in Rome?", metadata={"text": "test metadata"}
+    )
+
+
+def test_answer_from_dict_with_flat_and_non_flat_meta():
+    with pytest.raises(ValueError, match="Pass either the 'metadata' parameter or flattened metadata keys"):
+        Answer.from_dict(
+            {
+                "data": "Giorgio and I",
+                "query": "Who lives in Rome?",
+                "metadata": {"text": "test metadata"},
+                "text": "test metadata other",
+            }
+        )
+
+
+def test_extracted_answer_to_dict():
+    extracted_answer = ExtractedAnswer(
+        data="Giorgio and I",
+        query="Who lives in Rome?",
+        metadata={"text": "test metadata"},
+        document=Document(
+            id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            content="My name is Giorgio and I live in Rome.",
+            score=0.33144005810482535,
+        ),
+        probability=0.7661304473876953,
+        start=11,
+        end=24,
+    )
+
+    assert extracted_answer.to_dict() == {
+        "data": "Giorgio and I",
+        "query": "Who lives in Rome?",
+        "document": {
+            "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            "content": "My name is Giorgio and I live in Rome.",
+            "dataframe": None,
+            "blob": None,
+            "score": 0.33144005810482535,
+            "embedding": None,
+        },
+        "probability": 0.7661304473876953,
+        "start": 11,
+        "end": 24,
+        "text": "test metadata",
+    }
+
+
+def test_extracted_answer_to_dict_without_flattening():
+    extracted_answer = ExtractedAnswer(
+        data="Giorgio and I",
+        query="Who lives in Rome?",
+        metadata={"text": "test metadata"},
+        document=Document(
+            id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            content="My name is Giorgio and I live in Rome.",
+            score=0.33144005810482535,
+        ),
+        probability=0.7661304473876953,
+        start=11,
+        end=24,
+    )
+
+    assert extracted_answer.to_dict(flatten=False) == {
+        "data": "Giorgio and I",
+        "query": "Who lives in Rome?",
+        "metadata": {"text": "test metadata"},
+        "document": {
+            "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            "content": "My name is Giorgio and I live in Rome.",
+            "dataframe": None,
+            "blob": None,
+            "meta": {},
+            "score": 0.33144005810482535,
+            "embedding": None,
+        },
+        "probability": 0.7661304473876953,
+        "start": 11,
+        "end": 24,
+    }
+
+
+def test_extracted_answer_from_dict():
+    data = {
+        "data": "Giorgio and I",
+        "query": "Who lives in Rome?",
+        "document": {
+            "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            "content": "My name is Giorgio and I live in Rome.",
+            "dataframe": None,
+            "blob": None,
+            "score": 0.33144005810482535,
+            "embedding": None,
+        },
+        "probability": 0.7661304473876953,
+        "start": 11,
+        "end": 24,
+        "text": "test metadata",
+    }
+
+    assert ExtractedAnswer.from_dict(data) == ExtractedAnswer(
+        data="Giorgio and I",
+        query="Who lives in Rome?",
+        metadata={"text": "test metadata"},
+        document=Document(
+            id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            content="My name is Giorgio and I live in Rome.",
+            score=0.33144005810482535,
+        ),
+        probability=0.7661304473876953,
+        start=11,
+        end=24,
+    )
+
+
+def test_extracted_answer_from_dict_without_flattening():
+    data = {
+        "data": "Giorgio and I",
+        "query": "Who lives in Rome?",
+        "metadata": {"text": "test metadata"},
+        "document": {
+            "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            "content": "My name is Giorgio and I live in Rome.",
+            "dataframe": None,
+            "blob": None,
+            "meta": {},
+            "score": 0.33144005810482535,
+            "embedding": None,
+        },
+        "probability": 0.7661304473876953,
+        "start": 11,
+        "end": 24,
+    }
+
+    assert ExtractedAnswer.from_dict(data) == ExtractedAnswer(
+        data="Giorgio and I",
+        query="Who lives in Rome?",
+        metadata={"text": "test metadata"},
+        document=Document(
+            id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+            content="My name is Giorgio and I live in Rome.",
+            score=0.33144005810482535,
+        ),
+        probability=0.7661304473876953,
+        start=11,
+        end=24,
+    )
+
+
+def test_extracted_answer_from_dict_with_flat_and_non_flat_meta():
+    with pytest.raises(ValueError, match="Pass either the 'metadata' parameter or flattened metadata keys"):
+        ExtractedAnswer.from_dict(
+            {
+                "data": "Giorgio and I",
+                "query": "Who lives in Rome?",
+                "metadata": {"text": "test metadata"},
+                "document": {
+                    "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                    "content": "My name is Giorgio and I live in Rome.",
+                    "dataframe": None,
+                    "blob": None,
+                    "meta": {},
+                    "score": 0.33144005810482535,
+                    "embedding": None,
+                },
+                "probability": 0.7661304473876953,
+                "start": 11,
+                "end": 24,
+                "text": "test metadata other",
+            }
+        )
+
+
+def test_generated_answer_to_dict():
+    generated_answer = GeneratedAnswer(
+        data="Mark and I",
+        query="Who lives in Berlin?",
+        metadata={"text": "test metadata"},
+        documents=[
+            Document(
+                id="10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                content="My name is Mark and I live in Berlin.",
+                score=0.33144005810482535,
+            ),
+            Document(
+                id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                content="My name is Giorgio and I live in Rome.",
+                score=-0.17938556566116537,
+            ),
+            Document(
+                id="6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                content="My name is Jean and I live in Paris.",
+                score=-0.17938556566116537,
+            ),
+        ],
+    )
+
+    assert generated_answer.to_dict() == {
+        "data": "Mark and I",
+        "query": "Who lives in Berlin?",
+        "documents": [
+            {
+                "id": "10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                "content": "My name is Mark and I live in Berlin.",
+                "dataframe": None,
+                "blob": None,
+                "score": 0.33144005810482535,
+                "embedding": None,
+            },
+            {
+                "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                "content": "My name is Giorgio and I live in Rome.",
+                "dataframe": None,
+                "blob": None,
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+            {
+                "id": "6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                "content": "My name is Jean and I live in Paris.",
+                "dataframe": None,
+                "blob": None,
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+        ],
+        "text": "test metadata",
+    }
+
+
+def test_generated_answer_to_dict_without_flattening():
+    generated_answer = GeneratedAnswer(
+        data="Mark and I",
+        query="Who lives in Berlin?",
+        metadata={"text": "test metadata"},
+        documents=[
+            Document(
+                id="10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                content="My name is Mark and I live in Berlin.",
+                score=0.33144005810482535,
+            ),
+            Document(
+                id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                content="My name is Giorgio and I live in Rome.",
+                score=-0.17938556566116537,
+            ),
+            Document(
+                id="6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                content="My name is Jean and I live in Paris.",
+                score=-0.17938556566116537,
+            ),
+        ],
+    )
+
+    assert generated_answer.to_dict(flatten=False) == {
+        "data": "Mark and I",
+        "query": "Who lives in Berlin?",
+        "metadata": {"text": "test metadata"},
+        "documents": [
+            {
+                "id": "10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                "content": "My name is Mark and I live in Berlin.",
+                "dataframe": None,
+                "blob": None,
+                "meta": {},
+                "score": 0.33144005810482535,
+                "embedding": None,
+            },
+            {
+                "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                "content": "My name is Giorgio and I live in Rome.",
+                "dataframe": None,
+                "blob": None,
+                "meta": {},
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+            {
+                "id": "6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                "content": "My name is Jean and I live in Paris.",
+                "dataframe": None,
+                "blob": None,
+                "meta": {},
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+        ],
+    }
+
+
+def test_generated_answer_from_dict():
+    data = {
+        "data": "Mark and I",
+        "query": "Who lives in Berlin?",
+        "documents": [
+            {
+                "id": "10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                "content": "My name is Mark and I live in Berlin.",
+                "dataframe": None,
+                "blob": None,
+                "score": 0.33144005810482535,
+                "embedding": None,
+            },
+            {
+                "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                "content": "My name is Giorgio and I live in Rome.",
+                "dataframe": None,
+                "blob": None,
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+            {
+                "id": "6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                "content": "My name is Jean and I live in Paris.",
+                "dataframe": None,
+                "blob": None,
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+        ],
+        "text": "test metadata",
+    }
+
+    assert GeneratedAnswer.from_dict(data) == GeneratedAnswer(
+        data="Mark and I",
+        query="Who lives in Berlin?",
+        metadata={"text": "test metadata"},
+        documents=[
+            Document(
+                id="10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                content="My name is Mark and I live in Berlin.",
+                score=0.33144005810482535,
+            ),
+            Document(
+                id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                content="My name is Giorgio and I live in Rome.",
+                score=-0.17938556566116537,
+            ),
+            Document(
+                id="6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                content="My name is Jean and I live in Paris.",
+                score=-0.17938556566116537,
+            ),
+        ],
+    )
+
+
+def test_generated_answer_from_dict_without_flattening():
+    data = {
+        "data": "Mark and I",
+        "query": "Who lives in Berlin?",
+        "metadata": {"text": "test metadata"},
+        "documents": [
+            {
+                "id": "10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                "content": "My name is Mark and I live in Berlin.",
+                "dataframe": None,
+                "blob": None,
+                "meta": {},
+                "score": 0.33144005810482535,
+                "embedding": None,
+            },
+            {
+                "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                "content": "My name is Giorgio and I live in Rome.",
+                "dataframe": None,
+                "blob": None,
+                "meta": {},
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+            {
+                "id": "6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                "content": "My name is Jean and I live in Paris.",
+                "dataframe": None,
+                "blob": None,
+                "meta": {},
+                "score": -0.17938556566116537,
+                "embedding": None,
+            },
+        ],
+    }
+
+    assert GeneratedAnswer.from_dict(data) == GeneratedAnswer(
+        data="Mark and I",
+        query="Who lives in Berlin?",
+        metadata={"text": "test metadata"},
+        documents=[
+            Document(
+                id="10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                content="My name is Mark and I live in Berlin.",
+                score=0.33144005810482535,
+            ),
+            Document(
+                id="fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                content="My name is Giorgio and I live in Rome.",
+                score=-0.17938556566116537,
+            ),
+            Document(
+                id="6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                content="My name is Jean and I live in Paris.",
+                score=-0.17938556566116537,
+            ),
+        ],
+    )
+
+
+def test_generated_answer_from_dict_with_flat_and_non_flat_meta():
+    with pytest.raises(ValueError, match="Pass either the 'metadata' parameter or flattened metadata keys"):
+        GeneratedAnswer.from_dict(
+            {
+                "data": "Mark and I",
+                "query": "Who lives in Berlin?",
+                "metadata": {"text": "test metadata"},
+                "documents": [
+                    {
+                        "id": "10a183e965c2e107e20507c717f16559c58a8ba4bc7c577ea8dc32a8d6ca7a20",
+                        "content": "My name is Mark and I live in Berlin.",
+                        "dataframe": None,
+                        "blob": None,
+                        "meta": {},
+                        "score": 0.33144005810482535,
+                        "embedding": None,
+                    },
+                    {
+                        "id": "fb0f1efe94b3c78aa1c4e5a17a5ef8270f70e89d36a3665c8362675e8a769a27",
+                        "content": "My name is Giorgio and I live in Rome.",
+                        "dataframe": None,
+                        "blob": None,
+                        "meta": {},
+                        "score": -0.17938556566116537,
+                        "embedding": None,
+                    },
+                    {
+                        "id": "6c90b78ad94e4e634e2a067b5fe2d26d4ce95405ec222cbaefaeb09ab4dce81e",
+                        "content": "My name is Jean and I live in Paris.",
+                        "dataframe": None,
+                        "blob": None,
+                        "meta": {},
+                        "score": -0.17938556566116537,
+                        "embedding": None,
+                    },
+                ],
+                "text": "test metadata other",
+            }
+        )


### PR DESCRIPTION
### Related Issues

Related to #6505 

### Proposed Changes:

Adds `to_dict()` and `from_dict()` methods to Answer, ExtractedAnswer and GeneratedAnswer for serialization.
This is required so that Evaluation results of components that return these dataclasses, can be serialized.

The implementation is similar to the `to_dict()` and `from_dict()` implementations for the [Document class](https://github.com/deepset-ai/haystack/blob/main/haystack/dataclasses/document.py).

### How did you test it?

Units tests have been added.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
