### PR TITLE
fix[JsonSchemaValidator]: fix recusirve loop and fix for claude model

### DIFF
--- a/haystack/components/validators/__init__.py
+++ b/haystack/components/validators/__init__.py
@@ -1,3 +1,4 @@
 from haystack.components.validators.json_schema import JsonSchemaValidator
+from haystack.components.validators.json_format import JsonFormatValidator
 
-__all__ = ["JsonSchemaValidator"]
+__all__ = ["JsonSchemaValidator", "JsonFormatValidator"]

--- a/haystack/components/validators/json_format.py
+++ b/haystack/components/validators/json_format.py
@@ -1,0 +1,107 @@
+import json
+from typing import Dict, List, Optional
+
+from haystack import component
+from haystack.dataclasses import ChatMessage
+
+@component
+class JsonFormatValidator:
+    """
+    Validates content of `ChatMessage` to JSON format.
+    It allows to force LLM without json/tool mode to output valid JSON strings through a loop mechanism.
+
+    If content of a message conforms to the JSON format, the message is passed along the "validated" output.
+    If the content does not conform to the JSON format, the message is passed along the "validation_error" output.
+    In the latter case, the error message is constructed using the provided `error_template` or a default template.
+    These error ChatMessages can be used by LLMs in Haystack 2.x recovery loops.
+    """
+
+    # Default error description template
+    default_error_template = (
+        "The following generated JSON is not a valid JSON string.\n"
+        "Generated JSON: {failing_json}\n"
+        "Error details:\n- Message: {error_message}\n"
+        "Please modify it to be a valid JSON string and output ONLY the corrected JSON content. Please do not output anything else than the raw JSON string, this is the most important part of the task. Don't use any markdown and don't add any comment."
+    )
+
+    def __init__(self, error_template: Optional[str] = None):
+        """
+        :param error_template: A custom template string for formatting the error message in case of validation failure.
+        """
+        self.error_template = error_template
+
+    @component.output_types(
+        validated=List[ChatMessage], validation_error=List[ChatMessage]
+    )
+    def run(
+        self,
+        messages: List[ChatMessage],
+        error_template: Optional[str] = None,
+    ) -> Dict[str, List[ChatMessage]]:
+        """
+        Validates the last of the provided messages to JSON format.
+
+        If it does, the message is passed along the "validated" output. If it does not, the message is passed along
+        the "validation_error" output.
+
+        :param messages: A list of ChatMessage instances to be validated. The last message in this list is the one
+            that is validated.
+        :param error_template: A custom template string for formatting the error message in case of validation. If not
+            provided, the `error_template` from the component init is used.
+        :return:  A dictionary with the following keys:
+            - "validated": A list of messages if the last message is valid.
+            - "validation_error": A list of messages if the last message is invalid.
+        :raises ValueError: If no JSON schema is provided or if the message content is not a dictionary or a list of
+            dictionaries.
+        """
+        last_message = messages[-1]
+        try:
+            decoded_json_string = self._extract_json(last_message.content)
+            if type(decoded_json_string) is str:
+                messages.append(ChatMessage.from_user(decoded_json_string))
+                return {"validated": [ChatMessage.from_assistant(decoded_json_string)]}
+            return {"validated": [ChatMessage.from_assistant(json.dumps(decoded_json_string))]}
+        except json.JSONDecodeError as e:
+            error_template = (
+                error_template or self.error_template or self.default_error_template
+            )
+            recovery_prompt = self._construct_error_recovery_message(
+                error_template, str(e), failing_json=last_message.content
+            )
+            return {"validation_error": [ChatMessage.from_user(recovery_prompt)]}
+
+    def _construct_error_recovery_message(
+        self,
+        error_template: str,
+        error_message: str,
+        failing_json: str,
+    ) -> str:
+        """
+        Constructs an error recovery message using a specified template or the default one if none is provided.
+
+        :param error_template: A custom template string for formatting the error message in case of validation failure.
+        :param error_message: The error message returned by the JSON schema validator.
+        :param failing_json: The generated invalid JSON string.
+        """
+        error_template = error_template or self.default_error_template
+
+        return error_template.format(
+            error_message=error_message,
+            failing_json=failing_json,
+        )
+
+    def _extract_json(self, chat_content:str):
+        start_index = chat_content.find('{')
+
+        if start_index != -1:
+            end_index = chat_content.rfind('}')
+
+            if end_index != -1:
+                json_string = chat_content[start_index:end_index + 1]
+                json_data = json.loads(json_string)
+                return json_data
+
+            else:
+                raise json.JSONDecodeError("No closing '}' found.", chat_content, end_index)
+        else:
+            raise json.JSONDecodeError("No opening '{' found.", chat_content, start_index)


### PR DESCRIPTION
…output from an LLM

### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/7457 https://github.com/deepset-ai/haystack/issues/7455

### Proposed Changes:

- Claude Compatibility: modified the behaviour so that (i) error template is now a single message with generated json, error and schema (ii) make it so that validated messages are always "Assistant" chatmessage (for next pipeline step) and validation_errors are always "User" chatmessag (for LLM loops)
- 
- Recursive Loop in type conversion: used Claude OPUS to automatically generate a fix based on the written issue.

### How did you test it?

Tested on my personal use-case and it solved my issues.

### Notes for the reviewer

The behabviour is modified to only include the last messages from the conversation and not the whole history of messages (less cost for long pipeline loops, not necessary to havep previous messages)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
