### PR TITLE
fix: Update Route docs validation to allow more types 

### DIFF
--- a/haystack/nodes/other/route_documents.py
+++ b/haystack/nodes/other/route_documents.py
@@ -20,7 +20,7 @@ class RouteDocuments(BaseComponent):
     def __init__(
         self,
         split_by: str = "content_type",
-        metadata_values: Optional[Union[List[str], List[List[str]]]] = None,
+        metadata_values: Optional[Union[List[Union[str, bool, int]], List[List[Union[str, bool, int]]]]] = None,
         return_remaining: bool = False,
     ):
         """

--- a/releasenotes/notes/route-documents-metadata-values-types-7b6bdbc916d2624b.yaml
+++ b/releasenotes/notes/route-documents-metadata-values-types-7b6bdbc916d2624b.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     The types of meta data values accepted by RouteDocuments was unnecessarily restricted to string types.
     This causes validation errors (for example when loading from a yaml file) if a user tries to use a boolean type for example.
-    We add boolean and int types as valid types for metadata_values
+    We add boolean and int types as valid types for metadata_values.

--- a/releasenotes/notes/route-documents-metadata-values-types-7b6bdbc916d2624b.yaml
+++ b/releasenotes/notes/route-documents-metadata-values-types-7b6bdbc916d2624b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The types of meta data values accepted by RouteDocuments was unnecessarily restricted to string types.
+    This causes validation errors (for example when loading from a yaml file) if a user tries to use a boolean type for example.
+    We add boolean and int types as valid types for metadata_values

--- a/test/nodes/test_route_documents.py
+++ b/test/nodes/test_route_documents.py
@@ -52,7 +52,7 @@ def test_routedocuments_by_content_type_return_remaining(docs_diff_types):
 
 
 @pytest.mark.unit
-def test_routedocuments_by_metafield(docs):
+def test_routedocuments_by_metafield_str(docs):
     route_documents = RouteDocuments(split_by="meta_field", metadata_values=["test1", "test3", "test5"])
     assert route_documents.outgoing_edges == 3
     result, _ = route_documents.run(docs)
@@ -63,6 +63,40 @@ def test_routedocuments_by_metafield(docs):
     assert result["output_1"][0].meta["meta_field"] == "test1"
     assert result["output_2"][0].meta["meta_field"] == "test3"
     assert result["output_3"][0].meta["meta_field"] == "test5"
+
+
+@pytest.mark.unit
+def test_routedocuments_by_metafield_int():
+    docs = [
+        Document(content="doc 1", meta={"meta_field": 1}),
+        Document(content="doc 2", meta={"meta_field": 1}),
+        Document(content="doc 3", meta={"meta_field": 2}),
+    ]
+    route_documents = RouteDocuments(split_by="meta_field", metadata_values=[1, 2])
+    assert route_documents.outgoing_edges == 2
+    result, _ = route_documents.run(docs)
+    assert len(result["output_1"]) == 2
+    assert len(result["output_2"]) == 1
+    assert "output_4" not in result
+    assert result["output_1"][0].meta["meta_field"] == 1
+    assert result["output_2"][0].meta["meta_field"] == 2
+
+
+@pytest.mark.unit
+def test_routedocuments_by_metafield_bool():
+    docs = [
+        Document(content="doc 1", meta={"meta_field": True}),
+        Document(content="doc 2", meta={"meta_field": True}),
+        Document(content="doc 3", meta={"meta_field": False}),
+    ]
+    route_documents = RouteDocuments(split_by="meta_field", metadata_values=[True, False])
+    assert route_documents.outgoing_edges == 2
+    result, _ = route_documents.run(docs)
+    assert len(result["output_1"]) == 2
+    assert len(result["output_2"]) == 1
+    assert "output_4" not in result
+    assert result["output_1"][0].meta["meta_field"] == True
+    assert result["output_2"][0].meta["meta_field"] == False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The types of meta data values accepted by RouteDocuments was unecessarily restricted to string types. This causes validation errors (for example when loading from a yaml file) if a user tries to use a boolean type for example. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
added new unit tests showing that the sorting works with boolean and int types

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
