### PR TITLE
feat!: rename `model_name_or_path` to `model` in `NamedEntityExtractor`

### DIFF
--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -83,7 +83,7 @@ class NamedEntityExtractor:
         self,
         *,
         backend: Union[str, NamedEntityExtractorBackend],
-        model_name_or_path: str,
+        model: str,
         pipeline_kwargs: Optional[Dict[str, Any]] = None,
         device_id: int = -1,
     ) -> None:
@@ -92,7 +92,7 @@ class NamedEntityExtractor:
 
         :param backend:
             Backend to use for NER.
-        :param model_name_or_path:
+        :param model:
             Name of the model or a path to the model on
             the local disk.
 
@@ -115,12 +115,10 @@ class NamedEntityExtractor:
 
         self._backend: _NerBackend
         if backend == NamedEntityExtractorBackend.HUGGING_FACE:
-            self._backend = _HfBackend(
-                model_name_or_path=model_name_or_path, device_id=device_id, pipeline_kwargs=pipeline_kwargs
-            )
+            self._backend = _HfBackend(model_name_or_path=model, device_id=device_id, pipeline_kwargs=pipeline_kwargs)
         elif backend == NamedEntityExtractorBackend.SPACY:
             self._backend = _SpacyBackend(
-                model_name_or_path=model_name_or_path, device_id=device_id, pipeline_kwargs=pipeline_kwargs
+                model_name_or_path=model, device_id=device_id, pipeline_kwargs=pipeline_kwargs
             )
         else:
             raise ComponentError(f"Unknown NER backend '{type(backend).__name__}' for extractor")
@@ -153,7 +151,7 @@ class NamedEntityExtractor:
         return default_to_dict(
             self,
             backend=self._backend.type,
-            model_name_or_path=self._backend.model_name,
+            model=self._backend.model_name,
             device_id=self._backend.device_id,
             pipeline_kwargs=self._backend._pipeline_kwargs,
         )

--- a/releasenotes/notes/rename-model-param-ner-dce7536f2e7866fe.yaml
+++ b/releasenotes/notes/rename-model-param-ner-dce7536f2e7866fe.yaml
@@ -1,0 +1,3 @@
+---
+upgrade:
+    - Rename `model_name_or_path` to `model` in `NamedEntityExtractor`.

--- a/test/components/extractors/test_named_entity_extractor.py
+++ b/test/components/extractors/test_named_entity_extractor.py
@@ -6,22 +6,22 @@ from haystack.components.extractors import NamedEntityExtractor, NamedEntityExtr
 
 @pytest.mark.unit
 def test_named_entity_extractor_backend():
-    _ = NamedEntityExtractor(backend=NamedEntityExtractorBackend.HUGGING_FACE, model_name_or_path="dslim/bert-base-NER")
+    _ = NamedEntityExtractor(backend=NamedEntityExtractorBackend.HUGGING_FACE, model="dslim/bert-base-NER")
 
-    _ = NamedEntityExtractor(backend="hugging_face", model_name_or_path="dslim/bert-base-NER")
+    _ = NamedEntityExtractor(backend="hugging_face", model="dslim/bert-base-NER")
 
-    _ = NamedEntityExtractor(backend=NamedEntityExtractorBackend.SPACY, model_name_or_path="en_core_web_sm")
+    _ = NamedEntityExtractor(backend=NamedEntityExtractorBackend.SPACY, model="en_core_web_sm")
 
-    _ = NamedEntityExtractor(backend="spacy", model_name_or_path="en_core_web_sm")
+    _ = NamedEntityExtractor(backend="spacy", model="en_core_web_sm")
 
     with pytest.raises(ComponentError, match=r"Invalid backend"):
-        NamedEntityExtractor(backend="random_backend", model_name_or_path="dslim/bert-base-NER")
+        NamedEntityExtractor(backend="random_backend", model="dslim/bert-base-NER")
 
 
 @pytest.mark.unit
 def test_named_entity_extractor_serde():
     extractor = NamedEntityExtractor(
-        backend=NamedEntityExtractorBackend.HUGGING_FACE, model_name_or_path="dslim/bert-base-NER", device_id=-1
+        backend=NamedEntityExtractorBackend.HUGGING_FACE, model="dslim/bert-base-NER", device_id=-1
     )
 
     serde_data = extractor.to_dict()


### PR DESCRIPTION
### Related Issues

- related to #6534 

### Proposed Changes:

- Rename `model_name_or_path` to `model` in `NamedEntityExtractor`.

### How did you test it?

Local tests run, CI

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
