### PR TITLE
refactor: Refactor `StatisticalEvaluator`

### DIFF
--- a/haystack/components/eval/__init__.py
+++ b/haystack/components/eval/__init__.py
@@ -1,4 +1,4 @@
 from .sas_evaluator import SASEvaluator
-from .statistical_evaluator import StatisticalEvaluator
+from .statistical_evaluator import StatisticalEvaluator, StatisticalMetric
 
-__all__ = ["SASEvaluator", "StatisticalEvaluator"]
+__all__ = ["SASEvaluator", "StatisticalEvaluator", "StatisticalMetric"]

--- a/haystack/components/eval/statistical_evaluator.py
+++ b/haystack/components/eval/statistical_evaluator.py
@@ -20,10 +20,10 @@ class StatisticalMetric(Enum):
     @classmethod
     def from_str(cls, metric: str) -> "StatisticalMetric":
         map = {e.value: e for e in StatisticalMetric}
-        metric = map.get(string)
-        if metric is None:
+        metric_ = map.get(metric)
+        if metric_ is None:
             raise ValueError(f"Unknown statistical metric '{metric}'")
-        return metric
+        return metric_
 
 
 @component

--- a/haystack/components/eval/statistical_evaluator.py
+++ b/haystack/components/eval/statistical_evaluator.py
@@ -18,8 +18,12 @@ class StatisticalMetric(Enum):
     EM = "exact_match"
 
     @classmethod
-    def from_string(cls, metric: str) -> "StatisticalMetric":
-        return {"f1": cls.F1, "exact_match": cls.EM}[metric]
+    def from_str(cls, metric: str) -> "StatisticalMetric":
+        map = {e.value: e for e in StatisticalMetric}
+        metric = map.get(string)
+        if metric is None:
+            raise ValueError(f"Unknown statistical metric '{metric}'")
+        return metric
 
 
 @component
@@ -40,7 +44,7 @@ class StatisticalEvaluator:
         :param metric: Metric to use for evaluation in this component. Supported metrics are F1 and Exact Match.
         """
         if isinstance(metric, str):
-            metric = StatisticalMetric.from_string(metric)
+            metric = StatisticalMetric.from_str(metric)
         self._metric = metric
 
         self._metric_function = {StatisticalMetric.F1: self._f1, StatisticalMetric.EM: self._exact_match}[self._metric]

--- a/haystack/components/eval/statistical_evaluator.py
+++ b/haystack/components/eval/statistical_evaluator.py
@@ -1,12 +1,25 @@
 import collections
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from numpy import array as np_array
 from numpy import mean as np_mean
 
 from haystack import default_from_dict, default_to_dict
 from haystack.core.component import component
+
+
+class StatisticalMetric(Enum):
+    """
+    Metrics supported by the StatisticalEvaluator.
+    """
+
+    F1 = "f1"
+    EM = "exact_match"
+
+    @classmethod
+    def from_string(cls, metric: str) -> "StatisticalMetric":
+        return {"f1": cls.F1, "exact_match": cls.EM}[metric]
 
 
 @component
@@ -20,34 +33,24 @@ class StatisticalEvaluator:
     - Exact Match: Measures the proportion of cases where prediction is identical to the expected label.
     """
 
-    class Metric(Enum):
-        """
-        Supported metrics
-        """
-
-        F1 = "F1"
-        EM = "Exact Match"
-
-    def __init__(self, metric: Metric):
+    def __init__(self, metric: Union[str, StatisticalMetric]):
         """
         Creates a new instance of StatisticalEvaluator.
 
         :param metric: Metric to use for evaluation in this component. Supported metrics are F1 and Exact Match.
-        :type metric: Metric
         """
+        if isinstance(metric, str):
+            metric = StatisticalMetric.from_string(metric)
         self._metric = metric
 
