### PR TITLE
feat: Add `DiversityRanker`

### DIFF
--- a/haystack/components/rankers/__init__.py
+++ b/haystack/components/rankers/__init__.py
@@ -1,5 +1,6 @@
+from haystack.components.rankers.diversity import DiversityRanker
 from haystack.components.rankers.lost_in_the_middle import LostInTheMiddleRanker
 from haystack.components.rankers.meta_field import MetaFieldRanker
 from haystack.components.rankers.transformers_similarity import TransformersSimilarityRanker
 
-__all__ = ["LostInTheMiddleRanker", "MetaFieldRanker", "TransformersSimilarityRanker"]
+__all__ = ["DiversityRanker", "LostInTheMiddleRanker", "MetaFieldRanker", "TransformersSimilarityRanker"]

--- a/haystack/components/rankers/diversity.py
+++ b/haystack/components/rankers/diversity.py
@@ -1,0 +1,215 @@
+import logging
+from typing import Any, Dict, List, Literal, Optional
+
+from haystack import ComponentError, Document, component, default_from_dict, default_to_dict
+from haystack.lazy_imports import LazyImport
+from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
+
+logger = logging.getLogger(__name__)
+
+
+with LazyImport(message="Run 'pip install \"sentence-transformers>=2.2.0\"'") as torch_and_transformers_import:
+    import torch
+    from sentence_transformers import SentenceTransformer
+
+
+@component
+class DiversityRanker:
+    """
+    Implements a document ranking algorithm that orders documents in such a way as to maximize the overall diversity
+    of the documents.
+    It uses a pre-trained Sentence Transformers model to embed the query and the Documents.
+
+    Usage example:
+    ```python
+    from haystack import Document
+    from haystack.components.rankers import DiversityRanker
+
+    ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity="cosine")
+    docs = [Document(content="Paris"), Document(content="Berlin")]
+    query = "What is the capital of germany?"
+    output = ranker.run(query=query, documents=docs)
+    docs = output["documents"]
+    assert len(docs) == 2
+    assert docs[0].content == "Paris"
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        top_k: int = 10,
+        device: Optional[ComponentDevice] = None,
+        token: Optional[Secret] = Secret.from_env_var("HF_API_TOKEN", strict=False),
+        similarity: Literal["dot_product", "cosine"] = "dot_product",
+        prefix: str = "",
+        suffix: str = "",
+        meta_fields_to_embed: Optional[List[str]] = None,
+        embedding_separator: str = "\n",
+    ):
+        """
+        Initialize a DiversityRanker.
+
+        :param model: Local path or name of the model in Hugging Face's model hub,
+            such as `'sentence-transformers/all-MiniLM-L6-v2'`.
+        :param top_k: The maximum number of Documents to return per query.
+        :param device: The device on which the model is loaded. If `None`, the default device is automatically
+            selected.
+        :param token: The API token used to download private models from Hugging Face.
+        :param similarity: Similarity metric for comparing embeddings. Can be set to "dot_product" (default) or
+            "cosine".
+        :param prefix: A string to add to the beginning of each Document text before embedding.
+            Can be used to prepend the text with an instruction, as required by some embedding models,
+            such as E5 and bge.
+        :param suffix: A string to add to the end of each Document text before embedding.
+        :param meta_fields_to_embed: List of meta fields that should be embedded along with the Document content.
+        :param embedding_separator: Separator used to concatenate the meta fields to the Document content.
+        """
+        torch_and_transformers_import.check()
+
+        self.model_name_or_path = model
+        if top_k is None or top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+        self.top_k = top_k
+        self.device = ComponentDevice.resolve_device(device)
+        self.token = token
+        self.model = None
+        if similarity not in ["dot_product", "cosine"]:
+            raise ValueError(f"Similarity must be one of 'dot_product' or 'cosine', but got {similarity}.")
+        self.similarity = similarity
+        self.prefix = prefix
+        self.suffix = suffix
+        self.meta_fields_to_embed = meta_fields_to_embed or []
+        self.embedding_separator = embedding_separator
+
+    def warm_up(self):
+        """
+        Warm up the model used for scoring the Documents.
+        """
+        if self.model is None:
+            self.model = SentenceTransformer(
+                model_name_or_path=self.model_name_or_path,
+                device=self.device.to_torch_str(),
+                use_auth_token=self.token.resolve_value() if self.token else None,
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+        """
+        return default_to_dict(
+            self,
+            model=self.model_name_or_path,
+            device=self.device.to_dict(),
+            token=self.token.to_dict() if self.token else None,
+            top_k=self.top_k,
+            similarity=self.similarity,
+            prefix=self.prefix,
+            suffix=self.suffix,
+            meta_fields_to_embed=self.meta_fields_to_embed,
+            embedding_separator=self.embedding_separator,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DiversityRanker":
+        """
+        Deserialize this component from a dictionary.
+        """
+        serialized_device = data["init_parameters"]["device"]
+        data["init_parameters"]["device"] = ComponentDevice.from_dict(serialized_device)
+
+        deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
+        return default_from_dict(cls, data)
+
+    def _greedy_diversity_order(self, query: str, documents: List[Document]) -> List[Document]:
+        """
+        Orders the given list of documents to maximize diversity.
+
+        The algorithm first calculates embeddings for each document and the query. It starts by selecting the document
+        that is semantically closest to the query. Then, for each remaining document, it selects the one that, on
+        average, is least similar to the already selected documents. This process continues until all documents are
+        selected, resulting in a list where each subsequent document contributes the most to the overall diversity of
+        the selected set.
+
+        :param query: The search query.
+        :param documents: The list of Document objects to be ranked.
+
+        :return: A list of documents ordered to maximize diversity.
+        """
+
+        texts_to_embed = []
+        for doc in documents:
+            meta_values_to_embed = [
+                str(doc.meta[key]) for key in self.meta_fields_to_embed if key in doc.meta and doc.meta[key]
+            ]
+            text_to_embed = (
+                self.prefix + self.embedding_separator.join(meta_values_to_embed + [doc.content or ""]) + self.suffix
+            )
+            texts_to_embed.append(text_to_embed)
+
+        # Calculate embeddings
+        doc_embeddings = self.model.encode(texts_to_embed, convert_to_tensor=True)  # type: ignore[attr-defined]
+        query_embedding = self.model.encode([query], convert_to_tensor=True)  # type: ignore[attr-defined]
+
+        # Normalize embeddings to unit length for computing cosine similarity
+        if self.similarity == "cosine":
+            doc_embeddings /= torch.norm(doc_embeddings, p=2, dim=-1).unsqueeze(-1)
+            query_embedding /= torch.norm(query_embedding, p=2, dim=-1).unsqueeze(-1)
+
+        n = len(documents)
+        selected: List[int] = []
+
+        # Compute the similarity vector between the query and documents
+        query_doc_sim = query_embedding @ doc_embeddings.T
+
+        # Start with the document with the highest similarity to the query
+        selected.append(int(torch.argmax(query_doc_sim).item()))
+
+        selected_sum = doc_embeddings[selected[0]] / n
+
+        while len(selected) < n:
+            # Compute mean of dot products of all selected documents and all other documents
+            similarities = selected_sum @ doc_embeddings.T
+            # Mask documents that are already selected
+            similarities[selected] = torch.inf
+            # Select the document with the lowest total similarity score
+            index_unselected = int(torch.argmin(similarities).item())
+            selected.append(index_unselected)
+            # It's enough just to add to the selected vectors because dot product is distributive
+            # It's divided by n for numerical stability
+            selected_sum += doc_embeddings[index_unselected] / n
+
+        ranked_docs: List[Document] = [documents[i] for i in selected]
+
+        return ranked_docs
+
+    @component.output_types(documents=List[Document])
+    def run(self, query: str, documents: List[Document], top_k: Optional[int] = None):
+        """
+        Rank the documents based on their diversity and return the top_k documents.
+
+        :param query: The query.
+        :param documents: A list of Document objects that should be ranked.
+        :param top_k: The maximum number of documents to return.
+
+        :return: A list of top_k documents ranked based on diversity.
+        """
+        if query is None or len(query) == 0:
+            raise ValueError("Query is empty")
+
+        if not documents:
+            return {"documents": []}
+
+        if top_k is None:
+            top_k = self.top_k
+        elif top_k <= 0:
+            raise ValueError(f"top_k must be > 0, but got {top_k}")
+
+        if self.model is None:
+            raise ComponentError(
+                f"The component {self.__class__.__name__} wasn't warmed up. Run 'warm_up()' before calling 'run()'."
+            )
+
+        diversity_sorted = self._greedy_diversity_order(query=query, documents=documents)
+
+        return {"documents": diversity_sorted[:top_k]}

--- a/releasenotes/notes/add-diversity-ranker-6ecee21134eda673.yaml
+++ b/releasenotes/notes/add-diversity-ranker-6ecee21134eda673.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add `DiversityRanker`. Diversity Ranker orders documents in such a way as to maximize the overall diversity of the given documents. The ranker leverages sentence-transformer models to calculate semantic embeddings for each document and the query.

--- a/test/components/rankers/test_diversity.py
+++ b/test/components/rankers/test_diversity.py
@@ -1,0 +1,344 @@
+import pytest
+
+from haystack import ComponentError, Document
+from haystack.components.rankers import DiversityRanker
+from haystack.utils import ComponentDevice
+from haystack.utils.auth import Secret
+
+
+class TestDiversityRanker:
+    def test_init(self):
+        component = DiversityRanker()
+        assert component.model_name_or_path == "sentence-transformers/all-MiniLM-L6-v2"
+        assert component.top_k == 10
+        assert component.device == ComponentDevice.resolve_device(None)
+        assert component.similarity == "dot_product"
+        assert component.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert component.prefix == ""
+        assert component.suffix == ""
+        assert component.meta_fields_to_embed == []
+        assert component.embedding_separator == "\n"
+
+    def test_init_with_custom_init_parameters(self):
+        component = DiversityRanker(
+            model="sentence-transformers/msmarco-distilbert-base-v4",
+            top_k=5,
+            device=ComponentDevice.from_str("cuda:0"),
+            token=Secret.from_token("fake-api-token"),
+            similarity="cosine",
+            prefix="query:",
+            suffix="document:",
+            meta_fields_to_embed=["meta_field"],
+            embedding_separator="--",
+        )
+        assert component.model_name_or_path == "sentence-transformers/msmarco-distilbert-base-v4"
+        assert component.top_k == 5
+        assert component.device == ComponentDevice.from_str("cuda:0")
+        assert component.similarity == "cosine"
+        assert component.token == Secret.from_token("fake-api-token")
+        assert component.prefix == "query:"
+        assert component.suffix == "document:"
+        assert component.meta_fields_to_embed == ["meta_field"]
+        assert component.embedding_separator == "--"
+
+    def test_to_and_from_dict(self):
+        component = DiversityRanker()
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack.components.rankers.diversity.DiversityRanker",
+            "init_parameters": {
+                "model": "sentence-transformers/all-MiniLM-L6-v2",
+                "top_k": 10,
+                "device": ComponentDevice.resolve_device(None).to_dict(),
+                "similarity": "dot_product",
+                "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
+                "prefix": "",
+                "suffix": "",
+                "meta_fields_to_embed": [],
+                "embedding_separator": "\n",
+            },
+        }
+
+        ranker = DiversityRanker.from_dict(data)
+
+        assert ranker.model_name_or_path == "sentence-transformers/all-MiniLM-L6-v2"
+        assert ranker.top_k == 10
+        assert ranker.device == ComponentDevice.resolve_device(None)
+        assert ranker.similarity == "dot_product"
+        assert ranker.token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+        assert ranker.prefix == ""
+        assert ranker.suffix == ""
+        assert ranker.meta_fields_to_embed == []
+        assert ranker.embedding_separator == "\n"
+
+    def test_to_and_from_dict_with_custom_init_parameters(self):
+        component = DiversityRanker(
+            model="sentence-transformers/msmarco-distilbert-base-v4",
+            top_k=5,
+            device=ComponentDevice.from_str("cuda:0"),
+            token=Secret.from_env_var("ENV_VAR", strict=False),
+            similarity="cosine",
+            prefix="query:",
+            suffix="document:",
+            meta_fields_to_embed=["meta_field"],
+            embedding_separator="--",
+        )
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack.components.rankers.diversity.DiversityRanker",
+            "init_parameters": {
+                "model": "sentence-transformers/msmarco-distilbert-base-v4",
+                "top_k": 5,
+                "device": ComponentDevice.from_str("cuda:0").to_dict(),
+                "token": {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"},
+                "similarity": "cosine",
+                "prefix": "query:",
+                "suffix": "document:",
+                "meta_fields_to_embed": ["meta_field"],
+                "embedding_separator": "--",
+            },
+        }
+
+        ranker = DiversityRanker.from_dict(data)
+
+        assert ranker.model_name_or_path == "sentence-transformers/msmarco-distilbert-base-v4"
+        assert ranker.top_k == 5
+        assert ranker.device == ComponentDevice.from_str("cuda:0")
+        assert ranker.similarity == "cosine"
+        assert ranker.token == Secret.from_env_var("ENV_VAR", strict=False)
+        assert ranker.prefix == "query:"
+        assert ranker.suffix == "document:"
+        assert ranker.meta_fields_to_embed == ["meta_field"]
+        assert ranker.embedding_separator == "--"
+
+    def test_run_incorrect_similarity(self):
+        """
+        Tests that run method raises ValueError if similarity is incorrect
+        """
+        with pytest.raises(ValueError):
+            DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity="incorrect")
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_without_warm_up(self, similarity):
+        """
+        Tests that run method raises ComponentError if model is not warmed up
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", top_k=1, similarity=similarity)
+        documents = [Document(content="doc1"), Document(content="doc2")]
+
+        with pytest.raises(ComponentError):
+            ranker.run(query="test query", documents=documents)
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_empty_query(self, similarity):
+        """
+        Test that run method raises ValueError if query is empty or None.
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", top_k=3, similarity=similarity)
+        ranker.warm_up()
+        documents = [Document(content="doc1"), Document(content="doc2")]
+
+        with pytest.raises(ValueError):
+            ranker.run(query="", documents=documents)
+
+        with pytest.raises(ValueError):
+            ranker.run(query=None, documents=documents)
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_top_k(self, similarity):
+        """
+        Test that run method returns the correct number of documents for different top_k values passed at
+        initialization and runtime.
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, top_k=3)
+        ranker.warm_up()
+        query = "test query"
+        documents = [
+            Document(content="doc1"),
+            Document(content="doc2"),
+            Document(content="doc3"),
+            Document(content="doc4"),
+        ]
+
+        result = ranker.run(query=query, documents=documents)
+        ranked_docs = result["documents"]
+
+        assert isinstance(ranked_docs, list)
+        assert len(ranked_docs) == 3
+        assert all(isinstance(doc, Document) for doc in ranked_docs)
+
+        # Passing a different top_k at runtime
+        result = ranker.run(query=query, documents=documents, top_k=2)
+        ranked_docs = result["documents"]
+
+        assert isinstance(ranked_docs, list)
+        assert len(ranked_docs) == 2
+        assert all(isinstance(doc, Document) for doc in ranked_docs)
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_diversity_ranker_negative_top_k(self, similarity):
+        """
+        Tests that run method raises an error for negative top-k.
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, top_k=10)
+        ranker.warm_up()
+        query = "test"
+        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+
+        # Setting top_k at runtime
+        with pytest.raises(ValueError):
+            ranker.run(query=query, documents=documents, top_k=-5)
+
+        # Setting top_k at init
+        with pytest.raises(ValueError):
+            DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, top_k=-5)
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_diversity_ranker_top_k_is_none(self, similarity):
+        """
+        Tests that run method returns the correct order of documents for top-k set to None.
+        """
+        # Setting top_k to None at init should raise error
+        with pytest.raises(ValueError):
+            DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, top_k=None)
+
+        # Setting top_k to None is ignored during runtime, it should use top_k set at init.
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, top_k=2)
+        ranker.warm_up()
+        query = "test"
+        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+        result = ranker.run(query=query, documents=documents, top_k=None)
+
+        assert len(result["documents"]) == 2
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_with_less_documents_than_top_k(self, similarity):
+        """
+        Tests that run method returns the correct number of documents for top_k values greater than number of documents.
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity, top_k=5)
+        ranker.warm_up()
+        query = "test"
+        documents = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+        result = ranker.run(query=query, documents=documents)
+
+        assert len(result["documents"]) == 3
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_single_document_corner_case(self, similarity):
+        """
+        Tests that run method returns the correct number of documents for a single document
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity)
+        ranker.warm_up()
+        query = "test"
+        documents = [Document(content="doc1")]
+        result = ranker.run(query=query, documents=documents)
+
+        assert len(result["documents"]) == 1
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_no_documents_provided(self, similarity):
+        """
+        Test that run method returns an empty list if no documents are supplied.
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity)
+        ranker.warm_up()
+        query = "test query"
+        documents = []
+        results = ranker.run(query=query, documents=documents)
+
+        assert len(results["documents"]) == 0
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run(self, similarity):
+        """
+        Tests that run method returns documents in the correct order
+        """
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity)
+        ranker.warm_up()
+        query = "city"
+        documents = [
+            Document(content="France"),
+            Document(content="Germany"),
+            Document(content="Eiffel Tower"),
+            Document(content="Berlin"),
+            Document(content="Bananas"),
+            Document(content="Silicon Valley"),
+            Document(content="Brandenburg Gate"),
+        ]
+        result = ranker.run(query=query, documents=documents)
+        ranked_docs = result["documents"]
+        ranked_order = ", ".join([doc.content for doc in ranked_docs])
+        expected_order = "Berlin, Bananas, Eiffel Tower, Silicon Valley, France, Brandenburg Gate, Germany"
+
+        assert ranked_order == expected_order
+
+    @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])
+    def test_run_real_world_use_case(self, similarity):
+        ranker = DiversityRanker(model="sentence-transformers/all-MiniLM-L6-v2", similarity=similarity)
+        ranker.warm_up()
+        query = "What are the reasons for long-standing animosities between Russia and Poland?"
+
+        doc1 = Document(
+            "One of the earliest known events in Russian-Polish history dates back to 981, when the Grand Prince of Kiev , "
+            "Vladimir Svyatoslavich , seized the Cherven Cities from the Duchy of Poland . The relationship between two by "
+            "that time was mostly close and cordial, as there had been no serious wars between both. In 966, Poland "
+            "accepted Christianity from Rome while Kievan Rus' —the ancestor of Russia, Ukraine and Belarus—was "
+            "Christianized by Constantinople. In 1054, the internal Christian divide formally split the Church into "
+            "the Catholic and Orthodox branches separating the Poles from the Eastern Slavs."
+        )
+        doc2 = Document(
+            "Since the fall of the Soviet Union , with Lithuania , Ukraine and Belarus regaining independence, the "
+            "Polish Russian border has mostly been replaced by borders with the respective countries, but there still "
+            "is a 210 km long border between Poland and the Kaliningrad Oblast"
+        )
+        doc3 = Document(
+            "As part of Poland's plans to become fully energy independent from Russia within the next years, Piotr "
+            "Wozniak, president of state-controlled oil and gas company PGNiG , stated in February 2019: 'The strategy of "
+            "the company is just to forget about Eastern suppliers and especially about Gazprom .'[53] In 2020, the "
+            "Stockholm Arbitrary Tribunal ruled that PGNiG's long-term contract gas price with Gazprom linked to oil prices "
+            "should be changed to approximate the Western European gas market price, backdated to 1 November 2014 when "
+            "PGNiG requested a price review under the contract. Gazprom had to refund about $1.5 billion to PGNiG."
+        )
+        doc4 = Document(
+            "Both Poland and Russia had accused each other for their historical revisionism . Russia has repeatedly "
+            "accused Poland for not honoring Soviet Red Army soldiers fallen in World War II for Poland, notably in "
+            "2017, in which Poland was thought on 'attempting to impose its own version of history' after Moscow was "
+            "not allowed to join an international effort to renovate a World War II museum at Sobibór , site of a "
+            "notorious Sobibor extermination camp."
+        )
+        doc5 = Document(
+            "President of Russia Vladimir Putin and Prime Minister of Poland Leszek Miller in 2002 Modern Polish Russian "
+            "relations begin with the fall of communism in1989 in Poland ( Solidarity and the Polish Round Table "
+            "Agreement ) and 1991 in Russia ( dissolution of the Soviet Union ). With a new democratic government after "
+            "the 1989 elections , Poland regained full sovereignty, [2] and what was the Soviet Union, became 15 newly "
+            "independent states , including the Russian Federation . Relations between modern Poland and Russia suffer "
+            "from constant ups and downs."
+        )
+        doc6 = Document(
+            "Soviet influence in Poland finally ended with the Round Table Agreement of 1989 guaranteeing free elections "
+            "in Poland, the Revolutions of 1989 against Soviet-sponsored Communist governments in the Eastern Block , and "
+            "finally the formal dissolution of the Warsaw Pact."
+        )
+        doc7 = Document(
+            "Dmitry Medvedev and then Polish Prime Minister Donald Tusk , 6 December 2010 BBC News reported that one of "
+            "the main effects of the 2010 Polish Air Force Tu-154 crash would be the impact it has on Russian-Polish "
+            "relations. [38] It was thought if the inquiry into the crash were not transparent, it would increase "
+            "suspicions toward Russia in Poland."
+        )
+        doc8 = Document(
+            "Soviet control over the Polish People's Republic lessened after Stalin's death and Gomulka's Thaw , and "
+            "ceased completely after the fall of the communist government in Poland in late 1989, although the "
+            "Soviet-Russian Northern Group of Forces did not leave Polish soil until 1993. The continuing Soviet military "
+            "presence allowed the Soviet Union to heavily influence Polish politics."
+        )
+
+        documents = [doc1, doc2, doc3, doc4, doc5, doc6, doc7, doc8]
+        result = ranker.run(query=query, documents=documents)
+        expected_order = [doc5, doc7, doc3, doc1, doc4, doc2, doc6, doc8]
+        expected_content = " ".join([doc.content or "" for doc in expected_order])
+        result_content = " ".join([doc.content or "" for doc in result["documents"]])
+
+        # Check the order of ranked documents by comparing the content of the ranked documents
+        assert result_content == expected_content


### PR DESCRIPTION
### Related Issues

- fixes #7094 

### Proposed Changes:

Adds `DiversityRanker`.

Diversity Ranker orders documents in such a way as to maximize the overall diversity of the given documents. The ranker leverages sentence-transformer models to calculate semantic embeddings for each document and the query.

### How did you test it?

Tests have been added in `test_diversity.py`.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
