### PR TITLE
chore: extend stalebot to community triage

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,12 +4,12 @@ on:
     - cron: '30 1 * * *'
 
 jobs:
-  proposals:
+  makestale:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9
         with:
-          only-labels: 'proposal'
-          stale-pr-message: 'This proposal is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          only-labels: 'proposal,community-triage'
+          stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           days-before-stale: 30
           days-before-close: 10


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:

Let stalebot deal with stale issues when OP is not responsive

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
