### PR TITLE
fix: `HFInvocationLayer` - convert `use_auth_token` to `token`

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -183,6 +183,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         trust_remote_code = kwargs.get("trust_remote_code", False)
         hub_kwargs = {
             "revision": kwargs.get("revision", None),
+            # use_auth_token is no longer used in HuggingFace pipelines. We convert it to token
             "token": kwargs.get("use_auth_token", None),
             "trust_remote_code": trust_remote_code,
         }

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -183,7 +183,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         trust_remote_code = kwargs.get("trust_remote_code", False)
         hub_kwargs = {
             "revision": kwargs.get("revision", None),
-            "use_auth_token": kwargs.get("use_auth_token", None),
+            "token": kwargs.get("use_auth_token", None),
             "trust_remote_code": trust_remote_code,
         }
         model_kwargs = kwargs.get("model_kwargs", {})

--- a/test/prompt/invocation_layer/test_hugging_face.py
+++ b/test/prompt/invocation_layer/test_hugging_face.py
@@ -59,6 +59,9 @@ def test_constructor_with_model_name_only(mock_pipeline, mock_get_task):
     assert kwargs["task"] == "text2text-generation"
     assert kwargs["model"] == "google/flan-t5-base"
 
+    # use_auth_token is no longer used in HuggingFace pipelines and should never be passed
+    assert "use_auth_token" not in kwargs
+
     # no matter what kwargs we pass or don't pass, there are always 14 predefined kwargs passed to the pipeline
     assert len(kwargs) == 14
 
@@ -76,7 +79,7 @@ def test_constructor_with_model_name_only(mock_pipeline, mock_get_task):
         "pipeline_class",
         "use_fast",
         "revision",
-        "use_auth_token",
+        "token",
         "trust_remote_code",
     ]
 


### PR DESCRIPTION
### Related Issues

- fixes #6501

Investigating the issue, I discovered that all the problems disappear if we create a Hugging Face Pipeline using `token` instead of the old `use_auth_token`.

### Proposed Changes:

- Internally convert `use_auth_token` to `token`
- I chose to not change the parameter name in the public API, to avoid a breaking change. In 2.0, we already have the right parameter name.

### How did you test it?

CI. Addition to existing test. Manual verification (described here: https://github.com/deepset-ai/haystack/issues/6501#issuecomment-1851890184).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
