### PR TITLE
feat: Add new predefined template: chat with website

### DIFF
--- a/haystack/core/pipeline/predefined/chat_with_website.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/chat_with_website.yaml.jinja2
@@ -30,9 +30,15 @@ components:
   prompt:
     init_parameters:
       template: |
-      {% raw %}"\nAccording to the contents of this website:\n{% for document in\
-        \ documents %}\n  {{document.content}}\n{% endfor %}\nAnswer the given question:\
-        \ {{query}}\nAnswer:\n"{% endraw %}
+      {% raw %}
+        "According to the contents of this website:
+        {% for document in documents %}
+          {{document.content}}
+        {% endfor %}
+        Answer the given question: {{query}}
+        Answer:
+        "
+      {% endraw %}
     type: haystack.components.builders.prompt_builder.PromptBuilder
 
 connections:

--- a/haystack/core/pipeline/predefined/chat_with_website.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/chat_with_website.yaml.jinja2
@@ -1,0 +1,46 @@
+components:
+  converter:
+    init_parameters:
+      extractor_type: DefaultExtractor
+    type: haystack.components.converters.html.HTMLToDocument
+
+  fetcher:
+    init_parameters:
+      raise_on_failure: true
+      retry_attempts: 2
+      timeout: 3
+      user_agents:
+      - haystack/LinkContentFetcher/2.0.0b8
+    type: haystack.components.fetchers.link_content.LinkContentFetcher
+
+  llm:
+    init_parameters:
+      api_base_url: null
+      api_key:
+        env_vars:
+        - OPENAI_API_KEY
+        strict: true
+        type: env_var
+      generation_kwargs: {}
+      model: gpt-3.5-turbo
+      streaming_callback: null
+      system_prompt: null
+    type: haystack.components.generators.openai.OpenAIGenerator
+
+  prompt:
+    init_parameters:
+      template: |
+      {% raw %}"\nAccording to the contents of this website:\n{% for document in\
+        \ documents %}\n  {{document.content}}\n{% endfor %}\nAnswer the given question:\
+        \ {{query}}\nAnswer:\n"{% endraw %}
+    type: haystack.components.builders.prompt_builder.PromptBuilder
+
+connections:
+- receiver: converter.sources
+  sender: fetcher.streams
+- receiver: prompt.documents
+  sender: converter.documents
+- receiver: llm.prompt
+  sender: prompt.prompt
+
+metadata: {}

--- a/haystack/core/pipeline/predefined/generative_qa.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/generative_qa.yaml.jinja2
@@ -12,7 +12,7 @@ components:
 
   prompt_builder:
     init_parameters:
-      template: {% raw %}"Answer the question {{question}}.\n\nAnswer:\n"{% endraw %}
+      template: "{% raw %}Answer the question {{question}}.\n Answer:\n{% endraw %}"
     type: "haystack.components.builders.prompt_builder.PromptBuilder"
 
 

--- a/haystack/core/pipeline/predefined/rag.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/rag.yaml.jinja2
@@ -45,7 +45,15 @@ components:
   prompt_builder:
     init_parameters:
       template: |
-        {% raw %}"\nGiven these documents, answer the question.\n\nDocuments:\n{% for doc in documents %}\n{{ doc.content }}\n {% endfor %}\n\nQuestion: {{question}}\n\nAnswer:\n"{% endraw %}
+        {% raw %}
+          "Given these documents, answer the question.
+          Documents:
+          {% for doc in documents %}
+            {{ doc.content }}
+          {% endfor %}
+          Question: {{question}}
+          Answer:\n"
+        {% endraw %}
     type: "haystack.components.builders.prompt_builder.PromptBuilder"
 
 connections:

--- a/haystack/core/pipeline/predefined/rag.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/rag.yaml.jinja2
@@ -18,10 +18,10 @@ components:
     init_parameters:
       document_store:
         init_parameters:
-          bm25_algorithm": "BM25L"
-          bm25_parameters": {}
-          bm25_tokenization_regex": "(?u)\\b\\w\\w+\\b"
-          embedding_similarity_function": "dot_product"
+          bm25_algorithm: "BM25L"
+          bm25_parameters: {}
+          bm25_tokenization_regex: "(?u)\\b\\w\\w+\\b"
+          embedding_similarity_function: "dot_product"
         type: "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
       filters: None,
       return_embedding: false,
@@ -31,7 +31,7 @@ components:
 
   text_embedder:
     init_parameters:
-      batch_size": 32
+      batch_size: 32
       device:
         type: "single"
         device: "cpu"

--- a/haystack/core/pipeline/template.py
+++ b/haystack/core/pipeline/template.py
@@ -17,6 +17,7 @@ class PredefinedPipeline(Enum):
     GENERATIVE_QA = "generative_qa"
     RAG = "rag"
     INDEXING = "indexing"
+    CHAT_WITH_WEBSITE = "chat_with_website"
 
 
 class PipelineTemplate:

--- a/releasenotes/notes/chat-with-website-template-23bec121f1a78726.yaml
+++ b/releasenotes/notes/chat-with-website-template-23bec121f1a78726.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Add a new pipeline template `PredefinedPipeline.CHAT_WITH_WEBSITE` to quickly create a pipeline
+    that will answer questions based on data collected from one or more web pages.
+
+    Usage example:
+    ```python
+    from haystack import Pipeline, PredefinedPipeline
+
+    pipe = Pipeline.from_template(PredefinedPipeline.CHAT_WITH_WEBSITE)
+    result = pipe.run({
+        "fetcher": {"urls": ["https://haystack.deepset.ai/overview/quick-start"]},
+        "prompt": {"query": "How should I install Haystack?"}}
+    )
+
+    print(result["llm"]["replies"][0])
+    ```


### PR DESCRIPTION
### Related Issues

- Part of the getting started guide

### Proposed Changes:

Add a predefined template to be used like this:
```python
from haystack import Pipeline, PredefinedPipeline

pipe = Pipeline.from_template(PredefinedPipeline.CHAT_WITH_WEBSITE)
result = pipe.run({
    "fetcher": {"urls": ["https://haystack.deepset.ai/overview/quick-start"]},
    "prompt": {"query": "How should I install Haystack?"}}
)
print(result["llm"]["replies"][0])
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
