### PR TITLE
chore: improve Reno configuration

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,15 +1,14 @@
 default_branch: main
 collapse_pre_releases: true
 pre_release_tag_re: (?P<pre_release>-(?:[ab]|rc)+\d*)$
-prelude_section_name: ⭐ Highlights
+prelude_section_name: highlights
 template: |
   ---
-  prelude: >
+  highlights: >
       Replace this text with content to appear at the top of the section for this
-      release. This is equivalent to the "Highlights" section we used before.
-      The prelude might repeat some details that are also present in other notes
-      from the same release, that's ok. Not every release note requires a prelude,
-      use it only to describe major features or notable changes.
+      release. The highlights might repeat some details that are also present in other notes
+      from the same release, that's ok. Not every release note requires highlights,
+      use this section only to describe major features or notable changes.
   upgrade:
     - |
       List upgrade notes here, or remove this section.

--- a/releasenotes/notes/speedup-import-b542f7a8323ef376.yaml
+++ b/releasenotes/notes/speedup-import-b542f7a8323ef376.yaml
@@ -1,5 +1,4 @@
 ---
-prelude: >
 enhancements:
   - |
     Speed up import of Document dataclass.


### PR DESCRIPTION
### Related Issues

We found that `prelude_section_name` is not currently configured correctly.
So, Reno does not generate release notes for the `prelude` section.

### Proposed Changes:
- Fix the configuration and the template, renaming the `prelude` section to `highlights`

### How did you test it?
Not tested.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
