### PR TITLE
feat: Add RAG based OpenAPI service integration

### DIFF
--- a/haystack/components/connectors/__init__.py
+++ b/haystack/components/connectors/__init__.py
@@ -1,0 +1,3 @@
+from haystack.components.connectors.openapi_service import OpenAPIServiceConnector
+
+__all__ = ["OpenAPIServiceConnector"]

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -1,7 +1,6 @@
 import json
 import logging
-from typing import List, Dict, Any
-
+from typing import List, Dict, Any, Optional
 
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack import component
@@ -27,13 +26,13 @@ class OpenAPIServiceConnector:
     This can be done using the OpenAPIServiceToFunctions component.
     """
 
-    def __init__(self, service_auths: Dict[str, Any] = None):
+    def __init__(self, service_auths: Optional[Dict[str, Any]] = None):
         """
         Initializes the OpenAPIServiceConnector instance
         :param service_auths: A dictionary containing the service name and token to be used for authentication.
         """
         openapi_imports.check()
-        self.service_authentications = service_auths
+        self.service_authentications = service_auths or {}
 
     @component.output_types(service_response=Dict[str, Any])
     def run(self, messages: List[ChatMessage], service_openapi_spec: Any):

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -1,0 +1,146 @@
+import json
+import logging
+from typing import List, Dict, Any
+
+
+from haystack.dataclasses import ChatMessage, ChatRole
+from haystack import component
+from haystack.lazy_imports import LazyImport
+
+logger = logging.getLogger(__name__)
+
+with LazyImport("Run 'pip install openapi3'") as openapi_imports:
+    from openapi3 import OpenAPI
+
+
+@component
+class OpenAPIServiceConnector:
+    """
+    OpenAPIServiceConnector connects to OpenAPI services, allowing for the invocation of methods specified in
+    an OpenAPI specification of that service. It integrates with ChatMessage interface, where messages are used to
+    determine the method to be called and the parameters to be passed. The message payload should be a JSON formatted
+    string consisting of the method name and the parameters to be passed to the method. The method name and parameters
+    are then used to invoke the method on the OpenAPI service. The response from the service is returned as a
+    ChatMessage.
+
+    Before using this component, one needs to register functions from the OpenAPI specification with LLM.
+    This can be done using the OpenAPIServiceToFunctions component.
+    """
+
+    def __init__(self, service_auths: Dict[str, Any] = None):
+        """
+        Initializes the OpenAPIServiceConnector instance
+        :param service_auths: A dictionary containing the service name and token to be used for authentication.
+        """
+        openapi_imports.check()
+        self.service_authentications = service_auths
+
+    @component.output_types(service_response=Dict[str, Any])
+    def run(self, messages: List[ChatMessage], service_openapi_spec: Any):
+        """
+        Processes a list of chat messages to invoke a method on an OpenAPI service. It parses the last message in the
+        list, expecting it to contain an OpenAI function calling descriptor (name & parameters) in JSON format.
+
+        :param messages: A list of ``ChatMessage`` objects representing the chat history.
+        :type messages: List[ChatMessage]
+        :param service_openapi_spec: The OpenAPI JSON specification object of the service.
+        :type service_openapi_spec: JSON object
+        :return: A dictionary with a key ``"service_response"``, containing the response from the OpenAPI service.
+        :rtype: Dict[str, Any]
+        :raises ValueError: If the last message is not from the assistant or if it does not contain the correct payload
+        to invoke a method on the service.
+        """
+
+        last_message = messages[-1]
+        if not last_message.is_from(ChatRole.ASSISTANT):
+            raise ValueError(f"{last_message} is not from the assistant.")
+
+        method_invocation_descriptor = self._parse_message(last_message.content)
+
+        # instantiate the OpenAPI service for the given specification
+        openapi_service = OpenAPI(service_openapi_spec)
+        self._authenticate_service(openapi_service)
+
+        service_response = self._invoke_method(openapi_service, method_invocation_descriptor)
+        return {"service_response": [ChatMessage.from_user(str(service_response))]}
+
+    def _parse_message(self, content: str) -> Dict[str, Any]:
+        """
+        Parses the message content to extract the method invocation descriptor.
+
+        :param content: The JSON string content of the message.
+        :type content: str
+        :return: A dictionary with method name and arguments.
+        :rtype: Dict[str, Any]
+        :raises ValueError: If the content is not valid JSON or lacks required fields.
+        """
+        if not self._is_valid_json(content):
+            raise ValueError("Invalid JSON content, cannot parse invocation message.", content)
+
+        descriptor = json.loads(content)
+        if "name" not in descriptor or "arguments" not in descriptor:
+            raise ValueError("Missing required fields in the invocation message content.", content)
+
+        descriptor["arguments"] = json.loads(descriptor["arguments"])
+        return descriptor
+
+    def _authenticate_service(self, openapi_service: OpenAPI):
+        """
+        Authenticates with the OpenAPI service if required.
+
+        :param openapi_service: The OpenAPI service instance.
+        :type openapi_service: OpenAPI
+        :raises ValueError: If authentication fails or is not found.
+        """
+        if openapi_service.components.securitySchemes:
+            auth_method = list(openapi_service.components.securitySchemes.keys())[0]
+            service_title = openapi_service.info.title
+            if service_title not in self.service_authentications:
+                raise ValueError(f"Service {service_title} not found in service_authentications.")
+            openapi_service.authenticate(auth_method, self.service_authentications[service_title])
+
+    def _invoke_method(self, openapi_service: OpenAPI, method_invocation_descriptor: Dict[str, Any]) -> Any:
+        """
+        Invokes the specified method on the OpenAPI service.
+
+        :param openapi_service: The OpenAPI service instance.
+        :type openapi_service: OpenAPI
+        :param method_invocation_descriptor: The method name and arguments.
+        :type method_invocation_descriptor: Dict[str, Any]
+        :return: A service JSON response.
+        :rtype: Any
+        :raises RuntimeError: If the method is not found or invocation fails.
+        """
+        name = method_invocation_descriptor["name"]
+        # a bit convoluted, but we need to pass parameters, data, or both to the method
+        # depending on the openapi operation specification, can't use None as a default value
+        method_call_params = {
+            key: value
+            for key, value in {
+                "parameters": method_invocation_descriptor["arguments"].get("parameters"),
+                "data": method_invocation_descriptor["arguments"].get("requestBody"),
+            }.items()
+            if value is not None
+        }
+
+        method_to_call = getattr(openapi_service, f"call_{name}", None)
+        if not callable(method_to_call):
+            raise RuntimeError(f"Operation {name} not found in OpenAPI specification {openapi_service.info.title}")
+
+        # this will call the underlying service REST API
+        return method_to_call(**method_call_params)
+
+    def _is_valid_json(self, content: str):
+        """
+        Validates whether the provided content is a valid JSON string.
+
+        :param content: The string content to be checked.
+        :type content: str
+        :return: ``True`` if the content is a valid JSON string, ``False`` otherwise.
+        :rtype: bool
+        """
+        try:
+            json.loads(content)
+            return True
+        except json.JSONDecodeError:
+            return False

--- a/haystack/components/converters/__init__.py
+++ b/haystack/components/converters/__init__.py
@@ -4,6 +4,7 @@ from haystack.components.converters.azure import AzureOCRDocumentConverter
 from haystack.components.converters.pypdf import PyPDFToDocument
 from haystack.components.converters.html import HTMLToDocument
 from haystack.components.converters.markdown import MarkdownToDocument
+from haystack.components.converters.openapi_functions import OpenAPIServiceToFunctions
 
 __all__ = [
     "TextFileToDocument",
@@ -12,4 +13,5 @@ __all__ = [
     "PyPDFToDocument",
     "HTMLToDocument",
     "MarkdownToDocument",
+    "OpenAPIServiceToFunctions",
 ]

--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -115,7 +115,7 @@ class OpenAPIServiceToFunctions:
         # We check the version and require minimal fields to be present, so we can extract functions
         spec_version = service_openapi_spec.get("openapi")
         if not spec_version:
-            raise ValueError("Invalid OpenAPI spec provided. Could not extract version from %s", service_openapi_spec)
+            raise ValueError(f"Invalid OpenAPI spec provided. Could not extract version from {service_openapi_spec}")
         service_openapi_spec_version = int(spec_version.split(".")[0])
         min_required_version = 3
 

--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -1,0 +1,115 @@
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List, Dict, Any, Union
+
+from requests import RequestException
+
+from haystack import component, Document
+from haystack.dataclasses.byte_stream import ByteStream
+from haystack.lazy_imports import LazyImport
+
+logger = logging.getLogger(__name__)
+
+with LazyImport("Run 'pip install jsonref'") as openapi_imports:
+    import jsonref
+
+
+@component
+class OpenAPIServiceToFunctions:
+    """
+    OpenAPIServiceToFunctions is responsible for converting an OpenAPI service specification into a format suitable
+    for OpenAI function calling, based on the provided OpenAPI specification. Given an OpenAPI specification,
+    OpenAPIServiceToFunctions processes it, and extracts function definitions that can be invoked via OpenAI's
+    function calling mechanism. The format of the extracted functions is compatible with OpenAI's function calling
+    JSON format.
+
+    See https://github.com/OAI/OpenAPI-Specification for more details on OpenAPI specification.
+    See https://platform.openai.com/docs/guides/function-calling for more details on OpenAI function calling.
+    """
+
+    def __init__(self):
+        """
+        Initializes the OpenAPIServiceToFunctions instance
+        """
+        openapi_imports.check()
+
+    @component.output_types(documents=List[Document])
+    def run(self, sources: List[Union[str, Path, ByteStream]], system_messages: List[str]) -> Dict[str, Any]:
+        """
+        Processes OpenAPI specification URLs or files to extract functions that can be invoked via OpenAI function
+        calling mechanism. Each source is paired with a system message.
+
+        :param sources: A list of OpenAPI specification sources, which can be URLs, file paths, or ByteStream objects.
+        :type sources: List[Union[str, Path, ByteStream]]
+        :param system_messages: A list of system messages corresponding to each source.
+        :type system_messages: List[str]
+        :return: A dictionary with a key 'documents' containing a list of Document objects. Each Document object
+                 encapsulates a function definition and relevant metadata.
+        :rtype: Dict[str, Any]
+        :raises RuntimeError: If the OpenAPI specification cannot be downloaded or processed.
+        :raises ValueError: If the source type is not recognized or no functions are found in the OpenAPI specification.
+        """
+        documents: List[Document] = []
+        for source, system_message in zip(sources, system_messages):
+            try:
+                if isinstance(source, (str, Path)):
+                    if os.path.exists(source):
+                        with open(source, "r") as f:
+                            service_openapi_spec = jsonref.load(f)
+                    else:
+                        # Assume it is a URL
+                        service_openapi_spec = jsonref.jsonloader(uri=source)
+                elif isinstance(source, ByteStream):
+                    service_openapi_spec = jsonref.loads(source.data.decode("utf-8"))
+                else:
+                    raise ValueError(f"Invalid source type {type(source)}")
+                functions: List[Dict[str, Any]] = self._openapi_to_functions(service_openapi_spec)
+                docs = [
+                    Document(
+                        content=json.dumps(function),
+                        meta={"spec": service_openapi_spec, "system_message": system_message},
+                    )
+                    for function in functions
+                ]
+                documents.extend(docs)
+            except (RequestException, ValueError) as e:
+                logger.warning(f"Could not download {source}. Skipping it. Error: {e}")
+                continue
+
+        return {"documents": documents}
+
+    def _openapi_to_functions(self, service_openapi_spec: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Extracts functions from the OpenAPI specification of the service and converts them into a format
+        suitable for OpenAI function calling.
+
+        :param service_openapi_spec: The OpenAPI specification from which functions are to be extracted.
+        :type service_openapi_spec: Dict[str, Any]
+        :return: A list of dictionaries, each representing a function. Each dictionary includes the function's
+                 name, description, and a schema of its parameters.
+        :rtype: List[Dict[str, Any]]
+        """
+        functions: List[Dict[str, Any]] = []
+        for path_methods in service_openapi_spec["paths"].values():
+            for method_specification in path_methods.values():
+                resolved_spec = jsonref.replace_refs(method_specification)
+                function_name = resolved_spec.get("operationId")
+                desc = resolved_spec.get("description") or resolved_spec.get("summary", "")
+
+                schema = {"type": "object", "properties": {}}
+
+                req_body = (
+                    resolved_spec.get("requestBody", {}).get("content", {}).get("application/json", {}).get("schema")
+                )
+                if req_body:
+                    schema["properties"]["requestBody"] = req_body
+
+                params = resolved_spec.get("parameters", [])
+                if params:
+                    param_properties = {param["name"]: param["schema"] for param in params if "schema" in param}
+                    schema["properties"]["parameters"] = {"type": "object", "properties": param_properties}
+
+                functions.append({"name": function_name, "description": desc, "parameters": schema})
+        return functions

