### PR TITLE
feat: `Jinja2Builder`

### DIFF
--- a/haystack/components/builders/__init__.py
+++ b/haystack/components/builders/__init__.py
@@ -1,6 +1,7 @@
 from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.builders.jinja2_builder import Jinja2Builder
 from haystack.components.builders.dynamic_prompt_builder import DynamicPromptBuilder
 from haystack.components.builders.dynamic_chat_prompt_builder import DynamicChatPromptBuilder
 
-__all__ = ["AnswerBuilder", "PromptBuilder", "DynamicPromptBuilder", "DynamicChatPromptBuilder"]
+__all__ = ["AnswerBuilder", "Jinja2Builder", "PromptBuilder", "DynamicPromptBuilder", "DynamicChatPromptBuilder"]

--- a/haystack/components/builders/jinja2_builder.py
+++ b/haystack/components/builders/jinja2_builder.py
@@ -1,0 +1,42 @@
+from typing import Dict, Any
+
+from jinja2 import Template, meta
+
+from haystack import component
+from haystack import default_to_dict
+
+
+@component
+class Jinja2Builder:
+    """
+    Jinja2Builder is a component that renders a string from a template string using Jinja2 engine.
+    The template variables found in the template string are used as input types for the component and are all required.
+
+    Usage:
+    ```python
+    template = "Translate the following context to {{ target_language }}. Context: {{ snippet }}; Translation:"
+    builder = Jinja2Builder(template=template)
+    builder.run(target_language="spanish", snippet="I can't speak spanish.")
+    ```
+    """
+
+    def __init__(self, template: str):
+        """
+        Initialize the component with a template string.
+
+        :param template: Jinja2 template string, e.g. "Summarize this document: {documents}\\nSummary:"
+        :type template: str
+        """
+        self._template_string = template
+        self.template = Template(template)
+        ast = self.template.environment.parse(template)
+        template_variables = meta.find_undeclared_variables(ast)
+        for var in template_variables:
+            component.set_input_type(self, var, Any, "")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return default_to_dict(self, template=self._template_string)
+
+    @component.output_types(string=str)
+    def run(self, **kwargs):
+        return {"string": self.template.render(kwargs)}

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict
-
-from jinja2 import Template, meta
+from typing import Dict, Any
 
 from haystack import component, default_to_dict
+from haystack.components.builders.jinja2_builder import Jinja2Builder
 
 
 @component
@@ -26,16 +25,11 @@ class PromptBuilder:
         :param template: Jinja2 template string, e.g. "Summarize this document: {documents}\\nSummary:"
         :type template: str
         """
-        self._template_string = template
-        self.template = Template(template)
-        ast = self.template.environment.parse(template)
-        template_variables = meta.find_undeclared_variables(ast)
-        for var in template_variables:
-            component.set_input_type(self, var, Any, "")
+        self.builder = Jinja2Builder(template=template)
 
     def to_dict(self) -> Dict[str, Any]:
-        return default_to_dict(self, template=self._template_string)
+        return default_to_dict(self, template=self.builder._template_string)
 
     @component.output_types(prompt=str)
     def run(self, **kwargs):
-        return {"prompt": self.template.render(kwargs)}
+        return {"prompt": self.builder.run(**kwargs)["string"]}

--- a/releasenotes/notes/jinja2builder-37e5238c6f11a29e.yaml
+++ b/releasenotes/notes/jinja2builder-37e5238c6f11a29e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Introduces `Jinja2Builder`, functionally identical to `PromptBuilder` but with a different
+    output connection name (`string` instead of `prompt`).

--- a/test/components/builders/test_jinja2_builder.py
+++ b/test/components/builders/test_jinja2_builder.py
@@ -1,0 +1,33 @@
+from haystack.components.builders.jinja2_builder import Jinja2Builder
+
+
+def test_init():
+    builder = Jinja2Builder(template="This is a {{ variable }}")
+    assert builder._template_string == "This is a {{ variable }}"
+
+
+def test_to_dict():
+    builder = Jinja2Builder(template="This is a {{ variable }}")
+    res = builder.to_dict()
+    assert res == {
+        "type": "haystack.components.builders.jinja2_builder.Jinja2Builder",
+        "init_parameters": {"template": "This is a {{ variable }}"},
+    }
+
+
+def test_run():
+    builder = Jinja2Builder(template="This is a {{ variable }}")
+    res = builder.run(variable="test")
+    assert res == {"string": "This is a test"}
+
+
+def test_run_without_input():
+    builder = Jinja2Builder(template="This is a template without input")
+    res = builder.run()
+    assert res == {"string": "This is a template without input"}
+
+
+def test_run_with_missing_input():
+    builder = Jinja2Builder(template="This is a {{ variable }}")
+    res = builder.run()
+    assert res == {"string": "This is a "}

--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -5,7 +5,7 @@ from haystack.components.builders.prompt_builder import PromptBuilder
 
 def test_init():
     builder = PromptBuilder(template="This is a {{ variable }}")
-    assert builder._template_string == "This is a {{ variable }}"
+    assert builder.builder._template_string == "This is a {{ variable }}"
 
 
 def test_to_dict():


### PR DESCRIPTION
### Related Issues

- fixes [#6608](https://github.com/deepset-ai/haystack/issues/6608)

### Proposed Changes:

- Introduces Jinja2Builder, which for now is functionally identical to PromptBuilder but with a different output connection name (string instead of prompt).
- Simplifies PromptBuilder to make use of this component instead of duplicating the logic.

### How did you test it?
Unit tests

### Notes for the reviewer

n/a

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
