### PR TITLE
feat: Add complex types in OpenAPI support

### DIFF
--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -215,7 +215,7 @@ class OpenAPIServiceConnector:
             schema = request_body.get("content", {}).get("application/json", {}).get("schema", {})
             required_params = schema.get("required", [])
             for param_name in schema.get("properties", {}):
-                param_value = invocation_arguments.pop(param_name, None)
+                param_value = invocation_arguments.get(param_name)
                 if param_value:
                     method_call_params["data"][param_name] = param_value
                 else:

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -198,24 +198,30 @@ class OpenAPIServiceConnector:
 
         # Pack URL/query parameters under "parameters" key
         method_call_params: Dict[str, Dict[str, Any]] = defaultdict(dict)
-        if operation_dict.get("parameters"):
-            for param_name in [param["name"] for param in operation_dict.get("parameters", [])]:
-                param_value = invocation_arguments.pop(param_name, None)
-                if param_value:
-                    method_call_params["parameters"][param_name] = param_value
+        parameters = operation_dict.get("parameters", [])
+        request_body = operation_dict.get("requestBody", {})
+
+        for param in parameters:
+            param_name = param["name"]
+            param_value = invocation_arguments.pop(param_name, None)
+            if param_value:
+                method_call_params["parameters"][param_name] = param_value
+            else:
+                if param.get("required", False):
+                    raise ValueError(f"Missing parameter: '{param_name}' required for the '{name}' operation.")
 
         # Pack request body parameters under "data" key
-        if operation_dict.get("requestBody"):
-            for param_name in (
-                operation_dict.get("requestBody", {})
-                .get("content", {})
-                .get("application/json", {})
-                .get("schema", {})
-                .get("properties", {})
-            ):
+        if request_body:
+            schema = request_body.get("content", {}).get("application/json", {}).get("schema", {})
+            required_params = schema.get("required", [])
+            for param_name in schema.get("properties", {}):
                 param_value = invocation_arguments.pop(param_name, None)
                 if param_value:
                     method_call_params["data"][param_name] = param_value
-
+                else:
+                    if param_name in required_params:
+                        raise ValueError(
+                            f"Missing requestBody parameter: '{param_name}' required for the '{name}' operation."
+                        )
         # call the underlying service REST API with the parameters
         return method_to_call(**method_call_params)

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -200,7 +200,9 @@ class OpenAPIServiceConnector:
         method_call_params: Dict[str, Dict[str, Any]] = defaultdict(dict)
         if operation_dict.get("parameters"):
             for param_name in [param["name"] for param in operation_dict.get("parameters", [])]:
-                method_call_params["parameters"][param_name] = invocation_arguments.pop(param_name, "")
+                param_value = invocation_arguments.pop(param_name, None)
+                if param_value:
+                    method_call_params["parameters"][param_name] = param_value
 
         # Pack request body parameters under "data" key
         if operation_dict.get("requestBody"):
@@ -211,7 +213,9 @@ class OpenAPIServiceConnector:
                 .get("schema", {})
                 .get("properties", {})
             ):
-                method_call_params["data"][param_name] = invocation_arguments.pop(param_name, "")
+                param_value = invocation_arguments.pop(param_name, None)
+                if param_value:
+                    method_call_params["data"][param_name] = param_value
 
         # call the underlying service REST API with the parameters
         return method_to_call(**method_call_params)

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -203,7 +203,7 @@ class OpenAPIServiceConnector:
 
         for param in parameters:
             param_name = param["name"]
-            param_value = invocation_arguments.pop(param_name, None)
+            param_value = invocation_arguments.get(param_name)
             if param_value:
                 method_call_params["parameters"][param_name] = param_value
             else:

--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -212,13 +212,12 @@ class OpenAPIServiceToFunctions:
         Parses OpenAPI specification content, supporting both JSON and YAML formats.
 
         :param content: The content of the OpenAPI specification.
-        :type content: str
         :return: The parsed OpenAPI specification.
