### PR TITLE
feat: Add streaming to `HuggingFaceLocalGenerator`

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -1,9 +1,16 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 from haystack import component, default_from_dict, default_to_dict, logging
+from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
-from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
-from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
+from haystack.utils import (
+    ComponentDevice,
+    Secret,
+    deserialize_callable,
+    deserialize_secrets_inplace,
+    serialize_callable,
+)
+from haystack.utils.hf import HFTokenStreamingHandler, deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +54,7 @@ class HuggingFaceLocalGenerator:
         generation_kwargs: Optional[Dict[str, Any]] = None,
         huggingface_pipeline_kwargs: Optional[Dict[str, Any]] = None,
         stop_words: Optional[List[str]] = None,
+        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
     ):
         """
         Creates an instance of a HuggingFaceLocalGenerator.
@@ -80,6 +88,7 @@ class HuggingFaceLocalGenerator:
             If you provide this parameter, you should not specify the `stopping_criteria` in `generation_kwargs`.
             For some chat models, the output includes both the new text and the original prompt.
             In these cases, it's important to make sure your prompt has no stop words.
+        :param streaming_callback: An optional callable for handling streaming responses.
         """
         transformers_import.check()
 
@@ -113,6 +122,7 @@ class HuggingFaceLocalGenerator:
         self.stop_words = stop_words
         self.pipeline = None
         self.stopping_criteria_list = None
