### PR TITLE
feat!: Use `Secret` for passing authentication secrets to components

### DIFF
--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -29,10 +29,11 @@ class DynamicChatPromptBuilder:
     from haystack.components.generators.chat import OpenAIChatGenerator
     from haystack.dataclasses import ChatMessage
     from haystack import Pipeline
+    from haystack.utils import Secret
 
     # no parameter init, we don't use any runtime template variables
     prompt_builder = DynamicChatPromptBuilder()
-    llm = OpenAIChatGenerator(api_key="<your-api-key>", model="gpt-3.5-turbo")
+    llm = OpenAIChatGenerator(api_key=Secret.from_token("<your-api-key>"), model="gpt-3.5-turbo")
 
     pipe = Pipeline()
     pipe.add_component("prompt_builder", prompt_builder)

--- a/haystack/components/builders/dynamic_prompt_builder.py
+++ b/haystack/components/builders/dynamic_prompt_builder.py
@@ -21,9 +21,10 @@ class DynamicPromptBuilder:
     from haystack.components.builders import DynamicPromptBuilder
     from haystack.components.generators import OpenAIGenerator
     from haystack import Pipeline, component, Document
+    from haystack.utils import Secret
 
     prompt_builder = DynamicPromptBuilder(runtime_variables=["documents"])
-    llm = OpenAIGenerator(api_key="<your-api-key>", model="gpt-3.5-turbo")
+    llm = OpenAIGenerator(api_key=Secret.from_token("<your-api-key>"), model="gpt-3.5-turbo")
 
 
     @component

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -1,6 +1,7 @@
-from typing import List, Optional, Union, Dict
+from typing import List, Optional, Dict
 
 from haystack.lazy_imports import LazyImport
+from haystack.utils.auth import Secret
 
 with LazyImport(message="Run 'pip install \"sentence-transformers>=2.2.0\"'") as sentence_transformers_import:
     from sentence_transformers import SentenceTransformer
@@ -14,14 +15,12 @@ class _SentenceTransformersEmbeddingBackendFactory:
     _instances: Dict[str, "_SentenceTransformersEmbeddingBackend"] = {}
 
     @staticmethod
-    def get_embedding_backend(model: str, device: Optional[str] = None, use_auth_token: Union[bool, str, None] = None):
-        embedding_backend_id = f"{model}{device}{use_auth_token}"
+    def get_embedding_backend(model: str, device: Optional[str] = None, auth_token: Optional[Secret] = None):
+        embedding_backend_id = f"{model}{device}{auth_token}"
 
         if embedding_backend_id in _SentenceTransformersEmbeddingBackendFactory._instances:
             return _SentenceTransformersEmbeddingBackendFactory._instances[embedding_backend_id]
-        embedding_backend = _SentenceTransformersEmbeddingBackend(
-            model=model, device=device, use_auth_token=use_auth_token
-        )
+        embedding_backend = _SentenceTransformersEmbeddingBackend(model=model, device=device, auth_token=auth_token)
         _SentenceTransformersEmbeddingBackendFactory._instances[embedding_backend_id] = embedding_backend
         return embedding_backend
 
@@ -31,9 +30,11 @@ class _SentenceTransformersEmbeddingBackend:
     Class to manage Sentence Transformers embeddings.
     """
 
-    def __init__(self, model: str, device: Optional[str] = None, use_auth_token: Union[bool, str, None] = None):
+    def __init__(self, model: str, device: Optional[str] = None, auth_token: Optional[Secret] = None):
         sentence_transformers_import.check()
-        self.model = SentenceTransformer(model_name_or_path=model, device=device, use_auth_token=use_auth_token)
+        self.model = SentenceTransformer(
+            model_name_or_path=model, device=device, use_auth_token=auth_token.resolve_value() if auth_token else None
+        )
 
     def embed(self, data: List[str], **kwargs) -> List[List[float]]:
         embeddings = self.model.encode(data, **kwargs).tolist()

--- a/haystack/components/embedders/hf_utils.py
+++ b/haystack/components/embedders/hf_utils.py
@@ -1,26 +1,27 @@
 from typing import Optional
 
 from haystack.lazy_imports import LazyImport
+from haystack.utils.auth import Secret
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:
     from huggingface_hub import HfApi
     from huggingface_hub.utils import RepositoryNotFoundError
 
 
-def check_valid_model(model_id: str, token: Optional[str]) -> None:
+def check_valid_model(model_id: str, token: Optional[Secret]) -> None:
     """
     Check if the provided model ID corresponds to a valid model on HuggingFace Hub.
     Also check if the model is a embedding model.
 
     :param model_id: A string representing the HuggingFace model ID.
-    :param token: An optional string representing the authentication token.
+    :param token: The optional authentication token.
     :raises ValueError: If the model is not found or is not a embedding model.
     """
     transformers_import.check()
 
     api = HfApi()
     try:
-        model_info = api.model_info(model_id, token=token)
+        model_info = api.model_info(model_id, token=token.resolve_value() if token else None)
     except RepositoryNotFoundError as e:
         raise ValueError(
             f"Model {model_id} not found on HuggingFace Hub. Please provide a valid HuggingFace model_id."

--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -3,7 +3,8 @@ from typing import List, Optional, Dict, Any, Tuple
 from openai import OpenAI
 from tqdm import tqdm
 
-from haystack import component, Document, default_to_dict
+from haystack import component, Document, default_to_dict, default_from_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 
 @component
@@ -30,7 +31,7 @@ class OpenAIDocumentEmbedder:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         model: str = "text-embedding-ada-002",
         api_base_url: Optional[str] = None,
         organization: Optional[str] = None,
@@ -43,8 +44,7 @@ class OpenAIDocumentEmbedder:
     ):
         """
         Create a OpenAIDocumentEmbedder component.
