### PR TITLE
bug: fix Agent Final Response Discarding text after newline

### DIFF
--- a/haystack/agents/base.py
+++ b/haystack/agents/base.py
@@ -214,7 +214,7 @@ class Agent:
         memory: Optional[Memory] = None,
         prompt_parameters_resolver: Optional[Callable] = None,
         max_steps: int = 8,
-        final_answer_pattern: str = r"Final Answer\s*:\s*(.*)",
+        final_answer_pattern: str = r"(?s)Final Answer\s*:\s*(.*)",
         streaming: bool = True,
     ):
         """

--- a/releasenotes/notes/improve-agent-final-answer-matching-21f5710035a498d8.yaml
+++ b/releasenotes/notes/improve-agent-final-answer-matching-21f5710035a498d8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the bug that caused the agent to discard part of final answers if they were distributed across multiple lines.

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -149,6 +149,7 @@ def test_extract_final_answer():
         "Final Answer:42",
         "Final Answer:   ",
         "Final Answer:    The answer is 99    ",
+        "Final Answer: 42 should be the answer\n\nBut it's not the only one\n\n\n\n the answer is 1948",
     ]
     expected_answers = [
         "Florida",
@@ -159,6 +160,7 @@ def test_extract_final_answer():
         "42",
         "",
         "The answer is 99",
+        "42 should be the answer\n\nBut it's not the only one\n\n\n\n the answer is 1948"
     ]
 
     for example, expected_answer in zip(match_examples, expected_answers):

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -160,7 +160,7 @@ def test_extract_final_answer():
         "42",
         "",
         "The answer is 99",
-        "42 should be the answer\n\nBut it's not the only one\n\n\n\n the answer is 1948"
+        "42 should be the answer\n\nBut it's not the only one\n\n\n\n the answer is 1948",
     ]
 
     for example, expected_answer in zip(match_examples, expected_answers):

--- a/test/agents/test_agent.py
+++ b/test/agents/test_agent.py
@@ -149,7 +149,7 @@ def test_extract_final_answer():
         "Final Answer:42",
         "Final Answer:   ",
         "Final Answer:    The answer is 99    ",
-        "Final Answer: 42 should be the answer\n\nBut it's not the only one\n\n\n\n the answer is 1948",
+        "Final Answer:42 should be the answer\n\nBut it's not the only one\n\n\n\n the answer is 1948",
     ]
     expected_answers = [
         "Florida",
@@ -164,7 +164,7 @@ def test_extract_final_answer():
     ]
 
     for example, expected_answer in zip(match_examples, expected_answers):
-        agent_step = AgentStep(prompt_node_response=example, final_answer_pattern=r"Final Answer\s*:\s*(.*)")
+        agent_step = AgentStep(prompt_node_response=example, final_answer_pattern=r"(?s)Final Answer\s*:\s*(.*)")
         final_answer = agent_step.final_answer(query="irrelevant")
         assert final_answer["answers"][0].answer == expected_answer
 


### PR DESCRIPTION
### Related Issues

- fixes #5743

### Proposed Changes:

The agent would discard the final answer if this was distributed on multiple lines. I added a modifier in the regex so that the `.` matches also newline characters.

### How did you test it?

One possibility is to use the agent to generate code, in this case we should see the bug and then the fix.

### Notes for the reviewer

In the 2.0 I'd change this structure to pass a flag or to give a closing sequence as well.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
