### PR TITLE
feat: Add `DocumentMeanAveragePrecision`

### DIFF
--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -11,7 +11,7 @@ class DocumentMeanAveragePrecision:
     Each question can have multiple ground truth documents and multiple retrieved documents.
 
     `DocumentMeanAveragePrecision` doesn't normalize its inputs, the `DocumentCleaner` component
-    can be used to clean the documents before passing them to this evaluator.
+    should be used to clean and normalize the documents before passing them to this evaluator.
 
     Usage example:
     ```python

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -15,10 +15,6 @@ class DocumentMeanAveragePrecision:
 
     evaluator = DocumentMeanAveragePrecision()
     result = evaluator.run(
-        questions=[
-            "In what country is Normandy located?",
-            "When was the Latin version of the word Norman first recorded?",
-        ],
         ground_truth_documents=[
             [Document(content="France")],
             [Document(content="9th century"), Document(content="9th")],
@@ -38,17 +34,12 @@ class DocumentMeanAveragePrecision:
 
     @component.output_types(score=float, individual_scores=List[float])
     def run(
-        self,
-        questions: List[str],
-        ground_truth_documents: List[List[Document]],
-        retrieved_documents: List[List[Document]],
+        self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]
     ) -> Dict[str, Any]:
         """
         Run the DocumentMeanAveragePrecision on the given inputs.
         All lists must have the same length.
 
-        :param questions:
-            A list of questions.
         :param ground_truth_documents:
             A list of expected documents for each question.
         :param retrieved_documents:
@@ -58,8 +49,8 @@ class DocumentMeanAveragePrecision:
             - `score` - The average of calculated scores.
             - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents how high ground truth documents are ranked.
         """
-        if not len(questions) == len(ground_truth_documents) == len(retrieved_documents):
-            msg = "The length of questions, ground_truth_documents, and retrieved_documents must be the same."
+        if len(ground_truth_documents) != len(retrieved_documents):
+            msg = "The length of ground_truth_documents and retrieved_documents must be the same."
             raise ValueError(msg)
 
         individual_scores = []
@@ -84,6 +75,6 @@ class DocumentMeanAveragePrecision:
                     score = average_precision / relevant_documents
             individual_scores.append(score)
 
-        score = sum(individual_scores) / len(questions)
+        score = sum(individual_scores) / len(retrieved_documents)
 
         return {"score": score, "individual_scores": individual_scores}

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, List
+
+from haystack import Document, component
+
+
+@component
+class DocumentMeanAveragePrecision:
+    """
+    Evaluator that calculates the mean average precision of the retrieved documents.
+    Each question can have multiple ground truth documents and multiple retrieved documents.
+
+    Usage example:
+    ```python
+    from haystack.components.evaluators import AnswerExactMatchEvaluator
+
+    evaluator = DocumentMeanAveragePrecision()
+    result = evaluator.run(
+        questions=[
+            "In what country is Normandy located?",
+            "When was the Latin version of the word Norman first recorded?",
+        ],
+        ground_truth_documents=[
+            [Document(content="France")],
+            [Document(content="9th century"), Document(content="9th")],
+        ],
+        retrieved_documents=[
+            [Document(content="France")],
+            [Document(content="9th century"), Document(content="10th century"), Document(content="9th")],
+        ],
+    )
+
+    print(result["individual_scores"])
+    # [1.0, 0.8333333333333333]
+    print(result["score"])
+    # 0.9166666666666666
+    ```
+    """
+
+    @component.output_types(score=float, individual_scores=List[float])
+    def run(
+        self,
+        questions: List[str],
+        ground_truth_documents: List[List[Document]],
+        retrieved_documents: List[List[Document]],
+    ) -> Dict[str, Any]:
+        """
+        Run the DocumentMeanAveragePrecision on the given inputs.
+        All lists must have the same length.
+
+        :param questions:
+            A list of questions.
+        :param ground_truth_documents:
+            A list of expected documents for each question.
+        :param retrieved_documents:
+            A list of retrieved documents for each question.
+        :returns:
+            A dictionary with the following outputs:
+            - `score` - The average of calculated scores.
+            - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents how high ground truth documents are ranked.
+        """
+        if not len(questions) == len(ground_truth_documents) == len(retrieved_documents):
+            msg = "The length of questions, ground_truth_documents, and retrieved_documents must be the same."
+            raise ValueError(msg)
+
+        individual_scores = []
+
+        for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
+            score = 0.0
+            for ground_document in ground_truth:
+                if ground_document.content is None:
+                    continue
+
+                average_precision = 0.0
+                relevant_documents = 0
+
+                for rank, retrieved_document in enumerate(retrieved):
+                    if retrieved_document.content is None:
+                        continue
+
+                    if ground_document.content in retrieved_document.content:
+                        relevant_documents += 1
+                        average_precision += relevant_documents / (rank + 1)
+                if relevant_documents > 0:
+                    score = average_precision / relevant_documents
+            individual_scores.append(score)
+
+        score = sum(individual_scores) / len(questions)
+
+        return {"score": score, "individual_scores": individual_scores}

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -6,8 +6,12 @@ from haystack import Document, component
 @component
 class DocumentMeanAveragePrecision:
     """
-    Evaluator that calculates the mean average precision of the retrieved documents.
+    Evaluator that calculates the mean average precision of the retrieved documents, a metric
+    that measures how high retrieved documents are ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
+
+    `DocumentMeanAveragePrecision` doesn't normalize its inputs, the `DocumentCleaner` component
+    can be used to clean the documents before passing them to this evaluator.
 
     Usage example:
     ```python
