### PR TITLE
fix: mypy `"str" not callable` for `PromptModelInvocationLayer`

### DIFF
--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import importlib
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
 from haystack.nodes.base import BaseComponent
 from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
@@ -92,7 +92,7 @@ class PromptModel(BaseComponent):
             except ImportError as e:
                 msg = f"Can't find module {module_name}"
                 raise ValueError(msg) from e
-            invocation_layer_class = getattr(module, class_name)
+            invocation_layer_class = cast(Type[PromptModelInvocationLayer], getattr(module, class_name))
             if invocation_layer_class is None:
                 msg = f"Can'f find class {class_name} in module {module_name}"
                 ValueError(msg)

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -95,7 +95,7 @@ class PromptModel(BaseComponent):
             invocation_layer_class = cast(Type[PromptModelInvocationLayer], getattr(module, class_name))
             if invocation_layer_class is None:
                 msg = f"Can'f find class {class_name} in module {module_name}"
-                ValueError(msg)
+                raise ValueError(msg)
 
         if invocation_layer_class:
             return invocation_layer_class(

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -100,9 +100,7 @@ class PromptModel(BaseComponent):
             class_ = invocation_layer_class
 
         if class_:
-            return class_(
-                model_name_or_path=self.model_name_or_path, max_length=self.max_length, **all_kwargs
-            )
+            return class_(model_name_or_path=self.model_name_or_path, max_length=self.max_length, **all_kwargs)
 
         for invocation_layer in PromptModelInvocationLayer.invocation_layer_providers:
             if inspect.isabstract(invocation_layer):

--- a/haystack/nodes/prompt/prompt_model.py
+++ b/haystack/nodes/prompt/prompt_model.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import importlib
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast, overload
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
 from haystack.nodes.base import BaseComponent
 from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
@@ -92,13 +92,15 @@ class PromptModel(BaseComponent):
             except ImportError as e:
                 msg = f"Can't find module {module_name}"
                 raise ValueError(msg) from e
-            invocation_layer_class = cast(Type[PromptModelInvocationLayer], getattr(module, class_name))
-            if invocation_layer_class is None:
+            class_ = getattr(module, class_name)
+            if class_ is None:
                 msg = f"Can'f find class {class_name} in module {module_name}"
                 raise ValueError(msg)
+        else:
+            class_ = invocation_layer_class
 
-        if invocation_layer_class:
-            return invocation_layer_class(
+        if class_:
+            return class_(
                 model_name_or_path=self.model_name_or_path, max_length=self.max_length, **all_kwargs
             )
 

--- a/test/prompt/test_prompt_model.py
+++ b/test/prompt/test_prompt_model.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from haystack.nodes.prompt.prompt_model import PromptModel
-from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer, HFLocalInvocationLayer
+from haystack.nodes.prompt.invocation_layer import PromptModelInvocationLayer
 
 from .conftest import create_mock_layer_that_supports
 
@@ -40,7 +40,7 @@ def test_constructor_with_no_supported_model():
 
 
 @pytest.mark.unit
-def test_constructor_with_invocation_layer_class_string():
+def test_constructor_with_invocation_layer_class_string(mock_auto_tokenizer):
     model = PromptModel(
         invocation_layer_class="haystack.nodes.prompt.invocation_layer.CohereInvocationLayer", api_key="fake_api_key"
     )


### PR DESCRIPTION
### Related Issues

I am seeing a pylint error on Haystack v1.x after the [recent prompt model PR](https://github.com/deepset-ai/haystack/pull/6497). It's haystack/nodes/prompt/prompt_model.py:101: error: "str" not callable  [operator]  now that invocation_layer_class can be a string: https://github.com/deepset-ai/haystack/pull/6497/files#diff-8a69dcdf57e9a29aff18add4eaa63876f41273bfb905a5b2b9be988a78fe6f76R77

### Proposed Changes:

- Use two variables to avoid re-assignment and fix `"str" not callable``
- Add `raise` to fix `pointless-exception-statement`error
- Add mocked tokenizer to unit test to fix error caused by our `urlopen_mock` check

### How did you test it?

Ran mypy locally

### Notes for the reviewer

Other option could be # type: ignore 

The test added in the previous PR is not a unit test but marked as one and is failing for that reason: https://github.com/deepset-ai/haystack/pull/6497/files#diff-d1a8309a2d6fb001c0a8b7a97dcdb27b0e99626e3d35dd9ef8e33cedc04fe54eR43
It tries to load a tokenizer from the model hub.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
