### PR TITLE
chore: run ruff with fix during precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
   rev: v0.0.290
   hooks:
   - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/5931

### Proposed Changes:

- already enabled sorting of imports for ruff here:  https://github.com/deepset-ai/haystack/blob/fe0ac5c4a280b6196fc984d580d3dd2675f893ae/pyproject.toml#L300

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
