### PR TITLE
test: HuggingFaceLocalGenerator test stopwords

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -143,7 +143,7 @@ class HuggingFaceLocalGenerator:
         if self.pipeline is None:
             self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
 
-        if self.stop_words and self.stopping_criteria_list is None:
+        if self.stop_words:
             stop_words_criteria = StopWordsCriteria(
                 tokenizer=self.pipeline.tokenizer, stop_words=self.stop_words, device=self.pipeline.device
             )

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -264,7 +264,12 @@ with LazyImport(message="Run 'pip install transformers[torch]'") as torch_and_tr
                     return True
             return False
 
-        def is_stop_word_found(self, generated_text_ids: torch.Tensor, stop_id: torch.Tensor) -> bool:
+        @staticmethod
+        def is_stop_word_found(generated_text_ids: torch.Tensor, stop_id: torch.Tensor) -> bool:
+            """
+            Performs phrase matching, checking if a sequence of stop tokens appears in a continuous
+            or sequential order within the generated text.
+            """
             generated_text_ids = generated_text_ids[-1]
             len_generated_text_ids = generated_text_ids.size(0)
             len_stop_id = stop_id.size(0)

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -427,7 +427,7 @@ class TestHuggingFaceLocalGenerator:
     @pytest.mark.integration
     def test_stop_words_criteria_using_hf_tokenizer(self):
         """
-        Test that StopWordsCriteria will caught stop word tokens in a continuous and sequential order in the input_ids
+        Test that StopWordsCriteria catches stop word tokens in a continuous and sequential order in the input_ids
         using a real Huggingface tokenizer.
         """
         from transformers import AutoTokenizer

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -453,3 +453,4 @@ class TestHuggingFaceLocalGenerator:
         generator.warm_up()
         results = generator.run(prompt="something that triggers something")
         assert results["replies"] != []
+        assert generator.stopping_criteria_list is not None

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -301,7 +301,7 @@ class TestHuggingFaceLocalGenerator:
         )
 
     @patch("haystack.components.generators.hugging_face_local.pipeline")
-    def test_warm_up_doesn_reload(self, pipeline_mock):
+    def test_warm_up_doesnt_reload(self, pipeline_mock):
         generator = HuggingFaceLocalGenerator(
             model="google/flan-t5-base", task="text2text-generation", token=Secret.from_token("fake-api-token")
         )
@@ -385,41 +385,18 @@ class TestHuggingFaceLocalGenerator:
         with pytest.raises(RuntimeError, match="The generation model has not been loaded."):
             generator.run(prompt="irrelevant")
 
-    def test_stop_words_criteria(self):
+    def test_stop_words_criteria_with_a_mocked_tokenizer(self):
         """
-        Test that StopWordsCriteria will check stop word tokens in a continuous and sequential order
+        Test that StopWordsCriteria will caught stop word tokens in a continuous and sequential order in the input_ids
         """
-        # input ids for "unambiguously"
-        stop_words_id = torch.tensor([[73, 24621, 11937]])
-
-        # input ids for "This is ambiguously, but is unrelated."
-        input_ids1 = torch.tensor([[100, 19, 24621, 11937, 6, 68, 19, 73, 3897, 5]])
-        # input ids for "This is unambiguously"
-        input_ids2 = torch.tensor([[100, 19, 73, 24621, 11937]])
-
-        # We used to implement stop words algorithm using the torch.isin function like this:
-        # `all(torch.isin(stop_words_id, input_ids1)[0])`
-        # However, this algorithm is not correct as it will return True for presence of "unambiguously" in input_ids1
-        # and True for presence of "unambiguously" in input_ids2. This is because the algorithm will check
-        # if the stop word tokens are present in the input_ids, but it does not check if the stop word tokens are
-        # present in a continuous/sequential order.
-
-        # In "This is ambiguously, but is unrelated." sentence the "un" token comes from "unrelated" and the
-        # "ambiguously" token comes from "ambiguously". The algorithm will return True for presence of
-        # "unambiguously" in input_ids1 which is not correct.
-
+        stop_words_id = torch.LongTensor([[73, 24621, 11937]])  # "unambiguously"
+        # "This is ambiguously, but is unrelated."
+        input_ids_one = torch.LongTensor([[100, 19, 24621, 11937, 6, 68, 19, 73, 3897, 5]])
+        input_ids_two = torch.LongTensor([[100, 19, 73, 24621, 11937]])  # "This is unambiguously"
         stop_words_criteria = StopWordsCriteria(tokenizer=Mock(spec=PreTrainedTokenizerFast), stop_words=["mock data"])
-        # because we are mocking the tokenizer, we need to set the stop words manually
         stop_words_criteria.stop_ids = stop_words_id
