### PR TITLE
chore: Fix lazy import in HuggingFaceLocalGenerator

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict
-from haystack.components.generators.hf_utils import StopWordsCriteria
 
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -12,7 +12,7 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
     import torch
     from huggingface_hub import model_info
     from transformers import StoppingCriteriaList, pipeline
-    from haystack.components.generators.hf_utils import StopWordsCriteria
+    from haystack.components.generators.hf_utils import StopWordsCriteria  # pylint: disable=ungrouped-imports
 
 
 @component

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from haystack import component, default_to_dict, default_from_dict
-from haystack.components.generators.hf_utils import StopWordsCriteria
 from haystack.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
@@ -13,6 +12,7 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
     import torch
     from huggingface_hub import model_info
     from transformers import StoppingCriteriaList, pipeline
+    from haystack.components.generators.hf_utils import StopWordsCriteria
 
 
 @component


### PR DESCRIPTION
### Why:
The pull request addresses an issue related to lazy importing within the `HuggingFaceLocalGenerator` of the Haystack library. Specifically, it fixes an improper import of `StopWordsCriteria` that potentially causes failures when the component is utilized.

### What:
- A single line has been changed in `haystack/components/generators/hugging_face_local.py`.
- The `StopWordsCriteria` import statement has been moved from the global scope to within the function body, making it a lazy import.

### How can it be used:
- The change ensures that the `StopWordsCriteria` is only imported when necessary.

### How did you test it:
- Manually by running a docker image

### Notes for the reviewer:
- This change should not affect the overall functionality of the `HuggingFaceLocalGenerator`, but instead improve the reliability of imports.
- Ensure that this change does not negatively interact with any other import logic in the library.