### PR TITLE
feat: Add page breaks to default PDF to Document converter

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -31,7 +31,7 @@ class DefaultConverter:
 
     def convert(self, reader: "PdfReader") -> Document:
         """Extract text from the PDF and return a Document object with the text content."""
-        text = "\f".join(page.extract_text() for page in reader.pages if page.extract_text())
+        text = "\f".join(page.extract_text() for page in reader.pages)
         return Document(content=text)
 
 

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -31,7 +31,7 @@ class DefaultConverter:
 
     def convert(self, reader: "PdfReader") -> Document:
         """Extract text from the PDF and return a Document object with the text content."""
-        text = "".join(page.extract_text() for page in reader.pages if page.extract_text())
+        text = "\f".join(page.extract_text() for page in reader.pages if page.extract_text())
         return Document(content=text)
 
 

--- a/haystack/components/converters/utils.py
+++ b/haystack/components/converters/utils.py
@@ -28,7 +28,7 @@ def normalize_metadata(
     makes sure to return a list of dictionaries of the correct length for the converter to use.
 
     :param meta: the meta input of the converter, as-is
-    :sources_count: the number of sources the converter received
+    :param sources_count: the number of sources the converter received
     :returns: a list of dictionaries of the make length as the sources list
     """
     if meta is None:

--- a/releasenotes/notes/pypdf-page-breaks-b6842d93f4c69185.yaml
+++ b/releasenotes/notes/pypdf-page-breaks-b6842d93f4c69185.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Upgraded the default converter in PyPDFToDocument to insert page breaks "\f"
+    between each extracted page.
+    This allows for downstream components and applications to better be able to
+    keep track of the original PDF page a portion of text comes from.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -21,6 +21,7 @@ class TestPyPDFToDocument:
         with pytest.raises(ValueError):
             PyPDFToDocument(converter_name="non_existing_converter")
 
+    @pytest.mark.integration
     def test_run(self, test_files_path, pypdf_converter):
         """
         Test if the component runs correctly.
@@ -31,6 +32,7 @@ class TestPyPDFToDocument:
         assert len(docs) == 1
         assert "History" in docs[0].content
 
+    @pytest.mark.integration
     def test_page_breaks_added(self, test_files_path, pypdf_converter):
         paths = [test_files_path / "pdf" / "sample_pdf_1.pdf"]
         output = pypdf_converter.run(sources=paths)
@@ -60,6 +62,7 @@ class TestPyPDFToDocument:
             pypdf_converter.run(sources=paths)
             assert "Could not read non_existing_file.pdf" in caplog.text
 
+    @pytest.mark.integration
     def test_mixed_sources_run(self, test_files_path, pypdf_converter):
         """
         Test if the component runs correctly when mixed sources are provided.
@@ -74,6 +77,7 @@ class TestPyPDFToDocument:
         assert "History and standardization" in docs[0].content
         assert "History and standardization" in docs[1].content
 
+    @pytest.mark.integration
     def test_custom_converter(self, test_files_path):
         """
         Test if the component correctly handles custom converters.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -31,6 +31,13 @@ class TestPyPDFToDocument:
         assert len(docs) == 1
         assert "History" in docs[0].content
 
+    def test_page_breaks_added(self, test_files_path, pypdf_converter):
+        paths = [test_files_path / "pdf" / "sample_pdf_1.pdf"]
+        output = pypdf_converter.run(sources=paths)
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].content.count("\f") == 3
+
     def test_run_with_meta(self, test_files_path, pypdf_converter):
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
 

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -7,35 +7,36 @@ from haystack.components.converters.pypdf import PyPDFToDocument, CONVERTERS_REG
 from haystack.dataclasses import ByteStream
 
 
-@pytest.mark.integration
+@pytest.fixture
+def pypdf_converter():
+    return PyPDFToDocument()
+
+
 class TestPyPDFToDocument:
-    def test_init(self):
-        component = PyPDFToDocument()
-        assert component.converter_name == "default"
-        assert hasattr(component, "_converter")
+    def test_init(self, pypdf_converter):
+        assert pypdf_converter.converter_name == "default"
+        assert hasattr(pypdf_converter, "_converter")
 
     def test_init_fail_nonexisting_converter(self):
         with pytest.raises(ValueError):
             PyPDFToDocument(converter_name="non_existing_converter")
 
