### PR TITLE
README: remove the mention to 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </div>
 
 > [!WARNING]
-> You are currently looking at the readme of Haystack 2.0-Beta, an unstable version of what will eventually become Haystack 2.0. We are still maintaining Haystack 1.x which is the version of Haystack you should use in production. [Switch to Haystack 1.x, currently on 1.23 here](https://github.com/deepset-ai/haystack/tree/v1.x).
+> You are currently looking at the readme of Haystack 2.0-Beta, an unstable version of what will eventually become Haystack 2.0. We are still maintaining Haystack 1.x which is the version of Haystack you should use in production. [Switch to Haystack 1.x here](https://github.com/deepset-ai/haystack/tree/v1.x).
 
 [Haystack](https://haystack.deepset.ai/) is an end-to-end LLM framework that enables you to build applications powered by LLMs, Transformer models, vector search and more. Whether you want to perform retrieval-augmented generation (RAG), documentation search, question answering or answer generation, you can use state-of-the-art embedding models and LLMs with Haystack to build end-to-end NLP applications to solve your use case.
 


### PR DESCRIPTION
### Proposed Changes:

Remove mention of a specific 1.x release in the README.
(This information may become outdated in a short time).