### PR TITLE
feat: check tty / jupyter availability for logging config detection

### DIFF
--- a/haystack/logging.py
+++ b/haystack/logging.py
@@ -1,11 +1,12 @@
+import builtins
 import logging
 import os
 import sys
 import typing
 from typing import List, Optional
-import builtins
 
 import haystack.tracing.tracer
+import haystack.utils.jupyter
 
 if typing.TYPE_CHECKING:
     from structlog.typing import Processor, WrappedLogger, EventDict
@@ -60,8 +61,11 @@ def configure_logging(use_json: Optional[bool] = None) -> None:
     if use_json is None:  # explicit parameter takes precedence over everything else
         use_json_env_var = os.getenv(HAYSTACK_LOGGING_USE_JSON_ENV_VAR)
         if use_json_env_var is None:
-            # Automatically enable JSON logging if stderr is not a TTY
-            use_json = not (sys.stderr.isatty() or hasattr(builtins, "__IPYTHON__"))
+            # We try to guess if we are in an interactive terminal or not
+            interactive_terminal = (
+                sys.stderr.isatty() or hasattr(builtins, "__IPYTHON__") or haystack.utils.jupyter.is_in_jupyter()
+            )
+            use_json = not interactive_terminal
         else:
             # User gave us an explicit value via environment variable
             use_json = use_json_env_var.lower() == "true"

--- a/haystack/logging.py
+++ b/haystack/logging.py
@@ -3,6 +3,7 @@ import os
 import sys
 import typing
 from typing import List, Optional
+import builtins
 
 import haystack.tracing.tracer
 
@@ -60,10 +61,10 @@ def configure_logging(use_json: Optional[bool] = None) -> None:
         use_json_env_var = os.getenv(HAYSTACK_LOGGING_USE_JSON_ENV_VAR)
         if use_json_env_var is None:
             # Automatically enable JSON logging if stderr is not a TTY
-            use_json = not sys.stderr.isatty()
+            use_json = not (sys.stderr.isatty() or hasattr(builtins, "__IPYTHON__"))
         else:
             # User gave us an explicit value via environment variable
-            use_json = use_json_env_var == "true"
+            use_json = use_json_env_var.lower() == "true"
 
     shared_processors: List[Processor] = [
         # Add the log level to the event_dict for structlog to use

--- a/releasenotes/notes/logging-tty-detection-8136769cb4d1da67.yaml
+++ b/releasenotes/notes/logging-tty-detection-8136769cb4d1da67.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The `logging` module now detects if the standard output is a TTY. If it is not and `structlog` is installed, it
+    will automatically disable the console renderer and log in JSON format. This behavior can be overridden by setting
+    the environment variable `HAYSTACK_LOGGING_USE_JSON` to `false`.

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -60,7 +60,7 @@ class TestSkipLoggingConfiguration:
 
 class TestStructuredLoggingConsoleRendering:
     def test_log_filtering_when_using_debug(self, capfd: CaptureFixture) -> None:
-        haystack_logging.configure_logging()
+        haystack_logging.configure_logging(use_json=False)
 
         logger = logging.getLogger(__name__)
         logger.debug("Hello, structured logging!", extra={"key1": "value1", "key2": "value2"})
@@ -70,7 +70,7 @@ class TestStructuredLoggingConsoleRendering:
         assert output == ""
 
     def test_log_filtering_when_using_debug_and_log_level_is_debug(self, capfd: CaptureFixture) -> None:
-        haystack_logging.configure_logging()
+        haystack_logging.configure_logging(use_json=False)
 
         logger = logging.getLogger(__name__)
         logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/7027

### Proposed Changes:

- be a bit smarter than before and automatically switch to JSON logging if there is no tty (following the recipe from here: https://www.structlog.org/en/stable/logging-best-practices.html#pretty-printing-vs-structured-output and adapting it to Jupyter)   
- above behavior is of course disablable

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
