### PR TITLE
fix: use docstore.index for get_metadata_values_by_key (OpenSearch / elasticsearch)

### DIFF
--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -1559,6 +1559,7 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
         :param headers: Custom HTTP headers to pass to the client (for example, {'Authorization': 'Basic YWRtaW46cm9vdA=='})
                 Check out [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html) for more information.
         """
+        index = index or self.index
         body: dict = {
             "size": 0,
             "aggs": {"metadata_agg": {"composite": {"sources": [{key: {"terms": {"field": key}}}]}}},

--- a/haystack/document_stores/opensearch.py
+++ b/haystack/document_stores/opensearch.py
@@ -1521,6 +1521,7 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
         filters: Optional[FilterType] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        batch_size: int = 10,
     ) -> List[dict]:
         """
         Get values associated with a metadata key. The output is in the format:
@@ -1558,11 +1559,16 @@ class OpenSearchDocumentStore(SearchEngineDocumentStore):
                       self.index is used.
         :param headers: Custom HTTP headers to pass to the client (for example, {'Authorization': 'Basic YWRtaW46cm9vdA=='})
                 Check out [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html) for more information.
+        :param batch_size: Maximum number of results for each request.
+                    Limited to 10 values by default. You can increase this limit to decrease retrieval time.
+                    To reduce the pressure on the cluster, you shouldn't set this higher than 1,000.
         """
         index = index or self.index
         body: dict = {
             "size": 0,
-            "aggs": {"metadata_agg": {"composite": {"sources": [{key: {"terms": {"field": key}}}]}}},
+            "aggs": {
+                "metadata_agg": {"composite": {"sources": [{key: {"terms": {"field": key}}}], "size": batch_size}}
+            },
         }
         if query:
             body["query"] = {

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -324,6 +324,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         :param headers: Custom HTTP headers to pass to the client (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='})
                 Check out https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html for more information.
         """
+        index = index or self.index
         body: dict = {
             "size": 0,
             "aggs": {"metadata_agg": {"composite": {"sources": [{key: {"terms": {"field": key}}}]}}},

--- a/haystack/document_stores/search_engine.py
+++ b/haystack/document_stores/search_engine.py
@@ -286,6 +286,7 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
         filters: Optional[FilterType] = None,
         index: Optional[str] = None,
         headers: Optional[Dict[str, str]] = None,
+        batch_size: int = 10,
     ) -> List[dict]:
         """
         Get values associated with a metadata key. The output is in the format:
@@ -323,11 +324,16 @@ class SearchEngineDocumentStore(KeywordDocumentStore):
                       self.index will be used.
         :param headers: Custom HTTP headers to pass to the client (e.g. {'Authorization': 'Basic YWRtaW46cm9vdA=='})
                 Check out https://www.elastic.co/guide/en/elasticsearch/reference/current/http-clients.html for more information.
+        :param batch_size: Maximum number of results for each request.
+            Limited to 10 values by default. You can increase this limit to decrease retrieval time.
+            To reduce the pressure on the cluster, you shouldn't set this higher than 1,000.
         """
         index = index or self.index
         body: dict = {
             "size": 0,
-            "aggs": {"metadata_agg": {"composite": {"sources": [{key: {"terms": {"field": key}}}]}}},
+            "aggs": {
+                "metadata_agg": {"composite": {"sources": [{key: {"terms": {"field": key}}}], "size": batch_size}}
+            },
         }
         if query:
             body["query"] = {

--- a/test/document_stores/test_search_engine.py
+++ b/test/document_stores/test_search_engine.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 from haystack.document_stores.search_engine import SearchEngineDocumentStore
-from haystack.schema import FilterType
+from haystack.schema import Document, FilterType
 
 
 @pytest.mark.unit
@@ -59,6 +59,14 @@ class SearchEngineDocumentStoreTestAbstract:
         # test with filters & query
         result = ds.get_metadata_values_by_key(key="year", query="Bar")
         assert result == [{"count": 3, "value": "2021"}]
+
+    @pytest.mark.integration
+    def test_get_meta_values_by_key_with_batch_size(self, ds):
+        docs = [Document(f"content_{i}", meta={"name": f"name_{i}"}) for i in range(10_000)]
+        ds.write_documents(docs)
+
+        result = ds.get_metadata_values_by_key(key="name", batch_size=1_000)
+        assert result == sorted([{"count": 1, "value": f"name_{i}"} for i in range(10_000)], key=lambda x: x["value"])
 
     @pytest.mark.unit
     def test_query_return_embedding_true(self, mocked_document_store):


### PR DESCRIPTION
### Related Issues

All docstore methods normally take `self.index` as index param of opensearch / elasticsearch requests if no value for `index` has been passed explicitly. `get_metadata_values_by_key` misses this behavior. 

### Proposed Changes:
- `get_metadata_values_by_key` uses `self.index` if `index=None` 
- `batch_size` param added to `get_metadata_values_by_key` to controll efficient paging

### How did you test it?
- existing tests
- additional test for `batch_size`

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
