### PR TITLE
ci: make Tika service smoothly run on MacOs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,6 +169,11 @@ jobs:
         image: apache/tika:2.9.0.0
         ports:
           - 9998:9998
+        options: >-
+          --health-cmd "curl --fail -X GET http://localhost:9998/tika"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch: # Activate this workflow manually
   push:
     branches:
+      - tika-healthcheck
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
@@ -227,6 +228,11 @@ jobs:
     runs-on: macos-latest
     env:
       HAYSTACK_MPS_ENABLED: false
+    services:
+      tika:
+        image: apache/tika:2.9.0.0
+        ports:
+          - 9998:9998
     steps:
       - uses: actions/checkout@v4
 
@@ -245,9 +251,6 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
-
-      - name: Run Tika
-        run: docker run -d -p 9998:9998 apache/tika:2.9.0.0
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Activate this workflow manually
   push:
     branches:
-      - tika-healtcheck
+      - tika-healthcheck
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,11 +169,6 @@ jobs:
         image: apache/tika:2.9.0.0
         ports:
           - 9998:9998
-        options: >-
-          --health-cmd "curl --fail -X GET http://localhost:9998/tika"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch: # Activate this workflow manually
   push:
     branches:
-      - tika-healthcheck
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Activate this workflow manually
   push:
     branches:
-      - tika-healthcheck
+      - tika-healtcheck
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"
@@ -228,11 +228,7 @@ jobs:
     runs-on: macos-latest
     env:
       HAYSTACK_MPS_ENABLED: false
-    services:
-      tika:
-        image: apache/tika:2.9.0.0
-        ports:
-          - 9998:9998
+
     steps:
       - uses: actions/checkout@v4
 
@@ -251,6 +247,16 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Run Tika
+        run: |
+          docker run -d -p 9998:9998 \
+          --health-cmd='curl --fail -X GET http://localhost:9998/tika' \
+          --health-interval=5s \
+          --health-retries=5 \
+          --health-timeout=2s \
+          --health-start-period=1m \
+          apache/tika:2.9.0.0
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test


### PR DESCRIPTION
### Related Issues
- [the first Tika integration test is often failing in MacOs](https://github.com/deepset-ai/haystack/actions/runs/7290308355/job/19867245664)
- this happens because when the test begins, the service is not yet available, so it converts one file instead of 2

### Proposed Changes:
- try to add a healthcheck

### How did you test it?
CI

### Notes for the reviewer
~~There are conflicting resources on the healthcheck topic, so I'm not sure it works~~

Edit: we can't rely on github services (don't run on MacOs), so I'm manually setting the docker healthcheck...

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
