### PR TITLE
fix: `MetaFieldRanker` - use `weight` if passed in the `run` method

### DIFF
--- a/releasenotes/notes/fix-metafieldranker-weight-in-run-66ce13191e596214.yaml
+++ b/releasenotes/notes/fix-metafieldranker-weight-in-run-66ce13191e596214.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug in the `MetaFieldRanker` where the `weight` parameter passed to the `run` method was not being used.

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -1,5 +1,6 @@
-import pytest
 import logging
+
+import pytest
 
 from haystack import Document
 from haystack.components.rankers.meta_field import MetaFieldRanker
@@ -73,6 +74,16 @@ class TestMetaFieldRanker:
         ranker = MetaFieldRanker(meta_field="rating", weight=1.0)
         docs_before = [Document(content="abc", meta={"rating": value}) for value in [1.1, 0.5, 2.3]]
         output = ranker.run(documents=docs_before)
+        docs_after = output["documents"]
+
+        assert len(docs_after) == 3
+        sorted_scores = sorted([doc.meta["rating"] for doc in docs_after], reverse=True)
+        assert [doc.meta["rating"] for doc in docs_after] == sorted_scores
+
+    def test_run_with_weight_equal_to_1_passed_in_run_method(self):
+        ranker = MetaFieldRanker(meta_field="rating", weight=0.0)
+        docs_before = [Document(content="abc", meta={"rating": value}) for value in [1.1, 0.5, 2.3]]
+        output = ranker.run(documents=docs_before, weight=1.0)
         docs_after = output["documents"]
 
         assert len(docs_after) == 3


### PR DESCRIPTION
### Related Issues

- fixes #7304

### Proposed Changes:
Use `weight` (`=weight or self.weight`) instead of `self.weight` when computing the scores/rankings.

### How did you test it?
CI, new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
