### PR TITLE
feat: Add `AnswerRecallSingleHitEvaluator`

### DIFF
--- a/haystack/components/evaluators/answer_recall_single_hit.py
+++ b/haystack/components/evaluators/answer_recall_single_hit.py
@@ -1,0 +1,62 @@
+import itertools
+from typing import Any, Dict, List
+
+from haystack.core.component import component
+
+
+@component
+class AnswerRecallSingleHitEvaluator:
+    """
+    Evaluator that calculates the Recall single-hit score for a list of questions.
+    Returns both a list of scores for each question and the average.
+    Each question can have multiple ground truth answers and multiple predicted answers.
+
+    Usage example:
+    ```python
+    from haystack.components.evaluators import AnswerRecallSingleHitEvaluator
+
+    evaluator = AnswerRecallSingleHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Paris"], ["London"]],
+    )
+
+    print(result["scores"])
+    # [0.0, 0.0]
+    print(result["average"])
+    # 0.0
+    ```
+    """
+
+    @component.output_types(scores=List[float], average=float)
+    def run(
+        self, questions: List[str], ground_truth_answers: List[List[str]], predicted_answers: List[List[str]]
+    ) -> Dict[str, Any]:
+        """
+        Run the AnswerRecallSingleHitEvaluator on the given inputs.
+        All lists must have the same length.
+
+        :param questions:
+            A list of questions.
+        :param ground_truth_answers:
+            A list of expected answers for each question.
+        :param predicted_answers:
+            A list of predicted answers for each question.
+
+        A dictionary with the following outputs:
+        - `scores` - A list of numbers from 0.0 to 1.0 that represents the proportion of matching answers retrieved.
+        - `score` - The average of calculated scores.
+
+        """
+        if not len(questions) == len(ground_truth_answers) == len(predicted_answers):
+            msg = "The length of questions, ground_truth_answers, and predicted_answers must be the same."
+            raise ValueError(msg)
+
+        scores = []
+        for ground_truth, predicted in zip(ground_truth_answers, predicted_answers):
+            retrieved_ground_truths = {g for g, p in itertools.product(ground_truth, predicted) if g in p}
+            score = len(retrieved_ground_truths) / len(ground_truth)
+            scores.append(score)
+
+        return {"scores": scores, "average": sum(scores) / len(questions)}

--- a/releasenotes/notes/recall-single-hit-evaluator-424fcd4509851a8c.yaml
+++ b/releasenotes/notes/recall-single-hit-evaluator-424fcd4509851a8c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add `AnswerRecallSingleHitEvaluator`, a Component that can be used to calculate the Recall single-hit metric
+    given a list of questions, a list of expected answers for each question and the list of predicted
+    answers for each question.

--- a/test/components/evaluators/test_answer_recall_single_hit.py
+++ b/test/components/evaluators/test_answer_recall_single_hit.py
@@ -1,0 +1,91 @@
+import pytest
+
+from haystack.components.evaluators.answer_recall_single_hit import AnswerRecallSingleHitEvaluator
+
+
+def test_run_with_all_matching():
+    evaluator = AnswerRecallSingleHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["Paris"]],
+    )
+
+    assert result == {"scores": [1.0, 1.0], "average": 1.0}
+
+
+def test_run_with_no_matching():
+    evaluator = AnswerRecallSingleHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Paris"], ["London"]],
+    )
+
+    assert result == {"scores": [0.0, 0.0], "average": 0.0}
+
+
+def test_run_with_partial_matching():
+    evaluator = AnswerRecallSingleHitEvaluator()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_answers=[["Berlin"], ["Paris"]],
+        predicted_answers=[["Berlin"], ["London"]],
+    )
+
+    assert result == {"scores": [1.0, 0.0], "average": 0.5}
+
+
+def test_run_with_complex_data():
+    evaluator = AnswerRecallSingleHitEvaluator()
+    result = evaluator.run(
+        questions=[
+            "In what country is Normandy located?",
+            "When was the Latin version of the word Norman first recorded?",
+            "What developed in Normandy during the 1100s?",
+            "In what century did important classical music developments occur in Normandy?",
+            "From which countries did the Norse originate?",
+            "What century did the Normans first gain their separate identity?",
+        ],
+        ground_truth_answers=[
+            ["France"],
+            ["9th century", "9th"],
+            ["classical music", "classical"],
+            ["11th century", "the 11th"],
+            ["Denmark", "Iceland", "Norway", "Denmark, Iceland and Norway"],
+            ["10th century", "10th"],
+        ],
+        predicted_answers=[
+            ["France"],
+            ["9th century", "10th century", "9th"],
+            ["classical", "rock music", "dubstep"],
+            ["11th", "the 11th", "11th century"],
+            ["Denmark", "Norway", "Iceland"],
+            ["10th century", "the first half of the 10th century", "10th", "10th"],
+        ],
+    )
+    assert result == {"scores": [1.0, 1.0, 0.5, 1.0, 0.75, 1.0], "average": 0.875}
+
+
+def test_run_with_different_lengths():
+    evaluator = AnswerRecallSingleHitEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?"],
+            ground_truth_answers=[["Berlin"], ["Paris"]],
+            predicted_answers=[["Berlin"], ["London"]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_answers=[["Berlin"]],
+            predicted_answers=[["Berlin"], ["London"]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_answers=[["Berlin"], ["Paris"]],
+            predicted_answers=[["Berlin"]],
+        )


### PR DESCRIPTION
### Related Issues

Part of #6064.

### Proposed Changes:

Add `AnswerRecallSingleHitEvaluator` Component. It can ben used to calculate Recall single-hit metric.

### How did you test it?

I added tests.

### Notes for the reviewer

I didn't add the component in the package `__init__.py` on purpose to avoid conflicts with future PRs. 
When all the evaluators are done I'll update it.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
