### PR TITLE
fix: unpin OpenAI and fix problem with mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "tqdm",
   "tenacity",
   "lazy-imports",
-  "openai==1.13.3", # unpin after fix for https://github.com/deepset-ai/haystack/issues/7358
+  "openai>=1.1.0",
   "Jinja2",
   "posthog",  # telemetry
   "pyyaml",

--- a/test/components/generators/conftest.py
+++ b/test/components/generators/conftest.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from typing import Iterator
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from openai import Stream
 from openai.types.chat import ChatCompletionChunk
-from openai.types.chat.chat_completion_chunk import ChoiceDelta, Choice
+from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
 
 
 @pytest.fixture
@@ -33,8 +33,9 @@ def mock_chat_completion_chunk():
     """
 
     class MockStream(Stream[ChatCompletionChunk]):
-        def __init__(self, mock_chunk: ChatCompletionChunk, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+        def __init__(self, mock_chunk: ChatCompletionChunk, client=None, *args, **kwargs):
+            client = client or MagicMock()
+            super().__init__(client=client, *args, **kwargs)
             self.mock_chunk = mock_chunk
 
         def __stream__(self) -> Iterator[ChatCompletionChunk]:


### PR DESCRIPTION
### Related Issues

- fixes #7358

Starting from `openai==1.14.0`, `Stream` invokes a method of the client.
This made our test fail since our client was null.

### Proposed Changes:
Change the `MockStream` in tests to make it use a mock of the client.

### How did you test it?
CI.
Manual tests with `openai==1.14.0`  and `openai==1.1.0`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
