### PR TITLE
ci: Use better cache key for dependencies in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml', 'test/test_requirements.txt') }}
 
   unit-tests:
     name: Unit / ${{ matrix.os }}
@@ -125,7 +125,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml', 'test/test_requirements.txt') }}
 
       - name: Run
         run: pytest --cov-report xml:coverage.xml --cov="haystack" -m "not integration" test
@@ -194,7 +194,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml', 'test/test_requirements.txt') }}
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test
@@ -252,7 +252,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml', 'test/test_requirements.txt') }}
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test -k 'not tika'
@@ -303,7 +303,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml', 'test/test_requirements.txt') }}
 
       - name: Run
         run: pytest --maxfail=5 -m "integration" test -k 'not tika'


### PR DESCRIPTION
### Related Issues

- fixes #6882

### Proposed Changes:

Change how the dependencies cache key is generated to use the `pyproject.toml` and `test_requirements.txt` files instead of `github.run_attempt`.

Using `github.run_attempt` is problematic as it changes with partial reruns of a workflow, so the workflow would fail cause of missing dependencies and require a full rerun.

This change makes it possible to partially rerun the workflow.

### How did you test it?

Manually triggered workflow:
https://github.com/deepset-ai/haystack/actions/runs/7846212021

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
