### PR TITLE
feat: Add boolen to toggle prompt truncation

### DIFF
--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -1202,3 +1202,14 @@ async def test_aprompt(mock_model):
     mock_model.return_value.ainvoke = AsyncMock()
     await node._aprompt(PromptTemplate("test template"))
     mock_model.return_value.ainvoke.assert_awaited_once()
+
+
+@pytest.mark.unit
+@patch("haystack.nodes.prompt.prompt_node.PromptModel")
+def test_prompt_no_truncation(mock_model, caplog):
+    node = PromptNode(truncate=False)
+    mock_model.return_value.invoke = MagicMock()
+    prompt = "Repeating text" * 200 + "Docs: Berlin is an amazing city.; Answer:"
+    with caplog.at_level(logging.DEBUG):
+        _ = node.prompt(PromptTemplate(prompt))
+        assert prompt in caplog.text


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
We've found that in some situations we'd prefer the model provider (e.g. OpenAI) to return with an error message if the prompt is too long rather than truncate the end of the prompt which can lead to non-sensical answers depending on how the PromptTemplate is constructed. So I propose adding a parameter to toggle this behavior with the default behavior being unchanged (i.e. `truncation=True` is the same as the previous default behavior).

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test.

I also tested this manually with an Azure deployment and did see an error message returned as expected when setting `truncate=False`
```
haystack.errors.OpenAIError: OpenAI returned an error.
Status code: 400
Response body: {
  "error": {
    "message": "This model's maximum context length is 8192 tokens. However, you requested 14008 tokens (7008 in the messages, 7000 in the completion). Please reduce the length of the messages or completion.",
    "type": "invalid_request_error",
    "param": "messages",
    "code": "context_length_exceeded"
  }
}
```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
