### PR TITLE
fix: add new OpenAI model names to `_infer_model_format`

### DIFF
--- a/haystack/nodes/retriever/dense.py
+++ b/haystack/nodes/retriever/dense.py
@@ -1895,9 +1895,14 @@ class EmbeddingRetriever(DenseRetriever):
     @staticmethod
     def _infer_model_format(model_name_or_path: str, use_auth_token: Optional[Union[str, bool]]) -> str:
         # pylint: disable=too-many-return-statements
-        valid_openai_model_name = model_name_or_path in ["ada", "babbage", "davinci", "curie"] or any(
-            m in model_name_or_path for m in ["-ada-", "-babbage-", "-davinci-", "-curie-"]
-        )
+        valid_openai_model_name = model_name_or_path in [
+            "ada",
+            "babbage",
+            "davinci",
+            "curie",
+            "text-embedding-3-small",
+            "text-embedding-3-large",
+        ] or any(m in model_name_or_path for m in ["-ada-", "-babbage-", "-davinci-", "-curie-"])
         if valid_openai_model_name:
             return "openai"
         if model_name_or_path in COHERE_EMBEDDING_MODELS:


### PR DESCRIPTION
### Related Issues

- fixes #7296

### Proposed Changes:
Add new model names to those recognized as OpenAI models.
Otherwise, the wrong encoder would be used.

### How did you test it?

manual test, CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
