### PR TITLE
docs: fix description of timeout config for WeaviateDocumentStore

### DIFF
--- a/haystack/document_stores/weaviate.py
+++ b/haystack/document_stores/weaviate.py
@@ -104,7 +104,7 @@ class WeaviateDocumentStore(KeywordDocumentStore):
         :param host: Weaviate server connection URL for storing and processing documents and vectors.
                              For more details, see [Weaviate installation](https://weaviate.io/developers/weaviate/current/getting-started/installation.html).
         :param port: The port of the Weaviate instance.
-        :param timeout_config: The Weaviate timeout config as a tuple of (retries, time out seconds).
+        :param timeout_config: The Weaviate timeout config as a tuple of (connect timeout, read timeout).
         :param username: The Weaviate username (standard authentication using http_auth).
         :param password: Weaviate password (standard authentication using http_auth).
         :param scope: The scope of the credentials when using the OIDC Resource Owner Password or Client Credentials authentication flow.


### PR DESCRIPTION
### Related Issues

- fixes #7378 

### Proposed Changes:

Updating documentation for the `timeout_config` for the `WeaviateDocumentStore`. It is currently `(retries, time out seconds)` which is inconsistent with the Weaviate client [documentation](https://weaviate-python-client.readthedocs.io/en/stable/weaviate.html#weaviate.Client.timeout_config) of `(connect timeout, read timeout)`. Updating it to this

### How did you test it?

Verified manually that the parameter for the `connect_timeout` is not a retry parameter and is the connection timeout for the Weaviate DB. 

### Notes for the reviewer

Weaviate Client documentation: https://weaviate-python-client.readthedocs.io/en/stable/weaviate.html#weaviate.Client.timeout_config

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
