### PR TITLE
fix: specify CPU device in warm_up test

### DIFF
--- a/test/components/audio/test_whisper_local.py
+++ b/test/components/audio/test_whisper_local.py
@@ -71,7 +71,7 @@ class TestLocalWhisperTranscriber:
 
     def test_warmup(self):
         with patch("haystack.components.audio.whisper_local.whisper") as mocked_whisper:
-            transcriber = LocalWhisperTranscriber(model="large-v2")
+            transcriber = LocalWhisperTranscriber(model="large-v2", device=ComponentDevice.from_str("cpu"))
             mocked_whisper.load_model.assert_not_called()
             transcriber.warm_up()
             mocked_whisper.load_model.assert_called_once_with("large-v2", device=torch.device(type="cpu"))


### PR DESCRIPTION
This test fails if the default device is not CPU.

Now I am explicitly initializing the component with CPU device.