### PR TITLE
ci: Fix `pypi_release.yml` workflow to skip rc0 versions for v1.x

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -3,7 +3,9 @@ name: Project release on PyPi
 on:
   push:
     tags:
-      - "v[0-9].[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+      # We must not release versions tagged with -rc0 suffix
+      - "!v[0-9]+.[0-9]+.[0-9]-rc0"
 
 jobs:
   release-on-pypi:


### PR DESCRIPTION
`1.x` counterpart of #7327