### PR TITLE
feat: Add `__repr__` method to all Components

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -170,7 +170,9 @@ def _component_repr(component: Component) -> str:
         # This Component has been added in a Pipeline, let's get the name from there.
         result += f"\n{pipeline.get_component_name(component)}"
 
-    return f"{result}\n{component.__haystack_input__}\n{component.__haystack_output__}"
+    # We're explicitly ignoring the type here because we're sure that the component
+    # has the __haystack_input__ and __haystack_output__ attributes at this point
+    return f"{result}\n{component.__haystack_input__}\n{component.__haystack_output__}"  # type: ignore[attr-defined]
 
 
 class _Component:

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -165,13 +165,12 @@ def _component_repr(component: Component) -> str:
     All Components override their __repr__ method with this one.
     It prints the component name and the input/output sockets.
     """
-    # This is similar to a default __repr__ method but doesn't include the full module
-    component_name = f"{component.__class__.__name__} object at {hex(id(component))}"
+    result = object.__repr__(component)
     if pipeline := getattr(component, "__haystack_added_to_pipeline__"):
         # This Component has been added in a Pipeline, let's get the name from there.
-        component_name = pipeline.get_component_name(component)
+        result += f"\n{pipeline.get_component_name(component)}"
 
-    return f"{component_name}\n{component.__haystack_input__}\n{component.__haystack_output__}"
+    return f"{result}\n{component.__haystack_input__}\n{component.__haystack_output__}"
 
 
 class _Component:

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -160,6 +160,20 @@ class ComponentMeta(type):
         return instance
 
 
+def _component_repr(component: Component) -> str:
+    """
+    All Components override their __repr__ method with this one.
+    It prints the component name and the input/output sockets.
+    """
+    # This is similar to a default __repr__ method but doesn't include the full module
+    component_name = f"{component.__class__.__name__} object at {hex(id(component))}"
+    if pipeline := getattr(component, "__haystack_added_to_pipeline__"):
+        # This Component has been added in a Pipeline, let's get the name from there.
+        component_name = pipeline.get_component_name(component)
+
+    return f"{component_name}\n{component.__haystack_input__}\n{component.__haystack_output__}"
+
+
 class _Component:
     """
     See module's docstring.
@@ -331,6 +345,9 @@ class _Component:
             )
         self.registry[class_path] = class_
         logger.debug("Registered Component %s", class_)
+
+        # Override the __repr__ method with a default one
+        class_.__repr__ = _component_repr
 
         return class_
 

--- a/haystack/core/component/sockets.py
+++ b/haystack/core/component/sockets.py
@@ -82,8 +82,9 @@ class Sockets:
             return pipeline.get_component_name(self._component)
 
         # This Component has not been added to a Pipeline yet, so we can't know its name.
-        # Let's use the class name instead.
-        return str(self._component)
+        # Let's use default __repr__. We don't call repr() directly as Components have a custom
+        # __repr__ method and that would lead to infinite recursion since we call Sockets.__repr__ in it.
+        return object.__repr__(self._component)
 
     def __getattribute__(self, name):
         try:
@@ -96,12 +97,10 @@ class Sockets:
         return object.__getattribute__(self, name)
 
     def __repr__(self) -> str:
-        result = self._component_name()
+        result = ""
         if self._sockets_io_type == InputSocket:
-            result += " inputs:\n"
+            result = "Inputs:\n"
         elif self._sockets_io_type == OutputSocket:
-            result += " outputs:\n"
+            result = "Outputs:\n"
 
-        result += "\n".join([f"  - {n}: {_type_name(s.type)}" for n, s in self._sockets_dict.items()])
-
-        return result
+        return result + "\n".join([f"  - {n}: {_type_name(s.type)}" for n, s in self._sockets_dict.items()])

--- a/releasenotes/notes/component-repr-a6486af81530bc3b.yaml
+++ b/releasenotes/notes/component-repr-a6486af81530bc3b.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Add `__repr__` to all Components to print their I/O.
+    This can also be useful in Jupyter notebooks as this will be shown as a cell output
+    if the it's the last expression in a cell.

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -202,7 +202,7 @@ def test_repr():
             return {"value": value}
 
     comp = MockComponent()
