### PR TITLE
ci: skip Tika tests in macOS integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch: # Activate this workflow manually
   push:
     branches:
-      - rm-tika-tests-macos
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch: # Activate this workflow manually
   push:
     branches:
+      - rm-tika-tests-macos
       - main
       # release branches have the form v1.9.x
       - "v[0-9].*[0-9].x"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,8 +238,6 @@ jobs:
       - name: Install dependencies
         run: |
           brew install ffmpeg  # for local Whisper tests
-          brew install docker
-          colima start
 
       - name: Restore Python dependencies
         uses: actions/cache/restore@v3
@@ -247,18 +245,8 @@ jobs:
           path: ${{ env.pythonLocation }}
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-      - name: Run Tika
-        run: |
-          docker run -d -p 9998:9998 \
-          --health-cmd='curl --fail -X GET http://localhost:9998/tika' \
-          --health-interval=5s \
-          --health-retries=5 \
-          --health-timeout=2s \
-          --health-start-period=1m \
-          apache/tika:2.9.0.0
-
       - name: Run
-        run: pytest --maxfail=5 -m "integration" test
+        run: pytest --maxfail=5 -m "integration" test -k 'not tika'
 
       - name: Calculate alert data
         id: calculator


### PR DESCRIPTION
### Related Issues
- despite my try (#6619), Tika tests on macOS keep failing: https://github.com/deepset-ai/haystack/actions/runs/7338857067/job/19982190045
- macOS integration tests are significantly slower compared to other platforms. This also happens because we install Docker, which is only needed for Tika tests

### Proposed Changes:
- skip Tika tests on macOS, as we already do for Windows

### How did you test it?
I temporarily added this branch to those to be tested in the CI, so we can see if everything is OK.
Once the tests pass, I will remove this branch from the list.

**Update**:
- the tests ran correctly and significantly faster than before (7m instead of 10m): https://github.com/deepset-ai/haystack/actions/runs/7346846952/job/20002436166?pr=6654
- (I removed this branch from those to be tested)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
