### PR TITLE
fix: Fix pipeline with join node

### DIFF
--- a/haystack/nodes/file_converter/image.py
+++ b/haystack/nodes/file_converter/image.py
@@ -119,7 +119,7 @@ class ImageToTextConverter(BaseConverter):
 
         file_path = Path(file_path)
         image = Image.open(file_path)
-        pages = self._image_to_text(image)
+        pages = self._image_to_text(image)  # type: ignore
         if remove_numeric_tables is None:
             remove_numeric_tables = self.remove_numeric_tables
         if valid_languages is None:
@@ -160,7 +160,7 @@ class ImageToTextConverter(BaseConverter):
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 
-    def _image_to_text(self, image: "PpmImageFile") -> List[str]:  # type: ignore
+    def _image_to_text(self, image: "PpmImageFile") -> List[str]:
         """
         Extract text from image file.
 

--- a/haystack/nodes/file_converter/image.py
+++ b/haystack/nodes/file_converter/image.py
@@ -160,7 +160,7 @@ class ImageToTextConverter(BaseConverter):
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 
-    def _image_to_text(self, image: "Image") -> List[str]:
+    def _image_to_text(self, image: "PpmImageFile") -> List[str]:  # type: ignore
         """
         Extract text from image file.
 

--- a/haystack/nodes/file_converter/image.py
+++ b/haystack/nodes/file_converter/image.py
@@ -160,7 +160,7 @@ class ImageToTextConverter(BaseConverter):
         document = Document(content=text, meta=meta, id_hash_keys=id_hash_keys)
         return [document]
 
-    def _image_to_text(self, image: "PpmImageFile") -> List[str]:
+    def _image_to_text(self, image: "Image") -> List[str]:
         """
         Extract text from image file.
 

--- a/haystack/nodes/other/join_docs.py
+++ b/haystack/nodes/other/join_docs.py
@@ -60,6 +60,11 @@ class JoinDocuments(JoinNode):
 
     def run_accumulated(self, inputs: List[Dict], top_k_join: Optional[int] = None) -> Tuple[Dict, str]:
         results = [inp["documents"] for inp in inputs]
+
+        # Check if all results are non-empty
+        if all(res is None for res in results) or all(res == [] for res in results):
+            return {"documents": [], "labels": inputs[0].get("labels", None)}, "output_1"
+
         document_map = {doc.id: doc for result in results for doc in result}
 
         if self.join_mode == "concatenate":
@@ -100,7 +105,9 @@ class JoinDocuments(JoinNode):
 
     def run_batch_accumulated(self, inputs: List[dict], top_k_join: Optional[int] = None) -> Tuple[Dict, str]:
         # Join single document lists
-        if isinstance(inputs[0]["documents"][0], Document):
+        if inputs[0]["documents"] is None or inputs[0]["documents"] == []:
+            return {"documents": [], "labels": inputs[0].get("labels", None)}, "output_1"
+        elif isinstance(inputs[0]["documents"][0], Document):
             return self.run(inputs=inputs, top_k_join=top_k_join)
         # Join lists of document lists
         else:

--- a/haystack/nodes/other/join_docs.py
+++ b/haystack/nodes/other/join_docs.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from math import inf
-from typing import List, Optional
+from typing import List, Optional, Dict, Tuple
 
 from haystack.nodes.other.join import JoinNode
 from haystack.schema import Document
@@ -58,7 +58,7 @@ class JoinDocuments(JoinNode):
         self.top_k_join = top_k_join
         self.sort_by_score = sort_by_score
 
-    def run_accumulated(self, inputs: List[dict], top_k_join: Optional[int] = None):  # type: ignore
+    def run_accumulated(self, inputs: List[Dict], top_k_join: Optional[int] = None) -> Tuple[Dict, str]:
         results = [inp["documents"] for inp in inputs]
         document_map = {doc.id: doc for result in results for doc in result}
 
@@ -98,7 +98,7 @@ class JoinDocuments(JoinNode):
 
         return output, "output_1"
 
-    def run_batch_accumulated(self, inputs: List[dict], top_k_join: Optional[int] = None):  # type: ignore
+    def run_batch_accumulated(self, inputs: List[dict], top_k_join: Optional[int] = None) -> Tuple[Dict, str]:
         # Join single document lists
         if isinstance(inputs[0]["documents"][0], Document):
             return self.run(inputs=inputs, top_k_join=top_k_join)
@@ -117,7 +117,7 @@ class JoinDocuments(JoinNode):
 
             return output, "output_1"
 
-    def _concatenate_results(self, results, document_map):
+    def _concatenate_results(self, results: List[List[Document]], document_map: Dict) -> Dict[str, float]:
         """
         Concatenates multiple document result lists.
         Return the documents with the higher score.