-
-        # this is the correct algorithm to check if the stop word tokens are present in a continuous and sequential order
-        # For the input_ids1, the stop word tokens are present BUT not in a continuous order
-        present_and_continuous = stop_words_criteria(input_ids1, scores=None)
-        assert not present_and_continuous
-
-        # For the input_ids2, the stop word tokens are both present and in a continuous order
-        present_and_continuous = stop_words_criteria(input_ids2, scores=None)
-        assert present_and_continuous
+        assert not stop_words_criteria(input_ids_one, scores=None)
+        assert stop_words_criteria(input_ids_two, scores=None)
 
     @patch("haystack.components.generators.hugging_face_local.pipeline")
     @patch("haystack.components.generators.hugging_face_local.StopWordsCriteria")
@@ -428,32 +405,51 @@ class TestHuggingFaceLocalGenerator:
         self, pipeline_mock, stop_words_criteria_mock, stopping_criteria_list_mock
     ):
         """
-        Test that warm_up method sets the `stopping_criteria_list` attribute
-        if `stop_words` is provided
+        Test that warm_up method sets the `stopping_criteria_list` attribute if `stop_words` is provided
         """
         generator = HuggingFaceLocalGenerator(
-            model="google/flan-t5-base", task="text2text-generation", stop_words=["coca", "cola"]
+            model="google/flan-t5-small", task="text2text-generation", stop_words=["coca", "cola"]
         )
-
         generator.warm_up()
-
         stop_words_criteria_mock.assert_called_once()
         stopping_criteria_list_mock.assert_called_once()
-
         assert hasattr(generator, "stopping_criteria_list")
 
     def test_run_stop_words_removal(self):
-        """
-        Test that stop words are removed from the generated text
-        (does not test stopping text generation)
-        """
+        """Test that stop words are removed from the generated text (does not test stopping text generation)"""
         generator = HuggingFaceLocalGenerator(
-            model="google/flan-t5-base", task="text2text-generation", stop_words=["world"]
+            model="google/flan-t5-small", task="text2text-generation", stop_words=["world"]
         )
-
-        # create the pipeline object (simulating the warm_up)
         generator.pipeline = Mock(return_value=[{"generated_text": "Hello world"}])
-
         results = generator.run(prompt="irrelevant")
-
         assert results == {"replies": ["Hello"]}
+
+    @pytest.mark.integration
+    def test_stop_words_criteria_using_hf_tokenizer(self):
+        """
+        Test that StopWordsCriteria will caught stop word tokens in a continuous and sequential order in the input_ids
+        using a real Huggingface tokenizer.
+        """
+        from transformers import AutoTokenizer
+
+        model_name = "google/flan-t5-small"
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        criteria = StopWordsCriteria(tokenizer=tokenizer, stop_words=["unambiguously"])
+
+        text_one = "This is ambiguously, but is unrelated."
+        generated_text_ids = tokenizer.encode(text_one, add_special_tokens=False, return_tensors="pt")
+        assert criteria(generated_text_ids, scores=None) is False
+
+        text_two = "This is unambiguously"
+        generated_text_ids = tokenizer.encode(text_two, add_special_tokens=False, return_tensors="pt")
+        assert criteria(generated_text_ids, scores=None) is True
+
+    @pytest.mark.integration
+    def test_hf_pipeline_runs_with_our_criteria(self):
+        """Test that creating our own StopWordsCriteria and passing it to a Huggingface pipeline works."""
+        generator = HuggingFaceLocalGenerator(
+            model="google/flan-t5-small", task="text2text-generation", stop_words=["unambiguously"]
+        )
+        generator.warm_up()
+        results = generator.run(prompt="something that triggers something")
+        assert results["replies"] != []


### PR DESCRIPTION
### Related Issues

- fixes #6082

### Proposed Changes:

- kept the test that uses a mocked tokenizer (`test_stop_words_criteria_with_a_mocked_tokenizer`) testing that Haystack's `StopWordsCriteria` works
- added a test stop words using a Hugginface tokenizer, essentially the same as above but downloads a tokenizer from HF and uses it to generate input ids
- added a test that uses a Huggingface model + tokenizer + Haystack's StopWordsCriteria, its tests that all components work. 

- NOTE: the last test doesn't account if the huggingface model pipeline after run actually stopped at the right word, I would say that's covered with the first two tests, check my comments on https://github.com/deepset-ai/haystack/issues/6082 for more context on why I opted for this approach on testing


#### others

- cleaned up the `test_stop_words_criteria_with_a_mocked_tokenizer` and add a `docstring` to summarise the idea of the test
- removed the `if self.stopping_criteria_list is None` since at this point in the code it's always empty
- converted some methods to `@staticmethod`
- fixed some typos
- changed all the tests to use the `google/flan-t5-small` since it's 1/3 of the size of the `google--flan-t5-base`

```
948M	hub/models--google--flan-t5-base
297M	hub/models--google--flan-t5-small
```


### How did you test it?

- Run the tests locally

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
