### PR TITLE
add .haystack_debug to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ saved_models
 rest_api/file-upload/*
 **/feedback_squad_direct.json
 haystack/json-schemas
+.haystack_debug
 
 .DS_Store
 


### PR DESCRIPTION
Noticed .haystack_debug was generated as I was running the getting started sample.