### PR TITLE
feat: Add query and document prefix options for the TransformerSimilarityRanker

### DIFF
--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -42,6 +42,8 @@ class TransformersSimilarityRanker:
         device: Optional[ComponentDevice] = None,
         token: Union[bool, str, None] = None,
         top_k: int = 10,
+        query_prefix: str = "",
+        document_prefix: str = "",
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
         scale_score: bool = True,
@@ -60,6 +62,12 @@ class TransformersSimilarityRanker:
             If this parameter is set to `True`, the token generated when running
             `transformers-cli login` (stored in ~/.huggingface) is used.
         :param top_k: The maximum number of Documents to return per query.
+        :param query_prefix: A string to add to the beginning of the query text before ranking.
+            Can be used to prepend the text with an instruction, as required by some reranking models,
+            such as bge.
+        :param document_prefix: A string to add to the beginning of each Document text before ranking.
+            Can be used to prepend the text with an instruction, as required by some embedding models,
+            such as bge.
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
         :param scale_score: Whether the raw logit predictions will be scaled using a Sigmoid activation function.
@@ -77,7 +85,8 @@ class TransformersSimilarityRanker:
         if top_k <= 0:
             raise ValueError(f"top_k must be > 0, but got {top_k}")
         self.top_k = top_k
-        self.device = ComponentDevice.resolve_device(device)
+        self.query_prefix = query_prefix
+        self.document_prefix = document_prefix
         self.token = token
         self._model = None
         self.tokenizer = None
@@ -124,6 +133,8 @@ class TransformersSimilarityRanker:
             model=self.model,
             token=self.token if not isinstance(self.token, str) else None,  # don't serialize valid tokens
             top_k=self.top_k,
+            query_prefix=self.query_prefix,
+            document_prefix=self.document_prefix,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
             scale_score=self.scale_score,
@@ -199,7 +210,7 @@ class TransformersSimilarityRanker:
                 str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
             ]
             text_to_embed = self.embedding_separator.join(meta_values_to_embed + [doc.content or ""])
-            query_doc_pairs.append([query, text_to_embed])
+            query_doc_pairs.append([self.query_prefix + query, self.document_prefix + text_to_embed])
 
         features = self.tokenizer(
             query_doc_pairs, padding=True, truncation=True, return_tensors="pt"

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -85,6 +85,7 @@ class TransformersSimilarityRanker:
         if top_k <= 0:
             raise ValueError(f"top_k must be > 0, but got {top_k}")
         self.top_k = top_k
+        self.device = ComponentDevice.resolve_device(device)
         self.query_prefix = query_prefix
         self.document_prefix = document_prefix
         self.token = token

--- a/releasenotes/notes/ranker-prefix-bfaf09cd7da0852d.yaml
+++ b/releasenotes/notes/ranker-prefix-bfaf09cd7da0852d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add query and document prefix options for the TransformerSimilarityRanker

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -166,10 +166,8 @@ class TestSimilarityRanker:
         embedder = TransformersSimilarityRanker(
             model="model", query_prefix="query_instruction: ", document_prefix="document_instruction: "
         )
-        embedder.model = MagicMock()
+        embedder._model = MagicMock()
         embedder.tokenizer = MagicMock()
-        embedder.device = MagicMock()
-        embedder.warm_up()
 
         documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
 

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -19,6 +19,8 @@ class TestSimilarityRanker:
                 "device": ComponentDevice.resolve_device(None).to_dict(),
                 "top_k": 10,
                 "token": None,
+                "query_prefix": "",
+                "document_prefix": "",
                 "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
@@ -35,6 +37,8 @@ class TestSimilarityRanker:
             device=ComponentDevice.from_str("cuda:0"),
             token="my_token",
             top_k=5,
+            query_prefix="query_instruction: ",
+            document_prefix="document_instruction: ",
             scale_score=False,
             calibration_factor=None,
             score_threshold=0.01,
@@ -48,6 +52,8 @@ class TestSimilarityRanker:
                 "model": "my_model",
                 "token": None,  # we don't serialize valid tokens,
                 "top_k": 5,
+                "query_prefix": "query_instruction: ",
+                "document_prefix": "document_instruction: ",
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
                 "scale_score": False,
@@ -72,6 +78,8 @@ class TestSimilarityRanker:
             "init_parameters": {
                 "device": ComponentDevice.resolve_device(None).to_dict(),
                 "top_k": 10,
+                "query_prefix": "",
+                "document_prefix": "",
                 "token": None,
                 "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
                 "meta_fields_to_embed": [],
@@ -96,6 +104,8 @@ class TestSimilarityRanker:
                 "model": "my_model",
                 "token": None,
                 "top_k": 5,
+                "query_prefix": "",
+                "document_prefix": "",
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
                 "scale_score": False,
@@ -110,6 +120,8 @@ class TestSimilarityRanker:
         assert component.model == "my_model"
         assert component.token is None
         assert component.top_k == 5
+        assert component.query_prefix == ""
+        assert component.document_prefix == ""
         assert component.meta_fields_to_embed == []
         assert component.embedding_separator == "\n"
         assert not component.scale_score
@@ -140,6 +152,36 @@ class TestSimilarityRanker:
                 ["test", "meta_value 2\ndocument number 2"],
                 ["test", "meta_value 3\ndocument number 3"],
                 ["test", "meta_value 4\ndocument number 4"],
+            ],
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+    @patch("torch.sigmoid")
+    @patch("torch.sort")
+    def test_prefix(self, mocked_sort, mocked_sigmoid):
+        mocked_sort.return_value = (None, torch.tensor([0]))
+        mocked_sigmoid.return_value = torch.tensor([0])
+        embedder = TransformersSimilarityRanker(
+            model="model", query_prefix="query_instruction: ", document_prefix="document_instruction: "
+        )
+        embedder.model = MagicMock()
+        embedder.tokenizer = MagicMock()
+        embedder.device = MagicMock()
+        embedder.warm_up()
+
+        documents = [Document(content=f"document number {i}", meta={"meta_field": f"meta_value {i}"}) for i in range(5)]
+
+        embedder.run(query="test", documents=documents)
+
+        embedder.tokenizer.assert_called_once_with(
+            [
+                ["query_instruction: test", "document_instruction: document number 0"],
+                ["query_instruction: test", "document_instruction: document number 1"],
+                ["query_instruction: test", "document_instruction: document number 2"],
+                ["query_instruction: test", "document_instruction: document number 3"],
+                ["query_instruction: test", "document_instruction: document number 4"],
             ],
             padding=True,
             truncation=True,


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Add query and document prefix options for the TransformerSimilarityRanker, similar to what we have for our Embedders

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- added a new unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
