### PR TITLE
feat: add support for single meta dict in `TextFileToDocument`

### DIFF
--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -59,13 +59,15 @@ class TextFileToDocument:
         documents = []
 
         if meta is None:
-            meta_list = [{}] * len(sources)
+            meta_list: List[Dict[str, Any]] = [{}] * len(sources)
         elif isinstance(meta, dict):
             meta_list = [meta] * len(sources)
-        elif len(sources) != len(meta):
-            raise ValueError("The length of the metadata list must match the number of sources.")
-        else:
+        elif isinstance(meta, list):
+            if len(sources) != len(meta):
+                raise ValueError("The length of the metadata list must match the number of sources.")
             meta_list = meta
+        else:
+            raise ValueError("meta must be either a dictionary or a list of dictionaries.")
 
         for source, metadata in zip(sources, meta_list):
             try:

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -4,7 +4,7 @@ from typing import List, Union, Dict, Any, Optional
 
 from haystack import Document, component
 from haystack.dataclasses import ByteStream
-from haystack.components.converters.utils import get_bytestream_from_source
+from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 
 
 logger = logging.getLogger(__name__)
@@ -58,16 +58,7 @@ class TextFileToDocument:
         """
         documents = []
 
-        if meta is None:
-            meta_list: List[Dict[str, Any]] = [{}] * len(sources)
-        elif isinstance(meta, dict):
-            meta_list = [meta] * len(sources)
-        elif isinstance(meta, list):
-            if len(sources) != len(meta):
-                raise ValueError("The length of the metadata list must match the number of sources.")
-            meta_list = meta
-        else:
-            raise ValueError("meta must be either a dictionary or a list of dictionaries.")
+        meta_list = normalize_metadata(meta)
 
         for source, metadata in zip(sources, meta_list):
             try:

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -58,7 +58,7 @@ class TextFileToDocument:
         """
         documents = []
 
-        meta_list = normalize_metadata(meta)
+        meta_list = normalize_metadata(meta, sources_count=len(sources))
 
         for source, metadata in zip(sources, meta_list):
             try:

--- a/haystack/components/converters/utils.py
+++ b/haystack/components/converters/utils.py
@@ -22,7 +22,7 @@ def get_bytestream_from_source(source: Union[str, Path, ByteStream]) -> ByteStre
 
 def normalize_metadata(
     meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]], sources_count: int
