### PR TITLE
fix: Remove pipeline serialization from telemetry code

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from copy import copy, deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Set, TextIO, Tuple, Type, TypeVar, Union, Iterator
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Set, TextIO, Tuple, Type, TypeVar, Union
 
 import networkx  # type:ignore
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -560,14 +560,13 @@ class Pipeline:
 
     def walk(self) -> Iterator[Tuple[str, Component]]:
         """
-        Walks the pipeline, yielding tuples of component name and component instance in BFS order.
+        Walks the pipeline, yielding tuples of name and instance of each component exactly once in no guaranteed order.
+
         :returns:
             An iterator of tuples of component name and component instance.
         """
-        sources = [node for node, degree in self.graph.in_degree(self.graph.nodes()) if degree == 0]  # type: ignore
-        for layer in networkx.bfs_layers(self.graph, sources):
-            for component_name in layer:
-                yield component_name, self.get_component(component_name)
+        for component_name, instance in self.graph.nodes(data="instance"):
+            yield component_name, instance
 
     def warm_up(self):
         """

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from copy import copy, deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Set, TextIO, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Mapping, Optional, Set, TextIO, Tuple, Type, TypeVar, Union, Iterator
 
 import networkx  # type:ignore
 
@@ -557,6 +557,17 @@ class Pipeline:
         # used for running the pipeline we copy it.
         image_data = _to_mermaid_image(self.graph)
         Path(path).write_bytes(image_data)
+
+    def walk(self) -> Iterator[Tuple[str, Component]]:
+        """
+        Walks the pipeline, yielding tuples of component name and component instance in BFS order.
+        :returns:
+            An iterator of tuples of component name and component instance.
+        """
+        sources = [node for node, degree in self.graph.in_degree(self.graph.nodes()) if degree == 0]  # type: ignore
+        for layer in networkx.bfs_layers(self.graph, sources):
+            for component_name in layer:
+                yield component_name, self.get_component(component_name)
 
     def warm_up(self):
         """

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -560,7 +560,8 @@ class Pipeline:
 
     def walk(self) -> Iterator[Tuple[str, Component]]:
         """
-        Walks the pipeline, yielding tuples of name and instance of each component exactly once in no guaranteed order.
+        Visits each component in the pipeline exactly once and yields its name and instance.
+        No guarantees are provided on the visiting order.
 
         :returns:
             An iterator of tuples of component name and component instance.

--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -47,6 +47,18 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
     return default_to_dict(obj, **init_parameters)
 
 
+def generate_qualified_class_name(cls: Type[object]) -> str:
+    """
+    Generates a qualified class name for a class.
+
+    :param cls:
+        The class whose qualified name is to be generated.
+    :returns:
+        The qualified name of the class.
+    """
+    return f"{cls.__module__}.{cls.__name__}"
+
+
 def component_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
     """
     Creates a component instance from a dictionary. If a `from_dict` method is present in the
