### PR TITLE
docs: Update docs of MetaFieldRanker, TransformersSimilarityRanker

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional
 
 from dateutil.parser import parse as date_parse
 
-from haystack import Document, component, default_to_dict, logging
+from haystack import Document, component, logging
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 class MetaFieldRanker:
     """
     Ranks Documents based on the value of their specific meta field.
+
     The ranking can be performed in descending order or ascending order.
 
     Usage example:
@@ -43,27 +44,33 @@ class MetaFieldRanker:
         """
         Creates an instance of MetaFieldRanker.
 
-        :param meta_field: The name of the meta field to rank by.
-        :param weight: In range [0,1].
-                0 disables ranking by a meta field.
-                0.5 content and meta fields have the same impact for the ranking.
-                1 means ranking by a meta field only. The highest value comes first.
-        :param top_k: The maximum number of Documents you want the Ranker to return per query. If not provided, the
-                Ranker returns all documents it receives in the new ranking order.
-        :param ranking_mode: The mode used to combine the Retriever's and Ranker's scores.
-                Possible values are 'reciprocal_rank_fusion' (default) and 'linear_score'.
-                Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
-        :param sort_order: Whether to sort the meta field by ascending or descending order.
-                Possible values are `descending` (default) and `ascending`.
-        :param meta_value_type: Parse the meta value into the data type specified before sorting.
-                This will only work if all meta values stored under `meta_field` in the provided documents are strings.
-                For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
-                we would parse the string into a datetime object and then sort the documents by date.
-                The available options are:
-                -'float' will parse the meta values into floats.
-                -'int' will parse the meta values into integers.
-                -'date' will parse the meta values into datetime objects.
-                -'None' (default) will do no parsing.
+        :param meta_field:
+            The name of the meta field to rank by.
+        :param weight:
+            In range [0,1].
+            0 disables ranking by a meta field.
+            0.5 ranking from previous component and based on meta field have the same.
+            1 ranking by a meta field only.
+        :param top_k:
+            The maximum number of Documents to return per query.
+            If not provided, the Ranker returns all documents it receives in the new ranking order.
+        :param ranking_mode:
+            The mode used to combine the Retriever's and Ranker's scores.
+            Possible values are 'reciprocal_rank_fusion' (default) and 'linear_score'.
+            Use the 'linear_score' mode only with Retrievers or Rankers that return a score in range [0,1].
+        :param sort_order:
+            Whether to sort the meta field by ascending or descending order.
+            Possible values are `descending` (default) and `ascending`.
+        :param meta_value_type:
+            Parse the meta value into the data type specified before sorting.
+            This will only work if all meta values stored under `meta_field` in the provided documents are strings.
+            For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
+            we would parse the string into a datetime object and then sort the documents by date.
+            The available options are:
+            -'float' will parse the meta values into floats.
+            -'int' will parse the meta values into integers.
+            -'date' will parse the meta values into datetime objects.
+            -'None' (default) will do no parsing.
         """
 
         self.meta_field = meta_field
@@ -108,7 +115,8 @@ class MetaFieldRanker:
 
         if sort_order not in ["ascending", "descending"]:
             raise ValueError(
-                "The value of parameter <sort_order> must be 'ascending' or 'descending', but is currently set to '%s'.\n"
+                "The value of parameter <sort_order> must be 'ascending' or 'descending', "
+                "but is currently set to '%s'.\n"
                 "Change the <sort_order> value to 'ascending' or 'descending' when initializing the "
                 "MetaFieldRanker." % sort_order
             )
@@ -121,20 +129,6 @@ class MetaFieldRanker:
                 "MetaFieldRanker." % meta_value_type
             )
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serialize object to a dictionary.
-        """
-        return default_to_dict(
-            self,
-            meta_field=self.meta_field,
-            weight=self.weight,
-            top_k=self.top_k,
-            ranking_mode=self.ranking_mode,
-            sort_order=self.sort_order,
-            meta_value_type=self.meta_value_type,
-        )
-
     @component.output_types(documents=List[Document])
     def run(
         self,
@@ -146,35 +140,52 @@ class MetaFieldRanker:
         meta_value_type: Optional[Literal["float", "int", "date"]] = None,
     ):
         """
-        Use this method to rank a list of Documents based on the selected meta field by:
+        Ranks a list of Documents based on the selected meta field by:
         1. Sorting the Documents by the meta field in descending or ascending order.
-        2. Merging the scores from the meta field with the scores from the previous component according to the strategy and weight provided.
+        2. Merging the rankings from the previous component and based on the meta field according to ranking mode and
+        weight.
         3. Returning the top-k documents.
 
-        :param documents: Documents to be ranked.
-        :param top_k: (optional) The number of Documents you want the Ranker to return.
-                If not provided, the top_k provided at initialization time is used.
-        :param weight: (optional) In range [0,1].
-                0 disables ranking by a meta field.
-                0.5 content and meta fields have the same impact for the ranking.
-                1 means ranking by a meta field only. The highest value comes first.
-                If not provided, the weight provided at initialization time is used.
-        :param ranking_mode: (optional) The mode used to combine the Retriever's and Ranker's scores.
-                Possible values are 'reciprocal_rank_fusion' (default) and 'linear_score'.
-                Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
-                If not provided, the ranking_mode provided at initialization time is used.
-        :param sort_order: Whether to sort the meta field by ascending or descending order.
-                Possible values are `descending` (default) and `ascending`.
-                If not provided, the sort_order provided at initialization time is used.
-        :param meta_value_type: Parse the meta value into the data type specified before sorting.
-                This will only work if all meta values stored under `meta_field` in the provided documents are strings.
-                For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
-                we would parse the string into a datetime object and then sort the documents by date.
-                The available options are:
-                -'float' will parse the meta values into floats.
-                -'int' will parse the meta values into integers.
-                -'date' will parse the meta values into datetime objects.
-                -'None' (default) will do no parsing.
+        :param documents:
+            Documents to be ranked.
+        :param top_k:
+            The maximum number of Documents to return per query.
+            If not provided, the top_k provided at initialization time is used.
+        :param weight:
+            In range [0,1].
+            0 disables ranking by a meta field.
+            0.5 ranking from previous component and based on meta field have the same.
+            1 ranking by a meta field only.
+            If not provided, the weight provided at initialization time is used.
+        :param ranking_mode:
+            (optional) The mode used to combine the Retriever's and Ranker's scores.
+            Possible values are 'reciprocal_rank_fusion' (default) and 'linear_score'.
+            Use the 'score' mode only with Retrievers or Rankers that return a score in range [0,1].
+            If not provided, the ranking_mode provided at initialization time is used.
+        :param sort_order:
+            Whether to sort the meta field by ascending or descending order.
+            Possible values are `descending` (default) and `ascending`.
+            If not provided, the sort_order provided at initialization time is used.
+        :param meta_value_type:
+            Parse the meta value into the data type specified before sorting.
+            This will only work if all meta values stored under `meta_field` in the provided documents are strings.
+            For example, if we specified `meta_value_type="date"` then for the meta value `"date": "2015-02-01"`
+            we would parse the string into a datetime object and then sort the documents by date.
+            The available options are:
+            -'float' will parse the meta values into floats.
+            -'int' will parse the meta values into integers.
+            -'date' will parse the meta values into datetime objects.
+            -'None' (default) will do no parsing.
+        :returns:
+            A dictionary with the following keys:
+            - `documents`: List of Documents sorted by the specified meta field.
+
+        :raises ValueError:
+            If `top_k` is not > 0.
+            If `weight` is not in range [0,1].
+            If `ranking_mode` is not 'reciprocal_rank_fusion' or 'linear_score'.
+            If `sort_order` is not 'ascending' or 'descending'.
+            If `meta_value_type` is not 'float', 'int', 'date' or None.
         """
         if not documents:
             return {"documents": []}
