### PR TITLE
feat!: Rename ExtractiveReader's `confidence_threshold` to `score_threshold`

### DIFF
--- a/releasenotes/notes/rename-confidence-score-3ba604b8f9bd0454.yaml
+++ b/releasenotes/notes/rename-confidence-score-3ba604b8f9bd0454.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Renamed the confidence_threshold parameter of the ExtractiveReader to score_threshold as ExtractedAnswers have a score and this is what the threshold is for.
+    For consistency, the term confidence is not mentioned anymore in favor of score.

--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -98,7 +98,7 @@ def test_to_dict():
             "device": None,
             "token": None,  # don't serialize valid tokens
             "top_k": 20,
-            "confidence_threshold": None,
+            "score_threshold": None,
             "max_seq_length": 384,
             "stride": 128,
             "max_batch_size": None,
@@ -121,7 +121,7 @@ def test_to_dict_empty_model_kwargs():
             "device": None,
             "token": None,  # don't serialize valid tokens
             "top_k": 20,
-            "confidence_threshold": None,
+            "score_threshold": None,
             "max_seq_length": 384,
             "stride": 128,
             "max_batch_size": None,


### PR DESCRIPTION
### Related Issues

- While preparing the documentation page for Readers 2.0, @agnieszka-m found that the `confidence_threshold` is unintuitive as the Answers that are filtered based on the threshold have no confidence scores but only ~~probabilites~~ scores after refactoring answer class.

### Proposed Changes:

Renamed Reader's `confidence_threshold` to `score_threshold` as ExtractedAnswers have a ~~probability~~ score and this is what the threshold is for.
For consistency, the term confidence is not mentioned anymore in favor of score. Probability is still mentioned to explain the no_answer score.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

When this PR is merged, I will update the documentation page: https://docs.haystack.deepset.ai/v2.0/docs/extractivereader

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
