### PR TITLE
bug: run parameter "ranking_mode" does not override init param in meta field ranker

### DIFF
--- a/releasenotes/notes/updated-ranking-mode-in-meta-field-ranker-d1f1304cc422b202.yaml
+++ b/releasenotes/notes/updated-ranking-mode-in-meta-field-ranker-d1f1304cc422b202.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in the `MetaFieldRanker`: when the `ranking_mode` parameter was overridden in the `run` method,
+    the component was incorrectly using the `ranking_mode` parameter set in the `__init__` method.

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -221,3 +221,18 @@ class TestMetaFieldRanker:
         with caplog.at_level(logging.WARNING):
             ranker.run(documents=docs_before)
             assert "The score wasn't provided; defaulting to 0." in caplog.text
+
+    def test_different_ranking_mode_for_init_vs_run(self):
+        ranker = MetaFieldRanker(meta_field="rating", ranking_mode="linear_score", weight=0.5)
+        docs_before = [
+            Document(content="abc", meta={"rating": 1.3}, score=0.3),
+            Document(content="abc", meta={"rating": 0.7}, score=0.4),
+            Document(content="abc", meta={"rating": 2.1}, score=0.6),
+        ]
+        output = ranker.run(documents=docs_before)
+        docs_after = output["documents"]
+        assert docs_after[0].score == 0.8
+
+        output = ranker.run(documents=docs_before, ranking_mode="reciprocal_rank_fusion")
+        docs_after = output["documents"]
+        assert docs_after[0].score == 0.01626123744050767

--- a/test/components/rankers/test_metafield.py
+++ b/test/components/rankers/test_metafield.py
@@ -196,7 +196,7 @@ class TestMetaFieldRanker:
         ]
         output = ranker.run(documents=docs_before)
         docs_after = output["documents"]
-        assert docs_after[0].score == 0.01626123744050767
+        assert docs_after[0].score == pytest.approx(0.016261, abs=1e-5)
 
     @pytest.mark.parametrize("score", [-1, 2, 1.3, 2.1])
     def test_linear_score_raises_warning_if_doc_wrong_score(self, score, caplog):
@@ -235,4 +235,4 @@ class TestMetaFieldRanker:
 
         output = ranker.run(documents=docs_before, ranking_mode="reciprocal_rank_fusion")
         docs_after = output["documents"]
-        assert docs_after[0].score == 0.01626123744050767
+        assert docs_after[0].score == pytest.approx(0.016261, abs=1e-5)


### PR DESCRIPTION
### Related Issues

- fixes #7354 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->

The `_merge_rankings` method uses the `self.ranking_mode` value initialized in the constructor. 
If this value is overridden in the `run` method, the new `ranking_mode` is not considered for ranking calculations. Added an extra param to `_merge_rankings` to accept the updated `ranking_mode` value that is passed in the `run` method.

 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
