### PR TITLE
refact: Remove the override feature in `PipelineTemplate`

### DIFF
--- a/haystack/templates/pipeline.py
+++ b/haystack/templates/pipeline.py
@@ -2,15 +2,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Any, Optional, Union
 
-import requests
-import yaml
 from jinja2 import meta, TemplateSyntaxError, Environment, PackageLoader
 
 from haystack import Pipeline
 from haystack.core.errors import PipelineUnmarshalError
-from haystack.core.component import Component
-from haystack.core.errors import PipelineValidationError
-from haystack.core.serialization import component_to_dict
 
 
 TEMPLATE_FILE_EXTENSION = ".yaml.jinja2"
@@ -40,13 +35,6 @@ class PipelineTemplate:
     customize components as necessary. Its design philosophy centers on providing an accessible, yet powerful, tool
     for constructing pipelines that accommodate both common use cases and specialized requirements with ease.
 
-
-    The class enables two primary use cases:
-
-    1. Building a pipeline directly using all default components specified in a predefined or custom template.
-    2. Customizing pipelines by overriding default components with custom component settings, integrating user-provided
-    component instances, and adjusting component parameters conditionally.
-
     Examples of usage:
 
     - **Default Build**: Instantiating a pipeline with default settings for a "question answering" (qa) task.
@@ -58,22 +46,6 @@ class PipelineTemplate:
       print(pipe.run(data={"question": "What's the capital of Bosnia and Herzegovina? Be brief"}))
       ```
 
-    - **Custom Component Settings**: Customizing a pipeline by overriding a component, such as integrating a
-    streaming-capable generator for real-time feedback.
-      ```python
-      from haystack.components.generators import OpenAIGenerator
-      from haystack.components.generators.utils import print_streaming_chunk
-      from haystack.templates import PipelineTemplate, PredefinedPipeline
-
-      # Customize the pipeline with a streaming-capable question-answering generator
-      streaming_pipe = (
-        PipelineTemplate.from_predefined(PredefinedTemplate.GENERATIVE_QA)
-        .override("generator", OpenAIGenerator(streaming_callback=print_streaming_chunk))
-        .build()
-      )
-      streaming_pipe.run(data={"question": "What's the capital of Germany? Tell me about it"})
-      ```
-
     - **Customizing for Specific Tasks**: Building a pipeline for document indexing with specific components tailored
     to the task.
       ```python
@@ -82,7 +54,6 @@ class PipelineTemplate:
 
       # Customize the pipeline for document indexing with specific components, include PDF file converter
       pt = PipelineTemplate.from_predefined(PredefinedTemplate.INDEXING)
-      pt.override("embedder", SentenceTransformersDocumentEmbedder(progress_bar=True))
       pipe = pt.build(template_params={"use_pdf_file_converter": True})
 
       result = pipe.run(data={"sources": ["some_text_file.txt", "another_pdf_file.pdf"]})
@@ -111,59 +82,24 @@ class PipelineTemplate:
 
         # Store the list of undefined variables in the template. Components' names will be part of this list
         self.template_variables = meta.find_undeclared_variables(env.parse(template_content))
-        self.component_overrides: Dict[str, Any] = {}
         self._template_content = template_content
-
-    def override(self, component_name: str, component_instance: Component) -> "PipelineTemplate":
-        """
-        Overrides a component specified in the pipeline template with a custom component instance.
-
-        :param component_name: The name of the component within the template to override.
-        :param component_instance: The instance of the component to use as an override. Must be an instance
-        of a class annotated with `@component`.
-
-        :return: The instance of `PipelineTemplate` to allow for method chaining.
-
-        :raises PipelineValidationError: If the `component_name` does not exist in the template or if
-        `component_instance` is not a valid component.
-        """
-        # check if the component_name is allowed in the template
-        if component_name not in self.template_variables:
-            raise PipelineValidationError(f"Component '{component_name}' is not defined in the pipeline template")
-
-        if not isinstance(component_instance, Component):
-            raise PipelineValidationError(
-                f"'{type(component_instance)}' is not a Component. Is this class decorated with @component?"
-            )
-
-        self.component_overrides[component_name] = yaml.safe_dump(component_to_dict(component_instance))
-        return self
 
     def build(self, template_params: Optional[Dict[str, Any]] = None) -> Pipeline:
         """
-        Constructs a `Pipeline` instance based on the template and any overridden components.
+        Constructs a `Pipeline` instance based on the template.
 
         :param template_params: An optional dictionary of parameters to use when rendering the pipeline template.
 
         :return: An instance of `Pipeline` constructed from the rendered template and custom component configurations.
         """
         template_params = template_params or {}