-) -> Dict[str, Any]:
+) -> List[Dict[str, Any]]:
     """
     Given all the possible value of the meta input for a converter (None, dictionary or list of dicts),
     makes sure to return a list of dictionaries of the correct length for the converter to use.

--- a/haystack/components/converters/utils.py
+++ b/haystack/components/converters/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import List, Union, Dict, Any, Optional
 
 from haystack.dataclasses import ByteStream
 
@@ -18,3 +18,25 @@ def get_bytestream_from_source(source: Union[str, Path, ByteStream]) -> ByteStre
         bs.metadata["file_path"] = str(source)
         return bs
     raise ValueError(f"Unsupported source type {type(source)}")
+
+
+def normalize_metadata(
+    meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]], sources_count: int
+) -> Dict[str, Any]:
+    """
+    Given all the possible value of the meta input for a converter (None, dictionary or list of dicts),
+    makes sure to return a list of dictionaries of the correct length for the converter to use.
+
+    :param meta: the meta input of the converter, as-is
+    :sources_count: the number of sources the converter received
+    :returns: a list of dictionaries of the make length as the sources list
+    """
+    if meta is None:
+        return [{}] * sources_count
+    if isinstance(meta, dict):
+        return [meta] * sources_count
+    if isinstance(meta, list):
+        if sources_count != len(meta):
+            raise ValueError("The length of the metadata list must match the number of sources.")
+        return meta
+    raise ValueError("meta must be either None, a dictionary or a list of dictionaries.")

--- a/releasenotes/notes/single-metadata-txt-converter-a02bf90c60262701.yaml
+++ b/releasenotes/notes/single-metadata-txt-converter-a02bf90c60262701.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Adds support for single metadata dictionary input in `TextToDocument``.
+    Adds support for single metadata dictionary input in `TextFileToDocument``.

--- a/releasenotes/notes/single-metadata-txt-converter-a02bf90c60262701.yaml
+++ b/releasenotes/notes/single-metadata-txt-converter-a02bf90c60262701.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds support for single metadata dictionary input in `TextToDocument``.

--- a/test/components/converters/test_textfile_to_document.py
+++ b/test/components/converters/test_textfile_to_document.py
@@ -9,7 +9,7 @@ from haystack.components.converters.txt import TextFileToDocument
 
 
 class TestTextfileToDocument:
-    def test_run_no_meta(self, test_files_path):
+    def test_run(self, test_files_path):
         """
         Test if the component runs correctly with no metadata provided separately
         """
@@ -27,53 +27,6 @@ class TestTextfileToDocument:
         assert docs[0].meta["file_path"] == str(files[0])
         assert docs[1].meta["file_path"] == str(files[1])
         assert docs[2].meta == bytestream.metadata
-
-    def test_run_single_metadata_dictionary(self, test_files_path):
-        """
-        Test if the component runs correctly wne given a single metadata dictionary
-        """
-        bytestream = ByteStream.from_file_path(test_files_path / "txt" / "doc_3.txt")
-        bytestream.metadata["file_path"] = str(test_files_path / "txt" / "doc_3.txt")
-        bytestream.metadata["key"] = "value"
-        files = [str(test_files_path / "txt" / "doc_1.txt"), test_files_path / "txt" / "doc_2.txt", bytestream]
-        converter = TextFileToDocument()
-        output = converter.run(sources=files, meta={"test-key": "test-value"})
-        docs = output["documents"]
-        assert len(docs) == 3
-        assert "Some text for testing." in docs[0].content
-        assert "This is a test line." in docs[1].content
-        assert "That's yet another file!" in docs[2].content
-        assert docs[0].meta == {"file_path": str(files[0]), "test-key": "test-value"}
-        assert docs[1].meta == {"file_path": str(files[1]), "test-key": "test-value"}
-        assert docs[2].meta == {**bytestream.metadata, "test-key": "test-value"}
-
-    def test_run_correct_metadata_list(self, test_files_path):
-        """
-        Test if the component runs correctly wne given a list of metadata dictionaries of the correct length
-        """
-        bytestream = ByteStream.from_file_path(test_files_path / "txt" / "doc_3.txt")
-        bytestream.metadata["file_path"] = str(test_files_path / "txt" / "doc_3.txt")
-        bytestream.metadata["key"] = "value"
-        files = [str(test_files_path / "txt" / "doc_1.txt"), test_files_path / "txt" / "doc_2.txt", bytestream]
-        converter = TextFileToDocument()
-        output = converter.run(sources=files, meta=[{"a": "a"}, {"b": "b"}, {"c": "c"}])
-        docs = output["documents"]
-        assert len(docs) == 3
-        assert "Some text for testing." in docs[0].content
-        assert "This is a test line." in docs[1].content
-        assert "That's yet another file!" in docs[2].content
-        assert docs[0].meta == {"file_path": str(files[0]), "a": "a"}
-        assert docs[1].meta == {"file_path": str(files[1]), "b": "b"}
-        assert docs[2].meta == {**bytestream.metadata, "c": "c"}
-
-    def test_run_metadata_list_error_handling(self, test_files_path, caplog):
-        """
-        Test if the component correctly handles a list of metadata of the wrong length.
-        """
-        paths = [test_files_path / "txt" / "doc_1.txt", test_files_path / "txt" / "doc_3.txt"]
-        converter = TextFileToDocument()
-        with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources"):
-            converter.run(sources=paths, meta=[{"a": "a"}, {"b": "b"}, {"c": "c"}])
 
     def test_run_error_handling(self, test_files_path, caplog):
         """

--- a/test/components/converters/test_textfile_to_document.py
+++ b/test/components/converters/test_textfile_to_document.py
@@ -9,9 +9,9 @@ from haystack.components.converters.txt import TextFileToDocument
 
 
 class TestTextfileToDocument:
-    def test_run(self, test_files_path):
+    def test_run_no_meta(self, test_files_path):
         """
-        Test if the component runs correctly.
+        Test if the component runs correctly with no metadata provided separately
         """
         bytestream = ByteStream.from_file_path(test_files_path / "txt" / "doc_3.txt")
         bytestream.metadata["file_path"] = str(test_files_path / "txt" / "doc_3.txt")
@@ -27,6 +27,53 @@ class TestTextfileToDocument:
         assert docs[0].meta["file_path"] == str(files[0])
         assert docs[1].meta["file_path"] == str(files[1])
         assert docs[2].meta == bytestream.metadata
