### PR TITLE
feat: DynamicChatPromptBuilder add templating to all user/system messages

### DIFF
--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -137,10 +137,13 @@ class DynamicChatPromptBuilder:
         for message in prompt_source:
             if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
                 template = self._validate_template(message.content, set(template_variables.keys()))
-                templated_message = ChatMessage.with_role(
-                    content=template.render(template_variables), role=message.role
+                rendered_content = template.render(template_variables)
+                rendered_message = (
+                    ChatMessage.from_user(rendered_content)
+                    if message.is_from(ChatRole.USER)
+                    else ChatMessage.from_system(rendered_content)
                 )
-                processed_messages.append(templated_message)
+                processed_messages.append(rendered_message)
             else:
                 processed_messages.append(message)
         return {"prompt": processed_messages}

--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -108,39 +108,6 @@ class DynamicChatPromptBuilder:
 
         :returns: A dictionary with the following keys:
             - `prompt`: The updated list of `ChatMessage` instances after rendering the found templates.
-        """
-        kwargs = kwargs or {}
-        template_variables = template_variables or {}
-        template_variables_combined = {**kwargs, **template_variables}
-        if not template_variables_combined:
-            logger.warning(
-                "The DynamicChatPromptBuilder run method requires template variables, but none were provided. "
-                "Please provide an appropriate template variable to enable correct prompt generation."
-            )
-        result: List[ChatMessage] = self._process_chat_messages(prompt_source, template_variables_combined)
-        return {"prompt": result}
-
-    def _process_chat_messages(self, prompt_source: List[ChatMessage], template_variables: Dict[str, Any]):
-        """
-        Processes a list of `ChatMessage` instances to generate a chat prompt.
-
-        It treats all user and system messages as potentially having templates and renders them with the provided
-        template variables.
-
-        The resulting messages replace the original user and system messages in the list, forming a complete,
-        templated chat prompt.
-
-        It takes the last user message in the list, treats it as a template, and renders it with the provided
-        template variables. The resulting message replaces the last user message in the list, forming a complete,
-        templated chat prompt.
-
-        :param prompt_source:
-            A list of `ChatMessage` instances to be processed. All user and system messages are treated as
-            potentially having templates and are rendered with the provided template variables - if templates are found.
-        :param template_variables:
-            A dictionary of template variables used for rendering the templates in the chat messages.
-        :returns:
-            A list of `ChatMessage` instances after rendering the found templates.
         :raises ValueError:
             If `chat_messages` is empty or contains elements that are not instances of `ChatMessage`.
         :raises ValueError:
@@ -158,6 +125,14 @@ class DynamicChatPromptBuilder:
                 f"are ChatMessage instances."
             )
 
+        kwargs = kwargs or {}
+        template_variables = template_variables or {}
+        template_variables = {**kwargs, **template_variables}
+        if not template_variables:
+            logger.warning(
+                "The DynamicChatPromptBuilder run method requires template variables, but none were provided. "
+                "Please provide an appropriate template variable to enable correct prompt generation."
+            )
         processed_messages = []
         for message in prompt_source:
             if message.is_from(ChatRole.USER) or message.is_from(ChatRole.SYSTEM):
@@ -168,7 +143,7 @@ class DynamicChatPromptBuilder:
                 processed_messages.append(templated_message)
             else:
                 processed_messages.append(message)
-        return processed_messages
+        return {"prompt": processed_messages}
 
     def _validate_template(self, template_text: str, provided_variables: Set[str]):
         """

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -94,14 +94,3 @@ class ChatMessage:
         :returns: A new ChatMessage instance.
         """
         return cls(content, ChatRole.FUNCTION, name)
