### PR TITLE
test: monkeypatch some env vars in Predefined Pipelines tests

### DIFF
--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import os
 from typing import List, Optional
 from unittest.mock import patch
 
@@ -701,11 +700,8 @@ def test_describe_no_outputs():
     assert p.outputs() == {}
 
 
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY", None),
-    reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
-)
-def test_from_template():
+def test_from_template(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "fake_key")
     pipe = Pipeline.from_template(PredefinedPipeline.INDEXING)
     assert pipe.get_component("cleaner")
 

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import os
 from typing import List, Optional
 from unittest.mock import patch
 
@@ -700,6 +701,10 @@ def test_describe_no_outputs():
     assert p.outputs() == {}
 
 
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY", None),
+    reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+)
 def test_from_template():
     pipe = Pipeline.from_template(PredefinedPipeline.INDEXING)
     assert pipe.get_component("cleaner")

--- a/test/core/pipeline/test_templates.py
+++ b/test/core/pipeline/test_templates.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -43,6 +44,10 @@ class TestPipelineTemplate:
         tpl = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING)
         assert len(tpl.template_content)
 
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
     #  Building a pipeline directly using all default components specified in a predefined or custom template.
     def test_build_pipeline_with_default_components(self):
         rendered = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING).render()

--- a/test/core/pipeline/test_templates.py
+++ b/test/core/pipeline/test_templates.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 
 import pytest
@@ -44,12 +43,9 @@ class TestPipelineTemplate:
         tpl = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING)
         assert len(tpl.template_content)
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENAI_API_KEY", None),
-        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
-    )
     #  Building a pipeline directly using all default components specified in a predefined or custom template.
-    def test_build_pipeline_with_default_components(self):
+    def test_build_pipeline_with_default_components(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "fake_key")
         rendered = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING).render()
         pipeline = Pipeline.loads(rendered)
 


### PR DESCRIPTION
### Related Issues

Some tests in a PR by an external contributor are failing: https://github.com/deepset-ai/haystack/actions/runs/8175759835/job/22354455607

They (apparently) would need the OpenAI API key to pass, but in external PRs we don't pass the API key.

(Strangely, tests are only failing on Windows.
I can get the same failures locally on Ubuntu if I unset the environment variable. So maybe in Windows, the env var is set but has 0 length)

### Proposed Changes:
These specific tests just need the env var to be set, but they don't need to call OpenAI,
so I am monkeypatching the env var.

### How did you test it?
Local tests, CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
