### PR TITLE
fix: Fix `Pipeline.connect()` when multiple compatible sockets are found

### DIFF
--- a/haystack/core/component/connection.py
+++ b/haystack/core/component/connection.py
@@ -116,21 +116,24 @@ class Connection:
             name_matches = [
                 (out_sock, in_sock) for out_sock, in_sock in possible_connections if in_sock.name == out_sock.name
             ]
-            if len(name_matches) != 1:
-                # TODO allow for multiple connections at once if there is no ambiguity?
-                # TODO give priority to sockets that have no default values?
-                connections_status_str = _connections_status(
-                    sender_node=sender_node,
-                    sender_sockets=sender_sockets,
-                    receiver_node=receiver_node,
-                    receiver_sockets=receiver_sockets,
-                )
-                raise PipelineConnectError(
-                    f"Cannot connect '{sender_node}' with '{receiver_node}': more than one connection is possible "
-                    "between these components. Please specify the connection name, like: "
-                    f"pipeline.connect('{sender_node}.{possible_connections[0][0].name}', "
-                    f"'{receiver_node}.{possible_connections[0][1].name}').\n{connections_status_str}"
-                )
+            if len(name_matches) == 1:
+                # Sockets match by type and name, let's use this
+                return Connection(sender_node, name_matches[0][0], receiver_node, name_matches[0][1])
+
+            # TODO allow for multiple connections at once if there is no ambiguity?
+            # TODO give priority to sockets that have no default values?
+            connections_status_str = _connections_status(
+                sender_node=sender_node,
+                sender_sockets=sender_sockets,
+                receiver_node=receiver_node,
+                receiver_sockets=receiver_sockets,
+            )
+            raise PipelineConnectError(
+                f"Cannot connect '{sender_node}' with '{receiver_node}': more than one connection is possible "
+                "between these components. Please specify the connection name, like: "
+                f"pipeline.connect('{sender_node}.{possible_connections[0][0].name}', "
+                f"'{receiver_node}.{possible_connections[0][1].name}').\n{connections_status_str}"
+            )
 
         match = possible_connections[0]
         return Connection(sender_node, match[0], receiver_node, match[1])

--- a/releasenotes/notes/fix-connect-with-same-name-5ce470f7f0451362.yaml
+++ b/releasenotes/notes/fix-connect-with-same-name-5ce470f7f0451362.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `Pipeline.connect()` so it connects sockets with same name if multiple sockets with compatible types are found.

--- a/test/core/pipeline/test_connections.py
+++ b/test/core/pipeline/test_connections.py
@@ -386,3 +386,18 @@ def test_parse_connection():
     assert parse_connect_string("foobar") == ("foobar", None)
     assert parse_connect_string("foo.bar") == ("foo", "bar")
     assert parse_connect_string("foo.bar.baz") == ("foo", "bar.baz")
+
+
+def test_connect_with_same_socket_names():
+    SimpleComponent = factory.component_class("SimpleComponent", output_types={"documents": List})
+    ComponentWithMultipleInputs = factory.component_class(
+        "ComponentWithMultipleInputs", input_types={"question": Any, "documents": Any}
+    )
+
+    pipe = Pipeline()
+    pipe.add_component("simple", SimpleComponent())
+    pipe.add_component("multiple", ComponentWithMultipleInputs())
+
+    pipe.connect("simple", "multiple")
+
+    assert list(pipe.graph.edges) == [("simple", "multiple", "documents/documents")]


### PR DESCRIPTION
### Related Issues

Fix #6515

### Proposed Changes:

Change the `Pipeline.connect()` logic to correctly connect two sockets with identical name when multiple possible connections are found.

Previously if multiple input sockets were found that had a compatible type with the output socket the first input socket would be connect with the output. So the connection depended also on the order of declaration of the inputs.

Now if multiple compatible input sockets are found and one has the same name as the output socket the connection will be created between these two sockets.

### How did you test it?

I added a new unit test.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