-        rendered = self._template.render(**self.component_overrides, **template_params)
+        rendered = self._template.render(**template_params)
         try:
             return Pipeline.loads(rendered)
         except Exception as e:
             msg = f"Error unmarshalling pipeline: {e}\n"
             msg += f"Source:\n{rendered}"
             raise PipelineUnmarshalError(msg)
-
-    @classmethod
-    def from_string(cls, template_str: str) -> "PipelineTemplate":
-        """
-        Create a PipelineTemplate from a string.
-        :param template_str: The template string to use. Must contain valid Jinja syntax.
-        :return: An instance of `PipelineTemplate `.
-        """
-        return cls(template_str)
 
     @classmethod
     def from_file(cls, file_path: Union[Path, str]) -> "PipelineTemplate":
@@ -188,17 +124,6 @@ class PipelineTemplate:
 
         template_path = f"{TEMPLATE_HOME_DIR}/{predefined_pipeline.value}{TEMPLATE_FILE_EXTENSION}"
         return cls.from_file(template_path)
-
-    @classmethod
-    def from_url(cls, url: str) -> "PipelineTemplate":
-        """
-        Create a PipelineTemplate from a URL.
-        :param url: The URL to fetch the template from. Must contain valid Jinja2 syntax.
-        :return: An instance of `PipelineTemplate `.
-        """
-        response = requests.get(url, timeout=10)
-        response.raise_for_status()
-        return cls(response.text)
 
     @property
     def template_content(self) -> str:

--- a/haystack/templates/predefined/generative_qa.yaml.jinja2
+++ b/haystack/templates/predefined/generative_qa.yaml.jinja2
@@ -2,9 +2,6 @@
 
 {% block components %}
   generator:
-  {% if generator %}
-    {{ generator | indent }}
-  {% else %}
     init_parameters:
       api_key:
         env_vars: [ "OPENAI_API_KEY" ]
@@ -12,16 +9,12 @@
         type: "env_var"
       model: "gpt-3.5-turbo"
     type: "haystack.components.generators.openai.OpenAIGenerator"
-  {% endif %}
 
   prompt_builder:
-  {% if prompt_builder %}
-    {{ prompt_builder | indent }}
-  {% else %}
     init_parameters:
       template: {% raw %}"Answer the question {{question}}.\n\nAnswer:"{% endraw +%}
     type: "haystack.components.builders.prompt_builder.PromptBuilder"
-  {% endif %}
+
 {% endblock %}
 
 

--- a/haystack/templates/predefined/indexing.yaml.jinja2
+++ b/haystack/templates/predefined/indexing.yaml.jinja2
@@ -2,9 +2,6 @@
 
 {% block components %}
   cleaner:
-  {% if cleaner %}
-    {{ cleaner | indent }}
-  {% else %}
     init_parameters:
       remove_empty_lines: true
       remove_extra_whitespaces: true
@@ -12,12 +9,8 @@
       remove_repeated_substrings: false
       remove_substrings: None
     type: "haystack.components.preprocessors.document_cleaner.DocumentCleaner"
-  {% endif %}
 
   embedder:
-  {% if embedder %}
-    {{ embedder | indent }}
-  {% else %}
     init_parameters:
       batch_size: 32
       device:
@@ -30,7 +23,6 @@
       progress_bar: true
       suffix: ""
     type: "haystack.components.embedders.sentence_transformers_document_embedder.SentenceTransformersDocumentEmbedder"
-  {% endif %}
 
   # FileTypeRouter is used to route different file types to different file converters
   # The default mime types are set to text/plain. If we'll handle PDF files, we'll add application/pdf to mime types
@@ -41,59 +33,36 @@
   {% set default_mime_types = ["text/plain"] %}
   {% set additional_mime_types = ["application/pdf"] if use_pdf_file_converter | default(false) else [] %}
   {% set file_type_router_mime_types = default_mime_types + additional_mime_types %}
-  {% if file_type_router %}
-    {{ file_type_router | indent }}
-  {% else %}
     init_parameters:
       mime_types: {{ file_type_router_mime_types }}
     type: "haystack.components.routers.file_type_router.FileTypeRouter"
-  {% endif %}
   {% endwith %}
 
-  {% if doc_joiner %}
-    {{ doc_joiner | indent }}
-  {% else %}
   doc_joiner:
     init_parameters:
       join_mode: "concatenate"
     type: "haystack.components.joiners.document_joiner.DocumentJoiner"
-  {% endif %}
 
   splitter:
-  {% if splitter %}
-    {{ splitter | indent }}
-  {% else %}
     init_parameters:
       split_by: "word"
       split_length: 200
       split_overlap: 30
     type: "haystack.components.preprocessors.document_splitter.DocumentSplitter"
-  {% endif %}
 
   {% if use_pdf_file_converter %}
   pdf_file_converter:
-  {% if pdf_file_converter %}
-    {{ pdf_file_converter | indent }}
-  {% else %}
     init_parameters:
       converter_name: "default"
     type: "haystack.components.converters.pypdf.PyPDFToDocument"
   {% endif %}
