### PR TITLE
chore: fix formatting of `add-pipeline-templates-831f857c6387f8c3.yaml`

### DIFF
--- a/releasenotes/notes/add-pipeline-templates-831f857c6387f8c3.yaml
+++ b/releasenotes/notes/add-pipeline-templates-831f857c6387f8c3.yaml
@@ -1,6 +1,5 @@
 ---
-highlights:
- - |
+highlights:  >
    Introducing a flexible and dynamic approach to creating NLP pipelines with Haystack's new PipelineTemplate class!
    This innovative feature utilizes Jinja templated YAML files, allowing users to effortlessly construct and customize
    complex data processing pipelines for various NLP tasks. From question answering and document indexing to custom


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/actions/runs/8002246058/job/21855066081

### Proposed Changes:

Formatting was incorrect and it broke the release notes generation

### Notes for the reviewer

We should check the release notes syntax when they get merged.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
