### PR TITLE
Fix: Fix Pipeline.run() running components with only defaults in the wrong order

### DIFF
--- a/releasenotes/notes/fix-pipeline-run-disorder-382da1e6bd6db510.yaml
+++ b/releasenotes/notes/fix-pipeline-run-disorder-382da1e6bd6db510.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes `Pipeline.run()` logic so Components that have all their inputs with a default are run in the correct order.
+    This happened we gather a list of Components to run internally when running the Pipeline in the order they are
+    added during creation of the Pipeline.
+    This caused some Components to run before they received all their inputs.


### PR DESCRIPTION
### Related Issues

- fixes #7243

### Proposed Changes:

Changes the behaviour of `Pipeline.run()` to treat Components that have only default inputs the same way we treat Component with Variadic that are marked as lazy. This is done only when trying to remove Components from the internal `waiting_for_input` queue.

### How did you test it?

I added a new unit test and verified other weren't breaking.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
