### PR TITLE
feat: Improve OpenAPIServiceConnector service response serialization

### DIFF
--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -63,7 +63,12 @@ class OpenAPIServiceConnector:
         response_messages = []
         for method_invocation_descriptor in function_invocation_payloads:
             service_response = self._invoke_method(openapi_service, method_invocation_descriptor)
-            response_messages.append(ChatMessage.from_user(str(service_response)))
+            # openapi3 parses the JSON service response into a model object, which is not our focus at the moment.
+            # Instead, we require direct access to the raw JSON data of the response, rather than the model objects
+            # provided by the openapi3 library. This approach helps us avoid issues related to (de)serialization.
+            # By accessing the raw JSON response through `service_response._raw_data`, we can serialize this data
+            # into a string. Finally, we use this string to create a ChatMessage object.
+            response_messages.append(ChatMessage.from_user(json.dumps(service_response._raw_data)))
 
         return {"service_response": response_messages}
 

--- a/test/components/connectors/test_openapi_service.py
+++ b/test/components/connectors/test_openapi_service.py
@@ -2,6 +2,7 @@ import json
 import pytest
 from unittest.mock import MagicMock, Mock
 from openapi3 import OpenAPI
+from openapi3.schemas import Model
 from haystack.components.connectors import OpenAPIServiceConnector
 from haystack.dataclasses import ChatMessage
 
@@ -79,3 +80,11 @@ class TestOpenAPIServiceConnector:
         method_invocation_descriptor = {"name": "invalid_method", "arguments": {}}
         with pytest.raises(RuntimeError):
             connector._invoke_method(openapi_service_mock, method_invocation_descriptor)
+
+    def test_for_internal_raw_data_field(self):
+        # see https://github.com/deepset-ai/haystack/pull/6772 for details
+        model = Model(data={}, schema={})
+        assert hasattr(model, "_raw_data"), (
+            "openapi3 changed. Model should have a _raw_data field, we rely on it in OpenAPIServiceConnector"
+            " to get the raw data from the service response"
+        )


### PR DESCRIPTION
### Why:
This change modifies the `run` method in `openapi_service.py` to handle service responses better. Instead of directly converting the service response to a `ChatMessage` object, the code now accesses the raw JSON data of the response and serializes it into a string before creating the `ChatMessage` object. This approach avoids issues related to (de)serialization and allows us to manipulate the raw JSON as needed. 

A concrete need for this change request arose when a demo application required only a partial JSON service response. To save tokens and preserve the precious LLM context window, users can inject the subtree of JSON response into a ChatMessage instead of packing the entire JSON response into a message. Previously, this was not feasible as we mistakenly serialized an openapi3 model object into a string rather than using the raw JSON service response.

### What:
- The `service_response._raw_data` attribute is accessed, obtaining the raw JSON data of the service response.
- The JSON data is serialized into a string via `json.dumps`.
- A `ChatMessage` object is created using the serialized string.

### How can it be used:
- The updated method enables the serialization of service responses without relying on the openapi3 library's model objects for (de)serialization.
- The raw JSON data can be manipulated directly before serializing and creating the `ChatMessage` object, providing flexibility.

### How did you test it:
Manual tests were conducted by loading the JSON representation from openapi3 service responses in ChatMessage payload with `json.dumps()` and inspecting the data under the debugger. Subsequently, the JSON object service response was again successfully serialized back into str using `json.loads()`

### Notes for the reviewer:
The updated method relies on the `_raw_data` attribute, which is not officially documented by openapi3 but publicly accessible. This attribute provides access to the raw JSON data, but we should know that such attributes may change or be removed without notice in future library releases. Please keep an eye on openapi3 updates to help reduce potential compatibility issues.