+        self.streaming_callback = streaming_callback
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -142,10 +152,12 @@ class HuggingFaceLocalGenerator:
         :returns:
             Dictionary with serialized data.
         """
+        callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
         serialization_dict = default_to_dict(
             self,
             huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
             generation_kwargs=self.generation_kwargs,
+            streaming_callback=callback_name,
             stop_words=self.stop_words,
             token=self.token.to_dict() if self.token else None,
         )
@@ -168,6 +180,11 @@ class HuggingFaceLocalGenerator:
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
         deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
+        init_params = data.get("init_parameters", {})
+        serialized_callback_handler = init_params.get("streaming_callback")
+        if serialized_callback_handler:
+            data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
+
         return default_from_dict(cls, data)
 
     @component.output_types(replies=List[str])
@@ -192,6 +209,21 @@ class HuggingFaceLocalGenerator:
 
         # merge generation kwargs from init method with those from run method
         updated_generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
+
+        if self.streaming_callback:
+            num_responses = updated_generation_kwargs.get("num_return_sequences", 1)
+            if num_responses > 1:
+                logger.warning(
+                    "Streaming is enabled, but the number of responses is set to %d. "
+                    "Streaming is only supported for single response generation. "
+                    "Setting the number of responses to 1.",
+                    num_responses,
+                )
+                updated_generation_kwargs["num_return_sequences"] = 1
+            # streamer parameter hooks into HF streaming, HFTokenStreamingHandler is an adapter to our streaming
+            updated_generation_kwargs["streamer"] = HFTokenStreamingHandler(
+                self.pipeline.tokenizer, self.streaming_callback, self.stop_words
+            )
 
         output = self.pipeline(prompt, stopping_criteria=self.stopping_criteria_list, **updated_generation_kwargs)
         replies = [o["generated_text"] for o in output if "generated_text" in o]

--- a/releasenotes/notes/hugging-face-local-generator-streaming-callback-38a77d37199f9672.yaml
+++ b/releasenotes/notes/hugging-face-local-generator-streaming-callback-38a77d37199f9672.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Adds 'streaming_callback' parameter to 'HuggingFaceLocalGenerator', allowing users to handle streaming responses.

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -8,6 +8,7 @@ from transformers import PreTrainedTokenizerFast
 from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator, StopWordsCriteria
 from haystack.utils import ComponentDevice
 from haystack.utils.auth import Secret
+from haystack.utils.hf import HFTokenStreamingHandler
 
 
 class TestHuggingFaceLocalGenerator:
@@ -154,6 +155,7 @@ class TestHuggingFaceLocalGenerator:
                     "device": ComponentDevice.resolve_device(None).to_hf(),
                 },
                 "generation_kwargs": {"max_new_tokens": 512},
+                "streaming_callback": None,
                 "stop_words": None,
             },
         }
@@ -194,6 +196,7 @@ class TestHuggingFaceLocalGenerator:
                     },
                 },
                 "generation_kwargs": {"max_new_tokens": 100, "return_full_text": False},
+                "streaming_callback": None,
                 "stop_words": ["coca", "cola"],
             },
         }
@@ -238,6 +241,7 @@ class TestHuggingFaceLocalGenerator:
                     },
                 },
                 "generation_kwargs": {"max_new_tokens": 100, "return_full_text": False},
+                "streaming_callback": None,
                 "stop_words": ["coca", "cola"],
             },
         }
@@ -349,6 +353,29 @@ class TestHuggingFaceLocalGenerator:
         generator.pipeline.assert_called_once_with(
             "irrelevant", max_new_tokens=200, temperature=0.5, stopping_criteria=None
         )
+
+    def test_run_with_streaming(self):
+        def streaming_callback_handler(x):
+            return x
+
+        generator = HuggingFaceLocalGenerator(
+            model="google/flan-t5-base", task="text2text-generation", streaming_callback=streaming_callback_handler
+        )
+
+        # create the pipeline object (simulating the warm_up)
+        generator.pipeline = Mock(return_value=[{"generated_text": "Rome"}])
+
+        generator.run(prompt="irrelevant")
+
+        # when we use streaming, the pipeline should be called with the `streamer` argument being an instance of
+        # ouf our adapter class HFTokenStreamingHandler
+        assert isinstance(generator.pipeline.call_args.kwargs["streamer"], HFTokenStreamingHandler)
+        streamer = generator.pipeline.call_args.kwargs["streamer"]
+
+        # check that the streaming callback is set
+        assert streamer.token_handler == streaming_callback_handler
+        # the tokenizer should be set, here it is a mock
+        assert streamer.tokenizer
 
     def test_run_fails_without_warm_up(self):
         generator = HuggingFaceLocalGenerator(


### PR DESCRIPTION
### Why:
The change introduces a new `streaming_callback` parameter to the `HuggingFaceLocalGenerator` class, allowing users to handle streaming responses. This enhancement provides greater flexibility and customization in managing real-time responses from Hugging Face's local models.

- fixes https://github.com/deepset-ai/haystack/issues/6048

### What:
1. Modifies `haystack/components/generators/hugging_face_local.py`:
   - Adds `streaming_callback` as an optional parameter to the `HuggingFaceLocalGenerator` class.
   - Implements `streaming_callback` functionality within the `run` method.
   - Updates `to_dict` and `from_dict` methods to serialize and deserialize the `streaming_callback` parameter.

2. Adds `releasenotes/notes/hugging-face-local-generator-streaming-callback-38a77d37199f9672.yaml` to document the new feature.

3. Modifies `test/components/generators/test_hugging_face_local_generator.py` to include tests for the `streaming_callback` parameter.

### How can it be used:
1. Include `streaming_callback` when initializing a `HuggingFaceLocalGenerator` instance to handle streaming responses:
   ```python
   generator = HuggingFaceLocalGenerator(model="model_name", streaming_callback=streaming_callback_handler)
   ```
2. Implement the `streaming_callback` function to handle streaming responses as desired, for example:
   ```python
   def streaming_callback_handler(x):
       print(x)
   ```

### How did you test it:
1. Tested the `streaming_callback` by creating tests for:
   - Default behavior (no streaming callback)
   - Serialization and deserialization (to_dict and from_dict methods)
   - Custom streaming callback function implementation
   - Interaction with the `run` method

### Notes for the reviewer:
- Ensure that the `streaming_callback` function is compatible with the async context of the `HuggingFaceLocalGenerator`'s `run` method.
- Test the streaming feature with local Hugging Face models to validate the behavior.
- Test the serialization and deserialization functionality of the `streaming_callback` parameter.
- Consider adding integration tests for various Hugging Face models to ensure compatibility with different types of streaming data.