-
-    @classmethod
-    def with_role(cls, content: str, role: ChatRole) -> "ChatMessage":
-        """
-        Create a message from a specific role.
-
-        :param content: The text content of the message.
-        :param role: The role of the entity sending the message.
-        :returns: A new ChatMessage instance.
-        """
-        return cls(content, role, None)

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -94,3 +94,14 @@ class ChatMessage:
         :returns: A new ChatMessage instance.
         """
         return cls(content, ChatRole.FUNCTION, name)
+
+    @classmethod
+    def with_role(cls, content: str, role: ChatRole) -> "ChatMessage":
+        """
+        Create a message from a specific role.
+
+        :param content: The text content of the message.
+        :param role: The role of the entity sending the message.
+        :returns: A new ChatMessage instance.
+        """
+        return cls(content, role, None)

--- a/releasenotes/notes/dynamic-chat-prompt-templating-enhancement-e8d36cbf3be46da7.yaml
+++ b/releasenotes/notes/dynamic-chat-prompt-templating-enhancement-e8d36cbf3be46da7.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Enhanced DynamicChatPromptBuilder's capabilities by allowing all user and system messages to be templated with provided variables. This update ensures a more versatile and dynamic templating process, making chat prompt generation more efficient and customized to user needs.

--- a/test/components/builders/test_dynamic_chat_prompt_builder.py
+++ b/test/components/builders/test_dynamic_chat_prompt_builder.py
@@ -95,7 +95,7 @@ class TestDynamicChatPromptBuilder:
         language = "French"
         location = "Berlin"
         messages = [
-            ChatMessage.from_system("Write your response ins this language:{{language}}"),
+            ChatMessage.from_system("Write your response in this language:{{language}}"),
             ChatMessage.from_user("Tell me about {{location}}"),
         ]
 

--- a/test/components/builders/test_dynamic_chat_prompt_builder.py
+++ b/test/components/builders/test_dynamic_chat_prompt_builder.py
@@ -103,7 +103,7 @@ class TestDynamicChatPromptBuilder:
             template_variables={"language": language, "location": location}, prompt_source=messages
         )
         assert result["prompt"] == [
-            ChatMessage.from_system("Write your response ins this language:French"),
+            ChatMessage.from_system("Write your response in this language:French"),
             ChatMessage.from_user("Tell me about Berlin"),
         ], "The templated messages should match the expected output."
 

--- a/test/components/builders/test_dynamic_chat_prompt_builder.py
+++ b/test/components/builders/test_dynamic_chat_prompt_builder.py
@@ -42,23 +42,21 @@ class TestDynamicChatPromptBuilder:
         prompt_source = [ChatMessage.from_user(content="Hello, {{ who }}!")]
         template_variables = {"who": "World"}
 
-        result = prompt_builder._process_chat_messages(prompt_source, template_variables)
+        result = prompt_builder.run(prompt_source, template_variables)
 
-        assert result == [ChatMessage.from_user(content="Hello, World!")]
+        assert result == {"prompt": [ChatMessage.from_user(content="Hello, World!")]}
 
     def test_empty_chat_message_list(self):
         prompt_builder = DynamicChatPromptBuilder(runtime_variables=["documents"])
 
         with pytest.raises(ValueError):
-            prompt_builder._process_chat_messages(prompt_source=[], template_variables={})
+            prompt_builder.run(prompt_source=[], template_variables={})
 
     def test_chat_message_list_with_mixed_object_list(self):
         prompt_builder = DynamicChatPromptBuilder(runtime_variables=["documents"])
 
         with pytest.raises(ValueError):
-            prompt_builder._process_chat_messages(
-                prompt_source=[ChatMessage.from_user("Hello"), "there world"], template_variables={}
-            )
+            prompt_builder.run(prompt_source=[ChatMessage.from_user("Hello"), "there world"], template_variables={})
 
     def test_chat_message_list_with_missing_variables(self):
         prompt_builder = DynamicChatPromptBuilder(runtime_variables=["documents"])
@@ -66,7 +64,7 @@ class TestDynamicChatPromptBuilder:
 
         # Call the _process_chat_messages method and expect a ValueError
         with pytest.raises(ValueError):
-            prompt_builder._process_chat_messages(prompt_source, template_variables={})
+            prompt_builder.run(prompt_source, template_variables={})
 
     def test_missing_template_variables(self):
         prompt_builder = DynamicChatPromptBuilder(runtime_variables=["documents"])


### PR DESCRIPTION
### Why:
Enhances the `DynamicChatPromptBuilder` component by introducing more advanced and flexible chat message templating capabilities. The update ensures that not only the last user message but all user and system messages within a chat can be dynamically templated with provided variables. 

- fixes https://github.com/deepset-ai/haystack/issues/6926

### What:
- **Dynamic Chat Prompt Templating Improvement**: The core change involves updating the `_process_chat_messages` method within `dynamic_chat_prompt_builder.py` to apply templating to all user and system messages based on provided template variables instead of just the last user message. This is achieved by iterating through each chat message and rendering it with the template variables if applicable.
- **New ChatMessage Class Method**: A new method `with_role` was introduced in `chat_message.py`, facilitating the creation of templated messages while preserving their original roles (user, system, etc.).
- **Documentation and Testing Enhancements**: The release notes and test cases have been updated to reflect and verify the new templating capabilities. The newly added tests cover multiple scenarios, ensuring that templating works as expected for various message types and content.

### How can it be used:
- Enhanced chat prompt generation by allowing customized templates for user and system messages. This can be particularly useful for chatbots requiring dynamic responses based on user inputs or system states.

```python

        prompt_builder = DynamicChatPromptBuilder(runtime_variables=["language", "location"])
        language = "French"
        location = "Berlin"
        messages = [
            ChatMessage.from_system("Write your response ins this language:{{language}}"),
            ChatMessage.from_user("Tell me about {{location}}"),
        ]

        result = prompt_builder.run(
            template_variables={"language": language, "location": location}, prompt_source=messages
        )
        assert result["prompt"] == [
            ChatMessage.from_system("Write your response ins this language:French"),
            ChatMessage.from_user("Tell me about Berlin"),
        ]
```

### How did you test it:
- **Unit Tests**: Comprehensive unit tests were added to validate the new templating functionality. These tests include scenarios with multiple templated user and system messages, as well as mixed cases where some messages do not require templating. 
- **Pipeline Integration Test**: Testing was also extended to pipeline integration, ensuring that the templating works as expected when integrated with other components of the Haystack framework.
- **Validation**: Each test ensures that the templated output matches expected results, verifying both the correctness of the templating process and its compatibility with different message roles.

### Notes for the reviewer:
- The changes touch on critical components related to chat prompt generation, which is central to user interaction. Reviewers should ensure the templating logic's accuracy and efficiency, especially in scenarios with a large number of chat messages.
- Special attention should be given to the test cases to ensure they cover all plausible use cases and edge cases, ensuring robustness.
