### PR TITLE
feat: Add missing parameter base URL for OpenAI Embedder

### DIFF
--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -7,6 +7,8 @@ from tqdm import tqdm
 
 from haystack import component, Document, default_to_dict
 
+API_BASE_URL = "https://api.openai.com/v1"
+
 
 @component
 class OpenAIDocumentEmbedder:
@@ -34,6 +36,7 @@ class OpenAIDocumentEmbedder:
         self,
         api_key: Optional[str] = None,
         model_name: str = "text-embedding-ada-002",
+        api_base_url: str = API_BASE_URL,
         organization: Optional[str] = None,
         prefix: str = "",
         suffix: str = "",
@@ -70,6 +73,7 @@ class OpenAIDocumentEmbedder:
                 ) from e
 
         self.model_name = model_name
+        self.api_base_url = api_base_url
         self.organization = organization
         self.prefix = prefix
         self.suffix = suffix
@@ -79,6 +83,7 @@ class OpenAIDocumentEmbedder:
         self.embedding_separator = embedding_separator
 
         openai.api_key = api_key
+        openai.api_base = api_base_url
         if organization is not None:
             openai.organization = organization
 
@@ -96,6 +101,7 @@ class OpenAIDocumentEmbedder:
         return default_to_dict(
             self,
             model_name=self.model_name,
+            api_base_url=self.api_base_url,
             organization=self.organization,
             prefix=self.prefix,
             suffix=self.suffix,

--- a/releasenotes/notes/add-openai-embedder-base-url-d0c7a81451643ae9.yaml
+++ b/releasenotes/notes/add-openai-embedder-base-url-d0c7a81451643ae9.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add missing parameter "api_base_url" for OpenAIDocumentEmbedder


### PR DESCRIPTION
### Related Issues

- fixes #6597

### Proposed Changes:

Simply adding the parameters by copying exactly the structure of `GPTGenerator`


### How did you test it?

I haven't tested because it's a very small fix

### Notes for the reviewer

This change mimicks exactly the structure in `haystack/components/generators/openai.py` -> `GPTGenerator`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
