### PR TITLE
bug: fix Agent Final Response Discarding text after newline

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -214,7 +214,7 @@ class Agent:
         memory: Optional[Memory] = None,
         prompt_parameters_resolver: Optional[Callable] = None,
         max_steps: int = 8,
-        final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
+        final_answer_pattern: str = r"(?s)Final Answer\s*:\s*(.*)",
         streaming: bool = True,
     ):
         """

--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -214,7 +214,7 @@ class Agent:
         memory: Optional[Memory] = None,
         prompt_parameters_resolver: Optional[Callable] = None,
         max_steps: int = 8,
-        final_answer_pattern: str = r"(?s)Final Answer\s*:\s*(.*)",
+        final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
         streaming: bool = True,
     ):
         """


### PR DESCRIPTION
### Related Issues

- fixes #5743

### Proposed Changes:

The agent would discard the final answer if this was distributed on multiple lines. I added a modifier in the regex so that the `.` matches also newline characters.

### How did you test it?

One possibility is to use the agent to generate code, in this case we should see the bug and then the fix.

### Notes for the reviewer

In the 2.0 I'd change this structure to pass a flag or to give a closing sequence as well.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
