### PR TITLE
chore: Remove 'preview' from the release notes template

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -36,10 +36,7 @@ template: |
   fixes:
     - |
       Add normal bug fixes here, or remove this section.
-  preview:
-    - |
-      Add changes to Haystack version 2, or remove this section.
-      Haystack version 2 can be found under haystack/preview.
+
 sections:
   # The prelude section is implicitly included.
   - [upgrade, ⬆️ Upgrade Notes]
@@ -49,4 +46,3 @@ sections:
   - [deprecations, ⚠️ Deprecation Notes]
   - [security, Security Notes]
   - [fixes, 🐛 Bug Fixes]
-  - [preview, 🩵 Haystack 2.0 preview]


### PR DESCRIPTION
### Proposed Changes:

See title

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
