### PR TITLE
ci/test: replace `flaky` with `pytest-rerunfailures`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,11 @@ dependencies = [
   # Type check
   "mypy",
   # Test
-  "pytest<8.1.0",
+  "pytest",
   "pytest-cov",
   "pytest-custom_exit_code",  # used in the CI
   "pytest-asyncio",
-  "flaky",
+  "pytest-rerunfailures",
   "responses",
   "tox",
   "coverage",

--- a/test/core/pipeline/test_draw.py
+++ b/test/core/pipeline/test_draw.py
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import time
 from unittest.mock import MagicMock, patch
 
-import flaky
 import pytest
 import requests
 
@@ -14,7 +12,7 @@ from haystack.core.pipeline.draw import _to_mermaid_image, _to_mermaid_text
 from haystack.testing.sample_components import AddFixedValue, Double
 
 
-@flaky.flaky(max_runs=5, rerun_filter=lambda *_: time.sleep(5))
+@pytest.mark.flaky(reruns=5, reruns_delay=5)
 @pytest.mark.integration
 def test_to_mermaid_image():
     pipe = Pipeline()


### PR DESCRIPTION
### Related Issues

- `flaky` plugin seems unmaintained and is incompatible with the latest release of pytest. See https://github.com/box/flaky/issues/198 https://github.com/box/flaky/issues/192

### Proposed Changes:
- replace `flaky` with [`pytest-rerunfailures`](https://github.com/pytest-dev/pytest-rerunfailures), which seems actively maintained
- unpin `pytest`

### How did you test it?
Local test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
