### PR TITLE
fix: Adding `api_base_url` to `OpenAITextEmbeder` self assignments

### DIFF
--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -52,6 +52,7 @@ class OpenAITextEmbedder:
         """
         self.model = model
         self.dimensions = dimensions
+        self.api_base_url = api_base_url
         self.organization = organization
         self.prefix = prefix
         self.suffix = suffix

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -70,6 +70,7 @@ class OpenAITextEmbedder:
         return default_to_dict(
             self,
             model=self.model,
+            api_base_url=self.api_base_url,
             organization=self.organization,
             prefix=self.prefix,
             suffix=self.suffix,

--- a/releasenotes/notes/fix-openai-base-url-assignment-0570a494d88fe365.yaml
+++ b/releasenotes/notes/fix-openai-base-url-assignment-0570a494d88fe365.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Adds `api_base_url` to the self assignments of `OpenAITExtEmbedder` to resolve the base url for serialized embedders.
+    Adds `api_base_url` attribute to `OpenAITExtEmbedder`.
+    Previously, it was used only for initialization and was not serialized.

--- a/releasenotes/notes/fix-openai-base-url-assignment-0570a494d88fe365.yaml
+++ b/releasenotes/notes/fix-openai-base-url-assignment-0570a494d88fe365.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Adds `api_base_url` to the self assignments of `OpenAITExtEmbedder` to resolve the base url for serialized embedders.

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -13,6 +13,7 @@ class TestOpenAITextEmbedder:
 
         assert embedder.client.api_key == "fake-api-key"
         assert embedder.model == "text-embedding-ada-002"
+        assert embedder.api_base_url == None
         assert embedder.organization is None
         assert embedder.prefix == ""
         assert embedder.suffix == ""
@@ -21,12 +22,14 @@ class TestOpenAITextEmbedder:
         embedder = OpenAITextEmbedder(
             api_key=Secret.from_token("fake-api-key"),
             model="model",
+            api_base_url="https://my-custom-base-url.com",
             organization="fake-organization",
             prefix="prefix",
             suffix="suffix",
         )
         assert embedder.client.api_key == "fake-api-key"
         assert embedder.model == "model"
+        assert embedder.api_base_url == "https://my-custom-base-url.com"
         assert embedder.organization == "fake-organization"
         assert embedder.prefix == "prefix"
         assert embedder.suffix == "suffix"
@@ -44,6 +47,7 @@ class TestOpenAITextEmbedder:
             "type": "haystack.components.embedders.openai_text_embedder.OpenAITextEmbedder",
             "init_parameters": {
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
+                "api_base_url": None,
                 "dimensions": None,
                 "model": "text-embedding-ada-002",
                 "organization": None,
@@ -57,6 +61,7 @@ class TestOpenAITextEmbedder:
         component = OpenAITextEmbedder(
             api_key=Secret.from_env_var("ENV_VAR", strict=False),
             model="model",
+            api_base_url="https://my-custom-base-url.com",
             organization="fake-organization",
             prefix="prefix",
             suffix="suffix",
@@ -66,6 +71,7 @@ class TestOpenAITextEmbedder:
             "type": "haystack.components.embedders.openai_text_embedder.OpenAITextEmbedder",
             "init_parameters": {
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
+                "api_base_url": "https://my-custom-base-url.com",
                 "model": "model",
                 "dimensions": None,
                 "organization": "fake-organization",


### PR DESCRIPTION
I have made a very small fix for an issue that occurs for the `MistralTextEmbedder` which inherits this class. Without this assignments, serializing the component results in no `api_base_url` being listed.

I am skipping checking for `api_base_url` for now in the tests for mistral, until we can release this fix.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
