### PR TITLE
chore: bump transformers version to 4.36.2 with vulnerability fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "requests",
   "httpx",
   "pydantic<2",
-  "transformers==4.35.2",
+  "transformers==4.36.2",
   "pandas",
   "rank_bm25",
   "scikit-learn>=1.3.0", # TF-IDF and metrics
@@ -86,7 +86,7 @@ dependencies = [
 
 [project.optional-dependencies]
 inference = [
-  "transformers[torch,sentencepiece]==4.35.2",
+  "transformers[torch,sentencepiece]==4.36.2",
   "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
   "huggingface-hub>=0.5.0",
 ]


### PR DESCRIPTION

### Related Issues

No issue.

### Proposed Changes:
The transformers dependency has a critical vulnerability that is fix from 4.36.0 onwards. https://github.com/advisories/GHSA-v68g-wm8c-6x7j

### How did you test it?

Not tested.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