-        :rtype: Dict[str, Any]
         """
         open_api_spec_content = None
         try:
             open_api_spec_content = json.loads(content)
+            return jsonref.replace_refs(open_api_spec_content)
         except json.JSONDecodeError as json_error:
             # heuristic to confirm that the content is likely malformed JSON
             if content.strip().startswith(("{", "[")):

--- a/haystack/components/converters/openapi_functions.py
+++ b/haystack/components/converters/openapi_functions.py
@@ -29,10 +29,11 @@ class OpenAPIServiceToFunctions:
 
     Minimal requirements for OpenAPI specification:
     - OpenAPI version 3.0.0 or higher
-    - Each function must have a unique operationId
-    - Each function must have a description
-    - Each function must have a requestBody or parameters or both
-    - Each function must have a schema for the requestBody and/or parameters
+    - Each path must have:
+        - a unique operationId
+        - a description
+        - a requestBody or parameters or both
+        - a schema for the requestBody and/or parameters
 
 
     See https://github.com/OAI/OpenAPI-Specification for more details on OpenAPI specification.
@@ -124,15 +125,14 @@ class OpenAPIServiceToFunctions:
             )
 
         functions: List[Dict[str, Any]] = []
-        for methods in service_openapi_spec["paths"].values():
-            for method_spec in methods.values():
-                function_dict = self._parse_method_spec(method_spec)
+        for paths in service_openapi_spec["paths"].values():
+            for path_spec in paths.values():
+                function_dict = self._parse_endpoint_spec(path_spec)
                 if function_dict:
                     functions.append(function_dict)
         return functions
 
-    def _parse_method_spec(self, method_spec: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        resolved_spec = jsonref.replace_refs(method_spec)
+    def _parse_endpoint_spec(self, resolved_spec: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if not isinstance(resolved_spec, dict):
             logger.warning("Invalid OpenAPI spec format provided. Could not extract function.")
             return {}
@@ -142,30 +142,70 @@ class OpenAPIServiceToFunctions:
 
         schema: Dict[str, Any] = {"type": "object", "properties": {}}
 
-        req_body = (
-            resolved_spec.get("requestBody", {})
-            .get("content", {})
-            .get("application/json", {})
-            .get("schema", {})
-            .get("properties", {})
+        # requestBody section
+        req_body_schema = (
+            resolved_spec.get("requestBody", {}).get("content", {}).get("application/json", {}).get("schema", {})
         )
+        if "properties" in req_body_schema:
+            for prop_name, prop_schema in req_body_schema["properties"].items():
+                schema["properties"][prop_name] = self._parse_property_attributes(prop_schema)
 
-        params = resolved_spec.get("parameters", [])
-        param_properties = {
-            param["name"]: self._parse_property_attributes(param) for param in params if "schema" in param
-        }
+            if "required" in req_body_schema:
+                schema.setdefault("required", []).extend(req_body_schema["required"])
 
-        # merge request body and parameters
-        schema["properties"] = {**req_body, **param_properties}
-        required = [param["name"] for param in params if param.get("required")]
-        if required:
-            schema["required"] = required
+        # parameters section
+        for param in resolved_spec.get("parameters", []):
+            if "schema" in param:
+                schema_dict = self._parse_property_attributes(param["schema"])
+                # these attributes are not in param[schema] level but on param level
+                useful_attributes = ["description", "pattern", "enum"]
+                schema_dict.update({key: param[key] for key in useful_attributes if param.get(key)})
+                schema["properties"][param["name"]] = schema_dict
+                if param.get("required", False):
+                    schema.setdefault("required", []).append(param["name"])
 
         if function_name and description and schema["properties"]:
             return {"name": function_name, "description": description, "parameters": schema}
         else:
             logger.warning("Invalid OpenAPI spec format provided. Could not extract function from %s", resolved_spec)
             return {}
+
+    def _parse_property_attributes(
+        self, property_schema: Dict[str, Any], include_attributes: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Recursively parses the attributes of a property schema, including nested objects and arrays,
+        and includes specified attributes like description, pattern, etc.
+
+        :param property_schema: The schema of the property to parse.
+        :param include_attributes: The list of attributes to include in the parsed schema.
+        :return: The parsed schema of the property including the specified attributes.
+        """
+        include_attributes = include_attributes or ["description", "pattern", "enum"]
+
+        schema_type = property_schema.get("type")
+
+        parsed_schema = {"type": schema_type} if schema_type else {}
+        for attr in include_attributes:
+            if attr in property_schema:
+                parsed_schema[attr] = property_schema[attr]
+
+        if schema_type == "object":
+            properties = property_schema.get("properties", {})
+            parsed_properties = {
+                prop_name: self._parse_property_attributes(prop, include_attributes)
+                for prop_name, prop in properties.items()
+            }
+            parsed_schema["properties"] = parsed_properties
+
+            if "required" in property_schema:
+                parsed_schema["required"] = property_schema["required"]
+
+        elif schema_type == "array":
+            items = property_schema.get("items", {})
+            parsed_schema["items"] = self._parse_property_attributes(items, include_attributes)
+
+        return parsed_schema
 
     def _parse_openapi_spec(self, content: str) -> Dict[str, Any]:
         """
@@ -176,21 +216,25 @@ class OpenAPIServiceToFunctions:
         :return: The parsed OpenAPI specification.
         :rtype: Dict[str, Any]
         """
