### PR TITLE
chore: update CODEOWNERS in v1.x branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # in the repo. Unless a later match takes precedence,
 # @deepset-ai/core-engineering will be requested for review
 # when someone opens a pull request.
-*                       @deepset-ai/core-engineering
+*                       @deepset-ai/open-source-engineering
 
 # Documentation
-*.md                    @deepset-ai/documentation @deepset-ai/core-engineering
-releasenotes/notes/*    @deepset-ai/documentation @deepset-ai/core-engineering
+*.md                    @deepset-ai/documentation @deepset-ai/open-source-engineering
+releasenotes/notes/*    @deepset-ai/documentation @deepset-ai/open-source-engineering


### PR DESCRIPTION
### Related Issues

Twin PR of #7538

### Proposed Changes:

update CODEOWNERS to make sure a member of open-source engineering is automatically assigned to review PRs in v1.x branch (example: this didn't happen for #7543)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
