### PR TITLE
fix: move sensitive log to debug mode

### DIFF
--- a/haystack/components/routers/text_language_router.py
+++ b/haystack/components/routers/text_language_router.py
@@ -67,7 +67,9 @@ class TextLanguageRouter:
     def detect_language(self, text: str) -> Optional[str]:
         try:
             language = langdetect.detect(text)
-        except langdetect.LangDetectException:
-            logger.warning("Langdetect cannot detect the language of text: %s", text)
+        except langdetect.LangDetectException as exception:
+            logger.warning("Langdetect cannot detect the language of text. Error: %s", exception)
+            # Only log the text in debug mode, as it might contain sensitive information
+            logger.debug("Langdetect cannot detect the language of text: %s", text)
             language = None
         return language

--- a/releasenotes/notes/language-router-logging-6afed7b6b8a7ae78.yaml
+++ b/releasenotes/notes/language-router-logging-6afed7b6b8a7ae78.yaml
@@ -1,0 +1,12 @@
+---
+security:
+  - |
+    Remove the text value from a warning log in the `TextLanguageRouter` to avoid logging sensitive information.
+    The text can be still be shown by switching to the `debug` log level.
+
+    ```python
+    import logging
+
+    logging.basicConfig(format="%(levelname)s - %(name)s -  %(message)s", level=logging.WARNING)
+    logging.getLogger("haystack").setLevel(logging.DEBUG)
+    ```

--- a/test/components/routers/test_text_language_router.py
+++ b/test/components/routers/test_text_language_router.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from _pytest.logging import LogCaptureFixture
 
 from haystack import Document
 from haystack.components.routers import TextLanguageRouter
@@ -38,8 +39,15 @@ class TestTextLanguageRouter:
         result = classifier.run(text=german_sentence)
         assert result == {"unmatched": german_sentence}
 
-    def test_warning_if_no_language_detected(self, caplog):
+    def test_warning_if_no_language_detected(self, caplog: LogCaptureFixture):
         with caplog.at_level(logging.WARNING):
             classifier = TextLanguageRouter()
             classifier.run(text=".")
+            assert "Langdetect cannot detect the language of text. Error: No features in text." in caplog.text
+
+    def test_warning_if_no_language_detected_if_debug(self, caplog: LogCaptureFixture):
+        with caplog.at_level(logging.DEBUG):
+            classifier = TextLanguageRouter()
+            classifier.run(text=".")
+            assert "Langdetect cannot detect the language of text. Error: No features in text." in caplog.text
             assert "Langdetect cannot detect the language of text: ." in caplog.text


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/7028

### Proposed Changes:

- only log potentially sensitive text in debug mode
- log exception in warning mode (I checked that the exception doesn't contain the message)

### How did you test it?

- adapted + added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
