### PR TITLE
ci: temporarily pin pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
   # Type check
   "mypy",
   # Test
-  "pytest",
+  "pytest<8.1.0",
   "pytest-cov",
   "pytest-custom_exit_code",  # used in the CI
   "pytest-asyncio",


### PR DESCRIPTION
### Related Issues

[Tests are failing](https://github.com/deepset-ai/haystack/actions/runs/8137128846/job/22235082544?pr=7289) because pytest 8.1.0 broke the `flaky` plugin. See https://github.com/box/flaky/issues/198 

### Proposed Changes:
I am pinning pytest.
Then we will find a better course of action/an alternative to `flaky`.

### How did you test it?
CI
