### PR TITLE
refactor: Extract HF stop words handling in `hf_utils.py`

### DIFF
--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -77,7 +77,7 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
             self,
             tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
             stop_words: List[str],
-            device: Union[str, "torch.device"] = "cpu",
+            device: Union[str, torch.device] = "cpu",
         ):
             super().__init__()
             # check if tokenizer is a valid tokenizer
@@ -94,14 +94,14 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
             encoded_stop_words = tokenizer(stop_words, add_special_tokens=False, padding=True, return_tensors="pt")
             self.stop_ids = encoded_stop_words.input_ids.to(device)
 
-        def __call__(self, input_ids: "torch.LongTensor", scores: "torch.FloatTensor", **kwargs) -> bool:
+        def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
             for stop_id in self.stop_ids:
                 found_stop_word = self.is_stop_word_found(input_ids, stop_id)
                 if found_stop_word:
                     return True
             return False
 
-        def is_stop_word_found(self, generated_text_ids: "torch.Tensor", stop_id: "torch.Tensor") -> bool:
+        def is_stop_word_found(self, generated_text_ids: torch.Tensor, stop_id: torch.Tensor) -> bool:
             generated_text_ids = generated_text_ids[-1]
             len_generated_text_ids = generated_text_ids.size(0)
             len_stop_id = stop_id.size(0)

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -80,6 +80,12 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
             device: Union[str, "torch.device"] = "cpu",
         ):
             super().__init__()
+            # check if tokenizer is a valid tokenizer
+            if not isinstance(tokenizer, (PreTrainedTokenizer, PreTrainedTokenizerFast)):
+                raise ValueError(
+                    f"Invalid tokenizer provided for StopWordsCriteria - {tokenizer}. "
+                    f"Please provide a valid tokenizer from the HuggingFace Transformers library."
+                )
             encoded_stop_words = tokenizer(stop_words, add_special_tokens=False, padding=True, return_tensors="pt")
             self.stop_ids = encoded_stop_words.input_ids.to(device)
 

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -86,6 +86,11 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
                     f"Invalid tokenizer provided for StopWordsCriteria - {tokenizer}. "
                     f"Please provide a valid tokenizer from the HuggingFace Transformers library."
                 )
+            if not tokenizer.pad_token:
+                if tokenizer.eos_token:
+                    tokenizer.pad_token = tokenizer.eos_token
+                else:
+                    tokenizer.add_special_tokens({"pad_token": "[PAD]"})
             encoded_stop_words = tokenizer(stop_words, add_special_tokens=False, padding=True, return_tensors="pt")
             self.stop_ids = encoded_stop_words.input_ids.to(device)
 

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from haystack.lazy_imports import LazyImport
 
@@ -55,3 +55,44 @@ def check_valid_model(model_id: str, token: Optional[str]) -> None:
     allowed_model = model_info.pipeline_tag in ["text-generation", "text2text-generation"]
     if not allowed_model:
         raise ValueError(f"Model {model_id} is not a text generation model. Please provide a text generation model.")
+
+
+with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
+    import torch
+    from transformers import StoppingCriteria, PreTrainedTokenizer, PreTrainedTokenizerFast
+
+    class StopWordsCriteria(StoppingCriteria):
+        """
+        Stops text generation if any one of the stop words is generated.
+
+        Note: When a stop word is encountered, the generation of new text is stopped.
+        However, if the stop word is in the prompt itself, it can stop generating new text
+        prematurely after the first token. This is particularly important for LLMs designed
+        for dialogue generation. For these models, like for example mosaicml/mpt-7b-chat,
+        the output includes both the new text and the original prompt. Therefore, it's important
+        to make sure your prompt has no stop words.
+        """
+
+        def __init__(
+            self,
+            tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+            stop_words: List[str],
+            device: Union[str, "torch.device"] = "cpu",
+        ):
+            super().__init__()
+            encoded_stop_words = tokenizer(stop_words, add_special_tokens=False, padding=True, return_tensors="pt")
+            self.stop_ids = encoded_stop_words.input_ids.to(device)
+
+        def __call__(self, input_ids: "torch.LongTensor", scores: "torch.FloatTensor", **kwargs) -> bool:
+            for stop_id in self.stop_ids:
+                found_stop_word = self.is_stop_word_found(input_ids, stop_id)
+                if found_stop_word:
+                    return True
+            return False
+
+        def is_stop_word_found(self, generated_text_ids: "torch.Tensor", stop_id: "torch.Tensor") -> bool:
+            generated_text_ids = generated_text_ids[-1]
+            len_generated_text_ids = generated_text_ids.size(0)
+            len_stop_id = stop_id.size(0)
+            result = all(generated_text_ids[len_generated_text_ids - len_stop_id :].eq(stop_id))
+            return result

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from haystack import component, default_to_dict, default_from_dict
+from haystack.components.generators.hf_utils import StopWordsCriteria
 from haystack.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
@@ -11,49 +12,7 @@ SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
     import torch
     from huggingface_hub import model_info
