### PR TITLE
ci: fix release notes generation on `github_release` workflow

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:  # this is useful to re-generate the release page without a new tag being pushed
   push:
     tags:
-      - "v2.0.0-beta*"
+      - "v2.[0-9]+.[0-9]+*"
 
 jobs:
   generate-notes:
@@ -28,9 +28,33 @@ jobs:
           python -m pip install --upgrade pip
           pip install "reno<5"
 
-      - name: Generate release notes for beta versions
+      - name: Generate release notes for release candidates - minor releases
+        if: steps.version.outputs.current_pre_release != '' && endsWith(steps.version.outputs.current_release, '.0')
+        env:
+          # When generating notes for release candidates of minor versions, pick every vX.Y.Z-rcN but
+          # stop when encounter vX.Y.Z-rc0. The -rc0 tag is added automatically when
+          # we create the release branch, so we can assume it's always there.
+          EARLIEST_VERSION: v${{ steps.version.outputs.current_release }}-rc0
         run: |
-          reno report --no-show-source --ignore-cache --version v${{ steps.version.outputs.current_release }}-${{ steps.version.outputs.current_pre_release }} -o relnotes.rst
+          reno report --no-show-source --ignore-cache --earliest-version "$EARLIEST_VERSION" -o relnotes.rst
+
+      - name: Generate release notes for release candidates - bugfix releases
+        if: steps.version.outputs.current_pre_release != '' && !endsWith(steps.version.outputs.current_release, '.0')
+        env:
+          # When generating notes for release candidates of bugfix releases, pick every vX.Y.Z-rcN but
+          # stop when encounter vX.Y.Z-rc1.
+          # In this case, we don't have the -rc0 tag, because we don't need to go through commits on main,
+          # as we cherry-pick them into the release branch.
+          EARLIEST_VERSION: v${{ steps.version.outputs.current_release }}-rc1
+        run: |
+          reno report --no-show-source --ignore-cache --earliest-version "$EARLIEST_VERSION" -o relnotes.rst
+
+      - name: Generate release notes for the final release
+        if: steps.version.outputs.current_pre_release == ''
+        # When generating notes for the final release vX.Y.Z, we just pass --version and reno
+        # will automatically collapse all the vX.Y.Z-rcN.
+        run: |
+          reno report --no-show-source --ignore-cache --version v${{ steps.version.outputs.current_release }} -o relnotes.rst
 
       - name: Convert to Markdown
         uses: docker://pandoc/core:3.1


### PR DESCRIPTION
### Related Issues

- fixes #7506

### Proposed Changes:
- trigger on the right tag
- make it properly run both on minor releases (X.Y.0) and bugfix releases (X.Y.Z; Z!=0)

### How did you test it?
- used to release 2.0.1 on v2.0.x branch
- 
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
