### PR TITLE
ci: Update docs renderer

### DIFF
--- a/docs/pydoc/config/audio_api.yml
+++ b/docs/pydoc/config/audio_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Transcribes audio files.
   category_slug: haystack-api
   title: Audio

--- a/docs/pydoc/config/builders_api.yml
+++ b/docs/pydoc/config/builders_api.yml
@@ -1,7 +1,13 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/components/builders]
-    modules: ["answer_builder", "prompt_builder", "dynamic_prompt_builder", "dynamic_chat_prompt_builder"]
+    modules:
+      [
+        "answer_builder",
+        "prompt_builder",
+        "dynamic_prompt_builder",
+        "dynamic_chat_prompt_builder",
+      ]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -12,7 +18,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Extract the output of a Generator to an Answer format, and build prompts.
   category_slug: haystack-api
   title: Builders

--- a/docs/pydoc/config/caching_api.yml
+++ b/docs/pydoc/config/caching_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Checks if any document coming from the given URL is already present in the store.
   category_slug: haystack-api
   title: Caching

--- a/docs/pydoc/config/classifiers_api.yml
+++ b/docs/pydoc/config/classifiers_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Detects the language of the Documents and adds it to the metadata.
   category_slug: haystack-api
   title: Classifiers

--- a/docs/pydoc/config/connectors.yml
+++ b/docs/pydoc/config/connectors.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Various connectors to integrate with external services.
   category_slug: haystack-api
   title: Connectors

--- a/docs/pydoc/config/converters_api.yml
+++ b/docs/pydoc/config/converters_api.yml
@@ -1,7 +1,17 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/components/converters]
-    modules: ["azure", "html", "markdown", "pypdf", "tika", "txt", "output_adapter", "openapi_functions"]
+    modules:
+      [
+        "azure",
+        "html",
+        "markdown",
+        "pypdf",
+        "tika",
+        "txt",
+        "output_adapter",
+        "openapi_functions",
+      ]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -12,7 +22,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Various converters to transform data from one format to another.
   category_slug: haystack-api
   title: Converters

--- a/docs/pydoc/config/data_classess_api.yml
+++ b/docs/pydoc/config/data_classess_api.yml
@@ -1,7 +1,8 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/dataclasses]
-    modules: ["answer", "byte_stream", "chat_message", "document", "streaming_chunk"]
+    modules:
+      ["answer", "byte_stream", "chat_message", "document", "streaming_chunk"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -12,7 +13,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Core classes that carry data through the system.
   category_slug: haystack-api
   title: Data Classes

--- a/docs/pydoc/config/document_stores_api.yml
+++ b/docs/pydoc/config/document_stores_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Stores your texts and meta data and provides them to the Retriever at query time.
   category_slug: haystack-api
   title: Document Stores

--- a/docs/pydoc/config/document_writers_api.yml
+++ b/docs/pydoc/config/document_writers_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Writes Documents to a DocumentStore.
   category_slug: haystack-api
   title: Document Writers

--- a/docs/pydoc/config/embedders_api.yml
+++ b/docs/pydoc/config/embedders_api.yml
@@ -10,7 +10,7 @@ loaders:
         "openai_document_embedder",
         "openai_text_embedder",
         "sentence_transformers_document_embedder",
-        "sentence_transformers_text_embedder"
+        "sentence_transformers_text_embedder",
       ]
     ignore_when_discovered: ["__init__"]
 processors:
@@ -22,7 +22,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Transforms queries into vectors to look for similar or relevant Documents.
   category_slug: haystack-api
   title: Embedders

--- a/docs/pydoc/config/extractors_api.yml
+++ b/docs/pydoc/config/extractors_api.yml
@@ -14,7 +14,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Extracts predefined entities out of a piece of text.
   category_slug: haystack-api
   title: Extractors

