### PR TITLE
feat: Converters - allow passing `meta` in the `run` method

### DIFF
--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -68,8 +68,8 @@ class AzureOCRDocumentConverter:
         :param sources: List of file paths or ByteStream objects.
         :param meta: Optional list of metadata to attach to the Documents.
           The length of the list must match the number of sources. Defaults to `None`.
-        :return: A dictionary containing a list of Document objects under the 'documents' key.
-          It also contains the raw Azure response under the 'raw_azure_response' key.
+        :return: A dictionary containing a list of Document objects under the 'documents' key
+          and the raw Azure response under the 'raw_azure_response' key.
         """
         documents = []
         azure_output = []

--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -56,8 +56,8 @@ class AzureOCRDocumentConverter:
         self.endpoint = endpoint
         self.model_id = model_id
 
-    @component.output_types(documents=List[Document], azure=List[Dict])
-    def run(self, sources: List[Union[str, Path, ByteStream]]):
+    @component.output_types(documents=List[Document], raw_azure_response=List[Dict])
+    def run(self, sources: List[Union[str, Path, ByteStream]], meta: Optional[List[Dict[str, Any]]] = None):
         """
         Convert files to Documents using Azure's Document Intelligence service.
 
@@ -66,10 +66,20 @@ class AzureOCRDocumentConverter:
         the raw responses from Azure's Document Intelligence service.
 
         :param sources: List of file paths or ByteStream objects.
+        :param meta: Optional list of metadata to attach to the Documents.
+          The length of the list must match the number of sources. Defaults to `None`.
+        :return: A dictionary containing a list of Document objects under the 'documents' key.
+          It also contains the raw Azure response under the 'raw_azure_response' key.
         """
         documents = []
         azure_output = []
-        for source in sources:
+
+        if meta is None:
+            meta = [{}] * len(sources)
+        elif len(sources) != len(meta):
+            raise ValueError("The length of the metadata list must match the number of sources.")
+
+        for source, metadata in zip(sources, meta):
             try:
                 bytestream = get_bytestream_from_source(source=source)
             except Exception as e:
@@ -87,6 +97,8 @@ class AzureOCRDocumentConverter:
                 file_suffix = Path(bytestream.metadata["file_path"]).suffix
 
             document = AzureOCRDocumentConverter._convert_azure_result_to_document(result, file_suffix)
+            merged_metadata = {**bytestream.metadata, **metadata}
+            document.meta = merged_metadata
             documents.append(document)
 
         return {"documents": documents, "raw_azure_response": azure_output}

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -35,8 +35,8 @@ class HTMLToDocument:
 
         :param sources: List of HTML file paths or ByteStream objects.
         :param meta: Optional list of metadata to attach to the Documents.
-        The length of the list must match the number of sources. Defaults to `None`.
-        :return: List of converted Documents.
+          The length of the list must match the number of sources. Defaults to `None`.
+        :return: A dictionary containing a list of Document objects under the 'documents' key.
         """
 
         documents = []

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -41,19 +41,16 @@ class HTMLToDocument:
 
         documents = []
 
-        # Create metadata placeholders if not provided
-        if meta:
-            if len(sources) != len(meta):
-                raise ValueError("The length of the metadata list must match the number of sources.")
-        else:
+        if meta is None:
             meta = [{}] * len(sources)
+        elif len(sources) != len(meta):
+            raise ValueError("The length of the metadata list must match the number of sources.")
 
         extractor = extractors.ArticleExtractor(raise_on_failure=False)
 
         for source, metadata in zip(sources, meta):
             try:
                 bytestream = get_bytestream_from_source(source=source)
-                extracted_meta = bytestream.metadata
             except Exception as e:
                 logger.warning("Could not read %s. Skipping it. Error: %s", source, e)
                 continue
@@ -64,11 +61,8 @@ class HTMLToDocument:
                 logger.warning("Failed to extract text from %s. Skipping it. Error: %s", source, conversion_e)
                 continue
 
-            # Merge metadata received from ByteStream with supplied metadata
-            if extracted_meta:
-                # Supplied metadata overwrites metadata from ByteStream for overlapping keys.
-                metadata = {**extracted_meta, **metadata}
-            document = Document(content=text, meta=metadata)
+            merged_metadata = {**bytestream.metadata, **metadata}
+            document = Document(content=text, meta=merged_metadata)
             documents.append(document)
 
         return {"documents": documents}

--- a/haystack/components/converters/markdown.py
+++ b/haystack/components/converters/markdown.py
@@ -51,15 +51,19 @@ class MarkdownToDocument:
 
         :param sources: A list of markdown data sources (file paths or binary objects)
         :param meta: Optional list of metadata to attach to the Documents.
