### PR TITLE
feat: Add scaling and thresholding of the similarity ranker scores

### DIFF
--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -180,4 +180,8 @@ class TransformersSimilarityRanker:
             i = sorted_index
             documents[i].score = similarity_scores[i]
             ranked_docs.append(documents[i])
+
+        if self.score_threshold is not None:
+            ranked_docs = [doc for doc in ranked_docs if doc.score >= self.score_threshold]
+
         return {"documents": ranked_docs[:top_k]}

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -77,14 +77,29 @@ class TestSimilarityRanker:
 
     @pytest.mark.integration
     @pytest.mark.parametrize(
-        "query,docs_before_texts,expected_first_text",
+        "query,docs_before_texts,expected_first_text,scores",
         [
-            ("City in Bosnia and Herzegovina", ["Berlin", "Belgrade", "Sarajevo"], "Sarajevo"),
-            ("Machine learning", ["Python", "Bakery in Paris", "Tesla Giga Berlin"], "Python"),
-            ("Cubist movement", ["Nirvana", "Pablo Picasso", "Coffee"], "Pablo Picasso"),
+            (
+                "City in Bosnia and Herzegovina",
+                ["Berlin", "Belgrade", "Sarajevo"],
+                "Sarajevo",
+                [2.2864143829792738e-05, 0.00012495707778725773, 0.009869757108390331],
+            ),
+            (
+                "Machine learning",
+                ["Python", "Bakery in Paris", "Tesla Giga Berlin"],
+                "Python",
+                [1.9063229046878405e-05, 1.434577916370472e-05, 1.3049247172602918e-05],
+            ),
+            (
+                "Cubist movement",
+                ["Nirvana", "Pablo Picasso", "Coffee"],
+                "Pablo Picasso",
+                [1.3313065210240893e-05, 9.90335684036836e-05, 1.3518535524781328e-05],
+            ),
         ],
     )
-    def test_run(self, query, docs_before_texts, expected_first_text):
+    def test_run(self, query, docs_before_texts, expected_first_text, scores):
         """
         Test if the component ranks documents correctly.
         """
@@ -97,7 +112,7 @@ class TestSimilarityRanker:
         assert len(docs_after) == 3
         assert docs_after[0].content == expected_first_text
 
-        sorted_scores = sorted([doc.score for doc in docs_after], reverse=True)
+        sorted_scores = sorted(scores, reverse=True)
         assert [doc.score for doc in docs_after] == sorted_scores
 
     #  Returns an empty list if no documents are provided

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -19,6 +19,7 @@ class TestSimilarityRanker:
                 "model_name_or_path": "cross-encoder/ms-marco-MiniLM-L-6-v2",
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
+                "scale_score": True,
                 "model_kwargs": {},
             },
         }
@@ -29,6 +30,7 @@ class TestSimilarityRanker:
             device="cuda",
             token="my_token",
             top_k=5,
+            scale_score=False,
             model_kwargs={"torch_dtype": "auto"},
         )
         data = component.to_dict()
@@ -41,6 +43,7 @@ class TestSimilarityRanker:
                 "top_k": 5,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
+                "scale_score": False,
                 "model_kwargs": {"torch_dtype": "auto"},
             },
         }
@@ -53,6 +56,7 @@ class TestSimilarityRanker:
         )
         embedder.model = MagicMock()
         embedder.tokenizer = MagicMock()
+        embedder.scale_score_function = MagicMock()
 
         documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -20,6 +20,8 @@ class TestSimilarityRanker:
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
                 "scale_score": True,
+                "calibration_factor": 1.0,
+                "score_threshold": None,
                 "model_kwargs": {},
             },
         }
@@ -31,6 +33,8 @@ class TestSimilarityRanker:
             token="my_token",
             top_k=5,
             scale_score=False,
+            calibration_factor=None,
+            score_threshold=0.01,
             model_kwargs={"torch_dtype": "auto"},
         )
         data = component.to_dict()
@@ -44,19 +48,22 @@ class TestSimilarityRanker:
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
                 "scale_score": False,
+                "calibration_factor": None,
+                "score_threshold": 0.01,
                 "model_kwargs": {"torch_dtype": "auto"},
             },
         }
 
+    @patch("torch.sigmoid")
     @patch("torch.sort")
-    def test_embed_meta(self, mocked_sort):
+    def test_embed_meta(self, mocked_sort, mocked_sigmoid):
         mocked_sort.return_value = (None, torch.tensor([0]))
+        mocked_sigmoid.return_value = torch.tensor([0])
         embedder = TransformersSimilarityRanker(
             model_name_or_path="model", meta_fields_to_embed=["meta_field"], embedding_separator="\n"
         )
         embedder.model = MagicMock()
         embedder.tokenizer = MagicMock()
-        embedder.scale_score_function = MagicMock()
 
         documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -113,7 +113,9 @@ class TestSimilarityRanker:
         assert docs_after[0].content == expected_first_text
 
         sorted_scores = sorted(scores, reverse=True)
-        assert [doc.score for doc in docs_after] == sorted_scores
+        assert docs_after[0].score == pytest.approx(sorted_scores[0])
+        assert docs_after[1].score == pytest.approx(sorted_scores[1])
+        assert docs_after[2].score == pytest.approx(sorted_scores[2])
 
     #  Returns an empty list if no documents are provided
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Add the new init parameters:
  - `scale_score`: allows users to toggle if they would like their document scores to be raw logits or scaled between 0 and 1 (using the sigmoid function). This is a feature that already existed in Haystack v1 that is being moved over. 
  - `calibration_factor`: This follows the example from the `ExtractiveReader` which allows the user to better control the spread of scores when scaling the score using sigmoid. 
  - `score_threshold`: Also copied from the `ExtractiveReader`. This optionally allows users to set a score threshold where only documents with a score above this threshold are returned. 

### How did you test it?
- Updated existing tests
- [ ] Add new tests for `calibration_factor` and `score_threshold`

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
