### PR TITLE
ci: Fix delete outdated docs job in `readme_sync.yml`

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -47,4 +47,4 @@ jobs:
         if: github.ref_name == 'main' && github.event_name == 'push'
         env:
           README_API_KEY: ${{ secrets.README_API_KEY }}
-        run: python ./.github/utils/delete_outdated_docs.py --version=v2.0 --config-path ./docs/pydoc/config
+        run: hatch run readme:delete-outdated  --version=v2.0 --config-path ./docs/pydoc/config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ dependencies = [
 
 [tool.hatch.envs.readme.scripts]
 sync = "./.github/utils/pydoc-markdown.sh"
+delete-outdated = "python ./.github/utils/delete_outdated_docs.py {args}"
 
 [tool.hatch.envs.snippets]
 extra-dependencies = [


### PR DESCRIPTION
### Proposed Changes:

Change `readme_sync.yml` job that deletes outdated docs to run command via `hatch`.

This should fix failures like [this](https://github.com/deepset-ai/haystack/actions/runs/8078875531/job/22072073667).

 ### How did you test it?

I ran the command locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
