### PR TITLE
fix: make Weaviate DS handle fields consisting in empty lists

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -684,8 +684,9 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                             property_value = _doc[property]
                             if property in json_fields:
                                 property_value = doc.meta[property]
-                            self._update_schema(property, property_value, index)
-                            current_properties.append(property)
+                            if not isinstance(property_value, list) or len(property_value) > 0:
+                                self._update_schema(property, property_value, index)
+                                current_properties.append(property)
                         # update the date fields as there might be new ones
                         date_fields = self._get_date_properties(index)
 

--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -684,6 +684,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
                             property_value = _doc[property]
                             if property in json_fields:
                                 property_value = doc.meta[property]
+                            # if the property_value is an empty list, we can't infer the type
                             if not isinstance(property_value, list) or len(property_value) > 0:
                                 self._update_schema(property, property_value, index)
                                 current_properties.append(property)

--- a/releasenotes/notes/weaviate-handle-empty-list-8d3432080f8bfefd.yaml
+++ b/releasenotes/notes/weaviate-handle-empty-list-8d3432080f8bfefd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug that made it impossible to write Documents
+    to Weaviate when the some of the fields were empty lists
+    (e.g. `split_overlap` for preprocessed documents).

--- a/releasenotes/notes/weaviate-handle-empty-list-8d3432080f8bfefd.yaml
+++ b/releasenotes/notes/weaviate-handle-empty-list-8d3432080f8bfefd.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed a bug that made it impossible to write Documents
-    to Weaviate when the some of the fields were empty lists
+    to Weaviate when some of the fields were empty lists
     (e.g. `split_overlap` for preprocessed documents).

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -290,7 +290,10 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         preprocessed_docs = preprocessor.process(documents)
 
         ds.write_documents(preprocessed_docs)
-        assert ds.get_document_count() == 13
+
+        docs_from_weaviate = ds.get_all_documents()
+        for doc in docs_from_weaviate:
+            assert "_split_overlap" in doc.meta
 
     @pytest.mark.unit
     def test__get_auth_secret(self):

--- a/test/document_stores/test_weaviate.py
+++ b/test/document_stores/test_weaviate.py
@@ -266,7 +266,7 @@ class TestWeaviateDocumentStore(DocumentStoreBaseTestAbstract):
         embeddings.
         """
         ds.write_documents(documents)
-        assert ds.get_all_documents
+        assert ds.get_embedding_count() == 9
 
     @pytest.mark.integration
     def test_write_preprocessed_docs(self, ds, documents):


### PR DESCRIPTION
### Related Issues

- fixes #6550

During the conversion of Haystack docs to Weaviate docs,
to determine the type of a field, we were accessing the first element of a list that can also be empty.
https://github.com/deepset-ai/haystack/blob/07950d3961e6536c80b1f0928543cad41950b97b/haystack/document_stores/weaviate.py#L538

### Proposed Changes:

Now we skip this access if the list is empty.


### How did you test it?

CI, new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
