### PR TITLE
fix: Fix language servers never working with Components

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -307,7 +307,9 @@ class _Component:
                 namespace[key] = val
 
         # Recreate the decorated component class so it uses our metaclass
-        class_ = new_class(class_.__name__, class_.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace)
+        class_: class_.__name__ = new_class(
+            class_.__name__, class_.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace
+        )
 
         # Save the component in the class registry (for deserialization)
         class_path = f"{class_.__module__}.{class_.__name__}"

--- a/releasenotes/notes/fix-components-autocompletion-a2d87708309262b6.yaml
+++ b/releasenotes/notes/fix-components-autocompletion-a2d87708309262b6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix auto-complete never working for any Component


### PR DESCRIPTION
### Proposed Changes:

This PR fixes auto completion for most Python language servers. 

Most of them are not able to understand the types of classes decorated with `@component` and would treat all instances as `Any`. This happens because we recreate the class dynamically to use a custom metaclass in the `@component` decorator.

Adding the type hint fixes the issue and now the correct type is infered.

### How did you test it?

I tested it manually in VS Code.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
