### PR TITLE
refactor: TEI embedders refactoring

### DIFF
--- a/haystack/components/embedders/hugging_face_tei_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_tei_text_embedder.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -12,14 +13,17 @@ with LazyImport(message="Run 'pip install \"huggingface_hub>=0.22.0\"'") as hugg
 logger = logging.getLogger(__name__)
 
 
+# TODO: remove the default model in Haystack 2.3.0, as explained in the deprecation warning
+DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+
+
 @component
 class HuggingFaceTEITextEmbedder:
     """
     A component for embedding strings using HuggingFace Text-Embeddings-Inference endpoints.
 
-    This component can be used with embedding models hosted on Hugging Face Inference endpoints, the rate-limited
-    Inference API tier, for embedding models hosted on [the paid inference endpoint](https://huggingface.co/inference-endpoints)
-    and/or your own custom TEI endpoint.
+    This component can be used with embedding models hosted on Hugging Face Inference endpoints,
+    on the rate-limited Hugging Face Inference API or on your own custom TEI endpoint.
 
     Usage example:
     ```python
@@ -40,7 +44,7 @@ class HuggingFaceTEITextEmbedder:
 
     def __init__(
         self,
-        model: str = "BAAI/bge-small-en-v1.5",
+        model: Optional[str] = None,
         url: Optional[str] = None,
         token: Optional[Secret] = Secret.from_env_var("HF_API_TOKEN", strict=False),
         prefix: str = "",
@@ -50,10 +54,13 @@ class HuggingFaceTEITextEmbedder:
         Create an HuggingFaceTEITextEmbedder component.
 
         :param model:
-            ID of the model on HuggingFace Hub.
+            An optional string representing the ID of the model on HuggingFace Hub.
+            If not provided, the `url` parameter must be set to a valid TEI endpoint.
         :param url:
-            The URL of your self-deployed Text-Embeddings-Inference service or the URL of your paid HF Inference
-            Endpoint.
+            An optional string representing the URL of your self-deployed Text-Embeddings-Inference service
+            or the URL of your paid HF Inference Endpoint.
+            If not provided, the `model` parameter must be set to a valid model ID and the Hugging Face Inference API
+            will be used.
         :param token:
             The HuggingFace Hub token. This is needed if you are using a paid HF Inference Endpoint or serving
             a private or gated model.
@@ -64,13 +71,23 @@ class HuggingFaceTEITextEmbedder:
         """
         huggingface_hub_import.check()
 
+        if not model and not url:
+            warnings.warn(
+                f"Neither `model` nor `url` is provided. The component will use the default model: {DEFAULT_MODEL}. "
+                "This behavior is deprecated and will be removed in Haystack 2.3.0.",
+                DeprecationWarning,
+            )
+            model = DEFAULT_MODEL
+        elif model and url:
+            logger.warning("Both `model` and `url` are provided. The `model` parameter will be ignored. ")
+
         if url:
             r = urlparse(url)
             is_valid_url = all([r.scheme in ["http", "https"], r.netloc])
             if not is_valid_url:
                 raise ValueError(f"Invalid TEI endpoint URL provided: {url}")
-
-        check_valid_model(model, HFModelType.EMBEDDING, token)
+        elif model:
+            check_valid_model(model, HFModelType.EMBEDDING, token)
 
         self.model = model
         self.url = url

--- a/releasenotes/notes/tei-refactoring-75a8dc958ed5d66c.yaml
+++ b/releasenotes/notes/tei-refactoring-75a8dc958ed5d66c.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Improve the HuggingFaceTEITextEmbedder and HuggingFaceTEIDocumentEmbedder components:
+    if initialized with an appropriate `url` parameter, the components can run on a local network and do not require internet access.
+deprecations:
+  - |
+    The HuggingFaceTEITextEmbedder and HuggingFaceTEIDocumentEmbedder components require
+    specifying either a `url` or `model` parameter.
+    Starting from Haystack 2.3.0, the components will raise an error if neither parameter is provided.

--- a/test/components/embedders/test_hugging_face_tei_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_tei_document_embedder.py
@@ -65,11 +65,10 @@ class TestHuggingFaceTEIDocumentEmbedder:
         with pytest.raises(ValueError):
             HuggingFaceTEIDocumentEmbedder(model="sentence-transformers/all-mpnet-base-v2", url="invalid_url")
 
-    def test_initialize_with_url_but_invalid_model(self, mock_check_valid_model):
-        # When custom TEI endpoint is used via URL, model must be provided and valid HuggingFace Hub model id
+    def test_initialize_with_invalid_model(self, mock_check_valid_model):
         mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id")
         with pytest.raises(RepositoryNotFoundError):
-            HuggingFaceTEIDocumentEmbedder(model="invalid_model_id", url="https://some_embedding_model.com")
+            HuggingFaceTEIDocumentEmbedder(model="invalid_model_id")
 
     def test_to_dict(self, mock_check_valid_model):
         component = HuggingFaceTEIDocumentEmbedder()

--- a/test/components/embedders/test_hugging_face_tei_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_tei_text_embedder.py
@@ -51,11 +51,10 @@ class TestHuggingFaceTEITextEmbedder:
         with pytest.raises(ValueError):
             HuggingFaceTEITextEmbedder(model="sentence-transformers/all-mpnet-base-v2", url="invalid_url")
 
-    def test_initialize_with_url_but_invalid_model(self, mock_check_valid_model):
-        # When custom TEI endpoint is used via URL, model must be provided and valid HuggingFace Hub model id
+    def test_initialize_with_invalid_model(self, mock_check_valid_model):
         mock_check_valid_model.side_effect = RepositoryNotFoundError("Invalid model id")
         with pytest.raises(RepositoryNotFoundError):
-            HuggingFaceTEITextEmbedder(model="invalid_model_id", url="https://some_embedding_model.com")
+            HuggingFaceTEITextEmbedder(model="invalid_model_id")
 
     def test_to_dict(self, mock_check_valid_model):
         component = HuggingFaceTEITextEmbedder()


### PR DESCRIPTION
### Related Issues
part of #7279

### Proposed Changes:
The user must specify either `model` or `url`.
Previously, we asked to specify the model even if not used and this required accessing the web (see https://github.com/deepset-ai/haystack/issues/7279#issuecomment-1992360580).
The change is not breaking because temporary deprecation and fallback mechanisms have been implemented.

### How did you test it?

CI, adapted existing tests, manual tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
