### PR TITLE
docs: reorder and rename Classifier and CacheChecker files

### DIFF
--- a/docs/pydoc/config/caching.yml
+++ b/docs/pydoc/config/caching.yml
@@ -15,9 +15,9 @@ renderer:
   type: renderers.ReadmePreviewRenderer
   excerpt: Checks if any document coming from the given URL is already present in the store.
   category_slug: haystack-classes
-  title: UrlCacheChecker API
+  title: CacheChecker API
   slug: caching-api
-  order: 160
+  order: 7
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/docs/pydoc/config/classifier.yml
+++ b/docs/pydoc/config/classifier.yml
@@ -15,12 +15,12 @@ renderer:
   type: renderers.ReadmePreviewRenderer
   excerpt: Detects the language of the Documents and routes them appropriately.
   category_slug: haystack-classes
-  title: Language Classifier API
-  slug: language-classifier-api
+  title: Classifier API
+  slug: classifier-api
   order: 10
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: language_classifier_api.md
+    filename: classifier_api.md

--- a/docs/pydoc/config/joiner.yml
+++ b/docs/pydoc/config/joiner.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: haystack-classes
   title: Joiner API
   slug: joiner-api
-  order: 140
+  order: 75
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/docs/pydoc/config/others.yml
+++ b/docs/pydoc/config/others.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: haystack-classes
   title: Other Components API
   slug: others
-  order: 170
+  order: 180
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/docs/pydoc/config/others.yml
+++ b/docs/pydoc/config/others.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: haystack-classes
   title: Other Components API
   slug: others
-  order: 180
+  order: 85
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/docs/pydoc/config/whisper.yml
+++ b/docs/pydoc/config/whisper.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: haystack-classes
   title: WhisperTranscriber API
   slug: whisper-transcriber-api
-  order: 180
+  order: 170
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true

--- a/docs/pydoc/config/whisper.yml
+++ b/docs/pydoc/config/whisper.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: haystack-classes
   title: WhisperTranscriber API
   slug: whisper-transcriber-api
-  order: 170
+  order: 180
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true


### PR DESCRIPTION
### Proposed Changes:

Updated the pages to come in alphabetical order.
Renamed Language Classifiers to simply Classifiers (futureproofing).
Updated CacheChecker name.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
