### PR TITLE
test: Fix skipif with empty env var

### DIFF
--- a/test/components/embedders/test_openai_document_embedder.py
+++ b/test/components/embedders/test_openai_document_embedder.py
@@ -164,7 +164,7 @@ class TestOpenAIDocumentEmbedder:
         assert result["documents"] is not None
         assert not result["documents"]  # empty list
 
-    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
+    @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_run(self):
         docs = [

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -76,7 +76,7 @@ class TestOpenAITextEmbedder:
         with pytest.raises(TypeError, match="OpenAITextEmbedder expects a string as an input"):
             embedder.run(text=list_integers_input)
 
-    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
+    @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_run(self):
         model = "text-similarity-ada-001"

--- a/test/pipelines/test_indexing_pipeline.py
+++ b/test/pipelines/test_indexing_pipeline.py
@@ -67,7 +67,7 @@ class TestIndexingPipeline:
         with pytest.raises(ValueError, match="Could not find an embedder"):
             build_indexing_pipeline(document_store=document_store, embedding_model="invalid_model")
 
-    @pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
+    @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
     @pytest.mark.integration
     def test_open_ai_embedding_model(self):
         document_store = InMemoryDocumentStore()

--- a/test/pipelines/test_rag_pipelines.py
+++ b/test/pipelines/test_rag_pipelines.py
@@ -8,7 +8,7 @@ from haystack.pipeline_utils.rag import build_rag_pipeline
 from haystack.testing.factory import document_store_class
 
 
-@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OPENAI_API_KEY is not set")
+@pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
 @pytest.mark.integration
 def test_rag_pipeline(mock_chat_completion):
     rag_pipe = build_rag_pipeline(document_store=InMemoryDocumentStore())


### PR DESCRIPTION
### Proposed Changes:

Fix `skipif` not skipping tests if `OPENAI_API_KEY` is set to an empty string.

### How did you test it?

Run tests locally after settings `OPENAI_API_KEY` to empty string.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
