### PR TITLE
fix: do not use reserved attributes in the logger

### DIFF
--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -76,7 +76,7 @@ class CacheChecker:
 
         try:
             module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
-            logger.debug("Trying to import module '{module}'", module=module_name)
+            logger.debug("Trying to import module '{module_name}'", module_name=module_name)
             module = importlib.import_module(module_name)
         except (ImportError, DeserializationError) as e:
             raise DeserializationError(

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -79,7 +79,7 @@ class FilterRetriever:
             raise DeserializationError("Missing 'type' in document store's serialization data")
         try:
             module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
-            logger.debug("Trying to import module '{module}'", module=module_name)
+            logger.debug("Trying to import module '{module_name}'", module_name=module_name)
             module = importlib.import_module(module_name)
         except (ImportError, DeserializationError) as e:
             raise DeserializationError(

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -76,7 +76,7 @@ class DocumentWriter:
 
         try:
             module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
-            logger.debug("Trying to import module '{module}'", module=module_name)
+            logger.debug("Trying to import module '{module_name}'", module_name=module_name)
             module = importlib.import_module(module_name)
         except (ImportError, DeserializationError) as e:
             raise DeserializationError(

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -411,10 +411,10 @@ class _Component:
         if class_path in self.registry:
             # Corner case, but it may occur easily in notebooks when re-running cells.
             logger.debug(
-                "Component {component} is already registered. Previous imported from '{module}', new imported from '{new_module}'",
+                "Component {component} is already registered. Previous imported from '{module_name}', new imported from '{new_module_name}'",
                 component=class_path,
-                module=self.registry[class_path],
-                new_module=cls,
+                module_name=self.registry[class_path],
+                new_module_name=cls,
             )
         self.registry[class_path] = cls
         logger.debug("Registered Component {component}", component=cls)

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -849,7 +849,7 @@ class Pipeline:
                     ) as span:
                         span.set_content_tag("haystack.component.input", last_inputs[name])
 
-                        logger.info("Running component {name}", name=name)
+                        logger.info("Running component {component_name}", component_name=name)
                         res = comp.run(**last_inputs[name])
                         self.graph.nodes[name]["visits"] += 1
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -165,7 +165,7 @@ class Pipeline:
                     try:
                         # Import the module first...
                         module, _ = component_data["type"].rsplit(".", 1)
-                        logger.debug("Trying to import {module}", module=module)
+                        logger.debug("Trying to import module {module_name}", module_name=module)
                         importlib.import_module(module)
                         # ...then try again
                         if component_data["type"] not in component.registry:

--- a/releasenotes/notes/fix-logger-reserved-attributes-9e4d4920c1e41a62.yaml
+++ b/releasenotes/notes/fix-logger-reserved-attributes-9e4d4920c1e41a62.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Remove the usage of reserved keywords in the logger calls, causing a `KeyError` when setting the log level
+    to DEBUG.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -1,12 +1,13 @@
+import logging
 import os
 
 import pytest
 from openai import OpenAIError
-from haystack.utils.auth import Secret
 
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage, StreamingChunk
+from haystack.utils.auth import Secret
 
 
 @pytest.fixture
@@ -191,6 +192,7 @@ class TestOpenAIChatGenerator:
         assert "Hello" in response["replies"][0].content  # see mock_chat_completion_chunk
 
     def test_check_abnormal_completions(self, caplog):
+        caplog.set_level(logging.INFO)
         component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
         messages = [
             ChatMessage.from_assistant(

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -1,13 +1,14 @@
+import logging
 import os
 from typing import List
-from haystack.utils.auth import Secret
 
 import pytest
 from openai import OpenAIError
 
 from haystack.components.generators import OpenAIGenerator
 from haystack.components.generators.utils import print_streaming_chunk
-from haystack.dataclasses import StreamingChunk, ChatMessage
+from haystack.dataclasses import ChatMessage, StreamingChunk
+from haystack.utils.auth import Secret
 
 
 class TestOpenAIGenerator:
@@ -181,6 +182,7 @@ class TestOpenAIGenerator:
         assert [isinstance(reply, str) for reply in response["replies"]]
 
     def test_check_abnormal_completions(self, caplog):
+        caplog.set_level(logging.INFO)
         component = OpenAIGenerator(api_key=Secret.from_token("test-api-key"))
 
         # underlying implementation uses ChatMessage objects so we have to use them here

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -47,6 +47,7 @@ class TestStructuredLoggingConsoleRendering:
         haystack_logging.configure_logging(use_json=False)
 
         logger = logging.getLogger(__name__)
+        logger.setLevel(logging.INFO)
         logger.debug("Hello, structured logging!", extra={"key1": "value1", "key2": "value2"})
 
         # Use `capfd` to capture the output of the final structlog rendering result
@@ -372,7 +373,6 @@ class TestCompositeLogger:
         # the pytest fixture caplog only captures logs being rendered from the stdlib logging module
         assert caplog.messages == ["Hello, structured logging!"]
         assert caplog.records[0].name == "test.test_logging"
-        assert caplog.records[0].lineno == 370
 
         # Nothing should be captured by capfd since structlog is not configured
         assert capfd.readouterr().err == ""


### PR DESCRIPTION
### Related Issues

- fixes #7516

### Proposed Changes:

Remove all the occurrences of reserved attributes in the logging calls

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
