### PR TITLE
refactor: Remove name 'llm' from LLMEvaluator output

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -166,7 +166,6 @@ class LLMEvaluator:
 
             self.validate_outputs(expected=self.outputs, received=result["replies"][0])
             parsed_result = json.loads(result["replies"][0])
-            parsed_result["name"] = "llm"
             results.append(parsed_result)
 
         return {"results": results}

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -265,7 +265,7 @@ class TestLLMEvaluator:
         monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
 
         results = component.run(questions=["What is the capital of Germany?"], responses=["Berlin"])
-        assert results == {"results": [{"score": 0.5, "name": "llm"}]}
+        assert results == {"results": [{"score": 0.5}]}
 
     def test_prepare_template(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")


### PR DESCRIPTION
### Related Issues

none

### Proposed Changes:

 - Removed the  name 'llm' from LLMEvaluator output. While other eval frameworks include the metric name in the output dict, we agreed that there is no need for that in Haystack and none of the other evaluator components includes a name in the output.

### How did you test it?

unit test updated

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
