### PR TITLE
feat: Meta field ranker add `meta_value_type`

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -56,7 +56,11 @@ class MetaFieldRanker:
                 Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
         :param sort_order: Whether to sort the meta field by ascending or descending order.
                 Possible values are `descending` (default) and `ascending`.
-        :param meta_value_type: Parse the meta value into the data type specified if the meta value is a string.
+        :param meta_value_type: Parse the meta value into the data type specified only if all meta values are strings.
+                'float' will try to parse the meta values into floats.
+                'int' will try to parse the meta values into ints.
+                'date' will try to parse the meta values into datetime objects.
+                'None' (default) will do no parsing.
                 For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
                 we would parse the string into a datetime object.
         """
@@ -161,7 +165,11 @@ class MetaFieldRanker:
         :param sort_order: Whether to sort the meta field by ascending or descending order.
                 Possible values are `descending` (default) and `ascending`.
                 If not provided, the sort_order provided at initialization time is used.
-        :param meta_value_type: Parse the meta value into the data type specified if the meta value is a string.
+        :param meta_value_type: Parse the meta value into the data type specified only if all meta values are strings.
+                'float' will try to parse the meta values into floats.
+                'int' will try to parse the meta values into ints.
+                'date' will try to parse the meta values into datetime objects.
+                'None' (default) will do no parsing.
                 For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
                 we would parse the string into a datetime object.
         """

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -1,7 +1,8 @@
-from dateutil.parser import parse as date_parse
 import logging
 from collections import defaultdict
 from typing import List, Dict, Any, Optional, Literal, Callable
+from dateutil.parser import parse as date_parse
+
 
 from haystack import Document, component, default_to_dict
 

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -1,7 +1,7 @@
 from dateutil.parser import parse as date_parse
 import logging
 from collections import defaultdict
-from typing import List, Dict, Any, Optional, Literal
+from typing import List, Dict, Any, Optional, Literal, Callable
 
 from haystack import Document, component, default_to_dict
 
@@ -213,7 +213,7 @@ class MetaFieldRanker:
         # Sort the documents by self.meta_field
         reverse = sort_order == "descending"
         try:
-            sorted_by_meta = sorted(tuple_parsed_meta_and_docs, key=lambda x: x[0], reverse=reverse)
+            tuple_sorted_by_meta = sorted(tuple_parsed_meta_and_docs, key=lambda x: x[0], reverse=reverse)
         except TypeError as error:
             # Return original documents if mixed types that are not comparable are returned (e.g. int and list)
             logger.warning(
@@ -225,7 +225,7 @@ class MetaFieldRanker:
             return {"documents": documents[:top_k]}
 
         # Add the docs missing the meta_field back on the end
-        sorted_by_meta = [doc for meta, doc in sorted_by_meta]
+        sorted_by_meta = [doc for meta, doc in tuple_sorted_by_meta]
         sorted_documents = sorted_by_meta + docs_missing_meta_field
         sorted_documents = self._merge_rankings(documents, sorted_documents)
         return {"documents": sorted_documents[:top_k]}
@@ -251,6 +251,7 @@ class MetaFieldRanker:
             )
             return [d.meta[self.meta_field] for d in docs_with_meta_field]
 
