### PR TITLE
fix: add some tolerance to ExtractiveReader Roberta test

### DIFF
--- a/test/components/readers/test_extractive.py
+++ b/test/components/readers/test_extractive.py
@@ -640,7 +640,7 @@ def test_roberta():
     assert answers[1].data == "Angela Merkel"
     assert answers[1].score == pytest.approx(0.857952892780304)
     assert answers[2].data is None
-    assert answers[2].score == pytest.approx(0.019673851661650588)
+    assert answers[2].score == pytest.approx(0.019673851661650588, abs=1e-5)
     assert len(answers) == 3
     # uncomment assertions below when there is batching in v2
     # assert answers[0][0].data == "Olaf Scholz"


### PR DESCRIPTION
### Related Issues

- fixes failing CI: https://github.com/deepset-ai/haystack/actions/runs/7727442595/job/21066661586?pr=6857

### Proposed Changes:

Fix Roberta test for ExtractiveReader. Due to the recent transformers upgrade, the score is very slightly off and breaks the test.

### How did you test it?

CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
