### PR TITLE
feat: Add model kwargs to SentenceTransformersRanker

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -27,6 +27,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
     )
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
     from haystack.nodes.prompt.invocation_layer.handlers import HFTokenStreamingHandler
+    from haystack.utils.torch_utils import extract_torch_dtype
 
     class StopWordsCriteria(StoppingCriteria):
         """
@@ -177,7 +178,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         device_map = kwargs.get("device_map", None)
         device = kwargs.get("device") if device_map is None else None
         # prepare torch_dtype for pipeline invocation
-        torch_dtype = self._extract_torch_dtype(**kwargs)
+        torch_dtype = extract_torch_dtype(**kwargs)
         # and the model (prefer model instance over model_name_or_path str identifier)
         model = kwargs.get("model") or kwargs.get("model_name_or_path")
         trust_remote_code = kwargs.get("trust_remote_code", False)

--- a/haystack/nodes/prompt/invocation_layer/hugging_face.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face.py
@@ -27,7 +27,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
     )
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
     from haystack.nodes.prompt.invocation_layer.handlers import HFTokenStreamingHandler
-    from haystack.utils.torch_utils import extract_torch_dtype
+    from haystack.utils.torch_utils import resolve_torch_dtype
 
     class StopWordsCriteria(StoppingCriteria):
         """
@@ -178,7 +178,7 @@ class HFLocalInvocationLayer(PromptModelInvocationLayer):
         device_map = kwargs.get("device_map", None)
         device = kwargs.get("device") if device_map is None else None
         # prepare torch_dtype for pipeline invocation
-        torch_dtype = extract_torch_dtype(**kwargs)
+        torch_dtype = resolve_torch_dtype(kwargs.get("torch_dtype"))
         # and the model (prefer model instance over model_name_or_path str identifier)
         model = kwargs.get("model") or kwargs.get("model_name_or_path")
         trust_remote_code = kwargs.get("trust_remote_code", False)

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -18,7 +18,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
     from torch.nn import DataParallel
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
-    from haystack.utils.torch_utils import extract_torch_dtype
+    from haystack.utils.torch_utils import resolve_torch_dtype
 
 
 class SentenceTransformersRanker(BaseRanker):
@@ -94,7 +94,7 @@ class SentenceTransformersRanker(BaseRanker):
         self.progress_bar = progress_bar
         self.model_kwargs = model_kwargs
         kwargs = model_kwargs if model_kwargs else {}
