### PR TITLE
fix: Update `Component` protocol to fix some type checking issues

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -69,9 +69,10 @@
 """
 
 import inspect
+from collections.abc import Callable
 from copy import deepcopy
 from types import new_class
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
 
 from haystack import logging
 from haystack.core.errors import ComponentError
@@ -108,8 +109,12 @@ class Component(Protocol):
         isinstance(MyComponent, Component)
     """
 
-    def run(self, *args: Any, **kwargs: Any):  # pylint: disable=missing-function-docstring
-        ...
+    # This is the most reliable way to define the protocol for the `run` method.
+    # Defining a method doesn't work as different Components will have different
+    # arguments. Even defining here a method with `**kwargs` doesn't work as the
+    # expected signature must be identical.
+    # This makes most Language Servers and type checkers happy and shows less errors.
+    run: Callable[..., Dict[str, Any]]
 
 
 class ComponentMeta(type):

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -69,6 +69,7 @@
 """
 
 import inspect
+import sys
 from collections.abc import Callable
 from copy import deepcopy
 from types import new_class
@@ -114,7 +115,11 @@ class Component(Protocol):
     # arguments. Even defining here a method with `**kwargs` doesn't work as the
     # expected signature must be identical.
     # This makes most Language Servers and type checkers happy and shows less errors.
-    run: Callable[..., Dict[str, Any]]
+    # NOTE: This check can be removed when we drop Python 3.8 support.
+    if sys.version_info >= (3, 9):
+        run: Callable[..., Dict[str, Any]]
+    else:
+        run: Callable
 
 
 class ComponentMeta(type):

--- a/releasenotes/notes/fix-component-type-checking-issues-8eefa1157ffc3eba.yaml
+++ b/releasenotes/notes/fix-component-type-checking-issues-8eefa1157ffc3eba.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Update `Component` protocol to fix type checking issues with some Language Servers.
+    Most Language Servers and some type checkers would show warnings when calling `Pipeline.add_component()`
+    as technically most `Component`s weren't respecting the protocol we defined.

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -268,7 +268,6 @@ def test_is_greedy_flag_without_variadic_input(caplog):
     assert caplog.text == ""
     assert MockComponent().__haystack_is_greedy__
     assert (
-        caplog.text
-        == "WARNING  haystack.core.component.component:component.py:165 Component 'MockComponent' has no variadic input, but it's marked as greedy."
-        " This is not supported and can lead to unexpected behavior.\n"
+        "Component 'MockComponent' has no variadic input, but it's marked as greedy."
+        " This is not supported and can lead to unexpected behavior.\n" in caplog.text
     )


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

Changes the `Component` protocol so `Pipeline.add_component()` and other methods expecting a `Component` won't show a warning anymore. This happened only for Language Server and some type checkers.

Before:
![Screenshot 2024-02-29 at 16 58 42](https://github.com/deepset-ai/haystack/assets/3314350/4782f0d3-e042-4427-8982-28f50b4bd40d)

After:
![Screenshot 2024-02-29 at 16 58 22](https://github.com/deepset-ai/haystack/assets/3314350/82038dcf-c9e5-413e-b2b1-4287fb9995cd)


### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
