### PR TITLE
feat: add required flag for prompt builder inputs

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -30,7 +30,7 @@ class PromptBuilder:
         ast = self.template.environment.parse(template)
         template_variables = meta.find_undeclared_variables(ast)
         for var in template_variables:
-            component.set_input_type(self, var, Any, "")
+            component.set_input_type(self, var, Any)
 
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, template=self._template_string)


### PR DESCRIPTION
### Related Issues

- fixes #7441

### Proposed Changes:

Make {'is_mandatory': True} for all PromptBuilder inputs. PromptBuilder will now check the input variables during pipeline runs and throw ValueError if some of the template variables found in jinja templates are missing.
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

Tested by following the 2.0 RAG pipeline recipe from https://docs.haystack.deepset.ai/docs/creating-pipelines
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Not sure if this needs a new unit test for a small change like this, but I can definitely go add one if necessary.
An additional question would be if PromptBuilder.run() should check these parameters as well. I decided to leave it alone since this willwould alter the behavior in test.components.builders.test_run_without_input(), but it makes sense either way.

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
