### PR TITLE
chore: migrate `ExtractiveReader` to use secret management

### DIFF
--- a/releasenotes/notes/update-secret-management-extractive-reader-4a8ce8df1f2705f8.yaml
+++ b/releasenotes/notes/update-secret-management-extractive-reader-4a8ce8df1f2705f8.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Update secret handling for the `ExtractiveReader` component using the `Secret` type.
+
+    The default init parameter `token` is now required to either use a token or the environment `HF_API_TOKEN` variable
+    if authentication is required - The on-disk local token file is no longer supported.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/7307

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
