### PR TITLE
ci: Fix readme sync workflow

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'push'
         uses: readmeio/rdme@v8
         with:
-          rdme: docs ./docs/pydoc/temp --key=${{ secrets.README_API_KEY }} --version="${{ steps.version-getter.outputs.version }}"
+          rdme: docs ./docs/pydoc/temp --key=${{ secrets.README_API_KEY }} --version=${{ steps.version-getter.outputs.version }}
 
       - name: Delete outdated
         if: github.event_name == 'push'


### PR DESCRIPTION
`readme_sync.yml` is failing cause `rdme` action doesn't like quotes around arguments for some reason.

Failing workflow 👇 
https://github.com/deepset-ai/haystack/actions/runs/8189534095/job/22394497693