-        :param api_key: The OpenAI API key. It can be explicitly provided or automatically read from the
-                        environment variable OPENAI_API_KEY (recommended).
+        :param api_key: The OpenAI API key.
         :param model: The name of the model to use.
         :param api_base_url: The OpenAI API Base url, defaults to None. For more details, see OpenAI [docs](https://platform.openai.com/docs/api-reference/audio).
         :param organization: The Organization ID, defaults to `None`. See
@@ -57,6 +57,7 @@ class OpenAIDocumentEmbedder:
         :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document text.
         :param embedding_separator: Separator used to concatenate the meta fields to the Document text.
         """
+        self.api_key = api_key
         self.model = model
         self.api_base_url = api_base_url
         self.organization = organization
@@ -67,7 +68,7 @@ class OpenAIDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
 
-        self.client = OpenAI(api_key=api_key, organization=organization, base_url=api_base_url)
+        self.client = OpenAI(api_key=api_key.resolve_value(), organization=organization, base_url=api_base_url)
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -91,7 +92,13 @@ class OpenAIDocumentEmbedder:
             progress_bar=self.progress_bar,
             meta_fields_to_embed=self.meta_fields_to_embed,
             embedding_separator=self.embedding_separator,
+            api_key=self.api_key.to_dict(),
         )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OpenAIDocumentEmbedder":
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)
 
     def _prepare_texts_to_embed(self, documents: List[Document]) -> List[str]:
         """

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -1,9 +1,10 @@
-from typing import List, Optional, Union, Dict, Any
+from typing import List, Optional, Dict, Any
 
-from haystack import component, Document, default_to_dict
+from haystack import component, Document, default_to_dict, default_from_dict
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 
 @component
@@ -31,7 +32,7 @@ class SentenceTransformersDocumentEmbedder:
         self,
         model: str = "sentence-transformers/all-mpnet-base-v2",
         device: Optional[str] = None,
-        token: Union[bool, str, None] = None,
+        token: Optional[Secret] = Secret.from_env_var("HF_API_TOKEN", strict=False),
         prefix: str = "",
         suffix: str = "",
         batch_size: int = 32,
@@ -48,8 +49,6 @@ class SentenceTransformersDocumentEmbedder:
         :param device: Device (like 'cuda' / 'cpu') that should be used for computation.
             Defaults to CPU.
         :param token: The API token used to download private models from Hugging Face.
-            If this parameter is set to `True`, then the token generated when running
-            `transformers-cli login` (stored in ~/.huggingface) will be used.
         :param prefix: A string to add to the beginning of each Document text before embedding.
             Can be used to prepend the text with an instruction, as required by some embedding models,
             such as E5 and bge.
@@ -87,7 +86,7 @@ class SentenceTransformersDocumentEmbedder:
             self,
             model=self.model,
             device=self.device,
-            token=self.token if not isinstance(self.token, str) else None,  # don't serialize valid tokens
+            token=self.token.to_dict() if self.token else None,
             prefix=self.prefix,
             suffix=self.suffix,
             batch_size=self.batch_size,
@@ -97,13 +96,18 @@ class SentenceTransformersDocumentEmbedder:
             embedding_separator=self.embedding_separator,
         )
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SentenceTransformersDocumentEmbedder":
+        deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
+        return default_from_dict(cls, data)
+
     def warm_up(self):
         """
         Load the embedding backend.
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
-                model=self.model, device=self.device, use_auth_token=self.token
+                model=self.model, device=self.device, auth_token=self.token
             )
 
     @component.output_types(documents=List[Document])

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -1,9 +1,10 @@
-from typing import List, Optional, Union, Dict, Any
+from typing import List, Optional, Dict, Any
 
-from haystack import component, default_to_dict
+from haystack import component, default_to_dict, default_from_dict
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 
 @component
@@ -30,7 +31,7 @@ class SentenceTransformersTextEmbedder:
         self,
         model: str = "sentence-transformers/all-mpnet-base-v2",
         device: Optional[str] = None,
-        token: Union[bool, str, None] = None,
+        token: Optional[Secret] = Secret.from_env_var("HF_API_TOKEN", strict=False),
         prefix: str = "",
         suffix: str = "",
         batch_size: int = 32,
@@ -45,8 +46,6 @@ class SentenceTransformersTextEmbedder:
         :param device: Device (like 'cuda' / 'cpu') that should be used for computation.
             Defaults to CPU.
         :param token: The API token used to download private models from Hugging Face.
-            If this parameter is set to `True`, then the token generated when running
-            `transformers-cli login` (stored in ~/.huggingface) will be used.
         :param prefix: A string to add to the beginning of each Document text before embedding.
             Can be used to prepend the text with an instruction, as required by some embedding models,
             such as E5 and bge.
@@ -80,7 +79,7 @@ class SentenceTransformersTextEmbedder:
             self,
             model=self.model,
             device=self.device,
-            token=self.token if not isinstance(self.token, str) else None,  # don't serialize valid tokens
+            token=self.token.to_dict() if self.token else None,
             prefix=self.prefix,
             suffix=self.suffix,
             batch_size=self.batch_size,
@@ -88,13 +87,18 @@ class SentenceTransformersTextEmbedder:
             normalize_embeddings=self.normalize_embeddings,
         )
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SentenceTransformersTextEmbedder":
+        deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
+        return default_from_dict(cls, data)
+
     def warm_up(self):
         """
         Load the embedding backend.
         """
         if not hasattr(self, "embedding_backend"):
             self.embedding_backend = _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
-                model=self.model, device=self.device, use_auth_token=self.token
+                model=self.model, device=self.device, auth_token=self.token
             )
 
     @component.output_types(embedding=List[float])

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -110,6 +110,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         if api_key is None and azure_ad_token is None:
             raise ValueError("Please provide an API key or an Azure Active Directory token.")
 
+        # The check above makes mypy incorrectly infer that api_key is never None,
+        # which propagates the incorrect type.
         self.api_key = api_key  # type: ignore
         self.azure_ad_token = azure_ad_token
         self.generation_kwargs = generation_kwargs or {}

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -3,12 +3,13 @@ import os
 from typing import Optional, Callable, Dict, Any
 
 # pylint: disable=import-error
-from openai.lib.azure import AzureADTokenProvider, AzureOpenAI
+from openai.lib.azure import AzureOpenAI
 
 from haystack import default_to_dict, default_from_dict
 from haystack.components.generators import OpenAIGenerator
 from haystack.components.generators.utils import serialize_callback_handler, deserialize_callback_handler
 from haystack.dataclasses import StreamingChunk
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +29,9 @@ class AzureOpenAIGenerator(OpenAIGenerator):
 
     ```python
     from haystack.components.generators import AzureOpenAIGenerator
+    from haystack.utils import Secret
     client = AzureOpenAIGenerator(azure_endpoint="<Your Azure endpoint e.g. `https://your-company.azure.openai.com/>",
-                            api_key="<you api key>",
+                                api_key=Secret.from_token("<your-api-key>"),
                             azure_deployment="<this a model name, e.g. gpt-35-turbo>")
     response = client.run("What's Natural Language Processing? Be brief.")
     print(response)
@@ -56,9 +58,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         azure_endpoint: Optional[str] = None,
         api_version: Optional[str] = "2023-05-15",
         azure_deployment: Optional[str] = "gpt-35-turbo",
-        api_key: Optional[str] = None,
-        azure_ad_token: Optional[str] = None,
-        azure_ad_token_provider: Optional[AzureADTokenProvider] = None,
+        api_key: Optional[Secret] = Secret.from_env_var("AZURE_OPENAI_API_KEY", strict=False),
+        azure_ad_token: Optional[Secret] = Secret.from_env_var("AZURE_OPENAI_AD_TOKEN", strict=False),
         organization: Optional[str] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         system_prompt: Optional[str] = None,
@@ -70,8 +71,6 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         :param azure_deployment: The deployment of the model, usually the model name.
         :param api_key: The API key to use for authentication.
         :param azure_ad_token: Azure Active Directory token, see https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id
-        :param azure_ad_token_provider: A function that returns an Azure Active Directory token, will be invoked
-        on every request.
         :param organization: The Organization ID, defaults to `None`. See
         [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization).
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
@@ -108,6 +107,11 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         if not azure_endpoint:
             raise ValueError("Please provide an Azure endpoint or set the environment variable AZURE_OPENAI_ENDPOINT.")
 
+        if api_key is None and azure_ad_token is None:
+            raise ValueError("Please provide an API key or an Azure Active Directory token.")
+
+        self.api_key = api_key  # type: ignore
+        self.azure_ad_token = azure_ad_token
         self.generation_kwargs = generation_kwargs or {}
         self.system_prompt = system_prompt
         self.streaming_callback = streaming_callback
@@ -121,9 +125,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             api_version=api_version,
             azure_endpoint=azure_endpoint,
             azure_deployment=azure_deployment,
-            api_key=api_key,
-            azure_ad_token=azure_ad_token,
-            azure_ad_token_provider=azure_ad_token_provider,
+            api_key=api_key.resolve_value() if api_key is not None else None,
+            azure_ad_token=azure_ad_token.resolve_value() if azure_ad_token is not None else None,
             organization=organization,
         )
 
@@ -142,6 +145,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             streaming_callback=callback_name,
             generation_kwargs=self.generation_kwargs,
             system_prompt=self.system_prompt,
+            api_key=self.api_key.to_dict() if self.api_key is not None else None,
+            azure_ad_token=self.azure_ad_token.to_dict() if self.azure_ad_token is not None else None,
         )
 
     @classmethod
@@ -151,6 +156,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         :param data: The dictionary representation of this component.
         :return: The deserialized component instance.
         """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key", "azure_ad_token"])
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -115,6 +115,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         if api_key is None and azure_ad_token is None:
             raise ValueError("Please provide an API key or an Azure Active Directory token.")
 
