### PR TITLE
fix: deepcopy the inputs of components

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -5,7 +5,7 @@ import importlib
 import itertools
 import logging
 from collections import defaultdict
-from copy import copy
+from copy import copy, deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Set, TextIO, Tuple, Type, TypeVar, Union
@@ -686,6 +686,12 @@ class Pipeline:
         # never received by this method. It's handled by the `run()` method of the `Pipeline` class
         # defined in `haystack/pipeline.py`.
         # As of now we're ok with this, but we'll need to merge those two classes at some point.
+
+        # deepcopying the inputs prevents the Pipeline run logic from being altered unexpectedly
+        # when the same input reference is passed to multiple components.
+        for component_name, component_inputs in data.items():
+            data[component_name] = {k: deepcopy(v) for k, v in component_inputs.items()}
+
         for component_name, component_inputs in data.items():
             if component_name not in self.graph.nodes:
                 # This is not a component name, it must be the name of one or more input sockets.

--- a/releasenotes/notes/pipeline-same-input-ref-different-components-68d74cb17b35f8db.yaml
+++ b/releasenotes/notes/pipeline-same-input-ref-different-components-68d74cb17b35f8db.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Previously, when using the same input reference in different components, the Pipeline run logic had an
+    unexpected behavior. This has been fixed by deepcopying the inputs before passing them to the components.

--- a/test/core/pipeline/test_same_input_different_components.py
+++ b/test/core/pipeline/test_same_input_different_components.py
@@ -1,0 +1,84 @@
+from typing import List
+
+from haystack.components.builders import DynamicChatPromptBuilder
+from haystack import Pipeline
+from haystack.dataclasses import ChatMessage
+from haystack import component
+from unittest.mock import MagicMock
+
+
+class MethodTracker:
+    # This class is used to track the number of times a method is called and with which arguments
+    def __init__(self, method):
+        self.method = method
+        self.call_count = 0
+        self.called_with = None
+
+    def __call__(self, *args, **kwargs):
+        self.call_count += 1
+        self.called_with = (args, kwargs)
+        return self.method(*args, **kwargs)
+
+
+@component
+class MessageMerger:
+    @component.output_types(merged_message=str)
+    def run(self, messages: List[ChatMessage], metadata: dict = None):
+        return {"merged_message": "\n".join(t.content for t in messages)}
+
+
+@component
+class FakeGenerator:
+    # This component is a fake generator that always returns the same message
+    @component.output_types(replies=List[ChatMessage])
+    def run(self, messages: List[ChatMessage]):
+        return {"replies": [ChatMessage.from_assistant("Fake message")]}
+
+
+def test_same_input_different_components():
+    """
+    Test that passing the same input reference to different components
+    does not alter the correct Pipeline run logic.
+    """
+
+    prompt_builder = DynamicChatPromptBuilder()
+    llm = FakeGenerator()
+    mm1 = MessageMerger()
+    mm2 = MessageMerger()
+
+    mm1_tracked_run = MethodTracker(mm1.run)
+    mm1.run = mm1_tracked_run
+
+    mm2_tracked_run = MethodTracker(mm2.run)
+    mm2.run = mm2_tracked_run
+
+    pipe = Pipeline()
+    pipe.add_component("prompt_builder", prompt_builder)
+    pipe.add_component("llm", llm)
+    pipe.add_component("mm1", mm1)
+    pipe.add_component("mm2", mm2)
+
+    pipe.connect("prompt_builder.prompt", "llm.messages")
+    pipe.connect("prompt_builder.prompt", "mm1")
+    pipe.connect("llm.replies", "mm2")
+
+    location = "Berlin"
+    messages = [
+        ChatMessage.from_system("Always respond in English even if some input data is in other languages."),
+        ChatMessage.from_user("Tell me about {{location}}"),
+    ]
+    params = {"metadata": {"metadata_key": "metadata_value", "meta2": "value2"}}
+
+    pipe.run(
+        data={
+            "prompt_builder": {"template_variables": {"location": location}, "prompt_source": messages},
+            "mm1": params,
+            "mm2": params,
+        }
+    )
+
+    assert mm1_tracked_run.call_count == 1
+    assert mm1_tracked_run.called_with[1]["metadata"] == params["metadata"]
+
+    assert mm2_tracked_run.call_count == 1
+    assert mm2_tracked_run.called_with[1]["metadata"] == params["metadata"]


### PR DESCRIPTION
### Related Issues

- fixes #6986 

### Proposed Changes:
Previously, when using the same input reference in different components, the Pipeline run logic had an unexpected behavior (see the original issue). This has been fixed by deepcopying the inputs before passing them to the components.

### How did you test it?
CI, new test

### Notes for the reviewer
- I would be happy to discuss better solutions together
- Simply doing `data=deepcopy(data)` does not fix the issue.
  I think this happens because the same internal structure is reproduced, so if comp1 and comp2 share the same input reference, this also happens after deepcopy (comp1 and comp2 refer to the same deepcopied input)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
