### PR TITLE
perf: Speed up `Document` dataclass import

### DIFF
--- a/releasenotes/notes/speedup-import-b542f7a8323ef376.yaml
+++ b/releasenotes/notes/speedup-import-b542f7a8323ef376.yaml
@@ -1,0 +1,7 @@
+---
+prelude: >
+enhancements:
+  - |
+    Speed up import of Document dataclass.
+    Importing Document was slowed down cause we were importing the whole `pandas` and `numpy` packages.
+    This has now been changed to import only the necessary classes and functions.


### PR DESCRIPTION
### Proposed Changes:

`document.py` was really slow to import as it was importing the whole `numpy` and `pandas` packages.
This PR changes the import to only import `pandas.DataFrame`, `pandas.read_json` and `numpy.ndarray`.

On my local machine calling `import haystack` I saw a speed change from 4.35 seconds to 0.676 seconds.

### How did you test it?

I profiled `import haystack` using [`cProfile`](https://docs.python.org/3.8/library/profile.html) and visualized the report using [SnakeViz](https://jiffyclub.github.io/snakeviz/).

```
echo "import haystack" >> my_program.py
python -m cProfile -o my_report.prof my_program.py
snakeviz my_report.prof
```

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