@@ -103,7 +115,7 @@ def default_to_dict(obj: Any, **init_parameters) -> Dict[str, Any]:
     :returns:
         A dictionary representation of the instance.
     """
-    return {"type": f"{obj.__class__.__module__}.{obj.__class__.__name__}", "init_parameters": init_parameters}
+    return {"type": generate_qualified_class_name(type(obj)), "init_parameters": init_parameters}
 
 
 def default_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
@@ -130,6 +142,6 @@ def default_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
     init_params = data.get("init_parameters", {})
     if "type" not in data:
         raise DeserializationError("Missing 'type' in serialization data")
-    if data["type"] != f"{cls.__module__}.{cls.__name__}":
+    if data["type"] != generate_qualified_class_name(cls):
         raise DeserializationError(f"Class '{data['type']}' can't be deserialized as '{cls.__name__}'")
     return cls(**init_params)

--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -150,7 +150,7 @@ def pipeline_running(pipeline: "Pipeline") -> Optional[Tuple[str, Dict[str, Any]
         component_qualified_class_name = generate_qualified_class_name(type(instance))
         if hasattr(instance, "_get_telemetry_data"):
             telemetry_data = getattr(instance, "_get_telemetry_data")()
-            if type(telemetry_data) is not dict:
+            if not isinstance(telemetry_data, dict):
                 raise TypeError(
                     f"Telemetry data for component {component_name} must be a dictionary but is {type(telemetry_data)}."
                 )

--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -150,10 +150,11 @@ def pipeline_running(pipeline: "Pipeline") -> Optional[Tuple[str, Dict[str, Any]
         component_qualified_class_name = generate_qualified_class_name(type(instance))
         if hasattr(instance, "_get_telemetry_data"):
             telemetry_data = getattr(instance, "_get_telemetry_data")()
-            try:
-                components[component_qualified_class_name].append({"name": component_name, **telemetry_data})
-            except TypeError:
-                components[component_qualified_class_name].append({"name": component_name})
+            if type(telemetry_data) is not dict:
+                raise TypeError(
+                    f"Telemetry data for component {component_name} must be a dictionary but is {type(telemetry_data)}."
+                )
+            components[component_qualified_class_name].append({"name": component_name, **telemetry_data})
         else:
             components[component_qualified_class_name].append({"name": component_name})
 

--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -10,6 +10,7 @@ import posthog
 import yaml
 
 from haystack import logging as haystack_logging
+from haystack.core.serialization import generate_qualified_class_name
 from haystack.telemetry._environment import collect_system_specs
 
 if TYPE_CHECKING:
@@ -146,7 +147,7 @@ def pipeline_running(pipeline: "Pipeline") -> Optional[Tuple[str, Dict[str, Any]
     # Collect info about components
     components: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for component_name, instance in pipeline.graph.nodes(data="instance"):
-        component_qualified_class_name = ".".join([type(instance).__module__, type(instance).__name__])
+        component_qualified_class_name = generate_qualified_class_name(type(instance))
         if hasattr(instance, "_get_telemetry_data"):
             telemetry_data = getattr(instance, "_get_telemetry_data")()
             try:

--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -146,7 +146,7 @@ def pipeline_running(pipeline: "Pipeline") -> Optional[Tuple[str, Dict[str, Any]
 
     # Collect info about components
     components: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for component_name, instance in pipeline.graph.nodes(data="instance"):
+    for component_name, instance in pipeline.walk():
         component_qualified_class_name = generate_qualified_class_name(type(instance))
         if hasattr(instance, "_get_telemetry_data"):
             telemetry_data = getattr(instance, "_get_telemetry_data")()

--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -144,18 +144,18 @@ def pipeline_running(pipeline: "Pipeline") -> Optional[Tuple[str, Dict[str, Any]
     pipeline._last_telemetry_sent = datetime.datetime.now()
 
     # Collect info about components
-    pipeline_description = pipeline.to_dict()
     components: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
-    for component_name, component in pipeline_description["components"].items():
+    for component_name, component_data in pipeline.graph.nodes._nodes.items():
+        component_type = str(type(component_data["instance"]))
         instance = pipeline.get_component(component_name)
         if hasattr(instance, "_get_telemetry_data"):
             telemetry_data = getattr(instance, "_get_telemetry_data")()
             try:
-                components[component["type"]].append({"name": component_name, **telemetry_data})
+                components[component_type].append({"name": component_name, **telemetry_data})
             except TypeError:
-                components[component["type"]].append({"name": component_name})
+                components[component_type].append({"name": component_name})
         else:
-            components[component["type"]].append({"name": component_name})
+            components[component_type].append({"name": component_name})
 
     # Data sent to Posthog
     return "Pipeline run (2.x)", {

--- a/releasenotes/notes/remove-serialization-from-telemetry-a054f7f26f277d2b.yaml
+++ b/releasenotes/notes/remove-serialization-from-telemetry-a054f7f26f277d2b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix telemetry code that could cause a ValueError by trying to serialize a pipeline.
+    Telemetry code does not serialize pipelines anymore.

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -7,7 +7,7 @@ from haystack.core.pipeline import Pipeline
 from haystack.core.component import component
 from haystack.core.errors import DeserializationError
 from haystack.testing import factory
-from haystack.core.serialization import default_to_dict, default_from_dict
+from haystack.core.serialization import default_to_dict, default_from_dict, generate_qualified_class_name
 
 
 def test_default_component_to_dict():
@@ -77,3 +77,10 @@ def test_from_dict_import_type():
     from haystack.testing.sample_components.greet import Greet
 
     assert type(p.get_component("greeter")) == Greet
+
+
+def test_get_qualified_class_name():
+    MyComponent = factory.component_class("MyComponent")
+    comp = MyComponent()
+    res = generate_qualified_class_name(type(comp))
+    assert res == "haystack.testing.factory.MyComponent"

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -1,10 +1,9 @@
 import datetime
 from unittest.mock import Mock, patch
-import pytest
 
 from haystack import Pipeline, component
 from haystack.telemetry._telemetry import pipeline_running
-from haystack.utils.auth import TokenSecret, Secret
+from haystack.utils.auth import Secret, TokenSecret
 
 
 @patch("haystack.telemetry._telemetry.telemetry")


### PR DESCRIPTION
### Related Issues

- fixes #7255
~~probably also fixing #7277 we need to double check ~~
- fixes #7277 

### Proposed Changes:

Instead of using pipeline serialization to get all components, we now loop through the nodes in the pipeline graph.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
