### PR TITLE
feat: support single metadata dictionary in `PyPDFToDocument`

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -52,7 +52,7 @@ class PyPDFToDocument:
     from haystack.components.converters.pypdf import PyPDFToDocument
 
     converter = PyPDFToDocument()
-    results = converter.run(sources=["sample.pdf"])
+    results = converter.run(sources=["sample.pdf"], meta={"date_added": datetime.now().isoformat()})
     documents = results["documents"]
     print(documents[0].content)
     # 'This is a text from the PDF file.'

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from haystack.dataclasses import ByteStream
 from haystack.lazy_imports import LazyImport
 from haystack import Document, component, default_to_dict
-from haystack.components.converters.utils import get_bytestream_from_source
+from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 
 with LazyImport("Run 'pip install pypdf'") as pypdf_import:
     from pypdf import PdfReader
@@ -87,18 +87,17 @@ class PyPDFToDocument:
         Converts a list of PDF sources into Document objects using the configured converter.
 
         :param sources: A list of PDF data sources, which can be file paths or ByteStream objects.
-        :param meta: Optional list of metadata to attach to the Documents.
-          The length of the list must match the number of sources. Defaults to `None`.
+        :param meta: Optional metadata to attach to the Documents.
+          This value can be either a list of dictionaries or a single dictionary.
+          If it's a single dictionary, its content is added to the metadata of all produced Documents.
+          If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+          Defaults to `None`.
         :return: A dictionary containing a list of Document objects under the 'documents' key.
         """
         documents = []
+        meta_list = normalize_metadata(meta, sources_count=len(sources))
 
-        if meta is None:
-            meta = [{}] * len(sources)
-        elif len(sources) != len(meta):
-            raise ValueError("The length of the metadata list must match the number of sources.")
-
-        for source, metadata in zip(sources, meta):
+        for source, metadata in zip(sources, meta_list):
             try:
                 bytestream = get_bytestream_from_source(source)
             except Exception as e:

--- a/releasenotes/notes/single-meta-in-pypdf2document-99e15f1cb9f65892.yaml
+++ b/releasenotes/notes/single-meta-in-pypdf2document-99e15f1cb9f65892.yaml
@@ -1,0 +1,5 @@
+
+---
+enhancements:
+  - |
+    Adds support for single metadata dictionary input in `PyPDFToDocument`.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -40,8 +40,9 @@ class TestPyPDFToDocument:
             )
 
         # check that the metadata from the bytestream is merged with that from the meta parameter
-        assert output["documents"][0].meta == {"author": "test_author", "language": "it"}
-        assert output["documents"][1].meta == {"language": "it"}
+        assert output["documents"][0].meta["author"] == "test_author"
+        assert output["documents"][0].meta["language"] == "it"
+        assert output["documents"][1].meta["language"] == "it"
 
     def test_run_error_handling(self, test_files_path, caplog):
         """

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -24,10 +24,11 @@ class TestPyPDFToDocument:
         """
         paths = [test_files_path / "pdf" / "react_paper.pdf"]
         converter = PyPDFToDocument()
-        output = converter.run(sources=paths)
+        output = converter.run(sources=paths, meta={"test-key": "test-value"})
         docs = output["documents"]
         assert len(docs) == 1
         assert "ReAct" in docs[0].content
+        assert docs[0].meta["test-key"] == "test-value"
 
     def test_run_with_meta(self):
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -24,23 +24,24 @@ class TestPyPDFToDocument:
         """
         paths = [test_files_path / "pdf" / "react_paper.pdf"]
         converter = PyPDFToDocument()
-        output = converter.run(sources=paths, meta={"test-key": "test-value"})
+        output = converter.run(sources=paths)
         docs = output["documents"]
         assert len(docs) == 1
         assert "ReAct" in docs[0].content
         assert docs[0].meta["test-key"] == "test-value"
 
-    def test_run_with_meta(self):
+    def test_run_with_meta(self, test_files_path):
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
 
         converter = PyPDFToDocument()
         with patch("haystack.components.converters.pypdf.PdfReader"):
-            output = converter.run(sources=[bytestream], meta=[{"language": "it"}])
-
-        document = output["documents"][0]
+            output = converter.run(
+                sources=[bytestream, test_files_path / "pdf" / "react_paper.pdf"], meta={"language": "it"}
+            )
 
         # check that the metadata from the bytestream is merged with that from the meta parameter
-        assert document.meta == {"author": "test_author", "language": "it"}
+        assert output["documents"][0].meta == {"author": "test_author", "language": "it"}
+        assert output["documents"][1].meta == {"language": "it"}
 
     def test_run_error_handling(self, test_files_path, caplog):
         """

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -28,7 +28,6 @@ class TestPyPDFToDocument:
         docs = output["documents"]
         assert len(docs) == 1
         assert "ReAct" in docs[0].content
-        assert docs[0].meta["test-key"] == "test-value"
 
     def test_run_with_meta(self, test_files_path):
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/6392

### Proposed Changes:
Adds support for single metadata dictionary input in `PyPDFToDocument`. In this way, additional metadata can be added to all files processed by this component even when the length of the list of sources is unknown.

### How did you test it?

Added tests and run locally.

### Notes for the reviewer

See the linked issue and [this discussion](https://deepset-ai.slack.com/archives/C04F0D0FYKV/p1703077204120649) for context.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
