### PR TITLE
feat: MetaFieldRanker update

### DIFF
--- a/releasenotes/notes/metafieldranker_sort-order_refactor-2000d89dc40dc15a.yaml
+++ b/releasenotes/notes/metafieldranker_sort-order_refactor-2000d89dc40dc15a.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Prevent the ranker from throwing an error if one or more of the documents doesn't contain the specific meta data field. Now those documents will be ignored for ranking purposes and placed at the end of the ranked list so we don't completely throw them away.
+    Adding a sort_order that can have values of descending or ascending.
+    Added more runtime parameters.

--- a/releasenotes/notes/metafieldranker_sort-order_refactor-2000d89dc40dc15a.yaml
+++ b/releasenotes/notes/metafieldranker_sort-order_refactor-2000d89dc40dc15a.yaml
@@ -1,6 +1,6 @@
 ---
 enhancements:
   - |
-    Prevent the ranker from throwing an error if one or more of the documents doesn't contain the specific meta data field. Now those documents will be ignored for ranking purposes and placed at the end of the ranked list so we don't completely throw them away.
+    Prevent the `MetaFieldRanker` from throwing an error if one or more of the documents doesn't contain the specific meta data field. Now those documents will be ignored for ranking purposes and placed at the end of the ranked list so we don't completely throw them away.
     Adding a sort_order that can have values of descending or ascending.
     Added more runtime parameters.

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -79,13 +79,26 @@ class TestMetaFieldRanker:
         docs_after = output["documents"]
         assert docs_after == []
 
-    def test_raises_component_error_if_metadata_not_found(self, caplog):
+    def test_warning_if_meta_not_found(self, caplog):
         ranker = MetaFieldRanker(meta_field="rating")
         docs_before = [Document(content="abc", meta={"wrong_field": 1.3})]
         with caplog.at_level(logging.WARNING):
             ranker.run(documents=docs_before)
             assert (
                 "The parameter <meta_field> is currently set to 'rating', but none of the provided Documents have this meta key."
+                in caplog.text
+            )
+
+    def test_warning_if_some_meta_not_found(self, caplog):
+        ranker = MetaFieldRanker(meta_field="rating")
+        docs_before = [
+            Document(id="1", content="abc", meta={"wrong_field": 1.3}),
+            Document(id="2", content="def", meta={"rating": 1.3}),
+        ]
+        with caplog.at_level(logging.WARNING):
+            ranker.run(documents=docs_before)
+            assert (
+                "The parameter <meta_field> is currently set to 'rating' but the Documents with IDs 1 don't have this meta key."
                 in caplog.text
             )
 

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -75,9 +75,13 @@ class TestMetaFieldRanker:
         with pytest.raises(ComponentError):
             ranker.run(documents=docs_before)
 
-    def test_raises_component_error_if_wrong_ranking_mode(self):
+    def test_raises_value_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")
+
+    def test_raises_value_error_if_wrong_top_k(self):
+        with pytest.raises(ValueError):
+            MetaFieldRanker(meta_field="rating", top_k=-1)
 
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
     def test_raises_component_error_if_wrong_weight(self, score):

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 from haystack import Document, ComponentError
 from haystack.components.rankers.meta_field import MetaFieldRanker
@@ -15,25 +16,33 @@ class TestMetaFieldRanker:
                 "weight": 1.0,
                 "top_k": None,
                 "ranking_mode": "reciprocal_rank_fusion",
+                "infer_type": True,
             },
         }
 
     def test_to_dict_with_custom_init_parameters(self):
-        component = MetaFieldRanker(meta_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score")
+        component = MetaFieldRanker(
+            meta_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score", infer_type=False
+        )
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.rankers.meta_field.MetaFieldRanker",
-            "init_parameters": {"meta_field": "rating", "weight": 0.5, "top_k": 5, "ranking_mode": "linear_score"},
+            "init_parameters": {
+                "meta_field": "rating",
+                "weight": 0.5,
+                "top_k": 5,
+                "ranking_mode": "linear_score",
+                "infer_type": False,
+            },
         }
 
-    @pytest.mark.integration
-    @pytest.mark.parametrize("metafield_values, expected_first_value", [([1.3, 0.7, 2.1], 2.1), ([1, 5, 8], 8)])
-    def test_run(self, metafield_values, expected_first_value):
+    @pytest.mark.parametrize("meta_field_values, expected_first_value", [([1.3, 0.7, 2.1], 2.1), ([1, 5, 8], 8)])
+    def test_run(self, meta_field_values, expected_first_value):
         """
         Test if the component ranks documents correctly.
         """
         ranker = MetaFieldRanker(meta_field="rating")
