### PR TITLE
fix: fix leftover `model_name_or_path` param in e2e tests

### DIFF
--- a/e2e/pipelines/test_eval_rag_pipelines.py
+++ b/e2e/pipelines/test_eval_rag_pipelines.py
@@ -28,7 +28,7 @@ def test_bm25_rag_pipeline(tmp_path):
     rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
     rag_pipeline.add_component(
         instance=HuggingFaceLocalGenerator(
-            model_name_or_path="google/flan-t5-small",
+            model="google/flan-t5-small",
             task="text2text-generation",
             generation_kwargs={"max_new_tokens": 100, "temperature": 0.5, "do_sample": True},
         ),
@@ -102,7 +102,7 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
     rag_pipeline.add_component(instance=PromptBuilder(template=prompt_template), name="prompt_builder")
     rag_pipeline.add_component(
         instance=HuggingFaceLocalGenerator(
-            model_name_or_path="google/flan-t5-small",
+            model="google/flan-t5-small",
             task="text2text-generation",
             generation_kwargs={"max_new_tokens": 100, "temperature": 0.5, "do_sample": True},
         ),


### PR DESCRIPTION
### Related Issues

Failing e2e test.

### Proposed Changes:

Rename `model_name_or_path` to `model` for `HuggingFaceLocalGenerator`, to align the test to the changes introduced in this PR: https://github.com/deepset-ai/haystack/pull/6715

### How did you test it?

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
