### PR TITLE
ci: Fix `pypi_release.yml` workflow to skip rc0 versions

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -3,7 +3,9 @@ name: Project release on PyPi
 on:
   push:
     tags:
-      - "v[0-9].[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+      # We must not release versions tagged with -rc0 suffix
+      - "!v[0-9]+.[0-9]+.[0-9]-rc0"
 
 env:
   HATCH_VERSION: "1.9.3"


### PR DESCRIPTION
`pypi_release.yml` workflow right now is triggered for every tag with any suffix, also for `-rc0`.

We must not release those versions as we only tag that to make sure `reno` works correctly when generating release notes.
This is necessary cause it searches for the previous tag in the main trunk and doesn't check the release branches.