### PR TITLE
test: Simplify OpenAPIServiceConnector run test

### DIFF
--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -151,11 +151,11 @@ class OpenAPIServiceConnector:
                         openapi_service.authenticate(scheme_name, auth_credentials)
                         authenticated = True
                         break
-                    else:
-                        raise ValueError(
-                            f"Service {service_name} requires {scheme_name} security scheme but no "
-                            f"credentials were provided for it. Check the service configuration and credentials."
-                        )
+
+                    raise ValueError(
+                        f"Service {service_name} requires {scheme_name} security scheme but no "
+                        f"credentials were provided for it. Check the service configuration and credentials."
+                    )
             if not authenticated:
                 raise ValueError(
                     f"Service {service_name} requires authentication but no credentials were provided "

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import List, Dict, Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from haystack import component
 from haystack.dataclasses import ChatMessage, ChatRole
@@ -150,6 +150,7 @@ class OpenAPIServiceConnector:
                     if auth_credentials:
                         openapi_service.authenticate(scheme_name, auth_credentials)
                         authenticated = True
+                        break
                     else:
                         raise ValueError(
                             f"Service {service_name} requires {scheme_name} security scheme but no "


### PR DESCRIPTION
### Proposed Changes:

Rework `OpenAPIServiceConnector.run()` test to avoid making any HTTP request.
Since we rely on an external library to convert OpenAPI specs to a proper client it's fine to test we call the library.

### How did you test it?

I ran unit tests locally.

### Notes for the reviewer

This test keeps failing in CI making it quite annoying, see example faliure. 👇 
https://github.com/deepset-ai/haystack/actions/runs/7970654409/job/21759153102

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
