### PR TITLE
feat: Add support for `response_format` and `seed` in OpenAI and Azure OpenAI invocation layers

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -152,10 +152,12 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
             "frequency_penalty": kwargs_with_defaults.get("frequency_penalty", 0),
             "logit_bias": kwargs_with_defaults.get("logit_bias", {}),
         }
-        if kwargs_with_defaults.get("response_format", None):
-            base_payload["response_format"] = kwargs_with_defaults.get("response_format")
-        if kwargs_with_defaults.get("seed", None):
-            base_payload["seed"] = kwargs_with_defaults.get("seed")
+        response_format = kwargs_with_defaults.get("response_format", None)
+        if response_format:
+            base_payload["response_format"] = response_format
+        seed = kwargs_with_defaults.get("seed", None)
+        if seed:
+            base_payload["seed"] = seed
 
         return (prompt, base_payload, kwargs_with_defaults, stream, moderation)
 

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -95,6 +95,8 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
                 "stream",
                 "stream_handler",
                 "moderate_content",
+                "seed",
+                "response_format",
             ]
             if key in kwargs
         }
@@ -150,6 +152,10 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
             "frequency_penalty": kwargs_with_defaults.get("frequency_penalty", 0),
             "logit_bias": kwargs_with_defaults.get("logit_bias", {}),
         }
+        if kwargs_with_defaults.get("response_format", None):
+            base_payload["response_format"] = kwargs_with_defaults.get("response_format")
+        if kwargs_with_defaults.get("seed", None):
+            base_payload["seed"] = kwargs_with_defaults.get("seed")
 
         return (prompt, base_payload, kwargs_with_defaults, stream, moderation)
 


### PR DESCRIPTION
### Related Issues

- fixes #7410 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Allows users to pass `response_format` and `seed` through the `model_kwargs` of the PromptNode when using OpenAI or Azure OpenAI invocation layers. 

Example usage
```
openai = PromptNode(
    model_name_or_path="gpt-3.5-turbo",
    model_kwargs={"seed": 42, "response_format": {"type": "json_object"}},
    api_key=API_KEY
)
openai.prompt("Create a sample JSON output")
# ['{\n  "name": "John Doe",\n  "age": 30,\n  "city": "New York",\n  "email": "johndoe@example.com",\n  "phone": "555-555-5555"\n}']
```

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manually tested it.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
