### PR TITLE
feat: Add Mean Reciprocal Rank (MRR) metric to `StatisticalEvaluator`

### DIFF
--- a/haystack/components/evaluators/statistical_evaluator.py
+++ b/haystack/components/evaluators/statistical_evaluator.py
@@ -19,6 +19,7 @@ class StatisticalMetric(Enum):
     EM = "exact_match"
     RECALL_SINGLE_HIT = "recall_single_hit"
     RECALL_MULTI_HIT = "recall_multi_hit"
+    MRR = "mean_reciprocal_rank"
 
     @classmethod
     def from_str(cls, metric: str) -> "StatisticalMetric":
@@ -55,6 +56,7 @@ class StatisticalEvaluator:
             StatisticalMetric.EM: self._exact_match,
             StatisticalMetric.RECALL_SINGLE_HIT: self._recall_single_hit,
             StatisticalMetric.RECALL_MULTI_HIT: self._recall_multi_hit,
+            StatisticalMetric.MRR: self._mrr,
         }[self._metric]
 
     def to_dict(self) -> Dict[str, Any]:
@@ -111,7 +113,7 @@ class StatisticalEvaluator:
     @staticmethod
     def _exact_match(labels: List[str], predictions: List[str]) -> float:
         """
-        Measure the proportion of cases where predictiond is identical to the the expected label.
+        Measure the proportion of cases where prediction is identical to the the expected label.
         """
         if len(labels) != len(predictions):
             raise ValueError("The number of predictions and labels must be the same.")
@@ -150,3 +152,19 @@ class StatisticalEvaluator:
                 correct_retrievals += 1
 
         return correct_retrievals / len(labels)
+
+    @staticmethod
+    def _mrr(labels: List[str], predictions: List[str]) -> float:
+        """
+        Measures the mean reciprocal rank of times a label is present in at least one or more predictions.
+        """
+        if len(labels) == 0:
+            return 0.0
+
+        mrr_sum = 0.0
+        for label, prediction in zip(labels, predictions):
+            if label in prediction:
+                mrr_sum += 1 / (predictions.index(prediction) + 1)
+                break
+
+        return mrr_sum / len(labels)

--- a/releasenotes/notes/add-mrr-metric-362527e55e21c24c.yaml
+++ b/releasenotes/notes/add-mrr-metric-362527e55e21c24c.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add support for Mean Reciprocal Rank (MRR) Metric to `StatisticalEvaluator`.
+    MRR measures the mean reciprocal rank of times a label is present in at least one or more predictions.

--- a/test/components/evaluators/test_statistical_evaluator.py
+++ b/test/components/evaluators/test_statistical_evaluator.py
@@ -189,3 +189,37 @@ class TestStatisticalEvaluatorRecallMultiHit:
         result = evaluator.run(labels=labels, predictions=[])
         assert len(result) == 1
         assert result["result"] == 0.0
+
+
+class TestStatisticalEvaluatorMRR:
+    def test_run(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.MRR)
+        labels = ["Eiffel Tower", "Louvre Museum", "Colosseum", "Trajan's Column"]
+        predictions = [
+            "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
+            "The Eiffel Tower max height is 330 meters.",
+            "Louvre Museum is the world's largest art museum and a historic monument in Paris, France.",
+            "The Leaning Tower of Pisa is the campanile, or freestanding bell tower, of Pisa Cathedral.",
+        ]
+        result = evaluator.run(labels=labels, predictions=predictions)
+        assert len(result) == 1
+        assert result["result"] == 0.25
+
+    def test_run_with_empty_labels(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.MRR)
+        predictions = [
+            "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
+            "The Eiffel Tower max height is 330 meters.",
+            "Louvre Museum is the world's largest art museum and a historic monument in Paris, France.",
+            "The Leaning Tower of Pisa is the campanile, or freestanding bell tower, of Pisa Cathedral.",
+        ]
+        result = evaluator.run(labels=[], predictions=predictions)
+        assert len(result) == 1
+        assert result["result"] == 0.0
+
+    def test_run_with_empty_predictions(self):
+        evaluator = StatisticalEvaluator(metric=StatisticalMetric.MRR)
+        labels = ["Eiffel Tower", "Louvre Museum", "Colosseum", "Trajan's Column"]
+        result = evaluator.run(labels=labels, predictions=[])
+        assert len(result) == 1
+        assert result["result"] == 0.0


### PR DESCRIPTION
### Related Issues

fixes #6065

### Proposed Changes:

Add support for Mean Reciprocal Rank (MRR) Metric to `StatisticalEvaluator`.

MRR measures the mean reciprocal rank of times a label is present in at least one or more predictions.

### How did you test it?

Unit tests were added to `test_statistical_evaluator.py`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue

