### PR TITLE
feat: Change outputs of AnswerExactMatchEvaluator

### DIFF
--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -45,7 +45,7 @@ class AnswerExactMatchEvaluator:
             A list of predicted answers for each question.
         :returns:
             A dictionary with the following outputs:
-            - `scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the ground truth.
+            - `scores` - The number of matches per question.
             - `average` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
                          answer matched one of the ground truth answers.
         """
@@ -54,12 +54,9 @@ class AnswerExactMatchEvaluator:
 
         matches = []
         for truths, extracted in zip(ground_truth_answers, predicted_answers):
-            if set(truths) & set(extracted):
-                matches.append(1)
-            else:
-                matches.append(0)
+            matches.append(len(set(truths) & set(extracted)))
 
         # The proportion of questions where any predicted answer matched one of the ground truth answers
-        average = sum(matches) / len(questions)
+        average = sum(bool(m) for m in matches) / len(questions)
 
         return {"scores": matches, "average": average}

--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -45,7 +45,7 @@ class AnswerExactMatchEvaluator:
             A list of predicted answers for each question.
         :returns:
             A dictionary with the following outputs:
-            - `scores` - The number of matches per question.
+            - `scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the ground truth.
             - `average` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
                          answer matched one of the ground truth answers.
         """
@@ -54,9 +54,12 @@ class AnswerExactMatchEvaluator:
 
         matches = []
         for truths, extracted in zip(ground_truth_answers, predicted_answers):
-            matches.append(len(set(truths) & set(extracted)))
+            if set(truths) & set(extracted):
+                matches.append(1)
+            else:
+                matches.append(0)
 
         # The proportion of questions where any predicted answer matched one of the ground truth answers
-        average = sum(bool(m) for m in matches) / len(questions)
+        average = sum(matches) / len(questions)
 
         return {"scores": matches, "average": average}

--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from haystack.core.component import component
 
@@ -19,17 +19,20 @@ class AnswerExactMatchEvaluator:
     result = evaluator.run(
         questions=["What is the capital of Germany?", "What is the capital of France?"],
         ground_truth_answers=[["Berlin"], ["Paris"]],
-        predicted_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["Lyon"]],
     )
-    print(result["result"])
-    # 1.0
+
+    print(result["scores"])
+    # [1, 0]
+    print(result["average"])
+    # 0.5
     ```
     """
 
-    @component.output_types(result=float)
+    @component.output_types(scores=List[int], average=float)
     def run(
         self, questions: List[str], ground_truth_answers: List[List[str]], predicted_answers: List[List[str]]
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Any]:
         """
         Run the AnswerExactMatchEvaluator on the given inputs.
         All lists must have the same length.
@@ -42,18 +45,21 @@ class AnswerExactMatchEvaluator:
             A list of predicted answers for each question.
         :returns:
             A dictionary with the following outputs:
-            - `result` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
+            - `scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the ground truth.
+            - `average` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
                          answer matched one of the ground truth answers.
         """
         if not len(questions) == len(ground_truth_answers) == len(predicted_answers):
             raise ValueError("The length of questions, ground_truth_answers, and predicted_answers must be the same.")
 
-        matches = 0
+        matches = []
         for truths, extracted in zip(ground_truth_answers, predicted_answers):
             if set(truths) & set(extracted):
-                matches += 1
+                matches.append(1)
+            else:
+                matches.append(0)
 
         # The proportion of questions where any predicted answer matched one of the ground truth answers
-        result = matches / len(questions)
+        average = sum(matches) / len(questions)
 
-        return {"result": result}
+        return {"scores": matches, "average": average}

--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -22,14 +22,14 @@ class AnswerExactMatchEvaluator:
         predicted_answers=[["Berlin"], ["Lyon"]],
     )
 
-    print(result["scores"])
+    print(result["individual_scores"])
     # [1, 0]
