### PR TITLE
docs: Add missing docstrings to `NamedEntityExtractor`

### DIFF
--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -126,6 +126,9 @@ class NamedEntityExtractor:
             raise ComponentError(f"Unknown NER backend '{type(backend).__name__}' for extractor")
 
     def warm_up(self):
+        """
+        Initialize the named entity extractor backend.
+        """
         try:
             self._backend.initialize()
         except Exception as e:
@@ -135,6 +138,16 @@ class NamedEntityExtractor:
 
     @component.output_types(documents=List[Document])
     def run(self, documents: List[Document], batch_size: int = 1) -> Dict[str, Any]:
+        """
+         Run the named-entity extractor.
+
+        :param documents:
+             Documents to process.
+         :param batch_size:
+             Batch size used for processing the documents.
+         :returns:
+             The processed documents.
+        """
         texts = [doc.content if doc.content is not None else "" for doc in documents]
         annotations = self._backend.annotate(texts, batch_size=batch_size)
 
@@ -150,6 +163,9 @@ class NamedEntityExtractor:
         return {"documents": documents}
 
     def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
         return default_to_dict(
             self,
             backend=self._backend.type,
@@ -160,6 +176,12 @@ class NamedEntityExtractor:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "NamedEntityExtractor":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        """
         try:
             init_params = data["init_parameters"]
             init_params["device"] = ComponentDevice.from_dict(init_params["device"])

--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -143,9 +143,9 @@ class NamedEntityExtractor:
 
         :param documents:
              Documents to process.
-         :param batch_size:
+        :param batch_size:
              Batch size used for processing the documents.
-         :returns:
+        :returns:
              The processed documents.
         """
         texts = [doc.content if doc.content is not None else "" for doc in documents]


### PR DESCRIPTION
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
