### PR TITLE
feat: Allow setting metadata for `ByteStream` when created from file or from string

### DIFF
--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -34,7 +34,7 @@ class ByteStream:
         :param meta: Additional metadata to be stored with the ByteStream.
         """
         with open(filepath, "rb") as fd:
-            return cls(data=fd.read(), mime_type=mime_type, meta=meta)
+            return cls(data=fd.read(), mime_type=mime_type, meta=meta or {})
 
     @classmethod
     def from_string(
@@ -48,4 +48,4 @@ class ByteStream:
         :param mime_type: The mime type of the file.
         :param meta: Additional metadata to be stored with the ByteStream.
         """
-        return cls(data=text.encode(encoding), mime_type=mime_type, meta=meta)
+        return cls(data=text.encode(encoding), mime_type=mime_type, meta=meta or {})

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 
 
-@dataclass(frozen=True)
+@dataclass
 class ByteStream:
     """
     Base data class representing a binary object in the Haystack API.

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -14,25 +14,38 @@ class ByteStream:
     mime_type: Optional[str] = field(default=None)
 
     def to_file(self, destination_path: Path):
+        """
+        Write the ByteStream to a file. Note: the metadata will be lost.
+
+        :param destination_path: The path to write the ByteStream to.
+        """
         with open(destination_path, "wb") as fd:
             fd.write(self.data)
 
     @classmethod
-    def from_file_path(cls, filepath: Path, mime_type: Optional[str] = None) -> "ByteStream":
+    def from_file_path(
+        cls, filepath: Path, mime_type: Optional[str] = None, meta: Optional[Dict[str, Any]] = None
+    ) -> "ByteStream":
         """
         Create a ByteStream from the contents read from a file.
 
         :param filepath: A valid path to a file.
+        :param mime_type: The mime type of the file.
+        :param meta: Additional metadata to be stored with the ByteStream.
         """
         with open(filepath, "rb") as fd:
-            return cls(data=fd.read(), mime_type=mime_type)
+            return cls(data=fd.read(), mime_type=mime_type, meta=meta)
 
     @classmethod
-    def from_string(cls, text: str, encoding: str = "utf-8", mime_type: Optional[str] = None) -> "ByteStream":
+    def from_string(
+        cls, text: str, encoding: str = "utf-8", mime_type: Optional[str] = None, meta: Optional[Dict[str, Any]] = None
+    ) -> "ByteStream":
         """
         Create a ByteStream encoding a string.
 
         :param text: The string to encode
         :param encoding: The encoding used to convert the string into bytes
+        :param mime_type: The mime type of the file.
+        :param meta: Additional metadata to be stored with the ByteStream.
         """
-        return cls(data=text.encode(encoding), mime_type=mime_type)
+        return cls(data=text.encode(encoding), mime_type=mime_type, meta=meta)

--- a/releasenotes/notes/meta-in-bytestream-a29816c919c0be5a.yaml
+++ b/releasenotes/notes/meta-in-bytestream-a29816c919c0be5a.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Add meta parameter to `ByteStream.from_file_path()` and `ByteStream.from_string()`.

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -1,8 +1,4 @@
-import io
-
 from haystack.dataclasses import ByteStream
-
-import pytest
 
 
 def test_from_file_path(tmp_path, request):
@@ -19,6 +15,10 @@ def test_from_file_path(tmp_path, request):
     assert b.data == test_bytes
     assert b.mime_type == "text/plain"
 
+    b = ByteStream.from_file_path(test_path, meta={"foo": "bar"})
+    assert b.data == test_bytes
+    assert b.meta == {"foo": "bar"}
+
 
 def test_from_string():
     test_string = "Hello, world!"
@@ -29,6 +29,10 @@ def test_from_string():
     b = ByteStream.from_string(test_string, mime_type="text/plain")
     assert b.data.decode() == test_string
     assert b.mime_type == "text/plain"
+
+    b = ByteStream.from_string(test_string, meta={"foo": "bar"})
+    assert b.data.decode() == test_string
+    assert b.meta == {"foo": "bar"}
 
 
 def test_to_file(tmp_path, request):


### PR DESCRIPTION
### Related Issues

- fixes [#6217](https://github.com/deepset-ai/haystack/issues/6217)

### Proposed Changes:

- Add `meta` parameter to `ByteStream.from_file_path()` and `ByteStream.from_string()`.
- Improve docstrings
- Add tests

### How did you test it?

Unit tests

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