+        open_api_spec_content = None
         try:
-            return json.loads(content)
+            open_api_spec_content = json.loads(content)
         except json.JSONDecodeError as json_error:
             # heuristic to confirm that the content is likely malformed JSON
             if content.strip().startswith(("{", "[")):
                 raise json_error
 
         try:
-            return yaml.safe_load(content)
+            open_api_spec_content = yaml.safe_load(content)
         except yaml.YAMLError:
             error_message = (
                 "Failed to parse the OpenAPI specification. "
                 "The content does not appear to be valid JSON or YAML.\n\n"
             )
             raise RuntimeError(error_message, content)
+
+        # Replace references in the object with their resolved values, if any
+        return jsonref.replace_refs(open_api_spec_content)
 
     def _read_from_file(self, path: Union[str, Path]) -> Optional[str]:
         """
@@ -220,22 +264,3 @@ class OpenAPIServiceToFunctions:
         except RequestException as e:
             logger.warning("Error fetching URL: %s. Error: %s", url, e)
             return None
-
-    def _parse_property_attributes(self, property_schema: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Parses the attributes of a property schema and returns them if present.
-
-        :param property_schema: The schema of the property.
-        :type property_schema: dict
-        :return: A dictionary with the parsed attributes of the property.
-        :rtype: dict
-        """
-        # handle only a subset of possible OAS attributes
-        possible_attributes = ["pattern", "description", "examples", "enum"]
-
-        schema = property_schema.get("schema", {})
-        parsed_attributes = {"type": schema.get("type")}
-        for attribute in possible_attributes:
-            if attribute in property_schema:
-                parsed_attributes[attribute] = property_schema[attribute]
-        return parsed_attributes

--- a/releasenotes/notes/complex-types-openapi-support-84d3daf8927ad915.yaml
+++ b/releasenotes/notes/complex-types-openapi-support-84d3daf8927ad915.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Enhanced OpenAPI integration by handling complex user types in OpenAPIServiceConnector and OpenAPIServiceToFunctions.

--- a/releasenotes/notes/complex-types-openapi-support-84d3daf8927ad915.yaml
+++ b/releasenotes/notes/complex-types-openapi-support-84d3daf8927ad915.yaml
@@ -1,4 +1,4 @@
 ---
 features:
  - |
-   Enhanced OpenAPI integration by handling complex user types in OpenAPIServiceConnector and OpenAPIServiceToFunctions.
+   Enhanced OpenAPI integration by handling complex types of requests and responses in OpenAPIServiceConnector and OpenAPIServiceToFunctions.

--- a/test/components/connectors/test_openapi_service.py
+++ b/test/components/connectors/test_openapi_service.py
@@ -176,38 +176,6 @@ class TestOpenAPIServiceConnector:
         response = json.loads(result["service_response"][0].content)
         assert response == "Hello, John"
 
