### PR TITLE
fix: Update pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:
     paths:
       # Keep the list in sync with the paths defined in the `tests_skipper.yml` workflow
       - "haystack/**/*.py"
-      - "haystack/templates/predefined/*"
+      - "haystack/core/pipeline/predefined/*"
       - "test/**/*.py"
       - "test/test_requirements.txt"
 

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -13,7 +13,7 @@ on:
       # file outside the code changed (e.g. the release notes). Hence, we need a second filter down below.
       # keep the list in sync with the paths defined in the `tests.yml` workflow
       - "haystack/**/*.py"
-      - "haystack/templates/predefined/*"
+      - "haystack/core/pipeline/predefined/*"
       - "test/**/*.py"
       - "test/test_requirements.txt"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ extra-dependencies = [
   "langdetect",  # TextLanguageRouter and DocumentLanguageClassifier
   "sentence-transformers>=2.2.0",  # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "openai-whisper>=20231106",  # LocalWhisperTranscriber
+  "chroma-haystack",  # pipeline predefined templates
 
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions


### PR DESCRIPTION
### Related Issues

- broken CI on `main`

### Proposed Changes:

Install `chroma-haystack` when running the tests. This is needed to test the serialization roundtrip of some predefined pipeline templates

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
