### PR TITLE
chore: Update API docs to include OutputAdapter, OpenAPIServiceConnector,  and OpenAPIServiceToFunctions

### DIFF
--- a/docs/pydoc/config/connectors.yml
+++ b/docs/pydoc/config/connectors.yml
@@ -1,7 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack/components/converters]
-    modules: ["azure", "html", "markdown", "pypdf", "tika", "txt", "output_adapter", "openapi_functions"]
+    search_path: [../../../haystack/components/connectors]
+    modules: ["openapi_service"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -13,14 +13,14 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
-  excerpt: Various converters to transform data from one format to another.
+  excerpt: Various connectors to integrate with external services.
   category_slug: haystack-api
-  title: Converters
-  slug: converters-api
-  order: 20
+  title: Connectors
+  slug: connectors-api
+  order: 15
   markdown:
     descriptive_class_title: false
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: converters_api.md
+    filename: connectors_api.md


### PR DESCRIPTION
We forgot to include these in the API docs. Update the heading for converters to be more generic and reflect the addition of OutputAdapter and OpenAPIServiceToFunctions converters. 