### PR TITLE
docs: replace `text` with `content` in usage examples

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -22,14 +22,14 @@ class MetaFieldRanker:
 
     ranker = MetaFieldRanker(meta_field="rating")
     docs = [
-        Document(text="Paris", meta={"rating": 1.3}),
-        Document(text="Berlin", meta={"rating": 0.7}),
-        Document(text="Barcelona", meta={"rating": 2.1}),
+        Document(content="Paris", meta={"rating": 1.3}),
+        Document(content="Berlin", meta={"rating": 0.7}),
+        Document(content="Barcelona", meta={"rating": 2.1}),
     ]
 
     output = ranker.run(documents=docs)
     docs = output["documents"]
-    assert docs[0].text == "Barcelona"
+    assert docs[0].content == "Barcelona"
     """
 
     def __init__(

--- a/haystack/components/samplers/top_p.py
+++ b/haystack/components/samplers/top_p.py
@@ -28,9 +28,9 @@ class TopPSampler:
 
     sampler = TopPSampler(top_p=0.95, score_field="similarity_score")
     docs = [
-        Document(text="Berlin", meta={"similarity_score": -10.6}),
-        Document(text="Belgrade", meta={"similarity_score": -8.9}),
-        Document(text="Sarajevo", meta={"similarity_score": -4.6}),
+        Document(content="Berlin", meta={"similarity_score": -10.6}),
+        Document(content="Belgrade", meta={"similarity_score": -8.9}),
+        Document(content="Sarajevo", meta={"similarity_score": -4.6}),
     ]
     output = sampler.run(documents=docs)
     docs = output["documents"]

--- a/haystack/testing/factory.py
+++ b/haystack/testing/factory.py
@@ -35,7 +35,7 @@ def document_store_class(
 
     Create a DocumentStore class that returns a single document:
     ```python
-    doc = Document(id="fake_id", text="Fake content")
+    doc = Document(id="fake_id", content="Fake content")
     MyFakeStore = document_store_class("MyFakeComponent", documents=[doc])
     document_store = MyFakeStore()
     assert document_store.documents_count() == 1
@@ -52,7 +52,7 @@ def document_store_class(
 
     Create a DocumentStore class that returns a document and a custom count:
     ```python
-    doc = Document(id="fake_id", text="Fake content")
+    doc = Document(id="fake_id", content="Fake content")
     MyFakeStore = document_store_class("MyFakeComponent", documents=[doc], documents_count=100)
     document_store = MyFakeStore()
     assert document_store.documents_count() == 100


### PR DESCRIPTION
I forgot about this in #7205.
Took the opportunity to replace also other instances.