### PR TITLE
feat: support single metadata dictionary in `AzureOCRDocumentConverter`

### DIFF
--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -6,7 +6,7 @@ import logging
 from haystack.lazy_imports import LazyImport
 from haystack import component, Document, default_to_dict
 from haystack.dataclasses import ByteStream
-from haystack.components.converters.utils import get_bytestream_from_source
+from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class AzureOCRDocumentConverter:
     from haystack.components.converters.azure import AzureOCRDocumentConverter
 
     converter = AzureOCRDocumentConverter()
-    results = converter.run(sources=["image-based-document.pdf"])
+    results = converter.run(sources=["image-based-document.pdf"], meta={"date_added": datetime.now().isoformat()})
     documents = results["documents"]
     print(documents[0].content)
     # 'This is a text from the PDF file.'
@@ -77,20 +77,19 @@ class AzureOCRDocumentConverter:
         the raw responses from Azure's Document Intelligence service.
 
         :param sources: List of file paths or ByteStream objects.
-        :param meta: Optional list of metadata to attach to the Documents.
-          The length of the list must match the number of sources. Defaults to `None`.
+        :param meta: Optional metadata to attach to the Documents.
+          This value can be either a list of dictionaries or a single dictionary.
+          If it's a single dictionary, its content is added to the metadata of all produced Documents.
+          If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+          Defaults to `None`.
         :return: A dictionary containing a list of Document objects under the 'documents' key
           and the raw Azure response under the 'raw_azure_response' key.
         """
         documents = []
         azure_output = []
+        meta_list = normalize_metadata(meta=meta, sources_count=len(sources))
 
-        if meta is None:
-            meta = [{}] * len(sources)
-        elif len(sources) != len(meta):
-            raise ValueError("The length of the metadata list must match the number of sources.")
-
-        for source, metadata in zip(sources, meta):
+        for source, metadata in zip(sources, meta_list):
             try:
                 bytestream = get_bytestream_from_source(source=source)
             except Exception as e:

--- a/releasenotes/notes/single-meta-in-azureconverter-ce1cc196a9b161f3.yaml
+++ b/releasenotes/notes/single-meta-in-azureconverter-ce1cc196a9b161f3.yaml
@@ -1,4 +1,5 @@
 ---
 enhancements:
   - |
-    Adds support for single metadata dictionary input in `AzureOCRDocumentConverter`.
+    Adds support for single metadata dictionary input in `AzureOCRDocumentConverter`. In this way, additional metadata can be added to all files processed by this component even when the length of the list of sources is unknown.
+

--- a/releasenotes/notes/single-meta-in-azureconverter-ce1cc196a9b161f3.yaml
+++ b/releasenotes/notes/single-meta-in-azureconverter-ce1cc196a9b161f3.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds support for single metadata dictionary input in `AzureOCRDocumentConverter`.

--- a/test/components/converters/test_azure_ocr_doc_converter.py
+++ b/test/components/converters/test_azure_ocr_doc_converter.py
@@ -50,11 +50,12 @@ class TestAzureOCRDocumentConverter:
         with patch("haystack.components.converters.azure.DocumentAnalysisClient"):
             component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
 
-        output = component.run(sources=[bytestream], meta=[{"language": "it"}])
-        document = output["documents"][0]
+        output = component.run(sources=[bytestream], meta={"language": "it"})
 
         # check that the metadata from the bytestream is merged with that from the meta parameter
-        assert document.meta == {"author": "test_author", "language": "it"}
+        assert output["documents"][0].meta["author"] == "test_author"
+        assert output["documents"][0].meta["language"] == "it"
+        assert output["documents"][1].meta["language"] == "it"
 
     @pytest.mark.integration
     @pytest.mark.skipif(not os.environ.get("CORE_AZURE_CS_ENDPOINT", None), reason="Azure credentials not available")

--- a/test/components/converters/test_azure_ocr_doc_converter.py
+++ b/test/components/converters/test_azure_ocr_doc_converter.py
@@ -44,13 +44,14 @@ class TestAzureOCRDocumentConverter:
                 "pages": [{"lines": [{"content": "mocked line 1"}, {"content": "mocked line 2"}]}],
             }
 
-    def test_run_with_meta(self):
+    def test_run_with_meta(self, test_files_path):
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
-
         with patch("haystack.components.converters.azure.DocumentAnalysisClient"):
             component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
 
-        output = component.run(sources=[bytestream], meta={"language": "it"})
+        output = component.run(
+            sources=[bytestream, test_files_path / "pdf" / "sample_pdf_1.pdf"], meta={"language": "it"}
+        )
 
         # check that the metadata from the bytestream is merged with that from the meta parameter
         assert output["documents"][0].meta["author"] == "test_author"


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/6392

### Proposed Changes:
Adds support for single metadata dictionary input in `AzureOCRDocumentConverter`. In this way, additional metadata can be added to all files processed by this component even when the length of the list of sources is unknown.

### How did you test it?

Added tests and run locally.

### Notes for the reviewer

See the linked issue and [this discussion](https://deepset-ai.slack.com/archives/C04F0D0FYKV/p1703077204120649) for context.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
