### PR TITLE
tests: make `test_tracing` 3.12 compatible

### DIFF
--- a/test/core/pipeline/test_tracing.py
+++ b/test/core/pipeline/test_tracing.py
@@ -1,12 +1,12 @@
+from test.tracing.utils import SpyingSpan, SpyingTracer
 from typing import Optional
 from unittest.mock import ANY
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from haystack import component, Pipeline
-from haystack.tracing.tracer import enable_tracing, tracer
-from test.tracing.utils import SpyingSpan, SpyingTracer
+from haystack import Pipeline, component
+from haystack.tracing.tracer import tracer
 
 
 @component
@@ -52,7 +52,7 @@ class TestTracing:
                     "haystack.component.name": "hello",
                     "haystack.component.type": "Hello",
                     "haystack.component.input_types": {"word": "str"},
-                    "haystack.component.input_spec": {"word": {"type": "typing.Union[str, NoneType]", "senders": []}},
+                    "haystack.component.input_spec": {"word": {"type": ANY, "senders": []}},
                     "haystack.component.output_spec": {"output": {"type": "str", "senders": ["hello2"]}},
                     "haystack.component.visits": 1,
                 },
@@ -65,15 +65,20 @@ class TestTracing:
                     "haystack.component.name": "hello2",
                     "haystack.component.type": "Hello",
                     "haystack.component.input_types": {"word": "str"},
-                    "haystack.component.input_spec": {
-                        "word": {"type": "typing.Union[str, NoneType]", "senders": ["hello"]}
-                    },
+                    "haystack.component.input_spec": {"word": {"type": ANY, "senders": ["hello"]}},
                     "haystack.component.output_spec": {"output": {"type": "str", "senders": []}},
                     "haystack.component.visits": 1,
                 },
                 trace_id=ANY,
                 span_id=ANY,
             ),
+        ]
+
+        # We need to check the type of the input_spec because it can be rendered differently
+        # depending on the Python version 🫠
+        assert spying_tracer.spans[1].tags["haystack.component.input_spec"]["word"]["type"] in [
+            "typing.Union[str, NoneType]",
+            "typing.Optional[str]",
         ]
 
     def test_with_enabled_content_tracing(
@@ -102,7 +107,7 @@ class TestTracing:
                     "haystack.component.name": "hello",
                     "haystack.component.type": "Hello",
                     "haystack.component.input_types": {"word": "str"},
-                    "haystack.component.input_spec": {"word": {"type": "typing.Union[str, NoneType]", "senders": []}},
+                    "haystack.component.input_spec": {"word": {"type": ANY, "senders": []}},
                     "haystack.component.output_spec": {"output": {"type": "str", "senders": ["hello2"]}},
                     "haystack.component.input": {"word": "world"},
                     "haystack.component.visits": 1,
@@ -117,9 +122,7 @@ class TestTracing:
                     "haystack.component.name": "hello2",
                     "haystack.component.type": "Hello",
                     "haystack.component.input_types": {"word": "str"},
-                    "haystack.component.input_spec": {
-                        "word": {"type": "typing.Union[str, NoneType]", "senders": ["hello"]}
-                    },
+                    "haystack.component.input_spec": {"word": {"type": ANY, "senders": ["hello"]}},
                     "haystack.component.output_spec": {"output": {"type": "str", "senders": []}},
                     "haystack.component.input": {"word": "Hello, world!"},
                     "haystack.component.visits": 1,


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- optionals can have different representations depending on the Python version

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
