### PR TITLE
fix: Dont filter negative scores when using `BM25Okapi` and `scale_score=False`

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -208,12 +208,15 @@ class InMemoryDocumentStore:
         # get the last top_k indexes and reverse them
         top_docs_positions = np.argsort(docs_scores)[-top_k:][::-1]
 
+        # Negative values are possible under these conditions and should not be filtered out
+        negatives_are_valid = "Okapi" in self.bm25_algorithm.__name__ and not scale_score
+
         # Create documents with the BM25 score to return them
         return_documents = []
         for i in top_docs_positions:
             doc = all_documents[i]
             score = docs_scores[i]
-            if score <= 0.0:
+            if not negatives_are_valid and score <= 0.0:
                 continue
             doc_fields = doc.to_dict()
             doc_fields["score"] = score


### PR DESCRIPTION
### Related Issues

- fixes [#6801](https://github.com/deepset-ai/haystack/issues/6801)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
