### PR TITLE
chore: Use forward references for type hints in HuggingFaceLocalChatGenerator method, avoid NameError

### DIFF
--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -272,7 +272,7 @@ class HuggingFaceLocalChatGenerator:
         self,
         text: str,
         index: int,
-        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+        tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
         prompt: str,
         generation_kwargs: Dict[str, Any],
     ) -> ChatMessage:


### PR DESCRIPTION
It seems that Python evaluates annotations in method signatures when the class/function gets loaded. In this case, HuggingFaceLocalChatGenerator is loaded from the package init file. This is obviously different from how the function's or method's code is called when the lazy import checks are executed. 

After I added forward references for type hints ("PreTrainedTokenizer" and "PreTrainedTokenizerFast"), the NamedError didn't happen, and everything works as intended in env where transformers are not installed. 

Ther error trace was:

```
File "/opt/venv/lib/python3.10/site-packages/haystack/components/generators/chat/__init__.py", line 1, in <module>
    from haystack.components.generators.chat.hugging_face_local import HuggingFaceLocalChatGenerator
  File "/opt/venv/lib/python3.10/site-packages/haystack/components/generators/chat/hugging_face_local.py", line 26, in <module>
    class HuggingFaceLocalChatGenerator:
  File "/opt/venv/lib/python3.10/site-packages/haystack/components/generators/chat/hugging_face_local.py", line 275, in HuggingFaceLocalChatGenerator
    tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
NameError: name 'PreTrainedTokenizer' is not defined
```
