### PR TITLE
refactor!: make TGI generators compatible with `huggingface_hub>=0.22.0`

### DIFF
--- a/haystack/components/embedders/hugging_face_tei_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_tei_document_embedder.py
@@ -9,7 +9,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
 from haystack.utils.hf import HFModelType, check_valid_model
 
-with LazyImport(message="Run 'pip install huggingface_hub'") as huggingface_hub_import:
+with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\"'") as huggingface_hub_import:
     from huggingface_hub import InferenceClient
 
 logger = logging.getLogger(__name__)

--- a/haystack/components/embedders/hugging_face_tei_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_tei_text_embedder.py
@@ -6,7 +6,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
 from haystack.utils.hf import HFModelType, check_valid_model
 
-with LazyImport(message="Run 'pip install huggingface_hub'") as huggingface_hub_import:
+with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\"'") as huggingface_hub_import:
     from huggingface_hub import InferenceClient
 
 logger = logging.getLogger(__name__)

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -286,7 +286,7 @@ class HuggingFaceTGIChatGenerator:
             message = ChatMessage.from_assistant(tgr.generated_text)
             message.meta.update(
                 {
-                    "finish_reason": tgr.details.finish_reason.value,
+                    "finish_reason": tgr.details.finish_reason,
                     "index": _i,
                     "model": self.client.model,
                     "usage": {

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -9,12 +9,10 @@ from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inp
 from haystack.utils.hf import HFModelType, check_generation_params, check_valid_model, list_inference_deployed_models
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:
-    from huggingface_hub import InferenceClient
-    from huggingface_hub.inference._generated.types.text_generation import (
-        TextGenerationFinishReason,
+    from huggingface_hub import (
+        InferenceClient,
         TextGenerationOutput,
         TextGenerationOutputToken,
-        TextGenerationStreamDetails,
         TextGenerationStreamOutput,
     )
     from transformers import AutoTokenizer
@@ -267,7 +265,7 @@ class HuggingFaceTGIChatGenerator:
         message = ChatMessage.from_assistant(chunk.generated_text)
         message.meta.update(
             {
-                "finish_reason": chunk.details.finish_reason.value,
+                "finish_reason": chunk.details.finish_reason,
                 "index": 0,
                 "model": self.client.model,
                 "usage": {

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -8,7 +8,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 from haystack.utils.hf import HFModelType, check_generation_params, check_valid_model, list_inference_deployed_models
 
-with LazyImport(message="Run 'pip install transformers'") as transformers_import:
+with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\" transformers'") as transformers_import:
     from huggingface_hub import (
         InferenceClient,
         TextGenerationOutput,

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -9,8 +9,8 @@ from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inp
 from haystack.utils.hf import HFModelType, check_generation_params, check_valid_model, list_inference_deployed_models
 
 with LazyImport(message="Run 'pip install transformers'") as transformers_import:
-    from huggingface_hub import InferenceClient
-    from huggingface_hub.inference._generated.types.text_generation import (
+    from huggingface_hub import (
+        InferenceClient,
         TextGenerationOutput,
         TextGenerationOutputToken,
         TextGenerationStreamOutput,

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -8,7 +8,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 from haystack.utils.hf import HFModelType, check_generation_params, check_valid_model, list_inference_deployed_models
 
-with LazyImport(message="Run 'pip install transformers'") as transformers_import:
+with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\" transformers'") as transformers_import:
     from huggingface_hub import (
         InferenceClient,
         TextGenerationOutput,

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -252,7 +252,7 @@ class HuggingFaceTGIGenerator:
                 {
                     "model": self.client.model,
                     "index": _i,
-                    "finish_reason": tgr.details.finish_reason.value,
+                    "finish_reason": tgr.details.finish_reason,
                     "usage": {
                         "completion_tokens": len(tgr.details.tokens),
                         "prompt_tokens": prompt_token_count,

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -14,7 +14,7 @@ from haystack.utils.device import ComponentDevice
 with LazyImport(message="Run 'pip install transformers[torch]'") as torch_import:
     import torch
 
-with LazyImport(message="Run 'pip install huggingface_hub'") as huggingface_hub_import:
+with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\"'") as huggingface_hub_import:
     from huggingface_hub import HfApi, InferenceClient, model_info
     from huggingface_hub.utils import RepositoryNotFoundError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ format-check = "black --check ."
 [tool.hatch.envs.test]
 extra-dependencies = [
   "transformers[torch,sentencepiece]==4.38.2",  # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
-  "huggingface_hub<0.22.0", # TGI Generators and TEI Embedders
+  "huggingface_hub>=0.22.0", # TGI Generators and TEI Embedders
   "spacy>=3.7,<3.8",  # NamedEntityExtractor
   "spacy-curated-transformers>=0.2,<=0.3",  # NamedEntityExtractor
   "en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.7.3/en_core_web_trf-3.7.3-py3-none-any.whl",  # NamedEntityExtractor

--- a/releasenotes/notes/upgrade-tgi-to-new-hf-hub-51fcb3b6122fe020.yaml
+++ b/releasenotes/notes/upgrade-tgi-to-new-hf-hub-51fcb3b6122fe020.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    The `HuggingFaceTGIGenerator` and `HuggingFaceTGIChatGenerator` components have been modified to be compatible with
+    `huggingface_hub>=0.22.0`.
+
+    If you use these components, you may need to upgrade the `huggingface_hub` library.
+    To do this, run the following command in your environment:
+    ```bash
+    pip install "huggingface_hub>=0.22.0"
+    ```

--- a/test/components/generators/chat/test_hugging_face_tgi.py
+++ b/test/components/generators/chat/test_hugging_face_tgi.py
@@ -1,7 +1,11 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from huggingface_hub.inference._text_generation import FinishReason, StreamDetails, TextGenerationStreamResponse, Token
+from huggingface_hub.inference._generated.types.text_generation import (
+    TextGenerationOutputToken,
+    TextGenerationStreamDetails,
+    TextGenerationStreamOutput,
+)
 from huggingface_hub.utils import RepositoryNotFoundError
 
 from haystack.components.generators.chat import HuggingFaceTGIChatGenerator
@@ -328,13 +332,14 @@ class TestHuggingFaceTGIChatGenerator:
         # Create a fake streamed response
         # self needed here, don't remove
         def mock_iter(self):
-            yield TextGenerationStreamResponse(
-                generated_text=None, token=Token(id=1, text="I'm fine, thanks.", logprob=0.0, special=False)
-            )
-            yield TextGenerationStreamResponse(
+            yield TextGenerationStreamOutput(
                 generated_text=None,
-                token=Token(id=1, text="Ok bye", logprob=0.0, special=False),
-                details=StreamDetails(finish_reason=FinishReason.Length, generated_tokens=5),
+                token=TextGenerationOutputToken(id=1, text="I'm fine, thanks.", logprob=0.0, special=False),
+            )
+            yield TextGenerationStreamOutput(
+                generated_text=None,
+                token=TextGenerationOutputToken(id=1, text="Ok bye", logprob=0.0, special=False),
+                details=TextGenerationStreamDetails(finish_reason="length", generated_tokens=5, seed=None),
             )
 
         mock_response = Mock(**{"__iter__": mock_iter})

--- a/test/components/generators/chat/test_hugging_face_tgi.py
+++ b/test/components/generators/chat/test_hugging_face_tgi.py
@@ -1,11 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from huggingface_hub.inference._generated.types.text_generation import (
-    TextGenerationOutputToken,
-    TextGenerationStreamDetails,
-    TextGenerationStreamOutput,
-)
+from huggingface_hub import TextGenerationOutputToken, TextGenerationStreamDetails, TextGenerationStreamOutput
 from huggingface_hub.utils import RepositoryNotFoundError
 
 from haystack.components.generators.chat import HuggingFaceTGIChatGenerator

--- a/test/components/generators/test_hugging_face_tgi.py
+++ b/test/components/generators/test_hugging_face_tgi.py
@@ -1,7 +1,11 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from huggingface_hub.inference._text_generation import FinishReason, StreamDetails, TextGenerationStreamResponse, Token
+from huggingface_hub.inference._generated.types.text_generation import (
+    TextGenerationOutputToken,
+    TextGenerationStreamDetails,
+    TextGenerationStreamOutput,
+)
 from huggingface_hub.utils import RepositoryNotFoundError
 
 from haystack.components.generators import HuggingFaceTGIGenerator
@@ -270,13 +274,14 @@ class TestHuggingFaceTGIGenerator:
         # Create a fake streamed response
         # Don't remove self
         def mock_iter(self):
-            yield TextGenerationStreamResponse(
-                generated_text=None, token=Token(id=1, text="I'm fine, thanks.", logprob=0.0, special=False)
-            )
-            yield TextGenerationStreamResponse(
+            yield TextGenerationStreamOutput(
                 generated_text=None,
-                token=Token(id=1, text="Ok bye", logprob=0.0, special=False),
-                details=StreamDetails(finish_reason=FinishReason.Length, generated_tokens=5),
+                token=TextGenerationOutputToken(id=1, text="I'm fine, thanks.", logprob=0.0, special=False),
+            )
+            yield TextGenerationStreamOutput(
+                generated_text=None,
+                token=TextGenerationOutputToken(id=1, text="Ok bye", logprob=0.0, special=False),
+                details=TextGenerationStreamDetails(finish_reason="length", generated_tokens=5, seed=None),
             )
 
         mock_response = Mock(**{"__iter__": mock_iter})

--- a/test/components/generators/test_hugging_face_tgi.py
+++ b/test/components/generators/test_hugging_face_tgi.py
@@ -1,11 +1,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from huggingface_hub.inference._generated.types.text_generation import (
-    TextGenerationOutputToken,
-    TextGenerationStreamDetails,
-    TextGenerationStreamOutput,
-)
+from huggingface_hub import TextGenerationOutputToken, TextGenerationStreamDetails, TextGenerationStreamOutput
 from huggingface_hub.utils import RepositoryNotFoundError
 
 from haystack.components.generators import HuggingFaceTGIGenerator


### PR DESCRIPTION
### Related Issues

- fixes #7418

### Proposed Changes:
- Adopt all new abstractions of `huggingface_hub`: they are now public (and less susceptible to breaking changes, I hope)
- Encourage users to install `huggingface_hub>=0.22.0` in lazy_import message and release note. Since it is not a core dependency, there seems to be no effective way to make this encouragement mandatory.
- Remove pin from tests dependencies

### How did you test it?
- CI, adapted tests
- manual tests for both the generators, in streaming and non-streaming mode, with the HF Inference API and a local TGI container

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