@@ -134,11 +134,11 @@ class JoinDocuments(JoinNode):
             scores_map.update({idx: item_best_score.score})
         return scores_map
 
-    def _calculate_comb_sum(self, results):
+    def _calculate_comb_sum(self, results: List[List[Document]]):
         """
         Calculates a combination sum by multiplying each score by its weight.
         """
-        scores_map = defaultdict(int)
+        scores_map = defaultdict(float)
         weights = self.weights if self.weights else [1 / len(results)] * len(results)
 
         for result, weight in zip(results, weights):
@@ -147,14 +147,14 @@ class JoinDocuments(JoinNode):
 
         return scores_map
 
-    def _calculate_rrf(self, results):
+    def _calculate_rrf(self, results: List[List[Document]]) -> Dict[str, float]:
         """
         Calculates the reciprocal rank fusion. The constant K is set to 61 (60 was suggested by the original paper,
         plus 1 as python lists are 0-based and the paper used 1-based ranking).
         """
         K = 61
 
-        scores_map = defaultdict(int)
+        scores_map = defaultdict(float)
         weights = self.weights if self.weights else [1 / len(results)] * len(results)
 
         # Calculate weighted reciprocal rank fusion score

--- a/haystack/nodes/other/join_docs.py
+++ b/haystack/nodes/other/join_docs.py
@@ -123,7 +123,7 @@ class JoinDocuments(JoinNode):
         Return the documents with the higher score.
         """
         list_id = list(document_map.keys())
-        scores_map = {}
+        scores_map: Dict[str, float] = {}
         for idx in list_id:
             tmp = []
             for result in results:
@@ -134,11 +134,11 @@ class JoinDocuments(JoinNode):
             scores_map.update({idx: item_best_score.score})
         return scores_map
 
-    def _calculate_comb_sum(self, results: List[List[Document]]):
+    def _calculate_comb_sum(self, results: List[List[Document]]) -> Dict[str, float]:
         """
         Calculates a combination sum by multiplying each score by its weight.
         """
-        scores_map = defaultdict(float)
+        scores_map: Dict[str, float] = defaultdict(float)
         weights = self.weights if self.weights else [1 / len(results)] * len(results)
 
         for result, weight in zip(results, weights):
@@ -154,7 +154,7 @@ class JoinDocuments(JoinNode):
         """
         K = 61
 
-        scores_map = defaultdict(float)
+        scores_map: Dict[str, float] = defaultdict(float)
         weights = self.weights if self.weights else [1 / len(results)] * len(results)
 
         # Calculate weighted reciprocal rank fusion score

--- a/haystack/nodes/other/join_docs.py
+++ b/haystack/nodes/other/join_docs.py
@@ -105,9 +105,7 @@ class JoinDocuments(JoinNode):
 
     def run_batch_accumulated(self, inputs: List[dict], top_k_join: Optional[int] = None) -> Tuple[Dict, str]:
         # Join single document lists
-        if inputs[0]["documents"] is None or inputs[0]["documents"] == []:
-            return {"documents": [], "labels": inputs[0].get("labels", None)}, "output_1"
-        elif isinstance(inputs[0]["documents"][0], Document):
+        if isinstance(inputs[0]["documents"][0], Document):
             return self.run(inputs=inputs, top_k_join=top_k_join)
         # Join lists of document lists
         else:

--- a/haystack/nodes/other/shaper.py
+++ b/haystack/nodes/other/shaper.py
@@ -745,7 +745,11 @@ class Shaper(BaseComponent):
         meta: Optional[dict] = None,
         invocation_context: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Dict, str]:
-        invocation_context = invocation_context or {}
+        if invocation_context is None:
+            invocation_context = {}
+        else:
+            invocation_context = invocation_context.copy()
+
         if query and "query" not in invocation_context.keys():
             invocation_context["query"] = query
 
