### PR TITLE
feat: Add `AnswerRecallMultiHitEvaluator`

### DIFF
--- a/haystack/components/evaluators/answer_recall_multi_hit.py
+++ b/haystack/components/evaluators/answer_recall_multi_hit.py
@@ -1,0 +1,61 @@
+import itertools
+from typing import Any, Dict, List
+
+from haystack.core.component import component
+
+
+@component
+class AnswerRecallMultiHitEvaluator:
+    """
+    Evaluator that calculates the Recall multi-hit score for a list of questions.
+    The result is number from 0.0 to 1.0 that represents the proportion of matching answers retrieved across
+    all questions divided by the total number of relevant items in all answers.
+    Each question can have multiple ground truth answers and multiple predicted answers.
+
+    Usage example:
+    ```python
+    from haystack.components.evaluators import AnswerRecallMultiHitEvaluator
+
+    evaluator = AnswerRecallMultiHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["London"]],
+    )
+    print(result["score"])
+    # 0.5
+    ```
+    """
+
+    @component.output_types(score=float)
+    def run(
+        self, questions: List[str], ground_truth_answers: List[List[str]], predicted_answers: List[List[str]]
+    ) -> Dict[str, Any]:
+        """
+        Run the AnswerRecallMultiHitEvaluator on the given inputs.
+        All lists must have the same length.
+
+        :param questions:
+            A list of questions.
+        :param ground_truth_answers:
+            A list of expected answers for each question.
+        :param predicted_answers:
+            A list of predicted answers for each question.
+
+        :returns:
+            A dictionary with the following outputs:
+            - `score` - A number from 0.0 to 1.0 that represents the proportion of matching answers retrieved across
+                        all questions divided by the total number of relevant items in all answers.
+        """
+        if not len(questions) == len(ground_truth_answers) == len(predicted_answers):
+            msg = "The length of questions, ground_truth_answers, and predicted_answers must be the same."
+            raise ValueError(msg)
+
+        correct_retrievals = set()
+        for ground_truth, predicted in zip(ground_truth_answers, predicted_answers):
+            retrieved_ground_truths = {g for g, p in itertools.product(ground_truth, predicted) if g in p}
+            correct_retrievals.update(retrieved_ground_truths)
+
+        score = len(correct_retrievals) / sum(len(answers) for answers in ground_truth_answers)
+
+        return {"score": score}

--- a/releasenotes/notes/recall-multi-hit-evaluator-212e6331042befe1.yaml
+++ b/releasenotes/notes/recall-multi-hit-evaluator-212e6331042befe1.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add `AnswerRecallMultiHitEvaluator`, a Component that can be used to calculate the Recall multi-hit metric
+    given a list of questions, a list of expected answers for each question and the list of predicted
+    answers for each question.

--- a/test/components/evaluators/test_answer_recall_multi_hit.py
+++ b/test/components/evaluators/test_answer_recall_multi_hit.py
@@ -1,0 +1,91 @@
+import pytest
+
+from haystack.components.evaluators.answer_recall_multi_hit import AnswerRecallMultiHitEvaluator
+
+
+def test_run_with_all_matching():
+    evaluator = AnswerRecallMultiHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["Paris"]],
+    )
+
+    assert result == {"score": 1.0}
+
+
+def test_run_with_no_matching():
+    evaluator = AnswerRecallMultiHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Paris"], ["London"]],
+    )
+
+    assert result == {"score": 0.0}
+
+
+def test_run_with_partial_matching():
+    evaluator = AnswerRecallMultiHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["London"]],
+    )
+
+    assert result == {"score": 0.5}
+
+
+def test_run_with_complex_data():
+    evaluator = AnswerRecallMultiHitEvaluator()
+    result = evaluator.run(
+        questions=[
+            "In what country is Normandy located?",
+            "When was the Latin version of the word Norman first recorded?",
+            "What developed in Normandy during the 1100s?",
+            "In what century did important classical music developments occur in Normandy?",
+            "From which countries did the Norse originate?",
+            "What century did the Normans first gain their separate identity?",
+        ],
+        ground_truth_answers=[
+            ["France"],
+            ["9th century", "9th"],
+            ["classical music", "classical"],
+            ["11th century", "the 11th"],
+            ["Denmark", "Iceland", "Norway", "Denmark, Iceland and Norway"],
+            ["10th century", "10th"],
+        ],
+        predicted_answers=[
+            ["France"],
+            ["9th century", "10th century", "9th"],
+            ["classical", "rock music", "dubstep"],
+            ["11th", "the 11th", "11th century"],
+            ["Denmark", "Norway", "Iceland"],
+            ["10th century", "the first half of the 10th century", "10th", "10th"],
+        ],
+    )
+    assert result == {"score": 0.8461538461538461}
+
+
+def test_run_with_different_lengths():
+    evaluator = AnswerRecallMultiHitEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?"],
+            ground_truth_answers=[["Berlin"], ["Paris"]],
+            predicted_answers=[["Berlin"], ["London"]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_answers=[["Berlin"]],
+            predicted_answers=[["Berlin"], ["London"]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_answers=[["Berlin"], ["Paris"]],
+            predicted_answers=[["Berlin"]],
+        )


### PR DESCRIPTION
### Related Issues

Part of #6064.

### Proposed Changes:

Add `AnswerRecallMultiHitEvaluator` Component. It can ben used to calculate Recall multi-hit metric.

### How did you test it?

I added tests.

### Notes for the reviewer

I didn't add the component in the package `__init__.py` on purpose to avoid conflicts with future PRs. 
When all the evaluators are done I'll update it.

This components differs from the others as it doesn't return the score for each question as it can't be calculated.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
