### PR TITLE
feat: Change Pipeline.connect() to return Pipeline instance

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -210,7 +210,7 @@ class Pipeline:
             visits=0,
         )
 
-    def connect(self, connect_from: str, connect_to: str) -> None:
+    def connect(self, connect_from: str, connect_to: str) -> "Pipeline":
         """
         Connects two components together. All components to connect must exist in the pipeline.
         If connecting to an component that has several output connections, specify the inputs and output names as
@@ -223,7 +223,7 @@ class Pipeline:
                 in the format `component_name.connection_name` if the component has multiple inputs.
 
         Returns:
-            None
+            The Pipeline instance
 
         Raises:
             PipelineConnectError: if the two components cannot be connected (for example if one of the components is
@@ -339,7 +339,7 @@ class Pipeline:
 
         if receiver in sender_socket.receivers and sender in receiver_socket.senders:
             # This is already connected, nothing to do
-            return
+            return self
 
         if receiver_socket.senders and not receiver_socket.is_variadic:
             # Only variadic input sockets can receive from multiple senders
@@ -363,6 +363,7 @@ class Pipeline:
             to_socket=receiver_socket,
             mandatory=receiver_socket.is_mandatory,
         )
+        return self
 
     def get_component(self, name: str) -> Component:
         """

--- a/releasenotes/notes/connect-return-pipeline-dcc1e0786b19861e.yaml
+++ b/releasenotes/notes/connect-return-pipeline-dcc1e0786b19861e.yaml
@@ -1,0 +1,12 @@
+---
+enhancements:
+  - |
+    Change `Pipeline.connect()` to return the instance of `Pipeline`.
+    This way we can chain multiple `connect()` like so:
+    ```python
+    pipeline.connect("fetcher", "converter") \
+    .connect("converter", "splitter") \
+    .connect("splitter", "ranker") \
+    .connect("ranker", "prompt_builder") \
+    .connect("prompt_builder", "llm")
+    ```

--- a/test/core/pipeline/test_connect.py
+++ b/test/core/pipeline/test_connect.py
@@ -18,7 +18,7 @@ def test_connect():
     pipe = Pipeline()
     pipe.add_component("comp1", comp1)
     pipe.add_component("comp2", comp2)
-    pipe.connect("comp1.value", "comp2.value")
+    assert pipe.connect("comp1.value", "comp2.value") is pipe
 
     assert comp1.__haystack_output__.value.receivers == ["comp2"]
     assert comp2.__haystack_input__.value.senders == ["comp1"]


### PR DESCRIPTION
### Related Issues

- fixes #6773

### Proposed Changes:

Change `Pipeline.connect()` to return the `Pipeline` instance.

### How did you test it?

Updated tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
