### PR TITLE
fix: `AzureOCRDocumentConverter` - forward declaration of `AnalyzeResult` types

### DIFF
--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -185,7 +185,7 @@ class AzureOCRDocumentConverter:
         docs = [*tables, text]
         return docs
 
-    def _convert_tables(self, result: AnalyzeResult, meta: Optional[Dict[str, Any]]) -> List[Document]:
+    def _convert_tables(self, result: "AnalyzeResult", meta: Optional[Dict[str, Any]]) -> List[Document]:
         """
         Converts the tables extracted by Azure's Document Intelligence service into Haystack Documents.
         :param result: The AnalyzeResult Azure object
@@ -294,7 +294,7 @@ class AzureOCRDocumentConverter:
 
         return converted_tables
 
-    def _convert_to_natural_text(self, result: AnalyzeResult, meta: Optional[Dict[str, Any]]) -> Document:
+    def _convert_to_natural_text(self, result: "AnalyzeResult", meta: Optional[Dict[str, Any]]) -> Document:
         """
         This converts the `AnalyzeResult` object into a single Document. We add "\f" separators between to
         differentiate between the text on separate pages. This is the expected format for the PreProcessor.

--- a/releasenotes/notes/AnalyzeResult-forward-declaration-5ed1bd9b6dc62c6f.yaml
+++ b/releasenotes/notes/AnalyzeResult-forward-declaration-5ed1bd9b6dc62c6f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Forward declaration of `AnalyzeResult` type in `AzureOCRDocumentConverter`.
+
+    `AnalyzeResult` is already imported in a lazy import block.
+    The forward declaration avoids issues when `azure-ai-formrecognizer>=3.2.0b2` is not installed.


### PR DESCRIPTION
### Related Issues

- tests of Unstructured core-integration with the main branch of Haystack are failing: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/8623976624

### Proposed Changes:

Forward declaration of `AnalyzeResult` type in `AzureOCRDocumentConverter`.

`AnalyzeResult` is already imported in a lazy import block.
The forward declaration avoids issues when `azure-ai-formrecognizer>=3.2.0b2` is not installed.

### How did you test it?
CI.
Tried to run Unstructured core-integration tests with this fix. :heavy_check_mark: 


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
