### PR TITLE
Export (de)serialize_callable and (de)serialize_type in haystack.utils

### DIFF
--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -6,8 +6,8 @@ from jinja2.nativetypes import NativeEnvironment
 from typing_extensions import TypeAlias
 
 from haystack import component, default_to_dict, default_from_dict
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
-from haystack.utils.type_serialization import serialize_type, deserialize_type
+from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import serialize_type, deserialize_type
 
 
 class OutputAdaptationException(Exception):

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -6,8 +6,7 @@ from jinja2.nativetypes import NativeEnvironment
 from typing_extensions import TypeAlias
 
 from haystack import component, default_to_dict, default_from_dict
-from haystack.utils import serialize_callable, deserialize_callable
-from haystack.utils import serialize_type, deserialize_type
+from haystack.utils import serialize_callable, deserialize_callable, serialize_type, deserialize_type
 
 
 class OutputAdaptationException(Exception):

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -9,7 +9,7 @@ from haystack import default_to_dict, default_from_dict
 from haystack.components.generators import OpenAIGenerator
 from haystack.dataclasses import StreamingChunk
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -8,8 +8,7 @@ from openai.lib.azure import AzureOpenAI
 from haystack import default_to_dict, default_from_dict
 from haystack.components.generators import OpenAIGenerator
 from haystack.dataclasses import StreamingChunk
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import Secret, deserialize_secrets_inplace, serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -9,7 +9,7 @@ from haystack import default_to_dict, default_from_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingChunk
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -8,8 +8,7 @@ from openai.lib.azure import AzureOpenAI
 from haystack import default_to_dict, default_from_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingChunk
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import Secret, deserialize_secrets_inplace, serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -7,7 +7,7 @@ from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -6,8 +6,7 @@ from haystack import component, default_to_dict, default_from_dict
 from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import Secret, deserialize_secrets_inplace, serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -7,7 +7,7 @@ from haystack import component, default_to_dict, default_from_dict
 from haystack.dataclasses import ChatMessage, StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 from haystack.utils.hf import check_valid_model, HFModelType, check_generation_params, list_inference_deployed_models
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -12,8 +12,7 @@ from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import StreamingChunk, ChatMessage
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import Secret, deserialize_secrets_inplace, serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -13,7 +13,7 @@ from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import StreamingChunk, ChatMessage
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -6,8 +6,7 @@ from urllib.parse import urlparse
 from haystack import component, default_to_dict, default_from_dict
 from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
-from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils import serialize_callable, deserialize_callable
+from haystack.utils import Secret, deserialize_secrets_inplace, serialize_callable, deserialize_callable
 from haystack.utils.hf import check_valid_model, HFModelType, check_generation_params, list_inference_deployed_models
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -7,7 +7,7 @@ from haystack import component, default_to_dict, default_from_dict
 from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 from haystack.utils.hf import check_valid_model, HFModelType, check_generation_params, list_inference_deployed_models
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -9,7 +9,7 @@ from openai.types.chat import ChatCompletionChunk, ChatCompletion
 from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import StreamingChunk, ChatMessage
 from haystack.utils import Secret, deserialize_secrets_inplace
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -1,7 +1,7 @@
 from typing import Optional, Callable
 
 from haystack.dataclasses import StreamingChunk
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 
 def print_streaming_chunk(chunk: StreamingChunk) -> None:

--- a/haystack/components/others/multiplexer.py
+++ b/haystack/components/others/multiplexer.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.core.component.types import Variadic
-from haystack.utils.type_serialization import deserialize_type, serialize_type
+from haystack.utils import deserialize_type, serialize_type
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias

--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -5,7 +5,7 @@ from jinja2 import meta, Environment, TemplateSyntaxError
 from jinja2.nativetypes import NativeEnvironment
 
 from haystack import component, default_from_dict, default_to_dict
-from haystack.utils.type_serialization import serialize_type, deserialize_type
+from haystack.utils import serialize_type, deserialize_type
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -4,6 +4,8 @@ from .expit import expit
 from .filters import document_matches_filter
 from .jupyter import is_in_jupyter
 from .requests_utils import request_with_retry
+from .callable_serialization import serialize_callable, deserialize_callable
+from .type_serialization import serialize_type, deserialize_type
 
 __all__ = [
     "Secret",
@@ -16,4 +18,8 @@ __all__ = [
     "document_matches_filter",
     "is_in_jupyter",
     "request_with_retry",
+    "serialize_callable",
+    "deserialize_callable",
+    "serialize_type",
+    "deserialize_type",
 ]

--- a/test/utils/test_callable_serialization.py
+++ b/test/utils/test_callable_serialization.py
@@ -1,7 +1,7 @@
 import requests
 
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.utils.callable_serialization import serialize_callable, deserialize_callable
+from haystack.utils import serialize_callable, deserialize_callable
 
 
 def some_random_callable_for_testing(some_ignored_arg: str):


### PR DESCRIPTION
### Why:

We have multiple imports of serialization utilities, such as `(de)serialize_callable` and `(de)serialize_type`, scattered across various modules. This change aims to consolidate these imports into a single location, the `haystack.utils` module. This refactoring enhances code readability, simplifies maintenance, and promotes best practices by reducing duplicated imports.

### What:

* Unified import of `serialize_callable` and `deserialize_callable` in `haystack.utils`.
* Unified import of `serialize_type` and `deserialize_type` in `haystack.utils`.
* The original module export locations were left unchanges to minimize the disruption in dependencies. Dependencies like https://github.com/deepset-ai/haystack-core-integrations can update references at their own pace


### How can it be used:

* Cleaner and more consistent imports for serialization utilities, improving code readability and maintainability.
* Reduced complexity when modifying serialization functionality, as changes only need to be applied in the `haystack.utils` module.

### How did you test it:

- Manual review of modified files to ensure proper import syntax, functionality preservation, and redundancy removal.
- CI run

### Notes for the reviewer:

* Do a manual search as well please and make sure no usages were omitted 