### PR TITLE
fix: Fix multiplexer importing from wrong package

### DIFF
--- a/haystack/components/others/multiplexer.py
+++ b/haystack/components/others/multiplexer.py
@@ -3,8 +3,8 @@ import sys
 from typing import Any, Dict
 
 from haystack import component, default_from_dict, default_to_dict
-from haystack.components.routers.conditional_router import deserialize_type, serialize_type
 from haystack.core.component.types import Variadic
+from haystack.utils.type_serialization import deserialize_type, serialize_type
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias


### PR DESCRIPTION
### Proposed Changes:

Change import paths for `deserialize_type` and `serialize_type` in `multiplexer.py`.

### How did you test it?

I ran unit tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
