### PR TITLE
adding ruff rule for flake8-builtins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,10 @@ select = [
   "W",      # pycodestyle
   "YTT",    # flake8-2020
   "I",       # isort
+  # built-in shadowing
+  "A001",	# builtin-variable-shadowing
+  "A002",	# builtin-argument-shadowing
+  "A003",	# builtin-attribute-shadowing
   # docstring rules
   "D102",   # Missing docstring in public method
   "D103",   # Missing docstring in public function


### PR DESCRIPTION
### Proposed Changes:

I noticed the use of reserved keywords (e.g.: `dict`, `map`, `id`, `type`) as variables, this is safeguard to avoid more of that

see: https://docs.astral.sh/ruff/rules/#flake8-builtins-a
