### PR TITLE
fix: do not dump pipeline graph into the debug payload

### DIFF
--- a/haystack/core/pipeline/draw/draw.py
+++ b/haystack/core/pipeline/draw/draw.py
@@ -45,14 +45,6 @@ def _draw(
     logger.debug("Pipeline diagram saved at %s", path)
 
 
-def _convert_for_debug(graph: networkx.MultiDiGraph) -> Any:
-    """
-    Renders the pipeline graph with additional debug information into a text file that Mermaid can later render.
-    """
-    graph = _prepare_for_drawing(graph=graph, style_map={})
-    return _to_mermaid_text(graph=graph)
-
-
 def _convert(
     graph: networkx.MultiDiGraph, engine: RenderingEngines = "mermaid-image", style_map: Optional[Dict[str, str]] = None
 ) -> Any:

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -23,7 +23,7 @@ from haystack.core.errors import (
     PipelineValidationError,
 )
 from haystack.core.pipeline.descriptions import find_pipeline_outputs
-from haystack.core.pipeline.draw.draw import _draw, _convert_for_debug, RenderingEngines
+from haystack.core.pipeline.draw.draw import _draw, RenderingEngines
 from haystack.core.pipeline.validation import validate_pipeline_input, find_pipeline_inputs
 from haystack.core.component.connection import Connection, parse_connect_string
 from haystack.core.type_utils import _type_name
@@ -519,14 +519,12 @@ class Pipeline:
         """
         Stores a snapshot of this step into the self.debug dictionary of the pipeline.
         """
-        mermaid_graph = _convert_for_debug(deepcopy(self.graph))
         self._debug[step] = {
             "time": datetime.datetime.now(),
             "components_queue": components_queue,
             "mandatory_values_buffer": mandatory_values_buffer,
             "optional_values_buffer": optional_values_buffer,
             "pipeline_output": pipeline_output,
-            "diagram": mermaid_graph,
         }
 
     def _clear_visits_count(self):

--- a/releasenotes/notes/remove-image-from-debug-c83d61db92bcbfc2.yaml
+++ b/releasenotes/notes/remove-image-from-debug-c83d61db92bcbfc2.yaml
@@ -1,0 +1,5 @@
+---
+issues:
+  - |
+    Fix "TypeError: descriptor '__dict__' for 'XXX' objects doesn't apply to a 'XXX' object" when running
+    pipelines with `debug=True` by removing the graph image from the debug payload.


### PR DESCRIPTION
### Related Issues

- fixes #6265 

### Proposed Changes:

Remove the code with the problematic `deepcopy`, users can still `draw()` the pipeline after a debug run

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
