### PR TITLE
fix: Change `PromptBuilder` to have default values for all inputs

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -1,9 +1,8 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from jinja2 import Template, meta
 
-from haystack import component
-from haystack import default_to_dict
+from haystack import component, default_to_dict
 
 
 @component
@@ -31,7 +30,8 @@ class PromptBuilder:
         self.template = Template(template)
         ast = self.template.environment.parse(template)
         template_variables = meta.find_undeclared_variables(ast)
-        component.set_input_types(self, **{var: Any for var in template_variables})
+        for var in template_variables:
+            component.set_input_type(self, var, Any, "")
 
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, template=self._template_string)

--- a/releasenotes/notes/prompt-builder-default-value-95383dd6d17a05d5.yaml
+++ b/releasenotes/notes/prompt-builder-default-value-95383dd6d17a05d5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix `PromptBuilder` missing input default values.
+    These missing default value was causing the PromptBuilder to never run if certain inputs are not received.


### PR DESCRIPTION
### Proposed Changes:

This PR changes `PromptBuilder` so that all its inputs have a default value of `""`.

If `PromptBuilder` inputs are received from a cycle and are meant to optional, the `PromptBuilder` would never run waiting for those inputs. Settings a default value of `""` to all inputs makes sure that the `PromptBuilder` will run even with partial inputs that are not going to be received.

### How did you test it?

We manually tested a `Pipeline` that has a cycle that connects back in a `PromptBuilder`

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