+
+    def test_run_single_metadata_dictionary(self, test_files_path):
+        """
+        Test if the component runs correctly wne given a single metadata dictionary
+        """
+        bytestream = ByteStream.from_file_path(test_files_path / "txt" / "doc_3.txt")
+        bytestream.metadata["file_path"] = str(test_files_path / "txt" / "doc_3.txt")
+        bytestream.metadata["key"] = "value"
+        files = [str(test_files_path / "txt" / "doc_1.txt"), test_files_path / "txt" / "doc_2.txt", bytestream]
+        converter = TextFileToDocument()
+        output = converter.run(sources=files, meta={"test-key": "test-value"})
+        docs = output["documents"]
+        assert len(docs) == 3
+        assert "Some text for testing." in docs[0].content
+        assert "This is a test line." in docs[1].content
+        assert "That's yet another file!" in docs[2].content
+        assert docs[0].meta == {"file_path": str(files[0]), "test-key": "test-value"}
+        assert docs[1].meta == {"file_path": str(files[1]), "test-key": "test-value"}
+        assert docs[2].meta == {**bytestream.metadata, "test-key": "test-value"}
+
+    def test_run_correct_metadata_list(self, test_files_path):
+        """
+        Test if the component runs correctly wne given a list of metadata dictionaries of the correct length
+        """
+        bytestream = ByteStream.from_file_path(test_files_path / "txt" / "doc_3.txt")
+        bytestream.metadata["file_path"] = str(test_files_path / "txt" / "doc_3.txt")
+        bytestream.metadata["key"] = "value"
+        files = [str(test_files_path / "txt" / "doc_1.txt"), test_files_path / "txt" / "doc_2.txt", bytestream]
+        converter = TextFileToDocument()
+        output = converter.run(sources=files, meta=[{"a": "a"}, {"b": "b"}, {"c": "c"}])
+        docs = output["documents"]
+        assert len(docs) == 3
+        assert "Some text for testing." in docs[0].content
+        assert "This is a test line." in docs[1].content
+        assert "That's yet another file!" in docs[2].content
+        assert docs[0].meta == {"file_path": str(files[0]), "a": "a"}
+        assert docs[1].meta == {"file_path": str(files[1]), "b": "b"}
+        assert docs[2].meta == {**bytestream.metadata, "c": "c"}
+
+    def test_run_metadata_list_error_handling(self, test_files_path, caplog):
+        """
+        Test if the component correctly handles a list of metadata of the wrong length.
+        """
+        paths = [test_files_path / "txt" / "doc_1.txt", test_files_path / "txt" / "doc_3.txt"]
+        converter = TextFileToDocument()
+        with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources"):
+            converter.run(sources=paths, meta=[{"a": "a"}, {"b": "b"}, {"c": "c"}])
 
     def test_run_error_handling(self, test_files_path, caplog):
         """

--- a/test/components/converters/test_textfile_to_document.py
+++ b/test/components/converters/test_textfile_to_document.py
@@ -11,7 +11,7 @@ from haystack.components.converters.txt import TextFileToDocument
 class TestTextfileToDocument:
     def test_run(self, test_files_path):
         """
-        Test if the component runs correctly with no metadata provided separately
+        Test if the component runs correctly.
         """
         bytestream = ByteStream.from_file_path(test_files_path / "txt" / "doc_3.txt")
         bytestream.metadata["file_path"] = str(test_files_path / "txt" / "doc_3.txt")

--- a/test/components/converters/test_utils.py
+++ b/test/components/converters/test_utils.py
@@ -1,0 +1,29 @@
+import pytest
+from haystack.components.converters.utils import normalize_metadata
+
+
+def test_normalize_metadata_None():
+    assert normalize_metadata(None, sources_count=1) == [{}]
+    assert normalize_metadata(None, sources_count=3) == [{}, {}, {}]
+
+
+def test_normalize_metadata_single_dict():
+    assert normalize_metadata({"a": 1}, sources_count=1) == [{"a": 1}]
+    assert normalize_metadata({"a": 1}, sources_count=3) == [{"a": 1}, {"a": 1}, {"a": 1}]
+
+
+def test_normalize_metadata_list_of_right_size():
+    assert normalize_metadata([{"a": 1}], sources_count=1) == [{"a": 1}]
+    assert normalize_metadata([{"a": 1}, {"b": 2}, {"c": 3}], sources_count=3) == [{"a": 1}, {"b": 2}, {"c": 3}]
+
+
+def test_normalize_metadata_list_of_wrong_size():
+    with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources."):
+        normalize_metadata([{"a": 1}], sources_count=3)
+    with pytest.raises(ValueError, match="The length of the metadata list must match the number of sources."):
+        assert normalize_metadata([{"a": 1}, {"b": 2}, {"c": 3}], sources_count=1)
+
+
+def test_normalize_metadata_other_type():
+    with pytest.raises(ValueError, match="meta must be either None, a dictionary or a list of dictionaries."):
+        normalize_metadata(({"a": 1},), sources_count=1)


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/6392

### Proposed Changes:
Adds support for single metadata dictionary input in `TextFileToDocument`. In this way, additional metadata can be added to all files processed by this component even when the length of the list of sources is unknown.

### How did you test it?

Added tests and run locally.

### Notes for the reviewer

See the linked issue and [this discussion](https://deepset-ai.slack.com/archives/C04F0D0FYKV/p1703077204120649) for context.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
