### PR TITLE
fix: Fix `Pipeline.run()` getting stuck in a loop even though there are components that can run

### DIFF
--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -9,6 +9,7 @@ import pytest
 
 from haystack import Document
 from haystack.components.builders import PromptBuilder
+from haystack.components.builders.answer_builder import AnswerBuilder
 from haystack.components.others import Multiplexer
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.core.component import component
@@ -807,3 +808,39 @@ def test_correct_execution_order_of_components_with_only_defaults(spying_tracer)
             "Question: What is the capital of France?"
         }
     }
+
+
+def test_pipeline_is_not_stuck_with_components_with_only_defaults():
+    FakeGenerator = component_class(
+        "FakeGenerator", input_types={"prompt": str}, output_types={"replies": List[str]}, output={"replies": ["Paris"]}
+    )
+    docs = [Document(content="Rome is the capital of Italy"), Document(content="Paris is the capital of France")]
+    doc_store = InMemoryDocumentStore()
+    doc_store.write_documents(docs)
+    template = (
+        "Given the following information, answer the question.\n"
+        "Context:\n"
+        "{% for document in documents %}"
+        "    {{ document.content }}\n"
+        "{% endfor %}"
+        "Question: {{ query }}"
+    )
+
+    pipe = Pipeline()
+
+    pipe.add_component("retriever", InMemoryBM25Retriever(document_store=doc_store))
+    pipe.add_component("prompt_builder", PromptBuilder(template=template))
+    pipe.add_component("generator", FakeGenerator())
+    pipe.add_component("answer_builder", AnswerBuilder())
+
+    pipe.connect("retriever", "prompt_builder.documents")
+    pipe.connect("prompt_builder.prompt", "generator.prompt")
+    pipe.connect("generator.replies", "answer_builder.replies")
+    pipe.connect("retriever.documents", "answer_builder.documents")
+
+    query = "What is the capital of France?"
+    res = pipe.run({"query": query})
+    assert len(res) == 1
+    answers = res["answer_builder"]["answers"]
+    assert len(answers) == 1
+    assert answers[0].data == "Paris"


### PR DESCRIPTION
### Related Issues

- related to #7243

### Proposed Changes:

Add a missing check in `Pipeline.run()` that prevented Components with only default inputs to run when the Pipeline is stuck in a loop.

### How did you test it?

I ran the failing end to end test that was failing.

### Notes for the reviewer

No need for release notes as the bug was created with #7426 and it still has not been released.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
