### PR TITLE
feat: Add support for matching mime types using regex

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -74,6 +74,10 @@ class FileTypeRouter:
             else:
                 raise ValueError(f"Unsupported data source type: {type(source)}")
 
+            if mime_type is None:
+                mime_types["unclassified"].append(source)
+                continue
+
             matched = False
             for pattern in self.mime_type_patterns:
                 if pattern.match(mime_type):

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -84,11 +84,12 @@ class FileTypeRouter:
             elif isinstance(source, ByteStream):
                 mime_type = source.meta.get("content_type", None)
             else:
-                raise ValueError(f"Unsupported data source type: {type(source)}")
+                raise ValueError(f"Unsupported data source type: {type(source).__name__}")
+
             matched = False
-            if mime_type is not None:
+            if mime_type:
                 for pattern in self.mime_type_patterns:
-                    if pattern.match(mime_type):
+                    if pattern.fullmatch(mime_type):
                         mime_types[pattern.pattern].append(source)
                         matched = True
                         break

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -41,8 +41,8 @@ class FileTypeRouter:
     print(router_with_regex.run(sources=sources))
 
     # Expected output:
-    # defaultdict(<class 'list'>, {'text/plain': [PosixPath('file.txt')], 'application/pdf': [PosixPath('document.pdf')], 'unclassified': [PosixPath('song.mp3')]})
-    # defaultdict(<class 'list'>, {'audio/.*': [PosixPath('song.mp3')], 'text/plain': [PosixPath('file.txt')], 'unclassified': [PosixPath('document.pdf')]})
+    # {'text/plain': [PosixPath('file.txt')], 'application/pdf': [PosixPath('document.pdf')], 'unclassified': [PosixPath('song.mp3')]}
+    # {'audio/.*': [PosixPath('song.mp3')], 'text/plain': [PosixPath('file.txt')], 'unclassified': [PosixPath('document.pdf')]}
     ```
 
     :param mime_types: A list of MIME types or regex patterns to classify the incoming files or data streams.

--- a/releasenotes/notes/feature-regex-mime-type-support-36381e74f593eb84.yaml
+++ b/releasenotes/notes/feature-regex-mime-type-support-36381e74f593eb84.yaml
@@ -1,32 +1,24 @@
 ---
-highlights: >
-    Replace this text with content to appear at the top of the section for this
-    release. The highlights might repeat some details that are also present in other notes
-    from the same release, that's ok. Not every release note requires highlights,
-    use this section only to describe major features or notable changes.
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.
-    Upgrade notes should be rare: only list known/potential breaking changes,
-    or major changes that require user action before the upgrade.
-    Notes here must include steps that users can follow to 1. know if they're
-    affected and 2. handle the change gracefully on their end.
-features:
-  - |
-    List new features here, or remove this section.
 enhancements:
   - |
-    List new behavior that is too small to be
-    considered a new feature, or remove this section.
-issues:
-  - |
-    List known issues here, or remove this section. For example, if some change is experimental or known to not work in some cases, it should be mentioned here.
-deprecations:
-  - |
-    List deprecations notes here, or remove this section. Deprecations should not be used for something that is removed in the release, use upgrade section instead. Deprecation should allow time for users to make necessary changes for the removal to happen in a future release.
-security:
-  - |
-    Add security notes here, or remove this section.
-fixes:
-  - |
-    Add normal bug fixes here, or remove this section.
+    Enhanced FileTypeRouter with Regex Pattern Support for MIME Types: This introduces a significant enhancement to the `FileTypeRouter`, now featuring support for regex pattern matching for MIME types. This powerful addition allows for more granular control and flexibility in routing files based on their MIME types, enabling the handling of broad categories or specific MIME type patterns with ease. This feature is particularly beneficial for applications requiring sophisticated file classification and routing logic.
+
+    Usage example:
+    ```python
+    from haystack.components.routers import FileTypeRouter
+
+    router = FileTypeRouter(mime_types=[r"text/.*", r"application/(pdf|json)"])
+
+    # Example files to classify
+    file_paths = [
+        Path("document.pdf"),
+        Path("report.json"),
+        Path("notes.txt"),
+        Path("image.png"),
+    ]
+
+    result = router.run(sources=file_paths)
+
+    for mime_type, files in result.items():
+        print(f"MIME Type: {mime_type}, Files: {[str(file) for file in files]}")
+    ```

--- a/releasenotes/notes/feature-regex-mime-type-support-36381e74f593eb84.yaml
+++ b/releasenotes/notes/feature-regex-mime-type-support-36381e74f593eb84.yaml
@@ -1,0 +1,32 @@
+---
+highlights: >
+    Replace this text with content to appear at the top of the section for this
+    release. The highlights might repeat some details that are also present in other notes
+    from the same release, that's ok. Not every release note requires highlights,
+    use this section only to describe major features or notable changes.
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+    Upgrade notes should be rare: only list known/potential breaking changes,
+    or major changes that require user action before the upgrade.
+    Notes here must include steps that users can follow to 1. know if they're
+    affected and 2. handle the change gracefully on their end.
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List new behavior that is too small to be
+    considered a new feature, or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section. For example, if some change is experimental or known to not work in some cases, it should be mentioned here.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section. Deprecations should not be used for something that is removed in the release, use upgrade section instead. Deprecation should allow time for users to make necessary changes for the removal to happen in a future release.
+security:
+  - |
+    Add security notes here, or remove this section.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -22,13 +22,13 @@ class TestFileTypeRouter:
             test_files_path / "images" / "apple.jpg",
         ]
 
-        router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
+        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg"])
         output = router.run(sources=file_paths)
         assert output
-        assert len(output["text/plain"]) == 2
-        assert len(output["audio/x-wav"]) == 1
-        assert len(output["image/jpeg"]) == 1
-        assert not output["unclassified"]
+        assert len(output[r"text/plain"]) == 2
+        assert len(output[r"audio/x-wav"]) == 1
+        assert len(output[r"image/jpeg"]) == 1
+        assert not output.get("unclassified")
 
     def test_run_with_bytestreams(self, test_files_path):
         """
@@ -40,14 +40,12 @@ class TestFileTypeRouter:
             test_files_path / "audio" / "the context for this answer is here.wav",
             test_files_path / "images" / "apple.jpg",
         ]
-        mime_types = ["text/plain", "text/plain", "audio/x-wav", "image/jpeg"]
+        mime_types = [r"text/plain", r"text/plain", r"audio/x-wav", r"image/jpeg"]
         # Convert file paths to ByteStream objects and set metadata
         byte_streams = []
         for path, mime_type in zip(file_paths, mime_types):
             stream = ByteStream(path.read_bytes())
-
             stream.meta["content_type"] = mime_type
-
             byte_streams.append(stream)
 
         # add unclassified ByteStream
@@ -55,15 +53,18 @@ class TestFileTypeRouter:
         bs.meta["content_type"] = "unknown_type"
         byte_streams.append(bs)
 
-        router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
+        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg"])
         output = router.run(sources=byte_streams)
         assert output
-        assert len(output["text/plain"]) == 2
-        assert len(output["audio/x-wav"]) == 1
-        assert len(output["image/jpeg"]) == 1
+        assert len(output[r"text/plain"]) == 2
+        assert len(output[r"audio/x-wav"]) == 1
+        assert len(output[r"image/jpeg"]) == 1
         assert len(output.get("unclassified")) == 1
 
     def test_run_with_bytestreams_and_file_paths(self, test_files_path):
+        """
+        Test if the component raises an error for unsupported data source types.
+        """
         file_paths = [
             test_files_path / "txt" / "doc_1.txt",
             test_files_path / "audio" / "the context for this answer is here.wav",
@@ -71,7 +72,7 @@ class TestFileTypeRouter:
             test_files_path / "images" / "apple.jpg",
             test_files_path / "markdown" / "sample.md",
         ]
-        mime_types = ["text/plain", "audio/x-wav", "text/plain", "image/jpeg", "text/markdown"]
+        mime_types = [r"text/plain", r"audio/x-wav", r"text/plain", r"image/jpeg", r"text/markdown"]
         byte_stream_sources = []
         for path, mime_type in zip(file_paths, mime_types):
             stream = ByteStream(path.read_bytes())
@@ -80,18 +81,18 @@ class TestFileTypeRouter:
 
         mixed_sources = file_paths[:2] + byte_stream_sources[2:]
 
-        router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg", "text/markdown"])
+        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg", r"text/markdown"])
         output = router.run(sources=mixed_sources)
-        assert len(output["text/plain"]) == 2
-        assert len(output["audio/x-wav"]) == 1
-        assert len(output["image/jpeg"]) == 1
-        assert len(output["text/markdown"]) == 1
+        assert len(output[r"text/plain"]) == 2
+        assert len(output[r"audio/x-wav"]) == 1
+        assert len(output[r"image/jpeg"]) == 1
+        assert len(output[r"text/markdown"]) == 1
 
     def test_no_files(self):
         """
         Test that the component runs correctly when no files are provided.
         """
-        router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
+        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg"])
         output = router.run(sources=[])
         assert not output
 
@@ -104,13 +105,11 @@ class TestFileTypeRouter:
             test_files_path / "audio" / "ignored.mp3",
             test_files_path / "audio" / "this is the content of the document.wav",
         ]
-        router = FileTypeRouter(mime_types=["text/plain"])
+        router = FileTypeRouter(mime_types=[r"text/plain"])
         output = router.run(sources=file_paths)
-        assert len(output["text/plain"]) == 1
+        assert len(output[r"text/plain"]) == 1
         assert "mp3" not in output
-        assert len(output["unclassified"]) == 2
-        assert str(output["unclassified"][0]).endswith("ignored.mp3")
-        assert str(output["unclassified"][1]).endswith("this is the content of the document.wav")
+        assert len(output.get("unclassified")) == 2
 
     def test_no_extension(self, test_files_path):
         """
@@ -121,14 +120,22 @@ class TestFileTypeRouter:
             test_files_path / "txt" / "doc_2",
             test_files_path / "txt" / "doc_2.txt",
         ]
-        router = FileTypeRouter(mime_types=["text/plain"])
+        router = FileTypeRouter(mime_types=[r"text/plain"])
         output = router.run(sources=file_paths)
-        assert len(output["text/plain"]) == 2
-        assert len(output["unclassified"]) == 1
+        assert len(output[r"text/plain"]) == 2
+        assert len(output.get("unclassified")) == 1
+
+    def test_unsupported_source_type(self):
+        """
+        Test if the component raises an error for unsupported data source types.
+        """
+        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg"])
+        with pytest.raises(ValueError, match="Unsupported data source type:"):
+            router.run(sources=["some_unsupported_type"])
 
     def test_unknown_mime_type(self):
         """
         Test that the component handles files with unknown mime types.
         """
         with pytest.raises(ValueError, match="Unknown mime type:"):
-            FileTypeRouter(mime_types=["type_invalid"])
+            FileTypeRouter(mime_types=[r"type_invalid"])


### PR DESCRIPTION
### Related Issues

- fixes #6191 

### Proposed Changes:

Added support for matching mime types using Regular expressions 

### How did you test it?

Did run manual tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
