### PR TITLE
chore: set linting parameters to the minimum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 
 [tool.ruff]
-line-length = 1486
+line-length = 301
 target-version = "py38"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -350,11 +350,11 @@ max-complexity = 28
 
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["float", "int", "str"]
-max-args = 38  # Default is 5
-max-branches = 32  # Default is 12
-max-public-methods = 90  # Default is 20
-max-returns = 9  # Default is 6
-max-statements = 105  # Default is 50
+max-args = 14  # Default is 5
+max-branches = 21  # Default is 12
+max-public-methods = 20  # Default is 20
+max-returns = 7  # Default is 6
+max-statements = 60  # Default is 50
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

We should come up with a desired value for the maximum line length in the source code. Meanwhile, set the `line-length` linter parameter to the minimum possible without touching the code.

While there, let's do the same for other linting params

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
