### PR TITLE
test: Add fixture to block requests in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,3 +21,20 @@ def mock_tokenizer():
 @pytest.fixture()
 def test_files_path():
     return Path(__file__).parent / "test_files"
+
+
+@pytest.fixture(autouse=True)
+def request_blocker(request: pytest.FixtureRequest, monkeypatch):
+    """
+    This fixture is applied automatically to all tests.
+    Those that are not marked as integration will have the requests module
+    monkeypatched to avoid making HTTP requests by mistake.
+    """
+    marker = request.node.get_closest_marker("integration")
+    if marker is not None:
+        return
+
+    def urlopen_mock(self, method, url, *args, **kwargs):
+        raise RuntimeError(f"The test was about to {method} {self.scheme}://{self.host}{url}")
+
+    monkeypatch.setattr("urllib3.connectionpool.HTTPConnectionPool.urlopen", urlopen_mock)

--- a/test/pipelines/test_indexing_pipeline.py
+++ b/test/pipelines/test_indexing_pipeline.py
@@ -6,6 +6,7 @@ from haystack.document_stores import InMemoryDocumentStore
 
 class TestIndexingPipeline:
     #  indexing files without embeddings
+    @pytest.mark.integration
     def test_indexing_files_without_embeddings(self, test_files_path):
         file_paths = [test_files_path / "txt" / "doc_1.txt", test_files_path / "txt" / "doc_2.txt"]
         document_store = InMemoryDocumentStore()
@@ -36,6 +37,7 @@ class TestIndexingPipeline:
         assert result["documents_written"] >= 3
 
     #  indexing multiple files
+    @pytest.mark.integration
     def test_indexing_multiple_file_types(self, test_files_path):
         document_store = InMemoryDocumentStore()
         pipeline = build_indexing_pipeline(

--- a/test/pipelines/test_rag_pipelines.py
+++ b/test/pipelines/test_rag_pipelines.py
@@ -37,6 +37,7 @@ def mock_chat_completion():
         yield mock_chat_completion_create
 
 
+@pytest.mark.integration
 def test_rag_pipeline(mock_chat_completion):
     rag_pipe = build_rag_pipeline(document_store=InMemoryDocumentStore())
     answer = rag_pipe.run(query="question")


### PR DESCRIPTION
We used to have this fixture before the 2.x branching off.

I changed it a bit to reflect the way we write tests now. 
Previously it used to block all HTTP requests made in tests marked with `@pytest.mark.unit`.
Now it blocks them in tests that are NOT marked with `@pytest.mark.integration`.