### PR TITLE
feat: Add `VertexAIImageCaptioner` generator

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -38,7 +38,16 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf tika 'azure-ai-formrecognizer>=3.2.0b2'
+        run: |
+          pip install \
+            .[dev,audio] \
+            langdetect \
+            transformers[torch,sentencepiece]==4.35.2 \
+            'sentence-transformers>=2.2.0' \
+            pypdf \
+            tika \
+            'azure-ai-formrecognizer>=3.2.0b2' \
+            google-cloud-aiplatform
 
       - name: Mypy
         if: steps.files.outputs.any_changed == 'true'
@@ -69,7 +78,17 @@ jobs:
 
       - name: Install Haystack
         run: |
-          pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2'
+          pip install \
+            .[dev,audio] \
+            langdetect \
+            transformers[torch,sentencepiece]==4.35.2 \
+            'sentence-transformers>=2.2.0' \
+            pypdf \
+            markdown-it-py \
+            mdit_plain \
+            tika \
+            'azure-ai-formrecognizer>=3.2.0b2' \
+            google-cloud-aiplatform
 
       - name: Pylint
         if: steps.files.outputs.any_changed == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,8 @@ jobs:
             mdit_plain \
             tika \
             'azure-ai-formrecognizer>=3.2.0b2' \
-            boilerpy3
+            boilerpy3 \
+            google-cloud-aiplatform
 
       - name: Run
         run: pytest -m "not integration" test
@@ -178,7 +179,8 @@ jobs:
             mdit_plain \
             tika \
             'azure-ai-formrecognizer>=3.2.0b2' \
-            boilerpy3
+            boilerpy3 \
+            google-cloud-aiplatform
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test
@@ -245,7 +247,8 @@ jobs:
             mdit_plain \
             tika \
             'azure-ai-formrecognizer>=3.2.0b2' \
-            boilerpy3
+            boilerpy3 \
+            google-cloud-aiplatform
 
       - name: Run Tika
         run: docker run -d -p 9998:9998 apache/tika:2.9.0.0
@@ -307,7 +310,8 @@ jobs:
             mdit_plain \
             tika \
             'azure-ai-formrecognizer>=3.2.0b2' \
-            boilerpy3
+            boilerpy3 \
+            google-cloud-aiplatform
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test -k 'not tika'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,6 +98,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
+        shell: bash
         run: |
           pip install \
             .[dev,audio] \
@@ -299,6 +300,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
+        shell: bash
         run: |
           pip install \
             .[dev,audio] \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,18 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: |
+          pip install \
+            .[dev,audio] \
+            langdetect \
+            transformers[torch,sentencepiece]==4.35.2 \
+            'sentence-transformers>=2.2.0' \
+            pypdf \
+            markdown-it-py \
+            mdit_plain \
+            tika \
+            'azure-ai-formrecognizer>=3.2.0b2' \
+            boilerpy3
 
       - name: Run
         run: pytest -m "not integration" test
@@ -156,7 +167,18 @@ jobs:
           sudo apt install ffmpeg  # for local Whisper tests
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: |
+          pip install \
+            .[dev,audio] \
+            langdetect \
+            transformers[torch,sentencepiece]==4.35.2 \
+            'sentence-transformers>=2.2.0' \
+            pypdf \
+            markdown-it-py \
+            mdit_plain \
+            tika \
+            'azure-ai-formrecognizer>=3.2.0b2' \
+            boilerpy3
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test
@@ -212,7 +234,18 @@ jobs:
           colima start
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: |
+          pip install \
+            .[dev,audio] \
+            langdetect \
+            transformers[torch,sentencepiece]==4.35.2 \
+            'sentence-transformers>=2.2.0' \
+            pypdf \
+            markdown-it-py \
+            mdit_plain \
+            tika \
+            'azure-ai-formrecognizer>=3.2.0b2' \
+            boilerpy3
 
       - name: Run Tika
         run: docker run -d -p 9998:9998 apache/tika:2.9.0.0