--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -121,7 +121,7 @@ class OpenAPIServiceToFunctions:
 
         # Compare the versions
         if service_openapi_spec_version < min_required_version:
-            raise ValueError(f"Invalid OpenAPI spec version {service_openapi_spec_version}. " f"Must be at least 3.0.0")
+            raise ValueError(f"Invalid OpenAPI spec version {service_openapi_spec_version}. Must be at least 3.0.0")
 
         functions: List[Dict[str, Any]] = []
         for path_methods in service_openapi_spec["paths"].values():

--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -151,6 +151,6 @@ class OpenAPIServiceToFunctions:
         :rtype: Dict[str, Any]
         """
         try:
-            return jsonref.loads(content)
+            return json.loads(content)
         except json.JSONDecodeError:
             return yaml.safe_load(content)

--- a/releasenotes/notes/add-rag-openapi-services-f3e377c49ff0f258.yaml
+++ b/releasenotes/notes/add-rag-openapi-services-f3e377c49ff0f258.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds RAG OpenAPI services integration.

--- a/test/components/connectors/test_openapi_service.py
+++ b/test/components/connectors/test_openapi_service.py
@@ -1,0 +1,80 @@
+import json
+import pytest
+from unittest.mock import MagicMock, Mock
+from openapi3 import OpenAPI
+from haystack.components.connectors import OpenAPIServiceConnector
+
+
+@pytest.fixture
+def openapi_service_mock():
+    return MagicMock(spec=OpenAPI)
+
+
+@pytest.fixture
+def service_auths():
+    return {"TestService": "auth_token"}
+
+
+class TestOpenAPIServiceConnector:
+    @pytest.fixture
+    def connector(self, service_auths):
+        return OpenAPIServiceConnector(service_auths)
+
+    def test_parse_message_invalid_json(self, connector):
+        # Test invalid JSON content
+        with pytest.raises(ValueError):
+            connector._parse_message("invalid json")
+
+    def test_parse_valid_json_message(self):
+        connector = OpenAPIServiceConnector()
+
+        # The content format here is OpenAI function calling descriptor
+        content = (
+            '{"name": "compare_branches","arguments": "{\\n  \\"parameters\\": {\\n   '
+            ' \\"basehead\\": \\"main...openapi_container_v5\\",\\n   '
+            ' \\"owner\\": \\"deepset-ai\\",\\n    \\"repo\\": \\"haystack\\"\\n  }\\n}"}'
+        )
+        descriptor = connector._parse_message(content)
+
+        # Assert that the descriptor contains the expected method name and arguments
+        assert descriptor["name"] == "compare_branches"
+        assert descriptor["arguments"]["parameters"] == {
+            "basehead": "main...openapi_container_v5",
+            "owner": "deepset-ai",
+            "repo": "haystack",
+        }
+        # but not the requestBody
+        assert "requestBody" not in descriptor["arguments"]
+
+        # The content format here is OpenAI function calling descriptor
+        content = '{"name": "search","arguments": "{\\n  \\"requestBody\\": {\\n    \\"q\\": \\"haystack\\"\\n  }\\n}"}'
+        descriptor = connector._parse_message(content)
+        assert descriptor["name"] == "search"
+        assert descriptor["arguments"]["requestBody"] == {"q": "haystack"}
+
+        # but not the parameters
+        assert "parameters" not in descriptor["arguments"]
+
+    def test_parse_message_missing_fields(self, connector):
+        # Test JSON content with missing fields
+        with pytest.raises(ValueError):
+            connector._parse_message(json.dumps({"name": "test_method"}))
+
+    def test_authenticate_service_invalid(self, connector, openapi_service_mock):
+        # Test invalid or missing authentication
+        openapi_service_mock.components.securitySchemes = {"apiKey": {}}
+        with pytest.raises(ValueError):
+            connector._authenticate_service(openapi_service_mock)
+
+    def test_invoke_method_valid(self, connector, openapi_service_mock):
+        # Test valid method invocation
+        method_invocation_descriptor = {"name": "test_method", "arguments": {}}
+        openapi_service_mock.call_test_method = Mock(return_value="response")
+        result = connector._invoke_method(openapi_service_mock, method_invocation_descriptor)
+        assert result == "response"
+
+    def test_invoke_method_invalid(self, connector, openapi_service_mock):
+        # Test invalid method invocation
+        method_invocation_descriptor = {"name": "invalid_method", "arguments": {}}
+        with pytest.raises(RuntimeError):
+            connector._invoke_method(openapi_service_mock, method_invocation_descriptor)

--- a/test/components/converters/test_openapi_functions.py
+++ b/test/components/converters/test_openapi_functions.py
@@ -1,0 +1,49 @@
+from haystack.components.converters import OpenAPIServiceToFunctions
+
+
+class TestOpenAPIServiceToFunctions:
+    #  Extract functions from OpenAPI specification and convert them into a format suitable for OpenAI function calling
+    def test_extract_functions_from_openapi_specification(self):
+        service = OpenAPIServiceToFunctions()
+
+        # Define a sample OpenAPI specification
+        openapi_spec = {
+            "paths": {
+                "/path1": {
+                    "get": {
+                        "operationId": "function1",
+                        "description": "Function 1 description",
+                        "parameters": [{"name": "param1", "schema": {"type": "string"}}],
+                    }
+                },
+                "/path2": {
+                    "post": {
+                        "operationId": "function2",
+                        "summary": "Function 2 summary",
+                        "parameters": [{"name": "param2", "schema": {"type": "integer"}}],
+                    }
+                },
+            }
+        }
+
+        functions = service._openapi_to_functions(openapi_spec)
+
+        # Assert that the functions list contains the expected function definitions
+        assert functions == [
+            {
+                "name": "function1",
+                "description": "Function 1 description",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"parameters": {"type": "object", "properties": {"param1": {"type": "string"}}}},
+                },
+            },
+            {
+                "name": "function2",
+                "description": "Function 2 summary",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"parameters": {"type": "object", "properties": {"param2": {"type": "integer"}}}},
+                },
+            },
+        ]

--- a/test/components/converters/test_openapi_functions.py
+++ b/test/components/converters/test_openapi_functions.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import tempfile
 
 import pytest
@@ -193,8 +194,12 @@ class TestOpenAPIServiceToFunctions:
         assert doc.meta["system_message"] == "Some system message we don't care about here"
         assert doc.meta["spec"] == json.loads(json_serperdev_openapi_spec)
 
-    # test we can extract functions from openapi spec given in file
+    @pytest.mark.skipif(
+        sys.platform in ["win32", "cygwin"],
+        reason="Can't run on Windows Github CI, need access temp file but windows does not allow it",
+    )
     def test_run_with_file_source(self, json_serperdev_openapi_spec):
+        # test we can extract functions from openapi spec given in file
         service = OpenAPIServiceToFunctions()
         # write the spec to NamedTemporaryFile and check that it is parsed correctly
         with tempfile.NamedTemporaryFile() as tmp:

--- a/test/components/converters/test_openapi_functions.py
+++ b/test/components/converters/test_openapi_functions.py
@@ -1,49 +1,216 @@
+import json
+import tempfile
+
+import pytest
+
 from haystack.components.converters import OpenAPIServiceToFunctions
+from haystack.dataclasses import ByteStream
+
+
+@pytest.fixture
+def json_serperdev_openapi_spec():
+    serper_spec = """
+            {
+                "openapi": "3.0.0",
+                "info": {
+                    "title": "SerperDev",
+                    "version": "1.0.0",
+                    "description": "API for performing search queries"
+                },
+                "servers": [
+                    {
+                        "url": "https://google.serper.dev"
+                    }
+                ],
+                "paths": {
+                    "/search": {
+                        "post": {
+                            "operationId": "search",
+                            "description": "Search the web with Google",
+                            "requestBody": {
+                                "required": true,
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "q": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "responses": {
+                                "200": {
+                                    "description": "Successful response",
+                                    "content": {
+                                        "application/json": {
+                                            "schema": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "searchParameters": {
+                                                        "type": "undefined"
+                                                    },
+                                                    "knowledgeGraph": {
+                                                        "type": "undefined"
+                                                    },
+                                                    "answerBox": {
+                                                        "type": "undefined"
+                                                    },
+                                                    "organic": {
+                                                        "type": "undefined"
+                                                    },
+                                                    "topStories": {
+                                                        "type": "undefined"
+                                                    },
+                                                    "peopleAlsoAsk": {
+                                                        "type": "undefined"
+                                                    },
+                                                    "relatedSearches": {
+                                                        "type": "undefined"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "security": [
+                                {
+                                    "apikey": []
+                                }
+                            ]
+                        }
+                    }
+                },
+                "components": {
+                    "securitySchemes": {
+                        "apikey": {
+                            "type": "apiKey",
+                            "name": "x-api-key",
+                            "in": "header"
+                        }
+                    }
+                }
+            }
+            """
+    return serper_spec
+
+
+@pytest.fixture
+def yaml_serperdev_openapi_spec():
+    serper_spec = """
+            openapi: 3.0.0
+            info:
+              title: SerperDev
+              version: 1.0.0
+              description: API for performing search queries
+            servers:
+              - url: 'https://google.serper.dev'
+            paths:
+              /search:
+                post:
+                  operationId: search
+                  description: Search the web with Google
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          properties:
+                            q:
+                              type: string
+                  responses:
+                    '200':
+                      description: Successful response
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              searchParameters:
+                                type: undefined
+                              knowledgeGraph:
+                                type: undefined
+                              answerBox:
+                                type: undefined
+                              organic:
+                                type: undefined
+                              topStories:
+                                type: undefined
+                              peopleAlsoAsk:
+                                type: undefined
+                              relatedSearches:
+                                type: undefined
+                  security:
+                    - apikey: []
+            components:
+              securitySchemes:
+                apikey:
+                  type: apiKey
+                  name: x-api-key
+                  in: header
+            """
+    return serper_spec
 
 
 class TestOpenAPIServiceToFunctions:
-    #  Extract functions from OpenAPI specification and convert them into a format suitable for OpenAI function calling
-    def test_extract_functions_from_openapi_specification(self):
+    # test we can parse openapi spec given in json
+    def test_openapi_spec_parsing_json(self, json_serperdev_openapi_spec):
         service = OpenAPIServiceToFunctions()
 
-        # Define a sample OpenAPI specification
-        openapi_spec = {
-            "paths": {
-                "/path1": {
-                    "get": {
-                        "operationId": "function1",
-                        "description": "Function 1 description",
-                        "parameters": [{"name": "param1", "schema": {"type": "string"}}],
-                    }
-                },
-                "/path2": {
-                    "post": {
-                        "operationId": "function2",
-                        "summary": "Function 2 summary",
-                        "parameters": [{"name": "param2", "schema": {"type": "integer"}}],
-                    }
-                },
-            }
-        }
+        serper_spec_json = service._parse_openapi_spec(json_serperdev_openapi_spec)
+        assert serper_spec_json["openapi"] == "3.0.0"
+        assert serper_spec_json["info"]["title"] == "SerperDev"
 
-        functions = service._openapi_to_functions(openapi_spec)
+    # test we can parse openapi spec given in yaml
+    def test_openapi_spec_parsing_yaml(self, yaml_serperdev_openapi_spec):
+        service = OpenAPIServiceToFunctions()
 
-        # Assert that the functions list contains the expected function definitions
-        assert functions == [
-            {
-                "name": "function1",
-                "description": "Function 1 description",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"parameters": {"type": "object", "properties": {"param1": {"type": "string"}}}},
-                },
-            },
-            {
-                "name": "function2",
-                "description": "Function 2 summary",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"parameters": {"type": "object", "properties": {"param2": {"type": "integer"}}}},
-                },
-            },
-        ]
+        serper_spec_yaml = service._parse_openapi_spec(yaml_serperdev_openapi_spec)
+        assert serper_spec_yaml["openapi"] == "3.0.0"
+        assert serper_spec_yaml["info"]["title"] == "SerperDev"
+
+    # test we can extract functions from openapi spec given
+    def test_run_with_bytestream_source(self, json_serperdev_openapi_spec):
+        service = OpenAPIServiceToFunctions()
+        spec_stream = ByteStream.from_string(json_serperdev_openapi_spec)
+        result = service.run(sources=[spec_stream], system_messages=["Some system message we don't care about here"])
+        assert len(result["documents"]) == 1
+        doc = result["documents"][0]
+
+        # check that the content is as expected
+        assert (
+            doc.content
+            == '{"name": "search", "description": "Search the web with Google", "parameters": {"type": "object", '
+            '"properties": {"requestBody": {"type": "object", "properties": {"q": {"type": "string"}}}}}}'
+        )
+
+        # check that the metadata is as expected
+        assert doc.meta["system_message"] == "Some system message we don't care about here"
+        assert doc.meta["spec"] == json.loads(json_serperdev_openapi_spec)
+
+    # test we can extract functions from openapi spec given in file
+    def test_run_with_file_source(self, json_serperdev_openapi_spec):
+        service = OpenAPIServiceToFunctions()
+        # write the spec to NamedTemporaryFile and check that it is parsed correctly
+        with tempfile.NamedTemporaryFile() as tmp:
+            tmp.write(json_serperdev_openapi_spec.encode("utf-8"))
+            tmp.seek(0)
+            result = service.run(sources=[tmp.name], system_messages=["Some system message we don't care about here"])
+            assert len(result["documents"]) == 1
+            doc = result["documents"][0]
+
+            # check that the content is as expected
+            assert (
+                doc.content
+                == '{"name": "search", "description": "Search the web with Google", "parameters": {"type": "object", '
+                '"properties": {"requestBody": {"type": "object", "properties": {"q": {"type": "string"}}}}}}'
+            )
+
+            # check that the metadata is as expected
+            assert doc.meta["system_message"] == "Some system message we don't care about here"
+            assert doc.meta["spec"] == json.loads(json_serperdev_openapi_spec)

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -16,4 +16,5 @@ sentence-transformers>=2.2.0                    # SentenceTransformersTextEmbedd
 openai-whisper>=20231106                        # LocalWhisperTranscriber
 
 # OpenAPI
-jsonref openapi3                                # OpenAPIServiceConnector, OpenAPIServiceToFunctions
+jsonref                                        # OpenAPIServiceConnector, OpenAPIServiceToFunctions
+openapi3

--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -14,3 +14,6 @@ azure-ai-formrecognizer>=3.2.0b2                # AzureOCRDocumentConverter
 langdetect                                      # TextLanguageRouter and DocumentLanguageClassifier
 sentence-transformers>=2.2.0                    # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
 openai-whisper>=20231106                        # LocalWhisperTranscriber
+
+# OpenAPI
+jsonref openapi3                                # OpenAPIServiceConnector, OpenAPIServiceToFunctions


### PR DESCRIPTION
### Why:
This PR aims to enhance the Haystack 2.x framework by enabling it to connect with OpenAPI services. This will allow Haystack to seamlessly call methods specified in an OpenAPI specification and use retrieved data in service RAG, just like paragraphs of text are used in the gen-text RAG setup.

### What:
The PR introduces new components into the Haystack codebase: 

1. `OpenAPIServiceConnector`: This connector allows invoking methods as specified by an OpenAPI service. It uses `ChatMessage` objects to determine the method to call and its parameters. The responses from the service are returned within `ChatMessage` objects.

2. `OpenAPIServiceToFunctions`: This component converts an OpenAPI service specification into a format that can be utilized for function calling with LLMs. It's a crucial component that pre-processes OpenAPI specifications to ensure smooth integration and function invocation through the `OpenAPIServiceConnector`.

### How can it be used:
The following steps can be followed to use the new functionality introduced by this PR:

1. **OpenAPI Service Integration**: First, obtain an OpenAPI specification for the desired service. This specification will drive the available functions and methods that can be called using Haystack.

2. **Function Registration**: Use the `OpenAPIServiceToFunctions` component to register functions from the OpenAPI specification with the Haystack framework. This step prepares function definitions to be called via Haystack's interface.

3. **Method Invocation**: With the `OpenAPIServiceConnector`, invoke methods from within the framework by constructing `ChatMessage` payloads that include the method name and necessary parameters in a JSON formatted string.

To best understand this capability, perhaps it helps to follow the Python script that generated this PR text:
```python
import json

import requests

from haystack import Pipeline
from haystack.components.connectors import OpenAPIServiceConnector
from haystack.components.converters import OpenAPIServiceToFunctions
from haystack.components.generators.chat import GPTChatGenerator
from haystack.components.generators.utils import default_streaming_callback as dsc
from haystack.dataclasses import ChatMessage

indexing_pipeline = Pipeline()
indexing_pipeline.add_component("spec_to_functions", OpenAPIServiceToFunctions())
results = indexing_pipeline.run(data={"sources": ["https://bit.ly/3tdRUM0"],
                                      "system_messages": [requests.get("https://bit.ly/48eN0ND").text]})

top_1_document = results["spec_to_functions"]["documents"][0]
openai_functions_definition = json.loads(top_1_document.content)
openapi_spec = top_1_document.meta["spec"]


invoke_service_pipe = Pipeline()
invoke_service_pipe.add_component("functions_llm", GPTChatGenerator(model_name="gpt-3.5-turbo-0613"))
invoke_service_pipe.add_component("openapi_container", OpenAPIServiceConnector({"SerperDev":"6b5dad1c0651e5b557964129e573bbb1b73b2c2b"}))
invoke_service_pipe.connect("functions_llm.replies", "openapi_container.messages")


user_prompt = "Create PR by comparing branches main and rag_services, in project deepset-ai, repo haystack"
service_response = invoke_service_pipe.run(data={"messages": [ChatMessage.from_user(user_prompt)],
                                                 "generation_kwargs": {"functions": [openai_functions_definition]},
                                                 "service_openapi_spec": openapi_spec})

gen_pipe = Pipeline()
gen_pipe.add_component("llm", GPTChatGenerator(model_name="gpt-4-1106-preview",
                                                     streaming_callback=dsc))

github_pr_prompt_messages = ([ChatMessage.from_system(top_1_document.meta["system_message"])] +
                             service_response["openapi_container"]["service_response"])
final_result = gen_pipe.run(data={"messages": github_pr_prompt_messages})
```
#### Another example:
Note, however, that we are only scratching the surface of the possibilities of RAG services. One can combine them with a document store and invoke hundreds of registered open API services seamlessly. For a POC demo, have a look at this [notebook](https://github.com/vblagoje/notebooks/blob/main/haystack2x-demos/haystack_rag_services_demo.ipynb)


### How did you test it:
Unit tests were added to cover the new components:

1. For `OpenAPIServiceConnector`, tests include parsing message content for method invocation, authentication with the OpenAPI service, and successful/unsuccessful method invocation scenarios.

2. For `OpenAPIServiceToFunctions`, tests were written to check the extraction of functions from OpenAPI specifications, processing of specification files/URLs, and creating Haystack documents that contain function definitions.

Each unit test simulates scenarios for method invocations, OpenAPI specification processing, and error handling to ensure the components behave as expected.

### Notes for the reviewer:
- Reviewers should look at the added components in the context of the existing Haystack architecture to ensure compatibility and integration without issues.
- Attention should be given to the way the new components parse and use OpenAPI specifications, as this is fundamental to their functionality.
