### PR TITLE
feat: Add pipeline_kwargs to TransformersSummarizer

### DIFF
--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from haystack.schema import Document
 from haystack.nodes.summarizer.base import BaseSummarizer
 from haystack.lazy_imports import LazyImport
+from haystack.utils.torch_utils import extract_torch_dtype
 
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class TransformersSummarizer(BaseSummarizer):
         progress_bar: bool = True,
         use_auth_token: Optional[Union[str, bool]] = None,
         devices: Optional[List[Union[str, "torch.device"]]] = None,
+        pipeline_kwargs: Optional[dict] = None,
     ):
         """
         Load a summarization model from transformers.
@@ -107,6 +109,10 @@ class TransformersSummarizer(BaseSummarizer):
         if tokenizer is None:
             tokenizer = model_name_or_path
 
+        kwargs = pipeline_kwargs if pipeline_kwargs else {}
+        torch_dtype = extract_torch_dtype(**kwargs)
+        if torch_dtype:
+            kwargs["torch_dtype"] = torch_dtype
         self.summarizer = pipeline(
             task="summarization",
             model=model_name_or_path,
@@ -114,6 +120,7 @@ class TransformersSummarizer(BaseSummarizer):
             revision=model_version,
             device=self.devices[0],
             use_auth_token=use_auth_token,
+            **kwargs,
         )
         self.max_length = max_length
         self.min_length = min_length
@@ -121,6 +128,7 @@ class TransformersSummarizer(BaseSummarizer):
         self.print_log: Set[str] = set()
         self.batch_size = batch_size
         self.progress_bar = progress_bar
+        self.pipeline_kwargs = pipeline_kwargs
 
     def predict(self, documents: List[Document]) -> List[Document]:
         """
@@ -159,6 +167,7 @@ class TransformersSummarizer(BaseSummarizer):
             return_text=True,
             clean_up_tokenization_spaces=self.clean_up_tokenization_spaces,
             truncation=True,
+            batch_size=self.batch_size,
         )
 
         result: List[Document] = []

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -8,7 +8,6 @@ from tqdm import tqdm
 from haystack.schema import Document
 from haystack.nodes.summarizer.base import BaseSummarizer
 from haystack.lazy_imports import LazyImport
-from haystack.utils.torch_utils import extract_torch_dtype
 
 
 logger = logging.getLogger(__name__)
@@ -19,6 +18,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
     from haystack.utils.torch_utils import ListDataset
+    from haystack.utils.torch_utils import extract_torch_dtype
 
 
 class TransformersSummarizer(BaseSummarizer):

--- a/haystack/nodes/summarizer/transformers.py
+++ b/haystack/nodes/summarizer/transformers.py
@@ -18,7 +18,7 @@ with LazyImport(message="Run 'pip install farm-haystack[inference]'") as torch_a
     from transformers import pipeline
     from haystack.modeling.utils import initialize_device_settings  # pylint: disable=ungrouped-imports
     from haystack.utils.torch_utils import ListDataset
-    from haystack.utils.torch_utils import extract_torch_dtype
+    from haystack.utils.torch_utils import resolve_torch_dtype
 
 
 class TransformersSummarizer(BaseSummarizer):
@@ -110,7 +110,7 @@ class TransformersSummarizer(BaseSummarizer):
             tokenizer = model_name_or_path
 
         kwargs = pipeline_kwargs if pipeline_kwargs else {}
