### PR TITLE
bug: Crawler downloads pdfs to project root directory

### DIFF
--- a/haystack/nodes/connector/crawler.py
+++ b/haystack/nodes/connector/crawler.py
@@ -137,6 +137,8 @@ class Crawler(BaseComponent):
         options = Options()
         for option in set(webdriver_options):
             options.add_argument(option)
+        if self.output_dir:
+            options.add_experimental_option("prefs", {"download.default_directory": str(self.output_dir)})
 
         self.driver = selenium_webdriver.Chrome(service=Service(), options=options)
 

--- a/releasenotes/notes/correct-crawler-pdf-download-location-82a443be7b07e182.yaml
+++ b/releasenotes/notes/correct-crawler-pdf-download-location-82a443be7b07e182.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Correct the download location of crawled .pdf files from the present working directory to the specified output_dir param in the Crawler constructor

--- a/releasenotes/notes/correct-crawler-pdf-download-location-82a443be7b07e182.yaml
+++ b/releasenotes/notes/correct-crawler-pdf-download-location-82a443be7b07e182.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Correct the download location of crawled .pdf files from the present working directory to the specified output_dir param in the Crawler constructor
+    Ensure that the crawled files are downloaded to the `output_dir` directory, as specified in the `Crawler` 
+    constructor. Previously, some files were incorrectly downloaded to the current working directory.

--- a/test/nodes/test_connector.py
+++ b/test/nodes/test_connector.py
@@ -266,3 +266,15 @@ def test_crawler_custom_webdriver():
     crawler = Crawler(webdriver=webdriver)
 
     assert webdriver is crawler.driver
+
+
+@pytest.mark.integration
+def test_crawler_pdf_download_location(samples_path, tmp_path):
+    crawler = Crawler(output_dir=tmp_path)
+
+    file_name = "sample_pdf_1.pdf"
+    pdf_uri = (samples_path / "pdf" / file_name).absolute().as_uri()
+    documents = crawler.crawl(urls=[pdf_uri])
+    assert len(documents) == 1
+    assert (tmp_path / file_name).exists()
+    assert len(os.listdir(tmp_path)) == 2


### PR DESCRIPTION
### Related Issues

- fixes #6829 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

- When a .pdf is passed to Selenium's [webdriver.get()](https://selenium-python.readthedocs.io/api.html#selenium.webdriver.remote.webdriver.WebDriver.get) method, the .pdf is automatically downloaded to the current working directory. This issue happens [here](https://github.com/mohitlal31/haystack/blob/fd13e8e8323d6ae87cba3e7b1f4809d073953030/haystack/nodes/connector/crawler.py#L345). Whereas for .html files, the crawler extracts the information and manually saves it in the provided output directory.
- By default, we use Selenium's chromium webdriver that provides additional preferences to set the download location for a file. These preferences are defined [here](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/chrome/common/pref_names.h). 
- When a crawler object is initialized with an output directory, we use that directory as the download location. Else, the .pdf is downloaded to the PWD which is the current behaviour.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added a unit test
- Tested it using the following script
```
from haystack.nodes import Crawler

crawler = Crawler(output_dir="output_files")
docs = crawler.crawl(urls=["https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"])
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
