### PR TITLE
feat: Change `DocumentWriter` default `policy` from `DuplicatePolicy.FAIL` to `DuplicatePolicy.NONE`

### DIFF
--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -15,11 +15,15 @@ class DocumentWriter:
     A component for writing documents to a DocumentStore.
     """
 
-    def __init__(self, document_store: DocumentStore, policy: DuplicatePolicy = DuplicatePolicy.FAIL):
+    def __init__(self, document_store: DocumentStore, policy: DuplicatePolicy = DuplicatePolicy.NONE):
         """
         Create a DocumentWriter component.
 
-        :param policy: The policy to use when encountering duplicate documents (default is DuplicatePolicy.FAIL).
+        :param policy: the policy to apply when a Document with the same id already exists in the DocumentStore.
+            - `DuplicatePolicy.NONE`: Default policy, behaviour depends on the Document Store.
+            - `DuplicatePolicy.SKIP`: If a Document with the same id already exists, it is skipped and not written.
+            - `DuplicatePolicy.OVERWRITE`: If a Document with the same id already exists, it is overwritten.
+            - `DuplicatePolicy.FAIL`: If a Document with the same id already exists, an error is raised.
         """
         self.document_store = document_store
         self.policy = policy

--- a/releasenotes/notes/document-writer-default-policy-693027781629fc73.yaml
+++ b/releasenotes/notes/document-writer-default-policy-693027781629fc73.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Change `DocumentWriter` default `policy` from `DuplicatePolicy.FAIL` to `DuplicatePolicy.NONE`.
+    The `DocumentStore` protocol uses the same default so that different Document Stores can choose
+    the default policy that better fit.

--- a/test/components/writers/test_document_writer.py
+++ b/test/components/writers/test_document_writer.py
@@ -16,7 +16,7 @@ class TestDocumentWriter:
             "type": "haystack.components.writers.document_writer.DocumentWriter",
             "init_parameters": {
                 "document_store": {"type": "haystack.testing.factory.MockedDocumentStore", "init_parameters": {}},
-                "policy": "FAIL",
+                "policy": "NONE",
             },
         }
 


### PR DESCRIPTION
### Proposed Changes:

`DocumentStore` protocol default policy is `DuplicatePolicy.NONE`, this gives different Document Stores the chance to pick the default that best fit their implementation.

With this PR `DocumentWriter` default `policy` changes from `DuplicatePolicy.FAIL` to `DuplicatePolicy.NONE` too.

### How did you test it?

Run unit tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