+        # The check above makes mypy incorrectly infer that api_key is never None,
+        # which propagates the incorrect type.
         self.api_key = api_key  # type: ignore
         self.azure_ad_token = azure_ad_token
         self.generation_kwargs = generation_kwargs or {}

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -9,6 +9,7 @@ from haystack.components.generators.utils import serialize_callback_handler, des
 from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class HuggingFaceLocalChatGenerator:
         model: str = "HuggingFaceH4/zephyr-7b-beta",
         task: Optional[Literal["text-generation", "text2text-generation"]] = None,
         device: Optional[ComponentDevice] = None,
-        token: Optional[Union[str, bool]] = None,
+        token: Optional[Secret] = Secret.from_env_var("HF_API_TOKEN", strict=False),
         chat_template: Optional[str] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         huggingface_pipeline_kwargs: Optional[Dict[str, Any]] = None,
@@ -80,7 +81,6 @@ class HuggingFaceLocalChatGenerator:
         :param device: The device on which the model is loaded. If `None`, the default device is automatically
             selected. If a device/device map is specified in `huggingface_pipeline_kwargs`, it overrides this parameter.
         :param token: The token to use as HTTP bearer authorization for remote files.
-            If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface).
             If the token is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
         :param chat_template: This optional parameter allows you to specify a Jinja template for formatting chat
             messages. While high-quality and well-supported chat models typically include their own chat templates
@@ -112,6 +112,9 @@ class HuggingFaceLocalChatGenerator:
 
         huggingface_pipeline_kwargs = huggingface_pipeline_kwargs or {}
         generation_kwargs = generation_kwargs or {}
+
+        self.token = token
+        token = token.resolve_value() if token else None
 
         # check if the huggingface_pipeline_kwargs contain the essential parameters
         # otherwise, populate them with values from other init parameters
@@ -178,12 +181,11 @@ class HuggingFaceLocalChatGenerator:
             huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
             generation_kwargs=self.generation_kwargs,
             streaming_callback=callback_name,
+            token=self.token.to_dict() if self.token else None,
         )
 
         huggingface_pipeline_kwargs = serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"]
-        # we don't want to serialize valid tokens
-        if isinstance(huggingface_pipeline_kwargs["token"], str):
-            serialization_dict["init_parameters"]["huggingface_pipeline_kwargs"].pop("token")
+        huggingface_pipeline_kwargs.pop("token", None)
 
         serialize_hf_model_kwargs(huggingface_pipeline_kwargs)
         return serialization_dict
@@ -194,7 +196,7 @@ class HuggingFaceLocalChatGenerator:
         Deserialize this component from a dictionary.
         """
         torch_and_transformers_import.check()  # leave this, cls method
-
+        deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -13,6 +13,7 @@ from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.utils import serialize_callback_handler, deserialize_callback_handler
 from haystack.dataclasses import StreamingChunk, ChatMessage
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class OpenAIChatGenerator:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         model: str = "gpt-3.5-turbo",
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         api_base_url: Optional[str] = None,
@@ -73,8 +74,7 @@ class OpenAIChatGenerator:
         Creates an instance of OpenAIChatGenerator. Unless specified otherwise in the `model`, this is for OpenAI's
         GPT-3.5 model.
 
-        :param api_key: The OpenAI API key. It can be explicitly provided or automatically read from the
-            environment variable OPENAI_API_KEY (recommended).
+        :param api_key: The OpenAI API key.
         :param model: The name of the model to use.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
@@ -101,12 +101,13 @@ class OpenAIChatGenerator:
             - `logit_bias`: Add a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
         """
+        self.api_key = api_key
         self.model = model
         self.generation_kwargs = generation_kwargs or {}
         self.streaming_callback = streaming_callback
         self.api_base_url = api_base_url
         self.organization = organization
-        self.client = OpenAI(api_key=api_key, organization=organization, base_url=api_base_url)
+        self.client = OpenAI(api_key=api_key.resolve_value(), organization=organization, base_url=api_base_url)
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -127,6 +128,7 @@ class OpenAIChatGenerator:
             api_base_url=self.api_base_url,
             organization=self.organization,
             generation_kwargs=self.generation_kwargs,
+            api_key=self.api_key.to_dict(),
         )
 
     @classmethod
@@ -136,6 +138,7 @@ class OpenAIChatGenerator:
         :param data: The dictionary representation of this component.
         :return: The deserialized component instance.
         """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
@@ -334,7 +337,7 @@ class OpenAIChatGenerator:
 class GPTChatGenerator(OpenAIChatGenerator):
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         model: str = "gpt-3.5-turbo",
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
         api_base_url: Optional[str] = None,

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Union, Callable
 
 from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
+from haystack.utils import Secret
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:
     from huggingface_hub import InferenceClient, HfApi
@@ -36,20 +37,20 @@ def check_generation_params(kwargs: Optional[Dict[str, Any]], additional_accepte
             )
 
 
-def check_valid_model(model_id: str, token: Optional[str]) -> None:
+def check_valid_model(model_id: str, token: Optional[Secret]) -> None:
     """
     Check if the provided model ID corresponds to a valid model on HuggingFace Hub.
     Also check if the model is a text generation model.
 
     :param model_id: A string representing the HuggingFace model ID.
-    :param token: An optional string representing the authentication token.
+    :param token: An optional authentication token.
     :raises ValueError: If the model is not found or is not a text generation model.
     """
     transformers_import.check()
 
     api = HfApi()
     try:
-        model_info = api.model_info(model_id, token=token)
+        model_info = api.model_info(model_id, token=token.resolve_value() if token else None)
     except RepositoryNotFoundError as e:
         raise ValueError(
             f"Model {model_id} not found on HuggingFace Hub. Please provide a valid HuggingFace model_id."

--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -1,11 +1,11 @@
 import json
 import logging
 from typing import Dict, List, Optional, Any
-import os
 
 import requests
 
-from haystack import Document, component, default_to_dict, ComponentError
+from haystack import Document, component, default_to_dict, ComponentError, default_from_dict
+from haystack.utils import Secret, deserialize_secrets_inplace
 
 logger = logging.getLogger(__name__)
 
@@ -27,42 +27,46 @@ class SerperDevWebSearch:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: Secret = Secret.from_env_var("SERPERDEV_API_KEY"),
         top_k: Optional[int] = 10,
         allowed_domains: Optional[List[str]] = None,
         search_params: Optional[Dict[str, Any]] = None,
     ):
         """
