### PR TITLE
fix: `MetaFieldRanker` - make `weight` passed in `run` to be used even if 0

### DIFF
--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -191,7 +191,7 @@ class MetaFieldRanker:
             return {"documents": []}
 
         top_k = top_k or self.top_k
-        weight = weight or self.weight
+        weight = weight if weight is not None else self.weight
         ranking_mode = ranking_mode or self.ranking_mode
         sort_order = sort_order or self.sort_order
         meta_value_type = meta_value_type or self.meta_value_type

--- a/releasenotes/notes/fix-metafieldranker-weight-in-run-method-e4e11011a8b99c34.yaml
+++ b/releasenotes/notes/fix-metafieldranker-weight-in-run-method-e4e11011a8b99c34.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in the `MetaFieldRanker`: when the `weight` parameter was set to 0 in the `run` method,
+    the component was incorrectly using the default `weight` parameter set in the `__init__` method.


### PR DESCRIPTION
### Related Issues

- fixes #7341

### Proposed Changes:
Simply check if `weight` is not null

### How did you test it?
CI. Manual test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