@@ -330,8 +341,8 @@ class MetaFieldRanker:
         """
         Calculate the meta field score as a linear score between the greatest and the lowest score in the list.
         This linear scaling is useful for:
-          - Reducing the effect of outliers
-          - Creating scores that are meaningfully distributed in the range [0,1],
-             similar to scores coming from a Retriever or Ranker.
+        - Reducing the effect of outliers
+        - Creating scores that are meaningfully distributed in the range [0,1],
+        similar to scores coming from a Retriever or Ranker.
         """
         return (amount - rank) / amount

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -1,48 +1,12 @@
-import pytest
 import logging
+
+import pytest
 
 from haystack import Document
 from haystack.components.rankers.meta_field import MetaFieldRanker
 
 
 class TestMetaFieldRanker:
-    def test_to_dict(self):
-        component = MetaFieldRanker(meta_field="rating")
-        data = component.to_dict()
-        assert data == {
-            "type": "haystack.components.rankers.meta_field.MetaFieldRanker",
-            "init_parameters": {
-                "meta_field": "rating",
-                "weight": 1.0,
-                "top_k": None,
-                "ranking_mode": "reciprocal_rank_fusion",
-                "sort_order": "descending",
-                "meta_value_type": None,
-            },
-        }
-
-    def test_to_dict_with_custom_init_parameters(self):
-        component = MetaFieldRanker(
-            meta_field="rating",
-            weight=0.5,
-            top_k=5,
-            ranking_mode="linear_score",
-            sort_order="ascending",
-            meta_value_type="date",
-        )
-        data = component.to_dict()
-        assert data == {
-            "type": "haystack.components.rankers.meta_field.MetaFieldRanker",
-            "init_parameters": {
-                "meta_field": "rating",
-                "weight": 0.5,
-                "top_k": 5,
-                "ranking_mode": "linear_score",
-                "sort_order": "ascending",
-                "meta_value_type": "date",
-            },
-        }
-
     @pytest.mark.parametrize("meta_field_values, expected_first_value", [([1.3, 0.7, 2.1], 2.1), ([1, 5, 8], 8)])
     def test_run(self, meta_field_values, expected_first_value):
         """


### PR DESCRIPTION
### Related Issues

- fixes #7112 

### Proposed Changes:

- Update docstrings of MetaFieldRanker, TransformersSimilarityRanker
- Remove to_dict/from_dict that just uses the default implementation and the corresponding tests. There is no reason to test the default implementation of `component_to_dict(obj)`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

LostInTheMiddleRanker was done in a separate PR: https://github.com/deepset-ai/haystack/pull/7294

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
