### PR TITLE
fix: missing init imports for retrievers

### DIFF
--- a/haystack/components/retrievers/__init__.py
+++ b/haystack/components/retrievers/__init__.py
@@ -1,3 +1,5 @@
 from haystack.components.retrievers.filter_retriever import FilterRetriever
+from haystack.components.retrievers.in_memory.embedding_retriever import InMemoryEmbeddingRetriever
+from haystack.components.retrievers.in_memory.bm25_retriever import InMemoryBM25Retriever
 
-__all__ = ["FilterRetriever"]
+__all__ = ["FilterRetriever", "InMemoryEmbeddingRetriever", "InMemoryBM25Retriever"]


### PR DESCRIPTION
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
