### PR TITLE
Update prompt builders examples

### DIFF
--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -26,13 +26,13 @@ class DynamicChatPromptBuilder:
 
     ```python
     from haystack.components.builders import DynamicChatPromptBuilder
-    from haystack.components.generators.chat import GPTChatGenerator
+    from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.dataclasses import ChatMessage
     from haystack import Pipeline
 
     # no parameter init, we don't use any runtime template variables
     prompt_builder = DynamicChatPromptBuilder()
-    llm = GPTChatGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
+    llm = OpenAIChatGenerator(api_key="<your-api-key>", model_name="gpt-3.5-turbo")
 
     pipe = Pipeline()
     pipe.add_component("prompt_builder", prompt_builder)
@@ -75,10 +75,9 @@ class DynamicChatPromptBuilder:
 
     In the example above, the first query asks for general information about Berlin, and the second query requests
     the weather forecast for Berlin in the next few days. DynamicChatPromptBuilder efficiently handles these distinct
-    prompt structures by adjusting pipeline run parameters invocations, as opposed to a
-    regular PromptBuilder, which would require recreating or reloading the pipeline for each distinct type of query,
-    leading to inefficiency and potential service disruptions, especially in server environments where continuous
-    service is vital.
+    prompt structures by adjusting pipeline run parameters invocations, as opposed to a regular PromptBuilder, which
+    would require recreating or reloading the pipeline for each distinct type of query, leading to inefficiency and
+    potential service disruptions, especially in server environments where continuous service is vital.
 
     Note that the weather forecast in the example above is fictional, but it can be easily connected to a weather
     API to provide real weather forecasts.

--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -66,7 +66,6 @@ class DynamicChatPromptBuilder:
     closer to your visit.", role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'gpt-3.5-turbo-0613',
     'index': 0, 'finish_reason': 'stop', 'usage': {'prompt_tokens': 37, 'completion_tokens': 201,
     'total_tokens': 238}})]}}
-
     ```
 
     The primary advantage of using DynamicChatPromptBuilder is showcased in the examples provided above.


### PR DESCRIPTION
### Why:
This pull request updates the dynamic prompt builders examples, making them more user-friendly and comprehensive. The example switched from GPTChatGenerator to OpenAIChatGenerator to showcase the use of the OpenAI API for text generation. It also integrates the functionality of the new DynamicPromptBuilder class, demonstrating how to use runtime variables and connect them to the DocumentProducer component in the Haystack pipeline.

### What:

- Updated the examples in the `haystack/components/builders/dynamic_chat_prompt_builder.py` and `haystack/components/builders/dynamic_prompt_builder.py` files to use the OpenAI API instead of the GPT API.
- Added a new test, `test_example_in_pipeline`, in the `test/components/builders/test_dynamic_prompt_builder.py` file to demonstrate the usage of runtime variables, the DocumentProducer component, and the DynamicPromptBuilder in a Haystack pipeline.
- Modified the existing tests to reflect the updated code and structure.

### How can it be used:
Developers can use the updated examples as a starting point when implementing their own Haystack-based projects. The code demonstrates how to set up a Haystack pipeline using the DynamicPromptBuilder and RuntimeVariables, as well as how to generate prompts using the OpenAI API.

### How did you test it:
The updated tests cover the new functionality added in this pull request, ensuring that the code works as expected.

### Notes for the reviewer:
This pull request provides updated examples and tests for the DynamicPromptBuilder, making it easier for developers to integrate the OpenAI API into their Haystack-based projects.</s>
