### PR TITLE
feat: Add FileTypeRouter markdown support

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -76,7 +76,10 @@ class FileTypeRouter:
         :param path: The file path to get the MIME type for.
         :return: The MIME type of the provided file path, or None if the MIME type cannot be determined.
         """
-        return mimetypes.guess_type(path.as_posix())[0]
+        extension = path.suffix.lower()
+        mime_type = mimetypes.guess_type(path.as_posix())[0]
+        # lookup custom mappings if the mime type is not found
+        return self.get_custom_mime_mappings().get(extension, mime_type)
 
     def is_valid_mime_type_format(self, mime_type: str) -> bool:
         """
@@ -84,4 +87,13 @@ class FileTypeRouter:
         :param mime_type: The MIME type to check.
         :return: True if the provided MIME type is a valid MIME type format, False otherwise.
         """
-        return mime_type in mimetypes.types_map.values()
+        return mime_type in mimetypes.types_map.values() or mime_type in self.get_custom_mime_mappings().values()
+
+    @staticmethod
+    def get_custom_mime_mappings() -> Dict[str, str]:
+        """
+        Returns a dictionary of custom file extension to MIME type mappings.
+        """
+        # we add markdown because it is not added by the mimetypes module
+        # see https://github.com/python/cpython/pull/17995
+        return {".md": "text/markdown", ".markdown": "text/markdown"}

--- a/releasenotes/notes/add-markdown-file-type-router-support-39a607faa5c1436f.yaml
+++ b/releasenotes/notes/add-markdown-file-type-router-support-39a607faa5c1436f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds markdown mimetype support to the file type router i.e. `FileTypeRouter` class.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -69,8 +69,9 @@ class TestFileTypeRouter:
             test_files_path / "audio" / "the context for this answer is here.wav",
             test_files_path / "txt" / "doc_2.txt",
             test_files_path / "images" / "apple.jpg",
+            test_files_path / "markdown" / "sample.md",
         ]
-        mime_types = ["text/plain", "audio/x-wav", "text/plain", "image/jpeg"]
+        mime_types = ["text/plain", "audio/x-wav", "text/plain", "image/jpeg", "text/markdown"]
         byte_stream_sources = []
         for path, mime_type in zip(file_paths, mime_types):
             stream = ByteStream(path.read_bytes())
@@ -79,11 +80,12 @@ class TestFileTypeRouter:
 
         mixed_sources = file_paths[:2] + byte_stream_sources[2:]
 
-        router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
+        router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg", "text/markdown"])
         output = router.run(sources=mixed_sources)
         assert len(output["text/plain"]) == 2
         assert len(output["audio/x-wav"]) == 1
         assert len(output["image/jpeg"]) == 1
+        assert len(output["text/markdown"]) == 1
 
     def test_no_files(self):
         """


### PR DESCRIPTION
### Why:
Enhances the router's capability to recognize and handle Markdown files, which are commonly used in documentation and other text-based content.

- fixes https://github.com/deepset-ai/haystack/issues/6391
### What:
The modifications include two commits with the following changes:

   - **File: `haystack/components/routers/file_type_router.py`**
     - Added a method `get_custom_mime_mappings` to return a dictionary of custom file extension to MIME type mappings. This includes mappings for `.md` and `.markdown` files as `text/markdown`.
     - Updated the `get_mime_type` method to include custom MIME type mappings, allowing the router to recognize Markdown files.
   - **File: `test/components/routers/test_file_router.py`**
     - Modified the test `test_run_with_bytestreams_and_file_paths` to include a Markdown file and updated MIME types list to recognize `text/markdown`.

   - **File: `releasenotes/notes/add-markdown-file-type-router-support-39a607faa5c1436f.yaml`**
     - Added a release note file documenting the enhancement of adding Markdown MIME type support to the FileTypeRouter class.

### How can it be used:
The FileTypeRouter can now accurately categorize Markdown files (`text/markdown`). This feature is useful in content processing systems where different file types require distinct handling, ensuring that Markdown files are correctly identified and processed according to their specific format.

### How did you test it:
Testing was conducted through updates in the existing test case in `test/components/routers/test_file_router.py`, ensuring the FileTypeRouter correctly identifies Markdown files as `text/markdown`. This guarantees the new functionality works as intended without disrupting existing file type recognition.

### Notes for the reviewer:
- Please review the method `get_custom_mime_mappings` for alignment with code standards and best practices.
- Consider other file types that might benefit from similar support in future updates.
- Verify that the new Markdown file support does not negatively impact the handling of other file types already supported by FileTypeRouter.