### PR TITLE
docs: Add eval Components docs config

### DIFF
--- a/docs/pydoc/config/eval_api.yml
+++ b/docs/pydoc/config/eval_api.yml
@@ -1,0 +1,26 @@
+loaders:
+  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
+    search_path: [../../../haystack/components/eval]
+    modules: ["sas_evaluator", "statistical_evaluator"]
+    ignore_when_discovered: ["__init__"]
+processors:
+  - type: filter
+    expression:
+    documented_only: true
+    do_not_filter_modules: false
+    skip_empty_modules: true
+  - type: smart
+  - type: crossref
+renderer:
+  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  excerpt: Enables evaluation of LLMs generated answers.
+  category_slug: haystack-api
+  title: Evaluation
+  slug: eval-api
+  order: 180
+  markdown:
+    descriptive_class_title: false
+    descriptive_module_title: true
+    add_method_class_prefix: true
+    add_member_class_prefix: false
+    filename: eval_api.md

--- a/docs/pydoc/config/eval_api.yml
+++ b/docs/pydoc/config/eval_api.yml
@@ -17,7 +17,7 @@ renderer:
   category_slug: haystack-api
   title: Evaluation
   slug: eval-api
-  order: 180
+  order: 63
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true


### PR DESCRIPTION
### Related Issues

Part of #6903

### Proposed Changes:

Add configs to generate documentation for new eval Components.

### How did you test it?

Nothing to test.

### Notes for the reviewer

Depends on #6983

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
