### PR TITLE
chore: Remove deprecated GPTGenerator and GPTChatGenerator

### DIFF
--- a/haystack/components/generators/__init__.py
+++ b/haystack/components/generators/__init__.py
@@ -1,12 +1,6 @@
 from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator
 from haystack.components.generators.hugging_face_tgi import HuggingFaceTGIGenerator
-from haystack.components.generators.openai import OpenAIGenerator, GPTGenerator
+from haystack.components.generators.openai import OpenAIGenerator
 from haystack.components.generators.azure import AzureOpenAIGenerator
 
-__all__ = [
-    "HuggingFaceLocalGenerator",
-    "HuggingFaceTGIGenerator",
-    "OpenAIGenerator",
-    "GPTGenerator",
-    "AzureOpenAIGenerator",
-]
+__all__ = ["HuggingFaceLocalGenerator", "HuggingFaceTGIGenerator", "OpenAIGenerator", "AzureOpenAIGenerator"]

--- a/haystack/components/generators/chat/__init__.py
+++ b/haystack/components/generators/chat/__init__.py
@@ -1,6 +1,6 @@
 from haystack.components.generators.chat.hugging_face_local import HuggingFaceLocalChatGenerator
 from haystack.components.generators.chat.hugging_face_tgi import HuggingFaceTGIChatGenerator
-from haystack.components.generators.chat.openai import OpenAIChatGenerator, GPTChatGenerator
+from haystack.components.generators.chat.openai import OpenAIChatGenerator
 from haystack.components.generators.chat.azure import AzureOpenAIChatGenerator
 
 
@@ -8,6 +8,5 @@ __all__ = [
     "HuggingFaceLocalChatGenerator",
     "HuggingFaceTGIChatGenerator",
     "OpenAIChatGenerator",
-    "GPTChatGenerator",
     "AzureOpenAIChatGenerator",
 ]

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -2,7 +2,6 @@ import copy
 import dataclasses
 import json
 import logging
-import warnings
 from typing import Optional, List, Callable, Dict, Any, Union
 
 from openai import OpenAI, Stream  # type: ignore

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -331,29 +331,3 @@ class OpenAIChatGenerator:
             logger.warning(
                 "The completion for index %s has been truncated due to the content filter.", message.meta["index"]
             )
-
-
-class GPTChatGenerator(OpenAIChatGenerator):
-    def __init__(
-        self,
-        api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
-        model: str = "gpt-3.5-turbo",
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        api_base_url: Optional[str] = None,
-        organization: Optional[str] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
-    ):
-        warnings.warn(
-            "GPTChatGenerator is deprecated and will be removed in the next beta release. "
-            "Please use OpenAIChatGenerator instead.",
-            UserWarning,
-            stacklevel=2,
-        )
-        super().__init__(
-            api_key=api_key,
-            model=model,
-            streaming_callback=streaming_callback,
-            api_base_url=api_base_url,
-            organization=organization,
-            generation_kwargs=generation_kwargs,
-        )

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -277,31 +277,3 @@ class OpenAIGenerator:
             logger.warning(
                 "The completion for index %s has been truncated due to the content filter.", message.meta["index"]
             )
-
-
-class GPTGenerator(OpenAIGenerator):
-    def __init__(
-        self,
-        api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
-        model: str = "gpt-3.5-turbo",
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        api_base_url: Optional[str] = None,
-        organization: Optional[str] = None,
-        system_prompt: Optional[str] = None,
-        generation_kwargs: Optional[Dict[str, Any]] = None,
-    ):
-        warnings.warn(
-            "GPTGenerator is deprecated and will be removed in the next beta release. "
-            "Please use OpenAIGenerator instead.",
-            UserWarning,
-            stacklevel=2,
-        )
-        super().__init__(
-            api_key=api_key,
-            model=model,
-            streaming_callback=streaming_callback,
-            api_base_url=api_base_url,
-            organization=organization,
-            system_prompt=system_prompt,
-            generation_kwargs=generation_kwargs,
-        )

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-import warnings
 from typing import Optional, List, Callable, Dict, Any, Union
 
 from openai import OpenAI, Stream

--- a/releasenotes/notes/remove-gptgenerator-8eced280d3b720d3.yaml
+++ b/releasenotes/notes/remove-gptgenerator-8eced280d3b720d3.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Removed the deprecated GPTGenerator and GPTChatGenerator components. Use OpenAIGenerator and OpenAIChatGeneratornotes instead.


### PR DESCRIPTION
We deprecated GPTGenerator and GPTChatGenerator components in December in this PR: https://github.com/deepset-ai/haystack/pull/6626. It's time to remove them completely. Users can use OpenAIGenerator and OpenAIChatGenerator instead.