### PR TITLE
fix: Fix corner case when running Pipeline that causes it to get stuck in a loop

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -846,6 +846,7 @@ class Pipeline:
                     ) as span:
                         span.set_content_tag("haystack.component.input", last_inputs[name])
 
+                        logger.info("Running component {name}", name=name)
                         res = comp.run(**last_inputs[name])
                         self.graph.nodes[name]["visits"] += 1
 
@@ -959,6 +960,15 @@ class Pipeline:
                         # There was a lazy variadic or a component with only default waiting for input, we can run it
                         waiting_for_input.remove((name, comp))
                         to_run.append((name, comp))
+
+                        # Let's also add the default values for the inputs that are missing or the component
+                        # won't run and will put back in the waiting list causing an infinite loop.
+                        for input_socket in comp.__haystack_input__._sockets_dict.values():  # type: ignore
+                            if input_socket.is_mandatory:
+                                continue
+                            if input_socket.name not in last_inputs[name]:
+                                last_inputs[name][input_socket.name] = input_socket.default_value
+
                         continue
 
                     before_last_waiting_for_input = (

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -961,8 +961,8 @@ class Pipeline:
                         waiting_for_input.remove((name, comp))
                         to_run.append((name, comp))
 
-                        # Let's also add the default values for the inputs that are missing or the component
-                        # won't run and will put back in the waiting list causing an infinite loop.
+                        # Let's use the default value for the inputs that are still missing, or the component
+                        # won't run and will be put back in the waiting list, causing an infinite loop.
                         for input_socket in comp.__haystack_input__._sockets_dict.values():  # type: ignore
                             if input_socket.is_mandatory:
                                 continue

--- a/releasenotes/notes/fix-pipeline-run-loop-99f7ff9db16544d4.yaml
+++ b/releasenotes/notes/fix-pipeline-run-loop-99f7ff9db16544d4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug when running a Pipeline that would cause it to get stuck in an infinite loop


### PR DESCRIPTION
### Proposed Changes:

With PR #7434 we introduced this bug that would cause a Pipeline to get stuck in an infinite loop when running if the following conditions are met:
- The first Component has all defaults for its inputs
- The first Component receives one input from the user
- The first Component receives one input from a loop in the Pipeline
- The second Component has at least one default input

This PR fixes this bug by making sure that a Component with defaults has all the necessary inputs to run when adding it in the `to_run` list when we notice we're stuck in a loop with Components that can still run.

### How did you test it?

I added a unit test to reproduce the issue.

### Notes for the reviewer

This bug has been discovered after [this message](https://discord.com/channels/993534733298450452/1226997620988444783/1226997620988444783) on Discord.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
