### PR TITLE
feat: Add ByteStream and ChatMessage to Haystack init

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -2,7 +2,7 @@ from haystack.core.component import component
 from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.core.errors import DeserializationError, ComponentError
 from haystack.pipeline import Pipeline
-from haystack.dataclasses import Document, Answer, GeneratedAnswer, ExtractedAnswer
+from haystack.dataclasses import Answer, ByteStream, ChatMessage, Document, ExtractedAnswer, GeneratedAnswer
 
 
 __all__ = [
@@ -12,8 +12,10 @@ __all__ = [
     "DeserializationError",
     "ComponentError",
     "Pipeline",
-    "Document",
     "Answer",
-    "GeneratedAnswer",
+    "ByteStream",
+    "ChatMessage",
+    "Document",
     "ExtractedAnswer",
+    "GeneratedAnswer",
 ]


### PR DESCRIPTION
### Related Issues

I noticed when reviewing [this PR](https://github.com/deepset-ai/haystack/pull/6505/files#diff-bc91fff46047801b9ab1b9c636587f9849b0069aa1bf222a726631cdfb46ddaaR3) that current imports of Document and ChatMessage or ByteStream differ.
```python
from haystack import Answer, Document, ExtractedAnswer, GeneratedAnswer
from haystack.dataclasses.byte_stream import ByteStream
from haystack.dataclasses.chat_message import ChatMessage
```
As all of these are user facing and not just for internal use, as a user I would expect all of to work with
```python
from haystack import Answer, Document, ExtractedAnswer, GeneratedAnswer, ByteStream, ChatMessage
```
We shouldn't treat them differently.

### Proposed Changes:

- Added ByteStream and ChatMessage imports to Haystack's init.py

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

init.py gets longer with this change but I don't see a reason why we would treat some dataclasses different than others. What do you think?

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
