### PR TITLE
feat: Change `Pipeline.add_component` to fail when reusing `Component` instances

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -147,6 +147,12 @@ class ComponentMeta(type):
                 if run_signature.parameters[param].default != inspect.Parameter.empty:
                     socket_kwargs["default_value"] = run_signature.parameters[param].default
                 instance.__haystack_input__[param] = InputSocket(**socket_kwargs)
+
+        # Since a Component can't be used in multiple Pipelines at the same time
+        # we need to know if it's already owned by a Pipeline when adding it to one.
+        # We use this flag to check that.
+        instance.__haystack_pipeline_owned__ = False
+
         return instance
 
 

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -151,7 +151,7 @@ class ComponentMeta(type):
         # Since a Component can't be used in multiple Pipelines at the same time
         # we need to know if it's already owned by a Pipeline when adding it to one.
         # We use this flag to check that.
-        instance.__haystack_pipeline_owned__ = False
+        instance.__haystack_added_to_pipeline__ = None
 
         return instance
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -190,7 +190,7 @@ class Pipeline:
                 f"'{type(instance)}' doesn't seem to be a component. Is this class decorated with @component?"
             )
 
-        if getattr(instance, "__haystack_pipeline_owned__", False):
+        if getattr(instance, "__haystack_added_to_pipeline__", None):
             msg = (
                 "Component has already been added in another Pipeline. "
                 "Components can't be shared between Pipelines. Create a new instance instead."
@@ -201,7 +201,7 @@ class Pipeline:
         input_sockets = getattr(instance, "__haystack_input__", {})
         output_sockets = getattr(instance, "__haystack_output__", {})
 
-        setattr(instance, "__haystack_pipeline_owned__", True)
+        setattr(instance, "__haystack_added_to_pipeline__", self)
 
         # Add component to the graph, disconnected
         logger.debug("Adding component '%s' (%s)", name, instance)

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -190,9 +190,18 @@ class Pipeline:
                 f"'{type(instance)}' doesn't seem to be a component. Is this class decorated with @component?"
             )
 
+        if getattr(instance, "__haystack_pipeline_owned__", False):
+            msg = (
+                "Component has already been added in another Pipeline. "
+                "Components can't be shared between Pipelines. Create a new instance instead."
+            )
+            raise PipelineError(msg)
+
         # Create the component's input and output sockets
         input_sockets = getattr(instance, "__haystack_input__", {})
         output_sockets = getattr(instance, "__haystack_output__", {})
+
+        setattr(instance, "__haystack_pipeline_owned__", True)
 
         # Add component to the graph, disconnected
         logger.debug("Adding component '%s' (%s)", name, instance)

--- a/releasenotes/notes/components-reuse-ccc5f2d4b9d7f9ff.yaml
+++ b/releasenotes/notes/components-reuse-ccc5f2d4b9d7f9ff.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Change `Pipeline.add_component()` to fail if the `Component` instance has already been added in another `Pipeline`.

--- a/test/core/pipeline/test_connections.py
+++ b/test/core/pipeline/test_connections.py
@@ -338,11 +338,12 @@ def test_connect_receiver_socket_does_not_exist():
 def test_connect_many_outputs_to_the_same_input():
     add_1 = AddFixedValue()
     add_2 = AddFixedValue()
+    add_3 = AddFixedValue()
 
     pipe = Pipeline()
     pipe.add_component("first", add_1)
     pipe.add_component("second", add_2)
-    pipe.add_component("third", add_2)
+    pipe.add_component("third", add_3)
     pipe.connect("first.result", "second.value")
     with pytest.raises(PipelineConnectError, match=r"second.value is already connected to \['first'\]"):
         pipe.connect("third.result", "second.value")

--- a/test/core/pipeline/test_distinct_loops_pipeline.py
+++ b/test/core/pipeline/test_distinct_loops_pipeline.py
@@ -24,8 +24,6 @@ def test_pipeline_equally_long_branches():
     pipeline.connect("add_two", "multiplexer.value")
     pipeline.connect("add_one", "multiplexer.value")
 
-    pipeline.draw(Path(__file__).parent / Path(__file__).name.replace(".py", ".png"))
-
     results = pipeline.run({"multiplexer": {"value": 0}})
     assert results == {"remainder": {"remainder_is_0": 0}}
 

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -20,9 +20,9 @@ def test_add_component_to_different_pipelines():
     second_pipe = Pipeline()
     some_component = component_class("Some")()
 
-    assert not some_component.__haystack_pipeline_owned__
+    assert some_component.__haystack_added_to_pipeline__ is None
     first_pipe.add_component("some", some_component)
-    assert some_component.__haystack_pipeline_owned__
+    assert some_component.__haystack_added_to_pipeline__ is first_pipe
 
     with pytest.raises(PipelineError):
         second_pipe.add_component("some", some_component)

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -7,12 +7,25 @@ from typing import Optional
 import pytest
 
 from haystack.core.component.sockets import InputSocket, OutputSocket
-from haystack.core.errors import PipelineError, PipelineMaxLoops, PipelineRuntimeError
+from haystack.core.errors import PipelineError, PipelineRuntimeError
 from haystack.core.pipeline import Pipeline
 from haystack.testing.factory import component_class
-from haystack.testing.sample_components import AddFixedValue, Double, Sum, Threshold
+from haystack.testing.sample_components import AddFixedValue, Double
 
 logging.basicConfig(level=logging.DEBUG)
+
+
+def test_add_component_to_different_pipelines():
+    first_pipe = Pipeline()
+    second_pipe = Pipeline()
+    some_component = component_class("Some")()
+
+    assert not some_component.__haystack_pipeline_owned__
+    first_pipe.add_component("some", some_component)
+    assert some_component.__haystack_pipeline_owned__
+
+    with pytest.raises(PipelineError):
+        second_pipe.add_component("some", some_component)
 
 
 def test_run_with_component_that_does_not_return_dict():


### PR DESCRIPTION
### Related Issues

- fixes #6431

### Proposed Changes:

Add `__haystack_pipeline_owned__` field in all `Component` instances. Defaults to `False`.

Change `Pipeline.add_component()` to fail if the `Component` instance is already used in another `Pipeline`. The method will also set `__haystack_pipeline_owned__` to `True`.

### How did you test it?

Added a unit test.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