-        The length of the list must match the number of paths. Defaults to `None`.
+          The length of the list must match the number of paths. Defaults to `None`.
+        :return: A dictionary containing a list of Document objects under the 'documents' key.
         """
         parser = MarkdownIt(renderer_cls=RendererPlain)
         if self.table_to_single_line:
             parser.enable("table")
 
         documents = []
+
         if meta is None:
             meta = [{}] * len(sources)
+        elif len(sources) != len(meta):
+            raise ValueError("The length of the metadata list must match the number of sources.")
 
         for source, metadata in tqdm(
             zip(sources, meta),
@@ -79,7 +83,8 @@ class MarkdownToDocument:
                 logger.warning("Failed to extract text from %s. Skipping it. Error: %s", source, conversion_e)
                 continue
 
-            document = Document(content=text, meta=metadata)
+            merged_metadata = {**bytestream.metadata, **metadata}
+            document = Document(content=text, meta=merged_metadata)
             documents.append(document)
 
         return {"documents": documents}

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -53,7 +53,7 @@ class TextFileToDocument:
                 continue
             try:
                 encoding = bytestream.metadata.get("encoding", self.encoding)
-                text = Document(content=bytestream.data.decode(encoding))
+                text = bytestream.data.decode(encoding)
             except Exception as e:
                 logger.warning("Could not convert file %s. Skipping it. Error message: %s", source, e)
                 continue

--- a/releasenotes/notes/converters-allow-passing-meta-70fb498b6eb80468.yaml
+++ b/releasenotes/notes/converters-allow-passing-meta-70fb498b6eb80468.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Make all Converters accept `meta` in the `run` method, so that users can
+    provide their own metadata.
+    The length of this list should match the number of `sources`.

--- a/test/components/converters/test_markdown_to_document.py
+++ b/test/components/converters/test_markdown_to_document.py
@@ -42,7 +42,7 @@ class TestMarkdownToDocument:
         for doc in docs:
             assert "What to build with Haystack" in doc.content
             assert "# git clone https://github.com/deepset-ai/haystack.git" in doc.content
-            assert doc.meta == {"file_name": "sample.md"}
+            assert doc.meta["file_name"] == "sample.md"
 
     @pytest.mark.integration
     def test_run_wrong_file_type(self, test_files_path, caplog):

--- a/test/components/converters/test_markdown_to_document.py
+++ b/test/components/converters/test_markdown_to_document.py
@@ -1,5 +1,6 @@
 import logging
 
+from unittest.mock import patch
 import pytest
 
 from haystack.components.converters.markdown import MarkdownToDocument
@@ -30,19 +31,17 @@ class TestMarkdownToDocument:
             assert "What to build with Haystack" in doc.content
             assert "# git clone https://github.com/deepset-ai/haystack.git" in doc.content
 
-    @pytest.mark.integration
-    def test_run_metadata(self, test_files_path):
-        converter = MarkdownToDocument()
-        sources = [test_files_path / "markdown" / "sample.md"]
-        metadata = [{"file_name": "sample.md"}]
-        results = converter.run(sources=sources, meta=metadata)
-        docs = results["documents"]
+    def test_run_with_meta(self):
+        bytestream = ByteStream(data=b"test", metadata={"author": "test_author", "language": "en"})
 
-        assert len(docs) == 1
-        for doc in docs:
-            assert "What to build with Haystack" in doc.content
-            assert "# git clone https://github.com/deepset-ai/haystack.git" in doc.content
-            assert doc.meta["file_name"] == "sample.md"
+        converter = MarkdownToDocument()
+
+        with patch("haystack.components.converters.markdown.MarkdownIt"):
+            output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
+        document = output["documents"][0]
+
+        # check that the metadata from the bytestream is merged with that from the meta parameter
+        assert document.meta == {"author": "test_author", "language": "it"}
 
     @pytest.mark.integration
     def test_run_wrong_file_type(self, test_files_path, caplog):

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 import pytest
 
 from haystack import Document
@@ -27,6 +28,18 @@ class TestPyPDFToDocument:
         docs = output["documents"]
         assert len(docs) == 1
         assert "ReAct" in docs[0].content
+
+    def test_run_with_meta(self):
+        bytestream = ByteStream(data=b"test", metadata={"author": "test_author", "language": "en"})
+
+        converter = PyPDFToDocument()
+        with patch("haystack.components.converters.pypdf.PdfReader"):
+            output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
+
+        document = output["documents"][0]
+
+        # check that the metadata from the bytestream is merged with that from the meta parameter
+        assert document.meta == {"author": "test_author", "language": "it"}
 
     def test_run_error_handling(self, test_files_path, caplog):
         """