@@ -47,7 +51,7 @@ class DocumentMeanAveragePrecision:
         :returns:
             A dictionary with the following outputs:
             - `score` - The average of calculated scores.
-            - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents how high ground truth documents are ranked.
+            - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents how high retrieved documents are ranked.
         """
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."

--- a/releasenotes/notes/document-map-evaluator-de896c94b54fe3fa.yaml
+++ b/releasenotes/notes/document-map-evaluator-de896c94b54fe3fa.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add DocumentMeanAveragePrecision, it can be used to calculate mean average precision of retrieved documents.

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -7,7 +7,6 @@ from haystack.components.evaluators.document_map import DocumentMeanAveragePreci
 def test_run_with_all_matching():
     evaluator = DocumentMeanAveragePrecision()
     result = evaluator.run(
-        questions=["What is the capital of Germany?", "What is the capital of France?"],
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
     )
@@ -18,7 +17,6 @@ def test_run_with_all_matching():
 def test_run_with_no_matching():
     evaluator = DocumentMeanAveragePrecision()
     result = evaluator.run(
-        questions=["What is the capital of Germany?", "What is the capital of France?"],
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Paris")], [Document(content="London")]],
     )
@@ -29,7 +27,6 @@ def test_run_with_no_matching():
 def test_run_with_partial_matching():
     evaluator = DocumentMeanAveragePrecision()
     result = evaluator.run(
-        questions=["What is the capital of Germany?", "What is the capital of France?"],
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
     )
@@ -40,14 +37,6 @@ def test_run_with_partial_matching():
 def test_run_with_complex_data():
     evaluator = DocumentMeanAveragePrecision()
     result = evaluator.run(
-        questions=[
-            "In what country is Normandy located?",
-            "When was the Latin version of the word Norman first recorded?",
-            "What developed in Normandy during the 1100s?",
-            "In what century did important classical music developments occur in Normandy?",
-            "From which countries did the Norse originate?",
-            "What century did the Normans first gain their separate identity?",
-        ],
         ground_truth_documents=[
             [Document(content="France")],
             [Document(content="9th century"), Document(content="9th")],
@@ -77,15 +66,6 @@ def test_run_with_different_lengths():
     with pytest.raises(ValueError):
         evaluator = DocumentMeanAveragePrecision()
         evaluator.run(
-            questions=["What is the capital of Germany?"],
-            ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
-            retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
-        )
-
-    with pytest.raises(ValueError):
-        evaluator = DocumentMeanAveragePrecision()
-        evaluator.run(
-            questions=["What is the capital of Germany?", "What is the capital of France?"],
             ground_truth_documents=[[Document(content="Berlin")]],
             retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
         )
@@ -93,7 +73,6 @@ def test_run_with_different_lengths():
     with pytest.raises(ValueError):
         evaluator = DocumentMeanAveragePrecision()
         evaluator.run(
-            questions=["What is the capital of Germany?", "What is the capital of France?"],
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],
         )

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -1,0 +1,99 @@
+import pytest
+
+from haystack import Document
+from haystack.components.evaluators.document_map import DocumentMeanAveragePrecision
+
+
+def test_run_with_all_matching():
+    evaluator = DocumentMeanAveragePrecision()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+        retrieved_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+    )
+
+    assert result == {"individual_scores": [1.0, 1.0], "score": 1.0}
+
+
+def test_run_with_no_matching():
+    evaluator = DocumentMeanAveragePrecision()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+        retrieved_documents=[[Document(content="Paris")], [Document(content="London")]],
+    )
+
+    assert result == {"individual_scores": [0.0, 0.0], "score": 0.0}
+
+
+def test_run_with_partial_matching():
+    evaluator = DocumentMeanAveragePrecision()
+    result = evaluator.run(
+        questions=["What is the capital of Germany?", "What is the capital of France?"],
+        ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+        retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
+    )
+
+    assert result == {"individual_scores": [1.0, 0.0], "score": 0.5}
+
+
+def test_run_with_complex_data():
+    evaluator = DocumentMeanAveragePrecision()
+    result = evaluator.run(
+        questions=[
+            "In what country is Normandy located?",
+            "When was the Latin version of the word Norman first recorded?",
+            "What developed in Normandy during the 1100s?",
+            "In what century did important classical music developments occur in Normandy?",
+            "From which countries did the Norse originate?",
+            "What century did the Normans first gain their separate identity?",
+        ],
+        ground_truth_documents=[
+            [Document(content="France")],
+            [Document(content="9th century"), Document(content="9th")],
+            [Document(content="classical music"), Document(content="classical")],
+            [Document(content="11th century"), Document(content="the 11th")],
+            [Document(content="Denmark, Iceland and Norway")],
+            [Document(content="10th century"), Document(content="10th")],
+        ],
+        retrieved_documents=[
+            [Document(content="France")],
+            [Document(content="9th century"), Document(content="10th century"), Document(content="9th")],
+            [Document(content="classical"), Document(content="rock music"), Document(content="dubstep")],
+            [Document(content="11th"), Document(content="the 11th"), Document(content="11th century")],
+            [Document(content="Denmark"), Document(content="Norway"), Document(content="Iceland")],
+            [
+                Document(content="10th century"),
+                Document(content="the first half of the 10th century"),
+                Document(content="10th"),
+                Document(content="10th"),
+            ],
+        ],
+    )
+    assert result == {"individual_scores": [1.0, 0.8333333333333333, 1.0, 0.5, 0.0, 1.0], "score": 0.7222222222222222}
+
+
+def test_run_with_different_lengths():
+    with pytest.raises(ValueError):
+        evaluator = DocumentMeanAveragePrecision()
+        evaluator.run(
+            questions=["What is the capital of Germany?"],
+            ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+            retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator = DocumentMeanAveragePrecision()
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_documents=[[Document(content="Berlin")]],
+            retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
+        )
+
+    with pytest.raises(ValueError):
+        evaluator = DocumentMeanAveragePrecision()
+        evaluator.run(
+            questions=["What is the capital of Germany?", "What is the capital of France?"],
+            ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+            retrieved_documents=[[Document(content="Berlin")]],
+        )


### PR DESCRIPTION
### Related Issues

- fixes #6066

### Proposed Changes:

Add `DocumentMeanAveragePrecision` Component to calculate Mean Average Precision of a retrieved documents given a list of ground truth documents.

### How did you test it?

I added unit tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
