### PR TITLE
feat: Tweak `CacheChecker` output type

### DIFF
--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 
 from haystack import component, Document, default_from_dict, default_to_dict, DeserializationError
+from haystack.utils.type_serialization import serialize_type, deserialize_type
 from haystack.document_stores import DocumentStore
 
 
@@ -31,7 +32,12 @@ class CacheChecker:
         """
         Serialize this component to a dictionary.
         """
-        return default_to_dict(self, document_store=self.document_store.to_dict(), cache_field=self.cache_field)
+        return default_to_dict(
+            self,
+            document_store=self.document_store.to_dict(),
+            cache_field=self.cache_field,
+            cache_field_type=serialize_type(self.cache_field_type),
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "CacheChecker":
@@ -57,6 +63,8 @@ class CacheChecker:
         docstore = docstore_class.from_dict(init_params["document_store"])
 
         data["init_parameters"]["document_store"] = docstore
+        data["init_parameters"]["cache_field_type"] = deserialize_type(data["init_parameters"]["cache_field_type"])
+
         return default_from_dict(cls, data)
 
     def run(self, items: List[Any]):

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -19,7 +19,7 @@ class CacheChecker:
     cache field.
     """
 
-    def __init__(self, document_store: DocumentStore, cache_field: str, cache_field_type: Type):
+    def __init__(self, document_store: DocumentStore, cache_field: str, cache_field_type: Type = Any):
         """
         Create a UrlCacheChecker component.
         """

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -1,10 +1,12 @@
 from typing import List, Dict, Any
 
-import logging
 import importlib
+
+import logging
 
 from haystack import component, Document, default_from_dict, default_to_dict, DeserializationError
 from haystack.document_stores import DocumentStore
+
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +53,6 @@ class CacheChecker:
 
         docstore_class = getattr(module, type_)
         docstore = docstore_class.from_dict(init_params["document_store"])
-
         data["init_parameters"]["document_store"] = docstore
 
         return default_from_dict(cls, data)

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -53,8 +53,8 @@ class CacheChecker:
 
         docstore_class = getattr(module, type_)
         docstore = docstore_class.from_dict(init_params["document_store"])
-        data["init_parameters"]["document_store"] = docstore
 
+        data["init_parameters"]["document_store"] = docstore
         return default_from_dict(cls, data)
 
     @component.output_types(hits=List[Document], misses=List)

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Type
 
 import importlib
 
@@ -18,12 +18,14 @@ class CacheChecker:
     cache field.
     """
 
-    def __init__(self, document_store: DocumentStore, cache_field: str):
+    def __init__(self, document_store: DocumentStore, cache_field: str, cache_field_type: Type):
         """
         Create a UrlCacheChecker component.
         """
         self.document_store = document_store
         self.cache_field = cache_field
+        self.cache_field_type = cache_field_type
+        component.set_output_types(self, hits=List[Document], misses=List[cache_field_type])
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -57,7 +59,6 @@ class CacheChecker:
         data["init_parameters"]["document_store"] = docstore
         return default_from_dict(cls, data)
 
-    @component.output_types(hits=List[Document], misses=List[Any])
     def run(self, items: List[Any]):
         """
         Checks if any document associated with the specified field is already present in the store. If matching documents

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -1,12 +1,17 @@
-from typing import List, Dict, Any, Type
+from typing import List, Dict, Any
 
+import sys
 import importlib
-
 import logging
 
 from haystack import component, Document, default_from_dict, default_to_dict, DeserializationError
 from haystack.utils.type_serialization import serialize_type, deserialize_type
 from haystack.document_stores import DocumentStore
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 
 logger = logging.getLogger(__name__)
@@ -19,7 +24,7 @@ class CacheChecker:
     cache field.
     """
 
-    def __init__(self, document_store: DocumentStore, cache_field: str, cache_field_type: Type = Any):
+    def __init__(self, document_store: DocumentStore, cache_field: str, cache_field_type: TypeAlias = Any):
         """
         Create a UrlCacheChecker component.
         """

--- a/releasenotes/notes/cache_checker_output_type-0b05e75ca41aab61.yaml
+++ b/releasenotes/notes/cache_checker_output_type-0b05e75ca41aab61.yaml
@@ -1,3 +1,3 @@
 ---
 enhancements:
-  - Add `cache_field_type` to `CacheChecker` to make connections possible in a pipeline.
+  - Modify the output type of `CacheChecker` from `List[Any]` to `List` to make it possible to connect it in a Pipeline.

--- a/releasenotes/notes/cache_checker_output_type-0b05e75ca41aab61.yaml
+++ b/releasenotes/notes/cache_checker_output_type-0b05e75ca41aab61.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Add `cache_field_type` to `CacheChecker` to make connections possible in a pipeline.

--- a/test/components/caching/test_url_cache_checker.py
+++ b/test/components/caching/test_url_cache_checker.py
@@ -76,6 +76,6 @@ class TestCacheChecker:
             Document(content="doc4", meta={"url": "https://example.com/2"}),
         ]
         docstore.write_documents(documents)
