### PR TITLE
feat: Highlight optional connections in `Pipeline.draw()`

### DIFF
--- a/haystack/core/pipeline/draw/draw.py
+++ b/haystack/core/pipeline/draw/draw.py
@@ -76,7 +76,9 @@ def _prepare_for_drawing(graph: networkx.MultiDiGraph, style_map: Dict[str, str]
 
     # Label the edges
     for inp, outp, key, data in graph.edges(keys=True, data=True):
-        data["label"] = f"{data['from_socket'].name} -> {data['to_socket'].name}"
+        data[
+            "label"
+        ] = f"{data['from_socket'].name} -> {data['to_socket'].name}{' (opt.)' if not data['mandatory'] else ''}"
         graph.add_edge(inp, outp, key=key, **data)
 
     # Draw the inputs

--- a/haystack/core/pipeline/draw/mermaid.py
+++ b/haystack/core/pipeline/draw/mermaid.py
@@ -12,7 +12,10 @@ from haystack.core.type_utils import _type_name
 
 logger = logging.getLogger(__name__)
 
-
+ARROWTAIL_MANDATORY = "--"
+ARROWTAIL_OPTIONAL = "-."
+ARROWHEAD_MANDATORY = "-->"
+ARROWHEAD_OPTIONAL = ".->"
 MERMAID_STYLED_TEMPLATE = """
 %%{{ init: {{'theme': 'neutral' }} }}%%
 
@@ -81,11 +84,15 @@ def _to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
         if comp not in ["input", "output"]
     }
 
-    connections_list = [
-        f"{states[from_comp]} -- \"{conn_data['label']}<br><small><i>{conn_data['conn_type']}</i></small>\" --> {states[to_comp]}"
-        for from_comp, to_comp, conn_data in graph.edges(data=True)
-        if from_comp != "input" and to_comp != "output"
-    ]
+    connections_list = []
+    for from_comp, to_comp, conn_data in graph.edges(data=True):
+        if from_comp != "input" and to_comp != "output":
+            arrowtail = ARROWTAIL_MANDATORY if conn_data["mandatory"] else ARROWTAIL_OPTIONAL
+            arrowhead = ARROWHEAD_MANDATORY if conn_data["mandatory"] else ARROWHEAD_OPTIONAL
+            label = f'"{conn_data["label"]}<br><small><i>{conn_data["conn_type"]}</i></small>"'
+            conn_string = f"{states[from_comp]} {arrowtail} {label} {arrowhead} {states[to_comp]}"
+            connections_list.append(conn_string)
+
     input_connections = [
         f"i{{*}} -- \"{conn_data['label']}<br><small><i>{conn_data['conn_type']}</i></small>\" --> {states[to_comp]}"
         for _, to_comp, conn_data in graph.out_edges("input", data=True)

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -327,6 +327,7 @@ class Pipeline:
             conn_type=_type_name(connection.sender_socket.type),
             from_socket=connection.sender_socket,
             to_socket=connection.receiver_socket,
+            mandatory=connection.is_mandatory,
         )
 
         self._connections.append(connection)

--- a/releasenotes/notes/highlight-optional-conns-in-draw-cf107ee210b7b8e7.yaml
+++ b/releasenotes/notes/highlight-optional-conns-in-draw-cf107ee210b7b8e7.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Highlight optional connections in the `Pipeline.draw()` output.


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/6723

### Proposed Changes:

Modify the output of `Pipeline.draw()` to:
- add a ` (opt.)` suffix to optional connections.
- in Mermaid, make the relative arrow dotted instead of solid.

Example before:

![fixed_decision_pipeline](https://github.com/deepset-ai/haystack/assets/5703634/99238f80-a3e9-47cc-ab11-f6b47bdf590d)

Example after:

![fixed_decision_pipeline](https://github.com/deepset-ai/haystack/assets/5703634/c37c67ee-1ed3-43bb-8f47-47ce6fc46934)

### How did you test it?

Manual testing

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
