### PR TITLE
chore: add `accelerate` to lazy imports

### DIFF
--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     import torch
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
+    import accelerate  # pylint: disable=unused-import # the library is used but not imported directly
 
 
 @component

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     import torch
     from transformers import AutoModelForSequenceClassification, AutoTokenizer
-    import accelerate  # pylint: disable=unused-import # the library is used but not imported directly
+    import accelerate  # pylint: disable=unused-import # the library is used but not directly referenced
 
 
 @component

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -13,6 +13,7 @@ with LazyImport("Run 'pip install transformers[torch,sentencepiece]'") as torch_
     import torch
     from tokenizers import Encoding
     from transformers import AutoModelForQuestionAnswering, AutoTokenizer
+    import accelerate  # pylint: disable=unused-import # the library is used but not imported directly
 
 
 logger = logging.getLogger(__name__)

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -13,7 +13,7 @@ with LazyImport("Run 'pip install transformers[torch,sentencepiece]'") as torch_
     import torch
     from tokenizers import Encoding
     from transformers import AutoModelForQuestionAnswering, AutoTokenizer
-    import accelerate  # pylint: disable=unused-import # the library is used but not imported directly
+    import accelerate  # pylint: disable=unused-import # the library is used but not directly referenced
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Related Issues
Support for `device_map` was recently introduced in #6679.

This requires the `accelerate` library, which is automatically installed with `pip install transformers[torch]` (as underlined by @sjrl in #6679).
If the user has `transformers` but installed differently (as happens in Colab), the component fails at `warm_up`, as reported in https://github.com/deepset-ai/haystack/discussions/7020

**It would be better to make the component fail at init, with a clear error message**, similarly to other import errors in Haystack.

### Proposed Changes:
- Add the `accelerate` import to the lazy imports. The library is always (implicitly) used in these components.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