-        torch_dtype = extract_torch_dtype(**kwargs)
+        torch_dtype = resolve_torch_dtype(kwargs.get("torch_dtype"))
         if torch_dtype:
             kwargs["torch_dtype"] = torch_dtype
         self.summarizer = pipeline(

--- a/haystack/utils/torch_utils.py
+++ b/haystack/utils/torch_utils.py
@@ -52,3 +52,26 @@ def get_devices(devices: Optional[List[Union[str, torch.device]]]) -> List[torch
     ):
         return [torch.device("mps")]
     return [torch.device("cpu")]
+
+
+def extract_torch_dtype(**kwargs) -> Optional["torch.dtype"]:
+    """
+    Extract the torch dtype specified in kwargs. This function ensures the returned dtype is of a `torch.dtype` type.
+    """
+    torch_dtype_resolved = None
+    torch_dtype = kwargs.get("torch_dtype", None)
+    if torch_dtype is not None:
+        if isinstance(torch_dtype, str):
+            if "torch." in torch_dtype:
+                torch_dtype_resolved = getattr(torch, torch_dtype.strip("torch."))
+            elif torch_dtype == "auto":
+                torch_dtype_resolved = torch_dtype
+            else:
+                raise ValueError(
+                    f"torch_dtype should be a torch.dtype, a string with 'torch.' prefix or the string 'auto', got {torch_dtype}"
+                )
+        elif isinstance(torch_dtype, torch.dtype):
+            torch_dtype_resolved = torch_dtype
+        else:
+            raise ValueError(f"Invalid torch_dtype value {torch_dtype}")
+    return torch_dtype_resolved

--- a/releasenotes/notes/summarizer-kwargs-speed-148714d268773f60.yaml
+++ b/releasenotes/notes/summarizer-kwargs-speed-148714d268773f60.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Use batching in the predict method since multiple documents are usually passed at inference time.
+    Allow the model to be loaded in torch.float16 by adding pipeline_kwargs to the init method

--- a/test/nodes/test_summarizer.py
+++ b/test/nodes/test_summarizer.py
@@ -90,7 +90,7 @@ def test_summarization_batch_multiple_doc_lists(summarizer):
 
 @pytest.mark.unit
 def test_init_called_with():
-    with patch("deepset_cloud_custom_nodes.CNTransformersSummarizer.__init__") as mock_summarizer_init:
+    with patch("haystack.nodes.TransformersSummarizer.__init__") as mock_summarizer_init:
         mock_summarizer_init.return_value = None
         _ = TransformersSummarizer(
             model_name_or_path="fake_model", use_gpu=False, pipeline_kwargs={"torch_dtype": torch.float16}

--- a/test/nodes/test_summarizer.py
+++ b/test/nodes/test_summarizer.py
@@ -1,5 +1,8 @@
 import pytest
+from unittest.mock import patch
+import logging
 
+import torch
 import haystack
 from haystack.utils.torch_utils import ListDataset
 from haystack.schema import Document
@@ -83,3 +86,26 @@ def test_summarization_batch_multiple_doc_lists(summarizer):
     assert len(summarized_docs[0]) == len(DOCS)
     for expected_summary, summary in zip(EXPECTED_SUMMARIES, summarized_docs[0]):
         assert expected_summary == summary.meta["summary"]
+
+
+@pytest.mark.unit
+def test_init_called_with():
+    with patch("deepset_cloud_custom_nodes.CNTransformersSummarizer.__init__") as mock_summarizer_init:
+        mock_summarizer_init.return_value = None
+        _ = TransformersSummarizer(
+            model_name_or_path="fake_model", use_gpu=False, pipeline_kwargs={"torch_dtype": torch.float16}
+        )
+        mock_summarizer_init.assert_called_once_with(
+            model_name_or_path="fake_model", use_gpu=False, pipeline_kwargs={"torch_dtype": torch.float16}
+        )
+
+
+@pytest.mark.unit
+def test_summarization_device_warning(caplog, mock_models):
+    with caplog.at_level(logging.WARNING):
+        _ = TransformersSummarizer(
+            model_name_or_path="irrelevant/anyway",
+            use_gpu=True,
+            devices=[torch.device("cuda:0"), torch.device("cuda:1")],
+        )
+    assert "Multiple devices are not supported" in caplog.text


### PR DESCRIPTION
### Related Issues

- fixes N/A
- Needs PR https://github.com/deepset-ai/haystack/pull/6627 for the `extract_torch_dtype` method

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- fixes slow inference and indexing times for a client's pipeline that uses the TransformerSummarizer
- use batching in the predict method since multiple documents are usually passed at inference time
- allow the model to be loaded in torch.float16 by adding pipeline_kwargs to the init method

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
