### PR TITLE
chore: unschedule benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,9 +2,6 @@ name: Haystack 1.x Benchmarks
 
 on:
   workflow_dispatch:
-  schedule:
-    # At 00:01 on Sunday
-    - cron: "1 0 * * 0"
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Related Issues

Benchmarks are consistently failing.

### Proposed Changes:

Let's disable the workflow. It's been broken for months and fixing it seems non trivial, no point in wasting money and CO2 to spin up the runner

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
