### PR TITLE
refactor: reorganize imports in HF utils

### DIFF
--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -14,7 +14,7 @@ from haystack.utils.device import ComponentDevice
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_import:
     import torch
 
-with LazyImport(message="Run 'pip install transformers'") as transformers_import:
+with LazyImport(message="Run 'pip install huggingface_hub'") as huggingface_hub_import:
     from huggingface_hub import HfApi, InferenceClient, model_info
     from huggingface_hub.utils import RepositoryNotFoundError
 
@@ -120,7 +120,7 @@ def resolve_hf_pipeline_kwargs(
     :param token: The token to use as HTTP bearer authorization for remote files.
         If the token is also specified in the `huggingface_pipeline_kwargs`, this parameter will be ignored.
     """
-    transformers_import.check()
+    huggingface_hub_import.check()
 
     token = token.resolve_value() if token else None
     # check if the huggingface_pipeline_kwargs contain the essential parameters
@@ -173,7 +173,7 @@ def check_valid_model(model_id: str, model_type: HFModelType, token: Optional[Se
     :param token: The optional authentication token.
     :raises ValueError: If the model is not found or is not a embedding model.
     """
-    transformers_import.check()
+    huggingface_hub_import.check()
 
     api = HfApi()
     try:
@@ -202,7 +202,7 @@ def check_generation_params(kwargs: Optional[Dict[str, Any]], additional_accepte
     :param additional_accepted_params: An optional list of strings representing additional accepted parameters.
     :raises ValueError: If any unknown text generation parameters are provided.
     """
-    transformers_import.check()
+    huggingface_hub_import.check()
 
     if kwargs:
         accepted_params = {
@@ -219,10 +219,11 @@ def check_generation_params(kwargs: Optional[Dict[str, Any]], additional_accepte
             )
 
 
-with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_transformers_import:
+with LazyImport(message="Run 'pip install transformers[torch]'") as transformers_import:
     from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, StoppingCriteria, TextStreamer
 
-    torch_and_transformers_import.check()
+    torch_import.check()
+    transformers_import.check()
 
     class StopWordsCriteria(StoppingCriteria):
         """


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8413165168/job/23034987754
When testing Amazon Bedrock integration with Haystack main, tests are failing due to incorrect import check

### Proposed Changes:
- check `torch` import before introducing `StopWordsCriteria`
- more specific name for another import block

### How did you test it?
Manual tests on Amazon Bedrock integration, CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
