### PR TITLE
Ensure test_comparison_in checks an actual subset of documents

### DIFF
--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -1139,10 +1139,10 @@ class FilterDocumentsTest(AssertDocumentsEqualMixin, FilterableDocsFixtureMixin)
     # in comparator
     def test_comparison_in(self, document_store, filterable_docs):
         document_store.write_documents(filterable_docs)
-        result = document_store.filter_documents({"field": "meta.number", "operator": "in", "value": [9, 10]})
-        self.assert_documents_are_equal(
-            result, [d for d in filterable_docs if d.meta.get("number") is not None and d.meta["number"] in [9, 10]]
-        )
+        result = document_store.filter_documents({"field": "meta.number", "operator": "in", "value": [10, -10]})
+        assert len(result)
+        expected = [d for d in filterable_docs if d.meta.get("number") is not None and d.meta["number"] in [10, -10]]
+        self.assert_documents_are_equal(result, expected)
 
     def test_comparison_in_with_with_non_list(self, document_store, filterable_docs):
         document_store.write_documents(filterable_docs)

--- a/releasenotes/notes/fix-document-store-in-test-3640b8b079ff4539.yaml
+++ b/releasenotes/notes/fix-document-store-in-test-3640b8b079ff4539.yaml
@@ -1,0 +1,9 @@
+---
+
+fixes:
+  - |
+    The `test_comparison_in` test case in the base document store tests used to
+    always pass, no matter how the `in` filtering logic was implemented in
+    document stores. With the fix, the `in` logic is actually tested. Some tests
+    might start to fail for document stores that don't implement the `in` filter
+    correctly.


### PR DESCRIPTION
### Related Issues

- fixes #7217 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