-        docs_before = [Document(content="abc", meta={"rating": value}) for value in metafield_values]
+        docs_before = [Document(content="abc", meta={"rating": value}) for value in meta_field_values]
 
         output = ranker.run(documents=docs_before)
         docs_after = output["documents"]
@@ -44,32 +53,37 @@ class TestMetaFieldRanker:
         sorted_scores = sorted([doc.meta["rating"] for doc in docs_after], reverse=True)
         assert [doc.meta["rating"] for doc in docs_after] == sorted_scores
 
-    @pytest.mark.integration
+    def test_run_with_weight_equal_to_0(self):
+        ranker = MetaFieldRanker(meta_field="rating", weight=0)
+        docs_before = [Document(content="abc", meta={"rating": value}) for value in [1.1, 0.5, 2.3]]
+        output = ranker.run(documents=docs_before)
+        docs_after = output["documents"]
+
+        assert len(docs_after) == 3
+        sorted_scores = sorted([doc.meta["rating"] for doc in docs_after], reverse=True)
+        assert [doc.meta["rating"] for doc in docs_after] == sorted_scores
+
     def test_returns_empty_list_if_no_documents_are_provided(self):
         ranker = MetaFieldRanker(meta_field="rating")
         output = ranker.run(documents=[])
         docs_after = output["documents"]
         assert docs_after == []
 
-    @pytest.mark.integration
     def test_raises_component_error_if_metadata_not_found(self):
         ranker = MetaFieldRanker(meta_field="rating")
         docs_before = [Document(content="abc", meta={"wrong_field": 1.3})]
         with pytest.raises(ComponentError):
             ranker.run(documents=docs_before)
 
-    @pytest.mark.integration
     def test_raises_component_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")
 
-    @pytest.mark.integration
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
     def test_raises_component_error_if_wrong_weight(self, score):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", weight=score)
 