-        self._metric_function = {
-            StatisticalEvaluator.Metric.F1: self._f1,
-            StatisticalEvaluator.Metric.EM: self._exact_match,
-        }[self._metric]
+        self._metric_function = {StatisticalMetric.F1: self._f1, StatisticalMetric.EM: self._exact_match}[self._metric]
 
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, metric=self._metric.value)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "StatisticalEvaluator":
-        data["init_parameters"]["metric"] = StatisticalEvaluator.Metric(data["init_parameters"]["metric"])
+        data["init_parameters"]["metric"] = StatisticalMetric(data["init_parameters"]["metric"])
         return default_from_dict(cls, data)
 
     @component.output_types(result=float)
@@ -55,14 +58,19 @@ class StatisticalEvaluator:
         """
         Run the StatisticalEvaluator to compute the metric between a list of predictions and a list of labels.
         Both must be list of strings of same length.
-        Returns a dictionary containing the result of the chosen metric.
+
+        :param predictions: List of predictions.
+        :param labels: List of labels against which the predictions are compared.
+        :returns: A dictionary with the following outputs:
+                    * `result` - Calculated result of the chosen metric.
         """
         if len(labels) != len(predictions):
             raise ValueError("The number of predictions and labels must be the same.")
 
         return {"result": self._metric_function(labels, predictions)}
 
-    def _f1(self, labels: List[str], predictions: List[str]):
+    @staticmethod
+    def _f1(labels: List[str], predictions: List[str]):
         """
         Measure word overlap between predictions and labels.
         """
@@ -88,7 +96,8 @@ class StatisticalEvaluator:
 
         return np_mean(scores)
 
-    def _exact_match(self, labels: List[str], predictions: List[str]) -> float:
+    @staticmethod
+    def _exact_match(labels: List[str], predictions: List[str]) -> float:
         """
         Measure the proportion of cases where predictiond is identical to the the expected label.
         """

--- a/test/components/eval/test_statistical_evaluator.py
+++ b/test/components/eval/test_statistical_evaluator.py
@@ -1,19 +1,23 @@
 import pytest
 
