### PR TITLE
fix: fix output types in WebSearch components

### DIFF
--- a/haystack/components/websearch/searchapi.py
+++ b/haystack/components/websearch/searchapi.py
@@ -88,7 +88,7 @@ class SearchApiWebSearch:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    @component.output_types(documents=List[Document], links=Union[List[Document], List[str]])
+    @component.output_types(documents=List[Document], links=List[str])
     def run(self, query: str) -> Dict[str, Union[List[Document], List[str]]]:
         """
         Uses [SearchApi](https://www.searchapi.io/) to search the web.

--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -85,7 +85,7 @@ class SerperDevWebSearch:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
-    @component.output_types(documents=List[Document], links=Union[List[Document], List[str]])
+    @component.output_types(documents=List[Document], links=List[str])
     def run(self, query: str) -> Dict[str, Union[List[Document], List[str]]]:
         """
         Use [Serper](https://serper.dev/) to search the web.


### PR DESCRIPTION
### Related Issues

- fixes #7273

### Proposed Changes:
Restrict the output type of links to `List[str]`: this makes it possible to connect WebSearch components to the `LinkContentFetcher`. 

### How did you test it?
Manual test; CI.
(Maybe in the future, we should also add an e2e test for a Web RAG Pipeline)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