--- a/docs/pydoc/config/fetchers_api.yml
+++ b/docs/pydoc/config/fetchers_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Fetches content from a list of URLs and returns a list of extracted content streams.
   category_slug: haystack-api
   title: Fetchers

--- a/docs/pydoc/config/generators_api.yml
+++ b/docs/pydoc/config/generators_api.yml
@@ -22,7 +22,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Enables text generation using LLMs.
   category_slug: haystack-api
   title: Generators

--- a/docs/pydoc/config/joiners_api.yml
+++ b/docs/pydoc/config/joiners_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Components that join list of different objects
   category_slug: haystack-api
   title: Joiners

--- a/docs/pydoc/config/others_api.yml
+++ b/docs/pydoc/config/others_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Other utility components for Haystack Pipelines.
   category_slug: haystack-api
   title: Other Components

--- a/docs/pydoc/config/pipeline_api.yml
+++ b/docs/pydoc/config/pipeline_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Arranges components and integrations in flow.
   category_slug: haystack-api
   title: Pipeline

--- a/docs/pydoc/config/preprocessors_api.yml
+++ b/docs/pydoc/config/preprocessors_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Preprocess your Documents and texts. Clean, split, and more.
   category_slug: haystack-api
   title: PreProcessors

--- a/docs/pydoc/config/rankers_api.yml
+++ b/docs/pydoc/config/rankers_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Reorders a set of Documents based on their relevance to the query.
   category_slug: haystack-api
   title: Rankers

--- a/docs/pydoc/config/readers_api.yml
+++ b/docs/pydoc/config/readers_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Takes a query and a set of Documents as input and returns ExtractedAnswers by selecting a text span within the Documents.
   category_slug: haystack-api
   title: Readers

--- a/docs/pydoc/config/retrievers_api.yml
+++ b/docs/pydoc/config/retrievers_api.yml
@@ -17,7 +17,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Sweeps through a Document Store and returns a set of candidate Documents that are relevant to the query.
   category_slug: haystack-api
   title: Retrievers

--- a/docs/pydoc/config/routers_api.yml
+++ b/docs/pydoc/config/routers_api.yml
@@ -1,7 +1,13 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
     search_path: [../../../haystack/components/routers]
-    modules: ["conditional_router", "file_type_router", "metadata_router", "text_language_router"]
+    modules:
+      [
+        "conditional_router",
+        "file_type_router",
+        "metadata_router",
+        "text_language_router",
+      ]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -12,7 +18,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Routers is a group of components that route queries or Documents to other components that can handle them best.
   category_slug: haystack-api
   title: Routers

--- a/docs/pydoc/config/samplers_api.yml
+++ b/docs/pydoc/config/samplers_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Filters documents based on their similarity scores using top-p sampling.
   category_slug: haystack-api
   title: Samplers

--- a/docs/pydoc/config/utils_api.yml
+++ b/docs/pydoc/config/utils_api.yml
@@ -13,7 +13,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Utility functions and classes used across the library.
   category_slug: haystack-api
   title: Utils

--- a/docs/pydoc/config/validators_api.yml
+++ b/docs/pydoc/config/validators_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Validators validate LLM outputs
   category_slug: haystack-api
   title: Validators

--- a/docs/pydoc/config/websearch_api.yml
+++ b/docs/pydoc/config/websearch_api.yml
@@ -12,7 +12,7 @@ processors:
   - type: smart
   - type: crossref
 renderer:
-  type: haystack_pydoc_tools.renderers.ReadmePreviewRenderer
+  type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
   excerpt: Web search engine for Haystack.
   category_slug: haystack-api
   title: Websearch


### PR DESCRIPTION
### Proposed Changes:

Change the docs renderer to fix Readme upload failures in `main`.

### How did you test it?

I generated the docs locally and verified the category id matched the one from `2.1-unstable` instead of the one from `2.0`.

### Notes for the reviewer

The new renderer has been added with deepset-ai/haystack-pydoc-tools#2.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
