### PR TITLE
ci: notify e2e nightly failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,10 +35,10 @@ jobs:
       run: pip install hatch==${{ env.HATCH_VERSION }}
 
     - name: Run tests
-      run: exit 1 #hatch run test:e2e
+      run: hatch run test:e2e
 
     - name: Send event to Datadog
-      if: failure() #&& github.event_name == 'schedule'
+      if: failure() && github.event_name == 'schedule'
       uses: masci/datadog@v1
       with:
         api-key: ${{ secrets.CORE_DATADOG_API_KEY }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,4 +35,24 @@ jobs:
       run: pip install hatch==${{ env.HATCH_VERSION }}
 
     - name: Run tests
-      run: hatch run test:e2e
+      run: exit 1 #hatch run test:e2e
+
+    - name: Send event to Datadog
+      if: failure() #&& github.event_name == 'schedule'
+      uses: masci/datadog@v1
+      with:
+        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+        api-url: https://api.datadoghq.eu
+        events: |
+          - title: "${{ github.workflow }} workflow"
+            text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
+            alert_type: "error"
+            source_type_name: "Github"
+            host: ${{ github.repository_owner }}
+            tags:
+              - "project:${{ github.repository }}"
+              - "job:${{ github.job }}"
+              - "run_id:${{ github.run_id }}"
+              - "workflow:${{ github.workflow }}"
+              - "branch:${{ github.ref_name }}"
+              - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
### Related Issues

- fixes #5334

### Proposed Changes:
- introduce a job that send failure events to Datadog in case of nightly failures
- (in Datadog: configure the related monitor that sends notifications)

### How did you test it?
Tested on https://github.com/deepset-ai/haystack/pull/7429/commits/60fbefedad25e0386f84f56dfcd114a07cd99c3a -> triggered a Slack notification

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
