### PR TITLE
chore: update the INDEXING and RAG pipeline templates

### DIFF
--- a/haystack/core/pipeline/predefined/indexing.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/indexing.yaml.jinja2
@@ -5,88 +5,56 @@ components:
     init_parameters:
       remove_empty_lines: true
       remove_extra_whitespaces: true
-      remove_regex: None
+      remove_regex: null
       remove_repeated_substrings: false
-      remove_substrings: None
-    type: "haystack.components.preprocessors.document_cleaner.DocumentCleaner"
+      remove_substrings: null
+    type: haystack.components.preprocessors.document_cleaner.DocumentCleaner
+
+  converter:
+    init_parameters:
+      encoding: utf-8
+    type: haystack.components.converters.txt.TextFileToDocument
 
   embedder:
     init_parameters:
+      api_base_url: null
+      api_key:
+        env_vars:
+        - OPENAI_API_KEY
+        strict: true
+        type: env_var
       batch_size: 32
-      device:
-        type: "single"
-        device: "cpu"
-      embedding_separator: "\\n"
-      model: "sentence-transformers/all-MiniLM-L6-v2"
-      normalize_embeddings: false
-      prefix: ""
+      dimensions: null
+      embedding_separator: '\n'
+      meta_fields_to_embed: []
+      model: text-embedding-ada-002
+      organization: null
+      prefix: ''
       progress_bar: true
-      suffix: ""
-    type: "haystack.components.embedders.sentence_transformers_document_embedder.SentenceTransformersDocumentEmbedder"
-
-  # FileTypeRouter is used to route different file types to different file converters
-  # The default mime types are set to text/plain. If we'll handle PDF files, we'll add application/pdf to mime types
-  # Let's configure that part dynamically based on the use_pdf_file_converter flag
-
-  file_type_router:
-  {% with %}
-  {% set default_mime_types = ["text/plain"] %}
-  {% set additional_mime_types = ["application/pdf"] if use_pdf_file_converter | default(false) else [] %}
-  {% set file_type_router_mime_types = default_mime_types + additional_mime_types %}
-    init_parameters:
-      mime_types: {{ file_type_router_mime_types }}
-    type: "haystack.components.routers.file_type_router.FileTypeRouter"
-  {% endwith %}
-
-  doc_joiner:
-    init_parameters:
-      join_mode: "concatenate"
-    type: "haystack.components.joiners.document_joiner.DocumentJoiner"
+      suffix: ''
+    type: haystack.components.embedders.openai_document_embedder.OpenAIDocumentEmbedder
 
   splitter:
     init_parameters:
-      split_by: "word"
+      split_by: word
       split_length: 200
-      split_overlap: 30
-    type: "haystack.components.preprocessors.document_splitter.DocumentSplitter"
-
-  {% if use_pdf_file_converter %}
-  pdf_file_converter:
-    init_parameters:
-      converter_name: "default"
-    type: "haystack.components.converters.pypdf.PyPDFToDocument"
-  {% endif %}
-
-  text_file_converter:
-    init_parameters:
-      encoding: "utf-8"
-    type: "haystack.components.converters.txt.TextFileToDocument"
+      split_overlap: 0
+    type: haystack.components.preprocessors.document_splitter.DocumentSplitter
 
   writer:
     init_parameters:
       document_store:
         init_parameters:
-          bm25_algorithm: "BM25Okapi"
-          bm25_parameters: {}
-          bm25_tokenization_regex: "(?u)\\b\\w\\w+\\b"
-          embedding_similarity_function: "dot_product"
-        type: "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
-      policy: "FAIL"
-    type: "haystack.components.writers.document_writer.DocumentWriter"
+          collection_name: documents
+          embedding_function: default
+          persist_path: .
+        type: haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore
+      policy: NONE
+    type: haystack.components.writers.document_writer.DocumentWriter
 
 connections:
-- receiver: text_file_converter.sources
-  sender: file_type_router.text/plain
-- receiver: doc_joiner.documents
-  sender: text_file_converter.documents
-  {% if use_pdf_file_converter %}
-- receiver: pdf_file_converter.sources
-  sender: file_type_router.application/pdf
-- receiver: doc_joiner.documents
-  sender: pdf_file_converter.documents
-  {% endif %}
 - receiver: cleaner.documents
-  sender: doc_joiner.documents
+  sender: converter.documents
 - receiver: splitter.documents
   sender: cleaner.documents
 - receiver: embedder.documents
@@ -94,5 +62,4 @@ connections:
 - receiver: writer.documents
   sender: embedder.documents
 
-metadata:
-  {}
+metadata: {}

--- a/haystack/core/pipeline/predefined/rag.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/rag.yaml.jinja2
@@ -1,74 +1,68 @@
 ---
 
 components:
