### PR TITLE
Pinecone: change dummy vector

### DIFF
--- a/releasenotes/notes/pinecone-change-dummy-vector-b9fa90f2de6fb846.yaml
+++ b/releasenotes/notes/pinecone-change-dummy-vector-b9fa90f2de6fb846.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Change the dummy vector used internally in the Pinecone Document Store.
+    A recent change to the Pinecone API does not allow to use vectors filled with zeros
+    as was the previous dummy vector.


### PR DESCRIPTION
### Related Issues

- fixes #6931 
- similar to https://github.com/deepset-ai/haystack-core-integrations/issues/300

### Proposed Changes:

- I changed the value of the dummy vector
- I also refactored the code to create this dummy vector once at init time (to avoid duplication)

### How did you test it?

CI

Unfortunately, our CI tests are based on an outdated mock, which is also the reason why this problem never emerged until a user reported it. (in haystack-core-integrations, things are way better)

So I reproduced the issue and tested the change locally using this code:

```python
from haystack.utils import fetch_archive_from_http
from haystack.utils import convert_files_to_docs
from haystack.nodes import PreProcessor
from haystack.document_stores.pinecone import PineconeDocumentStore
from haystack.nodes import EmbeddingRetriever



doc_dir = "data/tutorial8"
s3_url = "https://s3.eu-central-1.amazonaws.com/deepset.ai-farm-qa/datasets/documents/preprocessing_tutorial8.zip"
fetch_archive_from_http(url=s3_url, output_dir=doc_dir)

all_docs = convert_files_to_docs(dir_path=doc_dir)

preprocessor = PreProcessor(
clean_empty_lines=True,
clean_whitespace=True,
split_by="word",
split_length=100,
split_respect_sentence_boundary=True
)

docs_default = preprocessor.process(all_docs) #create a dictionary with the data in the 'content' key

document_store = PineconeDocumentStore(api_key="FAKE-API-KEY",
        environment = "gcp-starter", index="default")


print(document_store.get_document_count())

document_store.write_documents(docs_default)

retriever = EmbeddingRetriever(
    document_store=document_store, embedding_model="sentence-transformers/multi-qa-mpnet-base-dot-v1"
)

print(retriever.retrieve("What is masking in language models?"))
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
