### PR TITLE
fix: put `HFTokenStreamingHandler` in a lazy_import block

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -19,7 +19,11 @@ SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
 with LazyImport(message="Run 'pip install transformers[torch]'") as transformers_import:
     from transformers import StoppingCriteriaList, pipeline
 
-    from haystack.utils.hf import HFTokenStreamingHandler, StopWordsCriteria, resolve_hf_pipeline_kwargs
+    from haystack.utils.hf import (  # pylint: disable=ungrouped-imports
+        HFTokenStreamingHandler,
+        StopWordsCriteria,
+        resolve_hf_pipeline_kwargs,
+    )
 
 
 @component

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -10,7 +10,7 @@ from haystack.utils import (
     deserialize_secrets_inplace,
     serialize_callable,
 )
-from haystack.utils.hf import HFTokenStreamingHandler, deserialize_hf_model_kwargs, serialize_hf_model_kwargs
+from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ SUPPORTED_TASKS = ["text-generation", "text2text-generation"]
 with LazyImport(message="Run 'pip install transformers[torch]'") as transformers_import:
     from transformers import StoppingCriteriaList, pipeline
 
-    from haystack.utils.hf import StopWordsCriteria, resolve_hf_pipeline_kwargs  # pylint: disable=ungrouped-imports
+    from haystack.utils.hf import HFTokenStreamingHandler, StopWordsCriteria, resolve_hf_pipeline_kwargs
 
 
 @component

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -222,8 +222,7 @@ def check_generation_params(kwargs: Optional[Dict[str, Any]], additional_accepte
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
     from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, StoppingCriteria, TextStreamer
 
-    transformers_import.check()
-    torch_import.check()
+    torch_and_transformers_import.check()
 
     class StopWordsCriteria(StoppingCriteria):
         """


### PR DESCRIPTION
### Related Issues
Several core-integrations tests with Haytstack main are failing after #7377
See for example https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8383450235/job/22959180165

This happens because `HFTokenStreamingHandler` import in HFLocalGenerator is not inside a lazy_import block,
even if the class needs `transformers`

### Proposed Changes:
put `HFTokenStreamingHandler` in a lazy_import block

### How did you test it?
- Locally rerun the failed core-integrations tests with this change
- CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
