### PR TITLE
docs: Fix usage examples for OpenAIDocumentEmbedder and SentenceTransformersDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -19,7 +19,7 @@ class OpenAIDocumentEmbedder:
     from haystack import Document
     from haystack.components.embedders import OpenAIDocumentEmbedder
 
-    doc = Document(text="I love pizza!")
+    doc = Document(content="I love pizza!")
 
     document_embedder = OpenAIDocumentEmbedder()
 

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -16,7 +16,7 @@ class SentenceTransformersDocumentEmbedder:
     ```python
     from haystack import Document
     from haystack.components.embedders import SentenceTransformersDocumentEmbedder
-    doc = Document(text="I love pizza!")
+    doc = Document(content="I love pizza!")
     doc_embedder = SentenceTransformersDocumentEmbedder()
     doc_embedder.warm_up()
 

--- a/releasenotes/notes/fix-embedders-docs-examples-72119352572012d7.yaml
+++ b/releasenotes/notes/fix-embedders-docs-examples-72119352572012d7.yaml
@@ -1,0 +1,4 @@
+---
+preview:
+  - |
+    Fix usage examples for OpenAIDocumentEmbedder and SentenceTransformersDocumentEmbedder.


### PR DESCRIPTION
### Proposed Changes:

Fix usage examples for OpenAIDocumentEmbedder and SentenceTransformersDocumentEmbedder.
Change `text` to `content` when creating `Document`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
