### PR TITLE
feat: Add `TextCleaner` component

### DIFF
--- a/haystack/components/preprocessors/__init__.py
+++ b/haystack/components/preprocessors/__init__.py
@@ -1,4 +1,5 @@
-from haystack.components.preprocessors.document_cleaner import DocumentCleaner
-from haystack.components.preprocessors.document_splitter import DocumentSplitter
+from .document_cleaner import DocumentCleaner
+from .document_splitter import DocumentSplitter
+from .text_cleaner import TextCleaner
 
-__all__ = ["DocumentSplitter", "DocumentCleaner"]
+__all__ = ["DocumentSplitter", "DocumentCleaner", "TextCleaner"]

--- a/haystack/components/preprocessors/text_cleaner.py
+++ b/haystack/components/preprocessors/text_cleaner.py
@@ -1,0 +1,61 @@
+import re
+import string
+from typing import Any, Dict, List, Optional
+
+from haystack import component
+
+
+@component
+class TextCleaner:
+    """
+    A preprocessor component to clean text data. It can remove substrings matching a list of regular expressions,
+    convert text to lowercase, remove punctuation, and remove numbers.
+    This is useful to cleanup text data before evaluation.
+    """
+
+    def __init__(
+        self,
+        remove_regexps: Optional[List[str]] = None,
+        convert_to_lowercase: bool = False,
+        remove_punctuation: bool = False,
+        remove_numbers: bool = False,
+    ):
+        """
+        Creates a new instance of TextCleaner.
+
+        :param remove_regexps: A list of regular expressions. If provided, it removes substrings
+            matching these regular expressions from the text. Defaults to None.
+        :type remove_regexps: Optional[List[str]], optional
+        :param convert_to_lowercase: If True, converts all characters to lowercase. Defaults to False.
+        :type convert_to_lowercase: bool, optional
+        :param remove_punctuation: If True, removes punctuation from the text. Defaults to False.
+        :type remove_punctuation: bool, optional
+        :param remove_numbers: If True, removes numerical digits from the text. Defaults to False.
+        :type remove_numbers: bool, optional
+        """
+        self._remove_regexps = remove_regexps
+        self._convert_to_lowercase = convert_to_lowercase
+        self._remove_punctuation = remove_punctuation
+        self._remove_numbers = remove_numbers
+
+    @component.output_types(texts=List[str])
+    def run(self, texts: List[str]) -> Dict[str, Any]:
+        """
+        Run the TextCleaner on the given list of strings.
+        """
+        if self._remove_regexps:
+            combined_regex = "|".join(self._remove_regexps)
+            texts = [re.sub(combined_regex, "", text, flags=re.IGNORECASE) for text in texts]
+
+        if self._convert_to_lowercase:
+            texts = [text.lower() for text in texts]
+
+        if self._remove_punctuation:
+            translator = str.maketrans("", "", string.punctuation)
+            texts = [text.translate(translator) for text in texts]
+
+        if self._remove_numbers:
+            translator = str.maketrans("", "", string.digits)
+            texts = [text.translate(translator) for text in texts]
+
+        return {"texts": texts}

--- a/haystack/components/preprocessors/text_cleaner.py
+++ b/haystack/components/preprocessors/text_cleaner.py
@@ -50,18 +50,11 @@ class TextCleaner:
         r"""
         Run the TextCleaner on the given list of strings.
 
-        Example usage:
-        ```python
-            cleaner = TextCleaner(
-                remove_regexps=[r"\d+", r"[^\w\s]"],
-                convert_to_lowercase=True,
-                remove_punctuation=True,
-                remove_numbers=True,
-            )
-            result = cleaner.run(texts=["Open%123. !$Source", "Haystack.AI##"])
-            assert result["texts"] == ["open source", "haystackai"]
-        ```
+        :param texts: List of strings to clean.
+        :returns: A dictionary with the following outputs:
+                * `texts` - The cleaned list of strings.
         """
+
         if self._regex:
             texts = [self._regex.sub("", text) for text in texts]
 

--- a/releasenotes/notes/text-cleaner-eee0eecbdec21427.yaml
+++ b/releasenotes/notes/text-cleaner-eee0eecbdec21427.yaml
@@ -3,4 +3,4 @@ features:
   - |
     Add `TextCleaner` Component to clean list of strings. It can remove substrings matching a list of regular expressions,
     convert text to lowercase, remove punctuation, and remove numbers.