+        parse_fn: Callable
         if meta_value_type == "float":
             parse_fn = float
         elif meta_value_type == "int":

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -242,7 +242,7 @@ class MetaFieldRanker:
         unique_meta_values = {doc.meta[self.meta_field] for doc in docs_with_meta_field}
         if not all(isinstance(meta_value, str) for meta_value in unique_meta_values):
             logger.warning(
-                "The parameter <meta_value_type> is currently set to %s, but not all of meta values in the "
+                "The parameter <meta_value_type> is currently set to '%s', but not all of meta values in the "
                 "provided Documents with IDs %s are strings.\n"
                 "Skipping parsing of the meta values.\n"
                 "Set all meta values found under the <meta_field> parameter to strings to use <meta_value_type>.",

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -56,13 +56,15 @@ class MetaFieldRanker:
                 Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
         :param sort_order: Whether to sort the meta field by ascending or descending order.
                 Possible values are `descending` (default) and `ascending`.
-        :param meta_value_type: Parse the meta value into the data type specified only if all meta values are strings.
-                'float' will try to parse the meta values into floats.
-                'int' will try to parse the meta values into ints.
-                'date' will try to parse the meta values into datetime objects.
-                'None' (default) will do no parsing.
+        :param meta_value_type: Parse the meta value into the data type specified before sorting.
+                This will only work if all meta values stored under `meta_field` in the provided documents are strings.
                 For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
-                we would parse the string into a datetime object.
+                we would parse the string into a datetime object and then sort the documents by date.
+                The available options are:
+                -'float' will parse the meta values into floats.
+                -'int' will parse the meta values into integers.
+                -'date' will parse the meta values into datetime objects.
+                -'None' (default) will do no parsing.
         """
 
         self.meta_field = meta_field
@@ -165,13 +167,15 @@ class MetaFieldRanker:
         :param sort_order: Whether to sort the meta field by ascending or descending order.
                 Possible values are `descending` (default) and `ascending`.
                 If not provided, the sort_order provided at initialization time is used.
-        :param meta_value_type: Parse the meta value into the data type specified only if all meta values are strings.
-                'float' will try to parse the meta values into floats.
-                'int' will try to parse the meta values into ints.
-                'date' will try to parse the meta values into datetime objects.
-                'None' (default) will do no parsing.
+        :param meta_value_type: Parse the meta value into the data type specified before sorting.
+                This will only work if all meta values stored under `meta_field` in the provided documents are strings.
                 For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
-                we would parse the string into a datetime object.
+                we would parse the string into a datetime object and then sort the documents by date.
+                The available options are:
+                -'float' will parse the meta values into floats.
+                -'int' will parse the meta values into integers.
+                -'date' will parse the meta values into datetime objects.
+                -'None' (default) will do no parsing.
         """
         if not documents:
             return {"documents": []}

--- a/releasenotes/notes/metafieldranker-meta-value-type-365ff1bdb412257b.yaml
+++ b/releasenotes/notes/metafieldranker-meta-value-type-365ff1bdb412257b.yaml
@@ -1,4 +1,6 @@
 ---
 features:
   - |
-    Add a new variable called meta_value_type that allows a user to parse the meta value into the data type specified if the meta value is a string. For example, if we specified meta_value_type="date" then for the meta value "date": "2015-02-01" we would parse the string into a datetime object.
+    Add a new variable called meta_value_type to the MetaFieldRanker that allows a user to parse the meta value into the data type specified as along as the meta value is a string.
+    The supported values for meta_value_type are '"float"', '"int"', '"date"', or 'None'. If None is passed then no parsing is done.
+    For example, if we specified meta_value_type="date" then for the meta value "date": "2015-02-01" we would parse the string into a datetime object.

--- a/releasenotes/notes/metafieldranker-meta-value-type-365ff1bdb412257b.yaml
+++ b/releasenotes/notes/metafieldranker-meta-value-type-365ff1bdb412257b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a new variable called meta_value_type that allows a user to parse the meta value into the data type specified if the meta value is a string. For example, if we specified meta_value_type="date" then for the meta value "date": "2015-02-01" we would parse the string into a datetime object.

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -92,11 +92,23 @@ class TestMetaFieldRanker:
     def test_meta_value_type_float(self):
         ranker = MetaFieldRanker(meta_field="rating", weight=1.0, meta_value_type="float")
         docs_before = [Document(content="abc", meta={"rating": value}) for value in ["1.1", "10.5", "2.3"]]
-        output = ranker.run(documents=docs_before)
-        docs_after = output["documents"]
+        docs_after = ranker.run(documents=docs_before)["documents"]
         assert len(docs_after) == 3
-        sorted_scores = [str(x) for x in sorted([float(doc.meta["rating"]) for doc in docs_after], reverse=True)]
-        assert [doc.meta["rating"] for doc in docs_after] == sorted_scores
+        assert [doc.meta["rating"] for doc in docs_after] == ["10.5", "2.3", "1.1"]
+
+    def test_meta_value_type_int(self):
+        ranker = MetaFieldRanker(meta_field="rating", weight=1.0, meta_value_type="int")
+        docs_before = [Document(content="abc", meta={"rating": value}) for value in ["1", "10", "2"]]
+        docs_after = ranker.run(documents=docs_before)["documents"]
+        assert len(docs_after) == 3
+        assert [doc.meta["rating"] for doc in docs_after] == ["10", "2", "1"]
+
+    def test_meta_value_type_date(self):
+        ranker = MetaFieldRanker(meta_field="rating", weight=1.0, meta_value_type="date")
+        docs_before = [Document(content="abc", meta={"rating": value}) for value in ["2022-10", "2023-01", "2022-11"]]
+        docs_after = ranker.run(documents=docs_before)["documents"]
+        assert len(docs_after) == 3
+        assert [doc.meta["rating"] for doc in docs_after] == ["2023-01", "2022-11", "2022-10"]
 
     def test_returns_empty_list_if_no_documents_are_provided(self):
         ranker = MetaFieldRanker(meta_field="rating")

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -17,12 +17,18 @@ class TestMetaFieldRanker:
                 "top_k": None,
                 "ranking_mode": "reciprocal_rank_fusion",
                 "sort_order": "descending",
+                "meta_value_type": None,
             },
         }
 
     def test_to_dict_with_custom_init_parameters(self):
         component = MetaFieldRanker(
-            meta_field="rating", weight=0.5, top_k=5, ranking_mode="linear_score", sort_order="ascending"
+            meta_field="rating",
+            weight=0.5,
+            top_k=5,
+            ranking_mode="linear_score",
+            sort_order="ascending",
+            meta_value_type="date",
         )
         data = component.to_dict()
         assert data == {
@@ -33,6 +39,7 @@ class TestMetaFieldRanker:
                 "top_k": 5,
                 "ranking_mode": "linear_score",
                 "sort_order": "ascending",
+                "meta_value_type": "date",
             },
         }
 
