### PR TITLE
chore: use the latest Python image

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -26,8 +26,8 @@ target "base" {
   dockerfile = "Dockerfile.base"
   tags = ["${IMAGE_NAME}:base-${IMAGE_TAG_SUFFIX}"]
   args = {
-    build_image = "python:3.10-slim"
-    base_image = "python:3.10-slim"
+    build_image = "python:3.12-slim"
+    base_image = "python:3.12-slim"
     haystack_version = "${HAYSTACK_VERSION}"
   }
   platforms = ["linux/amd64", "linux/arm64"]


### PR DESCRIPTION
### Related Issues

- fixes n/a

### Proposed Changes:

Use the latest Python version in the Haystack docker images.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
