### PR TITLE
ci: Fix `snippets_tests.yml`

### DIFF
--- a/.github/workflows/snippets_tests.yml
+++ b/.github/workflows/snippets_tests.yml
@@ -29,36 +29,11 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Install Black
-        run: |
-          pip install --upgrade pip
-          pip install .[dev]
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Check status
-        run: |
-          if ! black . --check; then
-            git status
-            echo "###################################################################################################"
-            echo "# "
-            echo "# CHECK FAILED! Black found issues with your code formatting."
-            echo "# "
-            echo "# Either:"
-            echo "# 1. Run Black locally before committing:"
-            echo "# "
-            echo "#     pip install .[formatting]"
-            echo "#     black ."
-            echo "# "
-            echo "# 2. Install the pre-commit hook:"
-            echo "# "
-            echo "#     pre-commit install"
-            echo "# "
-            echo "# 3. See https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md for help."
-            echo "# "
-            echo "# If you have further problems, please open an issue: https://github.com/deepset-ai/haystack/issues"
-            echo "# "
-            echo "##################################################################################################"
-            exit 1
-          fi
+        run: hatch run default:format-check
 
       - name: Calculate alert data
         id: calculator


### PR DESCRIPTION
`snippets_tests.yml` workflow is currently failing. That's caused by changes introduced with #7079, as we introduce `hatch` to ease some stuff in CI.

[Example failure](https://github.com/deepset-ai/haystack/actions/runs/8050672661/job/21986790151).