### PR TITLE
feat: add required flag for prompt builder inputs

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from jinja2 import Template, meta
 
@@ -10,8 +10,9 @@ class PromptBuilder:
     """
     PromptBuilder is a component that renders a prompt from a template string using Jinja2 templates.
 
-    The template variables found in the template string are used as input types for the component and are all optional.
-    If a template variable is not provided as an input, it will be replaced with an empty string in the rendered prompt.
+    The template variables found in the template string are used as input types for the component and are all optional,
+    unless explicitly specified. If an optional template variable is not provided as an input, it will be replaced with
+    an empty string in the rendered prompt.
 
     Usage example:
     ```python
@@ -21,18 +22,24 @@ class PromptBuilder:
     ```
     """
 
-    def __init__(self, template: str):
+    def __init__(self, template: str, required_variables: Optional[List[str]] = None):
         """
         Constructs a PromptBuilder component.
 
         :param template: A Jinja2 template string, e.g. "Summarize this document: {documents}\\nSummary:"
+        :param required_variables: An optional list of input variables that must be provided at all times.
         """
         self._template_string = template
         self.template = Template(template)
+        self.required_variables = required_variables or []
         ast = self.template.environment.parse(template)
         template_variables = meta.find_undeclared_variables(ast)
+
         for var in template_variables:
-            component.set_input_type(self, var, Any, "")
+            if var in self.required_variables:
+                component.set_input_type(self, var, Any)
+            else:
+                component.set_input_type(self, var, Any, "")
 
     def to_dict(self) -> Dict[str, Any]:
         return default_to_dict(self, template=self._template_string)
@@ -46,4 +53,9 @@ class PromptBuilder:
         :returns: A dictionary with the following keys:
             - `prompt`: The updated prompt text after rendering the prompt template.
         """
+        missing_variables = [var for var in self.required_variables if var not in kwargs]
+        if missing_variables:
+            missing_vars_str = ", ".join(missing_variables)
+            raise ValueError(f"Missing required input variables in PromptBuilder: {missing_vars_str}")
+
         return {"prompt": self.template.render(kwargs)}

--- a/releasenotes/notes/add-required-flag-for-prompt-builder-inputs-f5d3ffb3cb7df8d0.yaml
+++ b/releasenotes/notes/add-required-flag-for-prompt-builder-inputs-f5d3ffb3cb7df8d0.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Enhanced PromptBuilder to specify and enforce required variables in prompt templates.

--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -33,3 +33,13 @@ def test_run_with_missing_input():
     builder = PromptBuilder(template="This is a {{ variable }}")
     res = builder.run()
     assert res == {"prompt": "This is a "}
+
+
+def test_run_with_missing_required_input():
+    builder = PromptBuilder(template="This is a {{ foo }}, not a {{ bar }}", required_variables=["foo", "bar"])
+    with pytest.raises(ValueError, match="foo"):
+        builder.run(bar="bar")
+    with pytest.raises(ValueError, match="bar"):
+        builder.run(foo="foo")
+    with pytest.raises(ValueError, match="foo, bar"):
+        builder.run()


### PR DESCRIPTION
### Related Issues

- changes PromptBuilder behavior according to #7441

### Proposed Changes:

PromptBuilder now takes a new optional parameter `required_variables` upon initialization to specify a list of jinja template variables that must be provided at all times. During pipeline or component runs, a proper`ValueError` will be thrown if some of the required variables are missing.
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

Added a new unit test.
Tested by following the 2.0 RAG pipeline recipe from https://docs.haystack.deepset.ai/docs/creating-pipelines
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

For the sake of completeness, I also added a validation check in `PromptBuilder.run()`. 
<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
