### PR TITLE
refactor: Move HF-specific model serde code to a new submodule.

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -11,8 +11,7 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
 
-with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
-    import torch
+with LazyImport(message="Run 'pip install transformers[torch]'") as transformers_import:
     from huggingface_hub import model_info
     from transformers import StoppingCriteriaList, pipeline
 
@@ -84,7 +83,7 @@ class HuggingFaceLocalGenerator:
             For some chat models, the output includes both the new text and the original prompt.
             In these cases, it's important to make sure your prompt has no stop words.
         """
-        torch_and_transformers_import.check()
+        transformers_import.check()
 
         huggingface_pipeline_kwargs = huggingface_pipeline_kwargs or {}
         generation_kwargs = generation_kwargs or {}

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -5,6 +5,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.hf_utils import StopWordsCriteria
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
+from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -161,24 +162,8 @@ class HuggingFaceLocalGenerator:
         # we don't want to serialize valid tokens
         if isinstance(huggingface_pipeline_kwargs["token"], str):
             serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"].pop("token")
-        # convert torch.dtype to string for serialization
-        # 1. torch_dtype can be specified in huggingface_pipeline_kwargs
-        torch_dtype = huggingface_pipeline_kwargs.get("torch_dtype", None)
-        if isinstance(torch_dtype, torch.dtype):
-            serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]["torch_dtype"] = str(torch_dtype)
-        # 2. torch_dtype and bnb_4bit_compute_dtype can be specified in model_kwargs
-        model_kwargs = huggingface_pipeline_kwargs.get("model_kwargs", {})
-        for key, value in model_kwargs.items():
-            if key in ["torch_dtype", "bnb_4bit_compute_dtype"] and isinstance(value, torch.dtype):
-                serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"][key] = str(value)
-        # 3. bnb_4bit_compute_dtype can be specified in model_kwargs["quantization_config"]
-        quantization_config = model_kwargs.get("quantization_config", {})
-        bnb_4bit_compute_dtype = quantization_config.get("bnb_4bit_compute_dtype", None)
-        if isinstance(bnb_4bit_compute_dtype, torch.dtype):
-            serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"]["quantization_config"][
-                "bnb_4bit_compute_dtype"
-            ] = str(bnb_4bit_compute_dtype)
 
+        serialize_hf_model_kwargs(huggingface_pipeline_kwargs)
         return serialization_dict
 
     @classmethod
@@ -186,32 +171,7 @@ class HuggingFaceLocalGenerator:
         """
         Deserialize this component from a dictionary.
         """
-        torch_and_transformers_import.check()
-        init_params = data.get("init_parameters", {})
-        huggingface_pipeline_kwargs = init_params.get("huggingface_pipeline_kwargs", {})
-        model_kwargs = huggingface_pipeline_kwargs.get("model_kwargs", {})
-
-        # convert string to torch.dtype
-        # 1. torch_dtype can be specified in huggingface_pipeline_kwargs
-        torch_dtype = huggingface_pipeline_kwargs.get("torch_dtype", None)
-        if torch_dtype and torch_dtype.startswith("torch."):
-            data["init_parameters"]["huggingface_pipeline_kwargs"]["torch_dtype"] = getattr(
-                torch, torch_dtype.strip("torch.")
-            )
-        # 2. torch_dtype and bnb_4bit_compute_dtype can be specified in model_kwargs
-        for key, value in model_kwargs.items():
-            if key in ["torch_dtype", "bnb_4bit_compute_dtype"] and value.startswith("torch."):
-                data["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"][key] = getattr(
-                    torch, value.strip("torch.")
-                )
-        # 3. bnb_4bit_compute_dtype can be specified in model_kwargs["quantization_config"]
-        quantization_config = model_kwargs.get("quantization_config", {})
-        bnb_4bit_compute_dtype = quantization_config.get("bnb_4bit_compute_dtype", None)
-        if bnb_4bit_compute_dtype and bnb_4bit_compute_dtype.startswith("torch."):
-            data["init_parameters"]["huggingface_pipeline_kwargs"]["model_kwargs"]["quantization_config"][
-                "bnb_4bit_compute_dtype"
-            ] = getattr(torch, bnb_4bit_compute_dtype.strip("torch."))
-
+        deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
         return default_from_dict(cls, data)
 
     @component.output_types(replies=List[str])

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from haystack import ComponentError, Document, ExtractedAnswer, component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
+from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
 with LazyImport("Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     import torch
@@ -132,20 +133,7 @@ class ExtractiveReader:
             model_kwargs=self.model_kwargs,
         )
 
-        # convert torch.dtype to string for serialization
-        # 1. torch_dtype and bnb_4bit_compute_dtype can be specified in model_kwargs
-        model_kwargs = serialization_dict["init_parameters"]["model_kwargs"]
-        for key, value in model_kwargs.items():
-            if key in ["torch_dtype", "bnb_4bit_compute_dtype"] and isinstance(value, torch.dtype):
-                serialization_dict["init_parameters"]["model_kwargs"][key] = str(value)
-        # 2. bnb_4bit_compute_dtype can be specified in model_kwargs["quantization_config"]
-        quantization_config = model_kwargs.get("quantization_config", {})
-        bnb_4bit_compute_dtype = quantization_config.get("bnb_4bit_compute_dtype", None)
-        if isinstance(bnb_4bit_compute_dtype, torch.dtype):
-            serialization_dict["init_parameters"]["model_kwargs"]["quantization_config"][
-                "bnb_4bit_compute_dtype"
-            ] = str(bnb_4bit_compute_dtype)
-
+        serialize_hf_model_kwargs(serialization_dict["init_parameters"]["model_kwargs"])
         return serialization_dict
 
     @classmethod
@@ -153,25 +141,10 @@ class ExtractiveReader:
         """
         Deserialize this component from a dictionary.
         """
-        torch_and_transformers_import.check()
-        init_params = data.get("init_parameters", {})
-        model_kwargs = init_params.get("model_kwargs", {})
+        init_params = data["init_parameters"]
+        init_params["device"] = ComponentDevice.from_dict(init_params["device"])
+        deserialize_hf_model_kwargs(init_params["model_kwargs"])
 
-        serialized_device = init_params.get("device", {})
-        init_params["device"] = ComponentDevice.from_dict(serialized_device)
-
-        # convert string to torch.dtype
-        # 1. torch_dtype and bnb_4bit_compute_dtype can be specified in model_kwargs
-        for key, value in model_kwargs.items():
-            if key in ["torch_dtype", "bnb_4bit_compute_dtype"] and value.startswith("torch."):
-                data["init_parameters"]["model_kwargs"][key] = getattr(torch, value.strip("torch."))
-        # 2. bnb_4bit_compute_dtype can be specified in model_kwargs["quantization_config"]
-        quantization_config = model_kwargs.get("quantization_config", {})
-        bnb_4bit_compute_dtype = quantization_config.get("bnb_4bit_compute_dtype", None)
-        if isinstance(bnb_4bit_compute_dtype, str) and bnb_4bit_compute_dtype.startswith("torch."):
-            data["init_parameters"]["model_kwargs"]["quantization_config"]["bnb_4bit_compute_dtype"] = getattr(
-                torch, bnb_4bit_compute_dtype.strip("torch.")
-            )
         return default_from_dict(cls, data)
 
     def warm_up(self):

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict
+from haystack.lazy_imports import LazyImport
+
+
+with LazyImport(message="Run 'pip install transformers[torch]'") as torch_import:
+    import torch
+
+
+def serialize_hf_model_kwargs(kwargs: Dict[str, Any]):
+    """
+    Recursively serialize HuggingFace specific model keyword arguments
+    in-place to make them JSON serializable.
+    """
+    torch_import.check()
+
+    for k, v in kwargs.items():
+        # torch.dtype
+        if isinstance(v, torch.dtype):
+            kwargs[k] = str(v)
+
+        if isinstance(v, dict):
+            serialize_hf_model_kwargs(v)
+
+
+def deserialize_hf_model_kwargs(kwargs: Dict[str, Any]):
+    """
+    Recursively deserialize HuggingFace specific model keyword arguments
+    in-place to make them JSON serializable.
+    """
+    torch_import.check()
+
+    for k, v in kwargs.items():
+        # torch.dtype
+        if isinstance(v, str) and v.startswith("torch."):
+            dtype_str = v.split(".")[1]
+            dtype = getattr(torch, dtype_str, None)
+            if dtype is not None and isinstance(dtype, torch.dtype):
+                kwargs[k] = dtype
+
+        if isinstance(v, dict):
+            deserialize_hf_model_kwargs(v)


### PR DESCRIPTION
### Proposed Changes:

Moves some common code used to serialize/deserialize HF model args to a separate utility submodule.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
