### PR TITLE
ci: Update ruff pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: black-jupyter
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.290
+  rev: v0.3.0
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
### Related Issues

The current ruff-pre-commit version fails when parsing the toml after PR https://github.com/deepset-ai/haystack/pull/7266

```
ruff.....................................................................Failed
- hook id: ruff
- exit code: 2

ruff failed
  Cause: TOML parse error at line 292, column 12
    |
292 | [tool.ruff.lint]
    |            ^^^^
unknown field `lint`
```

### Proposed Changes:

- Update the ruff-pre-commit version to the latest release v0.3.0. Previously we used v0.0.290: https://github.com/astral-sh/ruff-pre-commit/releases/tag/v0.0.290

### How did you test it?

locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
