### PR TITLE
feat!: Rename `model_name` or `model_name_or_path` to `model` in all Transcriber classes

### DIFF
--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -32,23 +32,22 @@ class LocalWhisperTranscriber:
 
     def __init__(
         self,
-        model_name_or_path: WhisperLocalModel = "large",
+        model: WhisperLocalModel = "large",
         device: Optional[str] = None,
         whisper_params: Optional[Dict[str, Any]] = None,
     ):
         """
-        :param model_name_or_path: Name of the model to use. Set it to one of the following values:
-        :type model_name_or_path: Literal["tiny", "small", "medium", "large", "large-v2"]
+        :param model: Name of the model to use. Set it to one of the following values:
+        :type model: Literal["tiny", "small", "medium", "large", "large-v2"]
         :param device: Name of the torch device to use for inference. If None, CPU is used.
         :type device: Optional[str]
         """
         whisper_import.check()
-        if model_name_or_path not in get_args(WhisperLocalModel):
+        if model not in get_args(WhisperLocalModel):
             raise ValueError(
-                f"Model name '{model_name_or_path}' not recognized. Choose one among: "
-                f"{', '.join(get_args(WhisperLocalModel))}."
+                f"Model name '{model}' not recognized. Choose one among: " f"{', '.join(get_args(WhisperLocalModel))}."
             )
-        self.model_name = model_name_or_path
+        self.model = model
         self.whisper_params = whisper_params or {}
         self.device = torch.device(device) if device else torch.device("cpu")
         self._model = None
@@ -58,15 +57,13 @@ class LocalWhisperTranscriber:
         Loads the model.
         """
         if not self._model:
-            self._model = whisper.load_model(self.model_name, device=self.device)
+            self._model = whisper.load_model(self.model, device=self.device)
 
     def to_dict(self) -> Dict[str, Any]:
         """
         Serialize this component to a dictionary.
         """
-        return default_to_dict(
-            self, model_name_or_path=self.model_name, device=str(self.device), whisper_params=self.whisper_params
-        )
+        return default_to_dict(self, model=self.model, device=str(self.device), whisper_params=self.whisper_params)
 
     @component.output_types(documents=List[Document])
     def run(self, sources: List[Union[str, Path, ByteStream]], whisper_params: Optional[Dict[str, Any]] = None):

--- a/haystack/components/audio/whisper_remote.py
+++ b/haystack/components/audio/whisper_remote.py
@@ -25,7 +25,7 @@ class RemoteWhisperTranscriber:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model_name: str = "whisper-1",
+        model: str = "whisper-1",
         api_base_url: Optional[str] = None,
         organization: Optional[str] = None,
         **kwargs,
@@ -34,7 +34,7 @@ class RemoteWhisperTranscriber:
         Transcribes a list of audio files into a list of Documents.
 
         :param api_key: OpenAI API key.
-        :param model_name: Name of the model to use. It now accepts only `whisper-1`.
+        :param model: Name of the model to use. It now accepts only `whisper-1`.
         :param organization: The Organization ID, defaults to `None`. See
         [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization).
         :param api_base: An optional URL to use as the API base. Defaults to `None`. See OpenAI [docs](https://platform.openai.com/docs/api-reference/audio).
@@ -59,7 +59,7 @@ class RemoteWhisperTranscriber:
         """
 
         self.organization = organization
-        self.model_name = model_name
+        self.model = model
         self.api_base_url = api_base_url
 
         # Only response_format = "json" is supported
