### PR TITLE
fix: pipeline infinite loop problem caused by components with optional params

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -818,7 +818,9 @@ class Pipeline:
                             waiting_for_input.append((name, comp))
                         continue
 
-                if name in last_inputs and len(comp.__haystack_input__._sockets_dict) == len(last_inputs[name]):  # type: ignore
+                # Check: are all mandatory inputs are present in last_inputs[name]?
+                mandatory_inputs = {k for k, v in comp.__haystack_input__._sockets_dict.items() if v.is_mandatory}
+                if name in last_inputs and mandatory_inputs <= set(last_inputs[name].keys()):  # type: ignore
                     if self.graph.nodes[name]["visits"] > self.max_loops_allowed:
                         msg = f"Maximum loops count ({self.max_loops_allowed}) exceeded for component '{name}'"
                         raise PipelineMaxLoops(msg)


### PR DESCRIPTION
### Related Issues

- fixes #7561

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 Traced it back with the debugger, eventually found that line 798 `if name in last_inputs and len(comp.__haystack_input__._sockets_dict) == len(last_inputs[name]):  # type: ignore` was checking if `len(last_inputs[name])` was the same length as the expected sockets dict. 
 
However, this sockets dict may contain optional argument keys. If any of the optional sockets were not contained in the last_inputs dict, the conditional check would fail. 

Furthermore, if an optional argument key is marked as the output of some other component (which is what occurs in tutorial 28), it is not possible to supply when first running the pipeline, so there was no way to modify inputs to escape the infinite loop.

As it happens, this happens in the first pass of the loop in tutorial 28 because `error_message` and `invalid_replies` are present in the sockets dict, but they are not mandatory, and the last_inputs[name] dict only contains keys `passage` and `schema`, which are mandatory. 

Instead, this if statement needed to check that all the mandatory elements of the sockets dict are present in the `last_inputs[name]` dict. 

### How did you test it?

Test by running tutorial 28. It should now succeed. 


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt) x
- I have updated the related issue with new insights and changes x
- I added unit tests and updated the docstrings 
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code x
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue x
