### PR TITLE
feat: Reintroduce `max_loops_allowed` check in `Pipeline.run()`

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -17,6 +17,7 @@ from haystack.core.errors import (
     PipelineConnectError,
     PipelineDrawingError,
     PipelineError,
+    PipelineMaxLoops,
     PipelineRuntimeError,
     PipelineValidationError,
 )
@@ -661,6 +662,10 @@ class Pipeline:
         #     "input1": 1, "input2": 2,
         # }
 
+        # Reset the visits count for each component
+        for node in self.graph.nodes:
+            self.graph.nodes[node]["visits"] = 0
+
         # TODO: Remove this warmup once we can check reliably whether a component has been warmed up or not
         # As of now it's here to make sure we don't have failing tests that assume warm_up() is called in run()
         self.warm_up()
@@ -753,8 +758,12 @@ class Pipeline:
                     continue
 
             if name in last_inputs and len(comp.__haystack_input__._sockets_dict) == len(last_inputs[name]):  # type: ignore
+                if self.graph.nodes[name]["visits"] > self.max_loops_allowed:
+                    msg = f"Maximum loops count ({self.max_loops_allowed}) exceeded for component '{name}'"
+                    raise PipelineMaxLoops(msg)
                 # This component has all the inputs it needs to run
                 res = comp.run(**last_inputs[name])
+                self.graph.nodes[name]["visits"] += 1
 
                 if not isinstance(res, Mapping):
                     raise PipelineRuntimeError(

--- a/releasenotes/notes/max-loops-in-run-df9f5c068a723f71.yaml
+++ b/releasenotes/notes/max-loops-in-run-df9f5c068a723f71.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Change `Pipeline.run()` to check if `max_loops_allowed` has been reached.
+    If we attempt to run a Component that already ran the number of `max_loops_allowed` a `PipelineMaxLoops` will be raised.


### PR DESCRIPTION
### Proposed Changes:

Change `Pipeline.run()` to check if a Component has been ran the number of `max_loops_allowed`.
If we're about to run a Component that already ran the `max_loops_allowed` times we raise a `PipelineMaxLoops` exception.

### How did you test it?

I added a new unit test.

### Notes for the reviewer

The name of the argument is semantically incorrect as it doesn't actually check for the number of loops but the number of times a Component ran.

I don't want to cause a breaking change as of now so I chose not to rename it. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