@@ -81,7 +81,7 @@ class RemoteWhisperTranscriber:
         """
         return default_to_dict(
             self,
-            model_name=self.model_name,
+            model=self.model,
             organization=self.organization,
             api_base_url=self.api_base_url,
             **self.whisper_params,
@@ -113,7 +113,7 @@ class RemoteWhisperTranscriber:
             file = io.BytesIO(source.data)
             file.name = str(source.meta["file_path"]) if "file_path" in source.meta else "__fallback__.wav"
 
-            content = self.client.audio.transcriptions.create(file=file, model=self.model_name, **self.whisper_params)
+            content = self.client.audio.transcriptions.create(file=file, model=self.model, **self.whisper_params)
             doc = Document(content=content.text, meta=source.meta)
             documents.append(doc)
 

--- a/releasenotes/notes/rename-model-param--transcribers-71dbe7cfb86950e0.yaml
+++ b/releasenotes/notes/rename-model-param--transcribers-71dbe7cfb86950e0.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+    - |
+      Rename the transcriber parameters `model_name` and `model_name_or_path` to `model`. This change affects both
+      `LocalWhisperTranscriber` and `RemoteWhisperTranscriber` classes.

--- a/test/components/audio/test_whisper_local.py
+++ b/test/components/audio/test_whisper_local.py
@@ -15,35 +15,33 @@ SAMPLES_PATH = Path(__file__).parent.parent.parent / "test_files"
 class TestLocalWhisperTranscriber:
     def test_init(self):
         transcriber = LocalWhisperTranscriber(
-            model_name_or_path="large-v2"
+            model="large-v2"
         )  # Doesn't matter if it's huge, the model is not loaded in init.
-        assert transcriber.model_name == "large-v2"
+        assert transcriber.model == "large-v2"
         assert transcriber.device == torch.device("cpu")
         assert transcriber._model is None
 
     def test_init_wrong_model(self):
         with pytest.raises(ValueError, match="Model name 'whisper-1' not recognized"):
-            LocalWhisperTranscriber(model_name_or_path="whisper-1")
+            LocalWhisperTranscriber(model="whisper-1")
 
     def test_to_dict(self):
         transcriber = LocalWhisperTranscriber()
         data = transcriber.to_dict()
         assert data == {
             "type": "haystack.components.audio.whisper_local.LocalWhisperTranscriber",
-            "init_parameters": {"model_name_or_path": "large", "device": "cpu", "whisper_params": {}},
+            "init_parameters": {"model": "large", "device": "cpu", "whisper_params": {}},
         }
 
     def test_to_dict_with_custom_init_parameters(self):
         transcriber = LocalWhisperTranscriber(
-            model_name_or_path="tiny",
-            device="cuda",
-            whisper_params={"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
+            model="tiny", device="cuda", whisper_params={"return_segments": True, "temperature": [0.1, 0.6, 0.8]}
         )
         data = transcriber.to_dict()
         assert data == {
             "type": "haystack.components.audio.whisper_local.LocalWhisperTranscriber",
             "init_parameters": {
-                "model_name_or_path": "tiny",
+                "model": "tiny",
                 "device": "cuda",
                 "whisper_params": {"return_segments": True, "temperature": [0.1, 0.6, 0.8]},
             },
@@ -51,20 +49,20 @@ class TestLocalWhisperTranscriber:
 
     def test_warmup(self):
         with patch("haystack.components.audio.whisper_local.whisper") as mocked_whisper:
-            transcriber = LocalWhisperTranscriber(model_name_or_path="large-v2")
+            transcriber = LocalWhisperTranscriber(model="large-v2")
             mocked_whisper.load_model.assert_not_called()
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once_with("large-v2", device=torch.device(type="cpu"))
 
     def test_warmup_doesnt_reload(self):
         with patch("haystack.components.audio.whisper_local.whisper") as mocked_whisper:
-            transcriber = LocalWhisperTranscriber(model_name_or_path="large-v2")
+            transcriber = LocalWhisperTranscriber(model="large-v2")
             transcriber.warm_up()
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once()
 
     def test_run_with_path(self):
-        comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
+        comp = LocalWhisperTranscriber(model="large-v2")
         comp._model = MagicMock()
         comp._model.transcribe.return_value = {
             "text": "test transcription",
@@ -81,7 +79,7 @@ class TestLocalWhisperTranscriber:
         assert results["documents"] == [expected]
 
     def test_run_with_str(self):
-        comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
+        comp = LocalWhisperTranscriber(model="large-v2")
         comp._model = MagicMock()
         comp._model.transcribe.return_value = {
             "text": "test transcription",
@@ -100,7 +98,7 @@ class TestLocalWhisperTranscriber:
         assert results["documents"] == [expected]
 
     def test_transcribe(self):
-        comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
+        comp = LocalWhisperTranscriber(model="large-v2")
         comp._model = MagicMock()
         comp._model.transcribe.return_value = {
             "text": "test transcription",
@@ -117,7 +115,7 @@ class TestLocalWhisperTranscriber:
         assert results == [expected]
 
     def test_transcribe_stream(self):
-        comp = LocalWhisperTranscriber(model_name_or_path="large-v2")
+        comp = LocalWhisperTranscriber(model="large-v2")
         comp._model = MagicMock()
         comp._model.transcribe.return_value = {
             "text": "test transcription",
@@ -135,7 +133,7 @@ class TestLocalWhisperTranscriber:
     @pytest.mark.integration
     @pytest.mark.skipif(sys.platform in ["win32", "cygwin"], reason="ffmpeg not installed on Windows CI")
     def test_whisper_local_transcriber(self, test_files_path):
-        comp = LocalWhisperTranscriber(model_name_or_path="medium", whisper_params={"language": "english"})
+        comp = LocalWhisperTranscriber(model="medium", whisper_params={"language": "english"})
         comp.warm_up()
         output = comp.run(
             sources=[

--- a/test/components/audio/test_whisper_remote.py
+++ b/test/components/audio/test_whisper_remote.py
@@ -25,14 +25,14 @@ class TestRemoteWhisperTranscriber:
     def test_init_default(self):
         transcriber = RemoteWhisperTranscriber(api_key="test_api_key")
         assert transcriber.client.api_key == "test_api_key"
-        assert transcriber.model_name == "whisper-1"
+        assert transcriber.model == "whisper-1"
         assert transcriber.organization is None
         assert transcriber.whisper_params == {"response_format": "json"}
 
     def test_init_custom_parameters(self):
         transcriber = RemoteWhisperTranscriber(
             api_key="test_api_key",
-            model_name="whisper-1",
+            model="whisper-1",
             organization="test-org",
             api_base_url="test_api_url",
             language="en",
@@ -41,7 +41,7 @@ class TestRemoteWhisperTranscriber:
             temperature="0.5",
         )
 
-        assert transcriber.model_name == "whisper-1"
+        assert transcriber.model == "whisper-1"
         assert transcriber.organization == "test-org"
         assert transcriber.api_base_url == "test_api_url"
         assert transcriber.whisper_params == {
@@ -57,7 +57,7 @@ class TestRemoteWhisperTranscriber:
         assert data == {
             "type": "haystack.components.audio.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
-                "model_name": "whisper-1",
+                "model": "whisper-1",
                 "api_base_url": None,
                 "organization": None,
                 "response_format": "json",
@@ -67,7 +67,7 @@ class TestRemoteWhisperTranscriber:
     def test_to_dict_with_custom_init_parameters(self):
         transcriber = RemoteWhisperTranscriber(
             api_key="test_api_key",
-            model_name="whisper-1",
+            model="whisper-1",
             organization="test-org",
             api_base_url="test_api_url",
             language="en",
@@ -79,7 +79,7 @@ class TestRemoteWhisperTranscriber:
         assert data == {
             "type": "haystack.components.audio.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
-                "model_name": "whisper-1",
+                "model": "whisper-1",
                 "organization": "test-org",
                 "api_base_url": "test_api_url",
                 "language": "en",
@@ -95,7 +95,7 @@ class TestRemoteWhisperTranscriber:
         data = {
             "type": "haystack.components.audio.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
-                "model_name": "whisper-1",
+                "model": "whisper-1",
                 "api_base_url": "https://api.openai.com/v1",
                 "organization": None,
                 "response_format": "json",
@@ -104,7 +104,7 @@ class TestRemoteWhisperTranscriber:
 
         transcriber = RemoteWhisperTranscriber.from_dict(data)
 
-        assert transcriber.model_name == "whisper-1"
+        assert transcriber.model == "whisper-1"
         assert transcriber.organization is None
         assert transcriber.api_base_url == "https://api.openai.com/v1"
         assert transcriber.whisper_params == {"response_format": "json"}
@@ -115,7 +115,7 @@ class TestRemoteWhisperTranscriber:
         data = {
             "type": "haystack.components.audio.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
-                "model_name": "whisper-1",
+                "model": "whisper-1",
                 "organization": "test-org",
                 "api_base_url": "test_api_url",
                 "language": "en",
@@ -126,7 +126,7 @@ class TestRemoteWhisperTranscriber:
         }
         transcriber = RemoteWhisperTranscriber.from_dict(data)
 
-        assert transcriber.model_name == "whisper-1"
+        assert transcriber.model == "whisper-1"
         assert transcriber.organization == "test-org"
         assert transcriber.api_base_url == "test_api_url"
         assert transcriber.whisper_params == {
@@ -142,7 +142,7 @@ class TestRemoteWhisperTranscriber:
         data = {
             "type": "haystack.components.audio.whisper_remote.RemoteWhisperTranscriber",
             "init_parameters": {
-                "model_name": "whisper-1",
+                "model": "whisper-1",
                 "api_base_url": "https://api.openai.com/v1",
                 "organization": None,
                 "response_format": "json",


### PR DESCRIPTION
### Related Issues

- related to #6534 

### Proposed Changes:

- Rename `model_name` or `model_name_or_path` to `model` in all Transcriber classes.

### How did you test it?

Local tests run, CI

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
