### PR TITLE
feat: Add OutputAdapter

### DIFF
--- a/haystack/components/converters/__init__.py
+++ b/haystack/components/converters/__init__.py
@@ -5,6 +5,7 @@ from haystack.components.converters.pypdf import PyPDFToDocument
 from haystack.components.converters.html import HTMLToDocument
 from haystack.components.converters.markdown import MarkdownToDocument
 from haystack.components.converters.openapi_functions import OpenAPIServiceToFunctions
+from haystack.components.converters.output_adapter import OutputAdapter
 
 __all__ = [
     "TextFileToDocument",
@@ -14,4 +15,5 @@ __all__ = [
     "HTMLToDocument",
     "MarkdownToDocument",
     "OpenAPIServiceToFunctions",
+    "OutputAdapter",
 ]

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -1,11 +1,12 @@
 import json
-from typing import Optional, Dict, Any, Set, Callable
+from typing import Optional, Dict, Any, Set, Callable, TypeAlias
 
 import jinja2.runtime
 from jinja2 import TemplateSyntaxError, meta
 from jinja2.nativetypes import NativeEnvironment
-from haystack.utils.type_serialization import serialize_type, deserialize_type
+
 from haystack import component, default_to_dict, default_from_dict
+from haystack.utils.type_serialization import serialize_type, deserialize_type
 
 
 class OutputAdaptationException(Exception):
@@ -65,7 +66,7 @@ class OutputAdapter:
 
     predefined_filters = {"json_loads": lambda s: json.loads(s) if isinstance(s, str) else json.loads(str(s))}
 
-    def __init__(self, template: str, output_type: Any, custom_filters: Optional[Dict[str, Callable]] = None):
+    def __init__(self, template: str, output_type: TypeAlias, custom_filters: Optional[Dict[str, Callable]] = None):
         """
         Initializes the OutputAdapter with a set of adaptation rules.
         :param template: A Jinja2 template string that defines how to adapt the output data to the input of the

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -1,9 +1,10 @@
 import json
-from typing import Optional, Dict, Any, Set, Callable, TypeAlias
+from typing import Optional, Dict, Any, Set, Callable
 
 import jinja2.runtime
 from jinja2 import TemplateSyntaxError, meta
 from jinja2.nativetypes import NativeEnvironment
+from typing_extensions import TypeAlias
 
 from haystack import component, default_to_dict, default_from_dict
 from haystack.utils.type_serialization import serialize_type, deserialize_type

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -41,11 +41,29 @@ class OutputAdapter:
 
     Example pipeline setup:
 
+    ```python
+    from haystack import Pipeline, component
+    from haystack.components.converters import OutputAdapter
+
+    @component
+    class DocumentProducer:
+        @component.output_types(documents=dict)
+        def run(self):
+            return {"documents": [{"content": '{"framework": "Haystack"}'}]}
+
+    pipe = Pipeline()
+    pipe.add_component(
+        name="output_adapter",
+        instance=OutputAdapter(template="{{ documents[0].content | json_loads}}", output_type=str),
+    )
+    pipe.add_component(name="document_producer", instance=DocumentProducer())
+    pipe.connect("document_producer", "output_adapter")
+    result = pipe.run(data={})
+    assert result["output_adapter"]["output"] == {"framework": "Haystack"}
+    ```
     """
 
-    predefined_filters = {
-        "json_loads": lambda s: json.loads(s) if isinstance(s, str) else json.loads(str(s)),
-    }
+    predefined_filters = {"json_loads": lambda s: json.loads(s) if isinstance(s, str) else json.loads(str(s))}
 
     def __init__(self, template: str, output_type: Any, custom_filters: Optional[Dict[str, Callable]] = None):
         """

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -1,0 +1,130 @@
+import json
+from typing import Optional, Dict, Any, Set, Callable
+
+import jinja2.runtime
+from jinja2 import TemplateSyntaxError, meta
+from jinja2.nativetypes import NativeEnvironment
+from haystack.utils.type_serialization import serialize_type, deserialize_type
+from haystack import component, default_to_dict, default_from_dict
+
+
+class OutputAdaptationException(Exception):
+    """Exception raised when there is an error during output adaptation."""
+
+
+@component
+class OutputAdapter:
+    """
+    OutputAdapter in Haystack 2.x pipelines is designed to adapt the output of one component
+    to be compatible with the input of another component using Jinja2 template expressions.
+
+    The component configuration requires specifying the adaptation rules. Each rule comprises:
+    - 'template': A Jinja2 template string that defines how to adapt the input data.
+    - 'output_type': The type of the output data (e.g., str, List[int]).
+    - 'custom_filters': A dictionary of custom Jinja2 filters to be used in the template.
+
+    Example configuration:
+
+    ```python
+    from haystack.components.converters import OutputAdapter
+    adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+
+    input_data = {"documents": [{"content": "Test content"}]}
+    expected_output = {"output": "Test content"}
+
+    assert adapter.run(**input_data) == expected_output
+    ```
+
+    In the pipeline setup, the adapter is placed between components that require output/input adaptation.
+    The name under which the adapted value is published is `output`. Use this name to connect the OutputAdapter
+    to downstream components in the pipeline.
+
+    Example pipeline setup:
+
+    """
+
+    predefined_filters = {
+        "json_loads": lambda s: json.loads(s) if isinstance(s, str) else json.loads(str(s)),
+        "json_dumps": json.dumps,
+    }
+
+    def __init__(self, template: str, output_type: Any, custom_filters: Optional[Dict[str, Callable]] = None):
+        """
+        Initializes the OutputAdapter with a set of adaptation rules.
+        :param template: A Jinja2 template string that defines how to adapt the output data to the input of the
+        downstream component.
+        :param output_type: The type of the output data (e.g., str, List[int]).
+        :param custom_filters: A dictionary of custom Jinja2 filters to be used in the template.
+        """
+        self.custom_filters = {**(custom_filters or {}), **self.predefined_filters}
+        input_types: Set[str] = set()
+
+        # Create a Jinja native environment, we need it to:
+        # a) add custom filters to the environment for filter compilation stage
+        env = NativeEnvironment()
+        try:
+            env.parse(template)  # Validate template syntax
+            self.template = template
+        except TemplateSyntaxError as e:
+            raise ValueError(f"Invalid Jinja template '{template}': {e}") from e
+
+        for name, filter_func in self.custom_filters.items():
+            env.filters[name] = filter_func
+
+        # b) extract variables in the template
+        route_input_names = self._extract_variables(env)
+        input_types.update(route_input_names)
+
+        # the env is not needed, discarded automatically
+        component.set_input_types(self, **{var: Any for var in input_types})
+        component.set_output_types(self, **{"output": output_type})
+        self.output_type = output_type
+
+    def run(self, **kwargs):
+        """
+        Executes the output adaptation logic by applying the specified Jinja template expressions
+        to adapt the incoming data to a format suitable for downstream components.
+
+        :param kwargs: A dictionary containing the pipeline variables, which are inputs to the adaptation templates.
+        :return: A dictionary containing the adapted outputs, based on the adaptation rules.
+        :raises OutputAdaptationException: If there's an error during the adaptation process.
+        """
+        # check if kwargs are empty
+        if not kwargs:
+            raise ValueError("No input data provided for output adaptation")
+        env = NativeEnvironment()
+        for name, filter_func in self.custom_filters.items():
+            env.filters[name] = filter_func
+        adapted_outputs = {}
+        try:
+            adapted_output_template = env.from_string(self.template)
+            output_result = adapted_output_template.render(**kwargs)
+            if isinstance(output_result, jinja2.runtime.Undefined):
+                raise OutputAdaptationException(f"Undefined variable in the template {self.template}; kwargs: {kwargs}")
+
+            adapted_outputs["output"] = output_result
+        except Exception as e:
+            raise OutputAdaptationException(f"Error adapting {self.template} with {kwargs}: {e}") from e
+        return adapted_outputs
+
+    def to_dict(self) -> Dict[str, Any]:
+        # todo should we serialize the custom filters? And if so, can we do the same as for callback handlers?
+        return default_to_dict(self, template=self.template, output_type=serialize_type(self.output_type))
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OutputAdapter":
+        init_params = data.get("init_parameters", {})
+        init_params["output_type"] = deserialize_type(init_params["output_type"])
+        return default_from_dict(cls, data)
+
+    def _extract_variables(self, env: NativeEnvironment) -> Set[str]:
+        """
+        Extracts all variables from a list of Jinja template strings.
+
+        :param env: A Jinja native environment.
+        :return: A set of variable names extracted from the template strings.
+        """
+        variables = set()
+        ast = env.parse(self.template)
+        variables.update(meta.find_undeclared_variables(ast))
+        return variables

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -45,7 +45,6 @@ class OutputAdapter:
 
     predefined_filters = {
         "json_loads": lambda s: json.loads(s) if isinstance(s, str) else json.loads(str(s)),
-        "json_dumps": json.dumps,
     }
 
     def __init__(self, template: str, output_type: Any, custom_filters: Optional[Dict[str, Callable]] = None):

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -1,4 +1,3 @@
-import json
 from typing import Optional, Dict, Any, Set, Callable
 
 import jinja2.runtime
@@ -65,8 +64,6 @@ class OutputAdapter:
     ```
     """
 
-    predefined_filters = {"json_loads": lambda s: json.loads(s) if isinstance(s, str) else json.loads(str(s))}
-
     def __init__(self, template: str, output_type: TypeAlias, custom_filters: Optional[Dict[str, Callable]] = None):
         """
         Initializes the OutputAdapter with a set of adaptation rules.
@@ -75,7 +72,7 @@ class OutputAdapter:
         :param output_type: The type of the output data (e.g., str, List[int]).
         :param custom_filters: A dictionary of custom Jinja2 filters to be used in the template.
         """
-        self.custom_filters = {**(custom_filters or {}), **self.predefined_filters}
+        self.custom_filters = {**(custom_filters or {})}
         input_types: Set[str] = set()
 
         # Create a Jinja native environment, we need it to:

--- a/releasenotes/notes/add-output-adapter-5fab4cfcb0218925.yaml
+++ b/releasenotes/notes/add-output-adapter-5fab4cfcb0218925.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Introducing the OutputAdapter component which enables seamless data flow between pipeline components by adapting the output of one component to match the expected input of another using Jinja2 template expressions. This addition opens the door to greater flexibility in pipeline configurations, facilitating custom adaptation rules and exemplifying a structured approach to inter-component communication.

--- a/test/components/converters/test_output_adapter.py
+++ b/test/components/converters/test_output_adapter.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from haystack import Pipeline, component
@@ -26,9 +28,13 @@ class TestOutputAdapter:
 
         assert adapter.run(**input_data) == expected_output
 
-    #  OutputAdapter can handle predefined filters like 'json_loads' and 'json_dumps'.
+    #  OutputAdapter can add filter 'json_loads' and use it
     def test_predefined_filters(self):
-        adapter = OutputAdapter(template="{{ documents[0].content|json_loads }}", output_type=dict)
+        adapter = OutputAdapter(
+            template="{{ documents[0].content|json_loads }}",
+            output_type=dict,
+            custom_filters={"json_loads": lambda s: json.loads(str(s))},
+        )
 
         input_data = {"documents": [{"content": '{"key": "value"}'}]}
         expected_output = {"output": {"key": "value"}}
@@ -88,7 +94,11 @@ class TestOutputAdapter:
         pipe = Pipeline()
         pipe.add_component(
             name="output_adapter",
-            instance=OutputAdapter(template="{{ documents[0].content | json_loads}}", output_type=str),
+            instance=OutputAdapter(
+                template="{{ documents[0].content | json_loads}}",
+                output_type=str,
+                custom_filters={"json_loads": lambda s: json.loads(str(s))},
+            ),
         )
         pipe.add_component(name="document_producer", instance=DocumentProducer())
         pipe.connect("document_producer", "output_adapter")

--- a/test/components/converters/test_output_adapter.py
+++ b/test/components/converters/test_output_adapter.py
@@ -1,0 +1,97 @@
+import pytest
+
+from haystack import Pipeline, component
+from haystack.components.converters import OutputAdapter
+from haystack.components.converters.output_adapter import OutputAdaptationException
+
+
+class TestOutputAdapter:
+    #  OutputAdapter can be initialized with a valid Jinja2 template string and output type.
+    def test_initialized_with_valid_template_and_output_type(self):
+        template = "{{ documents[0].content }}"
+        output_type = str
+        adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+
+        assert adapter.template == template
+        assert adapter.__haystack_output__.output.name == "output"
+        assert adapter.__haystack_output__.output.type == output_type
+
+    #  OutputAdapter can adapt the output of one component to be compatible with the input of another
+    #  component using Jinja2 template expressions.
+    def test_output_adaptation(self):
+        adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+
+        input_data = {"documents": [{"content": "Test content"}]}
+        expected_output = {"output": "Test content"}
+
+        assert adapter.run(**input_data) == expected_output
+
+    #  OutputAdapter can handle predefined filters like 'json_loads' and 'json_dumps'.
+    def test_predefined_filters(self):
+        adapter = OutputAdapter(template="{{ documents[0].content|json_loads }}", output_type=dict)
+
+        input_data = {"documents": [{"content": '{"key": "value"}'}]}
+        expected_output = {"output": {"key": "value"}}
+
+        assert adapter.run(**input_data) == expected_output
+
+    #  OutputAdapter can handle custom filters provided in the component configuration.
+    def test_custom_filters(self):
+        def custom_filter(value):
+            return value.upper()
+
+        custom_filters = {"custom_filter": custom_filter}
+        adapter = OutputAdapter(
+            template="{{ documents[0].content|custom_filter }}", output_type=str, custom_filters=custom_filters
+        )
+
+        input_data = {"documents": [{"content": "test content"}]}
+        expected_output = {"output": "TEST CONTENT"}
+
+        assert adapter.run(**input_data) == expected_output
+
+    #  OutputAdapter raises an exception on init if the Jinja2 template string is invalid.
+    def test_invalid_template_string(self):
+        with pytest.raises(ValueError):
+            OutputAdapter(template="{{ documents[0].content }", output_type=str)
+
+    #  OutputAdapter raises an exception if no input data is provided for output adaptation.
+    def test_no_input_data_provided(self):
+        adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+        with pytest.raises(ValueError):
+            adapter.run()
+
+    #  OutputAdapter raises an exception if there's an error during the adaptation process.
+    def test_error_during_adaptation(self):
+        adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+        input_data = {"documents": [{"title": "Test title"}]}
+
+        with pytest.raises(OutputAdaptationException):
+            adapter.run(**input_data)
+
+    # OutputAdapter can be serialized to a dictionary and deserialized back to an OutputAdapter instance.
+    def test_sede(self):
+        adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
+        adapter_dict = adapter.to_dict()
+        deserialized_adapter = OutputAdapter.from_dict(adapter_dict)
+
+        assert adapter.template == deserialized_adapter.template
+        assert adapter.output_type == deserialized_adapter.output_type
+
+    def test_output_adapter_in_pipeline(self):
+        @component
+        class DocumentProducer:
+            @component.output_types(documents=dict)
+            def run(self):
+                return {"documents": [{"content": '{"framework": "Haystack"}'}]}
+
+        pipe = Pipeline()
+        pipe.add_component(
+            name="output_adapter",
+            instance=OutputAdapter(template="{{ documents[0].content | json_loads}}", output_type=str),
+        )
+        pipe.add_component(name="document_producer", instance=DocumentProducer())
+        pipe.connect("document_producer", "output_adapter")
+        result = pipe.run(data={})
+        assert result
+        assert result["output_adapter"]["output"] == {"framework": "Haystack"}


### PR DESCRIPTION
Part of https://github.com/deepset-ai/haystack/issues/6938


### Why:
Introduces a new `OutputAdapter` component to facilitate ease of the data flow between components within a pipeline. Its purpose is to transform the output from one component to align with the expected input of a subsequent component. This capability is particularly valuable when integrating components with mismatched interfaces, enhancing the pipeline design's modularity and flexibility.

- partially fixes https://github.com/deepset-ai/haystack/issues/6923

### What:
- Added `OutputAdapter` to `haystack/components/converters/__init__.py` to make it available as a component.
- Created a new file `output_adapter.py` implementing the `OutputAdapter` class, which includes adaptation logic utilizing Jinja2 template expressions.
- Introduced tests in `test_output_adapter.py` to verify functionality, error handling, and serialization/deserialization of the `OutputAdapter`.

### How can it be used:
- To adapt data between pipeline components without manual transformation, use the `OutputAdapter` where necessary. For example:
  ```python
  from haystack.components.converters import OutputAdapter
  adapter = OutputAdapter(template="{{ documents[0].content }}", output_type=str)
  ```
- This class can use predefined and custom Jinja2 filters to transform the data:
  ```python
  # Custom filter usage example
  def uppercase(value):
      return value.upper()
  adapter = OutputAdapter(template="{{ documents[0].content|uppercase }}", output_type=str, custom_filters={"uppercase": uppercase})
  ```

- In Haystack pipelines:
  ```python
  @component
  class DocumentProducer:
      @component.output_types(documents=dict)
      def run(self):
          return {"documents": [{"content": '{"framework": "Haystack"}'}]}

  pipe = Pipeline()
  pipe.add_component(
      name="output_adapter",
      instance=OutputAdapter(template="{{ documents[0].content | json_loads}}", output_type=str),
  )
  pipe.add_component(name="document_producer", instance=DocumentProducer())
  pipe.connect("document_producer", "output_adapter")
  result = pipe.run(data={})
  assert result
  assert result["output_adapter"]["output"] == {"framework": "Haystack"}
  ```

### How did you test it:
- The PR includes unit tests validating template initialization, output adaptation, filter application, and exception handling.
- The tests cover scenarios like using valid and invalid templates, handling empty input data, leveraging predefined and custom filters, and serialization/deserialization of the component.
- The tests ensure that the `OutputAdapter` behaves as expected in isolation and when placed within a pipeline.

### Notes for the reviewer:
- Is the namespace for `OutputAdapter` in converters? Do you have any other suggestions?
- Should we allow custom filters addition?
- Review the templates and filters implemented for adaptability and evaluate if any additional edge cases need to be covered.