### PR TITLE
Fixing incorrect docstring

### DIFF
--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -44,7 +44,7 @@ class HuggingFaceTGIGenerator:
                                      url="<your-tgi-endpoint-url>",
                                      token="<your-token>")
     client.warm_up()
-    response = client.run("What's Natural Language Processing?", max_new_tokens=120)
+    response = client.run("What's Natural Language Processing?")
     print(response)
     ```
 


### PR DESCRIPTION
The run method of `HuggingFaceTGIGenerator` does not have this input. There are generation kwargs, which might differ per model as far as I can tell? This code block will generate errors. I am also fixing docs