### PR TITLE
feat: Add `AnswerF1Evaluator`

### DIFF
--- a/haystack/components/evaluators/answer_f1.py
+++ b/haystack/components/evaluators/answer_f1.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List
+
+from haystack import default_from_dict, default_to_dict
+from haystack.core.component import component
+
+
+@component
+class AnswerF1Evaluator:
+    """
+    Evaluator that calculates the F1 score of the matches between the predicted and the ground truth answers.
+    We first calculate the F1 score for each question, sum all the scores and divide by the number of questions.
+    The result is a number from 0.0 to 1.0.
+
+    Each question can have multiple ground truth answers and multiple predicted answers.
+    """
+
+    def to_dict(self) -> Dict[str, Any]:
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AnswerF1Evaluator":
+        return default_from_dict(cls, data)
+
+    @component.output_types(result=float)
+    def run(
+        self, questions: List[str], ground_truth_answers: List[List[str]], predicted_answers: List[List[str]]
+    ) -> Dict[str, float]:
+        """
+        Run the AnswerF1Evaluator on the given inputs.
+        All lists must have the same length.
+
+        :param questions: A list of questions.
+        :param ground_truth_answers: A list of expected answers for each question.
+        :param predicted_answers: A list of predicted answers for each question.
+        :returns: A dictionary with the following outputs:
+                * `result` - A number from 0.0 to 1.0 that represents the average F1 score of the predicted
+                answer matched with the ground truth answers.
+        """
+        if not len(questions) == len(ground_truth_answers) == len(predicted_answers):
+            raise ValueError("The length of questions, ground_truth_answers, and predicted_answers must be the same.")
+
+        scores = []
+        for truths, predicted in zip(ground_truth_answers, predicted_answers):
+            if len(truths) == 0 and len(predicted) == 0:
+                scores.append(1.0)
+                continue
+
+            matches = len(set(truths) & set(predicted))
+            precision = matches / len(predicted)
+            recall = matches / len(truths)
+            if (tp := precision + recall) > 0:
+                f1 = 2 * (precision * recall) / tp
+            else:
+                f1 = 0.0
+            scores.append(f1)
+
+        result = sum(scores) / len(questions)
+
+        return {"result": result}

--- a/releasenotes/notes/f1-evaluator-87ef95d6a92ed839.yaml
+++ b/releasenotes/notes/f1-evaluator-87ef95d6a92ed839.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add `AnswerF1Evaluator`, a Component that can be used to calculate the F1 score metric
+    given a list of questions, a list of expected answers for each question and the list of predicted
+    answers for each question.

--- a/test/components/evaluators/test_answer_f1.py
+++ b/test/components/evaluators/test_answer_f1.py
@@ -1,0 +1,61 @@
+import pytest
+
+from haystack.components.evaluators.answer_f1 import AnswerF1Evaluator
+
+
+def test_run_with_all_matching():
+    evaluator = AnswerF1Evaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["Paris"]],
+    )
+
+    assert result["result"] == 1.0
+
+
+def test_run_with_no_matching():
+    evaluator = AnswerF1Evaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Paris"], ["London"]],
+    )
+
+    assert result["result"] == 0.0
+
+
+def test_run_with_partial_matching():
+    evaluator = AnswerF1Evaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["London"]],
+    )
+
+    assert result["result"] == 0.5
+
+
+def test_run_with_different_lengths():
+    evaluator = AnswerF1Evaluator()
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?"],
+            ground_truth_answers=[["Berlin"], ["Paris"]],
+            predicted_answers=[["Berlin"], ["London"]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_answers=[["Berlin"]],
+            predicted_answers=[["Berlin"], ["London"]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_answers=[["Berlin"], ["Paris"]],
+            predicted_answers=[["Berlin"]],
+        )


### PR DESCRIPTION
### Related Issues

- fixes #6068

### Proposed Changes:

Add `AnswerF1Evaluator`, a Component that can be used to calculate the F1 score metric given a list of questions, a list of expected answers for each question and the list of predicted answers for each question.

### How did you test it?

Added unit tests.

### Notes for the reviewer

I didn't add the component in the package `__ini__.py` on purpose to avoid conflicts with future PRs. 
When all the evaluators are done I'll update it.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
