### PR TITLE
feat: Add `HuggingFaceLocalChatGenerator`

### DIFF
--- a/haystack/components/generators/chat/__init__.py
+++ b/haystack/components/generators/chat/__init__.py
@@ -1,5 +1,13 @@
+from haystack.components.generators.chat.hugging_face_local import HuggingFaceLocalChatGenerator
 from haystack.components.generators.chat.hugging_face_tgi import HuggingFaceTGIChatGenerator
 from haystack.components.generators.chat.openai import OpenAIChatGenerator, GPTChatGenerator
 from haystack.components.generators.chat.azure import AzureOpenAIChatGenerator
 
-__all__ = ["HuggingFaceTGIChatGenerator", "OpenAIChatGenerator", "GPTChatGenerator", "AzureOpenAIChatGenerator"]
+
+__all__ = [
+    "HuggingFaceLocalChatGenerator",
+    "HuggingFaceTGIChatGenerator",
+    "OpenAIChatGenerator",
+    "GPTChatGenerator",
+    "AzureOpenAIChatGenerator",
+]

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -267,8 +267,8 @@ class HuggingFaceLocalChatGenerator:
         if stop_words_criteria:
             generation_kwargs["stopping_criteria"] = StoppingCriteriaList([stop_words_criteria])
 
-        num_responses = generation_kwargs.get("num_return_sequences", 1)
         if self.streaming_callback:
+            num_responses = generation_kwargs.get("num_return_sequences", 1)
             if num_responses > 1:
                 logger.warning(
                     "Streaming is enabled, but the number of responses is set to %d. "
@@ -277,6 +277,7 @@ class HuggingFaceLocalChatGenerator:
                     num_responses,
                 )
                 generation_kwargs["num_return_sequences"] = 1
