### PR TITLE
Pin `fastapi` version in `rest_api`

### DIFF
--- a/rest_api/pyproject.toml
+++ b/rest_api/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "farm-haystack",
-    "fastapi",
+    "fastapi~=0.108.0",
     "uvicorn<1",
     "python-multipart<1",  # optional FastAPI dependency for form data
     "pynvml",


### PR DESCRIPTION
Latest `fastapi` version breaks `rest_api`.

More info in [this discussion](https://github.com/deepset-ai/haystack/discussions/6766).