### PR TITLE
chore: forward-reference opentelemetry

### DIFF
--- a/haystack/tracing/opentelemetry.py
+++ b/haystack/tracing/opentelemetry.py
@@ -12,7 +12,7 @@ with LazyImport("Run 'pip install opentelemetry-sdk'") as opentelemetry_import:
 
 
 class OpenTelemetrySpan(Span):
-    def __init__(self, span: opentelemetry.trace.Span) -> None:
+    def __init__(self, span: "opentelemetry.trace.Span") -> None:
         self._span = span
 
     def set_tag(self, key: str, value: Any) -> None:
@@ -24,7 +24,7 @@ class OpenTelemetrySpan(Span):
 
 
 class OpenTelemetryTracer(Tracer):
-    def __init__(self, tracer: opentelemetry.trace.Tracer) -> None:
+    def __init__(self, tracer: "opentelemetry.trace.Tracer") -> None:
         opentelemetry_import.check()
         self._tracer = tracer
 


### PR DESCRIPTION
### Related Issues

Getting
```
  File "/opt/venv/lib/python3.10/site-packages/haystack/tracing/opentelemetry.py", line 15, in OpenTelemetrySpan
    def __init__(self, span: opentelemetry.trace.Span) -> None:
NameError: name 'opentelemetry' is not defined
```

when importing Haystack from `main`

### Proposed Changes:

Since `opentelemetry` is an optional dependency, use [forward references](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#forward-references) in the type annotations.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