+            # streamer parameter hooks into HF streaming, HFTokenStreamingHandler is an adapter to our streaming
             generation_kwargs["streamer"] = HFTokenStreamingHandler(tokenizer, self.streaming_callback, stop_words)
 
         # Prepare the prompt for the model

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -20,8 +20,11 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
 @component
 class HuggingFaceLocalChatGenerator:
     """
-    Generator based on a Hugging Face model.
-    This component provides an interface to generate text using a Hugging Face model that runs locally.
+
+    The `HuggingFaceLocalChatGenerator` class is a component designed for generating chat responses using models from
+    Hugging Face's model hub. It is tailored for local runtime text generation tasks and provides a convenient interface
+    for working with chat-based models, such as `mistralai/Mistral-7B-Instruct-v0.2` or `meta-llama/Llama-2-7b-chat-hf`
+    etc.
 
     Usage example:
     ```python
@@ -30,7 +33,7 @@ class HuggingFaceLocalChatGenerator:
 
 
 
-    generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2")
+    generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2", device="cuda:0")
     messages = [ChatMessage.from_user("What's Natural Language Processing? Be brief.")]
     print(generator.run(messages))
 
@@ -259,6 +262,15 @@ class HuggingFaceLocalChatGenerator:
 
         # pipeline call doesn't support stop_sequences, so we need to pop it
         stop_words = generation_kwargs.pop("stop_sequences", None)
+
+        # check all stop words are strings
+        if stop_words and not all(isinstance(word, str) for word in stop_words):
+            logger.warning(
+                "Invalid stop words provided. Stop words must be specified as a list of strings. "
+                "Ignoring stop words: %s",
+                stop_words,
+            )
+            stop_words = None
 
         # Set up stop words criteria if stop words exist
         stop_words_criteria = StopWordsCriteria(tokenizer, stop_words, self.pipeline.device) if stop_words else None

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -321,7 +321,7 @@ class HuggingFaceLocalChatGenerator:
         index: int,
         tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
         prompt: str,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
+        generation_kwargs: Dict[str, Any],
     ) -> ChatMessage:
         """
         Create a ChatMessage instance from the provided text, populated with metadata.

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -1,0 +1,265 @@
+import logging
+from typing import Any, Dict, List, Literal, Optional, Union, Callable
+
+from haystack import component, default_to_dict, default_from_dict
+from haystack.components.generators.hf_utils import StopWordsCriteria, check_generation_params
+from haystack.dataclasses import ChatMessage, StreamingChunk
+from haystack.lazy_imports import LazyImport
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
+
+with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
+    import torch
+    from huggingface_hub import model_info
+    from transformers import StoppingCriteriaList, pipeline
+
+
+@component
+class HuggingFaceLocalChatGenerator:
+    """
+    Generator based on a Hugging Face model.
+    This component provides an interface to generate text using a Hugging Face model that runs locally.
+
+    Usage example:
+    ```python
+    from haystack.components.generators import HuggingFaceLocalChatGenerator
+
+    generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2",
+                                          generation_kwargs={
+                                            "max_new_tokens": 500,
+                                            })
+    messages = [ChatMessage.from_system("\\nYou are a helpful, respectful and honest assistant"),
+                ChatMessage.from_user("What's Natural Language Processing?")]
+    print(generator.run(messages))
+    # {'replies': ['John Cusack']}
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str = "mistralai/Mistral-7B-Instruct-v0.2",
+        task: Optional[Literal["text-generation", "text2text-generation"]] = None,
+        device: Optional[str] = None,
+        token: Optional[Union[str, bool]] = None,
+        chat_template: Optional[str] = None,
+        generation_kwargs: Optional[Dict[str, Any]] = None,
+        huggingface_pipeline_kwargs: Optional[Dict[str, Any]] = None,
+        stop_words: Optional[List[str]] = None,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+    ):
+        """
+        :param model: The name or path of a Hugging Face model for text generation,
+            for example, "google/flan-t5-large".
+            If the model is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
+        :param task: The task for the Hugging Face pipeline.
+            Possible values are "text-generation" and "text2text-generation".
+            Generally, decoder-only models like GPT support "text-generation",
+            while encoder-decoder models like T5 support "text2text-generation".
+            If the task is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
+            If not specified, the component will attempt to infer the task from the model name,
+            calling the Hugging Face Hub API.
+        :param device: The device on which the model is loaded. (e.g., "cpu", "cuda:0").
+            If `device` or `device_map` is specified in the `huggingface_pipeline_kwargs`,
+            this parameter will be ignored.
+        :param token: The token to use as HTTP bearer authorization for remote files.
+            If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface).
+            If the token is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
+        :param chat_template: This optional parameter allows you to specify a Jinja template for formatting chat
+            messages. While high-quality and well-supported chat models typically include their own chat templates
+            accessible through their tokenizer, there are models that do not offer this feature. For such scenarios,
+            or if you wish to use a custom template instead of the model's default, you can use this parameter to
+            set your preferred chat template.
+        :param generation_kwargs: A dictionary containing keyword arguments to customize text generation.
+            Some examples: `max_length`, `max_new_tokens`, `temperature`, `top_k`, `top_p`,...
+            See Hugging Face's documentation for more information:
+            - https://huggingface.co/docs/transformers/main/en/generation_strategies#customize-text-generation
+            - https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.GenerationConfig
+        :param huggingface_pipeline_kwargs: Dictionary containing keyword arguments used to initialize the
+            Hugging Face pipeline for text generation.
+            These keyword arguments provide fine-grained control over the Hugging Face pipeline.
+            In case of duplication, these kwargs override `model`, `task`, `device`, and `token` init parameters.
+            See Hugging Face's [documentation](https://huggingface.co/docs/transformers/en/main_classes/pipelines#transformers.pipeline.task)
+            for more information on the available kwargs.
+            In this dictionary, you can also include `model_kwargs` to specify the kwargs
+            for model initialization:
+            https://huggingface.co/docs/transformers/en/main_classes/model#transformers.PreTrainedModel.from_pretrained
+        :param stop_words: A list of stop words. If any one of the stop words is generated, the generation is stopped.
+            If you provide this parameter, you should not specify the `stopping_criteria` in `generation_kwargs`.
+            For some chat models, the output includes both the new text and the original prompt.
+            In these cases, it's important to make sure your prompt has no stop words.
+        :param streaming_callback: An optional callable for handling streaming responses.
+        """
+        torch_and_transformers_import.check()
+
+        huggingface_pipeline_kwargs = huggingface_pipeline_kwargs or {}
+        generation_kwargs = generation_kwargs or {}
+
+        # check if the huggingface_pipeline_kwargs contain the essential parameters
+        # otherwise, populate them with values from other init parameters
+        huggingface_pipeline_kwargs.setdefault("model", model)
+        huggingface_pipeline_kwargs.setdefault("token", token)
+        if (
+            device is not None
+            and "device" not in huggingface_pipeline_kwargs
+            and "device_map" not in huggingface_pipeline_kwargs
+        ):
+            huggingface_pipeline_kwargs["device"] = device
+
+        # task identification and validation
+        if task is None:
+            if "task" in huggingface_pipeline_kwargs:
+                task = huggingface_pipeline_kwargs["task"]
+            elif isinstance(huggingface_pipeline_kwargs["model"], str):
+                task = model_info(
+                    huggingface_pipeline_kwargs["model"], token=huggingface_pipeline_kwargs["token"]
+                ).pipeline_tag
+
+        if task not in SUPPORTED_TASKS:
+            raise ValueError(
+                f"Task '{task}' is not supported. " f"The supported tasks are: {', '.join(SUPPORTED_TASKS)}."
+            )
+        huggingface_pipeline_kwargs["task"] = task
+
+        # if not specified, set return_full_text to False for text-generation
+        # only generated text is returned (excluding prompt)
+        if task == "text-generation":
+            generation_kwargs.setdefault("return_full_text", False)
+
+        if stop_words and "stopping_criteria" in generation_kwargs:
+            raise ValueError(
+                "Found both the `stop_words` init parameter and the `stopping_criteria` key in `generation_kwargs`. "
+                "Please specify only one of them."
+            )
+
+        self.huggingface_pipeline_kwargs = huggingface_pipeline_kwargs
+        self.generation_kwargs = generation_kwargs
+        self.stop_words = stop_words
+        self.chat_template = chat_template
+        self.streaming_callback = streaming_callback
+        self.pipeline = None
+        self.stopping_criteria_list = None
+
+    def _get_telemetry_data(self) -> Dict[str, Any]:
+        """
+        Data that is sent to Posthog for usage analytics.
+        """
+        if isinstance(self.huggingface_pipeline_kwargs["model"], str):
+            return {"model": self.huggingface_pipeline_kwargs["model"]}
+        return {"model": f"[object of type {type(self.huggingface_pipeline_kwargs['model'])}]"}
+
+    def warm_up(self):
+        if self.pipeline is None:
+            self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
+
+        if self.stop_words and self.stopping_criteria_list is None:
+            stop_words_criteria = StopWordsCriteria(
+                tokenizer=self.pipeline.tokenizer, stop_words=self.stop_words, device=self.pipeline.device
+            )
+            self.stopping_criteria_list = StoppingCriteriaList([stop_words_criteria])
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        serialization_dict = default_to_dict(
+            self,
+            huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
+            generation_kwargs=self.generation_kwargs,
+            stop_words=self.stop_words,
+        )
+
+        huggingface_pipeline_kwargs = serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]
+        # we don't want to serialize valid tokens
+        if isinstance(huggingface_pipeline_kwargs["token"], str):
+            serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"].pop("token")
+        # convert torch.dtype to string for serialization
+        # 1. torch_dtype can be specified in huggingface_pipeline_kwargs
+        torch_dtype = huggingface_pipeline_kwargs.get("torch_dtype", None)
+        if isinstance(torch_dtype, torch.dtype):
+            serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]["torch_dtype"] = str(torch_dtype)
+        # 2. torch_dtype and bnb_4bit_compute_dtype can be specified in model_kwargs
+        model_kwargs = huggingface_pipeline_kwargs.get("model_kwargs", {})
+        for key, value in model_kwargs.items():
+            if key in ["torch_dtype", "bnb_4bit_compute_dtype"] and isinstance(value, torch.dtype):
+                serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"][key] = str(value)
+        # 3. bnb_4bit_compute_dtype can be specified in model_kwargs["quantization_config"]
+        quantization_config = model_kwargs.get("quantization_config", {})
+        bnb_4bit_compute_dtype = quantization_config.get("bnb_4bit_compute_dtype", None)
+        if isinstance(bnb_4bit_compute_dtype, torch.dtype):
+            serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"]["quantization_config"][
+                "bnb_4bit_compute_dtype"
+            ] = str(bnb_4bit_compute_dtype)
+
+        return serialization_dict
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "HuggingFaceLocalChatGenerator":
+        """
+        Deserialize this component from a dictionary.
+        """
+        torch_and_transformers_import.check()
+        init_params = data.get("init_parameters", {})
+        huggingface_pipeline_kwargs = init_params.get("huggingface_pipeline_kwargs", {})
+        model_kwargs = huggingface_pipeline_kwargs.get("model_kwargs", {})
+
+        # convert string to torch.dtype
+        # 1. torch_dtype can be specified in huggingface_pipeline_kwargs
+        torch_dtype = huggingface_pipeline_kwargs.get("torch_dtype", None)
+        if torch_dtype and torch_dtype.startswith("torch."):
+            data["init_parameters"]["huggingface_pipeline_kwargs"]["torch_dtype"] = getattr(
+                torch, torch_dtype.strip("torch.")
+            )
+        # 2. torch_dtype and bnb_4bit_compute_dtype can be specified in model_kwargs
+        for key, value in model_kwargs.items():
+            if key in ["torch_dtype", "bnb_4bit_compute_dtype"] and value.startswith("torch."):
+                data["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"][key] = getattr(
+                    torch, value.strip("torch.")
+                )
+        # 3. bnb_4bit_compute_dtype can be specified in model_kwargs["quantization_config"]
+        quantization_config = model_kwargs.get("quantization_config", {})
+        bnb_4bit_compute_dtype = quantization_config.get("bnb_4bit_compute_dtype", None)
+        if bnb_4bit_compute_dtype and bnb_4bit_compute_dtype.startswith("torch."):
+            data["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"]["quantization_config"][
+                "bnb_4bit_compute_dtype"
+            ] = getattr(torch, bnb_4bit_compute_dtype.strip("torch."))
+
+        return default_from_dict(cls, data)
+
+    @component.output_types(replies=List[ChatMessage])
+    def run(self, messages: List[ChatMessage], generation_kwargs: Optional[Dict[str, Any]] = None):
+        """
+        Invoke the text generation inference based on the provided messages and generation parameters.
+
+        :param messages: A list of ChatMessage instances representing the input messages.
+        :param generation_kwargs: Additional keyword arguments for text generation.
+        :return: A list containing the generated responses as ChatMessage instances.
+        """
+        if self.pipeline is None:
+            raise RuntimeError("The generation model has not been loaded. Please call warm_up() before running.")
+
+        tokenizer = self.pipeline.tokenizer
+
+        # check generation kwargs given as parameters to override the default ones
+        additional_params = ["n", "stop_words"]
+        check_generation_params(generation_kwargs, additional_params)
+
+        # update generation kwargs by merging with the default ones
+        generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+        num_responses = generation_kwargs.pop("n", 1)
+
+        # apply either model's chat template or the user-provided one
+        prepared_prompt: str = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+        prompt_token_count: int = 100  # calculate_token_length(prepared_prompt, tokenizer)
+
+        return self._run_non_streaming(prepared_prompt, prompt_token_count, num_responses, generation_kwargs)
+
+    def _run_non_streaming(
+        self, prepared_prompt: str, prompt_token_count: int, num_responses: int, generation_kwargs: Dict[str, Any]
+    ) -> Dict[str, List[ChatMessage]]:
+        output = self.pipeline(prepared_prompt, stopping_criteria=self.stopping_criteria_list, **generation_kwargs)
+        replies = [o["generated_text"] for o in output if "generated_text" in o]
+        chat_messages = [ChatMessage.from_assistant(r) for r in replies]
+        return {"replies": chat_messages}

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -6,6 +6,7 @@ from haystack.components.generators.hf_utils import PIPELINE_SUPPORTED_TASKS
 
 from haystack import component, default_to_dict, default_from_dict
 from haystack.components.generators.hf_utils import StopWordsCriteria, HFTokenStreamingHandler
+from haystack.components.generators.utils import serialize_callback_handler, deserialize_callback_handler
 from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.lazy_imports import LazyImport
 
@@ -169,8 +170,12 @@ class HuggingFaceLocalChatGenerator:
         """
         Serialize this component to a dictionary.
         """
+        callback_name = serialize_callback_handler(self.streaming_callback) if self.streaming_callback else None
         serialization_dict = default_to_dict(
-            self, huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs, generation_kwargs=self.generation_kwargs
+            self,
+            huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
+            generation_kwargs=self.generation_kwargs,
+            streaming_callback=callback_name,
         )
 
         huggingface_pipeline_kwargs = serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]
@@ -202,8 +207,13 @@ class HuggingFaceLocalChatGenerator:
         """
         Deserialize this component from a dictionary.
         """
-        torch_and_transformers_import.check()
+        torch_and_transformers_import.check()  # leave this, cls method
+
         init_params = data.get("init_parameters", {})
+        serialized_callback_handler = init_params.get("streaming_callback")
+        if serialized_callback_handler:
+            data["init_parameters"]["streaming_callback"] = deserialize_callback_handler(serialized_callback_handler)
+
         huggingface_pipeline_kwargs = init_params.get("huggingface_pipeline_kwargs", {})
         model_kwargs = huggingface_pipeline_kwargs.get("model_kwargs", {})
 

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -265,6 +265,11 @@ class HuggingFaceLocalChatGenerator:
             messages, tokenize=False, chat_template=self.chat_template, add_generation_prompt=True
         )
 
+        # Prepare tokenizer for generation
+        generation_kwargs["pad_token_id"] = (
+            tokenizer.eos_token_id if not tokenizer.pad_token_id else generation_kwargs.get("pad_token_id", None)
+        )
+
         # Generate responses
         output = self.pipeline(prepared_prompt, **generation_kwargs)
         replies = [o.get("generated_text", "") for o in output]

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -14,7 +14,6 @@ from haystack.utils import ComponentDevice
 logger = logging.getLogger(__name__)
 
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
-    import torch
     from huggingface_hub import model_info
     from transformers import StoppingCriteriaList, pipeline, PreTrainedTokenizer, PreTrainedTokenizerFast
     from haystack.components.generators.hf_utils import StopWordsCriteria  # pylint: disable=ungrouped-imports

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Union, Callable
 from haystack.components.generators.hf_utils import PIPELINE_SUPPORTED_TASKS
 
 from haystack import component, default_to_dict, default_from_dict
-from haystack.components.generators.hf_utils import StopWordsCriteria, HFTokenStreamingHandler
+from haystack.components.generators.hf_utils import HFTokenStreamingHandler
 from haystack.components.generators.utils import serialize_callback_handler, deserialize_callback_handler
 from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.lazy_imports import LazyImport
@@ -16,6 +16,7 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
     import torch
     from huggingface_hub import model_info
     from transformers import StoppingCriteriaList, pipeline, PreTrainedTokenizer, PreTrainedTokenizerFast
+    from haystack.components.generators.hf_utils import StopWordsCriteria
 
 
 @component

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -16,7 +16,7 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
     import torch
     from huggingface_hub import model_info
     from transformers import StoppingCriteriaList, pipeline, PreTrainedTokenizer, PreTrainedTokenizerFast
-    from haystack.components.generators.hf_utils import StopWordsCriteria
+    from haystack.components.generators.hf_utils import StopWordsCriteria  # pylint: disable=ungrouped-imports
 
 
 @component

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -36,7 +36,8 @@ class HuggingFaceLocalChatGenerator:
 
 
 
-    generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2", device="cuda:0")
+    generator = HuggingFaceLocalChatGenerator(model="HuggingFaceH4/zephyr-7b-beta",
+                                             huggingface_pipeline_kwargs={"device_map":"auto"})
     messages = [ChatMessage.from_user("What's Natural Language Processing? Be brief.")]
     print(generator.run(messages))
 

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -8,6 +8,8 @@ with LazyImport(message="Run 'pip install transformers'") as transformers_import
     from huggingface_hub import InferenceClient, HfApi
     from huggingface_hub.utils import RepositoryNotFoundError
 
+PIPELINE_SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
+
 
 def check_generation_params(kwargs: Optional[Dict[str, Any]], additional_accepted_params: Optional[List[str]] = None):
     """
