### PR TITLE
Fix deepset logo rendering on pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Some examples of what you can do with Haystack:
 -   Use **user feedback** to evaluate, benchmark, and continuously improve your models.
 
 > [!TIP]
-><img src="docs/img/deepset-cloud-logo-lightblue.png"  width=30% height=30%>
+><img src="https://github.com/deepset-ai/haystack/raw/main/docs/img/deepset-cloud-logo-lightblue.png"  width=30% height=30%>
 >
 > Are you looking for a managed solution that benefits from Haystack? [deepset Cloud](https://www.deepset.ai/deepset-cloud?utm_campaign=developer-relations&utm_source=haystack&utm_medium=readme) is our fully managed, end-to-end platform to integrate LLMs with your data, which uses Haystack for the LLM pipelines architecture.
 


### PR DESCRIPTION
### Proposed Changes:

Rendering images on pypi.org does not work with relative URLs. I changed it to use an absolute link for Deepset's logo.

Right now it's being rendered like this:

![image](https://github.com/deepset-ai/haystack/assets/2649301/2bee725f-3033-4ed9-9fc5-4b47a7ceb81b)
