### PR TITLE
test: Add flaky as dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
   "pytest-cov",
   "pytest-custom_exit_code",  # used in the CI
   "pytest-asyncio",
+  "flaky",
   "responses",
   "tox",
   "coverage",


### PR DESCRIPTION
### Proposed Changes:

Add `flaky` dependency to mark flaky tests so they're automatically retried when failing.

More info on the library:
https://github.com/box/flaky

### How did you test it?

Nothing to test.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
