### PR TITLE
test: Check only top answer in extractive QA e2e test

### DIFF
--- a/e2e/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/pipelines/test_extractive_qa_pipeline.py
@@ -61,6 +61,10 @@ def test_extractive_qa_pipeline(tmp_path):
             assert hasattr(answer, "document_offset")
 
             assert hasattr(answer, "document")
-            # the answer is extracted from the correct document
-            if answer.document is not None:
-                assert answer.document.id == doc.id
+
+        # the top answer is extracted from the correct document
+        top_answer = extracted_answers[0]
+        if top_answer.document is not None:
+            if top_answer.document.id != doc.id:
+                print(top_answer.document.id, doc.id)
+            assert top_answer.document.id == doc.id


### PR DESCRIPTION
### Related Issues

- e2e test for extractive QA was failing since deduplication PR: https://github.com/deepset-ai/haystack/pull/6459
- Previously all returned answers were from the top relevant Document. With deduplication, some answers are from other Documents, which caused the e2e test to fail.

### Proposed Changes:

Check only the correctness of the top answer.

### How did you test it?

Ran e2e test locally. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