-        checker = CacheChecker(docstore, cache_field="url", cache_field_type=str)
+        checker = CacheChecker(docstore, cache_field="url")
         results = checker.run(items=["https://example.com/1", "https://example.com/5"])
         assert results == {"hits": [documents[0], documents[2]], "misses": ["https://example.com/5"]}

--- a/test/components/caching/test_url_cache_checker.py
+++ b/test/components/caching/test_url_cache_checker.py
@@ -6,28 +6,32 @@ from haystack.document_stores.in_memory import InMemoryDocumentStore
 from haystack.components.caching.cache_checker import CacheChecker
 
 
-class TestUrlCacheChecker:
+class TestCacheChecker:
     def test_to_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
-        component = CacheChecker(document_store=mocked_docstore_class(), cache_field="url")
+        component = CacheChecker(document_store=mocked_docstore_class(), cache_field="url", cache_field_type=str)
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.caching.cache_checker.CacheChecker",
             "init_parameters": {
                 "document_store": {"type": "haystack.testing.factory.MockedDocumentStore", "init_parameters": {}},
                 "cache_field": "url",
+                "cache_field_type": "str",
             },
         }
 
     def test_to_dict_with_custom_init_parameters(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
-        component = CacheChecker(document_store=mocked_docstore_class(), cache_field="my_url_field")
+        component = CacheChecker(
+            document_store=mocked_docstore_class(), cache_field="my_url_field", cache_field_type=str
+        )
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.caching.cache_checker.CacheChecker",
             "init_parameters": {
                 "document_store": {"type": "haystack.testing.factory.MockedDocumentStore", "init_parameters": {}},
                 "cache_field": "my_url_field",
+                "cache_field_type": "str",
             },
         }
 
@@ -40,11 +44,13 @@ class TestUrlCacheChecker:
                     "init_parameters": {},
                 },
                 "cache_field": "my_url_field",
+                "cache_field_type": "str",
             },
         }
         component = CacheChecker.from_dict(data)
         assert isinstance(component.document_store, InMemoryDocumentStore)
         assert component.cache_field == "my_url_field"
+        assert component.cache_field_type == str
 
     def test_from_dict_without_docstore(self):
         data = {"type": "haystack.components.caching.cache_checker.CacheChecker", "init_parameters": {}}
@@ -76,6 +82,6 @@ class TestUrlCacheChecker:
             Document(content="doc4", meta={"url": "https://example.com/2"}),
         ]
         docstore.write_documents(documents)
-        checker = CacheChecker(docstore, cache_field="url")
+        checker = CacheChecker(docstore, cache_field="url", cache_field_type=str)
         results = checker.run(items=["https://example.com/1", "https://example.com/5"])
         assert results == {"hits": [documents[0], documents[2]], "misses": ["https://example.com/5"]}

--- a/test/components/caching/test_url_cache_checker.py
+++ b/test/components/caching/test_url_cache_checker.py
@@ -9,29 +9,25 @@ from haystack.components.caching.cache_checker import CacheChecker
 class TestCacheChecker:
     def test_to_dict(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
-        component = CacheChecker(document_store=mocked_docstore_class(), cache_field="url", cache_field_type=str)
+        component = CacheChecker(document_store=mocked_docstore_class(), cache_field="url")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.caching.cache_checker.CacheChecker",
             "init_parameters": {
                 "document_store": {"type": "haystack.testing.factory.MockedDocumentStore", "init_parameters": {}},
                 "cache_field": "url",
-                "cache_field_type": "str",
             },
         }
 
     def test_to_dict_with_custom_init_parameters(self):
         mocked_docstore_class = document_store_class("MockedDocumentStore")
-        component = CacheChecker(
-            document_store=mocked_docstore_class(), cache_field="my_url_field", cache_field_type=str
-        )
+        component = CacheChecker(document_store=mocked_docstore_class(), cache_field="my_url_field")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.caching.cache_checker.CacheChecker",
             "init_parameters": {
                 "document_store": {"type": "haystack.testing.factory.MockedDocumentStore", "init_parameters": {}},
                 "cache_field": "my_url_field",
-                "cache_field_type": "str",
             },
         }
 
@@ -44,13 +40,11 @@ class TestCacheChecker:
                     "init_parameters": {},
                 },
                 "cache_field": "my_url_field",
-                "cache_field_type": "str",
             },
         }
         component = CacheChecker.from_dict(data)
         assert isinstance(component.document_store, InMemoryDocumentStore)
         assert component.cache_field == "my_url_field"
-        assert component.cache_field_type == str
 
     def test_from_dict_without_docstore(self):
         data = {"type": "haystack.components.caching.cache_checker.CacheChecker", "init_parameters": {}}


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

- Modify the output type of `CacheChecker` from `List[Any]` to `List` to make it possible to connect it in a Pipeline.

### How did you test it?

Unit tests

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