@@ -123,6 +130,21 @@ class TestMetaFieldRanker:
             assert len(output["documents"]) == 3
             assert "Tried to sort Documents with IDs 1,2,3, but got TypeError with the message:" in caplog.text
 
+    def test_warning_if_meta_value_parsing_error(self, caplog):
+        ranker = MetaFieldRanker(meta_field="rating", meta_value_type="float")
+        docs_before = [
+            Document(id="1", content="abc", meta={"rating": "1.3"}),
+            Document(id="2", content="abc", meta={"rating": "1.2"}),
+            Document(id="3", content="abc", meta={"rating": "not a float"}),
+        ]
+        with caplog.at_level(logging.WARNING):
+            output = ranker.run(documents=docs_before)
+            assert len(output["documents"]) == 3
+            assert (
+                "Tried to parse the meta values of Documents with IDs 1,2,3, but got ValueError with the message:"
+                in caplog.text
+            )
+
     def test_raises_value_error_if_wrong_ranking_mode(self):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", ranking_mode="wrong_mode")
@@ -139,6 +161,10 @@ class TestMetaFieldRanker:
     def test_raises_value_error_if_wrong_sort_order(self):
         with pytest.raises(ValueError):
             MetaFieldRanker(meta_field="rating", sort_order="wrong_order")
+
+    def test_raises_value_error_if_wrong_meta_value_type(self):
+        with pytest.raises(ValueError):
+            MetaFieldRanker(meta_field="rating", meta_value_type="wrong_type")
 
     def test_linear_score(self):
         ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)


### PR DESCRIPTION
### Related Issues

- resolves the RecentnessRanker in issue https://github.com/deepset-ai/haystack/issues/6673 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add a new variable called `meta_value_type` that allows a user to parse the meta value into the data type specified if the meta value is a string. For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"` we would parse the string into a datetime object. However, when returning the documents we still return the documents with their original meta data so the parsing is only used for sorting. 

The available options are:
- 'float' will parse the meta values into floats.
- 'int' will parse the meta values into integers.
- 'date' will parse the meta values into datetime objects.
- 'None' (default) will do no parsing.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
