### PR TITLE
fix: Fix error when calling `dir()` on a component instance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,6 @@ on:
       - "haystack/**/*.py"
       - "test/**/*.py"
       - "test/test_requirements.txt"
-      - "!haystack/core/**/*.py"
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -279,6 +279,9 @@ class _Component:
             the whole namespace from the decorated class.
             """
             for key, val in dict(class_.__dict__).items():
+                # __dict__ and __weakref__ are class-bound, we should let Python recreate them.
+                if key in ("__dict__", "__weakref__"):
+                    continue
                 namespace[key] = val
 
         # Recreate the decorated component class so it uses our metaclass

--- a/releasenotes/notes/fix-descriptor-__dict__-doesnt-apply-to-bf6d47872345ed24.yaml
+++ b/releasenotes/notes/fix-descriptor-__dict__-doesnt-apply-to-bf6d47872345ed24.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the error `descriptor '__dict__' for 'ComponentClassX' objects doesn't apply to a 'ComponentClassX' object` when calling
+    `dir()` on a component instance. This fix should allow auto-completion in code editors.


### PR DESCRIPTION
### Related Issues

- no issue, reported offline

Steps to reproduce:
```
In [1]: from haystack.components.builders import AnswerBuilder

In [2]: a = AnswerBuilder()

In [3]: dir(a)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 dir(a)

TypeError: descriptor '__dict__' for 'AnswerBuilder' objects doesn't apply to a 'AnswerBuilder' object
```

### Proposed Changes:

When programmatically creating the final class in the `_component` decorator, while building the class namespace skip `__dict__` and `__weakref__` so that Python will recreate them in the correct way.

### How did you test it?

Manually tested + unit/integration tests in CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