-    @pytest.mark.integration
     def test_linear_score(self):
         ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
         docs_before = [
@@ -81,7 +95,6 @@ class TestMetaFieldRanker:
         docs_after = output["documents"]
         assert docs_after[0].score == 0.8
 
-    @pytest.mark.integration
     def test_reciprocal_rank_fusion(self):
         ranker = MetaFieldRanker(meta_field="rating", ranking_mode="reciprocal_rank_fusion", weight=0.5)
         docs_before = [
@@ -93,22 +106,19 @@ class TestMetaFieldRanker:
         docs_after = output["documents"]
         assert docs_after[0].score == 0.01626123744050767
 
-    @pytest.mark.integration
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
-    def test_linear_score_raises_warning_if_doc_wrong_score(self, score):
+    def test_linear_score_raises_warning_if_doc_wrong_score(self, score, caplog):
         ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
         docs_before = [
-            Document(id=1, content="abc", meta={"rating": 1.3}, score=score),
-            Document(id=2, content="abc", meta={"rating": 0.7}, score=0.4),
-            Document(id=3, content="abc", meta={"rating": 2.1}, score=0.6),
+            Document(id="1", content="abc", meta={"rating": 1.3}, score=score),
+            Document(id="2", content="abc", meta={"rating": 0.7}, score=0.4),
+            Document(id="3", content="abc", meta={"rating": 2.1}, score=0.6),
         ]
-        with pytest.warns(
-            UserWarning, match=rf"The score {score} for Document 1 is outside the \[0,1\] range; defaulting to 0"
-        ):
+        with caplog.at_level(logging.WARNING):
             ranker.run(documents=docs_before)
+            assert f"The score {score} for Document 1 is outside the [0,1] range; defaulting to 0" in caplog.text
 
-    @pytest.mark.integration
-    def test_linear_score_raises_raises_warning_if_doc_without_score(self):
+    def test_linear_score_raises_raises_warning_if_doc_without_score(self, caplog):
         ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
         docs_before = [
             Document(content="abc", meta={"rating": 1.3}),
@@ -116,5 +126,6 @@ class TestMetaFieldRanker:
             Document(content="abc", meta={"rating": 2.1}),
         ]
 
-        with pytest.warns(UserWarning, match="The score wasn't provided; defaulting to 0."):
+        with caplog.at_level(logging.WARNING):
             ranker.run(documents=docs_before)
+            assert "The score wasn't provided; defaulting to 0." in caplog.text

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from haystack import Document, ComponentError
+from haystack import Document
 from haystack.components.rankers.meta_field import MetaFieldRanker
 
 
@@ -81,11 +81,11 @@ class TestMetaFieldRanker:
 
     def test_warning_if_meta_not_found(self, caplog):
         ranker = MetaFieldRanker(meta_field="rating")
-        docs_before = [Document(content="abc", meta={"wrong_field": 1.3})]
+        docs_before = [Document(id="1", content="abc", meta={"wrong_field": 1.3})]
         with caplog.at_level(logging.WARNING):
             ranker.run(documents=docs_before)
             assert (
-                "The parameter <meta_field> is currently set to 'rating', but none of the provided Documents have this meta key."
+                "The parameter <meta_field> is currently set to 'rating', but none of the provided Documents with IDs 1 have this meta key."
                 in caplog.text
             )
 

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -54,7 +54,16 @@ class TestMetaFieldRanker:
         assert [doc.meta["rating"] for doc in docs_after] == sorted_scores
 
     def test_run_with_weight_equal_to_0(self):
-        ranker = MetaFieldRanker(meta_field="rating", weight=0)
+        ranker = MetaFieldRanker(meta_field="rating", weight=0.0)
+        docs_before = [Document(content="abc", meta={"rating": value}) for value in [1.1, 0.5, 2.3]]
+        output = ranker.run(documents=docs_before)
+        docs_after = output["documents"]
+
+        assert len(docs_after) == 3
+        assert [doc.meta["rating"] for doc in docs_after] == [1.1, 0.5, 2.3]
+
+    def test_run_with_weight_equal_to_1(self):
+        ranker = MetaFieldRanker(meta_field="rating", weight=1.0)
         docs_before = [Document(content="abc", meta={"rating": value}) for value in [1.1, 0.5, 2.3]]
         output = ranker.run(documents=docs_before)
         docs_after = output["documents"]
@@ -64,7 +73,7 @@ class TestMetaFieldRanker:
         assert [doc.meta["rating"] for doc in docs_after] == sorted_scores
 
     def test_sort_order_ascending(self):
-        ranker = MetaFieldRanker(meta_field="rating", weight=0, sort_order="ascending")
+        ranker = MetaFieldRanker(meta_field="rating", weight=1.0, sort_order="ascending")
         docs_before = [Document(content="abc", meta={"rating": value}) for value in [1.1, 0.5, 2.3]]
         output = ranker.run(documents=docs_before)
         docs_after = output["documents"]

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -16,13 +16,13 @@ class TestMetaFieldRanker:
                 "weight": 1.0,
                 "top_k": None,
                 "ranking_mode": "reciprocal_rank_fusion",
-                "infer_type": False,
+                "sort_order": "descending",
             },
         }
 
     def test_to_dict_with_custom_init_parameters(self):
         component = MetaFieldRanker(
-            meta_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score", infer_type=True
+            meta_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score", sort_order="ascending"
         )
         data = component.to_dict()
         assert data == {
@@ -32,7 +32,7 @@ class TestMetaFieldRanker:
                 "weight": 0.5,
                 "top_k": 5,
                 "ranking_mode": "linear_score",
-                "infer_type": True,
+                "sort_order": "ascending",
             },
         }
 


### PR DESCRIPTION
### Related Issues

- partially addresses the RecentnessRanker in issue https://github.com/deepset-ai/haystack/issues/6673. Only partially because this does not introduce the `infer_type` boolean discussed with @masci that would toggle whether we try to auto detect the type of the specified meta_field if all values of that meta field value are strings. Instead in this PR we focused on robustness of the MetaFieldRanker to fail less often by handling more edge cases and writing appropriate warning messages for them. 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Makes the MetaFieldRanker more robust. Specifically to prevent the ranker from throwing an error if one or more of the documents doesn't contain the specific meta data field. Now those documents will be ignored for ranking purposes and placed at the end of the ranked list so we don't completely throw them away. 
- Adding a `sort_order` that can have values of `descending` or `ascending`. This allows the user to decide which direction to sort the meta values. Before we had `descending` hard-coded. `ascending` could be useful, for example, ranking golfers were the the lowest score is best. 
- Refactoring
  - Used logger.warning where appropriate
  - consolidated duplicate code
  - added more params to the run time so users have more flexibility 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

- updated and added unit tests
- removed integration markings since all tests run very fast 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
