### PR TITLE
feat: check document store and retriever dimensions before calculating embeddings for all documents

### DIFF
--- a/releasenotes/notes/verify-embed-dim-docustore-retriever-9ac88d8f0adc8a32.yaml
+++ b/releasenotes/notes/verify-embed-dim-docustore-retriever-9ac88d8f0adc8a32.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add a check to verify that the embedding dimension set in the docustore and retriever are equal before running embedding calculations.

--- a/releasenotes/notes/verify-embed-dim-docustore-retriever-9ac88d8f0adc8a32.yaml
+++ b/releasenotes/notes/verify-embed-dim-docustore-retriever-9ac88d8f0adc8a32.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Add a check to verify that the embedding dimension set in the docustore and retriever are equal before running embedding calculations.
+    Add a check to verify that the embedding dimension set in the FAISS Document Store and retriever are equal before running embedding calculations.

--- a/test/document_stores/test_faiss.py
+++ b/test/document_stores/test_faiss.py
@@ -42,6 +42,21 @@ class TestFAISSDocumentStore(DocumentStoreBaseTestAbstract):
                 isolation_level="AUTOCOMMIT",
             )
 
+    @pytest.mark.unit
+    def test_validate_embedding_dimension_unequal_embedding_dim(self, ds, documents):
+        retriever = MockDenseRetriever(document_store=ds, embedding_dim=384)
+        ds.write_documents(documents)
+        assert ds.get_document_count() == len(documents)
+        with pytest.raises(RuntimeError):
+            ds._validate_embedding_dimension(retriever)
+
+    @pytest.mark.unit
+    def test_validate_embedding_dimension_equal_embedding_dim(self, ds, documents):
+        retriever = MockDenseRetriever(document_store=ds, embedding_dim=768)
+        ds.write_documents(documents)
+        assert ds.get_document_count() == len(documents)
+        ds._validate_embedding_dimension(retriever)
+
     @pytest.mark.integration
     def test_delete_index(self, ds, documents):
         """Contrary to other Document Stores, FAISSDocumentStore doesn't raise if the index is empty"""


### PR DESCRIPTION
### Related Issues

- fixes #5188 

### Proposed Changes:

- Currently, in haystack v1.x, when `document_store.update_embeddings()` gets called, the embeddings are calculated for all the documents and then saved to the document store. If the embedding dimension set in the document store differs from that of the retriever model, a runtime error is raised. 
- However, we don't need to calculate embeddings for all the documents in the document store to raise this error. This is especially an issue when using paid APIs (openai) or when the embedding calculation is time consuming. 
- A more efficient alternative is to calculate the embedding of a single document and verify that the embedding dimensions match between the document store and the retriever.

### How did you test it?

- Added two unit tests in `test_faiss.py`
- Modified the `basic_faq_pipeline.py` to test the change. 
       - Used `FAISSDocumentStore` instead of `ElasticsearchDocumentStore`. I instantiated the docustore without the `embedding_dim` parameter. Therefore the default value `768` is set in the docustore making the embedding dimension of the retriever and docustore different.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