@@ -755,7 +759,7 @@ class Shaper(BaseComponent):
         if labels and "labels" not in invocation_context.keys():
             invocation_context["labels"] = labels
 
-        if documents != None and "documents" not in invocation_context.keys():
+        if documents is not None and "documents" not in invocation_context.keys():
             invocation_context["documents"] = documents
 
         if meta and "meta" not in invocation_context.keys():

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -247,7 +247,10 @@ class PromptNode(BaseComponent):
         """
         Prepare prompt invocation.
         """
-        invocation_context = invocation_context.copy() or {}
+        if invocation_context is None:
+            invocation_context = {}
+        else:
+            invocation_context = invocation_context.copy()
 
         if query and "query" not in invocation_context:
             invocation_context["query"] = query

--- a/haystack/nodes/prompt/prompt_node.py
+++ b/haystack/nodes/prompt/prompt_node.py
@@ -247,7 +247,7 @@ class PromptNode(BaseComponent):
         """
         Prepare prompt invocation.
         """
-        invocation_context = invocation_context or {}
+        invocation_context = invocation_context.copy() or {}
 
         if query and "query" not in invocation_context:
             invocation_context["query"] = query

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -928,19 +928,32 @@ class Pipeline:
                             existing_input = queue[n]
                             if "inputs" not in existing_input.keys():
                                 updated_input: Dict = {"inputs": [existing_input, node_output], "params": params}
-                                if queries:
+                                if "_debug" in existing_input.keys() or "_debug" in node_output.keys():
+                                    updated_input["_debug"] = {
+                                        **existing_input.get("_debug", {}),
+                                        **node_output.get("_debug", {}),
+                                    }
+                                additional_input = self._combine_node_outputs(existing_input, node_output)
+                                updated_input = {**additional_input, **updated_input}
+                                if queries and "queries" not in updated_input:
                                     updated_input["queries"] = queries
-                                if file_paths:
+                                if file_paths and "file_paths" not in updated_input:
                                     updated_input["file_paths"] = file_paths
-                                if labels:
+                                if labels and "labels" not in updated_input:
                                     updated_input["labels"] = labels
-                                if documents:
+                                if documents and "documents" not in updated_input:
                                     updated_input["documents"] = documents
-                                if meta:
+                                if meta and "meta" not in updated_input:
                                     updated_input["meta"] = meta
                             else:
                                 existing_input["inputs"].append(node_output)
-                                updated_input = existing_input
+                                if "_debug" in node_output.keys():
+                                    existing_input["_debug"] = {
+                                        **existing_input.get("_debug", {}),
+                                        **node_output.get("_debug", {}),
+                                    }
+                                additional_input = self._combine_node_outputs(existing_input, node_output)
+                                updated_input = {**additional_input, **existing_input}
                             queue[n] = updated_input
                         else:
                             queue[n] = node_output

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -610,6 +610,11 @@ class Pipeline:
                                     updated_input["meta"] = meta
                             else:
                                 existing_input["inputs"].append(node_output)
+                                if "_debug" in node_output.keys():
+                                    existing_input["_debug"] = {
+                                        **existing_input.get("_debug", {}),
+                                        **node_output.get("_debug", {}),
+                                    }
                                 additional_input = self._combine_node_outputs(existing_input, node_output)
                                 updated_input = {**additional_input, **existing_input}
                             queue[n] = updated_input
@@ -767,6 +772,11 @@ class Pipeline:
                                     updated_input["meta"] = meta
                             else:
                                 existing_input["inputs"].append(node_output)
