### PR TITLE
fix: Fix run order of variadic greedy components in Pipeline.run()

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -855,6 +855,17 @@ class Pipeline:
                             last_inputs[receiver_component_name][edge_data["to_socket"].name] = value
 
                         pair = (receiver_component_name, self.graph.nodes[receiver_component_name]["instance"])
+                        is_greedy = pair[1].__haystack_is_greedy__
+                        is_variadic = edge_data["to_socket"].is_variadic
+                        if is_variadic and is_greedy:
+                            # If the receiver is greedy, we can run it right away.
+                            # First we remove it from the lists it's in if it's there or we risk running it multiple times.
+                            if pair in to_run:
+                                to_run.remove(pair)
+                            if pair in waiting_for_input:
+                                waiting_for_input.remove(pair)
+                            to_run.append(pair)
+
                         if pair not in waiting_for_input and pair not in to_run:
                             to_run.append(pair)
 

--- a/releasenotes/notes/run-greedy-fix-6d4559126e7739ce.yaml
+++ b/releasenotes/notes/run-greedy-fix-6d4559126e7739ce.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix `Pipeline.run()` mistakenly running a Component before it should.
+    This can happen when a greedy variadic Component must be executed before a
+    Component with default inputs.


### PR DESCRIPTION
### Proposed Changes:

This PR fixes a bug that caused Components with default inputs to be executed before variadic greedy Components.

This could happen cause the internal list of Components that can run used in `Pipeline.run()` to keep track of the execution order also depends on the order the Components have been added in the Pipeline.

When starting run we iterate throught the Pipeline graph to understand which Components must run. In the order in which we iterate this graph depends on the order of addition. That reflects also down the line in the execution logic. This won't cause issues most of the times, since Components need to wait for their inputs to run.

Though greedy variadic Components and/or with default input values might be able to run even before they receive all their inputs. So if the order is mismatched we must add some safe guards to execute greedy variadic Components as soon as we can.

### How did you test it?

I added a unit test to verify the order of execution.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