-    This is mostly useful to clean generators predictions before evaluation.
+    This is mostly useful to clean generator predictions before evaluation.

--- a/releasenotes/notes/text-cleaner-eee0eecbdec21427.yaml
+++ b/releasenotes/notes/text-cleaner-eee0eecbdec21427.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add `TextCleaner` Component to clean list of strings. It can remove substrings matching a list of regular expressions,
+    convert text to lowercase, remove punctuation, and remove numbers.
+    This is mostly useful to clean generators predictions before evaluation.

--- a/test/components/preprocessors/test_text_cleaner.py
+++ b/test/components/preprocessors/test_text_cleaner.py
@@ -1,0 +1,68 @@
+from haystack.components.preprocessors import TextCleaner
+
+
+def test_init_default():
+    cleaner = TextCleaner()
+    assert cleaner._remove_regexps is None
+    assert not cleaner._convert_to_lowercase
+    assert not cleaner._remove_punctuation
+    assert not cleaner._remove_numbers
+
+
+def test_run():
+    cleaner = TextCleaner()
+    texts = ["Some text", "Some other text", "Yet another text"]
+    result = cleaner.run(texts=texts)
+    assert len(result) == 1
+    assert result["texts"] == texts
+
+
+def test_run_with_empty_inputs():
+    cleaner = TextCleaner()
+    result = cleaner.run(texts=[])
+    assert len(result) == 1
+    assert result["texts"] == []
+
+
+def test_run_with_regex():
+    cleaner = TextCleaner(remove_regexps=[r"\d+"])
+    result = cleaner.run(texts=["Open123 Source", "HaystackAI"])
+    assert len(result) == 1
+    assert result["texts"] == ["Open Source", "HaystackAI"]
+
+
+def test_run_with_multiple_regexps():
+    cleaner = TextCleaner(remove_regexps=[r"\d+", r"[^\w\s]"])
+    result = cleaner.run(texts=["Open123! Source", "Haystack.AI"])
+    assert len(result) == 1
+    assert result["texts"] == ["Open Source", "HaystackAI"]
+
+
+def test_run_with_convert_to_lowercase():
+    cleaner = TextCleaner(convert_to_lowercase=True)
+    result = cleaner.run(texts=["Open123! Source", "Haystack.AI"])
+    assert len(result) == 1
+    assert result["texts"] == ["open123! source", "haystack.ai"]
+
+
+def test_run_with_remove_punctuation():
+    cleaner = TextCleaner(remove_punctuation=True)
+    result = cleaner.run(texts=["Open123! Source", "Haystack.AI"])
+    assert len(result) == 1
+    assert result["texts"] == ["Open123 Source", "HaystackAI"]
+
+
+def test_run_with_remove_numbers():
+    cleaner = TextCleaner(remove_numbers=True)
+    result = cleaner.run(texts=["Open123! Source", "Haystack.AI"])
+    assert len(result) == 1
+    assert result["texts"] == ["Open! Source", "Haystack.AI"]
+
+
+def test_run_with_multiple_parameters():
+    cleaner = TextCleaner(
+        remove_regexps=[r"\d+", r"[^\w\s]"], convert_to_lowercase=True, remove_punctuation=True, remove_numbers=True
+    )
+    result = cleaner.run(texts=["Open%123. !$Source", "Haystack.AI##"])
+    assert len(result) == 1
+    assert result["texts"] == ["open source", "haystackai"]

--- a/test/components/preprocessors/test_text_cleaner.py
+++ b/test/components/preprocessors/test_text_cleaner.py
@@ -7,6 +7,8 @@ def test_init_default():
     assert not cleaner._convert_to_lowercase
     assert not cleaner._remove_punctuation
     assert not cleaner._remove_numbers
+    assert cleaner._regex is None
+    assert cleaner._translator is None
 
 
 def test_run():


### PR DESCRIPTION
### Related Issues

- Part of #6903

### Proposed Changes:

Add `TextCleaner` component. This is mostly useful between a generator and an evaluator to cleanup the generated LLM response.

### How did you test it?

I added unit tests.

### Notes for the reviewer

This stems from feedback received in PR #6980.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