-        with patch(
-            "haystack.components.connectors.openapi_service.OpenAPIServiceConnector._authenticate_service"
-        ), patch("haystack.components.connectors.openapi_service.OpenAPI") as MockOpenAPI:
-            mock_openapi_instance = MockOpenAPI.return_value
-
-            mock_method_callable = MagicMock()
-            mock_method_callable.return_value = MagicMock(_raw_data={"result": "Hello, John"})
-
-            mock_operation_self = MagicMock()
-            mock_operation_raw_element = {
-                "parameters": [
-                    {"name": "name", "in": "path", "required": True, "schema": {"type": "string"}},
-                    {"name": "message", "in": "query", "schema": {"type": "string"}},
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {"properties": {"message": {"type": "string"}}, "required": ["message"]}
-                        }
-                    }
-                },
-            }
-
-            type(mock_method_callable).operation = PropertyMock(return_value=mock_operation_self)
-            type(mock_operation_self).__self__ = PropertyMock(return_value=mock_operation_self)
-            mock_operation_self.raw_element = mock_operation_raw_element
-
-            setattr(mock_openapi_instance, "call_greet", mock_method_callable)
-            result = connector.run(messages=messages, service_openapi_spec=spec)
-            response = json.loads(result["service_response"][0].content)
-            assert response == {"result": "Hello, John"}
-
     def test_run_with_complex_types(self, test_files_path):
         connector = OpenAPIServiceConnector()
         spec_path = test_files_path / "json" / "complex_types_openapi_service.json"

--- a/test/components/connectors/test_openapi_service.py
+++ b/test/components/connectors/test_openapi_service.py
@@ -176,7 +176,8 @@ class TestOpenAPIServiceConnector:
         response = json.loads(result["service_response"][0].content)
         assert response == "Hello, John"
 
-    def test_run_with_complex_types(self, test_files_path):
+    @patch("haystack.components.connectors.openapi_service.OpenAPI")
+    def test_run_with_complex_types(self, openapi_mock, test_files_path):
         connector = OpenAPIServiceConnector()
         spec_path = test_files_path / "json" / "complex_types_openapi_service.json"
         with open(spec_path, "r") as file:
@@ -193,54 +194,46 @@ class TestOpenAPIServiceConnector:
                 }
             ]
         )
-        messages = [ChatMessage.from_assistant(mock_message)]
-        with patch(
-            "haystack.components.connectors.openapi_service.OpenAPIServiceConnector._authenticate_service"
-        ), patch("haystack.components.connectors.openapi_service.OpenAPI") as MockOpenAPI:
-            mock_openapi_instance = MockOpenAPI.return_value
 
-            mock_method_callable = MagicMock()
-            mock_method_callable.return_value = MagicMock(_raw_data={"result": "accepted"})
-
-            mock_operation_self = MagicMock()
-            mock_operation_raw_element = {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "transaction_amount": {"type": "number", "example": 150.75},
-                                    "description": {"type": "string", "example": "Monthly subscription fee"},
-                                    "payment_method_id": {"type": "string", "example": "visa_ending_in_1234"},
-                                    "payer": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"type": "string", "example": "Alex Smith"},
-                                            "email": {"type": "string", "example": "alex.smith@example.com"},
-                                            "identification": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {"type": "string", "example": "Driver's License"},
-                                                    "number": {"type": "string", "example": "D12345678"},
-                                                },
-                                                "required": ["type", "number"],
+        call_processPayment = Mock(return_value=Mock(_raw_data={"result": "accepted"}))
+        call_processPayment.operation.__self__ = Mock()
+        call_processPayment.operation.__self__.raw_element = {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "properties": {
+                                "transaction_amount": {"type": "number", "example": 150.75},
+                                "description": {"type": "string", "example": "Monthly subscription fee"},
+                                "payment_method_id": {"type": "string", "example": "visa_ending_in_1234"},
+                                "payer": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string", "example": "Alex Smith"},
+                                        "email": {"type": "string", "example": "alex.smith@example.com"},
+                                        "identification": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {"type": "string", "example": "Driver's License"},
+                                                "number": {"type": "string", "example": "D12345678"},
                                             },
+                                            "required": ["type", "number"],
                                         },