@@ -61,6 +63,8 @@ def check_valid_model(model_id: str, token: Optional[str]) -> None:
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
     import torch
     from transformers import StoppingCriteria, PreTrainedTokenizer, PreTrainedTokenizerFast, TextStreamer
+
+    transformers_import.check()
 
     class StopWordsCriteria(StoppingCriteria):
         """

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -122,5 +122,5 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
 
         def on_finalized_text(self, word: str, stream_end: bool = False):
             word_to_send = word + "\n" if stream_end else word
-            if word_to_send not in self.stop_words:
+            if word_to_send.strip() not in self.stop_words:
                 self.token_handler(StreamingChunk(content=word_to_send))

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -114,10 +114,13 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
             self,
             tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
             stream_handler: Callable[[StreamingChunk], None],
+            stop_words: Optional[List[str]] = None,
         ):
             super().__init__(tokenizer=tokenizer, skip_prompt=True)  # type: ignore
             self.token_handler = stream_handler
+            self.stop_words = stop_words or []
 
-        def on_finalized_text(self, token: str, stream_end: bool = False):
-            token_to_send = token + "\n" if stream_end else token
-            self.token_handler(StreamingChunk(content=token_to_send))
+        def on_finalized_text(self, word: str, stream_end: bool = False):
+            word_to_send = word + "\n" if stream_end else word
+            if word_to_send not in self.stop_words:
+                self.token_handler(StreamingChunk(content=word_to_send))

--- a/releasenotes/notes/add-hugging-face-chat-local-5fe7a88e24fde11b.yaml
+++ b/releasenotes/notes/add-hugging-face-chat-local-5fe7a88e24fde11b.yaml
@@ -1,0 +1,20 @@
+---
+features:
+  - |
+    Introducing the HuggingFaceLocalChatGenerator, a new chat-based generator designed for leveraging chat models from
+    Hugging Face's (HF) model hub. Users can now perform inference with chat-based models in a local runtime, utilizing
+    familiar HF generation parameters, stop words, and even employing custom chat templates for custom message formatting.
+    This component also supports streaming responses and is optimized for compatibility with a variety of devices.
+
+    Here is an example of how to use the HuggingFaceLocalChatGenerator:
+
+    ```python
+    from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
+    from haystack.dataclasses import ChatMessage
+
+
+
+    generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2", device="cuda:0")
+    messages = [ChatMessage.from_user("What's Natural Language Processing? Be brief.")]
+    print(generator.run(messages))
+    ```

--- a/releasenotes/notes/add-hugging-face-chat-local-5fe7a88e24fde11b.yaml
+++ b/releasenotes/notes/add-hugging-face-chat-local-5fe7a88e24fde11b.yaml
@@ -12,9 +12,8 @@ features:
     from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
     from haystack.dataclasses import ChatMessage
 
-
-
-    generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2", device="cuda:0")
+    generator = HuggingFaceLocalChatGenerator(model="HuggingFaceH4/zephyr-7b-beta")
+    generator.warm_up()
     messages = [ChatMessage.from_user("What's Natural Language Processing? Be brief.")]
     print(generator.run(messages))
     ```

--- a/test/components/generators/chat/test_hugging_face_local.py
+++ b/test/components/generators/chat/test_hugging_face_local.py
@@ -5,6 +5,7 @@ from transformers import PreTrainedTokenizer
 
 from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
 from haystack.dataclasses import ChatMessage, ChatRole
+from haystack.utils import ComponentDevice
 
 
 # used to test serialization of streaming_callback
@@ -53,52 +54,65 @@ class TestHuggingFaceLocalChatGenerator:
 
     def test_init_custom_token(self):
         generator = HuggingFaceLocalChatGenerator(
-            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", token="test-token"
+            model="mistralai/Mistral-7B-Instruct-v0.2",
+            task="text2text-generation",
+            token="test-token",
+            device=ComponentDevice.from_str("cpu"),
         )
 
         assert generator.huggingface_pipeline_kwargs == {
             "model": "mistralai/Mistral-7B-Instruct-v0.2",
             "task": "text2text-generation",
             "token": "test-token",
+            "device": "cpu",
         }
 
     def test_init_custom_device(self):
         generator = HuggingFaceLocalChatGenerator(
-            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", device="cuda:0"
+            model="mistralai/Mistral-7B-Instruct-v0.2",
+            task="text2text-generation",
+            device=ComponentDevice.from_str("cpu"),
         )
 
         assert generator.huggingface_pipeline_kwargs == {
             "model": "mistralai/Mistral-7B-Instruct-v0.2",
             "task": "text2text-generation",
             "token": None,
-            "device": "cuda:0",
+            "device": "cpu",
         }
 
     def test_init_task_parameter(self):
-        generator = HuggingFaceLocalChatGenerator(task="text2text-generation")
+        generator = HuggingFaceLocalChatGenerator(task="text2text-generation", device=ComponentDevice.from_str("cpu"))
 
         assert generator.huggingface_pipeline_kwargs == {
-            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "model": "HuggingFaceH4/zephyr-7b-beta",
             "task": "text2text-generation",
             "token": None,
+            "device": "cpu",
         }
 
     def test_init_task_in_huggingface_pipeline_kwargs(self):
-        generator = HuggingFaceLocalChatGenerator(huggingface_pipeline_kwargs={"task": "text2text-generation"})
+        generator = HuggingFaceLocalChatGenerator(
+            huggingface_pipeline_kwargs={"task": "text2text-generation"}, device=ComponentDevice.from_str("cpu")
+        )
 
         assert generator.huggingface_pipeline_kwargs == {
-            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "model": "HuggingFaceH4/zephyr-7b-beta",
             "task": "text2text-generation",
             "token": None,
+            "device": "cpu",
         }
 
     def test_init_task_inferred_from_model_name(self, model_info_mock):
-        generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2")
+        generator = HuggingFaceLocalChatGenerator(
+            model="mistralai/Mistral-7B-Instruct-v0.2", device=ComponentDevice.from_str("cpu")
+        )
 
         assert generator.huggingface_pipeline_kwargs == {
             "model": "mistralai/Mistral-7B-Instruct-v0.2",
             "task": "text2text-generation",
             "token": None,
+            "device": "cpu",
         }
 
     def test_init_invalid_task(self):
@@ -141,7 +155,9 @@ class TestHuggingFaceLocalChatGenerator:
     @patch("haystack.components.generators.chat.hugging_face_local.pipeline")
     def test_warm_up(self, pipeline_mock):
         generator = HuggingFaceLocalChatGenerator(
-            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation"
+            model="mistralai/Mistral-7B-Instruct-v0.2",
+            task="text2text-generation",
+            device=ComponentDevice.from_str("cpu"),
         )
 
         pipeline_mock.assert_not_called()
@@ -149,7 +165,7 @@ class TestHuggingFaceLocalChatGenerator:
         generator.warm_up()
 
         pipeline_mock.assert_called_once_with(
-            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", token=None
+            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", token=None, device="cpu"
         )
 
     def test_run(self, model_info_mock, mock_pipeline_tokenizer, chat_messages):

--- a/test/components/generators/chat/test_hugging_face_local.py
+++ b/test/components/generators/chat/test_hugging_face_local.py
@@ -1,8 +1,10 @@
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import patch, Mock
 
 import pytest
+from transformers import PreTrainedTokenizer
 
 from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
+from haystack.dataclasses import ChatMessage, ChatRole
 
 
 # used to test serialization of streaming_callback
@@ -10,10 +12,30 @@ def streaming_callback_handler(x):
     return x
 
 
+@pytest.fixture
+def model_info_mock():
+    with patch(
+        "haystack.components.generators.chat.hugging_face_local.model_info",
+        new=Mock(return_value=Mock(pipeline_tag="text2text-generation")),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_pipeline_tokenizer():
+    # Mocking the pipeline
+    mock_pipeline = Mock(return_value=[{"generated_text": "Berlin is cool"}])
+
+    # Mocking the tokenizer
+    mock_tokenizer = Mock(spec=PreTrainedTokenizer)
+    mock_tokenizer.encode.return_value = ["Berlin", "is", "cool"]
+    mock_pipeline.tokenizer = mock_tokenizer
+
+    return mock_pipeline
+
+
 class TestHuggingFaceLocalChatGenerator:
-    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
     def test_initialize_with_valid_model_and_generation_parameters(self, model_info_mock):
-        model_info_mock.return_value.pipeline_tag = "text2text-generation"
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"n": 1}
         stop_words = ["stop"]
@@ -70,9 +92,7 @@ class TestHuggingFaceLocalChatGenerator:
             "token": None,
         }
 
-    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
     def test_init_task_inferred_from_model_name(self, model_info_mock):
-        model_info_mock.return_value.pipeline_tag = "text2text-generation"
         generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2")
 
         assert generator.huggingface_pipeline_kwargs == {
@@ -85,10 +105,7 @@ class TestHuggingFaceLocalChatGenerator:
         with pytest.raises(ValueError, match="is not supported."):
             HuggingFaceLocalChatGenerator(task="text-classification")
 
-    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
     def test_to_dict(self, model_info_mock):
-        model_info_mock.return_value.pipeline_tag = "text2text-generation"
-        # Initialize the HuggingFaceLocalChatGenerator object with valid parameters
         generator = HuggingFaceLocalChatGenerator(
             model="NousResearch/Llama-2-7b-chat-hf",
             token="token",
@@ -106,9 +123,7 @@ class TestHuggingFaceLocalChatGenerator:
         assert "token" not in init_params["huggingface_pipeline_kwargs"]
         assert init_params["generation_kwargs"] == {"max_new_tokens": 512, "n": 5, "stop_sequences": ["stop", "words"]}
 
-    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
     def test_from_dict(self, model_info_mock):
-        model_info_mock.return_value.pipeline_tag = "text2text-generation"
         generator = HuggingFaceLocalChatGenerator(
             model="NousResearch/Llama-2-7b-chat-hf",
             generation_kwargs={"n": 5},
@@ -136,3 +151,29 @@ class TestHuggingFaceLocalChatGenerator:
         pipeline_mock.assert_called_once_with(
             model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", token=None
         )
+
+    def test_generate_text_response_with_valid_prompt_and_generation_parameters(
+        self, model_info_mock, mock_pipeline_tokenizer, chat_messages
+    ):
+        model = "meta-llama/Llama-2-13b-chat-hf"
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = HuggingFaceLocalChatGenerator(
+            model=model,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        # Use the mocked pipeline from the fixture
+        generator.pipeline = mock_pipeline_tokenizer
+
+        results = generator.run(messages=chat_messages)
+
+        assert "replies" in results
+        assert isinstance(results["replies"][0], ChatMessage)
+        chat_message = results["replies"][0]
+        assert chat_message.is_from(ChatRole.ASSISTANT)
+        assert chat_message.content == "Berlin is cool"

--- a/test/components/generators/chat/test_hugging_face_local.py
+++ b/test/components/generators/chat/test_hugging_face_local.py
@@ -1,0 +1,138 @@
+from unittest.mock import patch, MagicMock, Mock
+
+import pytest
+
+from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
+
+
+# used to test serialization of streaming_callback
+def streaming_callback_handler(x):
+    return x
+
+
+class TestHuggingFaceLocalChatGenerator:
+    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
+    def test_initialize_with_valid_model_and_generation_parameters(self, model_info_mock):
+        model_info_mock.return_value.pipeline_tag = "text2text-generation"
+        model = "HuggingFaceH4/zephyr-7b-alpha"
+        generation_kwargs = {"n": 1}
+        stop_words = ["stop"]
+        streaming_callback = None
+
+        generator = HuggingFaceLocalChatGenerator(
+            model=model,
+            generation_kwargs=generation_kwargs,
+            stop_words=stop_words,
+            streaming_callback=streaming_callback,
+        )
+
+        assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
+        assert generator.streaming_callback == streaming_callback
+
+    def test_init_custom_token(self):
+        generator = HuggingFaceLocalChatGenerator(
+            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", token="test-token"
+        )
+
+        assert generator.huggingface_pipeline_kwargs == {
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "task": "text2text-generation",
+            "token": "test-token",
+        }
+
+    def test_init_custom_device(self):
+        generator = HuggingFaceLocalChatGenerator(
+            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", device="cuda:0"
+        )
+
+        assert generator.huggingface_pipeline_kwargs == {
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "task": "text2text-generation",
+            "token": None,
+            "device": "cuda:0",
+        }
+
+    def test_init_task_parameter(self):
+        generator = HuggingFaceLocalChatGenerator(task="text2text-generation")
+
+        assert generator.huggingface_pipeline_kwargs == {
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "task": "text2text-generation",
+            "token": None,
+        }
+
+    def test_init_task_in_huggingface_pipeline_kwargs(self):
+        generator = HuggingFaceLocalChatGenerator(huggingface_pipeline_kwargs={"task": "text2text-generation"})
+
+        assert generator.huggingface_pipeline_kwargs == {
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "task": "text2text-generation",
+            "token": None,
+        }
+
+    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
+    def test_init_task_inferred_from_model_name(self, model_info_mock):
+        model_info_mock.return_value.pipeline_tag = "text2text-generation"
+        generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2")
+
+        assert generator.huggingface_pipeline_kwargs == {
+            "model": "mistralai/Mistral-7B-Instruct-v0.2",
+            "task": "text2text-generation",
+            "token": None,
+        }
+
+    def test_init_invalid_task(self):
+        with pytest.raises(ValueError, match="is not supported."):
+            HuggingFaceLocalChatGenerator(task="text-classification")
+
+    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
+    def test_to_dict(self, model_info_mock):
+        model_info_mock.return_value.pipeline_tag = "text2text-generation"
+        # Initialize the HuggingFaceLocalChatGenerator object with valid parameters
+        generator = HuggingFaceLocalChatGenerator(
+            model="NousResearch/Llama-2-7b-chat-hf",
+            token="token",
+            generation_kwargs={"n": 5},
+            stop_words=["stop", "words"],
+            streaming_callback=lambda x: x,
+        )
+
+        # Call the to_dict method
+        result = generator.to_dict()
+        init_params = result["init_parameters"]
+
+        # Assert that the init_params dictionary contains the expected keys and values
+        assert init_params["huggingface_pipeline_kwargs"]["model"] == "NousResearch/Llama-2-7b-chat-hf"
+        assert "token" not in init_params["huggingface_pipeline_kwargs"]
+        assert init_params["generation_kwargs"] == {"max_new_tokens": 512, "n": 5, "stop_sequences": ["stop", "words"]}
+
+    @patch("haystack.components.generators.chat.hugging_face_local.model_info")
+    def test_from_dict(self, model_info_mock):
+        model_info_mock.return_value.pipeline_tag = "text2text-generation"
+        generator = HuggingFaceLocalChatGenerator(
+            model="NousResearch/Llama-2-7b-chat-hf",
+            generation_kwargs={"n": 5},
+            stop_words=["stop", "words"],
+            streaming_callback=streaming_callback_handler,
+        )
+        # Call the to_dict method
+        result = generator.to_dict()
+
+        generator_2 = HuggingFaceLocalChatGenerator.from_dict(result)
+
+        assert generator_2.generation_kwargs == {"max_new_tokens": 512, "n": 5, "stop_sequences": ["stop", "words"]}
+        assert generator_2.streaming_callback is streaming_callback_handler
+
+    @patch("haystack.components.generators.chat.hugging_face_local.pipeline")
+    def test_warm_up(self, pipeline_mock):
+        generator = HuggingFaceLocalChatGenerator(
+            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation"
+        )
+
+        pipeline_mock.assert_not_called()
+
+        generator.warm_up()
+
+        pipeline_mock.assert_called_once_with(
+            model="mistralai/Mistral-7B-Instruct-v0.2", task="text2text-generation", token=None
+        )


### PR DESCRIPTION
### Why:
The addition in this PR aims to enhance the Haystack library by enabling local runtime text generation for chat models from the Hugging Face model hub. It empowers users to generate chat responses using chat-based models and provides customization through generation parameters, stop words, and chat templates.

- fixes https://github.com/deepset-ai/haystack/issues/6172

### What:
- Added `HuggingFaceLocalChatGenerator` for local runtime chat response generation.
- Extended `__init__.py` under `haystack/components/generators/chat/` to include the new chat generator.
- Implemented `hugging_face_local.py` containing the generator class with initializing, serialization, and run methods.
- Adjusted `hf_utils.py` with supporting classes and utility functions for the chat generator.
- Created a release note entry for the new feature in `add-hugging-face-chat-local-5fe7a88e24fde11b.yaml`.
- Wrote a unit test for the `HuggingFaceLocalChatGenerator` within `test_hugging_face_local.py`.

### How can it be used:
- Instantiate `HuggingFaceLocalChatGenerator` with model and device specifications:
```python
from haystack.components.generators.chat import HuggingFaceLocalChatGenerator
from haystack.dataclasses import ChatMessage

generator = HuggingFaceLocalChatGenerator(model="mistralai/Mistral-7B-Instruct-v0.2", device="cuda:0")
messages = [ChatMessage.from_user("What's Natural Language Processing? Be brief.")]
print(generator.run(messages))
```
- Customize chat templates and pass in generation parameters like `max_length`, and `temperature`.
- Run inference and receive chat responses packaged as `ChatMessage` instances.
- Use the `.to_dict()` and `.from_dict()` methods for serialization and deserialization of the chat generator instance.

### How did you test it:
- Mocked the external dependencies and utilized unit tests to validate the generator's behavior.
- Tested the initialization with various configurations and parameters.
- Ensured serialization and deserialization function correctly.
- Verified the `warm_up` method successfully prepares the pipeline for text generation.
- For manual tests feel free to use this [notebook](https://github.com/deepset-ai/haystack/issues/6172)

### Notes for the reviewer:
- Pay special attention to the new `HuggingFaceLocalChatGenerator` class that encompasses the core functionality.
- Review the changes introduced in `hf_utils.py` as they provide foundational support for the chat generator.
- The test cases under `test_hugging_face_local.py` are crucial to understand how the functionality is expected to perform and handle edge cases.
- The streaming feature is highlighted, implying potential for real-time chat generation applications.