### PR TITLE
fix: allow connecting the same components multiple times

### DIFF
--- a/haystack/core/component/connection.py
+++ b/haystack/core/component/connection.py
@@ -16,6 +16,10 @@ class Connection:
 
     def __post_init__(self):
         if self.sender and self.sender_socket and self.receiver and self.receiver_socket:
+            # If we're trying to connect the same sockets again, this should be a no-op
+            if self.receiver in self.sender_socket.receivers and self.sender in self.receiver_socket.senders:
+                return
+
             # Make sure the receiving socket isn't already connected, unless it's variadic. Sending sockets can be
             # connected as many times as needed, so they don't need this check
             if self.receiver_socket.senders and not self.receiver_socket.is_variadic:

--- a/releasenotes/notes/allow-connecting-same-components-again-e63cf719b9bf2a14.yaml
+++ b/releasenotes/notes/allow-connecting-same-components-again-e63cf719b9bf2a14.yaml
@@ -1,0 +1,5 @@
+---
+issues:
+  - |
+    Make `connect` idempotent, allowing connecting the same components more than once. Specially useful
+    in Jupiter notebooks. Fixes https://github.com/deepset-ai/haystack/issues/6359.

--- a/test/core/pipeline/test_reconnect.py
+++ b/test/core/pipeline/test_reconnect.py
@@ -1,0 +1,21 @@
+import pytest
+
+from haystack import Pipeline
+from haystack.core.errors import PipelineConnectError
+from haystack.testing.sample_components import Double
+
+
+def test_connect_component_twice():
+    pipe = Pipeline()
+    c1 = Double()
+    c2 = Double()
+    c3 = Double()
+    pipe.add_component("c1", c1)
+    pipe.add_component("c2", c2)
+    pipe.add_component("c3", c3)
+    pipe.connect("c1.value", "c2.value")
+    # the following should be a no-op
+    pipe.connect("c1.value", "c2.value")
+    # this should fail instead
+    with pytest.raises(PipelineConnectError):
+        pipe.connect("c3.value", "c2.value")


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/6359

### Proposed Changes:

If the connection endpoints are the same, do nothing instead of raising an error.

### How did you test it?

Dedicated unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