-                                        "required": ["name", "email", "identification"],
                                     },
+                                    "required": ["name", "email", "identification"],
                                 },
-                                "required": ["transaction_amount", "description", "payment_method_id", "payer"],
-                            }
+                            },
+                            "required": ["transaction_amount", "description", "payment_method_id", "payer"],
                         }
                     }
                 }
             }
+        }
+        mock_service = Mock(call_processPayment=call_processPayment)
+        mock_service.raw_element = {}
+        openapi_mock.return_value = mock_service
 
-            type(mock_method_callable).operation = PropertyMock(return_value=mock_operation_self)
-            type(mock_operation_self).__self__ = PropertyMock(return_value=mock_operation_self)
-            mock_operation_self.raw_element = mock_operation_raw_element
-
-            setattr(mock_openapi_instance, "call_processPayment", mock_method_callable)
-            result = connector.run(messages=messages, service_openapi_spec=spec)
-            response = json.loads(result["service_response"][0].content)
-            assert response == {"result": "accepted"}
+        messages = [ChatMessage.from_assistant(mock_message)]
+        result = connector.run(messages=messages, service_openapi_spec=spec)
+        response = json.loads(result["service_response"][0].content)
+        assert response == {"result": "accepted"}

--- a/test/components/connectors/test_openapi_service.py
+++ b/test/components/connectors/test_openapi_service.py
@@ -139,6 +139,8 @@ class TestOpenAPIServiceConnector:
 
         openapi_mock.assert_called_once_with(spec)
         mock_service.authenticate.assert_called_once_with("apikey", "fake_key")
+
+        # verify call went through on the wire with the correct parameters
         mock_service.call_compare_branches.assert_called_once_with(
             parameters={"basehead": "main...some_branch", "owner": "deepset-ai", "repo": "haystack"}
         )
@@ -173,6 +175,10 @@ class TestOpenAPIServiceConnector:
 
         messages = [ChatMessage.from_assistant(mock_message)]
         result = connector.run(messages=messages, service_openapi_spec=spec)
+
+        # verify call went through on the wire
+        mock_service.call_greet.assert_called_once_with(parameters={"name": "John"}, data={"message": "Hello"})
+
         response = json.loads(result["service_response"][0].content)
         assert response == "Hello, John"
 
