### PR TITLE
chore: add boilerpy3 to the core dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2'
 
       - name: Run
         run: pytest -m "not integration" test
@@ -156,7 +156,7 @@ jobs:
           sudo apt install ffmpeg  # for local Whisper tests
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2'
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test
@@ -212,7 +212,7 @@ jobs:
           colima start
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2'
 
       - name: Run Tika
         run: docker run -d -p 9998:9998 apache/tika:2.9.0.0
@@ -263,7 +263,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Haystack
-        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2' boilerpy3
+        run: pip install .[dev,audio] langdetect transformers[torch,sentencepiece]==4.35.2 'sentence-transformers>=2.2.0' pypdf markdown-it-py mdit_plain tika 'azure-ai-formrecognizer>=3.2.0b2'
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test -k 'not tika'

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -1,12 +1,10 @@
 import logging
+from boilerpy3 import extractors
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from haystack import Document, component
 from haystack.dataclasses import ByteStream
-from haystack.lazy_imports import LazyImport
-
-from boilerpy3 import extractors
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -1,7 +1,7 @@
 import logging
-from boilerpy3 import extractors
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+from boilerpy3 import extractors
 
 from haystack import Document, component
 from haystack.dataclasses import ByteStream

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -6,10 +6,9 @@ from haystack import Document, component
 from haystack.dataclasses import ByteStream
 from haystack.lazy_imports import LazyImport
 
-logger = logging.getLogger(__name__)
+from boilerpy3 import extractors
 
-with LazyImport("Run 'pip install boilerpy3'") as boilerpy3_import:
-    from boilerpy3 import extractors
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -29,12 +28,6 @@ class HTMLToDocument:
     ```
 
     """
-
-    def __init__(self):
-        """
-        Initializes the HTMLToDocument component.
-        """
-        boilerpy3_import.check()
 
     @component.output_types(documents=List[Document])
     def run(self, sources: List[Union[str, Path, ByteStream]], meta: Optional[List[Dict[str, Any]]] = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
   "more-itertools",  # TextDocumentSplitter
   "networkx", # Pipeline graphs
   "typing_extensions", # typing support for Python 3.8
+  "boilerpy3", # Fulltext extraction from HTML pages
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/ship-boilerpy3-0bffbd7955c89dd4.yaml
+++ b/releasenotes/notes/ship-boilerpy3-0bffbd7955c89dd4.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Include 'boilerpy3' in the 'haystack-ai' dependencies.


### PR DESCRIPTION
### Related Issues

The additional `pip install boilerpy3` is ubiquitous in our docs and code examples, let's just make it part of `haystack-ai`

### Proposed Changes:

Add `boilerpy3` as a dependency, it's only 22kb

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
