### PR TITLE
test: Mark OpenAPIServiceConnector integration test as flaky

### DIFF
--- a/test/components/connectors/test_openapi_service.py
+++ b/test/components/connectors/test_openapi_service.py
@@ -1,12 +1,14 @@
 import json
 import os
-
-import pytest
+import time
 from unittest.mock import MagicMock, Mock
 
+import flaky
+import pytest
 import requests
 from openapi3 import OpenAPI
 from openapi3.schemas import Model
+
 from haystack.components.connectors import OpenAPIServiceConnector
 from haystack.dataclasses import ChatMessage
 
@@ -140,6 +142,7 @@ class TestOpenAPIServiceConnector:
             " to get the raw data from the service response"
         )
 
+    @flaky.flaky(max_runs=5, rerun_filter=lambda *_: time.sleep(5))
     @pytest.mark.integration
     @pytest.mark.skipif(not os.getenv("GITHUB_TOKEN"), reason="GITHUB_TOKEN is not set")
     def test_run(self, genuine_fc_message, test_files_path):


### PR DESCRIPTION
### Proposed Changes:

Mark `test/components/connectors/test_openapi_service.py::TestOpenAPIServiceConnector::test_run` as flaky as it keeps failing randomly. 

See example failure 👇 
https://github.com/deepset-ai/haystack/actions/runs/7918059826/job/21616198301

### How did you test it?

I ran the test locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
