### PR TITLE
feat: Add `meta_fields_to_embed` to `TransformersSimilarityRanker`

### DIFF
--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -40,7 +40,7 @@ class TransformersSimilarityRanker:
         device: str = "cpu",
         token: Union[bool, str, None] = None,
         top_k: int = 10,
-        metadata_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
     ):
         """
@@ -53,7 +53,7 @@ class TransformersSimilarityRanker:
             If this parameter is set to `True`, the token generated when running
             `transformers-cli login` (stored in ~/.huggingface) is used.
         :param top_k: The maximum number of Documents to return per query.
-        :param metadata_fields_to_embed: List of meta fields that should be embedded along with the Document content.
+        :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
         torch_and_transformers_import.check()
@@ -66,7 +66,7 @@ class TransformersSimilarityRanker:
         self.token = token
         self.model = None
         self.tokenizer = None
-        self.metadata_fields_to_embed = metadata_fields_to_embed or []
+        self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
@@ -95,7 +95,7 @@ class TransformersSimilarityRanker:
             model_name_or_path=self.model_name_or_path,
             token=self.token if not isinstance(self.token, str) else None,  # don't serialize valid tokens
             top_k=self.top_k,
-            metadata_fields_to_embed=self.metadata_fields_to_embed,
+            metadata_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
 
@@ -127,7 +127,7 @@ class TransformersSimilarityRanker:
         query_doc_pairs = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.metadata_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
             ]
             text_to_embed = self.embedding_separator.join(meta_values_to_embed + [doc.content or ""])
             query_doc_pairs.append([query, text_to_embed])

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -95,7 +95,7 @@ class TransformersSimilarityRanker:
             model_name_or_path=self.model_name_or_path,
             token=self.token if not isinstance(self.token, str) else None,  # don't serialize valid tokens
             top_k=self.top_k,
-            metadata_fields_to_embed=self.meta_fields_to_embed,
+            meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
 

--- a/releasenotes/notes/transformers-similarity-embed-meta-7f2b15988549f805.yaml
+++ b/releasenotes/notes/transformers-similarity-embed-meta-7f2b15988549f805.yaml
@@ -2,4 +2,4 @@
 enhancements:
   - |
     Add meta_fields_to_embed following the implementation in SentenceTransformersDocumentEmbedder to be able to
-    embed metadata fields along with the content of the document.
+    embed meta fields along with the content of the document.

--- a/releasenotes/notes/transformers-similarity-embed-meta-7f2b15988549f805.yaml
+++ b/releasenotes/notes/transformers-similarity-embed-meta-7f2b15988549f805.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add metadata_fields_to_embed following the implementation in SentenceTransformersDocumentEmbedder to be able to
+    embed metadata fields along with the content of the document.

--- a/releasenotes/notes/transformers-similarity-embed-meta-7f2b15988549f805.yaml
+++ b/releasenotes/notes/transformers-similarity-embed-meta-7f2b15988549f805.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add metadata_fields_to_embed following the implementation in SentenceTransformersDocumentEmbedder to be able to
+    Add meta_fields_to_embed following the implementation in SentenceTransformersDocumentEmbedder to be able to
     embed metadata fields along with the content of the document.

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -43,7 +43,7 @@ class TestSimilarityRanker:
     def test_embed_metadata(self, mocked_sort):
         mocked_sort.return_value = (None, torch.tensor([0]))
         embedder = TransformersSimilarityRanker(
-            model_name_or_path="model", metadata_fields_to_embed=["meta_field"], embedding_separator="\n"
+            model_name_or_path="model", meta_fields_to_embed=["meta_field"], embedding_separator="\n"
         )
         embedder.model = MagicMock()
         embedder.tokenizer = MagicMock()

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -17,7 +17,7 @@ class TestSimilarityRanker:
                 "top_k": 10,
                 "token": None,
                 "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
-                "metadata_fields_to_embed": [],
+                "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
             },
         }
@@ -34,13 +34,13 @@ class TestSimilarityRanker:
                 "model_name_or_path": "my_model",
                 "token": None,  # we don't serialize valid tokens,
                 "top_k": 5,
-                "metadata_fields_to_embed": [],
+                "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
             },
         }
 
     @patch("torch.sort")
-    def test_embed_metadata(self, mocked_sort):
+    def test_embed_meta(self, mocked_sort):
         mocked_sort.return_value = (None, torch.tensor([0]))
         embedder = TransformersSimilarityRanker(
             model_name_or_path="model", meta_fields_to_embed=["meta_field"], embedding_separator="\n"

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -1,4 +1,6 @@
+from unittest.mock import MagicMock, patch
 import pytest
+import torch
 
 from haystack import Document, ComponentError
 from haystack.components.rankers.transformers_similarity import TransformersSimilarityRanker
@@ -15,6 +17,8 @@ class TestSimilarityRanker:
                 "top_k": 10,
                 "token": None,
                 "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+                "metadata_fields_to_embed": [],
+                "embedding_separator": "\n",
             },
         }
 
@@ -30,8 +34,36 @@ class TestSimilarityRanker:
                 "model_name_or_path": "my_model",
                 "token": None,  # we don't serialize valid tokens,
                 "top_k": 5,
+                "metadata_fields_to_embed": [],
+                "embedding_separator": "\n",
             },
         }
+
+    @patch("torch.sort")
+    def test_embed_metadata(self, mocked_sort):
+        mocked_sort.return_value = (None, torch.tensor([0]))
+        embedder = TransformersSimilarityRanker(
+            model_name_or_path="model", metadata_fields_to_embed=["meta_field"], embedding_separator="\n"
+        )
+        embedder.model = MagicMock()
+        embedder.tokenizer = MagicMock()
+
+        documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
+
+        embedder.run(query="test", documents=documents)
+
+        embedder.tokenizer.assert_called_once_with(
+            [
+                ["test", "meta_value 0\ndocument number 0"],
+                ["test", "meta_value 1\ndocument number 1"],
+                ["test", "meta_value 2\ndocument number 2"],
+                ["test", "meta_value 3\ndocument number 3"],
+                ["test", "meta_value 4\ndocument number 4"],
+            ],
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
 
     @pytest.mark.integration
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues

- fixes #6563 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add `metadata_fields_to_embed` following the implementation in `SentenceTransformersDocumentEmbedder` to be able to embed metadata fields along with the content of the document. 


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a new unit test to check the behavior. Updated existing tests for serializing the object.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