--- a/test/components/converters/test_textfile_to_document.py
+++ b/test/components/converters/test_textfile_to_document.py
@@ -56,3 +56,14 @@ class TestTextfileToDocument:
         bytestream.metadata["encoding"] = "utf-8"
         output = converter.run(sources=[bytestream])
         assert "Some text for testing." in output["documents"][0].content
+
+    def test_run_with_meta(self):
+        bytestream = ByteStream(data=b"test", metadata={"author": "test_author", "language": "en"})
+
+        converter = TextFileToDocument()
+
+        output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
+        document = output["documents"][0]
+
+        # check that the metadata from the bytestream is merged with that from the meta parameter
+        assert document.meta == {"author": "test_author", "language": "it"}

--- a/test/components/converters/test_tika_doc_converter.py
+++ b/test/components/converters/test_tika_doc_converter.py
@@ -20,12 +20,12 @@ class TestTikaDocumentConverter:
         assert len(documents) == 1
         assert documents[0].content == "Content of mock_file.pdf"
 
-    @patch("haystack.components.converters.tika.tika_parser.from_buffer")
     def test_run_with_meta(self):
         bytestream = ByteStream(data=b"test", metadata={"author": "test_author", "language": "en"})
 
         converter = TikaDocumentConverter()
-        output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
+        with patch("haystack.components.converters.tika.tika_parser.from_buffer"):
+            output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
         document = output["documents"][0]
 
         # check that the metadata from the bytestream is merged with that from the meta parameter

--- a/test/components/converters/test_tika_doc_converter.py
+++ b/test/components/converters/test_tika_doc_converter.py
@@ -20,6 +20,7 @@ class TestTikaDocumentConverter:
         assert len(documents) == 1
         assert documents[0].content == "Content of mock_file.pdf"
 
+    @patch("haystack.components.converters.tika.tika_parser.from_buffer")
     def test_run_with_meta(self):
         bytestream = ByteStream(data=b"test", metadata={"author": "test_author", "language": "en"})
 

--- a/test/components/converters/test_tika_doc_converter.py
+++ b/test/components/converters/test_tika_doc_converter.py
@@ -7,6 +7,8 @@ from haystack.components.converters.tika import TikaDocumentConverter
 
 
 class TestTikaDocumentConverter:
+    @patch("haystack.components.converters.tika.tika_parser.from_buffer")
+    @patch("haystack.components.converters.tika.get_bytestream_from_source")
     def test_run(self, mock_get_bytestream_from_source, mock_tika_parser):
         mock_get_bytestream_from_source.return_value = ByteStream(data=b"mock_data")
         mock_tika_parser.return_value = {"content": "Content of mock_file.pdf"}

--- a/test/components/converters/test_tika_doc_converter.py
+++ b/test/components/converters/test_tika_doc_converter.py
@@ -7,8 +7,6 @@ from haystack.components.converters.tika import TikaDocumentConverter
 
 
 class TestTikaDocumentConverter:
-    @patch("haystack.components.converters.tika.tika_parser.from_buffer")
-    @patch("haystack.components.converters.tika.get_bytestream_from_source")
     def test_run(self, mock_get_bytestream_from_source, mock_tika_parser):
         mock_get_bytestream_from_source.return_value = ByteStream(data=b"mock_data")
         mock_tika_parser.return_value = {"content": "Content of mock_file.pdf"}
@@ -19,6 +17,16 @@ class TestTikaDocumentConverter:
 
         assert len(documents) == 1
         assert documents[0].content == "Content of mock_file.pdf"
+
+    def test_run_with_meta(self):
+        bytestream = ByteStream(data=b"test", metadata={"author": "test_author", "language": "en"})
+
+        converter = TikaDocumentConverter()
+        output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
+        document = output["documents"][0]
+
+        # check that the metadata from the bytestream is merged with that from the meta parameter
+        assert document.meta == {"author": "test_author", "language": "it"}
 
     def test_run_nonexistent_file(self, caplog):
         component = TikaDocumentConverter()


### PR DESCRIPTION
### Related Issues

- part of #6546
- based on #6540
  _please do not merge the current one before the base has been merged_

### Proposed Changes:

- Make all Converters accept `meta` in the `run` method, so that users can provide their own metadata.
  The length of this list should match the number of `sources`.

### How did you test it?

CI, new unit tests

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