-    assert repr(comp) == f"MockComponent object at {hex(id(comp))}\nInputs:\n  - value: int\nOutputs:\n  - value: int"
+    assert repr(comp) == f"{object.__repr__(comp)}\nInputs:\n  - value: int\nOutputs:\n  - value: int"
 
 
 def test_repr_added_to_pipeline():
@@ -217,4 +217,4 @@ def test_repr_added_to_pipeline():
     pipe = Pipeline()
     comp = MockComponent()
     pipe.add_component("my_component", comp)
-    assert repr(comp) == "my_component\nInputs:\n  - value: int\nOutputs:\n  - value: int"
+    assert repr(comp) == f"{object.__repr__(comp)}\nmy_component\nInputs:\n  - value: int\nOutputs:\n  - value: int"

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -4,6 +4,7 @@ import pytest
 
 from haystack.core.component import Component, InputSocket, OutputSocket, component
 from haystack.core.errors import ComponentError
+from haystack.core.pipeline import Pipeline
 
 
 def test_correct_declaration():
@@ -189,3 +190,31 @@ def test_keyword_only_args():
     comp = MockComponent()
     component_inputs = {name: {"type": socket.type} for name, socket in comp.__haystack_input__._sockets_dict.items()}
     assert component_inputs == {"arg": {"type": int}}
+
+
+def test_repr():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_output_types(self, value=int)
+
+        def run(self, value: int):
+            return {"value": value}
+
+    comp = MockComponent()
+    assert repr(comp) == f"MockComponent object at {hex(id(comp))}\nInputs:\n  - value: int\nOutputs:\n  - value: int"
+
+
+def test_repr_added_to_pipeline():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_output_types(self, value=int)
+
+        def run(self, value: int):
+            return {"value": value}
+
+    pipe = Pipeline()
+    comp = MockComponent()
+    pipe.add_component("my_component", comp)
+    assert repr(comp) == "my_component\nInputs:\n  - value: int\nOutputs:\n  - value: int"

--- a/test/core/component/test_sockets.py
+++ b/test/core/component/test_sockets.py
@@ -23,19 +23,6 @@ class TestSockets:
         assert io._component == comp
         assert io._sockets_dict == {}
 
-    def test_component_name(self):
-        comp = component_class("SomeComponent")()
-        io = Sockets(component=comp, sockets_dict={}, sockets_io_type=InputSocket)
-        assert io._component_name() == str(comp)
-
-    def test_component_name_added_to_pipeline(self):
-        comp = component_class("SomeComponent")()
-        pipeline = Pipeline()
-        pipeline.add_component("my_component", comp)
-
-        io = Sockets(component=comp, sockets_dict={}, sockets_io_type=InputSocket)
-        assert io._component_name() == "my_component"
-
     def test_getattribute(self):
         comp = component_class("SomeComponent", input_types={"input_1": int, "input_2": int})()
         io = Sockets(component=comp, sockets_dict=comp.__haystack_input__._sockets_dict, sockets_io_type=InputSocket)
@@ -54,4 +41,4 @@ class TestSockets:
         comp = component_class("SomeComponent", input_types={"input_1": int, "input_2": int})()
         io = Sockets(component=comp, sockets_dict=comp.__haystack_input__._sockets_dict, sockets_io_type=InputSocket)
         res = repr(io)
-        assert res == f"{comp} inputs:\n  - input_1: int\n  - input_2: int"
+        assert res == "Inputs:\n  - input_1: int\n  - input_2: int"


### PR DESCRIPTION
### Related Issues

- fixes #6779

### Proposed Changes:

This PR changes the `@component` decorator so all Components have a `__repr__` method that returns a clear representation of their I/O sockets.

I also changed a bit `Sockets.__repr__` to avoid infinite recursion.

### How did you test it?

I added new tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