-from haystack.components.eval import StatisticalEvaluator
+from haystack.components.eval import StatisticalEvaluator, StatisticalMetric
 
 
 class TestStatisticalEvaluator:
     def test_init_default(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
-        assert evaluator._metric == StatisticalEvaluator.Metric.F1
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
+        assert evaluator._metric == StatisticalMetric.F1
+
+    def test_init_with_string(self):
+        evaluator = StatisticalEvaluator(metric="exact_match")
+        assert evaluator._metric == StatisticalMetric.EM
 
     def test_to_dict(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
 
         expected_dict = {
             "type": "haystack.components.eval.statistical_evaluator.StatisticalEvaluator",
-            "init_parameters": {"metric": "F1"},
+            "init_parameters": {"metric": "f1"},
         }
         assert evaluator.to_dict() == expected_dict
 
@@ -21,22 +25,22 @@ class TestStatisticalEvaluator:
         evaluator = StatisticalEvaluator.from_dict(
             {
                 "type": "haystack.components.eval.statistical_evaluator.StatisticalEvaluator",
-                "init_parameters": {"metric": "F1"},
+                "init_parameters": {"metric": "f1"},
             }
         )
 
-        assert evaluator._metric == StatisticalEvaluator.Metric.F1
+        assert evaluator._metric == StatisticalMetric.F1
 
 
 class TestStatisticalEvaluatorF1:
     def test_run_with_empty_inputs(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
         result = evaluator.run(labels=[], predictions=[])
         assert len(result) == 1
         assert result["result"] == 0.0
 
     def test_run_with_different_lengths(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
         labels = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
@@ -50,7 +54,7 @@ class TestStatisticalEvaluatorF1:
             evaluator.run(labels=labels, predictions=predictions)
 
     def test_run_with_matching_predictions(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
         labels = ["OpenSource", "HaystackAI", "LLMs"]
         predictions = ["OpenSource", "HaystackAI", "LLMs"]
         result = evaluator.run(labels=labels, predictions=predictions)
@@ -59,7 +63,7 @@ class TestStatisticalEvaluatorF1:
         assert result["result"] == 1.0
 
     def test_run_with_single_prediction(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
 
         result = evaluator.run(labels=["Source"], predictions=["Open Source"])
         assert len(result) == 1
@@ -67,7 +71,7 @@ class TestStatisticalEvaluatorF1:
 
     def test_run_with_mismatched_predictions(self):
         labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.F1)
         predictions = ["Open Source", "HaystackAI"]
         result = evaluator.run(labels=labels, predictions=predictions)
         assert len(result) == 1
@@ -76,13 +80,13 @@ class TestStatisticalEvaluatorF1:
 
 class TestStatisticalEvaluatorExactMatch:
     def test_run_with_empty_inputs(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.EM)
         result = evaluator.run(predictions=[], labels=[])
         assert len(result) == 1
         assert result["result"] == 0.0
 
     def test_run_with_different_lengths(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.EM)
         labels = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
@@ -97,7 +101,7 @@ class TestStatisticalEvaluatorExactMatch:
 
     def test_run_with_matching_predictions(self):
         labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.EM)
         predictions = ["OpenSource", "HaystackAI", "LLMs"]
         result = evaluator.run(labels=labels, predictions=predictions)
 
@@ -105,13 +109,13 @@ class TestStatisticalEvaluatorExactMatch:
         assert result["result"] == 1.0
 
     def test_run_with_single_prediction(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.EM)
         result = evaluator.run(labels=["OpenSource"], predictions=["OpenSource"])
         assert len(result) == 1
         assert result["result"] == 1.0
 
     def test_run_with_mismatched_predictions(self):
-        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.EM)
         labels = ["Source", "HaystackAI", "LLMs"]
         predictions = ["OpenSource", "HaystackAI", "LLMs"]
         result = evaluator.run(labels=labels, predictions=predictions)

--- a/test/components/eval/test_statistical_evaluator.py
+++ b/test/components/eval/test_statistical_evaluator.py
@@ -5,29 +5,15 @@ from haystack.components.eval import StatisticalEvaluator
 
 class TestStatisticalEvaluator:
     def test_init_default(self):
-        labels = ["label1", "label2", "label3"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1)
-        assert evaluator._labels == labels
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
         assert evaluator._metric == StatisticalEvaluator.Metric.F1
-        assert evaluator._regexes_to_ignore is None
-        assert evaluator._ignore_case is False
-        assert evaluator._ignore_punctuation is False
-        assert evaluator._ignore_numbers is False
 
     def test_to_dict(self):
-        labels = ["label1", "label2", "label3"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
 
         expected_dict = {
             "type": "haystack.components.eval.statistical_evaluator.StatisticalEvaluator",
-            "init_parameters": {
-                "labels": labels,
-                "metric": "F1",
-                "regexes_to_ignore": None,
-                "ignore_case": False,
-                "ignore_punctuation": False,
-                "ignore_numbers": False,
-            },
+            "init_parameters": {"metric": "F1"},
         }
         assert evaluator.to_dict() == expected_dict
 
@@ -35,225 +21,99 @@ class TestStatisticalEvaluator:
         evaluator = StatisticalEvaluator.from_dict(
             {
                 "type": "haystack.components.eval.statistical_evaluator.StatisticalEvaluator",
-                "init_parameters": {
-                    "labels": ["label1", "label2", "label3"],
-                    "metric": "F1",
-                    "regexes_to_ignore": None,
-                    "ignore_case": False,
-                    "ignore_punctuation": False,
-                    "ignore_numbers": False,
-                },
+                "init_parameters": {"metric": "F1"},
             }
         )
 
-        assert evaluator._labels == ["label1", "label2", "label3"]
         assert evaluator._metric == StatisticalEvaluator.Metric.F1
-        assert evaluator._regexes_to_ignore is None
-        assert evaluator._ignore_case is False
-        assert evaluator._ignore_punctuation is False
-        assert evaluator._ignore_numbers is False
 
 
 class TestStatisticalEvaluatorF1:
     def test_run_with_empty_inputs(self):
-        evaluator = StatisticalEvaluator(labels=[], metric=StatisticalEvaluator.Metric.F1)
-        result = evaluator.run(predictions=[])
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
+        result = evaluator.run(labels=[], predictions=[])
         assert len(result) == 1
         assert result["result"] == 0.0
 
     def test_run_with_different_lengths(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
         labels = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
         ]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1)
-
         predictions = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
             "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
         ]
         with pytest.raises(ValueError):
-            evaluator.run(predictions)
+            evaluator.run(labels=labels, predictions=predictions)
 
     def test_run_with_matching_predictions(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
         labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1)
         predictions = ["OpenSource", "HaystackAI", "LLMs"]
-        result = evaluator.run(predictions=predictions)
+        result = evaluator.run(labels=labels, predictions=predictions)
 
         assert len(result) == 1
         assert result["result"] == 1.0
 
     def test_run_with_single_prediction(self):
-        labels = ["Source"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
 
-        result = evaluator.run(predictions=["Open Source"])
+        result = evaluator.run(labels=["Source"], predictions=["Open Source"])
         assert len(result) == 1
         assert result["result"] == pytest.approx(2 / 3)
 
     def test_run_with_mismatched_predictions(self):
         labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1)
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.F1)
         predictions = ["Open Source", "HaystackAI"]
-        result = evaluator.run(predictions=predictions)
+        result = evaluator.run(labels=labels, predictions=predictions)
         assert len(result) == 1
-        assert result["result"] == pytest.approx(5 / 6)
-
-    def test_run_with_ignore_case(self):
-        labels = ["source", "HAYSTACKAI"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1, ignore_case=True)
-        predictions = ["Open Source", "HaystackAI"]
-        result = evaluator.run(predictions=predictions)
-        assert len(result) == 1
-        assert result["result"] == pytest.approx(5 / 6)
-
-    def test_run_with_ignore_punctuation(self):
-        labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1, ignore_punctuation=True)
-        predictions = ["Open Source!", "Haystack.AI"]
-        result = evaluator.run(predictions=predictions)
-
-        assert result["result"] == pytest.approx(5 / 6)
-
-    def test_run_with_ignore_numbers(self):
-        labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.F1, ignore_numbers=True)
-        predictions = ["Open Source123", "HaystackAI"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == pytest.approx(5 / 6)
-
-    def test_run_with_regex_to_ignore(self):
-        labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(
-            labels=labels, metric=StatisticalEvaluator.Metric.F1, regexes_to_ignore=[r"\d+"]
-        )
-        predictions = ["Open123 Source", "HaystackAI"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == pytest.approx(5 / 6)
-
-    def test_run_with_multiple_regex_to_ignore(self):
-        labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(
-            labels=labels, metric=StatisticalEvaluator.Metric.F1, regexes_to_ignore=[r"\d+", r"[^\w\s]"]
-        )
-        predictions = ["Open123! Source", "Haystack.AI"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == pytest.approx(5 / 6)
-
-    def test_run_with_multiple_ignore_parameters(self):
-        labels = ["Source", "HaystackAI"]
-        evaluator = StatisticalEvaluator(
-            labels=labels,
-            metric=StatisticalEvaluator.Metric.F1,
-            ignore_numbers=True,
-            ignore_punctuation=True,
-            ignore_case=True,
-            regexes_to_ignore=[r"[^\w\s\d]+"],
-        )
-        predictions = ["Open%123. !$Source", "Haystack.AI##"]
-        result = evaluator.run(predictions=predictions)
         assert result["result"] == pytest.approx(5 / 6)
 
 
 class TestStatisticalEvaluatorExactMatch:
     def test_run_with_empty_inputs(self):
-        evaluator = StatisticalEvaluator(labels=[], metric=StatisticalEvaluator.Metric.EM)
-        result = evaluator.run(predictions=[])
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        result = evaluator.run(predictions=[], labels=[])
         assert len(result) == 1
         assert result["result"] == 0.0
 
     def test_run_with_different_lengths(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
         labels = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
         ]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM)
-
         predictions = [
             "A construction budget of US $2.3 billion",
             "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
             "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
         ]
         with pytest.raises(ValueError):
-            evaluator.run(predictions)
+            evaluator.run(labels=labels, predictions=predictions)
 
     def test_run_with_matching_predictions(self):
         labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM)
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
         predictions = ["OpenSource", "HaystackAI", "LLMs"]
-        result = evaluator.run(predictions=predictions)
+        result = evaluator.run(labels=labels, predictions=predictions)
 
         assert len(result) == 1
         assert result["result"] == 1.0
 
     def test_run_with_single_prediction(self):
-        labels = ["OpenSource"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM)
-
-        result = evaluator.run(predictions=["OpenSource"])
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
+        result = evaluator.run(labels=["OpenSource"], predictions=["OpenSource"])
         assert len(result) == 1
         assert result["result"] == 1.0
 
     def test_run_with_mismatched_predictions(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalEvaluator.Metric.EM)
         labels = ["Source", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM)
         predictions = ["OpenSource", "HaystackAI", "LLMs"]
-        result = evaluator.run(predictions=predictions)
+        result = evaluator.run(labels=labels, predictions=predictions)
         assert len(result) == 1
         assert result["result"] == 2 / 3
-
-    def test_run_with_ignore_case(self):
-        labels = ["opensource", "HAYSTACKAI", "llMs"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM, ignore_case=True)
-        predictions = ["OpenSource", "HaystackAI", "LLMs"]
-        result = evaluator.run(predictions=predictions)
-        assert len(result) == 1
-        assert result["result"] == 1.0
-
-    def test_run_with_ignore_punctuation(self):
-        labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM, ignore_punctuation=True)
-        predictions = ["OpenSource!", "Haystack.AI", "LLMs,"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == 1.0
-
-    def test_run_with_ignore_numbers(self):
-        labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(labels=labels, metric=StatisticalEvaluator.Metric.EM, ignore_numbers=True)
-        predictions = ["OpenSource123", "HaystackAI", "LLMs456"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == 1.0
-
-    def test_run_with_regex_to_ignore(self):
-        labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(
-            labels=labels, metric=StatisticalEvaluator.Metric.EM, regexes_to_ignore=[r"\d+"]
-        )
-        predictions = ["Open123Source", "HaystackAI", "LLMs456"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == 1.0
-
-    def test_run_with_multiple_regex_to_ignore(self):
-        labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(
-            labels=labels, metric=StatisticalEvaluator.Metric.EM, regexes_to_ignore=[r"\d+", r"\W+"]
-        )
-        predictions = ["Open123!Source", "Haystack.AI", "LLMs456,"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == 1.0
-
-    def test_run_with_multiple_ignore_parameters(self):
-        labels = ["OpenSource", "HaystackAI", "LLMs"]
-        evaluator = StatisticalEvaluator(
-            labels=labels,
-            metric=StatisticalEvaluator.Metric.EM,
-            ignore_numbers=True,
-            ignore_punctuation=True,
-            ignore_case=True,
-            regexes_to_ignore=[r"[^\w\s\d]+"],
-        )
-        predictions = ["Open%123!$Source", "Haystack.AI##", "^^LLMs456,"]
-        result = evaluator.run(predictions=predictions)
-        assert result["result"] == 1.0


### PR DESCRIPTION
### Related Issues

- Part of #6903

### Proposed Changes:

Remove preprocessing in `StatisticalEvaluator` as we're going to use the `TextCleaner` component from #6997.

Move `labels` from `__init__` to `run`.

### How did you test it?

I updated unit tests.

### Notes for the reviewer

This stems from feedback received in PR #6980.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
