### PR TITLE
fix: rename `model_name_or_path` to `model` in `HuggingFaceLocalGenerator` test

### DIFF
--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -184,7 +184,7 @@ class TestHuggingFaceLocalGenerator:
 
     def test_to_dict_with_quantization_config(self):
         component = HuggingFaceLocalGenerator(
-            model_name_or_path="gpt2",
+            model="gpt2",
             task="text-generation",
             device="cuda:0",
             token="test-token",


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/actions/runs/7501830147/job/20423561987
- related to #6534 

### Proposed Changes:
rename `model_name_or_path` to `model` in `HuggingFaceLocalGenerator` test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