-    def test_run(self, test_files_path):
+    def test_run(self, test_files_path, pypdf_converter):
         """
         Test if the component runs correctly.
         """
-        paths = [test_files_path / "pdf" / "react_paper.pdf"]
-        converter = PyPDFToDocument()
-        output = converter.run(sources=paths)
+        paths = [test_files_path / "pdf" / "sample_pdf_1.pdf"]
+        output = pypdf_converter.run(sources=paths)
         docs = output["documents"]
         assert len(docs) == 1
-        assert "ReAct" in docs[0].content
+        assert "History" in docs[0].content
 
-    def test_run_with_meta(self, test_files_path):
+    def test_run_with_meta(self, test_files_path, pypdf_converter):
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
 
-        converter = PyPDFToDocument()
         with patch("haystack.components.converters.pypdf.PdfReader"):
-            output = converter.run(
-                sources=[bytestream, test_files_path / "pdf" / "react_paper.pdf"], meta={"language": "it"}
+            output = pypdf_converter.run(
+                sources=[bytestream, test_files_path / "pdf" / "sample_pdf_1.pdf"], meta={"language": "it"}
             )
 
         # check that the metadata from the bytestream is merged with that from the meta parameter
@@ -43,30 +44,28 @@ class TestPyPDFToDocument:
         assert output["documents"][0].meta["language"] == "it"
         assert output["documents"][1].meta["language"] == "it"
 
-    def test_run_error_handling(self, test_files_path, caplog):
+    def test_run_error_handling(self, test_files_path, pypdf_converter, caplog):
         """
         Test if the component correctly handles errors.
         """
         paths = ["non_existing_file.pdf"]
-        converter = PyPDFToDocument()
         with caplog.at_level(logging.WARNING):
-            converter.run(sources=paths)
+            pypdf_converter.run(sources=paths)
             assert "Could not read non_existing_file.pdf" in caplog.text
 
-    def test_mixed_sources_run(self, test_files_path):
+    def test_mixed_sources_run(self, test_files_path, pypdf_converter):
         """
         Test if the component runs correctly when mixed sources are provided.
         """
-        paths = [test_files_path / "pdf" / "react_paper.pdf"]
-        with open(test_files_path / "pdf" / "react_paper.pdf", "rb") as f:
+        paths = [test_files_path / "pdf" / "sample_pdf_1.pdf"]
+        with open(test_files_path / "pdf" / "sample_pdf_1.pdf", "rb") as f:
             paths.append(ByteStream(f.read()))
 
-        converter = PyPDFToDocument()
-        output = converter.run(sources=paths)
+        output = pypdf_converter.run(sources=paths)
         docs = output["documents"]
         assert len(docs) == 2
-        assert "ReAct" in docs[0].content
-        assert "ReAct" in docs[1].content
+        assert "History and standardization" in docs[0].content
+        assert "History and standardization" in docs[1].content
 
     def test_custom_converter(self, test_files_path):
         """
@@ -74,7 +73,7 @@ class TestPyPDFToDocument:
         """
         from pypdf import PdfReader
 
-        paths = [test_files_path / "pdf" / "react_paper.pdf"]
+        paths = [test_files_path / "pdf" / "sample_pdf_1.pdf"]
 
         class MyCustomConverter:
             def convert(self, reader: PdfReader) -> Document:


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/6706

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
In Haystack v1 we learned that being able to keep track of the source page number that a Document comes from when converting a PDF into Haystack Document is extremely useful for down stream applications. In particular when users want to easily retrieve the original PDF page that is being referenced in an answer or retrieved Haystack Document.

We accomplished this in Haystack v1 by counting page breaks "\f" in the text outputted by the v1 PDFToText converters. However, our current DefaultConverter in v2 for the PyPDFToDocument does not count empty pages or keeps the page breaks. 

So in this PR we:
- updated the `DefaultConverter` to add back in page breaks
- count empty pages so we can correctly count the total number of pages in the PDF

This brings us in line with Haystack v1 functionality and matches the behavior of other converters in Haystack v2 like the AzureOCRDocumentConverter.

Additionally
- Sped up the tests and removed integration marking

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added a new unit test


### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
