### PR TITLE
feat: Make Pipeline wait for connected inputs even if they're optional

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -64,7 +64,6 @@ class Pipeline:
         self.max_loops_allowed = max_loops_allowed
         self.graph = networkx.MultiDiGraph()
         self._connections: List[Connection] = []
-        self._mandatory_connections: Dict[str, List[Connection]] = defaultdict(list)
         self._debug: Dict[int, Dict[str, Any]] = {}
         self._debug_path = Path(debug_path)
 
@@ -330,8 +329,6 @@ class Pipeline:
         )
 
         self._connections.append(connection)
-        if connection.is_mandatory:
-            self._mandatory_connections[connection.receiver].append(connection)
 
     def get_component(self, name: str) -> Component:
         """
@@ -443,14 +440,6 @@ class Pipeline:
         if debug:
             logger.info("Debug mode ON.")
             os.makedirs("debug", exist_ok=True)
-
-        logger.debug(
-            "Mandatory connections:\n%s",
-            "\n".join(
-                f" - {component}: {', '.join([str(s) for s in sockets])}"
-                for component, sockets in self._mandatory_connections.items()
-            ),
-        )
 
         self.warm_up()
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -573,7 +573,7 @@ class Pipeline:
         Returns True if a component is ready to run, False otherwise.
         """
         connections_with_value = {conn for conn in mandatory_values_buffer.keys() if conn.receiver == component_name}
-        expected_connections = set(self._mandatory_connections[component_name])
+        expected_connections = {conn for conn in self._connections if conn.receiver == component_name}
         if expected_connections.issubset(connections_with_value):
             logger.debug("Component '%s' is ready to run. All mandatory values were received.", component_name)
             return True

--- a/releasenotes/notes/pipeline_wait_optional_connected_inputs-c2fe08cf5e51640c.yaml
+++ b/releasenotes/notes/pipeline_wait_optional_connected_inputs-c2fe08cf5e51640c.yaml
@@ -1,0 +1,34 @@
+---
+upgrade:
+  - |
+    Make Pipeline wait for connected inputs even if they're optional.
+
+    So far Pipeline would not wait for an input coming from a connection that already has a default value.
+    This PR modifies the behavior of the Pipeline to wait for such connections. This normally means that components
+    that used to trigger earlier might now need to wait for other components to send their values before they could be
+    run.
+
+    For example, here is an affected pipeline:
+
+    ```python
+    @component
+    class WithDefault:
+        @component.output_types(c=int)
+        def run(self, a: int, b: int = 2):
+            return {"c": a + b}
+
+    pipeline = Pipeline()
+    pipeline.add_component("first", WithDefault())
+    pipeline.add_component("second", WithDefault())
+    pipeline.add_component("third", WithDefault())
+    pipeline.connect("first", "second.a")
+    pipeline.connect("second", "third.b")
+    ```
+
+    before, the order of execution would be `first -> third -> second`. From now on, it becomes
+    `first -> second -> third`, because third is forced to wait for second to produce the value of `b` that it should
+    use for the calculations.
+
+    This change should only affect early misfiring of some components that, incorrectly, did not wait for some
+    optional input values to be produced. However there might be corner cases which a correct order of execution is
+    affected. If that is the case, please reference this PR on your issue: #6727

--- a/test/core/pipeline/test_default_value.py
+++ b/test/core/pipeline/test_default_value.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 @component
 class WithDefault:
-    @component.output_types(b=int)
+    @component.output_types(c=int)
     def run(self, a: int, b: int = 2):
         return {"c": a + b}
 
@@ -30,3 +30,17 @@ def test_pipeline(tmp_path):
     # Rely on default value for 'b'
     results = pipeline.run({"with_defaults": {"a": 40}})
     assert results == {"with_defaults": {"c": 42}}
+
+
+def test_pipeline_wait_on_connected_optional_inputs(tmp_path):
+    pipeline = Pipeline()
+    pipeline.add_component("first", WithDefault())
+    pipeline.add_component("second", WithDefault())
+    pipeline.add_component("third", WithDefault())
+    pipeline.connect("first", "second.a")
+    pipeline.connect("second", "third.b")
+
+    pipeline.draw(tmp_path / "default_value.png")
+
+    results = pipeline.run({"first": {"a": 1}, "third": {"a": 2}})
+    assert results == {"third": {"c": 7}}


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/6723

### Proposed Changes:

Make Pipeline wait for connected inputs even if they're optional.

So far Pipeline would not wait for an input coming from a connection that already has a default value. 
This PR modifies the behavior of the Pipeline to wait for such connections. This normally means that components
that used to trigger earlier might now need to wait for other components to send their values before they could be 
run.

For example, here is an affected pipeline:

```python
@component
class WithDefault:
    @component.output_types(c=int)
    def run(self, a: int, b: int = 2):
        return {"c": a + b}

pipeline = Pipeline()
pipeline.add_component("first", WithDefault())
pipeline.add_component("second", WithDefault())
pipeline.add_component("third", WithDefault())
pipeline.connect("first", "second.a")
pipeline.connect("second", "third.b")
```
![default_value](https://github.com/deepset-ai/haystack/assets/5703634/56e1e403-a4ae-4913-b738-d5b097a98c11)

before, the order of execution would be `first -> third -> second`. From now on, it becomes 
`first -> second -> third`, because third is forced to wait for second to produce the value of `b` that it should 
use for the calculations.

This change should only affect early misfiring of some components that, incorrectly, did not wait for some 
optional input values to be produced. However there might be corner cases which a correct order of execution is 
affected. If that is the case, please reference this PR on your issue: #6727

### How did you test it?

Manual testing, local run of the full test suite, CI.

### Notes for the reviewer
 The actual change is the one line change in `Pipeline._ready_to_run()`. All the other deleted lines are due to the fact that `self._mandatory_connections` is now unused and therefore has been removed.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
