### PR TITLE
refactor: Rename `DocumentMeanAveragePrecision` and `DocumentMeanReciprocalRank`

### DIFF
--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -4,20 +4,20 @@ from haystack import Document, component
 
 
 @component
-class DocumentMeanAveragePrecision:
+class DocumentMeanAveragePrecisionEvaluator:
     """
     Evaluator that calculates the mean average precision of the retrieved documents, a metric
     that measures how high retrieved documents are ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
 
-    `DocumentMeanAveragePrecision` doesn't normalize its inputs, the `DocumentCleaner` component
+    `DocumentMeanAveragePrecisionEvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
     should be used to clean and normalize the documents before passing them to this evaluator.
 
     Usage example:
     ```python
     from haystack.components.evaluators import AnswerExactMatchEvaluator
 
-    evaluator = DocumentMeanAveragePrecision()
+    evaluator = DocumentMeanAveragePrecisionEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -41,7 +41,7 @@ class DocumentMeanAveragePrecision:
         self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]
     ) -> Dict[str, Any]:
         """
-        Run the DocumentMeanAveragePrecision on the given inputs.
+        Run the DocumentMeanAveragePrecisionEvaluator on the given inputs.
         All lists must have the same length.
 
         :param ground_truth_documents:

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -4,20 +4,20 @@ from haystack import Document, component
 
 
 @component
-class DocumentMeanAveragePrecisionEvaluator:
+class DocumentMAPEvaluator:
     """
     Evaluator that calculates the mean average precision of the retrieved documents, a metric
     that measures how high retrieved documents are ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
 
-    `DocumentMeanAveragePrecisionEvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
+    `DocumentMAPEvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
     should be used to clean and normalize the documents before passing them to this evaluator.
 
     Usage example:
     ```python
     from haystack.components.evaluators import AnswerExactMatchEvaluator
 
-    evaluator = DocumentMeanAveragePrecisionEvaluator()
+    evaluator = DocumentMAPEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -41,7 +41,7 @@ class DocumentMeanAveragePrecisionEvaluator:
         self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]
     ) -> Dict[str, Any]:
         """
-        Run the DocumentMeanAveragePrecisionEvaluator on the given inputs.
+        Run the DocumentMAPEvaluator on the given inputs.
         All lists must have the same length.
 
         :param ground_truth_documents:

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -4,20 +4,20 @@ from haystack import Document, component
 
 
 @component
-class DocumentMeanReciprocalRank:
+class DocumentMeanReciprocalRankEvaluator:
     """
     Evaluator that calculates the mean reciprocal rank of the retrieved documents.
 
     MRR measures how high the first retrieved document is ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
 
-    `DocumentMeanReciprocalRank` doesn't normalize its inputs, the `DocumentCleaner` component
+    `DocumentMeanReciprocalRankEvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
     should be used to clean and normalize the documents before passing them to this evaluator.
 
     Usage example:
     ```python
     from haystack.components.evaluators import AnswerExactMatchEvaluator
-    evaluator = DocumentMeanReciprocalRank()
+    evaluator = DocumentMeanReciprocalRankEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -40,7 +40,7 @@ class DocumentMeanReciprocalRank:
         self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]
     ) -> Dict[str, Any]:
         """
-        Run the DocumentMeanReciprocalRank on the given inputs.
+        Run the DocumentMeanReciprocalRankEvaluator on the given inputs.
 
         `ground_truth_documents` and `retrieved_documents` must have the same length.
 

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -4,20 +4,20 @@ from haystack import Document, component
 
 
 @component
-class DocumentMeanReciprocalRankEvaluator:
+class DocumentMRREvaluator:
     """
     Evaluator that calculates the mean reciprocal rank of the retrieved documents.
 
     MRR measures how high the first retrieved document is ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
 
-    `DocumentMeanReciprocalRankEvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
+    `DocumentMRREvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
     should be used to clean and normalize the documents before passing them to this evaluator.
 
     Usage example:
     ```python
     from haystack.components.evaluators import AnswerExactMatchEvaluator
-    evaluator = DocumentMeanReciprocalRankEvaluator()
+    evaluator = DocumentMRREvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -40,7 +40,7 @@ class DocumentMeanReciprocalRankEvaluator:
         self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]
     ) -> Dict[str, Any]:
         """
