### PR TITLE
fix: HuggingFaceTGIGenerator gets stuck when model is not supported 

### DIFF
--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -4,9 +4,13 @@ from typing import Any, Dict, List, Optional, Iterable, Callable
 from urllib.parse import urlparse
 
 from haystack import component, default_to_dict, default_from_dict
+from haystack.components.generators.hf_utils import (
+    check_valid_model,
+    check_generation_params,
+    list_inference_deployed_models,
+)
 from haystack.components.generators.utils import serialize_callback_handler, deserialize_callback_handler
 from haystack.dataclasses import ChatMessage, StreamingChunk
-from haystack.components.generators.hf_utils import check_valid_model, check_generation_params
 from haystack.lazy_imports import LazyImport
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:
@@ -137,8 +141,21 @@ class HuggingFaceTGIChatGenerator:
 
     def warm_up(self) -> None:
         """
-        Load the tokenizer.
+        If the url is not provided, check if the model is deployed on the free tier of the HF inference API.
+        Load the tokenizer
         """
+
+        # is this user using HF free tier inference API?
+        if self.model and not self.url:
+            deployed_models = list_inference_deployed_models()
+            # Determine if the specified model is deployed in the free tier.
+            if self.model not in deployed_models:
+                raise ValueError(
+                    f"The model {self.model} is not deployed on the free tier of the HF inference API. "
+                    "To use free tier models provide the model ID and the token. Valid models are: "
+                    f"{deployed_models}"
+                )
+
         self.tokenizer = AutoTokenizer.from_pretrained(self.model, token=self.token)
         # mypy can't infer that chat_template attribute exists on the object returned by AutoTokenizer.from_pretrained
         chat_template = getattr(self.tokenizer, "chat_template", None)

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -81,8 +81,8 @@ def inference_deployed_models(headers: Optional[Dict] = None) -> List[Dict[str, 
         message = payload["error"] if "error" in payload else "Unknown TGI error"
         error_type = payload["error_type"] if "error_type" in payload else "Unknown TGI error type"
         raise Exception(f"Failed to fetch TGI deployed models: {message}. Error type: {error_type}")
-    else:
-        return payload
+
+    return payload
 
 
 def is_inference_deployed_model(model_id: str, headers: Optional[Dict] = None) -> bool:

--- a/haystack/components/generators/hf_utils.py
+++ b/haystack/components/generators/hf_utils.py
@@ -85,21 +85,6 @@ def inference_deployed_models(headers: Optional[Dict] = None) -> List[Dict[str, 
     return payload
 
 
-def is_inference_deployed_model(model_id: str, headers: Optional[Dict] = None) -> bool:
-    """
-    Check if a model is currently deployed with text-generation-inference-support
-
-    :param model_id: The model id to check (e.g. codellama/CodeLlama-13b-hf, HuggingFaceH4/zephyr-7b-alpha etc.)
-    :type model_id: str
-    :param headers: Optional dictionary of headers to include in the request
-    :type headers: Optional[Dict]
-    :raises Exception: If the request to the TGI API fails
-    :return: True if the model is currently deployed, False otherwise
-    """
-    deployed_models = inference_deployed_models(headers)
-    return model_id in [model["model_id"] for model in deployed_models]
-
-
 def list_inference_deployed_models(headers: Optional[Dict] = None) -> List[str]:
     """
     List all currently deployed models on HF TGI free tier

--- a/releasenotes/notes/add-hf-free-tier-checks-99384060139d5d30.yaml
+++ b/releasenotes/notes/add-hf-free-tier-checks-99384060139d5d30.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Resolves a bug where the HuggingFaceTGIGenerator and HuggingFaceTGIChatGenerator encountered issues if provided
+    with valid models that were not available on the HuggingFace inference API rate-limited tier. The fix, detailed
+    in [GitHub issue #6816](https://github.com/deepset-ai/haystack/issues/6816) and its GitHub PR, ensures these
+    components now correctly handle model availability, eliminating previous limitations.

--- a/test/components/generators/test_hf_utils.py
+++ b/test/components/generators/test_hf_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from haystack.components.generators.hf_utils import check_generation_params
+from haystack.components.generators.hf_utils import check_generation_params, list_inference_deployed_models
 
 
 def test_empty_dictionary():
@@ -42,3 +42,23 @@ def test_additional_accepted_params_unknown_parameter():
     # Although strange_param is not generation param the check_generation_params
     # does not raise exception because strange_param is passed as additional_accepted_params
     check_generation_params(kwargs, additional_accepted_params)
+
+
+@pytest.mark.integration
+def test_hf_free_tier_models():
+    # maintainer note:
+    # leave this test as integration test because it requires network access
+    # and because we need to check if the default TGI models are still listed there
+    # if the test fails, it's likely because the TGI free-tier models have changed or the API is down
+
+    free_tier_models = list_inference_deployed_models()
+    assert len(free_tier_models) > 0
+
+    # first test some old models that should not be there
+    assert "google/flan-t5-base" not in free_tier_models
+
+    # and then test some new models that should be there
+    # use this opportunity to test the default HuggingFaceTGIGenerator and HuggingFaceTGIChatGenerator
+    # are still listed there
+    assert "mistralai/Mistral-7B-v0.1" in free_tier_models
+    assert "HuggingFaceH4/zephyr-7b-beta" in free_tier_models


### PR DESCRIPTION
### Why:
This change introduces functionality to check if a model is deployed on the free tier of the Hugging Face (HF) Inference API, and handles cases where the user-provided model is not available on the HF Inference API's rate-limited tier. This enhancement was designed to resolve an issue where the `HuggingFaceTGIGenerator` and `HuggingFaceTGIChatGenerator` encountered problems when provided with valid models not available on the HF inference API's rate-limited tier.

- fixes https://github.com/deepset-ai/haystack/issues/6816

### What:
- Modified `haystack/components/generators/chat/hugging_face_tgi.py` to import new functions, `check_generation_params`, `check_valid_model`, `list_inference_deployed_models` from `hf_utils`. Added code to check if the specified model is deployed in the free tier when the URL is not provided.
- Modified `haystack/components/generators/hf_utils.py` to include new functions: `inference_deployed_models`, `is_inference_deployed_model`, and `list_inference_deployed_models`. These functions interact with the Hugging Face Text Generation Inference API to obtain information on deployed models.
- Added `releasenotes/notes/add-hf-free-tier-checks-99384060139d5d30.yaml` to document the fix addressing the HuggingFace generator issue with models not available on the HF inference API's rate-limited tier.
- Modified `test/components/generators/test_hf_utils.py` to include an integration test for listing HF free-tier models by calling the `list_inference_deployed_models` function.

### How can it be used:
- Developers utilizing the `HuggingFaceTGIGenerator` or `HuggingFaceTGIChatGenerator` components can now rely on these components to correctly handle model availability on the HF Inference API free tier.

### How did you test it:
- Unit tests for `check_generation_params` functionality were executed using `test_hf_utils.py`.
- An integration test was added to `test_hf_utils.py` to verify that the `list_inference_deployed_models` function returns a list of currently deployed models on the HF Inference API free tier.

### Notes for the reviewer:

- The new `list_inference_deployed_models` function is used in `hugging_face_tgi.py` and includes tests in `test_hf_utils.py`.
- Ensure that the integration test for `list_inference_deployed_models` in `test_hf_utils.py` passes and the appropriate models are returned. In the case of a failure, confirm that the default TGI models are still listed there, or if the API is down.