### PR TITLE
build: pin openai>=1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "tqdm",
   "tenacity",
   "lazy-imports",
-  "openai",
+  "openai>=1.1.0",
   "Jinja2",
   "posthog",  # telemetry
   "pyyaml",


### PR DESCRIPTION
### Related Issues

- Haystack is now compatible with the OpenAI client (openai package) >1 (#6584)
- Haystack does not work with openai<1
- the first stable release of openai>1 is 1.1.0 (1.0.0 was buggy)

### Proposed Changes:

- pin openai>=1.1.0
- this prevents people who already have openai<1 installed from running `pip install haystack-ai` and getting incompatibility bugs

### How did you test it?

Local test with openai==1.1.0

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
