### PR TITLE
fix: Fix missing format string prefixes in `pipeline.py`

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -306,7 +306,7 @@ class Pipeline:
             or not connection.sender
             or not connection.receiver
         ):
-            raise PipelineConnectError("Connection must have both sender and receiver: {connection}")
+            raise PipelineConnectError(f"Connection must have both sender and receiver: {connection}")
 
         # Create the connection
         logger.debug(
@@ -435,7 +435,7 @@ class Pipeline:
             instance = self.graph.nodes[component_name]["instance"]
             for socket_name, socket in instance.__canals_input__.items():
                 if socket.senders == [] and socket.is_mandatory and socket_name not in component_inputs:
-                    raise ValueError("Missing input for component {component_name}: {socket_name}")
+                    raise ValueError(f"Missing input for component {component_name}: {socket_name}")
             for input_name in component_inputs.keys():
                 if input_name not in instance.__canals_input__:
                     raise ValueError(f"Input {input_name} not found in component {component_name}.")
@@ -445,7 +445,7 @@ class Pipeline:
             for socket_name, socket in instance.__canals_input__.items():
                 component_inputs = data.get(component_name, {})
                 if socket.senders == [] and socket.is_mandatory and socket_name not in component_inputs:
-                    raise ValueError("Missing input for component {component_name}: {socket_name}")
+                    raise ValueError(f"Missing input for component {component_name}: {socket_name}")
                 if socket.senders and socket_name in component_inputs and not socket.is_variadic:
                     raise ValueError(
                         f"Input {socket_name} for component {component_name} is already sent by {socket.senders}."


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
We should add a lint for this common error, incidentally. If there's one available, that is.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
