### PR TITLE
test: Skip integration tests if env var is missing

### DIFF
--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 
 import numpy as np
@@ -163,6 +164,7 @@ class TestOpenAIDocumentEmbedder:
         assert result["documents"] is not None
         assert not result["documents"]  # empty list
 
+    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_run(self):
         docs = [

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from openai import OpenAIError
 
@@ -74,6 +76,7 @@ class TestOpenAITextEmbedder:
         with pytest.raises(TypeError, match="OpenAITextEmbedder expects a string as an input"):
             embedder.run(text=list_integers_input)
 
+    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_run(self):
         model = "text-similarity-ada-001"

--- a/test/pipelines/test_indexing_pipeline.py
+++ b/test/pipelines/test_indexing_pipeline.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from haystack.pipeline_utils.indexing import build_indexing_pipeline
@@ -65,6 +67,7 @@ class TestIndexingPipeline:
         with pytest.raises(ValueError, match="Could not find an embedder"):
             build_indexing_pipeline(document_store=document_store, embedding_model="invalid_model")
 
+    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_open_ai_embedding_model(self):
         document_store = InMemoryDocumentStore()

--- a/test/pipelines/test_rag_pipelines.py
+++ b/test/pipelines/test_rag_pipelines.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from haystack.dataclasses import Answer
@@ -6,6 +8,7 @@ from haystack.pipeline_utils.rag import build_rag_pipeline
 from haystack.testing.factory import document_store_class
 
 
+@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
 @pytest.mark.integration
 def test_rag_pipeline(mock_chat_completion):
     rag_pipe = build_rag_pipeline(document_store=InMemoryDocumentStore())


### PR DESCRIPTION
### Proposed Changes:

Skip integration tests if `OPENAI_API_KEY` is not set.

PR opened by external contributors don't have access to CI secrets, so they're always going to fail.

This change will prevent those failures.

Example of PR check failing 👇 
https://github.com/deepset-ai/haystack/actions/runs/7445097734/job/20253017272?pr=6680

### How did you test it?

Ran tests locally.

### Notes for the reviewer

Let's update #6680 after this is merged.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