-        Run the DocumentMeanReciprocalRankEvaluator on the given inputs.
+        Run the DocumentMRREvaluator on the given inputs.
 
         `ground_truth_documents` and `retrieved_documents` must have the same length.
 

--- a/releasenotes/notes/document-map-evaluator-de896c94b54fe3fa.yaml
+++ b/releasenotes/notes/document-map-evaluator-de896c94b54fe3fa.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add DocumentMeanAveragePrecision, it can be used to calculate mean average precision of retrieved documents.
+    Add DocumentMeanAveragePrecisionEvaluator, it can be used to calculate mean average precision of retrieved documents.

--- a/releasenotes/notes/document-map-evaluator-de896c94b54fe3fa.yaml
+++ b/releasenotes/notes/document-map-evaluator-de896c94b54fe3fa.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add DocumentMeanAveragePrecisionEvaluator, it can be used to calculate mean average precision of retrieved documents.
+    Add DocumentMAPEvaluator, it can be used to calculate mean average precision of retrieved documents.

--- a/releasenotes/notes/document-mrr-evaluator-fa7c266cc91201a7.yaml
+++ b/releasenotes/notes/document-mrr-evaluator-fa7c266cc91201a7.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add DocumentMeanReciprocalRank, it can be used to calculate mean reciprocal rank of retrieved documents.
+    Add DocumentMeanReciprocalRankEvaluator, it can be used to calculate mean reciprocal rank of retrieved documents.

--- a/releasenotes/notes/document-mrr-evaluator-fa7c266cc91201a7.yaml
+++ b/releasenotes/notes/document-mrr-evaluator-fa7c266cc91201a7.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add DocumentMeanReciprocalRankEvaluator, it can be used to calculate mean reciprocal rank of retrieved documents.
+    Add DocumentMRREvaluator, it can be used to calculate mean reciprocal rank of retrieved documents.

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -1,11 +1,11 @@
 import pytest
 
 from haystack import Document
-from haystack.components.evaluators.document_map import DocumentMeanAveragePrecisionEvaluator
+from haystack.components.evaluators.document_map import DocumentMAPEvaluator
 
 
 def test_run_with_all_matching():
-    evaluator = DocumentMeanAveragePrecisionEvaluator()
+    evaluator = DocumentMAPEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
@@ -15,7 +15,7 @@ def test_run_with_all_matching():
 
 
 def test_run_with_no_matching():
-    evaluator = DocumentMeanAveragePrecisionEvaluator()
+    evaluator = DocumentMAPEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Paris")], [Document(content="London")]],
@@ -25,7 +25,7 @@ def test_run_with_no_matching():
 
 
 def test_run_with_partial_matching():
-    evaluator = DocumentMeanAveragePrecisionEvaluator()
+    evaluator = DocumentMAPEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
@@ -35,7 +35,7 @@ def test_run_with_partial_matching():
 
 
 def test_run_with_complex_data():
-    evaluator = DocumentMeanAveragePrecisionEvaluator()
+    evaluator = DocumentMAPEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -64,14 +64,14 @@ def test_run_with_complex_data():
 
 def test_run_with_different_lengths():
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanAveragePrecisionEvaluator()
+        evaluator = DocumentMAPEvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")]],
             retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
         )
 
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanAveragePrecisionEvaluator()
+        evaluator = DocumentMAPEvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -1,11 +1,11 @@
 import pytest
 
 from haystack import Document
-from haystack.components.evaluators.document_map import DocumentMeanAveragePrecision
+from haystack.components.evaluators.document_map import DocumentMeanAveragePrecisionEvaluator
 
 
 def test_run_with_all_matching():
-    evaluator = DocumentMeanAveragePrecision()
+    evaluator = DocumentMeanAveragePrecisionEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
@@ -15,7 +15,7 @@ def test_run_with_all_matching():
 
 
 def test_run_with_no_matching():
-    evaluator = DocumentMeanAveragePrecision()
+    evaluator = DocumentMeanAveragePrecisionEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Paris")], [Document(content="London")]],
@@ -25,7 +25,7 @@ def test_run_with_no_matching():
 
 
 def test_run_with_partial_matching():
-    evaluator = DocumentMeanAveragePrecision()
+    evaluator = DocumentMeanAveragePrecisionEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
@@ -35,7 +35,7 @@ def test_run_with_partial_matching():
 
 
 def test_run_with_complex_data():