-        :param api_key: API key for the SerperDev API.  It can be
-        explicitly provided or automatically read from the
-        environment variable SERPERDEV_API_KEY (recommended).
+        :param api_key: API key for the SerperDev API.
         :param top_k: Number of documents to return.
         :param allowed_domains: List of domains to limit the search to.
         :param search_params: Additional parameters passed to the SerperDev API.
         For example, you can set 'num' to 20 to increase the number of search results.
         See the [Serper Dev website](https://serper.dev/) for more details.
         """
-        api_key = api_key or os.environ.get("SERPERDEV_API_KEY")
-        # we check whether api_key is None or an empty string
-        if not api_key:
-            msg = (
-                "SerperDevWebSearch expects an API key. "
-                "Set the SERPERDEV_API_KEY environment variable (recommended) or pass it explicitly."
-            )
-            raise ValueError(msg)
-
         self.api_key = api_key
         self.top_k = top_k
         self.allowed_domains = allowed_domains
         self.search_params = search_params or {}
+
+        # Ensure that the API key is resolved.
+        _ = self.api_key.resolve_value()
 
     def to_dict(self) -> Dict[str, Any]:
         """
         Serialize this component to a dictionary.
         """
         return default_to_dict(
-            self, top_k=self.top_k, allowed_domains=self.allowed_domains, search_params=self.search_params
+            self,
+            top_k=self.top_k,
+            allowed_domains=self.allowed_domains,
+            search_params=self.search_params,
+            api_key=self.api_key.to_dict(),
         )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SerperDevWebSearch":
+        """
+        Deserialize this component from a dictionary.
+        """
+        deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
+        return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document], links=List[str])
     def run(self, query: str):
@@ -76,10 +80,10 @@ class SerperDevWebSearch:
         payload = json.dumps(
             {"q": query_prepend + query, "gl": "us", "hl": "en", "autocorrect": True, **self.search_params}
         )
-        headers = {"X-API-KEY": self.api_key, "Content-Type": "application/json"}
+        headers = {"X-API-KEY": self.api_key.resolve_value(), "Content-Type": "application/json"}
 
         try:
-            response = requests.post(SERPERDEV_BASE_URL, headers=headers, data=payload, timeout=30)
+            response = requests.post(SERPERDEV_BASE_URL, headers=headers, data=payload, timeout=30)  # type: ignore
             response.raise_for_status()  # Will raise an HTTPError for bad responses
         except requests.Timeout:
             raise TimeoutError(f"Request to {self.__class__.__name__} timed out.")

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -2,4 +2,4 @@ from haystack.utils.expit import expit
 from haystack.utils.requests_utils import request_with_retry
 from haystack.utils.filters import document_matches_filter
 from haystack.utils.device import ComponentDevice, DeviceType, Device, DeviceMap
-from haystack.utils.auth import Secret
+from haystack.utils.auth import Secret, deserialize_secrets_inplace

--- a/haystack/utils/auth.py
+++ b/haystack/utils/auth.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 
@@ -193,3 +193,21 @@ class EnvVarSecret(Secret):
         if out is None and self._strict:
             raise ValueError(f"None of the following authentication environment variables are set: {self._env_vars}")
         return out
+
+
+def deserialize_secrets_inplace(data: Dict[str, Any], keys: Iterable[str], *, recursive: bool = False):
+    """
+    Deserialize secrets in a dictionary inplace.
+
+    :param data:
+        The dictionary with the serialized data.
+    :param keys:
+        The keys of the secrets to deserialize.
+    :param recursive:
+        Whether to recursively deserialize nested dictionaries.
+    """
+    for k, v in data.items():
+        if isinstance(v, dict) and recursive:
+            deserialize_secrets_inplace(v, keys)
+        elif k in keys and v is not None:
+            data[k] = Secret.from_dict(v)

--- a/releasenotes/notes/secret-handling-for-components-d576a28135a224db.yaml
+++ b/releasenotes/notes/secret-handling-for-components-d576a28135a224db.yaml
@@ -4,3 +4,37 @@ features:
     Expose a `Secret` type to provide consistent API for any component that requires secrets for authentication.
     Currently supports string tokens and environment variables. Token-based secrets are automatically
     prevented from being serialized to disk (to prevent accidental leakage of secrets).
+    ```python
+    @component
+    class MyComponent:
+      def __init__(self, api_key: Optional[Secret] = None, **kwargs):
+        self.api_key = api_key
+        self.backend = None
+
+      def warm_up(self):
+        # Call resolve_value to yield a single result. The semantics of the result is policy-dependent.
+        # Currently, all supported policies will return a single string token.
+        self.backend = SomeBackend(api_key=self.api_key.resolve_value() if self.api_key else None, ...)
+
+      def to_dict(self):
+        # Serialize the policy like any other (custom) data. If the policy is token-based, it will
+        # raise an error.
+        return default_to_dict(self, api_key=self.api_key.to_dict() if self.api_key else None, ...)
+
+      @classmethod
+      def from_dict(cls, data):
+        # Deserialize the policy data before passing it to the generic from_dict function.
+        api_key_data = data["init_parameters"]["api_key"]
+        api_key = Secret.from_dict(api_key_data) if api_key_data is not None else None
+        data["init_parameters"]["api_key"] = api_key
+        return default_from_dict(cls, data)
+
+    # No authentication.
+    component = MyComponent(api_key=None)
+    # Token based authentication
+    component = MyComponent(api_key=Secret.from_token("sk-randomAPIkeyasdsa32ekasd32e"))
+    component.to_dict() # Error! Can't serialize authentication tokens
+    # Environment variable based authentication
+    component = MyComponent(api_key=Secret.from_env("OPENAI_API_KEY"))
+    component.to_dict() # This is fine
+    ```

--- a/releasenotes/notes/update-secret-handling-in-components-925d4f3c3c9530db.yaml
+++ b/releasenotes/notes/update-secret-handling-in-components-925d4f3c3c9530db.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    Update secret handling for components using the `Secret` type. The following components are affected:
+    `RemoteWhisperTranscriber`, `AzureOCRDocumentConverter`, `AzureOpenAIDocumentEmbedder`, `AzureOpenAITextEmbedder`, `HuggingFaceTEIDocumentEmbedder`, `HuggingFaceTEITextEmbedder`, `OpenAIDocumentEmbedder`, `SentenceTransformersDocumentEmbedder`, `SentenceTransformersTextEmbedder`, `AzureOpenAIGenerator`, `AzureOpenAIChatGenerator`, `HuggingFaceLocalChatGenerator`, `HuggingFaceTGIChatGenerator`, `OpenAIChatGenerator`, `HuggingFaceLocalGenerator`, `HuggingFaceTGIGenerator`, `OpenAIGenerator`, `TransformersSimilarityRanker`, `SearchApiWebSearch`, `SerperDevWebSearch`
+
+    The default init parameters for `api_key`, `token`, `azure_ad_token` have been adjusted to use environment variables wherever possible. The `azure_ad_token_provider` parameter has been removed from Azure-based components. Components based on Hugging
+    Face are now required to either use a token or an environment variable if authentication is required - The on-disk local token file is no longer supported.

--- a/test/components/converters/test_azure_ocr_doc_converter.py
+++ b/test/components/converters/test_azure_ocr_doc_converter.py
@@ -5,6 +5,7 @@ import pytest
 
 from haystack.components.converters.azure import AzureOCRDocumentConverter
 from haystack.dataclasses import ByteStream
+from haystack.utils import Secret
 
 
 class TestAzureOCRDocumentConverter:
@@ -13,15 +14,23 @@ class TestAzureOCRDocumentConverter:
         with pytest.raises(ValueError):
             AzureOCRDocumentConverter(endpoint="test_endpoint")
 
-    def test_to_dict(self):
-        component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
+    @patch("haystack.utils.auth.EnvVarSecret.resolve_value")
+    def test_to_dict(self, mock_resolve_value):
+        mock_resolve_value.return_value = "test_api_key"
+        component = AzureOCRDocumentConverter(endpoint="test_endpoint")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.converters.azure.AzureOCRDocumentConverter",
-            "init_parameters": {"endpoint": "test_endpoint", "model_id": "prebuilt-read"},
+            "init_parameters": {
+                "api_key": {"env_vars": ["AZURE_AI_API_KEY"], "strict": True, "type": "env_var"},
+                "endpoint": "test_endpoint",
+                "model_id": "prebuilt-read",
+            },
         }
 
-    def test_run(self, test_files_path):
+    @patch("haystack.utils.auth.EnvVarSecret.resolve_value")
+    def test_run(self, mock_resolve_value, test_files_path):
+        mock_resolve_value.return_value = "test_api_key"
         with patch("haystack.components.converters.azure.DocumentAnalysisClient") as mock_azure_client:
             mock_result = Mock(pages=[Mock(lines=[Mock(content="mocked line 1"), Mock(content="mocked line 2")])])
             mock_result.to_dict.return_value = {
@@ -32,7 +41,7 @@ class TestAzureOCRDocumentConverter:
             }
             mock_azure_client.return_value.begin_analyze_document.return_value.result.return_value = mock_result
 
-            component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
+            component = AzureOCRDocumentConverter(endpoint="test_endpoint")
             output = component.run(sources=[test_files_path / "pdf" / "sample_pdf_1.pdf"])
             document = output["documents"][0]
             assert document.content == "mocked line 1\nmocked line 2\n\f"
@@ -44,11 +53,12 @@ class TestAzureOCRDocumentConverter:
                 "pages": [{"lines": [{"content": "mocked line 1"}, {"content": "mocked line 2"}]}],
             }
 
-    def test_run_with_meta(self, test_files_path):
+    @patch("haystack.utils.auth.EnvVarSecret.resolve_value")
+    def test_run_with_meta(self, mock_resolve_value, test_files_path):
+        mock_resolve_value.return_value = "test_api_key"
         bytestream = ByteStream(data=b"test", meta={"author": "test_author", "language": "en"})
         with patch("haystack.components.converters.azure.DocumentAnalysisClient"):
-            component = AzureOCRDocumentConverter(endpoint="test_endpoint", api_key="test_credential_key")
-
+            component = AzureOCRDocumentConverter(endpoint="test_endpoint")
         output = component.run(
             sources=[bytestream, test_files_path / "pdf" / "sample_pdf_1.pdf"], meta={"language": "it"}
         )
@@ -63,7 +73,7 @@ class TestAzureOCRDocumentConverter:
     @pytest.mark.skipif(not os.environ.get("CORE_AZURE_CS_API_KEY", None), reason="Azure credentials not available")
     def test_run_with_pdf_file(self, test_files_path):
         component = AzureOCRDocumentConverter(
-            endpoint=os.environ["CORE_AZURE_CS_ENDPOINT"], api_key=os.environ["CORE_AZURE_CS_API_KEY"]
+            endpoint=os.environ["CORE_AZURE_CS_ENDPOINT"], api_key=Secret.from_env_var("CORE_AZURE_CS_API_KEY")
         )
         output = component.run(sources=[test_files_path / "pdf" / "sample_pdf_1.pdf"])
         documents = output["documents"]
@@ -77,7 +87,7 @@ class TestAzureOCRDocumentConverter:
     @pytest.mark.skipif(not os.environ.get("CORE_AZURE_CS_API_KEY", None), reason="Azure credentials not available")
     def test_with_image_file(self, test_files_path):
         component = AzureOCRDocumentConverter(
-            endpoint=os.environ["CORE_AZURE_CS_ENDPOINT"], api_key=os.environ["CORE_AZURE_CS_API_KEY"]
+            endpoint=os.environ["CORE_AZURE_CS_ENDPOINT"], api_key=Secret.from_env_var("CORE_AZURE_CS_API_KEY")
         )
         output = component.run(sources=[test_files_path / "images" / "haystack-logo.png"])
         documents = output["documents"]
@@ -90,7 +100,7 @@ class TestAzureOCRDocumentConverter:
     @pytest.mark.skipif(not os.environ.get("CORE_AZURE_CS_API_KEY", None), reason="Azure credentials not available")
     def test_run_with_docx_file(self, test_files_path):
         component = AzureOCRDocumentConverter(
-            endpoint=os.environ["CORE_AZURE_CS_ENDPOINT"], api_key=os.environ["CORE_AZURE_CS_API_KEY"]
+            endpoint=os.environ["CORE_AZURE_CS_ENDPOINT"], api_key=Secret.from_env_var("CORE_AZURE_CS_API_KEY")
         )
         output = component.run(sources=[test_files_path / "docx" / "sample_docx.docx"])
         documents = output["documents"]

--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -19,14 +19,15 @@ class TestAzureOpenAIDocumentEmbedder:
         assert embedder.meta_fields_to_embed == []
         assert embedder.embedding_separator == "\n"
 
-    def test_to_dict(self):
-        component = AzureOpenAIDocumentEmbedder(
-            api_key="fake-api-key", azure_endpoint="https://example-resource.azure.openai.com/"
-        )
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        component = AzureOpenAIDocumentEmbedder(azure_endpoint="https://example-resource.azure.openai.com/")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.embedders.azure_document_embedder.AzureOpenAIDocumentEmbedder",
             "init_parameters": {
+                "api_key": {"env_vars": ["AZURE_OPENAI_API_KEY"], "strict": False, "type": "env_var"},
+                "azure_ad_token": {"env_vars": ["AZURE_OPENAI_AD_TOKEN"], "strict": False, "type": "env_var"},
                 "api_version": "2023-05-15",
                 "azure_deployment": "text-embedding-ada-002",
                 "azure_endpoint": "https://example-resource.azure.openai.com/",

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -16,14 +16,15 @@ class TestAzureOpenAITextEmbedder:
         assert embedder.prefix == ""
         assert embedder.suffix == ""
 
-    def test_to_dict(self):
-        component = AzureOpenAITextEmbedder(
-            api_key="fake-api-key", azure_endpoint="https://example-resource.azure.openai.com/"
-        )
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        component = AzureOpenAITextEmbedder(azure_endpoint="https://example-resource.azure.openai.com/")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.embedders.azure_text_embedder.AzureOpenAITextEmbedder",
             "init_parameters": {
+                "api_key": {"env_vars": ["AZURE_OPENAI_API_KEY"], "strict": False, "type": "env_var"},
+                "azure_ad_token": {"env_vars": ["AZURE_OPENAI_AD_TOKEN"], "strict": False, "type": "env_var"},
                 "azure_deployment": "text-embedding-ada-002",
                 "organization": None,
                 "azure_endpoint": "https://example-resource.azure.openai.com/",

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -1,7 +1,7 @@
 import os
+from haystack.utils.auth import Secret
 
 import pytest
-from openai import OpenAIError
 
 from haystack.components.embedders.openai_text_embedder import OpenAITextEmbedder
 
@@ -19,7 +19,11 @@ class TestOpenAITextEmbedder:
 
     def test_init_with_parameters(self):
         embedder = OpenAITextEmbedder(
-            api_key="fake-api-key", model="model", organization="fake-organization", prefix="prefix", suffix="suffix"
+            api_key=Secret.from_token("fake-api-key"),
+            model="model",
+            organization="fake-organization",
+            prefix="prefix",
+            suffix="suffix",
         )
         assert embedder.client.api_key == "fake-api-key"
         assert embedder.model == "model"
@@ -29,25 +33,38 @@ class TestOpenAITextEmbedder:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(OpenAIError):
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
             OpenAITextEmbedder()
 
-    def test_to_dict(self):
-        component = OpenAITextEmbedder(api_key="fake-api-key")
+    def test_to_dict(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
+        component = OpenAITextEmbedder()
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.embedders.openai_text_embedder.OpenAITextEmbedder",
-            "init_parameters": {"model": "text-embedding-ada-002", "organization": None, "prefix": "", "suffix": ""},
+            "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
+                "model": "text-embedding-ada-002",
+                "organization": None,
+                "prefix": "",
+                "suffix": "",
+            },
         }
 
-    def test_to_dict_with_custom_init_parameters(self):
+    def test_to_dict_with_custom_init_parameters(self, monkeypatch):
+        monkeypatch.setenv("ENV_VAR", "fake-api-key")
         component = OpenAITextEmbedder(
-            api_key="fake-api-key", model="model", organization="fake-organization", prefix="prefix", suffix="suffix"
+            api_key=Secret.from_env_var("ENV_VAR", strict=False),
+            model="model",
+            organization="fake-organization",
+            prefix="prefix",
+            suffix="suffix",
         )
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.embedders.openai_text_embedder.OpenAITextEmbedder",
             "init_parameters": {
+                "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
                 "model": "model",
                 "organization": "fake-organization",
                 "prefix": "prefix",
@@ -56,7 +73,7 @@ class TestOpenAITextEmbedder:
         }
 
     def test_run_wrong_input_format(self):
-        embedder = OpenAITextEmbedder(api_key="fake-api-key")
+        embedder = OpenAITextEmbedder(api_key=Secret.from_token("fake-api-key"))
 
         list_integers_input = [1, 2, 3]
 

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -3,6 +3,7 @@ import pytest
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
 )
+from haystack.utils.auth import Secret
 
 
 @patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
@@ -22,10 +23,10 @@ def test_factory_behavior(mock_sentence_transformer):
 @patch("haystack.components.embedders.backends.sentence_transformers_backend.SentenceTransformer")
 def test_model_initialization(mock_sentence_transformer):
     _SentenceTransformersEmbeddingBackendFactory.get_embedding_backend(
-        model="model", device="cpu", use_auth_token="my_token"
+        model="model", device="cpu", auth_token=Secret.from_token("fake-api-token")
     )
     mock_sentence_transformer.assert_called_once_with(
-        model_name_or_path="model", device="cpu", use_auth_token="my_token"
+        model_name_or_path="model", device="cpu", use_auth_token="fake-api-token"
     )
 
 

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -6,11 +6,13 @@ from openai import OpenAIError
 from haystack.components.generators.chat import AzureOpenAIChatGenerator
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage
+from haystack.utils.auth import Secret
 
 
 class TestOpenAIChatGenerator:
-    def test_init_default(self):
-        component = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint", api_key="test-api-key")
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        component = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")
         assert component.client.api_key == "test-api-key"
         assert component.azure_deployment == "gpt-35-turbo"
         assert component.streaming_callback is None
@@ -18,13 +20,14 @@ class TestOpenAIChatGenerator:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN", raising=False)
         with pytest.raises(OpenAIError):
             AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")
 
     def test_init_with_parameters(self):
         component = AzureOpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
             azure_endpoint="some-non-existing-endpoint",
-            api_key="test-api-key",
             streaming_callback=print_streaming_chunk,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
@@ -33,12 +36,15 @@ class TestOpenAIChatGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    def test_to_dict_default(self):
-        component = AzureOpenAIChatGenerator(api_key="test-api-key", azure_endpoint="some-non-existing-endpoint")
+    def test_to_dict_default(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        component = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.generators.chat.azure.AzureOpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["AZURE_OPENAI_API_KEY"], "strict": False, "type": "env_var"},
+                "azure_ad_token": {"env_vars": ["AZURE_OPENAI_AD_TOKEN"], "strict": False, "type": "env_var"},
                 "api_version": "2023-05-15",
                 "azure_endpoint": "some-non-existing-endpoint",
                 "azure_deployment": "gpt-35-turbo",
@@ -48,9 +54,11 @@ class TestOpenAIChatGenerator:
             },
         }
 
-    def test_to_dict_with_parameters(self):
+    def test_to_dict_with_parameters(self, monkeypatch):
+        monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = AzureOpenAIChatGenerator(
-            api_key="test-api-key",
+            api_key=Secret.from_env_var("ENV_VAR", strict=False),
+            azure_ad_token=Secret.from_env_var("ENV_VAR1", strict=False),
             azure_endpoint="some-non-existing-endpoint",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
@@ -58,6 +66,8 @@ class TestOpenAIChatGenerator:
         assert data == {
             "type": "haystack.components.generators.chat.azure.AzureOpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
+                "azure_ad_token": {"env_vars": ["ENV_VAR1"], "strict": False, "type": "env_var"},
                 "api_version": "2023-05-15",
                 "azure_endpoint": "some-non-existing-endpoint",
                 "azure_deployment": "gpt-35-turbo",

--- a/test/components/generators/chat/test_hugging_face_tgi.py
+++ b/test/components/generators/chat/test_hugging_face_tgi.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock, Mock
+from haystack.utils.auth import Secret
 
 import pytest
 from huggingface_hub.inference._text_generation import TextGenerationStreamResponse, Token, StreamDetails, FinishReason
@@ -59,7 +60,7 @@ class TestHuggingFaceTGIChatGenerator:
         # Initialize the HuggingFaceTGIChatGenerator object with valid parameters
         generator = HuggingFaceTGIChatGenerator(
             model="NousResearch/Llama-2-7b-chat-hf",
-            token="token",
+            token=Secret.from_env_var("ENV_VAR", strict=False),
             generation_kwargs={"n": 5},
             stop_words=["stop", "words"],
             streaming_callback=lambda x: x,
@@ -71,7 +72,7 @@ class TestHuggingFaceTGIChatGenerator:
 
         # Assert that the init_params dictionary contains the expected keys and values
         assert init_params["model"] == "NousResearch/Llama-2-7b-chat-hf"
-        assert init_params["token"] is None
+        assert init_params["token"] == {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"}
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
 
     def test_from_dict(self, mock_check_valid_model):

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from openai import OpenAIError
+from haystack.utils.auth import Secret
 
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.generators.utils import print_streaming_chunk
@@ -17,8 +18,9 @@ def chat_messages():
 
 
 class TestOpenAIChatGenerator:
-    def test_init_default(self):
-        component = OpenAIChatGenerator(api_key="test-api-key")
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIChatGenerator()
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-3.5-turbo"
         assert component.streaming_callback is None
@@ -26,12 +28,12 @@ class TestOpenAIChatGenerator:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(OpenAIError):
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
             OpenAIChatGenerator()
 
     def test_init_with_parameters(self):
         component = OpenAIChatGenerator(
-            api_key="test-api-key",
+            api_key=Secret.from_token("test-api-key"),
             model="gpt-4",
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
@@ -42,12 +44,14 @@ class TestOpenAIChatGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    def test_to_dict_default(self):
-        component = OpenAIChatGenerator(api_key="test-api-key")
+    def test_to_dict_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIChatGenerator()
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-3.5-turbo",
                 "organization": None,
                 "streaming_callback": None,
@@ -56,9 +60,10 @@ class TestOpenAIChatGenerator:
             },
         }
 
-    def test_to_dict_with_parameters(self):
+    def test_to_dict_with_parameters(self, monkeypatch):
+        monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = OpenAIChatGenerator(
-            api_key="test-api-key",
+            api_key=Secret.from_env_var("ENV_VAR"),
             model="gpt-4",
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
@@ -68,6 +73,7 @@ class TestOpenAIChatGenerator:
         assert data == {
             "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "organization": None,
                 "api_base_url": "test-base-url",
@@ -76,9 +82,9 @@ class TestOpenAIChatGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self):
+    def test_to_dict_with_lambda_streaming_callback(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = OpenAIChatGenerator(
-            api_key="test-api-key",
             model="gpt-4",
             streaming_callback=lambda x: x,
             api_base_url="test-base-url",
@@ -88,6 +94,7 @@ class TestOpenAIChatGenerator:
         assert data == {
             "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "organization": None,
                 "api_base_url": "test-base-url",
@@ -96,10 +103,12 @@ class TestOpenAIChatGenerator:
             },
         }
 
-    def test_from_dict(self):
+    def test_from_dict(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake-api-key")
         data = {
             "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
@@ -111,12 +120,14 @@ class TestOpenAIChatGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.api_key == Secret.from_env_var("OPENAI_API_KEY")
 
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         data = {
             "type": "haystack.components.generators.chat.openai.OpenAIChatGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "organization": None,
                 "api_base_url": "test-base-url",
@@ -124,11 +135,11 @@ class TestOpenAIChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
-        with pytest.raises(OpenAIError):
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
             OpenAIChatGenerator.from_dict(data)
 
     def test_run(self, chat_messages, mock_chat_completion):
-        component = OpenAIChatGenerator()
+        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
         response = component.run(chat_messages)
 
         # check that the component returns the correct ChatMessage response
@@ -139,7 +150,9 @@ class TestOpenAIChatGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
     def test_run_with_params(self, chat_messages, mock_chat_completion):
-        component = OpenAIChatGenerator(generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+        )
         response = component.run(chat_messages)
 
         # check that the component calls the OpenAI API with the correct parameters
@@ -161,7 +174,9 @@ class TestOpenAIChatGenerator:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
-        component = OpenAIChatGenerator(streaming_callback=streaming_callback)
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback
+        )
         response = component.run(chat_messages)
 
         # check we called the streaming callback
@@ -176,7 +191,7 @@ class TestOpenAIChatGenerator:
         assert "Hello" in response["replies"][0].content  # see mock_chat_completion_chunk
 
     def test_check_abnormal_completions(self, caplog):
-        component = OpenAIChatGenerator(api_key="test-api-key")
+        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
         messages = [
             ChatMessage.from_assistant(
                 "", meta={"finish_reason": "content_filter" if i % 2 == 0 else "length", "index": i}
@@ -208,7 +223,7 @@ class TestOpenAIChatGenerator:
     @pytest.mark.integration
     def test_live_run(self):
         chat_messages = [ChatMessage.from_user("What's the capital of France")]
-        component = OpenAIChatGenerator(api_key=os.environ.get("OPENAI_API_KEY"), generation_kwargs={"n": 1})
+        component = OpenAIChatGenerator(generation_kwargs={"n": 1})
         results = component.run(chat_messages)
         assert len(results["replies"]) == 1
         message: ChatMessage = results["replies"][0]
@@ -222,7 +237,7 @@ class TestOpenAIChatGenerator:
     )
     @pytest.mark.integration
     def test_live_run_wrong_model(self, chat_messages):
-        component = OpenAIChatGenerator(model="something-obviously-wrong", api_key=os.environ.get("OPENAI_API_KEY"))
+        component = OpenAIChatGenerator(model="something-obviously-wrong")
         with pytest.raises(OpenAIError):
             component.run(chat_messages)
 

--- a/test/components/generators/test_hugging_face_tgi.py
+++ b/test/components/generators/test_hugging_face_tgi.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock, Mock
+from haystack.utils.auth import Secret
 
 import pytest
 from huggingface_hub.inference._text_generation import TextGenerationStreamResponse, Token, StreamDetails, FinishReason
@@ -59,7 +60,10 @@ class TestHuggingFaceTGIGenerator:
     def test_to_dict(self, mock_check_valid_model):
         # Initialize the HuggingFaceRemoteGenerator object with valid parameters
         generator = HuggingFaceTGIGenerator(
-            token="token", generation_kwargs={"n": 5}, stop_words=["stop", "words"], streaming_callback=lambda x: x
+            token=Secret.from_env_var("ENV_VAR", strict=False),
+            generation_kwargs={"n": 5},
+            stop_words=["stop", "words"],
+            streaming_callback=lambda x: x,
         )
 
         # Call the to_dict method
@@ -68,7 +72,7 @@ class TestHuggingFaceTGIGenerator:
 
         # Assert that the init_params dictionary contains the expected keys and values
         assert init_params["model"] == "mistralai/Mistral-7B-v0.1"
-        assert not init_params["token"]
+        assert init_params["token"] == {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"}
         assert init_params["generation_kwargs"] == {"n": 5, "stop_sequences": ["stop", "words"]}
 
     def test_from_dict(self, mock_check_valid_model):

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -1,5 +1,6 @@
 import os
 from typing import List
+from haystack.utils.auth import Secret
 
 import pytest
 from openai import OpenAIError
@@ -10,8 +11,9 @@ from haystack.dataclasses import StreamingChunk, ChatMessage
 
 
 class TestOpenAIGenerator:
-    def test_init_default(self):
-        component = OpenAIGenerator(api_key="test-api-key")
+    def test_init_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIGenerator()
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-3.5-turbo"
         assert component.streaming_callback is None
@@ -19,12 +21,12 @@ class TestOpenAIGenerator:
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with pytest.raises(OpenAIError):
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
             OpenAIGenerator()
 
     def test_init_with_parameters(self):
         component = OpenAIGenerator(
-            api_key="test-api-key",
+            api_key=Secret.from_token("test-api-key"),
             model="gpt-4",
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
@@ -35,12 +37,14 @@ class TestOpenAIGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
-    def test_to_dict_default(self):
-        component = OpenAIGenerator(api_key="test-api-key")
+    def test_to_dict_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIGenerator()
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.generators.openai.OpenAIGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-3.5-turbo",
                 "streaming_callback": None,
                 "system_prompt": None,
@@ -49,9 +53,10 @@ class TestOpenAIGenerator:
             },
         }
 
-    def test_to_dict_with_parameters(self):
+    def test_to_dict_with_parameters(self, monkeypatch):
+        monkeypatch.setenv("ENV_VAR", "test-api-key")
         component = OpenAIGenerator(
-            api_key="test-api-key",
+            api_key=Secret.from_env_var("ENV_VAR"),
             model="gpt-4",
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
@@ -61,6 +66,7 @@ class TestOpenAIGenerator:
         assert data == {
             "type": "haystack.components.generators.openai.OpenAIGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "system_prompt": None,
                 "api_base_url": "test-base-url",
@@ -69,9 +75,9 @@ class TestOpenAIGenerator:
             },
         }
 
-    def test_to_dict_with_lambda_streaming_callback(self):
+    def test_to_dict_with_lambda_streaming_callback(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = OpenAIGenerator(
-            api_key="test-api-key",
             model="gpt-4",
             streaming_callback=lambda x: x,
             api_base_url="test-base-url",
@@ -81,6 +87,7 @@ class TestOpenAIGenerator:
         assert data == {
             "type": "haystack.components.generators.openai.OpenAIGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "system_prompt": None,
                 "api_base_url": "test-base-url",
@@ -94,6 +101,7 @@ class TestOpenAIGenerator:
         data = {
             "type": "haystack.components.generators.openai.OpenAIGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "system_prompt": None,
                 "api_base_url": "test-base-url",
@@ -106,23 +114,25 @@ class TestOpenAIGenerator:
         assert component.streaming_callback is print_streaming_chunk
         assert component.api_base_url == "test-base-url"
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.api_key == Secret.from_env_var("OPENAI_API_KEY")
 
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         data = {
             "type": "haystack.components.generators.openai.OpenAIGenerator",
             "init_parameters": {
+                "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
-        with pytest.raises(OpenAIError):
+        with pytest.raises(ValueError, match="None of the .* environment variables are set"):
             OpenAIGenerator.from_dict(data)
 
     def test_run(self, mock_chat_completion):
-        component = OpenAIGenerator(api_key="test-api-key")
+        component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"))
         response = component.run("What's Natural Language Processing?")
 
         # check that the component returns the correct ChatMessage response
@@ -139,7 +149,7 @@ class TestOpenAIGenerator:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
-        component = OpenAIGenerator(streaming_callback=streaming_callback)
+        component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback)
         response = component.run("Come on, stream!")
 
         # check we called the streaming callback
@@ -153,7 +163,9 @@ class TestOpenAIGenerator:
         assert "Hello" in response["replies"][0]  # see mock_chat_completion_chunk
 
     def test_run_with_params(self, mock_chat_completion):
-        component = OpenAIGenerator(api_key="test-api-key", generation_kwargs={"max_tokens": 10, "temperature": 0.5})
+        component = OpenAIGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+        )
         response = component.run("What's Natural Language Processing?")
 
         # check that the component calls the OpenAI API with the correct parameters
@@ -169,7 +181,7 @@ class TestOpenAIGenerator:
         assert [isinstance(reply, str) for reply in response["replies"]]
 
     def test_check_abnormal_completions(self, caplog):
-        component = OpenAIGenerator(api_key="test-api-key")
+        component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"))
 
         # underlying implementation uses ChatMessage objects so we have to use them here
         messages: List[ChatMessage] = []
@@ -202,7 +214,7 @@ class TestOpenAIGenerator:
     )
     @pytest.mark.integration
     def test_live_run(self):
-        component = OpenAIGenerator(api_key=os.environ.get("OPENAI_API_KEY"))
+        component = OpenAIGenerator()
         results = component.run("What's the capital of France?")
         assert len(results["replies"]) == 1
         assert len(results["meta"]) == 1
@@ -224,7 +236,7 @@ class TestOpenAIGenerator:
     )
     @pytest.mark.integration
     def test_live_run_wrong_model(self):
-        component = OpenAIGenerator(model="something-obviously-wrong", api_key=os.environ.get("OPENAI_API_KEY"))
+        component = OpenAIGenerator(model="something-obviously-wrong")
         with pytest.raises(OpenAIError):
             component.run("Whatever")
 
@@ -244,7 +256,7 @@ class TestOpenAIGenerator:
                 self.responses += chunk.content if chunk.content else ""
 
         callback = Callback()
-        component = OpenAIGenerator(os.environ.get("OPENAI_API_KEY"), streaming_callback=callback)
+        component = OpenAIGenerator(streaming_callback=callback)
         results = component.run("What's the capital of France?")
 
         assert len(results["replies"]) == 1

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+from haystack.utils.auth import Secret
 
 import pytest
 import logging
@@ -19,7 +20,7 @@ class TestSimilarityRanker:
             "init_parameters": {
                 "device": None,
                 "top_k": 10,
-                "token": None,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "query_prefix": "",
                 "document_prefix": "",
                 "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
@@ -36,7 +37,7 @@ class TestSimilarityRanker:
         component = TransformersSimilarityRanker(
             model="my_model",
             device=ComponentDevice.from_str("cuda:0"),
-            token="my_token",
+            token=Secret.from_env_var("ENV_VAR", strict=False),
             top_k=5,
             query_prefix="query_instruction: ",
             document_prefix="document_instruction: ",
@@ -51,7 +52,7 @@ class TestSimilarityRanker:
             "init_parameters": {
                 "device": None,
                 "model": "my_model",
-                "token": None,  # we don't serialize valid tokens,
+                "token": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
                 "top_k": 5,
                 "query_prefix": "query_instruction: ",
                 "document_prefix": "document_instruction: ",
@@ -84,7 +85,7 @@ class TestSimilarityRanker:
                 "top_k": 10,
                 "query_prefix": "",
                 "document_prefix": "",
-                "token": None,
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
@@ -110,7 +111,7 @@ class TestSimilarityRanker:
         ],
     )
     def test_to_dict_device_map(self, device_map, expected):
-        component = TransformersSimilarityRanker(model_kwargs={"device_map": device_map})
+        component = TransformersSimilarityRanker(model_kwargs={"device_map": device_map}, token=None)
         data = component.to_dict()
 
         assert data == {


### PR DESCRIPTION
### Related Issues

- fixes #6854 

### Proposed Changes:
Update secret handling for components using the `Secret` type. The following components are affected:
    `RemoteWhisperTranscriber`, `AzureOCRDocumentConverter`, `AzureOpenAIDocumentEmbedder`, `AzureOpenAITextEmbedder`, `HuggingFaceTEIDocumentEmbedder`, `HuggingFaceTEITextEmbedder`, `OpenAIDocumentEmbedder`, `SentenceTransformersDocumentEmbedder`, `SentenceTransformersTextEmbedder`, `AzureOpenAIGenerator`, `AzureOpenAIChatGenerator`, `HuggingFaceLocalChatGenerator`, `HuggingFaceTGIChatGenerator`, `OpenAIChatGenerator`, `HuggingFaceLocalGenerator`, `HuggingFaceTGIGenerator`, `OpenAIGenerator`, `TransformersSimilarityRanker`, `SearchApiWebSearch`, `SerperDevWebSearch`

The default init parameters for `api_key`, `token`, `azure_ad_token` have been adjusted to use environment variables wherever possible. The `azure_ad_token_provider` parameter has been removed from Azure-based components. Components based on Hugging Face are now required to either use a token or an environment variable if authentication is required - The on-disk local token file is no longer supported.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Full test suite

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
This is a very breaking change, so having multiple pairs of eyes would be great.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
