### PR TITLE
ci: Fix `readme_sync.yml` workflow to ignore non `1.x` versions

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - v1.x
       # release branches have the form v1.9.x
-      - "v[0-9].*[0-9].x"
+      - "v1.*[0-9].x"
 
 jobs:
   sync:


### PR DESCRIPTION
Relates to #7330.

Change `readme_sync.yml` in to ignore version branches different from `1.x.x`, this changes the version used in `v1.x` branch only.