### PR TITLE
feat: Update searchapi format, default to Google, allow search engine selection

### DIFF
--- a/haystack/components/websearch/searchapi.py
+++ b/haystack/components/websearch/searchapi.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -21,7 +20,8 @@ class SearchApiWebSearch:
     """
     Uses [SearchApi](https://www.searchapi.io/) to search the web for relevant documents.
 
-    See the [SearchApi website](https://www.searchapi.io/) for more details.
+    See the [SearchApi website](https://www.searchapi.io/) for more details. The default search engine is Google,
+    however, users can change it by setting the `engine` parameter in the `search_params`.
 
     Usage example:
     ```python
@@ -101,12 +101,12 @@ class SearchApiWebSearch:
         :raises SearchApiError: If an error occurs while querying the SearchApi API.
         """
         query_prepend = "OR ".join(f"site:{domain} " for domain in self.allowed_domains) if self.allowed_domains else ""
-
-        payload = json.dumps({"q": query_prepend + " " + query, **self.search_params})
-        headers = {"Authorization": f"Bearer {self.api_key.resolve_value()}", "X-SearchApi-Source": "Haystack"}
+        if "engine" not in self.search_params:
+            self.search_params["engine"] = "google"
+        payload = {"q": query_prepend + " " + query, "api_key": self.api_key.resolve_value(), **self.search_params}
 
         try:
-            response = requests.get(SEARCHAPI_BASE_URL, headers=headers, params=payload, timeout=90)
+            response = requests.get(SEARCHAPI_BASE_URL, params=payload, timeout=90)
             response.raise_for_status()  # Will raise an HTTPError for bad responses
         except requests.Timeout as error:
             raise TimeoutError(f"Request to {self.__class__.__name__} timed out.") from error

--- a/releasenotes/notes/update-searchapi-new-format-74d8794a8a6f5581.yaml
+++ b/releasenotes/notes/update-searchapi-new-format-74d8794a8a6f5581.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+ - |
+   Updated the SearchApiWebSearch component with new search format and allowed users to specify the search engine via the `engine`
+   parameter in `search_params`. The default search engine is Google, making it easier for users to tailor their web searches.

--- a/test/components/websearch/test_searchapi.py
+++ b/test/components/websearch/test_searchapi.py
@@ -1,13 +1,12 @@
 import os
 from unittest.mock import Mock, patch
-from haystack.utils.auth import Secret
 
 import pytest
-from requests import Timeout, RequestException, HTTPError
+from requests import HTTPError, RequestException, Timeout
 
 from haystack import Document
 from haystack.components.websearch.searchapi import SearchApiError, SearchApiWebSearch
-
+from haystack.utils.auth import Secret
 
 EXAMPLE_SEARCHAPI_RESPONSE = {
     "search_metadata": {
@@ -385,7 +384,7 @@ class TestSearchApiSearchAPI:
                 "api_key": {"env_vars": ["SEARCHAPI_API_KEY"], "strict": True, "type": "env_var"},
                 "top_k": 10,
                 "allowed_domains": ["testdomain.com"],
-                "search_params": {"param": "test params"},
+                "search_params": {"param": "test params", "engine": "google"},
             },
         }
 


### PR DESCRIPTION
### Why:
The update in the web search API component focuses on updating to a new format and also enhancing flexibility. Specifically, it addresses the need for users to specify their preferred search engine when conducting web searches through the API. 

- fixes https://github.com/deepset-ai/haystack/issues/7447

### What:
- Extended the documentation to inform users they can now specify a search engine via the `search_params` argument, with Google being the default.
- Altered the payload creation process by:
  - Checking if the `engine` parameter is not present in `search_params` and setting it to "google" by default.
  - Removing the JSON serialization process for the `payload` variable.
  - Adjusting the way the API key is included in the request, moving it from the request headers to the payload.
  - Simplifying the request by eliminating custom headers, relying instead on default headers and passing the payload as parameters.

### How can it be used:
- To specify a search engine other than Google, users can now adjust the `search_params` like so:
```python
from haystack.components.websearch import SearchApiWebSearch, SerperDevWebSearch
from haystack.utils import Secret

web_search = SearchApiWebSearch(api_key=Secret.from_token("YOUR-API-KEY"), search_params={"engine": "bing"})
query = "What is the capital of Germany?"

response = web_search.run(query)
print(response)

```
- This update maintains backward compatibility while allowing for new feature usage without additional overhead for users preferring the default settings.

### How did you test it:
- Manually tested the updated component with different search engine parameters to ensure the correct engine is utilized.
- Conducted unit tests to verify that the default search engine is Google when no engine is specified.

### Notes for the reviewer:
- Review the updated documentation to ensure it clearly communicates the new feature and its default behavior.
- Verify that the removal of custom headers does not impact the API's authentication process or response handling.