-  answer_builder:
-    init_parameters: {}
-    type: "haystack.components.builders.answer_builder.AnswerBuilder"
-
-  generator:
+  llm:
     init_parameters:
+      api_base_url: null
       api_key:
-        env_vars: [ "OPENAI_API_KEY" ]
+        env_vars:
+        - OPENAI_API_KEY
         strict: true
-        type: "env_var"
-      model: "gpt-3.5-turbo"
-    type: "haystack.components.generators.openai.OpenAIGenerator"
+        type: env_var
+      generation_kwargs: {}
+      model: gpt-3.5-turbo
+      streaming_callback: null
+      system_prompt: null
+    type: haystack.components.generators.openai.OpenAIGenerator
+
+  prompt_builder:
+    init_parameters:
+      template: |
+      {% raw %}
+        "Given these documents, answer the question.
+        Documents:
+        {% for doc in documents %}\
+        {{ doc.content }}
+        {% endfor %}
+        Question: {{query}}
+
+        Answer:"
+      {% endraw %}
+    type: haystack.components.builders.prompt_builder.PromptBuilder
 
   retriever:
     init_parameters:
       document_store:
         init_parameters:
-          bm25_algorithm: "BM25L"
-          bm25_parameters: {}
-          bm25_tokenization_regex: "(?u)\\b\\w\\w+\\b"
-          embedding_similarity_function: "dot_product"
-        type: "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
-      filters: None,
-      return_embedding: false,
-      scale_score: false,
+          collection_name: documents
+          embedding_function: default
+          persist_path: .
+        type: haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore
+      filters: null
       top_k: 10
-    type: "haystack.components.retrievers.in_memory.embedding_retriever.InMemoryEmbeddingRetriever"
+    type: haystack_integrations.components.retrievers.chroma.retriever.ChromaEmbeddingRetriever
 
   text_embedder:
     init_parameters:
-      batch_size: 32
-      device:
-        type: "single"
-        device: "cpu"
-      model: "sentence-transformers/all-mpnet-base-v2"
-      normalize_embeddings: false
-      prefix: ""
-      progress_bar: true
-      suffix: ""
-    type: "haystack.components.embedders.sentence_transformers_text_embedder.SentenceTransformersTextEmbedder"
-
-  prompt_builder:
-    init_parameters:
-      template: |
-        {% raw %}
-          "Given these documents, answer the question.
-          Documents:
-          {% for doc in documents %}
-            {{ doc.content }}
-          {% endfor %}
-          Question: {{question}}
-          Answer:\n"
-        {% endraw %}
-    type: "haystack.components.builders.prompt_builder.PromptBuilder"
+      api_base_url: null
+      api_key:
+        env_vars:
+        - OPENAI_API_KEY
+        strict: true
+        type: env_var
+      dimensions: null
+      model: text-embedding-ada-002
+      organization: null
+      prefix: ''
+      suffix: ''
+    type: haystack.components.embedders.openai_text_embedder.OpenAITextEmbedder
 
 connections:
 - receiver: retriever.query_embedding
   sender: text_embedder.embedding
 - receiver: prompt_builder.documents
   sender: retriever.documents
-- receiver: answer_builder.documents
-  sender: retriever.documents
-- receiver: generator.prompt
+- receiver: llm.prompt
   sender: prompt_builder.prompt
-- receiver: answer_builder.replies
-  sender: generator.replies
-- receiver: answer_builder.meta
-  sender: generator.meta
 
-metadata:
-  {}
+metadata: {}

--- a/releasenotes/notes/add-pipeline-templates-831f857c6387f8c3.yaml
+++ b/releasenotes/notes/add-pipeline-templates-831f857c6387f8c3.yaml
@@ -9,15 +9,5 @@ highlights:  >
    from haystack import Pipeline, PredefinedPipeline
 
    pipe = Pipeline.from_template(PredefinedPipeline.INDEXING)
-   result = pipe.run(data={"sources": ["some_local_dir/and_text_file.txt"]})
-   ```
-
-   The above example creates a PredefinedPipeline.INDEXING pipeline ready to be used. We can use the same template
-   to create a slightly different indexing pipeline, adding a PDF to text converter:
-
-   ```python
-   from haystack import Pipeline, PredefinedPipeline
-
-   pipe = Pipeline.from_template(PredefinedPipeline.INDEXING, template_params={"use_pdf_file_converter": True})
-   result = pipe.run(query="What's the meaning of life?")
+   result = pipe.run({"converter": {"sources": ["some_file.txt"]}})
    ```


### PR DESCRIPTION
### Related Issues

- part of the getting started guide

### Proposed Changes:

Make the template use Chroma as document store, so that data is persisted and can be used later from (let's say) a RAG pipeline.

### How did you test it?

Manually tested

### Notes for the reviewer

We temporarily removed `use_pdf_file_converter`, it's not used in the getting started and it's one less thing to document right now.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
