### PR TITLE
feat: Add split_by="page" to the preprocessor

### DIFF
--- a/releasenotes/notes/preprocessor-split-by-page-2de0b59175f4203e.yaml
+++ b/releasenotes/notes/preprocessor-split-by-page-2de0b59175f4203e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Added new option split_by="page" to the preprocessor so we can chunk documents by page break.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add `split_by="page"` to the preprocess (like we have in Haystack v2). Will be needed for a project in deepset Cloud. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
