### PR TITLE
feat: Weights and score normalization for DocumentJoiner with reciprocal rank fusion

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -142,10 +142,18 @@ class DocumentJoiner:
 
         scores_map = defaultdict(int)
         documents_map = {}
-        for documents in document_lists:
+        weights = self.weights if self.weights else [1 / len(document_lists)] * len(document_lists)
+
+        # Calculate weighted reciprocal rank fusion score
+        for documents, weight in zip(document_lists, weights):
             for rank, doc in enumerate(documents):
-                scores_map[doc.id] += 1 / (k + rank)
+                scores_map[doc.id] += (weight * len(document_lists)) / (k + rank)
                 documents_map[doc.id] = doc
+
+        # Normalize scores. Note: len(results) / k is the maximum possible score,
+        # achieved by being ranked first in all doc lists with non-zero weight.
+        for id in scores_map:
+            scores_map[id] /= len(document_lists) / k
 
         for doc in documents_map.values():
             doc.score = scores_map[doc.id]

--- a/releasenotes/notes/weights-normalize-docjoin-rrf-v2-9cad33012fe90a55.yaml
+++ b/releasenotes/notes/weights-normalize-docjoin-rrf-v2-9cad33012fe90a55.yaml
@@ -1,5 +1,4 @@
 ---
 enhancements:
   - |
-    Enables score weighting and normalization for
-    DocumentJoiner node with reciprocal rank fusion.
+    Introduces weighted score normalization for the DocumentJoiner's reciprocal rank fusion, enhancing the relevance of document sorting by allowing customizable influence on the final scores

--- a/releasenotes/notes/weights-normalize-docjoin-rrf-v2-9cad33012fe90a55.yaml
+++ b/releasenotes/notes/weights-normalize-docjoin-rrf-v2-9cad33012fe90a55.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Enables score weighting and normalization for
+    DocumentJoiner node with reciprocal rank fusion.


### PR DESCRIPTION
### Related Issues

- fixes #6617 by adding weighting and score normalization for the `DocumentJoiner` node with reciprocal rank fusion.

### Proposed Changes:

- Add weighting for `DocumentJoiner` node with reciprocal rank fusion.
- Add score normalization for `DocumentJoiner` node with reciprocal rank fusion.

### How did you test it?

- Testing pending.

### Checklist

- [X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [ ] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [X] I documented my code
- [X] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
