### PR TITLE
fix: MongoDB Atlas Vector Search

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,10 +122,10 @@ jobs:
         include:
           - topic: document_stores
             os: ubuntu-latest
-            dependencies: elasticsearch8,faiss,weaviate,pinecone,opensearch,inference,crawler,preprocessing,file-conversion,pdf,ocr,metrics,dev
+            dependencies: elasticsearch8,faiss,weaviate,pinecone,opensearch,mongodb,inference,crawler,preprocessing,file-conversion,pdf,ocr,metrics,dev
           - topic: document_stores
             os: windows-latest
-            dependencies: elasticsearch8,faiss,weaviate,pinecone,opensearch,inference,crawler,preprocessing,file-conversion,pdf,ocr,metrics,dev
+            dependencies: elasticsearch8,faiss,weaviate,pinecone,opensearch,mongodb,inference,crawler,preprocessing,file-conversion,pdf,ocr,metrics,dev
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/releasenotes/notes/mongodb-vector-search-2f40a9c67eed6e7c.yaml
+++ b/releasenotes/notes/mongodb-vector-search-2f40a9c67eed6e7c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug that caused the EmbeddingRetriever to return no documents when used with a MongoDBAtlasDocumentStore. MongoDBAtlasDocumentStore now accepts a vector_search_index parameter, which needs to be created before in the MongoDB Atlas Web UI following [their documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/#std-label-avs-create-index).

--- a/test/document_stores/test_mongodb_atlas.py
+++ b/test/document_stores/test_mongodb_atlas.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pymongo
+import pytest
+from numpy import float32, random
+
+from haystack.document_stores import mongodb_atlas
+from haystack.document_stores.mongodb_atlas import MongoDBAtlasDocumentStore
+
+
+class TestMongoDBDocumentStore:
+    @pytest.fixture
+    def mocked_ds(self):
+        class DSMock(MongoDBAtlasDocumentStore):
+            # We mock a subclass to avoid messing up the actual class object
+            pass
+
+        mongodb_atlas._validate_mongo_connection_string = MagicMock()
+        mongodb_atlas._validate_database_name = MagicMock()
+        mongodb_atlas._validate_collection_name = MagicMock()
+        mongodb_atlas._get_collection = MagicMock()
+        pymongo.MongoClient = MagicMock()
+
+        mocked_ds = DSMock(
+            mongo_connection_string="mongodb+srv://{mongo_atlas_username}:{mongo_atlas_password}@{mongo_atlas_host}/?{mongo_atlas_params_string}",
+            database_name="test_db",
+            collection_name="test_collection",
+            embedding_dim=1536,
+        )
+
+        return mocked_ds
+
+    @pytest.mark.unit
+    def test_error_is_raised_if_vector_index_name_is_not_set_for_vector_search(self, mocked_ds):
+        with pytest.raises(ValueError):
+            mocked_ds.vector_search_index = None
+            mocked_ds.query_by_embedding(query_emb=random.rand(768))
+
+    @pytest.mark.unit
+    def test_vector_index_name_is_set_for_vector_search(self, mocked_ds):
+        mocked_ds.vector_search_index = "vector_search_index"
+        with patch.object(mocked_ds, "_get_collection", return_value=MagicMock()) as mock_get_collection:
+            query_emb = random.rand(768)
+            mocked_ds.query_by_embedding(query_emb=query_emb)
+            expected_emb_in_call = query_emb.astype(float32)
+            mocked_ds.normalize_embedding(expected_emb_in_call)
+            # check that the correct arguments are passed to collection.aggregate()
+            mock_get_collection().aggregate.assert_called()
+            mock_get_collection().aggregate.assert_called_once_with(
+                [
+                    {
+                        "$vectorSearch": {
+                            "index": "vector_search_index",
+                            "queryVector": expected_emb_in_call.tolist(),
+                            "path": "embedding",
+                            "numCandidates": 100,
+                            "limit": 10,
+                        }
+                    },
+                    {"$match": {}},
+                    {"$project": {"embedding": False}},
+                    {"$set": {"score": {"$meta": "vectorSearchScore"}}},
+                ]
+            )


### PR DESCRIPTION
### Related Issues

- fixes #6632
- fixes #6643

### Proposed Changes:

- Added an optional parameter `vector_search_index` to the init of `MongoDBAtlasDocumentStore`
- Update the implementation of `query_by_embedding` to use MongoDB Atlas Vector Search
- Throw an error if `query_by_embedding` is called but no `vector_search_index` is set, which is required to run vector search

### How did you test it?

Tested with a M0 free tier cluster and the example code from the issue. As expected, relevant documents are returned after the fix.
Database with a vector search index needs to be configured through the Atlas web UI following their [docs](https://www.mongodb.com/docs/atlas/atlas-vector-search/create-index/#std-label-avs-create-index):
<img width="1225" alt="image" src="https://github.com/deepset-ai/haystack/assets/4181769/3da653ce-5c0c-43ff-9559-edd1c04e4b1f">


### Notes for the reviewer

Unfortunately `create_search_index` and `list_search_indexes` require a MongoDB server version 7.0+ Atlas cluster. The free M0 tier clusters run on version 6. So with version 6 there seems to be no way to programmatically create a vector_search_index. Users need to create the index in the Atlas web UI before they can use it in Haystack. 

Let's talk about what tests make sense as part of this PR. For example, two unit tests checking that the error is thrown if `query_by_embedding` is called without setting `vector_search_index` before. And if `vector_search_index` is set that it is used in `query_by_embedding`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
