### PR TITLE
refactor: TGI Generator refactoring

### DIFF
--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -7,7 +7,7 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
-from haystack.utils.hf import HFModelType, check_generation_params, check_valid_model, list_inference_deployed_models
+from haystack.utils.hf import HFModelType, check_generation_params, check_valid_model
 
 with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\"'") as huggingface_hub_import:
     from huggingface_hub import (

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -120,8 +120,7 @@ class HuggingFaceTGIGenerator:
             is_valid_url = all([r.scheme in ["http", "https"], r.netloc])
             if not is_valid_url:
                 raise ValueError(f"Invalid TGI endpoint URL provided: {url}")
-
-        if model and not url:
+        elif model:
             check_valid_model(model, HFModelType.GENERATION, token)
 
         # handle generation kwargs setup

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -98,7 +98,7 @@ class HuggingFaceTGIGenerator:
         """
         huggingface_hub_import.check()
 
-        if (not model and not url) or (model and url):
+        if not model and not url:
             raise ValueError("You must provide either a model or a TGI endpoint URL.")
 
         if url:
@@ -106,8 +106,10 @@ class HuggingFaceTGIGenerator:
             is_valid_url = all([r.scheme in ["http", "https"], r.netloc])
             if not is_valid_url:
                 raise ValueError(f"Invalid TGI endpoint URL provided: {url}")
+            if model:
+                logger.warning("Both model and url are provided. The model parameter will be ignored. ")
 
-        if model:
+        if model and not url:
             check_valid_model(model, HFModelType.GENERATION, token)
             # TODO: remove this check when the huggingface_hub bugfix release is out
             # https://github.com/huggingface/huggingface_hub/issues/2135
@@ -129,8 +131,8 @@ class HuggingFaceTGIGenerator:
         self.url = url
         self.token = token
         self.generation_kwargs = generation_kwargs
-        self._client = InferenceClient(url or model, token=token.resolve_value() if token else None)
         self.streaming_callback = streaming_callback
+        self._client = InferenceClient(url or model, token=token.resolve_value() if token else None)
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -50,7 +50,6 @@ class HuggingFaceTGIGenerator:
     from haystack.utils import Secret
 
     client = HuggingFaceTGIGenerator(model="mistralai/Mistral-7B-v0.1", token=Secret.from_token("<your-api-key>"))
-    client.warm_up()
     response = client.run("What's Natural Language Processing?", max_new_tokens=120)
     print(response)
     ```
@@ -62,7 +61,6 @@ class HuggingFaceTGIGenerator:
     from haystack.components.generators import HuggingFaceTGIGenerator
     client = HuggingFaceTGIGenerator(url="<your-tgi-endpoint-url>",
                                      token=Secret.from_token("<your-api-key>"))
-    client.warm_up()
     response = client.run("What's Natural Language Processing?")
     print(response)
     ```
@@ -100,14 +98,14 @@ class HuggingFaceTGIGenerator:
 
         if not model and not url:
             raise ValueError("You must provide either a model or a TGI endpoint URL.")
+        if model and url:
+            logger.warning("Both `model` and `url` are provided. The `model` parameter will be ignored. ")
 
         if url:
             r = urlparse(url)
             is_valid_url = all([r.scheme in ["http", "https"], r.netloc])
             if not is_valid_url:
                 raise ValueError(f"Invalid TGI endpoint URL provided: {url}")
-            if model:
-                logger.warning("Both model and url are provided. The model parameter will be ignored. ")
 
         if model and not url:
             check_valid_model(model, HFModelType.GENERATION, token)

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -31,24 +31,19 @@ class HuggingFaceTGIGenerator:
     Enables text generation using HuggingFace Hub hosted non-chat LLMs.
 
     This component is designed to seamlessly inference models deployed on the Text Generation Inference (TGI) backend.
-    You can use this component for LLMs hosted on Hugging Face inference endpoints, the rate-limited
-    Inference API tier.
+    You can use this component for LLMs hosted on Hugging Face inference endpoints.
 
     Key Features and Compatibility:
-     - Primary Compatibility: designed to work seamlessly with any non-based model deployed using the TGI
+    - Primary Compatibility: designed to work seamlessly with models deployed using the TGI
        framework. For more information on TGI, visit [text-generation-inference](https://github.com/huggingface/text-generation-inference)
 
-    - Hugging Face Inference Endpoints: Supports inference of TGI chat LLMs deployed on Hugging Face
+    - Hugging Face Inference Endpoints: Supports inference of LLMs deployed on Hugging Face
        inference endpoints. For more details, refer to [inference-endpoints](https://huggingface.co/inference-endpoints)
 
-    - Inference API Support: supports inference of TGI LLMs hosted on the rate-limited Inference
+    - Inference API Support: supports inference of LLMs hosted on the rate-limited Inference
       API tier. Learn more about the Inference API at [inference-api](https://huggingface.co/inference-api).
-      Discover available chat models using the following command: `wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference | grep chat`
-      and simply use the model ID as the model parameter for this component. You'll also need to provide a valid
-      Hugging Face API token as the token parameter.
+      In this case, you need to provide a valid Hugging Face token.
 
-    - Custom TGI Endpoints: supports inference of TGI chat LLMs deployed on custom TGI endpoints. Anyone can
-      deploy their own TGI endpoint using the TGI framework. For more details, refer to [inference-endpoints](https://huggingface.co/inference-endpoints)
 
      Input and Output Format:
       - String Format: This component uses the str format for structuring both input and output,
@@ -64,7 +59,8 @@ class HuggingFaceTGIGenerator:
     ```
 
     Or for LLMs hosted on paid https://huggingface.co/inference-endpoints endpoint, and/or your own custom TGI endpoint.
-    In these two cases, you'll need to provide the URL of the endpoint as well as a valid token:
+    In these two cases, you'll need to provide the URL of the endpoint.
+    For Inference Endpoints, you also need to provide a valid Hugging Face token.
 
     ```python
     from haystack.components.generators import HuggingFaceTGIGenerator

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -14,7 +14,7 @@ from haystack.utils.device import ComponentDevice
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_import:
     import torch
 
-with LazyImport(message="Run 'pip install transformers'") as transformers_import:
+with LazyImport(message="Run 'pip install huggingface_hub'") as huggingface_hub_import:
     from huggingface_hub import HfApi, InferenceClient, model_info
     from huggingface_hub.utils import RepositoryNotFoundError
 
@@ -120,7 +120,7 @@ def resolve_hf_pipeline_kwargs(
     :param token: The token to use as HTTP bearer authorization for remote files.
         If the token is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
     """
-    transformers_import.check()
+    huggingface_hub_import.check()
 
     token = token.resolve_value() if token else None
     # check if the huggingface_pipeline_kwargs contain the essential parameters
@@ -173,7 +173,7 @@ def check_valid_model(model_id: str, model_type: HFModelType, token: Optional[Se
     :param token: The optional authentication token.
     :raises ValueError: If the model is not found or is not a embedding model.
     """
-    transformers_import.check()
+    huggingface_hub_import.check()
 
     api = HfApi()
     try:
@@ -202,7 +202,7 @@ def check_generation_params(kwargs: Optional[Dict[str, Any]], additional_accepte
     :param additional_accepted_params: An optional list of strings representing additional accepted parameters.
     :raises ValueError: If any unknown text generation parameters are provided.
     """
-    transformers_import.check()
+    huggingface_hub_import.check()
 
     if kwargs:
         accepted_params = {

--- a/releasenotes/notes/tgi-refactoring-62885781f81e18d1.yaml
+++ b/releasenotes/notes/tgi-refactoring-62885781f81e18d1.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    Improve the HuggingFaceTGIGenerator component.
+    - Lighter: the component only depends on the `huggingface_hub` library.
+    - If initialized with an appropriate `url` parameter, the component can run on a local network and does not require internet access.
+deprecations:
+  - |
+    - The HuggingFaceTGIGenerator component requires specifying either a `url` or `model` parameter.
+      Starting from Haystack 2.3.0, the component will raise an error if neither parameter is provided.
+    - The `warm_up` method of the HuggingFaceTGIGenerator component is deprecated and will be removed in 2.3.0 release.

--- a/test/components/generators/test_hugging_face_tgi.py
+++ b/test/components/generators/test_hugging_face_tgi.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from huggingface_hub import TextGenerationOutputToken, TextGenerationStreamDetails, TextGenerationStreamOutput
-from huggingface_hub.utils import RepositoryNotFoundError
 
 from haystack.components.generators.hugging_face_tgi import DEFAULT_MODEL, HuggingFaceTGIGenerator
 from haystack.dataclasses import StreamingChunk

--- a/test/components/generators/test_hugging_face_tgi.py
+++ b/test/components/generators/test_hugging_face_tgi.py
@@ -68,13 +68,13 @@ class TestHuggingFaceTGIGenerator:
             **{"stop_sequences": ["stop"]},
             **{"max_new_tokens": 512},
         }
-        assert generator.tokenizer is None
-        assert generator.client is not None
+        assert generator._client is not None
         assert generator.streaming_callback == streaming_callback
 
     def test_to_dict(self, mock_check_valid_model):
         # Initialize the HuggingFaceRemoteGenerator object with valid parameters
         generator = HuggingFaceTGIGenerator(
+            model="mistralai/Mistral-7B-v0.1",
             token=Secret.from_env_var("ENV_VAR", strict=False),
             generation_kwargs={"n": 5},
             stop_words=["stop", "words"],


### PR DESCRIPTION
### Related Issues

- part of #7279
- part of  #7384

### Proposed Changes:

- **clearer**: the user must specify either `model` or `url`.
Previously, we asked to specify the model even if not used and this required accessing the web (see #7087).
The change is not breaking because temporary deprecation and fallback mechanisms have been implemented.

- the component no longer depends on `transformers`, but only on the much **lighter** `huggingface_hub`
- remove the tokenizer: it was dependent on `transformers`, required access to the network and was only used to count prompt tokens: when using this component, the users never pay per used token

- if the user specifies a `url`, this component can perfectly run on a **local network** and does not require access to HF Hub (requested in #7229)

- validation is only performed in `__init__` (not in `warm_up`)

- removed the too restrictive check described in #7384

- the applied changes seem compatible with a similar refactoring of the ChatGenerator

### How did you test it?
CI, adapted tests
extensive manual tests: with HF Inference API, local TGI container and paid HF Inference Endpoint

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
