### PR TITLE
ci: bump transformers to 4.37.1 in test_requirements

### DIFF
--- a/test/test_requirements.txt
+++ b/test/test_requirements.txt
@@ -2,7 +2,7 @@
 
 # Package                                        Components
 
-transformers[torch,sentencepiece]==4.36.2       # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
+transformers[torch,sentencepiece]==4.37.1       # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
 spacy>=3.7,<3.8                                 # NamedEntityExtractor
 spacy-curated-transformers>=0.2,<=0.3           # NamedEntityExtractor
 https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.7.3/en_core_web_trf-3.7.3-py3-none-any.whl # NamedEntityExtractor


### PR DESCRIPTION
### Related Issues

- part of #6812

### How did you test it?

CI; run an experiment with HF Local Generator on Colab (using Phi 2 model, a new addition to this release of Transformers)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
