### PR TITLE
refactor!: rename all remaining `metadata` to `meta`

### DIFF
--- a/examples/retrievers/in_memory_bm25_rag.py
+++ b/examples/retrievers/in_memory_bm25_rag.py
@@ -28,7 +28,7 @@ rag_pipeline.add_component(instance=AnswerBuilder(), name="answer_builder")
 rag_pipeline.connect("retriever", "prompt_builder.documents")
 rag_pipeline.connect("prompt_builder", "llm")
 rag_pipeline.connect("llm.replies", "answer_builder.replies")
-rag_pipeline.connect("llm.metadata", "answer_builder.metadata")
+rag_pipeline.connect("llm.meta", "answer_builder.meta")
 rag_pipeline.connect("retriever", "answer_builder.documents")
 
 # Draw the pipeline

--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -49,7 +49,7 @@ class DynamicChatPromptBuilder:
 
     >> {'llm': {'replies': [ChatMessage(content="Berlin is the capital city of Germany and one of the most vibrant
     and diverse cities in Europe. Here are some key things to know...Enjoy your time exploring the vibrant and dynamic
-    capital of Germany!", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, metadata={'model': 'gpt-3.5-turbo-0613',
+    capital of Germany!", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'gpt-3.5-turbo-0613',
     'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 27, 'completion_tokens': 681, 'total_tokens':
     708}})]}}
 
@@ -63,7 +63,7 @@ class DynamicChatPromptBuilder:
     print(res)
     >> {'llm': {'replies': [ChatMessage(content="Here is the weather forecast for Berlin in the next 5
     days:\n\nDay 1: Mostly cloudy with a high of 22°C (72°F) and...so it's always a good idea to check for updates
-    closer to your visit.", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, metadata={'model': 'gpt-3.5-turbo-0613',
+    closer to your visit.", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'gpt-3.5-turbo-0613',
     'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 37, 'completion_tokens': 201,
     'total_tokens': 238}})]}}
 

--- a/haystack/components/embedders/hugging_face_tei_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_tei_document_embedder.py
@@ -88,7 +88,7 @@ class HuggingFaceTEIDocumentEmbedder:
         suffix: str = "",
         batch_size: int = 32,
         progress_bar: bool = True,
-        metadata_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
     ):
         """
@@ -105,7 +105,7 @@ class HuggingFaceTEIDocumentEmbedder:
         :param batch_size: Number of Documents to encode at once.
         :param progress_bar: Whether to show a progress bar or not. Can be helpful to disable in production deployments
                              to keep the logs clean.
-        :param metadata_fields_to_embed: List of meta fields that should be embedded along with the Document text.
+        :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document text.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document text.
         """
         transformers_import.check()
@@ -129,7 +129,7 @@ class HuggingFaceTEIDocumentEmbedder:
         self.suffix = suffix
         self.batch_size = batch_size
         self.progress_bar = progress_bar
-        self.metadata_fields_to_embed = metadata_fields_to_embed or []
+        self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
     def to_dict(self) -> Dict[str, Any]:
@@ -145,7 +145,7 @@ class HuggingFaceTEIDocumentEmbedder:
             suffix=self.suffix,
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
-            metadata_fields_to_embed=self.metadata_fields_to_embed,
+            meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
 