@@ -187,7 +193,7 @@ class TestOpenAPIServiceConnector:
                 {
                     "id": "call_NJr1NBz2Th7iUWJpRIJZoJIA",
                     "function": {
-                        "arguments": '{"parameters": {"transaction_amount": 150.75, "description": "Monthly subscription fee", "payment_method_id": "visa_ending_in_1234", "payer": {"name": "Alex Smith", "email": "alex.smith@example.com", "identification": {"type": "Driver\'s License", "number": "D12345678"}}}}',
+                        "arguments": '{"transaction_amount": 150.75, "description": "Monthly subscription fee", "payment_method_id": "visa_ending_in_1234", "payer": {"name": "Alex Smith", "email": "alex.smith@example.com", "identification": {"type": "Driver\'s License", "number": "D12345678"}}}',
                         "name": "processPayment",
                     },
                     "type": "function",
@@ -235,5 +241,90 @@ class TestOpenAPIServiceConnector:
 
         messages = [ChatMessage.from_assistant(mock_message)]
         result = connector.run(messages=messages, service_openapi_spec=spec)
+
+        # verify call went through on the wire
+        mock_service.call_processPayment.assert_called_once_with(
+            data={
+                "transaction_amount": 150.75,
+                "description": "Monthly subscription fee",
+                "payment_method_id": "visa_ending_in_1234",
+                "payer": {
+                    "name": "Alex Smith",
+                    "email": "alex.smith@example.com",
+                    "identification": {"type": "Driver's License", "number": "D12345678"},
+                },
+            }
+        )
+
         response = json.loads(result["service_response"][0].content)
         assert response == {"result": "accepted"}
+
+    @patch("haystack.components.connectors.openapi_service.OpenAPI")
+    def test_run_with_request_params_missing_in_invocation_args(self, openapi_mock, test_files_path):
+        connector = OpenAPIServiceConnector()
+        spec_path = test_files_path / "yaml" / "openapi_greeting_service.yml"
+        with open(spec_path, "r") as file:
+            spec = json.loads(file.read())
+        mock_message = json.dumps(
+            [
+                {
+                    "id": "call_NJr1NBz2Th7iUWJpRIJZoJIA",
+                    "function": {"arguments": '{"message": "Hello"}', "name": "greet"},
+                    "type": "function",
+                }
+            ]
+        )
+        call_greet = Mock(return_value=Mock(_raw_data="Hello, John"))
+        call_greet.operation.__self__ = Mock()
+        call_greet.operation.__self__.raw_element = {
+            "parameters": [{"name": "name", "required": True}],
+            "requestBody": {
+                "content": {"application/json": {"schema": {"properties": {"message": {"type": "string"}}}}}
+            },
+        }
+
+        mock_service = Mock(call_greet=call_greet)
+        mock_service.raw_element = {}
+        openapi_mock.return_value = mock_service
+
+        messages = [ChatMessage.from_assistant(mock_message)]
+        with pytest.raises(ValueError, match="Missing parameter: 'name' required for the 'greet' operation."):
+            connector.run(messages=messages, service_openapi_spec=spec)
+
+    @patch("haystack.components.connectors.openapi_service.OpenAPI")
+    def test_run_with_body_properties_missing_in_invocation_args(self, openapi_mock, test_files_path):
+        connector = OpenAPIServiceConnector()
+        spec_path = test_files_path / "yaml" / "openapi_greeting_service.yml"
+        with open(spec_path, "r") as file:
+            spec = json.loads(file.read())
+        mock_message = json.dumps(
+            [
+                {
+                    "id": "call_NJr1NBz2Th7iUWJpRIJZoJIA",
+                    "function": {"arguments": '{"name": "John"}', "name": "greet"},
+                    "type": "function",
+                }
+            ]
+        )
+        call_greet = Mock(return_value=Mock(_raw_data="Hello, John"))
+        call_greet.operation.__self__ = Mock()
+        call_greet.operation.__self__.raw_element = {
+            "parameters": [{"name": "name"}],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"properties": {"message": {"type": "string"}}, "required": ["message"]}
+                    }
+                }
+            },
+        }
+
+        mock_service = Mock(call_greet=call_greet)
+        mock_service.raw_element = {}
+        openapi_mock.return_value = mock_service
+
+        messages = [ChatMessage.from_assistant(mock_message)]
+        with pytest.raises(
+            ValueError, match="Missing requestBody parameter: 'message' required for the 'greet' operation."
+        ):
+            connector.run(messages=messages, service_openapi_spec=spec)

--- a/test/components/converters/test_openapi_functions.py
+++ b/test/components/converters/test_openapi_functions.py
@@ -239,3 +239,43 @@ class TestOpenAPIServiceToFunctions:
         # check that the metadata is as expected, system_message should not be present
         assert "system_message" not in doc.meta
         assert doc.meta["spec"] == json.loads(json_serperdev_openapi_spec)
+
+    def test_complex_types_conversion(self, test_files_path):
+        service = OpenAPIServiceToFunctions()
+        result = service.run(sources=[test_files_path / "json" / "complex_types_openapi_service.json"])
+        assert len(result["documents"]) == 1
+        pp_spec = {
+            "name": "processPayment",
+            "description": "Process a new payment using the specified payment method",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "transaction_amount": {"type": "number", "description": "The amount to be paid"},
+                    "description": {"type": "string", "description": "A brief description of the payment"},
+                    "payment_method_id": {"type": "string", "description": "The payment method to be used"},
+                    "payer": {
+                        "type": "object",
+                        "description": "Information about the payer, including their name, email, and identification number",
+                        "properties": {
+                            "name": {"type": "string", "description": "The payer's name"},
+                            "email": {"type": "string", "description": "The payer's email address"},
+                            "identification": {
+                                "type": "object",
+                                "description": "The payer's identification number",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "description": "The type of identification document (e.g., CPF, CNPJ)",
+                                    },
+                                    "number": {"type": "string", "description": "The identification number"},
+                                },
+                                "required": ["type", "number"],
+                            },
+                        },
+                        "required": ["name", "email", "identification"],
+                    },
+                },
+                "required": ["transaction_amount", "description", "payment_method_id", "payer"],
+            },
+        }
+        assert result["documents"][0].content == json.dumps(pp_spec)

