### PR TITLE
refactor: Rename `Pipeline.connect()` arguments

### DIFF
--- a/releasenotes/notes/rename-connect-arguments-2d99d9d5cbe9ab4c.yaml
+++ b/releasenotes/notes/rename-connect-arguments-2d99d9d5cbe9ab4c.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    `Pipeline.connect()` arguments have renamed for clarity. This is a breaking change if `connect` was called
+    with keyword arguments only.
+    `connect_from` and `connect_to` arguments have been renamed respectively to `sender` and `receiver`.
+    The behaviour of `Pipeline.connect()` is not changed.
+features:
+  - |
+    Rename `Pipeline.connect()` arguments for clarity


### PR DESCRIPTION
### Proposed Changes:

`Pipeline.connect()` arguments have renamed for clarity. This is a breaking change if `connect` was called
with keyword arguments only.

`connect_from` and `connect_to` arguments have been renamed respectively to `sender` and `receiver`.
The behaviour of `Pipeline.connect()` is not changed.

This is overdue since we decided on the name convention of `sender` and `receiver`.

### How did you test it?

I ran unit tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