-        torch_dtype = extract_torch_dtype(**kwargs)
+        torch_dtype = resolve_torch_dtype(kwargs.get("torch_dtype"))
         if torch_dtype:
             kwargs["torch_dtype"] = torch_dtype
         self.transformer_model = AutoModelForSequenceClassification.from_pretrained(

--- a/haystack/nodes/ranker/sentence_transformers.py
+++ b/haystack/nodes/ranker/sentence_transformers.py
@@ -101,7 +101,7 @@ class SentenceTransformersRanker(BaseRanker):
             pretrained_model_name_or_path=model_name_or_path,
             revision=model_version,
             use_auth_token=use_auth_token,
-            **kwargs
+            **kwargs,
         )
         self.transformer_model.to(str(self.devices[0]))
         self.transformer_tokenizer = AutoTokenizer.from_pretrained(

--- a/haystack/utils/torch_utils.py
+++ b/haystack/utils/torch_utils.py
@@ -52,3 +52,26 @@ def get_devices(devices: Optional[List[Union[str, torch.device]]]) -> List[torch
     ):
         return [torch.device("mps")]
     return [torch.device("cpu")]
+
+
+def extract_torch_dtype(**kwargs) -> Optional["torch.dtype"]:
+    """
+    Extract the torch dtype specified in kwargs. This function ensures the returned dtype is of a `torch.dtype` type.
+    """
+    torch_dtype_resolved = None
+    torch_dtype = kwargs.get("torch_dtype", None)
+    if torch_dtype is not None:
+        if isinstance(torch_dtype, str):
+            if "torch." in torch_dtype:
+                torch_dtype_resolved = getattr(torch, torch_dtype.strip("torch."))
+            elif torch_dtype == "auto":
+                torch_dtype_resolved = torch_dtype
+            else:
+                raise ValueError(
+                    f"torch_dtype should be a torch.dtype, a string with 'torch.' prefix or the string 'auto', got {torch_dtype}"
+                )
+        elif isinstance(torch_dtype, torch.dtype):
+            torch_dtype_resolved = torch_dtype
+        else:
+            raise ValueError(f"Invalid torch_dtype value {torch_dtype}")
+    return torch_dtype_resolved

--- a/haystack/utils/torch_utils.py
+++ b/haystack/utils/torch_utils.py
@@ -54,12 +54,11 @@ def get_devices(devices: Optional[List[Union[str, torch.device]]]) -> List[torch
     return [torch.device("cpu")]
 
 
-def extract_torch_dtype(**kwargs) -> Optional["torch.dtype"]:
+def resolve_torch_dtype(torch_dtype: Optional[Union[str, "torch.dtype"]]) -> Optional["torch.dtype"]:
     """
     Extract the torch dtype specified in kwargs. This function ensures the returned dtype is of a `torch.dtype` type.
     """
     torch_dtype_resolved = None
-    torch_dtype = kwargs.get("torch_dtype", None)
     if torch_dtype is not None:
         if isinstance(torch_dtype, str):
             if "torch." in torch_dtype:

--- a/releasenotes/notes/ranker-model-kwargs-0f60508b69d7d46e.yaml
+++ b/releasenotes/notes/ranker-model-kwargs-0f60508b69d7d46e.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add model_kwargs argument to SentenceTransformersRanker to be able to pass through HF transformers loading options
+    

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -235,6 +235,18 @@ def test_ranker(docs, mock_transformer_model, mock_transformer_tokenizer):
 
 
 @pytest.mark.unit
+def test_init_called_with():
+    with patch("deepset_cloud_custom_nodes.CNSentenceTransformersRanker.__init__") as mock_ranker_init:
+        mock_ranker_init.return_value = None
+        _ = SentenceTransformersRanker(
+            model_name_or_path="fake_model", use_gpu=False, model_kwargs={"torch_dtype": torch.float16}
+        )
+        mock_ranker_init.assert_called_once_with(
+            model_name_or_path="fake_model", use_gpu=False, model_kwargs={"torch_dtype": torch.float16}
+        )
+
+
+@pytest.mark.unit
 def test_ranker_run(docs, mock_transformer_model, mock_transformer_tokenizer):
     with patch("torch.nn.DataParallel"):
         ranker = SentenceTransformersRanker(model_name_or_path="fake_model")

--- a/test/nodes/test_ranker.py
+++ b/test/nodes/test_ranker.py
@@ -236,7 +236,7 @@ def test_ranker(docs, mock_transformer_model, mock_transformer_tokenizer):
 
 @pytest.mark.unit
 def test_init_called_with():
-    with patch("deepset_cloud_custom_nodes.CNSentenceTransformersRanker.__init__") as mock_ranker_init:
+    with patch("haystack.nodes.SentenceTransformersRanker.__init__") as mock_ranker_init:
         mock_ranker_init.return_value = None
         _ = SentenceTransformersRanker(
             model_name_or_path="fake_model", use_gpu=False, model_kwargs={"torch_dtype": torch.float16}

--- a/test/utils/test_torch_utils.py
+++ b/test/utils/test_torch_utils.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from haystack.utils.torch_utils import extract_torch_dtype
+
+
+def test_extract_torch_dtype() -> None:
+    torch_dtype = extract_torch_dtype(**{"torch_dtype": torch.float16})
+    assert torch_dtype == torch.float16
+
+
+def test_extract_torch_dtype_none() -> None:
+    torch_dtype = extract_torch_dtype(**{})
+    assert torch_dtype is None
+
+
+def test_extract_torch_dtype_str() -> None:
+    torch_dtype = extract_torch_dtype(**{"torch_dtype": "torch.float16"})
+    assert torch_dtype == torch.float16
+
+
+def test_extract_torch_dtype_auto() -> None:
+    torch_dtype = extract_torch_dtype(**{"torch_dtype": "auto"})
+    assert torch_dtype == "auto"
+
+
+def test_extract_torch_dtype_invalid() -> None:
+    with pytest.raises(ValueError):
+        _ = extract_torch_dtype(**{"torch_dtype": "random string"})

--- a/test/utils/test_torch_utils.py
+++ b/test/utils/test_torch_utils.py
@@ -1,29 +1,29 @@
 import pytest
 import torch
 
-from haystack.utils.torch_utils import extract_torch_dtype
+from haystack.utils.torch_utils import resolve_torch_dtype
 
 
 def test_extract_torch_dtype() -> None:
-    torch_dtype = extract_torch_dtype(**{"torch_dtype": torch.float16})
+    torch_dtype = resolve_torch_dtype(**{"torch_dtype": torch.float16})
     assert torch_dtype == torch.float16
 
 
 def test_extract_torch_dtype_none() -> None:
-    torch_dtype = extract_torch_dtype(**{})
+    torch_dtype = resolve_torch_dtype(**{})
     assert torch_dtype is None
 
 
 def test_extract_torch_dtype_str() -> None:
-    torch_dtype = extract_torch_dtype(**{"torch_dtype": "torch.float16"})
+    torch_dtype = resolve_torch_dtype(**{"torch_dtype": "torch.float16"})
     assert torch_dtype == torch.float16
 
 
 def test_extract_torch_dtype_auto() -> None:
-    torch_dtype = extract_torch_dtype(**{"torch_dtype": "auto"})
+    torch_dtype = resolve_torch_dtype(**{"torch_dtype": "auto"})
     assert torch_dtype == "auto"
 
 
 def test_extract_torch_dtype_invalid() -> None:
     with pytest.raises(ValueError):
-        _ = extract_torch_dtype(**{"torch_dtype": "random string"})
+        _ = resolve_torch_dtype(**{"torch_dtype": "random string"})


### PR DESCRIPTION
### Related Issues

- fixes N/A

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates cross encoder init to take model kwargs so we can pass float16 as a loading option. Increases speed of ranking 40 docs by 4x when using float16.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
