### PR TITLE
fix: add the `@component` decorator to `HuggingFaceTGIChatGenerator`

### DIFF
--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -16,6 +16,7 @@ with LazyImport(message="Run 'pip install transformers'") as transformers_import
 logger = logging.getLogger(__name__)
 
 
+@component
 class HuggingFaceTGIChatGenerator:
     """
     Enables text generation using HuggingFace Hub hosted chat-based LLMs. This component is designed to seamlessly

--- a/releasenotes/notes/tgi-chat-missing-decorator-799b2a133ee4708c.yaml
+++ b/releasenotes/notes/tgi-chat-missing-decorator-799b2a133ee4708c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add the `@component` decorator to `HuggingFaceTGIChatGenerator`.
+    The lack of this decorator made it impossible to use the `HuggingFaceTGIChatGenerator` in a pipeline.


### PR DESCRIPTION
### Related Issues

- fixes #7379

### Proposed Changes:
Add the `@component` decorator to `HuggingFaceTGIChatGenerator`.
The lack of this decorator made it impossible to use the `HuggingFaceTGIChatGenerator` in a pipeline.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
