### PR TITLE
feat: skip unknown file types [DC-1108]

### DIFF
--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -26,7 +26,7 @@ class FileTypeClassifier(BaseComponent):
 
     outgoing_edges = len(DEFAULT_TYPES)
 
-    def __init__(self, supported_types: Optional[List[str]] = None, full_analysis: bool = False):
+    def __init__(self, supported_types: Optional[List[str]] = None, full_analysis: bool = False, raise_on_error: bool = True):
         """
         Node that sends out files on a different output edge depending on their extension.
 
@@ -35,9 +35,11 @@ class FileTypeClassifier(BaseComponent):
             You can't use lists with duplicate elements.
         :param full_analysis: If True, the whole file is analyzed to determine the file type.
             If False, only the first 2049 bytes are analyzed.
+        :param raise_on_error: If True, the node will raise an exception if the file type is not supported.
         """
         self.full_analysis = full_analysis
         self._default_types = False
+        self._raise_on_error = raise_on_error
         if supported_types is None:
             self._default_types = True
             supported_types = DEFAULT_TYPES
@@ -121,6 +123,13 @@ class FileTypeClassifier(BaseComponent):
         try:
             index = self.supported_types.index(extension) + 1
         except ValueError:
+            if self._raise_on_error is False:
+                logger.warning(
+                    f"Unsupported files of type '{extension}' ({paths[0]}) found. "
+                    "Unsupported files will be ignored during indexing as `raise_on_error` is set to `False`. "
+                    f"The supported types are: {self.supported_types}. "
+                )
+                return None, None
             raise ValueError(
                 f"Files of type '{extension}' ({paths[0]}) are not supported. "
                 f"The supported types are: {self.supported_types}. "

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -127,9 +127,12 @@ class FileTypeClassifier(BaseComponent):
         except ValueError:
             if self._raise_on_error is False:
                 logger.warning(
-                    f"Unsupported files of type '{extension}' ({paths[0]}) found. "
+                    "Unsupported files of type '%s' (%s) found. "
                     "Unsupported file types will be ignored during indexing as `raise_on_error` is set to `False`. "
-                    f"The supported types are: {self.supported_types}. "
+                    "The supported types are: %s. ",
+                    extension,
+                    paths[0],
+                    self.supported_types,
                 )
                 return None, None
             raise ValueError(

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -126,7 +126,7 @@ class FileTypeClassifier(BaseComponent):
             if self._raise_on_error is False:
                 logger.warning(
                     f"Unsupported files of type '{extension}' ({paths[0]}) found. "
-                    "Unsupported files will be ignored during indexing as `raise_on_error` is set to `False`. "
+                    "Unsupported file types will be ignored during indexing as `raise_on_error` is set to `False`. "
                     f"The supported types are: {self.supported_types}. "
                 )
                 return None, None

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -26,7 +26,9 @@ class FileTypeClassifier(BaseComponent):
 
     outgoing_edges = len(DEFAULT_TYPES)
 
-    def __init__(self, supported_types: Optional[List[str]] = None, full_analysis: bool = False, raise_on_error: bool = True):
+    def __init__(
+        self, supported_types: Optional[List[str]] = None, full_analysis: bool = False, raise_on_error: bool = True
+    ):
         """
         Node that sends out files on a different output edge depending on their extension.
 

--- a/test/nodes/test_filetype_classifier.py
+++ b/test/nodes/test_filetype_classifier.py
@@ -166,3 +166,18 @@ def test_filetype_classifier_batched_same_media_extensions(tmp_path):
     output, edge = node.run_batch(test_files)
     assert edge == "output_1"
     assert output == {"file_paths": test_files}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("file_type", ["csv", "json", "xml", "pptx", "xlsx"])
+def test_filetype_classifier_raise_on_error_disabled_unsupported_file_types(tmp_path, caplog, file_type):
+    node = FileTypeClassifier(raise_on_error=False)
+    test_file = tmp_path / f"test.{file_type}"
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        output, edge = node.run(test_file)
+        assert edge == output == None
+        assert (
+            f"Unsupported files of type '{file_type}' ({test_file!s}) found. Unsupported file types will be ignored"
+            in caplog.text
+        )


### PR DESCRIPTION
### Related Issues

- fixes #DC-1108
https://deepset.atlassian.net/browse/DC-1108

### Proposed Changes:
Allow skipping of unspecified file types in FileClassifier using a newly introduced flag `raise_on_error`. If `raise_on_error` is set to False, the file will be skipped (sent to a dead edge). Additionally, a warning is logged.

**Use cases:**
We want to enable deepset Cloud users: 
- to upload other file types than .txt/.pdf in their workspace and run pipelines independent of file types available in their workspace
- schedule directories of files for indexing (containing different file types) without pre-cleaning and matching for specific pipelines


### How did you test it?

unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