--- a/test/components/converters/test_openapi_functions.py
+++ b/test/components/converters/test_openapi_functions.py
@@ -241,41 +241,11 @@ class TestOpenAPIServiceToFunctions:
         assert doc.meta["spec"] == json.loads(json_serperdev_openapi_spec)
 
     def test_complex_types_conversion(self, test_files_path):
+        # ensure that complex types from OpenAPI spec are converted to the expected format in OpenAI function calling
         service = OpenAPIServiceToFunctions()
         result = service.run(sources=[test_files_path / "json" / "complex_types_openapi_service.json"])
         assert len(result["documents"]) == 1
-        pp_spec = {
-            "name": "processPayment",
-            "description": "Process a new payment using the specified payment method",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "transaction_amount": {"type": "number", "description": "The amount to be paid"},
-                    "description": {"type": "string", "description": "A brief description of the payment"},
-                    "payment_method_id": {"type": "string", "description": "The payment method to be used"},
-                    "payer": {
-                        "type": "object",
-                        "description": "Information about the payer, including their name, email, and identification number",
-                        "properties": {
-                            "name": {"type": "string", "description": "The payer's name"},
-                            "email": {"type": "string", "description": "The payer's email address"},
-                            "identification": {
-                                "type": "object",
-                                "description": "The payer's identification number",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "description": "The type of identification document (e.g., CPF, CNPJ)",
-                                    },
-                                    "number": {"type": "string", "description": "The identification number"},
-                                },
-                                "required": ["type", "number"],
-                            },
-                        },
-                        "required": ["name", "email", "identification"],
-                    },
-                },
-                "required": ["transaction_amount", "description", "payment_method_id", "payer"],
-            },
-        }
-        assert result["documents"][0].content == json.dumps(pp_spec)
+
+        with open(test_files_path / "json" / "complex_types_openai_spec.json") as openai_spec_file:
+            desired_output = json.load(openai_spec_file)
+        assert result["documents"][0].content == json.dumps(desired_output)

--- a/test/test_files/json/complex_types_openai_spec.json
+++ b/test/test_files/json/complex_types_openai_spec.json
@@ -1,0 +1,64 @@
+{
+    "name": "processPayment",
+    "description": "Process a new payment using the specified payment method",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "transaction_amount": {
+                "type": "number",
+                "description": "The amount to be paid"
+            },
+            "description": {
+                "type": "string",
+                "description": "A brief description of the payment"
+            },
+            "payment_method_id": {
+                "type": "string",
+                "description": "The payment method to be used"
+            },
+            "payer": {
+                "type": "object",
+                "description": "Information about the payer, including their name, email, and identification number",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The payer's name"
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The payer's email address"
+                    },
+                    "identification": {
+                        "type": "object",
+                        "description": "The payer's identification number",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "The type of identification document (e.g., CPF, CNPJ)"
+                            },
+                            "number": {
+                                "type": "string",
+                                "description": "The identification number"
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "number"
+                        ]
+                    }
+                },
+                "required": [
+                    "name",
+                    "email",
+                    "identification"
+                ]
+            }
+        },
+        "required": [
+            "transaction_amount",
+            "description",
+            "payment_method_id",
+            "payer"
+        ]
+    }
+}

