### PR TITLE
refactor: Simplify `Pipeline.__eq__` logic

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -62,20 +62,9 @@ class Pipeline:
         Equal pipelines share every metadata, node and edge, but they're not required to use
         the same node instances: this allows pipeline saved and then loaded back to be equal to themselves.
         """
-        if (
-            not isinstance(other, type(self))
-            or not getattr(self, "metadata") == getattr(other, "metadata")
-            or not getattr(self, "max_loops_allowed") == getattr(other, "max_loops_allowed")
-            or not hasattr(self, "graph")
-            or not hasattr(other, "graph")
-        ):
+        if not isinstance(other, Pipeline):
             return False
-
-        return (
-            self.graph.adj == other.graph.adj
-            and self._comparable_nodes_list(self.graph) == self._comparable_nodes_list(other.graph)
-            and self.graph.graph == other.graph.graph
-        )
+        return self.to_dict() == other.to_dict()
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -171,18 +160,6 @@ class Pipeline:
             pipe.connect(connect_from=connection["sender"], connect_to=connection["receiver"])
 
         return pipe
-
-    def _comparable_nodes_list(self, graph: networkx.MultiDiGraph) -> List[Dict[str, Any]]:
-        """
-        Replaces instances of nodes with their class name in order to make sure they're comparable.
-        """
-        nodes = []
-        for node in graph.nodes:
-            comparable_node = graph.nodes[node]
-            comparable_node["instance"] = comparable_node["instance"].__class__
-            nodes.append(comparable_node)
-        nodes.sort()
-        return nodes
 
     def add_component(self, name: str, instance: Component) -> None:
         """


### PR DESCRIPTION
### Proposed Changes:

Simplify how `Pipeline` instances are compared.

### How did you test it?

I ran unit tests locally.

### Notes for the reviewer

I didn't add a release notes as this doesn't change the behaviour of `__eq__`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
