### PR TITLE
fix: make `minor_version_release.yml` to run on the v1.x branch

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -1,4 +1,4 @@
-name: Minor Version Release
+name: Minor Version Release (1.x)
 
 on:
   workflow_dispatch:
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
+        with:
+          ref: "v1.x"
 
       - name: Define all versions
         id: versions
@@ -30,12 +32,12 @@ jobs:
           git checkout -b v${{ steps.versions.outputs.current_release_minor }}.x
           git push -u origin v${{ steps.versions.outputs.current_release_minor }}.x --tags
 
-      - name: Bump version on main
+      - name: Bump version on v1.x
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout main
+          git checkout v1.x
           NEW_VERSION=$(awk -F. '/[0-9]+\./{$2++;print}' OFS=. < VERSION.txt)
           echo "$NEW_VERSION" > VERSION.txt
           cat VERSION.txt

--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -45,7 +45,7 @@ jobs:
           git commit -m "Update unstable version to $NEW_VERSION"
           VERSION_TAG="v$NEW_VERSION"
           git tag $VERSION_TAG -m"$VERSION_TAG"
-          git push --atomic origin main $VERSION_TAG
+          git push --atomic origin v1.x $VERSION_TAG
 
       - uses: actions/setup-python@v5
         with:
@@ -58,5 +58,5 @@ jobs:
         env:
           RDME_API_KEY: ${{ secrets.README_API_KEY }}
         run: |
-          git checkout main
+          git checkout v1.x
           python ./.github/utils/release_docs.py --new-version ${{ steps.versions.outputs.current_release_minor }}


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

Changes all mentions of the workflow to `main` to `v1.x` to make the workflow work on the correct branch.

### How did you test it?

Can't test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