-    evaluator = DocumentMeanAveragePrecision()
+    evaluator = DocumentMeanAveragePrecisionEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -64,14 +64,14 @@ def test_run_with_complex_data():
 
 def test_run_with_different_lengths():
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanAveragePrecision()
+        evaluator = DocumentMeanAveragePrecisionEvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")]],
             retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
         )
 
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanAveragePrecision()
+        evaluator = DocumentMeanAveragePrecisionEvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],

--- a/test/components/evaluators/test_document_mrr.py
+++ b/test/components/evaluators/test_document_mrr.py
@@ -1,11 +1,11 @@
 import pytest
 
 from haystack import Document
-from haystack.components.evaluators.document_mrr import DocumentMeanReciprocalRankEvaluator
+from haystack.components.evaluators.document_mrr import DocumentMRREvaluator
 
 
 def test_run_with_all_matching():
-    evaluator = DocumentMeanReciprocalRankEvaluator()
+    evaluator = DocumentMRREvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
@@ -15,7 +15,7 @@ def test_run_with_all_matching():
 
 
 def test_run_with_no_matching():
-    evaluator = DocumentMeanReciprocalRankEvaluator()
+    evaluator = DocumentMRREvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Paris")], [Document(content="London")]],
@@ -25,7 +25,7 @@ def test_run_with_no_matching():
 
 
 def test_run_with_partial_matching():
-    evaluator = DocumentMeanReciprocalRankEvaluator()
+    evaluator = DocumentMRREvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
@@ -35,7 +35,7 @@ def test_run_with_partial_matching():
 
 
 def test_run_with_complex_data():
-    evaluator = DocumentMeanReciprocalRankEvaluator()
+    evaluator = DocumentMRREvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -68,14 +68,14 @@ def test_run_with_complex_data():
 
 def test_run_with_different_lengths():
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanReciprocalRankEvaluator()
+        evaluator = DocumentMRREvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")]],
             retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
         )
 
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanReciprocalRankEvaluator()
+        evaluator = DocumentMRREvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],

--- a/test/components/evaluators/test_document_mrr.py
+++ b/test/components/evaluators/test_document_mrr.py
@@ -1,11 +1,11 @@
 import pytest
 
 from haystack import Document
-from haystack.components.evaluators.document_mrr import DocumentMeanReciprocalRank
+from haystack.components.evaluators.document_mrr import DocumentMeanReciprocalRankEvaluator
 
 
 def test_run_with_all_matching():
-    evaluator = DocumentMeanReciprocalRank()
+    evaluator = DocumentMeanReciprocalRankEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
@@ -15,7 +15,7 @@ def test_run_with_all_matching():
 
 
 def test_run_with_no_matching():
-    evaluator = DocumentMeanReciprocalRank()
+    evaluator = DocumentMeanReciprocalRankEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Paris")], [Document(content="London")]],
@@ -25,7 +25,7 @@ def test_run_with_no_matching():
 
 
 def test_run_with_partial_matching():
-    evaluator = DocumentMeanReciprocalRank()
+    evaluator = DocumentMeanReciprocalRankEvaluator()
     result = evaluator.run(
         ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
         retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
@@ -35,7 +35,7 @@ def test_run_with_partial_matching():
 
 
 def test_run_with_complex_data():
-    evaluator = DocumentMeanReciprocalRank()
+    evaluator = DocumentMeanReciprocalRankEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
             [Document(content="France")],
@@ -68,14 +68,14 @@ def test_run_with_complex_data():
 
 def test_run_with_different_lengths():
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanReciprocalRank()
+        evaluator = DocumentMeanReciprocalRankEvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")]],
             retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
         )
 
     with pytest.raises(ValueError):
-        evaluator = DocumentMeanReciprocalRank()
+        evaluator = DocumentMeanReciprocalRankEvaluator()
         evaluator.run(
             ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
             retrieved_documents=[[Document(content="Berlin")]],


### PR DESCRIPTION
### Proposed Changes:

Rename `DocumentMeanAveragePrecision` and `DocumentMeanReciprocalRank` to `DocumentMeanAveragePrecisionEvaluator` and `DocumentMeanReciprocalRankEvaluator` respectively.

### How did you test it?

N/A

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