+                                if "_debug" in node_output.keys():
+                                    existing_input["_debug"] = {
+                                        **existing_input.get("_debug", {}),
+                                        **node_output.get("_debug", {}),
+                                    }
                                 additional_input = self._combine_node_outputs(existing_input, node_output)
                                 updated_input = {**additional_input, **existing_input}
                             queue[n] = updated_input

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -623,30 +623,18 @@ class Pipeline:
 
     def _combine_node_outputs(self, existing_input: Dict[str, Any], node_output: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Combines the outputs of two nodes into a single input for a downstream node. This is useful for join nodes.
+        Combines the outputs of two nodes into a single input for a downstream node.
+        For matching keys first node's (existing_input) value is kept. This is used for join nodes.
 
         :param existing_input: The output of the first node.
         :param node_output: The output of the second node.
         """
         additional_input = {}
-        # TODO Should we support overwriting keys that exist in both? --> first node's value is kept
-        # Add shared items from existing_input and node_output that have matching values
-        shared_items = {
-            k: existing_input[k] for k in existing_input if k in node_output and existing_input[k] == node_output[k]
-        }
-        for key in shared_items:
+        combined = {**node_output, **existing_input}
+        for key in combined:
+            # Don't overwrite these keys since they are set in Pipeline.run
             if key not in ["inputs", "params", "_debug"]:
-                additional_input[key] = shared_items[key]
-        unique_existing_input = {k: v for k, v in existing_input.items() if k not in shared_items}
-        # Add unique keys from existing_input
-        for key in unique_existing_input:
-            if key not in ["inputs", "params", "_debug"]:
-                additional_input[key] = unique_existing_input[key]
-        # Add unique keys from node_output
-        unique_node_output = {k: v for k, v in node_output.items() if k not in shared_items}
-        for key in unique_node_output:
-            if key not in ["inputs", "params", "_debug"]:
-                additional_input[key] = unique_node_output[key]
+                additional_input[key] = combined[key]
         return additional_input
 
     async def _arun(  # noqa: C901,PLR0912 type: ignore

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -788,6 +788,7 @@ class Pipeline:
 
         return node_output
 
+    # pylint: disable=too-many-branches
     def run_batch(  # noqa: C901,PLR0912 type: ignore
         self,
         queries: Optional[List[str]] = None,

--- a/haystack/pipelines/base.py
+++ b/haystack/pipelines/base.py
@@ -623,6 +623,12 @@ class Pipeline:
         return node_output
 
     def _combine_node_outputs(self, existing_input: Dict[str, Any], node_output: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Combines the outputs of two nodes into a single input for a downstream node. This is useful for join nodes.
+
+        :param existing_input: The output of the first node.
+        :param node_output: The output of the second node.
+        """
         additional_input = {}
         # Pass keys that appear in both inputs that have the same values
         shared_items = {
@@ -749,16 +755,8 @@ class Pipeline:
                                         **existing_input.get("_debug", {}),
                                         **node_output.get("_debug", {}),
                                     }
-                                # Pass keys that appear in both inputs that have the same values
-                                shared_items = {
-                                    k: existing_input[k]
-                                    for k in existing_input
-                                    if k in node_output and existing_input[k] == node_output[k]
-                                }
-                                for key in shared_items:
-                                    if key != "inputs" or key != "params" or key != "_debug":
-                                        updated_input[key] = shared_items[key]
-                                # TODO Auto pass on keys that only appear once
+                                additional_input = self._combine_node_outputs(existing_input, node_output)
+                                updated_input = {**additional_input, **updated_input}
                                 if query and "query" not in updated_input:
                                     updated_input["query"] = query
                                 if file_paths and "file_paths" not in updated_input:
@@ -770,9 +768,9 @@ class Pipeline:
                                 if meta and "meta" not in updated_input:
                                     updated_input["meta"] = meta
                             else:
-                                # TODO Would need to redo the shared items here to work with more than 2 streams joining
                                 existing_input["inputs"].append(node_output)
-                                updated_input = existing_input
+                                additional_input = self._combine_node_outputs(existing_input, node_output)
+                                updated_input = {**additional_input, **existing_input}
                             queue[n] = updated_input
                         else:
                             queue[n] = node_output

--- a/releasenotes/notes/fix-pipeline-with-join-node-5f23a426cd4d88d9.yaml
+++ b/releasenotes/notes/fix-pipeline-with-join-node-5f23a426cd4d88d9.yaml
@@ -1,4 +1,69 @@
 ---
 fixes:
   - |
-    Fixes pipelines using join nodes to properly pass on additional key value pairs from nodes prior to the join node to nodes that come after the join node.
+    When using a `Pipeline` with a `JoinNode` (e.g. `JoinDocuments`) all information from the previous nodes was lost
+    other than a few select fields (e.g. `documents`). This was due to the `JoinNode` not properly passing on
+    the information from the previous nodes. This has been fixed and now all information from the previous nodes is
+    passed on to the next node in the pipeline.
+
+    For example, this is a pipeline that rewrites the `query` during pipeline execution combined with a hybrid retrieval
+    setup that requires a `JoinDocuments` node. Specifically the first prompt node rewrites the `query` to fix all
+    spelling errors, and this new `query` is used for retrieval. And now the `JoinDocuments` node will now pass on the
+    rewritten `query` so it can be used by the `QAPromptNode` node whereas before it would pass on the original query.
+    ```python
+    from haystack import Pipeline
+    from haystack.nodes import BM25Retriever, EmbeddingRetriever, PromptNode, Shaper, JoinDocuments, PromptTemplate
+    from haystack.document_stores import InMemoryDocumentStore
+
+    document_store = InMemoryDocumentStore(use_bm25=True)
+    dicts = [{"content": "The capital of Germany is Berlin."}, {"content": "The capital of France is Paris."}]
+    document_store.write_documents(dicts)
+
+    query_prompt_node = PromptNode(
+        model_name_or_path="gpt-3.5-turbo",
+        api_key="",
+        default_prompt_template=PromptTemplate("You are a spell checker. Given a user query return the same query with all spelling errors fixed.\nUser Query: {query}\nSpell Checked Query:")
+    )
+    shaper = Shaper(
+        func="join_strings",
+        inputs={"strings": "results"},
+        outputs=["query"],
+    )
+    qa_prompt_node = PromptNode(
+        model_name_or_path="gpt-3.5-turbo",
+        api_key="",
+        default_prompt_template=PromptTemplate("Answer the user query. Query: {query}")
+    )
+    sparse_retriever = BM25Retriever(
+        document_store=document_store,
+        top_k=2
+    )
+    dense_retriever = EmbeddingRetriever(
+        document_store=document_store,
+        embedding_model="intfloat/e5-base-v2",
+        model_format="sentence_transformers",
+        top_k=2
+    )
+    document_store.update_embeddings(dense_retriever)
+
+    pipeline = Pipeline()
+    pipeline.add_node(component=query_prompt_node, name="QueryPromptNode", inputs=["Query"])
+    pipeline.add_node(component=shaper, name="ListToString", inputs=["QueryPromptNode"])
+    pipeline.add_node(component=sparse_retriever, name="BM25", inputs=["ListToString"])
+    pipeline.add_node(component=dense_retriever, name="Embedding", inputs=["ListToString"])
+    pipeline.add_node(
+        component=JoinDocuments(join_mode="concatenate"), name="Join", inputs=["BM25", "Embedding"]
+    )
+    pipeline.add_node(component=qa_prompt_node, name="QAPromptNode", inputs=["Join"])
+
+    out = pipeline.run(query="What is the captial of Grmny?", debug=True)
+    print(out["invocation_context"])
+    # Before Fix
+    # {'query': 'What is the captial of Grmny?',  <-- Original Query!!
+    #   'results': ['The capital of Germany is Berlin.'],
+    #   'prompts': ['Answer the user query. Query: What is the captial of Grmny?'],  <-- Original Query!!
+    # After Fix
+    # {'query': 'What is the capital of Germany?',  <-- Rewritten Query!!
+    #   'results': ['The capital of Germany is Berlin.'],
+    #   'prompts': ['Answer the user query. Query: What is the capital of Germany?'],  <-- Rewritten Query!!
+    ```

--- a/releasenotes/notes/fix-pipeline-with-join-node-5f23a426cd4d88d9.yaml
+++ b/releasenotes/notes/fix-pipeline-with-join-node-5f23a426cd4d88d9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes pipelines using join nodes to properly pass on additional key value pairs from nodes prior to the join node to nodes that come after the join node.

--- a/test/nodes/test_join_documents.py
+++ b/test/nodes/test_join_documents.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from haystack import Document
+from haystack import Document, Pipeline
 from haystack.nodes.other.join_docs import JoinDocuments
 from copy import deepcopy
 
@@ -149,3 +149,33 @@ def test_joindocuments_rrf_weights():
     assert result_none["documents"] == result_even["documents"]
     assert result_uneven["documents"] != result_none["documents"]
     assert result_uneven["documents"][0].score > result_none["documents"][0].score
+
+
+@pytest.mark.unit
+def test_join_node_empty_documents():
+    pipe = Pipeline()
+    join_node = JoinDocuments(join_mode="concatenate")
+    pipe.add_node(component=join_node, name="Join", inputs=["Query"])
+
+    # Test single document lists
+    output = pipe.run(query="test", documents=[])
+    assert len(output["documents"]) == 0
+
+    # Test lists of document lists
+    output = join_node.run_batch(queries=["test"], documents=[])
+    assert len(output[0]["documents"]) == 0
+
+
+@pytest.mark.unit
+def test_join_node_none_documents():
+    pipe = Pipeline()
+    join_node = JoinDocuments(join_mode="concatenate")
+    pipe.add_node(component=join_node, name="Join", inputs=["Query"])
+
+    # Test single document lists
+    output = pipe.run(query="test", documents=None)
+    assert len(output["documents"]) == 0
+
+    # Test lists of document lists
+    output = join_node.run_batch(queries=["test"], documents=None)
+    assert len(output[0]["documents"]) == 0

--- a/test/nodes/test_join_documents.py
+++ b/test/nodes/test_join_documents.py
@@ -161,10 +161,6 @@ def test_join_node_empty_documents():
     output = pipe.run(query="test", documents=[])
     assert len(output["documents"]) == 0
 
-    # Test lists of document lists
-    output = join_node.run_batch(queries=["test"], documents=[])
-    assert len(output[0]["documents"]) == 0
-
 
 @pytest.mark.unit
 def test_join_node_none_documents():
@@ -175,7 +171,3 @@ def test_join_node_none_documents():
     # Test single document lists
     output = pipe.run(query="test", documents=None)
     assert len(output["documents"]) == 0
-
-    # Test lists of document lists
-    output = join_node.run_batch(queries=["test"], documents=None)
-    assert len(output[0]["documents"]) == 0

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -2174,17 +2174,20 @@ def test_pipeline_execution_using_join_preserves_previous_keys_three_streams():
     assert len(res["documents"]) == 3
 
 
+@pytest.mark.unit
 def test_pipeline_execution_using_join_preserves_changed_query():
     shaper1 = Shaper(func="rename", params={"value": "This is a test."}, outputs=["query"])
-    shaper2 = Shaper(func="rename", params={"value": "dummy value"}, outputs=["dummy"])
+    shaper2 = Shaper(func="rename", params={"value": "dummy value 1"}, outputs=["dummy1"])
+    shaper3 = Shaper(func="rename", params={"value": "dummy value 2"}, outputs=["dummy2"])
     pipeline = Pipeline()
     pipeline.add_node(component=shaper1, name="Shaper1", inputs=["Query"])
-    pipeline.add_node(component=JoinDocuments(join_mode="concatenate"), name="Join", inputs=["Shaper1"])
-    pipeline.add_node(component=shaper2, name="DummyNode", inputs=["Join"])
+    pipeline.add_node(component=shaper2, name="DummyNode1", inputs=["Query"])
+    pipeline.add_node(component=JoinDocuments(join_mode="concatenate"), name="Join", inputs=["Shaper1", "DummyNode1"])
+    pipeline.add_node(component=shaper3, name="DummyNode2", inputs=["Join"])
     res = pipeline.run(query="Alpha Beta Gamma Delta", debug=True, documents=[Document(content="Test Document")])
     assert res["_debug"]["Shaper1"]["input"]["query"] == "Alpha Beta Gamma Delta"
     assert res["_debug"]["Join"]["input"]["query"] == "This is a test."
-    assert res["_debug"]["DummyNode"]["input"]["query"] == "This is a test."
+    assert res["_debug"]["DummyNode2"]["input"]["query"] == "This is a test."
     assert res["query"] == "This is a test."
 
 

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -39,7 +39,7 @@ from haystack.pipelines.utils import generate_code
 from haystack.errors import PipelineConfigError
 from haystack.nodes import PreProcessor, TextConverter
 from haystack.utils.deepsetcloud import DeepsetCloudError
-from haystack import Answer
+from haystack import Answer, Document
 
 from ..conftest import (
     MOCK_DC,
@@ -2172,6 +2172,20 @@ def test_pipeline_execution_using_join_preserves_previous_keys_three_streams():
     assert res["test_key2"] == "Alpha Beta Gamma Delta"
     assert res["invocation_context"] == {"query": "Alpha Beta Gamma Delta", "test_key1": "Alpha Beta Gamma Delta"}
     assert len(res["documents"]) == 3
+
+
+def test_pipeline_execution_using_join_preserves_changed_query():
+    shaper1 = Shaper(func="rename", params={"value": "This is a test."}, outputs=["query"])
+    shaper2 = Shaper(func="rename", params={"value": "dummy value"}, outputs=["dummy"])
+    pipeline = Pipeline()
+    pipeline.add_node(component=shaper1, name="Shaper1", inputs=["Query"])
+    pipeline.add_node(component=JoinDocuments(join_mode="concatenate"), name="Join", inputs=["Shaper1"])
+    pipeline.add_node(component=shaper2, name="DummyNode", inputs=["Join"])
+    res = pipeline.run(query="Alpha Beta Gamma Delta", debug=True, documents=[Document(content="Test Document")])
+    assert res["_debug"]["Shaper1"]["input"]["query"] == "Alpha Beta Gamma Delta"
+    assert res["_debug"]["Join"]["input"]["query"] == "This is a test."
+    assert res["_debug"]["DummyNode"]["input"]["query"] == "This is a test."
+    assert res["query"] == "This is a test."
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:
We have started to develop multi prompt node pipelines for clients. Some of the most popular ones include rewriting the query during the pipeline execution. Here is a simple example using a PromptNode as a spell checker for the incoming user query. 

```python
from haystack import Pipeline
from haystack.nodes import BM25Retriever, EmbeddingRetriever, PromptNode, Shaper, JoinDocuments, PromptTemplate
from haystack.document_stores import InMemoryDocumentStore

document_store = InMemoryDocumentStore(use_bm25=True)
dicts = [{"content": "The capital of Germany is Berlin."}, {"content": "The capital of France is Paris."}]
document_store.write_documents(dicts)

query_prompt_node = PromptNode(
    model_name_or_path="gpt-3.5-turbo",
    api_key="",
    default_prompt_template=PromptTemplate("You are a spell checker. Given a user query return the same query with all spelling errors fixed.\nUser Query: {query}\nSpell Checked Query:")
)
shaper = Shaper(
    func="join_strings",
    inputs={"strings": "results"},
    outputs=["query"],
)
qa_prompt_node = PromptNode(
    model_name_or_path="gpt-3.5-turbo",
    api_key="",
    default_prompt_template=PromptTemplate("Answer the user query. Query: {query}")
)
sparse_retriever = BM25Retriever(
    document_store=document_store,
    top_k=2
)
dense_retriever = EmbeddingRetriever(
    document_store=document_store,
    embedding_model="intfloat/e5-base-v2",
    model_format="sentence_transformers",
    top_k=2
)
document_store.update_embeddings(dense_retriever)

pipeline = Pipeline()
pipeline.add_node(component=query_prompt_node, name="QueryPromptNode", inputs=["Query"])
pipeline.add_node(component=shaper, name="ListToString", inputs=["QueryPromptNode"])
pipeline.add_node(component=sparse_retriever, name="BM25", inputs=["ListToString"])
pipeline.add_node(component=dense_retriever, name="Embedding", inputs=["ListToString"])
pipeline.add_node(
    component=JoinDocuments(join_mode="concatenate"), name="Join", inputs=["BM25", "Embedding"]
)
pipeline.add_node(component=qa_prompt_node, name="QAPromptNode", inputs=["Join"])

out = pipeline.run(query="What is the captial of Grmny?", debug=True)
print(out["invocation_context"])
# Current v1.x branch
# {'query': 'What is the captial of Grmny?',  <-- Original Query!!
#   'results': ['The capital of Germany is Berlin.'],
#   'prompts': ['Answer the user query. Query: What is the captial of Grmny?'],  <-- Original Query!!
# After this PR
# {'query': 'What is the capital of Germany?',  <-- Rewritten Query!!
#   'results': ['The capital of Germany is Berlin.'],
#   'prompts': ['Answer the user query. Query: What is the capital of Germany?'],  <-- Rewritten Query!!
```
The issue is that the `query` used in the second prompt node (`qa_prompt_node`) is the original query and not the one rewritten by the first prompt node (`query_prompt_node`). This has to do with how information the `Pipeline.run` method passes through `JoinNodes` specifically.

This PR fixes this issue by updating the `Pipeline.run` method to properly pass `node_output` information through a `JoinNode`.

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
