### PR TITLE
refactor!: uniform run api for LocalWhisperTranscriber

### DIFF
--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -1,9 +1,11 @@
-from typing import List, Optional, Dict, Any, Union, BinaryIO, Literal, get_args, Sequence
+from typing import List, Optional, Dict, Tuple, Any, Union, Literal, get_args
 
 import logging
+import tempfile
 from pathlib import Path
 
 from haystack import component, Document, default_to_dict, ComponentError
+from haystack.dataclasses import ByteStream
 from haystack.lazy_imports import LazyImport
 
 with LazyImport(
@@ -67,7 +69,7 @@ class LocalWhisperTranscriber:
         )
 
     @component.output_types(documents=List[Document])
-    def run(self, audio_files: List[Path], whisper_params: Optional[Dict[str, Any]] = None):
+    def run(self, sources: List[Union[str, Path, ByteStream]], whisper_params: Optional[Dict[str, Any]] = None):
         """
         Transcribe the audio files into a list of Documents, one for each input file.
 
@@ -87,10 +89,10 @@ class LocalWhisperTranscriber:
         if whisper_params is None:
             whisper_params = self.whisper_params
 
-        documents = self.transcribe(audio_files, **whisper_params)
+        documents = self.transcribe(sources, **whisper_params)
         return {"documents": documents}
 
-    def transcribe(self, audio_files: Sequence[Union[str, Path, BinaryIO]], **kwargs) -> List[Document]:
+    def transcribe(self, sources: List[Union[str, Path, ByteStream]], **kwargs) -> List[Document]:
         """
         Transcribe the audio files into a list of Documents, one for each input file.
 
@@ -104,17 +106,15 @@ class LocalWhisperTranscriber:
             alignment data. Another key called `audio_file` contains the path to the audio file used for the
             transcription.
         """
-        transcriptions = self._raw_transcribe(audio_files=audio_files, **kwargs)
+        transcriptions = self._raw_transcribe(sources, **kwargs)
         documents = []
-        for audio, transcript in zip(audio_files, transcriptions):
+        for path, transcript in transcriptions.items():
             content = transcript.pop("text")
-            if not isinstance(audio, (str, Path)):
-                audio = "<<binary stream>>"
-            doc = Document(content=content, meta={"audio_file": audio, **transcript})
+            doc = Document(content=content, meta={"audio_file": path, **transcript})
             documents.append(doc)
         return documents
 
-    def _raw_transcribe(self, audio_files: Sequence[Union[str, Path, BinaryIO]], **kwargs) -> List[Dict[str, Any]]:
+    def _raw_transcribe(self, sources: List[Union[str, Path, ByteStream]], **kwargs) -> Dict[Path, Any]:
         """
         Transcribe the given audio files. Returns the output of the model, a dictionary, for each input file.
 
@@ -123,18 +123,31 @@ class LocalWhisperTranscriber:
         [github repo](https://github.com/openai/whisper).
 
         :param audio_files: A list of paths or binary streams to transcribe.
-        :returns: A list of transcriptions.
+        :returns: A dictionary of  file_path -> transcription.
         """
-        return_segments = kwargs.pop("return_segments", False)
-        transcriptions = []
-        for audio_file in audio_files:
-            if isinstance(audio_file, (str, Path)):
-                audio_file = open(audio_file, "rb")
+        if self._model is None:
+            raise ComponentError("Model is not loaded, please run 'warm_up()' before calling 'run()'")
 
-            # mypy compains that _model is not guaranteed to be not None. It is: check self.warm_up()
-            transcription = self._model.transcribe(audio_file.name, **kwargs)  # type: ignore
+        return_segments = kwargs.pop("return_segments", False)
+        transcriptions: Dict[Path, Any] = {}
+        for source in sources:
+            if not isinstance(source, ByteStream):
+                path = Path(source)
+                source = ByteStream.from_file_path(path)
+                source.metadata["file_path"] = path
+            else:
+                # If we received a ByteStream instance that doesn't have the "file_path" metadata set,
+                # we dump the bytes into a temporary file.
+                path = source.metadata.get("file_path")
+                if path is None:
+                    fp = tempfile.NamedTemporaryFile(delete=False)
+                    path = Path(fp.name)
+                    source.to_file(path)
+                    source.metadata["file_path"] = path
+
+            transcription = self._model.transcribe(str(path), **kwargs)
             if not return_segments:
                 transcription.pop("segments", None)
-            transcriptions.append(transcription)
+            transcriptions[path] = transcription
 
         return transcriptions

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Tuple, Any, Union, Literal, get_args
+from typing import List, Optional, Dict, Any, Union, Literal, get_args
 
 import logging
 import tempfile

--- a/releasenotes/notes/change-localwhispertranscriber-run-3b0a818060867720.yaml
+++ b/releasenotes/notes/change-localwhispertranscriber-run-3b0a818060867720.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    If you have a `LocalWhisperTranscriber` in a pipeline, change the `audio_files`
+    input name to `sources`. Similarly for standalone invocation of the component,
+    pass `sources` instead of `audio_files` to the `run()` method.
+enhancements:
+  - |
+    Add support for `ByteStream` to `LocalWhisperTranscriber` and uniform the
+    input socket names to the other components in Haystack.


### PR DESCRIPTION
### Related Issues

- part of #6101 

### Proposed Changes:

- Uniforms the `run` argument names for `LocalWhisperTranscriber`
- Component had support for binary input but it was not exposed through the `run` API, that was also fixed

### How did you test it?

- Unit and Integration tests, locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