-    from transformers import (
-        pipeline,
-        StoppingCriteriaList,
-        StoppingCriteria,
-        PreTrainedTokenizer,
-        PreTrainedTokenizerFast,
-    )
-
-    class StopWordsCriteria(StoppingCriteria):
-        """
-        Stops text generation if any one of the stop words is generated.
-
-        Note: When a stop word is encountered, the generation of new text is stopped.
-        However, if the stop word is in the prompt itself, it can stop generating new text
-        prematurely after the first token. This is particularly important for LLMs designed
-        for dialogue generation. For these models, like for example mosaicml/mpt-7b-chat,
-        the output includes both the new text and the original prompt. Therefore, it's important
-        to make sure your prompt has no stop words.
-        """
-
-        def __init__(
-            self,
-            tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
-            stop_words: List[str],
-            device: Union[str, "torch.device"] = "cpu",
-        ):
-            super().__init__()
-            encoded_stop_words = tokenizer(stop_words, add_special_tokens=False, padding=True, return_tensors="pt")
-            self.stop_ids = encoded_stop_words.input_ids.to(device)
-
-        def __call__(self, input_ids: "torch.LongTensor", scores: "torch.FloatTensor", **kwargs) -> bool:
-            for stop_id in self.stop_ids:
-                found_stop_word = self.is_stop_word_found(input_ids, stop_id)
-                if found_stop_word:
-                    return True
-            return False
-
-        def is_stop_word_found(self, generated_text_ids: "torch.Tensor", stop_id: "torch.Tensor") -> bool:
-            generated_text_ids = generated_text_ids[-1]
-            len_generated_text_ids = generated_text_ids.size(0)
-            len_stop_id = stop_id.size(0)
-            result = all(generated_text_ids[len_generated_text_ids - len_stop_id :].eq(stop_id))
-            return result
+    from transformers import StoppingCriteriaList, pipeline
 
 
 @component

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, Mock
 
 import pytest
 import torch
+from transformers import PreTrainedTokenizerFast
 
 from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator, StopWordsCriteria
 
@@ -362,7 +363,7 @@ class TestHuggingFaceLocalGenerator:
         # "ambiguously" token comes from "ambiguously". The algorithm will return True for presence of
         # "unambiguously" in input_ids1 which is not correct.
 
-        stop_words_criteria = StopWordsCriteria(tokenizer=Mock(), stop_words=["mock data"])
+        stop_words_criteria = StopWordsCriteria(tokenizer=Mock(spec=PreTrainedTokenizerFast), stop_words=["mock data"])
         # because we are mocking the tokenizer, we need to set the stop words manually
         stop_words_criteria.stop_ids = stop_words_id
 


### PR DESCRIPTION
### Why:
The changes in the pull request serve to improve the modularization and robustness of the stop words criteria feature in the Haystack library. The motivation behind these adjustments is to ensure that the functionality for stopping text generation when specific words are produced is localized, easier to maintain, and less prone to errors caused by invalid tokenizer usage or missing special tokens in the tokenizer. By encapsulating this functionality into the `hf_utils` module and explicitly checking for a valid tokenizer and required special tokens, the quality of the Haystack library is enhanced, and developers can more reliably integrate stopping criteria into their text generation processes.

### What:
- Moved the `StopWordsCriteria` class from `hugging_face_local.py` to `hf_utils.py`.
    - This centralizes utility methods related to the Hugging Face Transformers in one place.
    - Allows for better code reuse and modularization.
- Added checks for a valid tokenizer instance within the `StopWordsCriteria` class.
    - Ensures the tokenizer provided is either `PreTrainedTokenizer` or `PreTrainedTokenizerFast`.
- Included logic to handle missing padding tokens in the tokenizer.
    - Sets the `eos_token` as the `pad_token` if `pad_token` is absent.
    - Adds a special token "[PAD]" as `pad_token` if both `pad_token` and `eos_token` are missing.
- Removed the old implementation of `StopWordsCriteria` from `hugging_face_local.py`.
    - Reduces code duplication and potential inconsistencies.
  
### How can it be used:
- Importing the `StopWordsCriteria` in text generation components:
  ```python
  from haystack.components.generators.hf_utils import StopWordsCriteria
  ```
- Using `StopWordsCriteria` during the text generation to stop generation when stop words are encountered:
  ```python
  tokenizer = # your instance of `PreTrainedTokenizer` or `PreTrainedTokenizerFast`
  stop_words = ["stopword1", "stopword2"]
  stopping_criteria = StopWordsCriteria(tokenizer=tokenizer, stop_words=stop_words, device="cpu")
  ```
- Ensuring that a tokenizer has the needed `pad_token` before initializing the `StopWordsCriteria`:
  ```python
  # Assuming `tokenizer` lacks a `pad_token`
  if not tokenizer.pad_token and tokenizer.eos_token:
      tokenizer.pad_token = tokenizer.eos_token
  elif not tokenizer.pad_token:
      tokenizer.add_special_tokens({"pad_token": "[PAD]"})
  ```

### How did you test it:
- No new tests were added, and the existing tests will be executed in CI. 
- Manual tests were [completed](https://github.com/vblagoje/notebooks/blob/main/haystack2x-experiments/stop_words_tests.ipynb) to make sure that stop words continue to work for non-chat models
  
It is recommended to verify these tests were part of the PR and seek additional tests if necessary, especially considering the newly added checks for the tokenizer's validity and padding token presence.

### Notes for the reviewer:
- Care should be taken to review the assumptions made about tokenizers, particularly the decision to use `eos_token` as a `pad_token` or the addition of a "[PAD]" token. This could have implications for models that use these tokens in specific ways.
- Ensure the new centralization of the `StopWordsCriteria` class does not conflict with its usage across different components in the Haystack library.
- The removal of code from `hugging_face_local.py` indicates refactoring, which usually demands thorough regression tests to ensure no features were broken in the process.
- Special consideration should be given to reviewing the newly included device parameter handling, making sure that the transition of tensors to the specified device (`cpu` or `cuda`) is working smoothly.
- There is no information provided about backward compatibility or how these changes might affect existing users of the Haystack library. If this is a concern, it may be worth discussing the impact of these changes on the library's versioning and release notes.
