### PR TITLE
ci: custom release creator for beta versions

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:  # this is useful to re-generate the release page without a new tag being pushed
   push:
     tags:
-      - "v[0-9].[0-9]+.[0-9]+*"
+      - "v2.0.0-beta*"
 
 jobs:
   generate-notes:
@@ -20,28 +20,15 @@ jobs:
       - name: Parse version
         id: version
         run: |
-          echo "current_release=$(awk -F \- {'print $1'} < VERSION.txt)" >> "$GITHUB_OUTPUT"
-          echo "current_pre_release=$(awk -F \- {'print $2'} < VERSION.txt)" >> "$GITHUB_OUTPUT"
+          echo "current_release=$(awk -F \\- '{print $1}' < VERSION.txt)" >> "$GITHUB_OUTPUT"
+          echo "current_pre_release=$(awk -F \\- '{print $2}' < VERSION.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Install reno
         run: |
           python -m pip install --upgrade pip
           pip install "reno<5"
 
-      - name: Generate release notes for release candidates
-        if: steps.version.outputs.current_pre_release != ''
-        env:
-          # When generating notes for release candidates, pick every vX.Y.Z-rcN but
-          # stop when encounter vX.Y.Z-rc0. The -rc0 tag is added automatically when
-          # we create the release branch, so we can assume it's always there.
-          EARLIEST_VERSION: v${{ steps.version.outputs.current_release }}-rc0
-        run: |
-          reno report --no-show-source --ignore-cache --earliest-version $EARLIEST_VERSION -o relnotes.rst
-
-      - name: Generate release notes for the final release
-        if: steps.version.outputs.current_pre_release == ''
-        # When generating notes for the final release vX.Y.Z, we just pass --version and reno
-        # will automatically collapse all the vX.Y.Z-rcN.
+      - name: Generate release notes for beta versions
         run: |
           reno report --no-show-source --ignore-cache --version v${{ steps.version.outputs.current_release }} -o relnotes.rst
 
@@ -53,3 +40,9 @@ jobs:
       - name: Debug
         run: |
           cat relnotes.md
+
+      - uses: ncipollo/release-action@v1
+        with:
+          bodyFile: "relnotes.md"
+          prerelease: ${{ steps.version.outputs.current_pre_release }}
+          allowUpdates: true


### PR DESCRIPTION
### Related Issues

- Automate the current beta releases

### Proposed Changes:

At every tag `v2.0.0-beta.X` reno will go through the release notes and publish them in a Github pre-release

### How did you test it?

Partially tested on a test repo

### Notes for the reviewer

This is temporary, until we don't branch off the final 2.0.0

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