-  {% endif %}
 
   text_file_converter:
-  {% if text_file_converter %}
-    {{ text_file_converter | indent }}
-  {% else %}
     init_parameters:
       encoding: "utf-8"
     type: "haystack.components.converters.txt.TextFileToDocument"
-  {% endif %}
 
   writer:
-  {% if text_file_converter %}
-    {{ text_file_converter | indent }}
-  {% else %}
     init_parameters:
       document_store:
         init_parameters:
@@ -104,7 +73,6 @@
         type: "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
       policy: "FAIL"
     type: "haystack.components.writers.document_writer.DocumentWriter"
-  {% endif %}
 {% endblock %}
 
 {% block connections %}

--- a/haystack/templates/predefined/rag.yaml.jinja2
+++ b/haystack/templates/predefined/rag.yaml.jinja2
@@ -2,17 +2,10 @@
 
 {% block components %}
   answer_builder:
-  {% if answer_builder %}
-    {{ answer_builder }}
-  {% else %}
     init_parameters: {}
     type: "haystack.components.builders.answer_builder.AnswerBuilder"
-  {% endif %}
 
   generator:
-  {% if generator %}
-    {{ generator }}
-  {% else %}
     init_parameters:
       api_key:
         env_vars: [ "OPENAI_API_KEY" ]
@@ -20,12 +13,8 @@
         type: "env_var"
       model: "gpt-3.5-turbo"
     type: "haystack.components.generators.openai.OpenAIGenerator"
-  {% endif %}
 
   retriever:
-  {% if retriever %}
-    {{ retriever }}
-  {% else %}
     init_parameters:
       document_store:
         init_parameters:
@@ -39,12 +28,8 @@
       scale_score: false,
       top_k: 10
     type: "haystack.components.retrievers.in_memory.embedding_retriever.InMemoryEmbeddingRetriever"
-  {% endif %}
 
   text_embedder:
-  {% if text_embedder %}
-    {{ text_embedder }}
-  {% else %}
     init_parameters:
       batch_size": 32
       device:
@@ -56,15 +41,12 @@
       progress_bar: true
       suffix: ""
     type: "haystack.components.embedders.sentence_transformers_text_embedder.SentenceTransformersTextEmbedder"
-  {% endif %}
 
   prompt_builder:
-  {% if prompt_builder %}
     init_parameters:
       template: |
         {% raw %}"\nGiven these documents, answer the question.\n\nDocuments:\n{% for doc in documents %}\n{{ doc.content }}\n {% endfor %}\n\nQuestion: {{question}}\n\nAnswer:\n"{% endraw %}
     type: "haystack.components.builders.prompt_builder.PromptBuilder"
-  {% endif %}
 {% endblock %}
 
 {% block connections %}

--- a/releasenotes/notes/add-pipeline-templates-831f857c6387f8c3.yaml
+++ b/releasenotes/notes/add-pipeline-templates-831f857c6387f8c3.yaml
@@ -12,16 +12,13 @@ highlights:  >
    from haystack.templates import PipelineTemplate, PredefinedPipeline
 
    pt = PipelineTemplate(PredefinedPipeline.INDEXING)
-   pt.override("embedder", SentenceTransformersDocumentEmbedder(progress_bar=True))
    pipe = pt.build(template_params={"use_pdf_file_converter": True})
-
    result = pipe.run(data={"sources": ["some_local_dir/and_text_file.txt", "some_other_local_dir/and_pdf_file.pdf"]})
    print(result)
    ```
 
-   In the above example, a PredefinedPipeline.INDEXING enum is used to create a pipeline with a custom instance of
-   SentenceTransformersDocumentEmbedder and the PDF file converter enabled. The pipeline is then run on a list of
-   local files and the result is printed (number of indexed documents).
+   In the above example, a PredefinedPipeline.INDEXING enum is used to create a pipeline with the PDF file converter
+   enabled. The pipeline is then run on a list of local files and the result is printed (number of indexed documents).
 
    We could have of course used the same PipelineTemplate class to create any other pre-defined pipeline or even a
    custom pipeline with custom components and settings.
@@ -35,4 +32,4 @@ highlights:  >
    print(result)
    ```
 
-   PipelineTemplate can load templates from various inputs, including strings, files, predefined templates, and URLs.
+   PipelineTemplate can load templates from various inputs, including strings, files, and predefined templates.


### PR DESCRIPTION
### Related Issues

- No issue, part of the getting start guide

### Proposed Changes:

As we better defined the onboarding path for new users, we realised the `override` feature can get in the way, pushing users in the wrong direction. This PR removes the feature altogether, further simplifying the predefined templates.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

This is not the last step of the refactoring, more to come.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
