### PR TITLE
chore: Upgrade transformers to 4.38.2 in test environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ on:
       - "haystack/**/*.py"
       - "haystack/core/pipeline/predefined/*"
       - "test/**/*.py"
+      - "pyproject.toml"
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/tests_skipper.yml
+++ b/.github/workflows/tests_skipper.yml
@@ -36,6 +36,7 @@ jobs:
               - haystack/**/*.py
               - "haystack/templates/predefined/*"
               - test/**/*.py
+              - "pyproject.toml"
 
   catch-all:
     # Don't run this check if the PR contains both code and non-code changes (e.g. release notes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ format-check = "black --check ."
 
 [tool.hatch.envs.test]
 extra-dependencies = [
-  "transformers[torch,sentencepiece]==4.37.2",  # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
+  "transformers[torch,sentencepiece]==4.38.2",  # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
   "spacy>=3.7,<3.8",  # NamedEntityExtractor
   "spacy-curated-transformers>=0.2,<=0.3",  # NamedEntityExtractor
   "en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.7.3/en_core_web_trf-3.7.3-py3-none-any.whl",  # NamedEntityExtractor


### PR DESCRIPTION
### Proposed Changes:
Transformers 4.38.2 was released 2 weeks ago and should be stable.
As usual, we are updating the dependency in the test environment
to ensure we are still compatible.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
