### PR TITLE
ci: only only skip tests if no code  changes at all

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ on:
       - synchronize
       - ready_for_review
     paths:
+      # Keep the list in sync with the paths defined in the `tests_skipper.yml` workflow
       - "haystack/**/*.py"
       - "haystack/templates/predefined/*"
       - "test/**/*.py"

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -9,6 +9,8 @@ on:
       - synchronize
       - ready_for_review
     paths-ignore:
+      # we skip the tests unless the code changes. The problem is that GitHub will run the check anyway if any other
+      # file outside the code changed (e.g. the release notes). Hence, we need a second filter down below.
       - "haystack/**/*.py"
       - "test/**/*.py"
       - "test/test_requirements.txt"
@@ -17,6 +19,20 @@ jobs:
   catch-all:
     name: Catch-all check
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v4
+      - name: Check for changed code
+        # Don't run this check if the PR contains both code and non-code changes (e.g. release notes)
+        id: changes
+        uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a
+        with:
+          filters: |
+            code_changes:
+              - haystack/**/*.py
+              - test/**/*.py
+              - test/test_requirements.txt
       - name: Skip tests
+        if: steps.changes.outputs.code_changes == 'false'
         run: echo "Skipped!"

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -16,15 +16,16 @@ on:
       - "test/test_requirements.txt"
 
 jobs:
-  catch-all:
-    name: Catch-all check
+  check_if_changed:
+    name: Check if changed
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
+    outputs:
+      code_changes: ${{ steps.changes.outputs.code_changes }}
     steps:
       - uses: actions/checkout@v4
       - name: Check for changed code
-        # Don't run this check if the PR contains both code and non-code changes (e.g. release notes)
         id: changes
         uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a
         with:
@@ -33,6 +34,13 @@ jobs:
               - haystack/**/*.py
               - test/**/*.py
               - test/test_requirements.txt
+
+  catch-all:
+    # Don't run this check if the PR contains both code and non-code changes (e.g. release notes)
+    needs: check_if_changed
+    if: needs.check_if_changed.outputs.code_changes == 'false'
+    name: Catch-all check
+    runs-on: ubuntu-latest
+    steps:
       - name: Skip tests
-        if: steps.changes.outputs.code_changes == 'false'
         run: echo "Skipped!"

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -11,7 +11,9 @@ on:
     paths-ignore:
       # we skip the tests unless the code changes. The problem is that GitHub will run the check anyway if any other
       # file outside the code changed (e.g. the release notes). Hence, we need a second filter down below.
+      # keep the list in sync with the paths defined in the `tests.yml` workflow
       - "haystack/**/*.py"
+      - "haystack/templates/predefined/*"
       - "test/**/*.py"
       - "test/test_requirements.txt"
 
@@ -29,9 +31,11 @@ jobs:
         id: changes
         uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a
         with:
+          # keep the list in sync with the paths defined in the `tests.yml` workflow
           filters: |
             code_changes:
               - haystack/**/*.py
+              - "haystack/templates/predefined/*"
               - test/**/*.py
               - test/test_requirements.txt
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound="Pipeline")
 
 
+# Fake change to test CI
 class Pipeline:
     """
     Components orchestration engine.

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound="Pipeline")
 
 
-# Fake change to test CI
 class Pipeline:
     """
     Components orchestration engine.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- previously the CI skipped the tests if there was at least one no code change (which is quite normal since you usually add release notes)
  - [GH docs on `paths-ignore` filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths)
      >  If any path names do not match patterns in paths-ignore, **even if some path names match the patterns**, the workflow will run.
- this now adds a separate filter to ensure that there is really no code change

### How did you test it?

- manual as part of this PR

### Notes for the reviewer

- I thought I could use `!` (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths) but that faces the same problem as the previous solution

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
