### PR TITLE
feat: Add ByteStream to_string method

### DIFF
--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -58,8 +58,4 @@ class ByteStream:
         :return: The string representation of the ByteStream.
         :raises UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
         """
-        try:
-            return self.data.decode(encoding)
-        except UnicodeDecodeError as e:
-            error_msg = f"Failed to decode ByteStream data with encoding '{encoding}': {e.reason}"
-            raise ValueError(error_msg) from e
+        return self.data.decode(encoding)

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -49,3 +49,17 @@ class ByteStream:
         :param meta: Additional metadata to be stored with the ByteStream.
         """
         return cls(data=text.encode(encoding), mime_type=mime_type, meta=meta or {})
+
+    def to_string(self, encoding: str = "utf-8") -> str:
+        """
+        Convert the ByteStream to a string, metadata will not be included.
+
+        :param encoding: The encoding used to convert the bytes to a string. Defaults to "utf-8".
+        :return: The string representation of the ByteStream.
+        :raises UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
+        """
+        try:
+            return self.data.decode(encoding)
+        except UnicodeDecodeError as e:
+            error_msg = f"Failed to decode ByteStream data with encoding '{encoding}': {e.reason}"
+            raise ValueError(error_msg) from e

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -46,7 +46,7 @@ def test_to_string():
 def test_to_string_encoding():
     test_string = "Hello, world!"
     b = ByteStream.from_string(test_string)
-    assert b.to_string("utf-8") == test_string
+    assert b.to_string("ISO-8859-1") == test_string
 
 
 def test_to_string_encoding_error():

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -1,3 +1,5 @@
+import pytest
+
 from haystack.dataclasses import ByteStream
 
 
@@ -33,6 +35,25 @@ def test_from_string():
     b = ByteStream.from_string(test_string, meta={"foo": "bar"})
     assert b.data.decode() == test_string
     assert b.meta == {"foo": "bar"}
+
+
+def test_to_string():
+    test_string = "Hello, world!"
+    b = ByteStream.from_string(test_string)
+    assert b.to_string() == test_string
+
+
+def test_to_string_encoding():
+    test_string = "Hello, world!"
+    b = ByteStream.from_string(test_string)
+    assert b.to_string("utf-8") == test_string
+
+
+def test_to_string_encoding_error():
+    # test that it raises ValueError if the encoding is not valid
+    b = ByteStream.from_string("Hello, world!")
+    with pytest.raises(ValueError):
+        b.to_string("utf-16")
 
 
 def test_to_file(tmp_path, request):

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -43,10 +43,15 @@ def test_to_string():
     assert b.to_string() == test_string
 
 
-def test_to_string_encoding():
-    test_string = "Hello, world!"
-    b = ByteStream.from_string(test_string)
-    assert b.to_string("ISO-8859-1") == test_string
+def test_to_from_string_encoding():
+    test_string = "Hello Baščaršija!"
+    with pytest.raises(UnicodeEncodeError):
+        ByteStream.from_string(test_string, encoding="ISO-8859-1")
+
+    bs = ByteStream.from_string(test_string)  # default encoding is utf-8
+
+    assert bs.to_string(encoding="ISO-8859-1") != test_string
+    assert bs.to_string(encoding="utf-8") == test_string
 
 
 def test_to_string_encoding_error():

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -52,7 +52,7 @@ def test_to_string_encoding():
 def test_to_string_encoding_error():
     # test that it raises ValueError if the encoding is not valid
     b = ByteStream.from_string("Hello, world!")
-    with pytest.raises(ValueError):
+    with pytest.raises(UnicodeDecodeError):
         b.to_string("utf-16")
 
 


### PR DESCRIPTION
### Why:
Adds `to_string` method in the `ByteStream` class which arises from the requirement to convert byte data back into its original string format for certain use cases. This enhancement provides a convenient and intuitive way to achieve this, enriching the class's functionalities.

In addition, we already have a method from_string that creates a ByteStream instance from a string by encoding it to bytes. A to_string method provides the symmetric operation, converting the byte stream to a string. This symmetry in API design improves intuitiveness and usability.

### What:
* A new method named `to_string` has been added to the `ByteStream` class in `haystack/dataclasses/byte_stream.py`, enabling conversion of byte data to its original string representation.
* The method accepts an optional encoding parameter for controlling the decoding process and defaults to `utf-8`.
* Custom error handling, specifically a `UnicodeDecodeError`, is implemented to ensure graceful failure in case of encoding issues.

### How can it be used:
* The `to_string` method can be applied to `ByteStream` instances when users wish to extract the original text content.

Example usage:
```python
bs = ByteStream.from_string('hello, world!')
text = bs.to_string()
assert text == 'hello, world!'
```

### How did you test it:
* Unit tests have been added to `test/dataclasses/test_byte_stream.py` verifying correct functionality of the `to_string` method in different scenarios, including valid and invalid encoding cases.

### Notes for the reviewer:
* The changes mainly concern the `ByteStream` class and its test class, keeping the impact localized.
