### PR TITLE
build: depend on `haystack_bm25` instead of `rank_bm25`

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -4,7 +4,7 @@ from typing import Literal, Any, Dict, List, Optional, Iterable
 import logging
 
 import numpy as np
-import rank_bm25
+from haystack_bm25 import rank_bm25
 from tqdm.auto import tqdm
 
 from haystack import default_from_dict, default_to_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
   "pandas",
-  "haystack_bm25",
+  "haystack-bm25",
   "tqdm",
   "tenacity",
   "lazy-imports",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
   "pandas",
-  "rank_bm25",
+  "haystack_bm25",
   "tqdm",
   "tenacity",
   "lazy-imports",

--- a/releasenotes/notes/switch-bm25-dep-9b9d1c596f5ff4d0.yaml
+++ b/releasenotes/notes/switch-bm25-dep-9b9d1c596f5ff4d0.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Depend on our own rank_bm25 fork.


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack/issues/1006

### Proposed Changes:

Let Haystack depend on our own fork of the unmaintained `rank_bm25` called `haystack_bm25`, now available on conda forge.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
