### PR TITLE
chore: restore to_dict method

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -1,8 +1,8 @@
-from typing import Any
+from typing import Any, Dict
 
 from jinja2 import Template, meta
 
-from haystack import component
+from haystack import component, default_to_dict
 
 
 @component
@@ -31,6 +31,9 @@ class PromptBuilder:
         template_variables = meta.find_undeclared_variables(ast)
         for var in template_variables:
             component.set_input_type(self, var, Any, "")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return default_to_dict(self, template=self._template_string)
 
     @component.output_types(prompt=str)
     def run(self, **kwargs):

--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -8,6 +8,15 @@ def test_init():
     assert builder._template_string == "This is a {{ variable }}"
 
 
+def test_to_dict():
+    builder = PromptBuilder(template="This is a {{ variable }}")
+    res = builder.to_dict()
+    assert res == {
+        "type": "haystack.components.builders.prompt_builder.PromptBuilder",
+        "init_parameters": {"template": "This is a {{ variable }}"},
+    }
+
+
 def test_run():
     builder = PromptBuilder(template="This is a {{ variable }}")
     res = builder.run(variable="test")


### PR DESCRIPTION
### Related Issues

- reverts wrong commit in #7248

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