--- a/test/test_files/json/complex_types_openapi_service.json
+++ b/test/test_files/json/complex_types_openapi_service.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Payment API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080"
+    }
+  ],
+  "paths": {
+    "/new_payment": {
+      "post": {
+        "summary": "Process a new payment",
+        "description": "Process a new payment using the specified payment method",
+        "operationId": "processPayment",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "transaction_amount": {
+                    "type": "number",
+                    "description": "The amount to be paid"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A brief description of the payment"
+                  },
+                  "payment_method_id": {
+                    "type": "string",
+                    "description": "The payment method to be used"
+                  },
+                  "payer": {
+                    "$ref": "#/components/schemas/Payer"
+                  }
+                },
+                "required": [
+                  "transaction_amount",
+                  "description",
+                  "payment_method_id",
+                  "payer"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Payment processed successfully"
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Payer": {
+        "type": "object",
+        "description": "Information about the payer, including their name, email, and identification number",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The payer's name"
+          },
+          "email": {
+            "type": "string",
+            "description": "The payer's email address"
+          },
+          "identification": {
+            "type": "object",
+            "description": "The payer's identification number",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "The type of identification document (e.g., CPF, CNPJ)"
+              },
+              "number": {
+                "type": "string",
+                "description": "The identification number"
+              }
+            },
+            "required": [
+              "type",
+              "number"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "identification"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Why:

Enhances the OpenAPI service connector to handle complex types of requests and responses. This improvement ensures Haystack users can invoke a broader range of OpenAPI specifications via OpenAPIServiceConnector and convert them to OpenAI function calling specification via OpenAPIServiceToFunctions

### What:

- In `openapi_service.py`, the connector now supports cases where request parameters or body properties might be missing in the invocation arguments.
- In `openapi_functions.py`, the parsing logic for OpenAPI specifications has been updated to:
  - Support more specific requirements for paths, including unique operationIds, descriptions, requestBody, parameters, and schemas.
  - Improve parameter handling by merging request body properties and parameters, maintaining the correct schema definitions and required fields.
- In `test_openapi_service.py`, new tests have been added to ensure proper handling of mix-params, request body, and complex types.
- A new complex `complex_types_openapi_service.json` file has been added to `test/test_files/json/` to test complex type handling.

### How can it be used:

- Developers building connectors can now rely on improved support for complex types and request bodies, enabling them to work with more OpenAPI specifications with better compatibility.
- Testers can use the provided test cases as examples of how to test similar scenarios in their projects.

Example usage:

```python
from haystack.components.connectors import OpenAPIServiceConnector

# Initialize OpenAPIServiceConnector
connector = OpenAPIServiceConnector()

# Load the complex types OpenAPI spec from file
spec_path = Path("test/test_files/json/complex_types_openapi_service.json")
with open(spec_path, "r") as file:
    spec = json.load(file)

# Process a payment through the OpenAPI connector
response = connector.run(
    messages="[{\"id\": \"call_NJr1NBz2Th7iUWJpRIJZoJIA\", \"function\": {\"name\": \"processPayment\", \"arguments\": \"{\\"parameters\\": {\\"transaction_amount\\": 150.75, \\"description\\": \\"Monthly subscription fee\\", \\"payment_method_id\\": \\"visa_ending_in_1234\\", \\"payer\\": {\\"name\\": \\"Alex Smith\\", \\"email\\": \\"alex.smith@example.com\\", \\"identification\\": {\\"type\\": \\"Driver's License\\", \\"number\\": \\"D12345678\\"}}}}\", \"type\": \"function\"}]"
)[0].content

assert response == '{"result": "accepted"}'
```

### How did you test it:

- Added two new test cases in `test_openapi_service.py`:
  - A test for a connector using a service with mix-params and request body.
  - A test for converting a complex types OpenAPI specification using the `OpenAPIServiceToFunctions()` class.
- Added a new complex OpenAPI specification file (`complex_types_openapi_service.json`) to ensure proper handling of complex types (e.g., nested objects).

### Notes for the reviewer:

- Pay attention to changes in `openapi_service.py` and `openapi_functions.py`, specifically to the new conditional blocks that handle cases where request parameters or body properties might be missing.
- The new test cases are designed to cover the enhanced functionality; please ensure that all tests pass.
- The new complex OpenAPI specification (`complex_types_openapi_service.json`) represents the kind of more complex cases that the connector should be able to process correctly.
- These changes should have minimal impact on other parts of the codebase, as they mainly improve the OpenAPI service connector's functionality.