@@ -163,9 +163,7 @@ class HuggingFaceTEIDocumentEmbedder:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.meta[key])
-                for key in self.metadata_fields_to_embed
-                if key in doc.meta and doc.meta[key] is not None
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key] is not None
             ]
 
             text_to_embed = (

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -21,8 +21,8 @@ class OpenAITextEmbedder:
     print(text_embedder.run(text_to_embed))
 
     # {'embedding': [0.017020374536514282, -0.023255806416273117, ...],
-    # 'metadata': {'model': 'text-embedding-ada-002-v2',
-    #              'usage': {'prompt_tokens': 4, 'total_tokens': 4}}}
+    # 'meta': {'model': 'text-embedding-ada-002-v2',
+    #          'usage': {'prompt_tokens': 4, 'total_tokens': 4}}}
     ```
     """
 
@@ -71,7 +71,7 @@ class OpenAITextEmbedder:
             self, model_name=self.model_name, organization=self.organization, prefix=self.prefix, suffix=self.suffix
         )
 
-    @component.output_types(embedding=List[float], metadata=Dict[str, Any])
+    @component.output_types(embedding=List[float], meta=Dict[str, Any])
     def run(self, text: str):
         """Embed a string."""
         if not isinstance(text, str):
@@ -87,6 +87,6 @@ class OpenAITextEmbedder:
         text_to_embed = text_to_embed.replace("\n", " ")
 
         response = self.client.embeddings.create(model=self.model_name, input=text_to_embed)
-        metadata = {"model": response.model, "usage": dict(response.usage)}
+        meta = {"model": response.model, "usage": dict(response.usage)}
 
-        return {"embedding": response.data[0].embedding, "metadata": metadata}
+        return {"embedding": response.data[0].embedding, "meta": meta}

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -37,7 +37,7 @@ class SentenceTransformersDocumentEmbedder:
         batch_size: int = 32,
         progress_bar: bool = True,
         normalize_embeddings: bool = False,
-        metadata_fields_to_embed: Optional[List[str]] = None,
+        meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
     ):
         """
@@ -57,7 +57,7 @@ class SentenceTransformersDocumentEmbedder:
         :param batch_size: Number of strings to encode at once.
         :param progress_bar: If true, displays progress bar during embedding.
         :param normalize_embeddings: If set to true, returned vectors will have length 1.
-        :param metadata_fields_to_embed: List of meta fields that should be embedded along with the Document content.
+        :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         """
 
@@ -70,7 +70,7 @@ class SentenceTransformersDocumentEmbedder:
         self.batch_size = batch_size
         self.progress_bar = progress_bar
         self.normalize_embeddings = normalize_embeddings
-        self.metadata_fields_to_embed = metadata_fields_to_embed or []
+        self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
@@ -93,7 +93,7 @@ class SentenceTransformersDocumentEmbedder:
             batch_size=self.batch_size,
             progress_bar=self.progress_bar,
             normalize_embeddings=self.normalize_embeddings,
-            metadata_fields_to_embed=self.metadata_fields_to_embed,
+            meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
         )
 
@@ -125,7 +125,7 @@ class SentenceTransformersDocumentEmbedder:
         texts_to_embed = []
         for doc in documents:
             meta_values_to_embed = [
-                str(doc.meta[key]) for key in self.metadata_fields_to_embed if key in doc.meta and doc.meta[key]
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
             ]
             text_to_embed = (
                 self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -18,11 +18,11 @@ class MetaFieldRanker:
     from haystack import Document
     from haystack.components.rankers import MetaFieldRanker
 
-    ranker = MetaFieldRanker(metadata_field="rating")
+    ranker = MetaFieldRanker(meta_field="rating")
     docs = [
-        Document(text="Paris", metadata={"rating": 1.3}),
-        Document(text="Berlin", metadata={"rating": 0.7}),
-        Document(text="Barcelona", metadata={"rating": 2.1}),
+        Document(text="Paris", meta={"rating": 1.3}),
+        Document(text="Berlin", meta={"rating": 0.7}),
+        Document(text="Barcelona", meta={"rating": 2.1}),
     ]
 
     output = ranker.run(documents=docs)
@@ -32,7 +32,7 @@ class MetaFieldRanker:
 
     def __init__(
         self,
-        metadata_field: str,
+        meta_field: str,
         weight: float = 1.0,
         top_k: Optional[int] = None,
         ranking_mode: Literal["reciprocal_rank_fusion", "linear_score"] = "reciprocal_rank_fusion",
@@ -40,7 +40,7 @@ class MetaFieldRanker:
         """
         Creates an instance of MetaFieldRanker.
 
-        :param metadata_field: The name of the metadata field to rank by.
+        :param meta_field: The name of the metadata field to rank by.
         :param weight: In range [0,1].
                 0 disables ranking by a metadata field.
                 0.5 content and metadata fields have the same impact for the ranking.
@@ -51,7 +51,7 @@ class MetaFieldRanker:
                 Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
         """
 
-        self.metadata_field = metadata_field
+        self.meta_field = meta_field
         self.weight = weight
         self.top_k = top_k
         self.ranking_mode = ranking_mode
@@ -82,11 +82,7 @@ class MetaFieldRanker:
         Serialize object to a dictionary.
         """
         return default_to_dict(
-            self,
-            metadata_field=self.metadata_field,
-            weight=self.weight,
-            top_k=self.top_k,
-            ranking_mode=self.ranking_mode,
+            self, meta_field=self.meta_field, weight=self.weight, top_k=self.top_k, ranking_mode=self.ranking_mode
         )
 
     @component.output_types(documents=List[Document])
@@ -109,15 +105,15 @@ class MetaFieldRanker:
             raise ValueError(f"top_k must be > 0, but got {top_k}")
 
         try:
-            sorted_by_metadata = sorted(documents, key=lambda doc: doc.meta[self.metadata_field], reverse=True)
+            sorted_by_metadata = sorted(documents, key=lambda doc: doc.meta[self.meta_field], reverse=True)
         except KeyError:
             raise ComponentError(
                 """
-                The parameter <metadata_field> is currently set to '{}' but the Documents {} don't have this metadata key.\n
+                The parameter <meta_field> is currently set to '{}' but the Documents {} don't have this metadata key.\n
                 Double-check the names of the metadata fields in your documents \n
-                and set <metadata_field> to the name of the field that contains the metadata you want to use for ranking.
+                and set <meta_field> to the name of the field that contains the metadata you want to use for ranking.
                 """.format(
-                    self.metadata_field, ",".join([doc.id for doc in documents if self.metadata_field not in doc.meta])
+                    self.meta_field, ",".join([doc.id for doc in documents if self.meta_field not in doc.meta])
                 )
             )
 

--- a/haystack/pipeline_utils/indexing.py
+++ b/haystack/pipeline_utils/indexing.py
@@ -29,7 +29,7 @@ def download_files(sources: List[str]) -> List[str]:
 
     all_files = []
     for stream in streams["streams"]:
-        file_suffix = ".html" if stream.metadata["content_type"] == "text/html" else ".pdf"
+        file_suffix = ".html" if stream.meta["content_type"] == "text/html" else ".pdf"
         f = NamedTemporaryFile(delete=False, suffix=file_suffix)
         stream.to_file(Path(f.name))
         all_files.append(f.name)

--- a/releasenotes/notes/change-metadata-to-meta-0fada93f04628c79.yaml
+++ b/releasenotes/notes/change-metadata-to-meta-0fada93f04628c79.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Rename `metadata` to `meta`.
+    Rename `metadata_fields_to_embed` to `meta_fields_to_embed` in all Embedders.
+    Rename `metadata_field` to `meta_field` in `MetaFieldRanker`.

--- a/test/components/embedders/test_hugging_face_tei_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_tei_document_embedder.py
@@ -34,7 +34,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
         assert embedder.suffix == ""
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
-        assert embedder.metadata_fields_to_embed == []
+        assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
     def test_init_with_parameters(self, mock_check_valid_model):
@@ -46,7 +46,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
             suffix="suffix",
             batch_size=64,
             progress_bar=False,
-            metadata_fields_to_embed=["test_field"],
+            meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
 
@@ -57,7 +57,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
         assert embedder.suffix == "suffix"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
-        assert embedder.metadata_fields_to_embed == ["test_field"]
+        assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
     def test_initialize_with_invalid_url(self, mock_check_valid_model):
@@ -83,7 +83,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
                 "suffix": "",
                 "batch_size": 32,
                 "progress_bar": True,
-                "metadata_fields_to_embed": [],
+                "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
             },
         }
@@ -97,7 +97,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
             suffix="suffix",
             batch_size=64,
             progress_bar=False,
-            metadata_fields_to_embed=["test_field"],
+            meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
 
@@ -112,7 +112,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
                 "suffix": "suffix",
                 "batch_size": 64,
                 "progress_bar": False,
-                "metadata_fields_to_embed": ["test_field"],
+                "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
             },
         }
@@ -126,7 +126,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
             model="sentence-transformers/all-mpnet-base-v2",
             url="https://some_embedding_model.com",
             token="fake-api-token",
-            metadata_fields_to_embed=["meta_field"],
+            meta_fields_to_embed=["meta_field"],
             embedding_separator=" | ",
         )
 
@@ -195,7 +195,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
                 token="fake-api-token",
                 prefix="prefix ",
                 suffix=" suffix",
-                metadata_fields_to_embed=["topic"],
+                meta_fields_to_embed=["topic"],
                 embedding_separator=" | ",
             )
 
@@ -231,7 +231,7 @@ class TestHuggingFaceTEIDocumentEmbedder:
                 token="fake-api-token",
                 prefix="prefix ",
                 suffix=" suffix",
-                metadata_fields_to_embed=["topic"],
+                meta_fields_to_embed=["topic"],
                 embedding_separator=" | ",
                 batch_size=1,
             )

--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -31,7 +31,7 @@ class TestOpenAIDocumentEmbedder:
         assert embedder.suffix == ""
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
-        assert embedder.metadata_fields_to_embed == []
+        assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
     def test_init_with_parameters(self):
@@ -43,7 +43,7 @@ class TestOpenAIDocumentEmbedder:
             suffix="suffix",
             batch_size=64,
             progress_bar=False,
-            metadata_fields_to_embed=["test_field"],
+            meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
         assert embedder.organization == "my-org"
@@ -52,7 +52,7 @@ class TestOpenAIDocumentEmbedder:
         assert embedder.suffix == "suffix"
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
-        assert embedder.metadata_fields_to_embed == ["test_field"]
+        assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
     def test_init_fail_wo_api_key(self, monkeypatch):
@@ -73,7 +73,7 @@ class TestOpenAIDocumentEmbedder:
                 "suffix": "",
                 "batch_size": 32,
                 "progress_bar": True,
-                "metadata_fields_to_embed": [],
+                "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
             },
         }
@@ -87,7 +87,7 @@ class TestOpenAIDocumentEmbedder:
             suffix="suffix",
             batch_size=64,
             progress_bar=False,
-            metadata_fields_to_embed=["test_field"],
+            meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
         data = component.to_dict()
@@ -101,7 +101,7 @@ class TestOpenAIDocumentEmbedder:
                 "suffix": "suffix",
                 "batch_size": 64,
                 "progress_bar": False,
-                "metadata_fields_to_embed": ["test_field"],
+                "meta_fields_to_embed": ["test_field"],
                 "embedding_separator": " | ",
             },
         }
@@ -112,7 +112,7 @@ class TestOpenAIDocumentEmbedder:
         ]
 
         embedder = OpenAIDocumentEmbedder(
-            api_key="fake-api-key", metadata_fields_to_embed=["meta_field"], embedding_separator=" | "
+            api_key="fake-api-key", meta_fields_to_embed=["meta_field"], embedding_separator=" | "
         )
 
         prepared_texts = embedder._prepare_texts_to_embed(documents)
@@ -172,13 +172,11 @@ class TestOpenAIDocumentEmbedder:
 
         model = "text-similarity-ada-001"
 
-        embedder = OpenAIDocumentEmbedder(
-            model_name=model, metadata_fields_to_embed=["topic"], embedding_separator=" | "
-        )
+        embedder = OpenAIDocumentEmbedder(model_name=model, meta_fields_to_embed=["topic"], embedding_separator=" | ")
 
         result = embedder.run(documents=docs)
         documents_with_embeddings = result["documents"]
-        metadata = result["metadata"]
+        metadata = result["meta"]
 
         assert isinstance(documents_with_embeddings, list)
         assert len(documents_with_embeddings) == len(docs)

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -83,7 +83,4 @@ class TestOpenAITextEmbedder:
 
         assert len(result["embedding"]) == 1024
         assert all(isinstance(x, float) for x in result["embedding"])
-        assert result["metadata"] == {
-            "model": "text-similarity-ada:001",
-            "usage": {"prompt_tokens": 6, "total_tokens": 6},
-        }
+        assert result["meta"] == {"model": "text-similarity-ada:001", "usage": {"prompt_tokens": 6, "total_tokens": 6}}

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -17,7 +17,7 @@ class TestSentenceTransformersDocumentEmbedder:
         assert embedder.batch_size == 32
         assert embedder.progress_bar is True
         assert embedder.normalize_embeddings is False
-        assert embedder.metadata_fields_to_embed == []
+        assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
     def test_init_with_parameters(self):
@@ -30,7 +30,7 @@ class TestSentenceTransformersDocumentEmbedder:
             batch_size=64,
             progress_bar=False,
             normalize_embeddings=True,
-            metadata_fields_to_embed=["test_field"],
+            meta_fields_to_embed=["test_field"],
             embedding_separator=" | ",
         )
         assert embedder.model_name_or_path == "model"
@@ -41,7 +41,7 @@ class TestSentenceTransformersDocumentEmbedder:
         assert embedder.batch_size == 64
         assert embedder.progress_bar is False
         assert embedder.normalize_embeddings is True
-        assert embedder.metadata_fields_to_embed == ["test_field"]
+        assert embedder.meta_fields_to_embed == ["test_field"]
         assert embedder.embedding_separator == " | "
 
     def test_to_dict(self):
@@ -59,7 +59,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "progress_bar": True,
                 "normalize_embeddings": False,
                 "embedding_separator": "\n",
-                "metadata_fields_to_embed": [],
+                "meta_fields_to_embed": [],
             },
         }
 
@@ -73,7 +73,7 @@ class TestSentenceTransformersDocumentEmbedder:
             batch_size=64,
             progress_bar=False,
             normalize_embeddings=True,
-            metadata_fields_to_embed=["meta_field"],
+            meta_fields_to_embed=["meta_field"],
             embedding_separator=" - ",
         )
         data = component.to_dict()
@@ -90,7 +90,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "progress_bar": False,
                 "normalize_embeddings": True,
                 "embedding_separator": " - ",
-                "metadata_fields_to_embed": ["meta_field"],
+                "meta_fields_to_embed": ["meta_field"],
             },
         }
 
@@ -149,7 +149,7 @@ class TestSentenceTransformersDocumentEmbedder:
 
     def test_embed_metadata(self):
         embedder = SentenceTransformersDocumentEmbedder(
-            model_name_or_path="model", metadata_fields_to_embed=["meta_field"], embedding_separator="\n"
+            model_name_or_path="model", meta_fields_to_embed=["meta_field"], embedding_separator="\n"
         )
         embedder.embedding_backend = MagicMock()
 
@@ -175,7 +175,7 @@ class TestSentenceTransformersDocumentEmbedder:
             model_name_or_path="model",
             prefix="my_prefix ",
             suffix=" my_suffix",
-            metadata_fields_to_embed=["meta_field"],
+            meta_fields_to_embed=["meta_field"],
             embedding_separator="\n",
         )
         embedder.embedding_backend = MagicMock()

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -6,12 +6,12 @@ from haystack.components.rankers.meta_field import MetaFieldRanker
 
 class TestMetaFieldRanker:
     def test_to_dict(self):
-        component = MetaFieldRanker(metadata_field="rating")
+        component = MetaFieldRanker(meta_field="rating")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.rankers.meta_field.MetaFieldRanker",
             "init_parameters": {
-                "metadata_field": "rating",
+                "meta_field": "rating",
                 "weight": 1.0,
                 "top_k": None,
                 "ranking_mode": "reciprocal_rank_fusion",
@@ -19,11 +19,11 @@ class TestMetaFieldRanker:
         }
 
     def test_to_dict_with_custom_init_parameters(self):
-        component = MetaFieldRanker(metadata_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score")
+        component = MetaFieldRanker(meta_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.rankers.meta_field.MetaFieldRanker",
-            "init_parameters": {"metadata_field": "rating", "weight": 0.5, "top_k": 5, "ranking_mode": "linear_score"},
+            "init_parameters": {"meta_field": "rating", "weight": 0.5, "top_k": 5, "ranking_mode": "linear_score"},
         }
 
     @pytest.mark.integration
@@ -32,7 +32,7 @@ class TestMetaFieldRanker:
         """
         Test if the component ranks documents correctly.
         """
-        ranker = MetaFieldRanker(metadata_field="rating")
+        ranker = MetaFieldRanker(meta_field="rating")
         docs_before = [Document(content="abc", meta={"rating": value}) for value in metafield_values]
 
         output = ranker.run(documents=docs_before)
@@ -46,14 +46,14 @@ class TestMetaFieldRanker:
 
     @pytest.mark.integration
     def test_returns_empty_list_if_no_documents_are_provided(self):
-        ranker = MetaFieldRanker(metadata_field="rating")
+        ranker = MetaFieldRanker(meta_field="rating")
         output = ranker.run(documents=[])
         docs_after = output["documents"]
         assert docs_after == []
 
     @pytest.mark.integration
     def test_raises_component_error_if_metadata_not_found(self):
-        ranker = MetaFieldRanker(metadata_field="rating")
+        ranker = MetaFieldRanker(meta_field="rating")
         docs_before = [Document(content="abc", meta={"wrong_field": 1.3})]
         with pytest.raises(ComponentError):
             ranker.run(documents=docs_before)
@@ -61,17 +61,17 @@ class TestMetaFieldRanker:
     @pytest.mark.integration
     def test_raises_component_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
-            MetaFieldRanker(metadata_field="rating", ranking_mode="wrong_mode")
+            MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")
 
     @pytest.mark.integration
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
     def test_raises_component_error_if_wrong_weight(self, score):
         with pytest.raises(ValueError):
-            MetaFieldRanker(metadata_field="rating", weight=score)
+            MetaFieldRanker(meta_field="rating", weight=score)
 
     @pytest.mark.integration
     def test_linear_score(self):
-        ranker = MetaFieldRanker(metadata_field="rating", ranking_mode="linear_score", weight=0.5)
+        ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
         docs_before = [
             Document(content="abc", meta={"rating": 1.3}, score=0.3),
             Document(content="abc", meta={"rating": 0.7}, score=0.4),
@@ -83,7 +83,7 @@ class TestMetaFieldRanker:
 
     @pytest.mark.integration
     def test_reciprocal_rank_fusion(self):
-        ranker = MetaFieldRanker(metadata_field="rating", ranking_mode="reciprocal_rank_fusion", weight=0.5)
+        ranker = MetaFieldRanker(meta_field="rating", ranking_mode="reciprocal_rank_fusion", weight=0.5)
         docs_before = [
             Document(content="abc", meta={"rating": 1.3}, score=0.3),
             Document(content="abc", meta={"rating": 0.7}, score=0.4),
@@ -96,7 +96,7 @@ class TestMetaFieldRanker:
     @pytest.mark.integration
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
     def test_linear_score_raises_warning_if_doc_wrong_score(self, score):
-        ranker = MetaFieldRanker(metadata_field="rating", ranking_mode="linear_score", weight=0.5)
+        ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
         docs_before = [
             Document(id=1, content="abc", meta={"rating": 1.3}, score=score),
             Document(id=2, content="abc", meta={"rating": 0.7}, score=0.4),
@@ -109,7 +109,7 @@ class TestMetaFieldRanker:
 
     @pytest.mark.integration
     def test_linear_score_raises_raises_warning_if_doc_without_score(self):
-        ranker = MetaFieldRanker(metadata_field="rating", ranking_mode="linear_score", weight=0.5)
+        ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
         docs_before = [
             Document(content="abc", meta={"rating": 1.3}),
             Document(content="abc", meta={"rating": 0.7}),

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -124,7 +124,7 @@ class TestRouter:
     def test_complex_condition(self):
         routes = [
             {
-                "condition": "{{messages[-1].metadata.finish_reason == 'function_call'}}",
+                "condition": "{{messages[-1].meta.finish_reason == 'function_call'}}",
                 "output": "{{streams}}",
                 "output_type": List[int],
                 "output_name": "streams",
@@ -138,7 +138,7 @@ class TestRouter:
         ]
         router = ConditionalRouter(routes)
         message = mock.MagicMock()
-        message.metadata.finish_reason = "function_call"
+        message.meta.finish_reason = "function_call"
         result = router.run(messages=[message], streams=[1, 2, 3], query="my query")
         assert result == {"streams": [1, 2, 3]}
 


### PR DESCRIPTION
### Related Issues
- part of #6570
- continues the work done in #6605 and #6612


### Proposed Changes:

- change `metadata` to `meta`
- (in some cases, I may gone a little too far with the renaming, but probably it's not a problem)

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
