### PR TITLE
fix: restore transparent background for Pipeline images

### DIFF
--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -70,7 +70,7 @@ def _to_mermaid_image(graph: networkx.MultiDiGraph):
     graphbytes = graph_styled.encode("ascii")
     base64_bytes = base64.b64encode(graphbytes)
     base64_string = base64_bytes.decode("ascii")
-    url = "https://mermaid.ink/img/" + base64_string
+    url = f"https://mermaid.ink/img/{base64_string}?type=png"
 
     logging.debug("Rendeding graph at %s", url)
     try:

--- a/releasenotes/notes/pipe-draw-transparent-bg-2e0c8ff586f8e70c.yaml
+++ b/releasenotes/notes/pipe-draw-transparent-bg-2e0c8ff586f8e70c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Restore transparent background for images generated with Pipeline.draw and Pipeline.show


### PR DESCRIPTION
### Related Issues

- fixes #7085

### Proposed Changes:
Simply force the image to be a PNG:
this makes the background transparent (https://github.com/jihchi/mermaid.ink/issues/130).

### How did you test it?
- CI
- [Manual test on Colab](https://colab.research.google.com/drive/1K3qzGvPcAJCyVWFDQzzi54D6ryOZrsZd?usp=sharing)
- Manual test on VSCode

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
