### PR TITLE
docs: Add warm_up() call to HuggingFaceLocalGenerator usage example

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -32,6 +32,8 @@ class HuggingFaceLocalGenerator:
         task="text2text-generation",
         generation_kwargs={"max_new_tokens": 100, "temperature": 0.9})
 
+    generator.warm_up()
+
     print(generator.run("Who is the best American actor?"))
     # {'replies': ['John Cusack']}
     ```


### PR DESCRIPTION
### Related Issues

- No existing issue

### Proposed Changes:

- Add warm_up() call in usage example of HuggingFaceLocalGenerator

### How did you test it?

- Ran the usage example locally. Didn't work before. Now it does.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
