### PR TITLE
Fix `__version__` handling

### DIFF
--- a/haystack/version.py
+++ b/haystack/version.py
@@ -1,13 +1,6 @@
 from importlib import metadata
 
-# haystack is distributed as a separate package called `haystack-ai`.
-# We want to keep all preview dependencies separate from the current Haystack version,
-# so imports in haystack must only import from haystack.
-# Since we need to access __version__ in haystack without importing from
-# haystack we must set it here too.
-# When installing `haystack-ai` we want to use that package version though
-# as `farm-haystack` might not be installed and cause this to fail.
 try:
     __version__ = str(metadata.version("haystack-ai"))
 except metadata.PackageNotFoundError:
-    __version__ = str(metadata.version("farm-haystack"))
+    __version__ = "main"

--- a/releasenotes/notes/fix-version-47afaec913788a01.yaml
+++ b/releasenotes/notes/fix-version-47afaec913788a01.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Haystack imports failing when using local development environment that doesn't have `haystack-ai` installed.


### PR DESCRIPTION
### Related Issues

- fixes #6759

### Proposed Changes:

Set `__version__` to `"main"` if `haystack-ai` is not installed.
This can happen when using a local clone of the repository for development purposes.

### How did you test it?

Manually locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