-    print(result["average"])
+    print(result["score"])
     # 0.5
     ```
     """
 
-    @component.output_types(scores=List[int], average=float)
+    @component.output_types(individual_scores=List[int], score=float)
     def run(
         self, questions: List[str], ground_truth_answers: List[List[str]], predicted_answers: List[List[str]]
     ) -> Dict[str, Any]:
@@ -45,8 +45,8 @@ class AnswerExactMatchEvaluator:
             A list of predicted answers for each question.
         :returns:
             A dictionary with the following outputs:
-            - `scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the ground truth.
-            - `average` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
+            - `individual_scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the ground truth.
+            - `score` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
                          answer matched one of the ground truth answers.
         """
         if not len(questions) == len(ground_truth_answers) == len(predicted_answers):
@@ -62,4 +62,4 @@ class AnswerExactMatchEvaluator:
         # The proportion of questions where any predicted answer matched one of the ground truth answers
         average = sum(matches) / len(questions)
 
-        return {"scores": matches, "average": average}
+        return {"individual_scores": matches, "score": average}

--- a/test/components/evaluators/test_answer_exact_match.py
+++ b/test/components/evaluators/test_answer_exact_match.py
@@ -11,7 +11,7 @@ def test_run_with_all_matching():
         predicted_answers=[["Berlin"], ["Paris"]],
     )
 
-    assert result["result"] == 1.0
+    assert result == {"scores": [1, 1], "average": 1.0}
 
 
 def test_run_with_no_matching():
@@ -64,7 +64,7 @@ def test_run_with_complex_data():
             ["10th century", "the first half of the 10th century", "10th", "10th"],
         ],
     )
-    assert result == {"scores": [1, 1, 0, 1, 0, 1], "average": 0.6666666666666666}
+    assert result == {"scores": [1, 2, 0, 2, 0, 2], "average": 0.6666666666666666}
 
 
 def test_run_with_different_lengths():

--- a/test/components/evaluators/test_answer_exact_match.py
+++ b/test/components/evaluators/test_answer_exact_match.py
@@ -22,7 +22,7 @@ def test_run_with_no_matching():
         predicted_answers=[["Paris"], ["London"]],
     )
 
-    assert result["result"] == 0.0
+    assert result == {"scores": [0, 0], "average": 0.0}
 
 
 def test_run_with_partial_matching():
@@ -33,7 +33,38 @@ def test_run_with_partial_matching():
         predicted_answers=[["Berlin"], ["London"]],
     )
 
-    assert result["result"] == 0.5
+    assert result == {"scores": [1, 0], "average": 0.5}
+
+
+def test_run_with_complex_data():
+    evaluator = AnswerExactMatchEvaluator()
+    result = evaluator.run(
+        questions=[
+            "In what country is Normandy located?",
+            "When was the Latin version of the word Norman first recorded?",
+            "What developed in Normandy during the 1100s?",
+            "In what century did important classical music developments occur in Normandy?",
+            "From which countries did the Norse originate?",
+            "What century did the Normans first gain their separate identity?",
+        ],
+        ground_truth_answers=[
+            ["France"],
+            ["9th century", "9th"],
+            ["classical music", "classical"],
+            ["11th century", "the 11th"],
+            ["Denmark", "Iceland", "Norway"],
+            ["10th century", "10th"],
+        ],
+        predicted_answers=[
+            ["France"],
+            ["9th century", "10th century", "9th"],
+            ["classic music", "rock music", "dubstep"],
+            ["11th", "the 11th", "11th century"],
+            ["Denmark, Iceland and Norway"],
+            ["10th century", "the first half of the 10th century", "10th", "10th"],
+        ],
+    )
+    assert result == {"scores": [1, 1, 0, 1, 0, 1], "average": 0.6666666666666666}
 
 
 def test_run_with_different_lengths():

--- a/test/components/evaluators/test_answer_exact_match.py
+++ b/test/components/evaluators/test_answer_exact_match.py
@@ -11,7 +11,7 @@ def test_run_with_all_matching():
         predicted_answers=[["Berlin"], ["Paris"]],
     )
 
-    assert result == {"scores": [1, 1], "average": 1.0}
+    assert result["result"] == 1.0
 
 
 def test_run_with_no_matching():
@@ -64,7 +64,7 @@ def test_run_with_complex_data():
             ["10th century", "the first half of the 10th century", "10th", "10th"],
         ],
     )
-    assert result == {"scores": [1, 2, 0, 2, 0, 2], "average": 0.6666666666666666}
+    assert result == {"scores": [1, 1, 0, 1, 0, 1], "average": 0.6666666666666666}
 
 
 def test_run_with_different_lengths():

--- a/test/components/evaluators/test_answer_exact_match.py
+++ b/test/components/evaluators/test_answer_exact_match.py
@@ -11,7 +11,7 @@ def test_run_with_all_matching():
         predicted_answers=[["Berlin"], ["Paris"]],
     )
 
-    assert result["result"] == 1.0
+    assert result == {"individual_scores": [1, 1], "score": 1.0}
 
 
 def test_run_with_no_matching():
@@ -22,7 +22,7 @@ def test_run_with_no_matching():
         predicted_answers=[["Paris"], ["London"]],
     )
 
-    assert result == {"scores": [0, 0], "average": 0.0}
+    assert result == {"individual_scores": [0, 0], "score": 0.0}
 
 
 def test_run_with_partial_matching():
@@ -33,7 +33,7 @@ def test_run_with_partial_matching():
         predicted_answers=[["Berlin"], ["London"]],
     )
 
-    assert result == {"scores": [1, 0], "average": 0.5}
+    assert result == {"individual_scores": [1, 0], "score": 0.5}
 
 
 def test_run_with_complex_data():
@@ -64,7 +64,7 @@ def test_run_with_complex_data():
             ["10th century", "the first half of the 10th century", "10th", "10th"],
         ],
     )
-    assert result == {"scores": [1, 1, 0, 1, 0, 1], "average": 0.6666666666666666}
+    assert result == {"individual_scores": [1, 1, 0, 1, 0, 1], "score": 0.6666666666666666}
 
 
 def test_run_with_different_lengths():


### PR DESCRIPTION
### Proposed Changes:

Standardize outputs with other evaluators.
This PR also adds a new test with more complex data.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

This decision stems from this [discussion](https://github.com/deepset-ai/haystack/pull/7073#discussion_r1531859980).

I ignored the release notes as this has still not been released and the PR that added this Component already has release notes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
