### PR TITLE
feat: Add method to set a Component input type with default value

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -31,8 +31,7 @@ class PromptBuilder:
         self.template = Template(template)
         ast = self.template.environment.parse(template)
         template_variables = meta.find_undeclared_variables(ast)
-        for var in template_variables:
-            component.set_input_type(self, var, Any, "")
+        component.set_input_types(self, **{var: Any for var in template_variables})
 
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, template=self._template_string)

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -31,7 +31,8 @@ class PromptBuilder:
         self.template = Template(template)
         ast = self.template.environment.parse(template)
         template_variables = meta.find_undeclared_variables(ast)
-        component.set_input_types(self, **{var: Any for var in template_variables})
+        for var in template_variables:
+            component.set_input_type(self, var, Any, "")
 
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, template=self._template_string)

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -166,7 +166,7 @@ class _Component:
     def __init__(self):
         self.registry = {}
 
-    def set_input_type(self, instance: Component, name: str, type: Any, default: Any = _empty):
+    def set_input_type(self, instance, name: str, type: Any, default: Any = _empty):
         """
         Add a single input socket to the component instance.
 

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -74,7 +74,7 @@ from typing import Protocol, runtime_checkable, Any
 from types import new_class
 from copy import deepcopy
 
-from haystack.core.component.sockets import InputSocket, OutputSocket
+from haystack.core.component.sockets import InputSocket, OutputSocket, _empty
 from haystack.core.errors import ComponentError
 
 logger = logging.getLogger(__name__)
@@ -165,6 +165,19 @@ class _Component:
 
     def __init__(self):
         self.registry = {}
+
+    def set_input_type(self, instance: Component, name: str, type: Any, default: Any = _empty):
+        """
+        Add a single input socket to the component instance.
+
+        :param instance: Component instance where the input type will be added.
+        :param name: name of the input socket.
+        :param type: type of the input socket.
+        :param default: default value of the input socket, defaults to _empty
+        """
+        if not hasattr(instance, "__canals_input__"):
+            instance.__canals_input__ = {}
+        instance.__canals_input__[name] = InputSocket(name=name, type=type, default_value=default)
 
     def set_input_types(self, instance, **types):
         """

--- a/releasenotes/notes/set-input-type-328589ee51ffa21b.yaml
+++ b/releasenotes/notes/set-input-type-328589ee51ffa21b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add `component.set_input_type()` function to set a Component input name, type and default value.


### PR DESCRIPTION
### Proposed Changes:

Add method to set a Component input type with default value. 

### How did you test it?

I tested it manually.

### Notes for the reviewer

This is a necessary improvement for the Pipeline run refactoring that is coming up.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
