### PR TITLE
chore: Rename GPT generators, deprecate old names

### DIFF
--- a/e2e/pipelines/test_rag_pipelines.py
+++ b/e2e/pipelines/test_rag_pipelines.py
@@ -7,7 +7,7 @@ from haystack.document_stores import InMemoryDocumentStore
 from haystack.components.writers import DocumentWriter
 from haystack.components.retrievers import InMemoryBM25Retriever, InMemoryEmbeddingRetriever
 from haystack.components.embedders import SentenceTransformersTextEmbedder, SentenceTransformersDocumentEmbedder
-from haystack.components.generators import GPTGenerator
+from haystack.components.generators import OpenAIGenerator
 from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 
@@ -30,7 +30,7 @@ def test_bm25_rag_pipeline(tmp_path):
     rag_pipeline = Pipeline()
     rag_pipeline.add_component(instance=InMemoryBM25Retriever(document_store=InMemoryDocumentStore()), name="retriever")
     rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-    rag_pipeline.add_component(instance=GPTGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
+    rag_pipeline.add_component(instance=OpenAIGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
     rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
     rag_pipeline.connect("retriever", "prompt_builder.documents")
     rag_pipeline.connect("prompt_builder", "llm")
@@ -102,7 +102,7 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
         instance=InMemoryEmbeddingRetriever(document_store=InMemoryDocumentStore()), name="retriever"
     )
     rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-    rag_pipeline.add_component(instance=GPTGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
+    rag_pipeline.add_component(instance=OpenAIGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
     rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
     rag_pipeline.connect("text_embedder", "retriever")
     rag_pipeline.connect("retriever", "prompt_builder.documents")

--- a/examples/pipeline_loop_to_autocorrect_json.py
+++ b/examples/pipeline_loop_to_autocorrect_json.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from haystack import Pipeline
-from haystack.components.generators.openai import GPTGenerator
+from haystack.components.generators.openai import OpenAIGenerator
 from haystack.components.builders.prompt_builder import PromptBuilder
 import random
 from haystack import component
@@ -83,7 +83,7 @@ prompt_template = """
 # Let's build the pipeline (Make sure to set OPENAI_API_KEY as an environment variable)
 pipeline = Pipeline(max_loops_allowed=5)
 pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-pipeline.add_component(instance=GPTGenerator(), name="llm")
+pipeline.add_component(instance=OpenAIGenerator(), name="llm")
 pipeline.add_component(instance=OutputParser(pydantic_model=CitiesData), name="output_parser")
 
 pipeline.connect("prompt_builder", "llm")

--- a/examples/pipeline_loop_to_autocorrect_json.py
+++ b/examples/pipeline_loop_to_autocorrect_json.py
@@ -84,7 +84,7 @@ prompt_template = """
 pipeline = Pipeline(max_loops_allowed=5)
 pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
 pipeline.add_component(instance=OpenAIGenerator(), name="llm")
-pipeline.add_component(instance=OutputParser(pydantic_model=CitiesData), name="output_parser")
+pipeline.add_component(instance=OutputParser(pydantic_model=CitiesData), name="output_parser")  # type: ignore
 
 pipeline.connect("prompt_builder", "llm")
 pipeline.connect("llm", "output_parser")

--- a/examples/pipelines/rag_pipeline.py
+++ b/examples/pipelines/rag_pipeline.py
@@ -2,7 +2,7 @@ import os
 from haystack import Pipeline, Document
 from haystack.document_stores import InMemoryDocumentStore
 from haystack.components.retrievers import InMemoryBM25Retriever
-from haystack.components.generators import GPTGenerator
+from haystack.components.generators import OpenAIGenerator
 from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 
@@ -20,7 +20,7 @@ documents = [
 ]
 document_store.write_documents(documents)
 
-# Build a RAG pipeline with a Retriever to get relevant documents to the query and a GPTGenerator interacting with LLMs using a custom prompt.
+# Build a RAG pipeline with a Retriever to get relevant documents to the query and a OpenAIGenerator interacting with LLMs using a custom prompt.
 prompt_template = """
 Given these documents, answer the question.\nDocuments:
 {% for doc in documents %}
@@ -33,7 +33,7 @@ Given these documents, answer the question.\nDocuments:
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(instance=InMemoryBM25Retriever(document_store=document_store), name="retriever")
 rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-rag_pipeline.add_component(instance=GPTGenerator(api_key=OPENAI_API_KEY), name="llm")
+rag_pipeline.add_component(instance=OpenAIGenerator(api_key=OPENAI_API_KEY), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
 rag_pipeline.connect("prompt_builder", "llm")

--- a/examples/rag/rag_self_correction.py
+++ b/examples/rag/rag_self_correction.py
@@ -7,7 +7,7 @@ from canals.component.types import Variadic
 from haystack import Pipeline, Document, component, default_to_dict, default_from_dict, DeserializationError
 from haystack.document_stores import InMemoryDocumentStore
 from haystack.components.retrievers import InMemoryBM25Retriever
-from haystack.components.generators import GPTGenerator
+from haystack.components.generators import OpenAIGenerator
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.others import Multiplexer
 from haystack.components.routers.conditional_router import ConditionalRouter
@@ -99,7 +99,7 @@ def self_correcting_pipeline():
         ),
         name="prompt_builder",
     )
-    rag_pipeline.add_component(instance=GPTGenerator(), name="llm")
+    rag_pipeline.add_component(instance=OpenAIGenerator(), name="llm")
     rag_pipeline.add_component(
         instance=ConditionalRouter(
             routes=[

--- a/examples/retrievers/in_memory_bm25_rag.py
+++ b/examples/retrievers/in_memory_bm25_rag.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from haystack import Document
 from haystack import Pipeline
@@ -31,7 +32,7 @@ rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 # Draw the pipeline
-rag_pipeline.draw("./rag_pipeline.png")
+rag_pipeline.draw(Path("./rag_pipeline.png"))
 
 # Add Documents
 documents = [
@@ -43,7 +44,7 @@ documents = [
         content="In certain parts of the world, like the Maldives, Puerto Rico, and San Diego, you can witness the phenomenon of bioluminescent waves."
     ),
 ]
-rag_pipeline.get_component("retriever").document_store.write_documents(documents)
+rag_pipeline.get_component("retriever").document_store.write_documents(documents)  # type: ignore
 
 # Run the pipeline
 question = "How many languages are there?"

--- a/examples/retrievers/in_memory_bm25_rag.py
+++ b/examples/retrievers/in_memory_bm25_rag.py
@@ -4,7 +4,7 @@ from haystack import Document
 from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
-from haystack.components.generators import GPTGenerator
+from haystack.components.generators import OpenAIGenerator
 from haystack.components.retrievers import InMemoryBM25Retriever
 from haystack.document_stores import InMemoryDocumentStore
 
@@ -22,7 +22,7 @@ prompt_template = """
 rag_pipeline = Pipeline()
 rag_pipeline.add_component(instance=InMemoryBM25Retriever(document_store=InMemoryDocumentStore()), name="retriever")
 rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
-rag_pipeline.add_component(instance=GPTGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
+rag_pipeline.add_component(instance=OpenAIGenerator(api_key=os.environ.get("OPENAI_API_KEY")), name="llm")
 rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
 rag_pipeline.connect("prompt_builder", "llm")

--- a/haystack/components/builders/dynamic_prompt_builder.py
+++ b/haystack/components/builders/dynamic_prompt_builder.py
@@ -30,13 +30,13 @@ class DynamicPromptBuilder:
 
     ```python
     from haystack.components.builders import DynamicPromptBuilder
-    from haystack.components.generators.chat import GPTChatGenerator
+    from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.dataclasses import ChatMessage
     from haystack import Pipeline
 
     # no parameter init, we don't use any runtime template variables
     prompt_builder = DynamicPromptBuilder()
-    llm = GPTChatGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
+    llm = OpenAIChatGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
 
     pipe = Pipeline()
     pipe.add_component("prompt_builder", prompt_builder)
@@ -88,14 +88,14 @@ class DynamicPromptBuilder:
 
     ```python
     from haystack.components.builders import DynamicPromptBuilder
-    from haystack.components.generators.chat import GPTChatGenerator
+    from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.dataclasses import ChatMessage, Document
     from haystack import Pipeline, component
     from typing import List
 
     # we'll use documents runtime variable in our template, so we need to specify it in the init
     prompt_builder = DynamicPromptBuilder(runtime_variables=["documents"])
-    llm = GPTChatGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
+    llm = OpenAIChatGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
 
 
     @component
@@ -135,7 +135,7 @@ class DynamicPromptBuilder:
 
     ```python
     prompt_builder = DynamicPromptBuilder(runtime_variables=["documents"], chat_mode=False)
-    llm = GPTGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
+    llm = OpenAIGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
 
 
     @component

--- a/haystack/components/generators/__init__.py
+++ b/haystack/components/generators/__init__.py
@@ -1,5 +1,5 @@
 from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator
 from haystack.components.generators.hugging_face_tgi import HuggingFaceTGIGenerator
-from haystack.components.generators.openai import GPTGenerator
+from haystack.components.generators.openai import OpenAIGenerator, GPTGenerator
 
-__all__ = ["HuggingFaceLocalGenerator", "HuggingFaceTGIGenerator", "GPTGenerator"]
+__all__ = ["HuggingFaceLocalGenerator", "HuggingFaceTGIGenerator", "OpenAIGenerator", "GPTGenerator"]

--- a/haystack/components/generators/chat/__init__.py
+++ b/haystack/components/generators/chat/__init__.py
@@ -1,4 +1,4 @@
 from haystack.components.generators.chat.hugging_face_tgi import HuggingFaceTGIChatGenerator
-from haystack.components.generators.chat.openai import GPTChatGenerator
+from haystack.components.generators.chat.openai import OpenAIChatGenerator, GPTChatGenerator
 
-__all__ = ["HuggingFaceTGIChatGenerator", "GPTChatGenerator"]
+__all__ = ["HuggingFaceTGIChatGenerator", "OpenAIChatGenerator", "GPTChatGenerator"]

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import logging
+import warnings
 from typing import Optional, List, Callable, Dict, Any, Union
 
 from openai import OpenAI, Stream
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @component
-class GPTChatGenerator:
+class OpenAIChatGenerator:
     """
     Enables text generation using OpenAI's large language models (LLMs). It supports gpt-4 and gpt-3.5-turbo
     family of models accessed through the chat completions API endpoint.
@@ -27,12 +28,12 @@ class GPTChatGenerator:
     [documentation](https://platform.openai.com/docs/api-reference/chat).
 
     ```python
-    from haystack.components.generators.chat import GPTChatGenerator
+    from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.dataclasses import ChatMessage
 
     messages = [ChatMessage.from_user("What's Natural Language Processing?")]
 
-    client = GPTChatGenerator()
+    client = OpenAIChatGenerator()
     response = client.run(messages)
     print(response)
 
@@ -66,7 +67,7 @@ class GPTChatGenerator:
         generation_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
-        Creates an instance of ChatGPTGenerator. Unless specified otherwise in the `model_name`, this is for OpenAI's
+        Creates an instance of OpenAIChatGenerator. Unless specified otherwise in the `model_name`, this is for OpenAI's
         GPT-3.5 model.
 
         :param api_key: The OpenAI API key. It can be explicitly provided or automatically read from the
@@ -126,7 +127,7 @@ class GPTChatGenerator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GPTChatGenerator":
+    def from_dict(cls, data: Dict[str, Any]) -> "OpenAIChatGenerator":
         """
         Deserialize this component from a dictionary.
         :param data: The dictionary representation of this component.
@@ -277,3 +278,14 @@ class GPTChatGenerator:
             logger.warning(
                 "The completion for index %s has been truncated due to the content filter.", message.meta["index"]
             )
+
+
+class GPTChatGenerator(OpenAIChatGenerator):
+    def __init__(self):
+        warnings.warn(
+            "GPTChatGenerator is deprecated and will be removed in the next beta release. "
+            "Please use OpenAIChatGenerator instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -293,7 +293,7 @@ class GPTChatGenerator(OpenAIChatGenerator):
         warnings.warn(
             "GPTChatGenerator is deprecated and will be removed in the next beta release. "
             "Please use OpenAIChatGenerator instead.",
-            DeprecationWarning,
+            UserWarning,
             stacklevel=2,
         )
         super().__init__(

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -281,11 +281,26 @@ class OpenAIChatGenerator:
 
 
 class GPTChatGenerator(OpenAIChatGenerator):
-    def __init__(self):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "gpt-3.5-turbo",
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        api_base_url: Optional[str] = None,
+        organization: Optional[str] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+    ):
         warnings.warn(
             "GPTChatGenerator is deprecated and will be removed in the next beta release. "
             "Please use OpenAIChatGenerator instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__()
+        super().__init__(
+            api_key=api_key,
+            model_name=model_name,
+            streaming_callback=streaming_callback,
+            api_base_url=api_base_url,
+            organization=organization,
+            generation_kwargs=generation_kwargs,
+        )

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import logging
+import warnings
 from typing import Optional, List, Callable, Dict, Any, Union
 
 from openai import OpenAI, Stream
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @component
-class GPTGenerator:
+class OpenAIGenerator:
     """
     Enables text generation using OpenAI's large language models (LLMs). It supports gpt-4 and gpt-3.5-turbo
     family of models.
@@ -27,8 +28,8 @@ class GPTGenerator:
     [documentation](https://platform.openai.com/docs/api-reference/chat).
 
     ```python
-    from haystack.components.generators import GPTGenerator
-    client = GPTGenerator()
+    from haystack.components.generators import OpenAIGenerator
+    client = OpenAIGenerator()
     response = client.run("What's Natural Language Processing? Be brief.")
     print(response)
 
@@ -59,7 +60,7 @@ class GPTGenerator:
         generation_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
-        Creates an instance of GPTGenerator. Unless specified otherwise in the `model_name`, this is for OpenAI's
+        Creates an instance of OpenAIGenerator. Unless specified otherwise in the `model_name`, this is for OpenAI's
         GPT-3.5 model.
 
         :param api_key: The OpenAI API key. It can be explicitly provided or automatically read from the
@@ -123,7 +124,7 @@ class GPTGenerator:
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GPTGenerator":
+    def from_dict(cls, data: Dict[str, Any]) -> "OpenAIGenerator":
         """
         Deserialize this component from a dictionary.
         :param data: The dictionary representation of this component.
@@ -279,3 +280,14 @@ class GPTGenerator:
             logger.warning(
                 "The completion for index %s has been truncated due to the content filter.", message.meta["index"]
             )
+
+
+class GPTGenerator(OpenAIGenerator):
+    def __init__(self):
+        warnings.warn(
+            "GPTGenerator is deprecated and will be removed in the next beta release. "
+            "Please use OpenAIGenerator instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -296,7 +296,7 @@ class GPTGenerator(OpenAIGenerator):
         warnings.warn(
             "GPTGenerator is deprecated and will be removed in the next beta release. "
             "Please use OpenAIGenerator instead.",
-            DeprecationWarning,
+            UserWarning,
             stacklevel=2,
         )
         super().__init__(

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -283,11 +283,28 @@ class OpenAIGenerator:
 
 
 class GPTGenerator(OpenAIGenerator):
-    def __init__(self):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "gpt-3.5-turbo",
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        api_base_url: Optional[str] = None,
+        organization: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+    ):
         warnings.warn(
             "GPTGenerator is deprecated and will be removed in the next beta release. "
             "Please use OpenAIGenerator instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__()
+        super().__init__(
+            api_key=api_key,
+            model_name=model_name,
+            streaming_callback=streaming_callback,
+            api_base_url=api_base_url,
+            organization=organization,
+            system_prompt=system_prompt,
+            generation_kwargs=generation_kwargs,
+        )

--- a/haystack/pipeline_utils/rag.py
+++ b/haystack/pipeline_utils/rag.py
@@ -8,7 +8,7 @@ from haystack import Pipeline
 from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 from haystack.components.embedders import SentenceTransformersTextEmbedder
-from haystack.components.generators import GPTGenerator, HuggingFaceTGIGenerator
+from haystack.components.generators import OpenAIGenerator, HuggingFaceTGIGenerator
 from haystack.components.retrievers import InMemoryEmbeddingRetriever
 from haystack.dataclasses import Answer
 from haystack.document_stores import InMemoryDocumentStore, DocumentStore
@@ -179,13 +179,13 @@ class _GeneratorResolver(ABC):
 
 class _OpenAIResolved(_GeneratorResolver):
     """
-    Resolves the OpenAI GPTGenerator.
+    Resolves the OpenAIGenerator.
     """
 
     def resolve(self, model_key: str, api_key: str) -> Any:
         # does the model_key match the pattern OpenAI GPT pattern?
         if re.match(r"^gpt-4-.*", model_key) or re.match(r"^gpt-3.5-.*", model_key):
-            return GPTGenerator(model_name=model_key, api_key=api_key)
+            return OpenAIGenerator(model_name=model_key, api_key=api_key)
         return None
 
 

--- a/releasenotes/notes/rename-gpt-generators-f25011d251fafd6d.yaml
+++ b/releasenotes/notes/rename-gpt-generators-f25011d251fafd6d.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Deprecate GPTGenerator and GPTChatGenerator. Replace them with OpenAIGenerator and OpenAIChatGenerator.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from openai import OpenAIError
 
-from haystack.components.generators.chat import GPTChatGenerator
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.generators.utils import default_streaming_callback
 from haystack.dataclasses import ChatMessage, StreamingChunk
 
@@ -16,9 +16,9 @@ def chat_messages():
     ]
 
 
-class TestGPTChatGenerator:
+class TestOpenAIChatGenerator:
     def test_init_default(self):
-        component = GPTChatGenerator(api_key="test-api-key")
+        component = OpenAIChatGenerator(api_key="test-api-key")
         assert component.client.api_key == "test-api-key"
         assert component.model_name == "gpt-3.5-turbo"
         assert component.streaming_callback is None
@@ -27,10 +27,10 @@ class TestGPTChatGenerator:
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with pytest.raises(OpenAIError):
-            GPTChatGenerator()
+            OpenAIChatGenerator()
 
     def test_init_with_parameters(self):
-        component = GPTChatGenerator(
+        component = OpenAIChatGenerator(
             api_key="test-api-key",
             model_name="gpt-4",
             streaming_callback=default_streaming_callback,
@@ -43,10 +43,10 @@ class TestGPTChatGenerator:
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
     def test_to_dict_default(self):
-        component = GPTChatGenerator(api_key="test-api-key")
+        component = OpenAIChatGenerator(api_key="test-api-key")
         data = component.to_dict()
         assert data == {
-            "type": "haystack.components.generators.chat.openai.GPTChatGenerator",
+            "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
                 "model_name": "gpt-3.5-turbo",
                 "organization": None,
@@ -57,7 +57,7 @@ class TestGPTChatGenerator:
         }
 
     def test_to_dict_with_parameters(self):
-        component = GPTChatGenerator(
+        component = OpenAIChatGenerator(
             api_key="test-api-key",
             model_name="gpt-4",
             streaming_callback=default_streaming_callback,
@@ -66,7 +66,7 @@ class TestGPTChatGenerator:
         )
         data = component.to_dict()
         assert data == {
-            "type": "haystack.components.generators.chat.openai.GPTChatGenerator",
+            "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
                 "model_name": "gpt-4",
                 "organization": None,
@@ -77,7 +77,7 @@ class TestGPTChatGenerator:
         }
 
     def test_to_dict_with_lambda_streaming_callback(self):
-        component = GPTChatGenerator(
+        component = OpenAIChatGenerator(
             api_key="test-api-key",
             model_name="gpt-4",
             streaming_callback=lambda x: x,
@@ -86,7 +86,7 @@ class TestGPTChatGenerator:
         )
         data = component.to_dict()
         assert data == {
-            "type": "haystack.components.generators.chat.openai.GPTChatGenerator",
+            "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
                 "model_name": "gpt-4",
                 "organization": None,
@@ -98,7 +98,7 @@ class TestGPTChatGenerator:
 
     def test_from_dict(self):
         data = {
-            "type": "haystack.components.generators.chat.openai.GPTChatGenerator",
+            "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
                 "model_name": "gpt-4",
                 "api_base_url": "test-base-url",
@@ -106,7 +106,7 @@ class TestGPTChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
-        component = GPTChatGenerator.from_dict(data)
+        component = OpenAIChatGenerator.from_dict(data)
         assert component.model_name == "gpt-4"
         assert component.streaming_callback is default_streaming_callback
         assert component.api_base_url == "test-base-url"
@@ -115,7 +115,7 @@ class TestGPTChatGenerator:
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         data = {
-            "type": "haystack.components.generators.chat.openai.GPTChatGenerator",
+            "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
                 "model_name": "gpt-4",
                 "organization": None,
@@ -125,10 +125,10 @@ class TestGPTChatGenerator:
             },
         }
         with pytest.raises(OpenAIError):
-            GPTChatGenerator.from_dict(data)
+            OpenAIChatGenerator.from_dict(data)
 
     def test_run(self, chat_messages, mock_chat_completion):
-        component = GPTChatGenerator()
+        component = OpenAIChatGenerator()
         response = component.run(chat_messages)
 
         # check that the component returns the correct ChatMessage response
@@ -139,7 +139,7 @@ class TestGPTChatGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
     def test_run_with_params(self, chat_messages, mock_chat_completion):
-        component = GPTChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        component = OpenAIChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
         response = component.run(chat_messages)
 
         # check that the component calls the OpenAI API with the correct parameters
@@ -161,7 +161,7 @@ class TestGPTChatGenerator:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
-        component = GPTChatGenerator(streaming_callback=streaming_callback)
+        component = OpenAIChatGenerator(streaming_callback=streaming_callback)
         response = component.run(chat_messages)
 
         # check we called the streaming callback
@@ -176,7 +176,7 @@ class TestGPTChatGenerator:
         assert "Hello" in response["replies"][0].content  # see mock_chat_completion_chunk
 
     def test_check_abnormal_completions(self, caplog):
-        component = GPTChatGenerator(api_key="test-api-key")
+        component = OpenAIChatGenerator(api_key="test-api-key")
         messages = [
             ChatMessage.from_assistant(
                 "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
@@ -208,7 +208,7 @@ class TestGPTChatGenerator:
     @pytest.mark.integration
     def test_live_run(self):
         chat_messages = [ChatMessage.from_user("What's the capital of France")]
-        component = GPTChatGenerator(api_key=os.environ.get("OPENAI_API_KEY"), generation_kwargs={"n": 1})
+        component = OpenAIChatGenerator(api_key=os.environ.get("OPENAI_API_KEY"), generation_kwargs={"n": 1})
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
@@ -222,7 +222,9 @@ class TestGPTChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run_wrong_model(self, chat_messages):
-        component = GPTChatGenerator(model_name="something-obviously-wrong", api_key=os.environ.get("OPENAI_API_KEY"))
+        component = OpenAIChatGenerator(
+            model_name="something-obviously-wrong", api_key=os.environ.get("OPENAI_API_KEY")
+        )
         with pytest.raises(OpenAIError):
             component.run(chat_messages)
 
@@ -242,7 +244,7 @@ class TestGPTChatGenerator:
                 self.responses += chunk.content if chunk.content else ""
 
         callback = Callback()
-        component = GPTChatGenerator(streaming_callback=callback)
+        component = OpenAIChatGenerator(streaming_callback=callback)
         results = component.run([ChatMessage.from_user("What's the capital of France?")])
 
         assert len(results["replies"]) == 1


### PR DESCRIPTION
### Why:
The purpose of this pull request is to rename GPT generators within the Haystack framework. The change aims to update the naming convention of these generators to align with current naming standards. 

- fixes https://github.com/deepset-ai/haystack/issues/6587

The decision to rename the class from GPTChatGenerator to OpenAIChatGenerator is rooted in the need for compatibility with various providers and models. Unlike the original name, which specifically referenced 'GPT', the new name, OpenAIChatGenerator, is more inclusive and accurately reflects the class's capability to work seamlessly with a diverse range of providers such as together.ai, anyscale, and deepinfra.com, as well as with different AI models like mixtral. 

### What:
The pull request includes several modifications across various files in the Haystack repository. The key changes are:
1. Renaming `GPTGenerator` to `OpenAIGenerator` and `GPTChatGenerator` to `OpenAIChatGenerator`.
2. Updating all instances where these classes are referenced in the code, including in test files, example scripts, and component initializations.
3. Adding a deprecation warning to the old class names, indicating that they will be removed in future releases.

### How can it be used:
After merging this pull request, developers can still use old names but they'll get a warning to migrate to (`OpenAIGenerator` and `OpenAIChatGenerator`). 

### How did you test it:
The changes include updates to various test files, ensuring that the renamed classes are correctly instantiated and function as expected. Additionally, the modifications in example scripts and other parts of the codebase were likely tested to confirm that they correctly reference the new class names.

### Notes for the reviewer:
- Please review the changes for consistency and ensure that all instances of the old class names have been updated to the new names.
- Consider the impact of these changes on existing users of the library and ensure that the deprecation warnings are clear and informative.
- Verify that all tests pass with the new changes and that there are no unexpected side effects or issues introduced by the renaming.