@@ -263,7 +296,18 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: |
+          pip install \
+            .[dev,audio] \
+            langdetect \
+            transformers[torch,sentencepiece]==4.35.2 \
+            'sentence-transformers>=2.2.0' \
+            pypdf \
+            markdown-it-py \
+            mdit_plain \
+            tika \
+            'azure-ai-formrecognizer>=3.2.0b2' \
+            boilerpy3
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test -k 'not tika'

--- a/haystack/components/generators/google_vertex/captioner.py
+++ b/haystack/components/generators/google_vertex/captioner.py
@@ -1,0 +1,57 @@
+from typing import List, Dict, Optional, Any
+import logging
+
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.core.component import component
+from haystack.dataclasses.byte_stream import ByteStream
+from haystack.lazy_imports import LazyImport
+
+with LazyImport("Run 'pip install google-cloud-aiplatform'") as vertexai_import:
+    import vertexai
+    from vertexai.vision_models import ImageTextModel, Image
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class VertexAIImageCaptioner:
+    def __init__(self, *, model: str = "imagetext", project_id: str, location: Optional[str] = None, **kwargs):
+        """
+        Generate image captions using a Google Vertex AI model.
+
+        Authenticates using Google Cloud Application Default Credentials (ADCs).
+        For more information see the official Google documentation:
+        https://cloud.google.com/docs/authentication/provide-credentials-adc
+
+        :param project_id: ID of the GCP project to use.
+        :param model: Name of the model to use, defaults to "imagetext".
+        :param location: The default location to use when making API calls, if not set uses us-central-1.
+            Defaults to None.
+        :param kwargs: Additional keyword arguments to pass to the model.
+            For a list of supported arguments see the `ImageTextModel.get_captions()` documentation.
+        """
+        vertexai_import.check()
+
+        # Login to GCP. This will fail if user has not set up their gcloud SDK
+        vertexai.init(project=project_id, location=location)
+
+        self._model_name = model
+        self._project_id = project_id
+        self._location = location
+        self._kwargs = kwargs
+
+        self._model = ImageTextModel.from_pretrained(self._model_name)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return default_to_dict(
+            self, model=self._model_name, project_id=self._project_id, location=self._location, **self._kwargs
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VertexAIImageCaptioner":
+        return default_from_dict(cls, data)
+
+    @component.output_types(captions=List[str])
+    def run(self, image: ByteStream):
+        captions = self._model.get_captions(image=Image(image.data), **self._kwargs)
+        return {"captions": captions}

--- a/releasenotes/notes/main-5e63f71fc94c0d78.yaml
+++ b/releasenotes/notes/main-5e63f71fc94c0d78.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Add new generator `VertexAIImageCaptioner` to generate image captions using Google Vertex AI.
+    Sample usage:
+    ```python
+    from pathlib import Path
+
+    from haystack.dataclasses.byte_stream import ByteStream
+    from haystack.components.generators.google_vertex.captioner import VertexAIImageCaptioner
+
+    captioner = VertexAIImageCaptioner(project_id="myproject-123456", number_of_results=3, language="fr")
+    image = ByteStream.from_file_path(Path("path", "to", "my", "image.png"))
+    res = captioner.run(image=image)
+    for caption in res["captions"]:
+      print(caption)
+    ```

--- a/test/components/generators/google_vertex/test_captioner.py
+++ b/test/components/generators/google_vertex/test_captioner.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch, Mock
+
+from haystack.dataclasses.byte_stream import ByteStream
+from haystack.components.generators.google_vertex.captioner import VertexAIImageCaptioner
+
+
+@patch("haystack.components.generators.google_vertex.captioner.vertexai")
+@patch("haystack.components.generators.google_vertex.captioner.ImageTextModel")
+def test_init(mock_model_class, mock_vertexai):
+    captioner = VertexAIImageCaptioner(
+        model="imagetext", project_id="myproject-123456", number_of_results=1, language="it"
+    )
+    mock_vertexai.init.assert_called_once_with(project="myproject-123456", location=None)
+    mock_model_class.from_pretrained.assert_called_once_with("imagetext")
+    assert captioner._model_name == "imagetext"
+    assert captioner._project_id == "myproject-123456"
+    assert captioner._location is None
+    assert captioner._kwargs == {"number_of_results": 1, "language": "it"}
+
+
+@patch("haystack.components.generators.google_vertex.captioner.vertexai")
+@patch("haystack.components.generators.google_vertex.captioner.ImageTextModel")
+def test_to_dict(_mock_model_class, _mock_vertexai):
+    captioner = VertexAIImageCaptioner(
+        model="imagetext", project_id="myproject-123456", number_of_results=1, language="it"
+    )
+    assert captioner.to_dict() == {
+        "type": "haystack.components.generators.google_vertex.captioner.VertexAIImageCaptioner",
+        "init_parameters": {
+            "model": "imagetext",
+            "project_id": "myproject-123456",
+            "location": None,
+            "number_of_results": 1,
+            "language": "it",
+        },
+    }
+
+
+@patch("haystack.components.generators.google_vertex.captioner.vertexai")
+@patch("haystack.components.generators.google_vertex.captioner.ImageTextModel")
+def test_from_dict(_mock_model_class, _mock_vertexai):
+    captioner = VertexAIImageCaptioner.from_dict(
+        {
+            "type": "haystack.components.generators.google_vertex.captioner.VertexAIImageCaptioner",
+            "init_parameters": {
+                "model": "imagetext",
+                "project_id": "myproject-123456",
+                "number_of_results": 1,
+                "language": "it",
+            },
+        }
+    )
+    assert captioner._model_name == "imagetext"
+    assert captioner._project_id == "myproject-123456"
+    assert captioner._location is None
+    assert captioner._kwargs == {"number_of_results": 1, "language": "it"}
+    assert captioner._model is not None
+
+
+@patch("haystack.components.generators.google_vertex.captioner.vertexai")
+@patch("haystack.components.generators.google_vertex.captioner.ImageTextModel")
+def test_run_calls_get_captions(mock_model_class, _mock_vertexai):
+    mock_model = Mock()
+    mock_model_class.from_pretrained.return_value = mock_model
+    captioner = VertexAIImageCaptioner(
+        model="imagetext", project_id="myproject-123456", number_of_results=1, language="it"
+    )
+
+    image = ByteStream(data=b"image data")
+    captioner.run(image=image)
+    mock_model.get_captions.assert_called_once()
+    assert len(mock_model.get_captions.call_args.kwargs) == 3
+    assert mock_model.get_captions.call_args.kwargs["image"]._image_bytes == image.data
+    assert mock_model.get_captions.call_args.kwargs["number_of_results"] == 1
+    assert mock_model.get_captions.call_args.kwargs["language"] == "it"


### PR DESCRIPTION
### Related Issues

Part of #6518 

### Proposed Changes:

Add new generator `VertexAIImageCaptioner` to generate image captions using Google Vertex AI.

Sample usage:

```python
from pathlib import Path

from haystack.dataclasses.byte_stream import ByteStream
from haystack.components.generators.google_vertex.captioner import VertexAIImageCaptioner

captioner = VertexAIImageCaptioner(project_id="myproject-123456", number_of_results=3, language="fr")
image = ByteStream.from_file_path(Path("path", "to", "my", "image.png"))
res = captioner.run(image=image)
for caption in res["captions"]:
  print(caption)
```


### How did you test it?

I added some unit tests to verify basic functionalities and tested it manually.

### Notes for the reviewer

This doesn't include any integration tests as we need to figure out a nice way to authenticate with GCP, as Vertex AI doesn't support API keys authorization.

Other PR will follow this one to add other generators for Vertex AI.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
