### PR TITLE
feat: keyword extractor

### DIFF
--- a/e2e/pipelines/test_keyword_extractor.py
+++ b/e2e/pipelines/test_keyword_extractor.py
@@ -1,0 +1,147 @@
+import pytest
+
+from haystack import Document, Pipeline
+from haystack.components.extractors import (
+    HighlightedText,
+    KeywordsExtractor,
+    KeywordsExtractorBackend,
+    KeyWordsSelection,
+)
+
+
+@pytest.fixture
+def raw_texts():
+    return [
+        (
+            "Supervised learning is the machine learning task of learning a"
+            "function that maps an input to an output based on example input-output pairs. "
+            "It infers a function from labeled training data consisting of a set of training examples. "
+            "In supervised learning, each example is a pair consisting of an input object "
+            "(typically a vector) and a desired output value (also called the supervisory signal). "
+            "A supervised learning algorithm analyzes the training data and produces an inferred "
+            "function, which can be used for mapping new examples. An optimal scenario will allow for "
+            "the algorithm to correctly determine the class labels for unseen instances. "
+            "This requires the learning algorithm to generalize from the training data to unseen "
+            "situations in a 'reasonable' way (see inductive bias)."
+        ),
+        (
+            "Haystack is an open-source framework for building production-ready LLM applications "
+            "retrieval-augmented generative pipelines and state-of-the-art search systems "
+            "that work intelligently over large document collections. "
+            "Learn more about Haystack and how it works."
+        ),
+        "",  # Intentionally empty.
+    ]
+
+
+@pytest.fixture
+def yake_keywords_five():
+    return [
+        {
+            "keywords": [
+                KeyWordsSelection(entity="machine learning task", score=0.026288458458349206),
+                KeyWordsSelection(entity="afunction that maps", score=0.047289948689021914),
+                KeyWordsSelection(entity="Supervised learning", score=0.07732438104871593),
+                KeyWordsSelection(entity="learning", score=0.0775411459456495),
+                KeyWordsSelection(entity="maps an input", score=0.08445317698651879),
+            ],
+            "highlight": HighlightedText(
+                text=(
+                    "<kw>Supervised learning</kw> is the <kw>machine learning task</kw> of <kw>learning</kw> "
+                    "<kw>afunction that maps</kw> an input to an output based on example input-output pairs. "
+                    "It infers a function from labeled training data consisting of a set of training examples. "
+                    "In <kw>supervised learning</kw>, each example is a pair consisting of an input object "
+                    "(typically a vector) and a desired output value (also called the supervisory signal). "
+                    "A <kw>supervised learning</kw> algorithm analyzes the training data and produces an "
+                    "inferred function, which can be used for mapping new examples. An optimal scenario will "
+                    "allow for the algorithm to correctly determine the class labels for unseen instances. "
+                    "This requires the <kw>learning</kw> algorithm to generalize from the training data to "
+                    "unseen situations in a 'reasonable' way (see inductive bias)."
+                )
+            ),
+        },
+        {
+            "keywords": [
+                KeyWordsSelection(entity="building production-ready LLM", score=0.006534094663438077),
+                KeyWordsSelection(entity="production-ready LLM applications", score=0.006534094663438078),
+                KeyWordsSelection(entity="LLM applications retrieval-augmented", score=0.006534094663438078),
+                KeyWordsSelection(entity="large document collections", score=0.00944562772813063),
+                KeyWordsSelection(entity="applications retrieval-augmented generative", score=0.01560948497642163),
+            ],
+            "highlight": HighlightedText(
+                text=(
+                    "Haystack is an open-source framework for <kw>building production-ready LLM</kw> "
+                    "<kw>applications retrieval-augmented generative</kw> pipelines and state-of-the-art "
+                    "search systems that work intelligently over <kw>large document collections</kw>. "
+                    "Learn more about Haystack and how it works."
+                )
+            ),
+        },
+        {"keywords": [], "highlight": HighlightedText(text="")},
+    ]
+
+
+@pytest.fixture
+def yake_keywords_one():
+    return [
+        {
+            "keywords": [KeyWordsSelection(entity="machine learning task", score=0.026288458458349206)],
+            "highlight": HighlightedText(
+                text=(
+                    "Supervised learning is the <kw>machine learning task</kw> of learning afunction that maps an "
+                    "input to an output based on example input-output pairs. It infers a function from labeled "
+                    "training data consisting of a set of training examples. In supervised learning, each example "
+                    "is a pair consisting of an input object (typically a vector) and a desired output value "
+                    "(also called the supervisory signal). A supervised learning algorithm analyzes the training "
+                    "data and produces an inferred function, which can be used for mapping new examples. "
+                    "An optimal scenario will allow for the algorithm to correctly determine the class labels "
+                    "for unseen instances. This requires the learning algorithm to generalize from the training "
+                    "data to unseen situations in a 'reasonable' way (see inductive bias)."
+                )
+            ),
+        },
+        {
+            "keywords": [KeyWordsSelection(entity="building production-ready LLM", score=0.006534094663438077)],
+            "highlight": HighlightedText(
+                text=(
+                    "Haystack is an open-source framework for <kw>building production-ready LLM</kw> "
+                    "applications retrieval-augmented generative pipelines and state-of-the-art search systems "
+                    "that work intelligently over large document collections. Learn more about Haystack and how it works."
+                )
+            ),
+        },
+        {"keywords": [], "highlight": HighlightedText(text="")},
+    ]
+
+
+@pytest.mark.parametrize("top_n, expected", [(5, "yake_keywords_five"), (1, "yake_keywords_one")])
+def test_keywords_extractor_yake_backend(raw_texts, top_n, expected, request: pytest.FixtureRequest):
+    expected = request.getfixturevalue(expected)
+    extractor = KeywordsExtractor(backend=KeywordsExtractorBackend.YAKE, top_n=top_n)
+    extractor.warm_up()
+    _extract_and_check_predictions(extractor, raw_texts, expected)
+
+
+@pytest.mark.parametrize("top_n, expected", [(5, "yake_keywords_five"), (1, "yake_keywords_one")])
+def test_keyword_extractor_extractor_in_pipeline(raw_texts, top_n, expected, request: pytest.FixtureRequest):
+    expected = request.getfixturevalue(expected)
+    pipeline = Pipeline()
+    pipeline.add_component(
+        name="keyword_extractor", instance=KeywordsExtractor(backend=KeywordsExtractorBackend.YAKE, top_n=top_n)
+    )
+
+    outputs = pipeline.run({"keyword_extractor": {"documents": [Document(content=text) for text in raw_texts]}})[
+        "keyword_extractor"
+    ]["documents"]
+    predicted = [KeywordsExtractor.get_stored_annotations(doc) for doc in outputs]
+
+    assert predicted == expected
+
+
+def _extract_and_check_predictions(extractor, texts, expected):
+    docs = [Document(content=text) for text in texts]
+    outputs = extractor.run(documents=docs)["documents"]
+    assert all(id(a) == id(b) for a, b in zip(docs, outputs))
+    predicted = [KeywordsExtractor.get_stored_annotations(doc) for doc in outputs]
+
+    assert predicted == expected

--- a/haystack/components/extractors/__init__.py
+++ b/haystack/components/extractors/__init__.py
@@ -1,7 +1,21 @@
+from haystack.components.extractors.keyword_extractor import (
+    HighlightedText,
+    KeywordsExtractor,
+    KeywordsExtractorBackend,
+    KeyWordsSelection,
+)
 from haystack.components.extractors.named_entity_extractor import (
     NamedEntityAnnotation,
     NamedEntityExtractor,
     NamedEntityExtractorBackend,
 )
 
-__all__ = ["NamedEntityExtractor", "NamedEntityExtractorBackend", "NamedEntityAnnotation"]
+__all__ = [
+    "NamedEntityExtractor",
+    "NamedEntityExtractorBackend",
+    "NamedEntityAnnotation",
+    "KeywordsExtractorBackend",
+    "KeywordsExtractor",
+    "KeyWordsSelection",
+    "HighlightedText",
+]

--- a/haystack/components/extractors/keyword_extractor.py
+++ b/haystack/components/extractors/keyword_extractor.py
@@ -143,10 +143,10 @@ class KeywordsExtractor:
             backend = KeywordsExtractorBackend(backend)
         # Ignore the backend_kwargs if it is not a dictionary
         backend_kwargs = backend_kwargs if isinstance(backend_kwargs, dict) else {}
-        selected_backend = _SupportedBackendModel.get_backend(backend.value)
+        selected_backend: _KWExtracorBackend = _SupportedBackendModel.get_backend(backend.value)
 
         self._backend: _KWExtracorBackend = selected_backend(
-            type=backend, backend_kwargs=backend_kwargs, top_n=top_n, max_ngram_size=max_ngram_size
+            backend_type=backend, backend_kwargs=backend_kwargs, top_n=top_n, max_ngram_size=max_ngram_size
         )
 
     @component.output_types(documents=List[Document])
@@ -282,10 +282,14 @@ class _KWExtracorBackend(ABC):
     """
 
     def __init__(
-        self, type: KeywordsExtractorBackend, top_n: int, max_ngram_size: int, backend_kwargs: Optional[Dict[str, Any]]
+        self,
+        backend_type: KeywordsExtractorBackend,
+        top_n: int,
+        max_ngram_size: int,
+        backend_kwargs: Optional[Dict[str, Any]],
     ) -> None:
         super().__init__()
-        self._type = type
+        self._type = backend_type
         self._top_n = top_n
         self._max_ngram_size = max_ngram_size
         self._backend_kwargs = backend_kwargs
@@ -338,7 +342,11 @@ class _YakeBackend(_KWExtracorBackend):
     """It uses yake package for extracting keywords for documents."""
 
     def __init__(
-        self, type: KeywordsExtractorBackend, top_n: int, max_ngram_size: int, backend_kwargs: Optional[Dict[str, Any]]
+        self,
+        backend_type: KeywordsExtractorBackend,
+        top_n: int,
+        max_ngram_size: int,
+        backend_kwargs: Optional[Dict[str, Any]],
     ) -> None:
         """
         Initialize the Yake KeywordExtractor.
@@ -348,7 +356,7 @@ class _YakeBackend(_KWExtracorBackend):
         :param backend_kwargs:
             Additional keyword arguments to pass to the backend. Defaults to None.
         """
-        super().__init__(type, top_n, max_ngram_size, backend_kwargs)
+        super().__init__(backend_type, top_n, max_ngram_size, backend_kwargs)
         yake_import.check()
 
     def initialize(self):
@@ -386,7 +394,11 @@ class _KeyBertBackend(_KWExtracorBackend):
     """It uses KeyBert package for extracting keywords for documents."""
 
     def __init__(
-        self, type: KeywordsExtractorBackend, top_n: int, max_ngram_size: int, backend_kwargs: Optional[Dict[str, Any]]
+        self,
+        backend_type: KeywordsExtractorBackend,
+        top_n: int,
+        max_ngram_size: int,
+        backend_kwargs: Optional[Dict[str, Any]],
     ) -> None:
         """
         Initialize the KeyBert KeywordExtractor.
@@ -419,7 +431,7 @@ class _KeyBertBackend(_KWExtracorBackend):
         if backend_kwargs.get("keyphrase_ngram_range") is None:
             _backend_kwargs["keyphrase_ngram_range"] = (max_ngram_size, max_ngram_size)
 
-        super().__init__(type, top_n, max_ngram_size, backend_kwargs=_backend_kwargs)
+        super().__init__(backend_type, top_n, max_ngram_size, backend_kwargs=_backend_kwargs)
 
         # Initialize the KeyBert model
         self._keybert_model: _KeyBertModel = _SupportedBackendModel.get_model_type(self._type.value)(

--- a/haystack/components/extractors/keyword_extractor.py
+++ b/haystack/components/extractors/keyword_extractor.py
@@ -1,0 +1,379 @@
+import concurrent.futures
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum, EnumMeta
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from tqdm import tqdm
+
+from haystack import ComponentError, DeserializationError, Document, component, default_from_dict, default_to_dict
+from haystack.lazy_imports import LazyImport
+
+with LazyImport(message="Run 'pip install yake'") as yake_import:
+    import yake
+    from yake.highlight import TextHighlighter
+
+
+class _BackendkwEnumMeta(EnumMeta):
+    """
+    Metaclass for fine-grained error handling of backend enums.
+    """
+
+    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1):
+        if names is None:
+            try:
+                return EnumMeta.__call__(cls, value, names, module=module, qualname=qualname, type=type, start=start)
+            except ValueError:
+                supported_backends = ", ".join(sorted(v.value for v in cls))
+                raise ComponentError(
+                    f"Invalid backend `{value}` for keyword extractor. " f"Supported backends: {supported_backends}"
+                )
+        else:
+            return EnumMeta.__call__(  # pylint: disable=too-many-function-args
+                cls, value, names, module, qualname, type, start
+            )
+
+
+class KeywordsExtractorBackend(Enum, metaclass=_BackendkwEnumMeta):
+    """
+    Enum for specifying the backend to use for keyword extraction.
+    """
+
+    #: Uses keyBert with sentence-transfomer model.
+    KEYBERT = "keybert"
+
+    #: Uses the yake package.
+    YAKE = "yake"
+
+
+@dataclass
+class KeyWordsSelection:
+    """Represents a keyword selection.
+
+    Attributes:
+        entity (str): The keyword entity.
+        start (int, optional): The start position of the keyword in the text.
+        end (int, optional): The end position of the keyword in the text.
+        score (float, optional): The score associated with the keyword.
+    """
+
+    entity: str
+    score: Optional[float] = None
+
+
+@dataclass
+class HighlightedText:
+    """Represents a highlighted text.
+
+    Attributes:
+        text (str): The highlighted text.
+    """
+
+    text: str
+
+
+@component
+class KeywordsExtractor:
+    """
+    Extracts keywords from a list of documents using different backends.
+    The component supports the following backends:
+    - YAKE: Uses the yake package to extract keywords.
+
+    Usage example:
+    ```python
+    from pprint import pprint
+    from haystack.dataclasses import Document
+    from haystack.components.extractors import KeywordsExtractor, KeywordsExtractorBackend
+
+    documents = [
+        Document(content="Supervised learning is the machine learning task"),
+        Document(content="A supervised learning algorithm analyzes the training data."),
+    ]
+
+    extractor = KeywordsExtractor(backend=KeywordsExtractorBackend.YAKE)
+    extractor.warm_up()
+    result = extractor.run(documents)["documents"]
+
+    keywords = [KeywordsExtractor.get_stored_annotations(doc) for doc in result]
+    pprint(keywords)
+    ```
+
+    :param backend:
+        The backend to use for keyword extraction.
+        It can be either a string representing the backend name or an instance of `KeywordsExtractorBackend`.
+    :param backend_kwargs:
+        Additional keyword arguments to pass to the backend.
+    :param top_n:
+        The number of keywords to extract from each document. Defaults to 3.
+    :param max_ngram_size:
+        The maximum size of n-grams to consider when extracting keywords.
+        This is also needed for highliting keywords. Defaults to 3.
+
+    :raises ComponentError:
+        If an unknown keyword backend is provided.
+    """
+
+    _METADATA_KEYWORDS_KEY = "keywords"
+    _METADATA_HIGHLIGHTS_KEY = "highlight"
+
+    def __init__(
+        self,
+        *,
+        backend: Union[str, KeywordsExtractorBackend],
+        backend_kwargs: Optional[Dict[str, Any]] = None,
+        top_n: int = 3,
+        max_ngram_size: int = 3,
+    ) -> None:
+        """
+        Initialize the KeywordExtractor.
+
+        :param data:
+            backend (Union[str, KeywordsExtractorBackend]): The backend to use for keyword extraction.
+                It can be either a string representing the backend name or an instance of `KeywordsExtractorBackend`.
+        :param backend_kwargs:
+
+        Raises:
+            ComponentError: If an unknown keyword backend is provided.
+        """
+        if isinstance(backend, str):
+            backend = KeywordsExtractorBackend(backend)
+
+        if backend == KeywordsExtractorBackend.KEYBERT:
+            raise ComponentError(f"'{type(backend).__name__}' is not ready yet")
+        elif backend == KeywordsExtractorBackend.YAKE:
+            self._backend = _YakeBackend(backend_kwargs=backend_kwargs, top_n=top_n, max_ngram_size=max_ngram_size)
+        else:
+            raise ComponentError(f"Unknown keyword backend '{type(backend).__name__}' for extractor")
+
+    def warm_up(self):
+        """
+        Initializes the keyword extractor.
+
+        Raises:
+            ComponentError: If the keyword extractor fails to initialize.
+        """
+        try:
+            self._backend.initialize()
+        except Exception as e:
+            raise ComponentError(f"Keywords extractor with backend '{self.type} failed to initialize.") from e
+
+    @component.output_types(documents=List[Document])
+    def run(self, documents: List[Document], concurrent_workers=10) -> Dict[str, Any]:
+        """
+        Run the keyword extractor component on a list of documents.
+
+        :param documents:
+            A list of Document objects to extract keywords from.
+
+        Raises:
+            ComponentError: If the keyword extractor backend does not return the correct number of annotations.
+
+        :returns:
+            Dict[str, Any]: A dictionary containing the extracted keywords for each document.
+        """
+        result = defaultdict(list)
+
+        doc: Document
+        texts = {doc.id: doc.content if doc.content is not None else "" for doc in documents}
+
+        with tqdm(total=len(texts)) as pbar, concurrent.futures.ThreadPoolExecutor(
+            max_workers=concurrent_workers
+        ) as executor:
+            future_to_dataset = {executor.submit(self._backend.extract, doc): doc_id for doc_id, doc in texts.items()}
+            for future in concurrent.futures.as_completed(future_to_dataset):
+                doc_id = future_to_dataset[future]
+                result[doc_id] = (future.result(), self._backend.highlight(texts[doc_id]))
+
+                pbar.update(1)
+
+        for doc in documents:
+            doc.meta[self._METADATA_KEYWORDS_KEY] = result[doc.id][0]
+            doc.meta[self._METADATA_HIGHLIGHTS_KEY] = result[doc.id][1]
+
+        return {"documents": documents}
+
+    def __iter__(self):
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+
+        dict_ = default_to_dict(self, backend=self._backend._type, backend_kwargs=self._backend._backend_kwargs)
+        for key, value in dict_.items():
+            yield key, value
+
+    # It's just kept the method for the sake of compatibility with the rest of the codebase
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "KeywordsExtractor":
+        """Deserialize a KeywordsExtractor instance from a dictionary.
+
+        :param data:
+            A dictionary containing the serialized representation of a KeywordsExtractor instance.
+
+        Raises:
+            DeserializationError: If there is an error during deserialization.
+
+        :returns:
+            KeywordsExtractor: A deserialized KeywordsExtractor instance.
+        """
+        try:
+            return default_from_dict(cls, data)
+        except Exception as e:
+            raise DeserializationError(f"Couldn't deserialize {cls.__name__} instance") from e
+
+    @property
+    def initialized(self) -> bool:
+        """
+        Returns if the extractor is ready to extract keywords.
+        """
+        return self._backend.initialized
+
+    @property
+    def type(self) -> KeywordsExtractorBackend:
+        """
+        Returns the type of the backend.
+        """
+        return self._backend._type
+
+    @property
+    def top_n(self) -> KeywordsExtractorBackend:
+        """
+        Returns the type of the backend.
+        """
+        return self._backend._top_n
+
+    @classmethod
+    def get_stored_annotations(cls, document: Document) -> Optional[Dict[str, Union[List[KeyWordsSelection], str]]]:
+        """
+        Returns the document's keywords stored
+        in its metadata, if any.
+
+        :param document:
+            Document whose annotations are to be fetched.
+        :returns:
+            a dictionary containing the keywords and highlights.
+        """
+
+        return {
+            cls._METADATA_KEYWORDS_KEY: document.meta.get(cls._METADATA_KEYWORDS_KEY),
+            cls._METADATA_HIGHLIGHTS_KEY: document.meta.get(cls._METADATA_HIGHLIGHTS_KEY),
+        }
+
+
+class _KWExtracorBackend(ABC):
+    """
+    This class represents the abstract base class for keyword extractor backends.
+
+    :param data:
+        ABC (type): The base class for defining abstract base classes.
+    """
+
+    def __init__(
+        self, type: KeywordsExtractorBackend, top_n: int, max_ngram_size: int, backend_kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        super().__init__()
+        self._type = type
+        self._top_n = top_n
+        self._max_ngram_size = max_ngram_size
+        self._backend_kwargs = backend_kwargs if isinstance(backend_kwargs, dict) else {}
+        self._keywords: dict = {}
+
+    @property
+    @abstractmethod
+    def initialized(self) -> bool:
+        """
+        Returns if the backend has been initialized, i.e, ready to extract keywords.
+        """
+
+    @abstractmethod
+    def extract(self, texts: Dict[str, str], max_workers: int) -> List[KeyWordsSelection]:
+        """
+        Annotates a multiple texts and returns a list of keywords for each text.
+
+        :param texts:
+            A dictionary including document_id as key and text as value.
+        :param max_workers:
+            The maximum number of workers to use for parallel processing.
+
+        :returns:
+            list of keywords
+        """
+
+    @abstractmethod
+    def highlight(self, text: str, keywords: List[str]) -> HighlightedText:
+        """
+        Highlights the keywords in the text.
+
+        :param text:
+            The text to highlight.
+        :param keywords:
+            The keywords to highlight.
+
+        :returns:
+            The highlighted text.
+        """
+
+    @abstractmethod
+    def initialize(self):
+        """
+        Initializes the backend.
+        This would usually entail loading models, etc.
+        """
+
+
+class _YakeBackend(_KWExtracorBackend):
+    """It uses yake package for extracting keywords for documents."""
+
+    def __init__(self, *, top_n: int, max_ngram_size: int, backend_kwargs: Optional[Dict[str, Any]]) -> None:
+        """
+        Initialize the Yake KeywordExtractor.
+
+        :param top_n:
+            The number of top keywords to extract. Defaults to 3.
+        :param backend_kwargs:
+            Additional keyword arguments to pass to the backend. Defaults to None.
+        """
+        super().__init__(KeywordsExtractorBackend.YAKE, top_n, max_ngram_size, backend_kwargs)
+        yake_import.check()
+
+    def initialize(self):
+        pass
+
+    @property
+    def initialized(self) -> bool:
+        return True
+
+    def extract(self, text: str) -> List[KeyWordsSelection]:
+        "extract keywords from a list of documents using Yake backend."
+        extractor = yake.KeywordExtractor(top=self._top_n, n=self._max_ngram_size, **self._backend_kwargs)
+
+        self._keywords = extractor.extract_keywords(text)
+        return [KeyWordsSelection(entity=record[0], score=record[1]) for record in self._keywords]
+
+    def highlight(self, text: str) -> HighlightedText:
+        """
+        Highlights the keywords in the text.
+
+        :param text:
+            The text to highlight.
+        :param keywords:
+            The keywords to highlight.
+
+        :returns:
+            The highlighted text.
+        """
+        highlighter = TextHighlighter(max_ngram_size=self._max_ngram_size)
+
+        return HighlightedText(highlighter.highlight(text, self._keywords))

--- a/haystack/components/extractors/keyword_extractor.py
+++ b/haystack/components/extractors/keyword_extractor.py
@@ -454,9 +454,12 @@ class _KeyBertBackend(_KWExtracorBackend):
         "extract keywords from a list of documents using KeyBert backend."
         if not self.initialized:
             raise ComponentError(f"{self._keybert_model} was not initialized - Did you call `warm_up()`?")
+        extractor = KeyBERT(self._keybert_model._model)
+        self._keywords = extractor.extract_keywords(text, top_n=self._top_n, **self._backend_kwargs)
+        return [KeyWordsSelection(entity=record[0], score=record[1]) for record in self._keywords]
 
     def highlight(self, text: str) -> HighlightedText:
-        pass
+        return HighlightedText("")
 
 
 class _KeyBertModel(ABC):
@@ -480,9 +483,8 @@ class _KeyBertModel(ABC):
         pass
 
     @property
-    @abstractmethod
     def _initialized(self) -> bool:
-        self._model is not None
+        return self._model is not None
 
 
 class _SentenceTransformerModel(_KeyBertModel):

--- a/proposals/text/0000-keyword-extractor.md
+++ b/proposals/text/0000-keyword-extractor.md
@@ -1,0 +1,156 @@
+- Title: keywords extractor component
+- Decision driver: Hadis
+- Start Date: 2024-04-21
+- Proposal PR: (fill in after opening the PR)
+- Github Issue or Discussion: [issue 7083](https://github.com/deepset-ai/haystack/issues/7083)
+
+# Summary
+
+The proposal aims to enhance the keyword extraction component in Haystack by introducing multiple backend options, parallel processing capabilities, and robust error handling. This enhancement will provide users with flexible, scalable, and accurate methods for extracting keywords from text data and highlight them.
+
+
+# Basic example
+
+```python
+from haystack import Document
+from haystack.components.extractors import KeywordsExtractor, KeywordsExtractorBackend
+
+# Initialize the KeywordsExtractor with the YAKE backend
+extractor = KeywordsExtractor(backend="sentence_transformer")
+extractor.warm_up()
+
+# Define documents
+documents = [
+    Document(content="Supervised learning is the machine learning task"),
+    Document(content="A supervised learning algorithm analyzes the training data."),
+]
+
+# Extract keywords from documents
+result = extractor.run(documents)["documents"]
+
+# Retrieve keywords for each document
+keywords = [KeywordsExtractor.get_stored_annotations(doc) for doc in result]
+print(keywords)
+```
+
+# Motivation
+
+Keyword extraction is a fundamental task in natural language processing, supporting various use cases such as document summarization, information retrieval, and content analysis. There are different approach to extract keywords including unsupervised approaches (TF.IDF, YAKE) and using pretrained models (such as sentence-transformer). The goal of this proposal is to introduce a component that allow user to extract keyword with its preferred method and add it to his pipeline.
+
+# Detailed design
+
+The provided code defines a Python class KeywordsExtractor that is used to extract keywords from a list of documents. This class supports two backends for keyword extraction: YAKE and sentence_transformer. sentence_transformer uses KeyBert package in background (more detail in [implementation datial](#implementation-detail))). User could use any sentence_transformer model to extract keywords, as default, it uses `all-MiniLM-L6-v2`.
+For sake of backward compatibility with different approaches, user could pass any acceptable parameter from Yake, KeyBert and sentence-transfommer as `backend_kwargs` . For example, in the following code `model` is accepted parameter from `KeyBert` and `model_name_or_path` is compatible with `sentence-transformer`.
+
+```python
+extractor = KeywordsExtractor(backend="sentence_transformer", backend_kwargs={"model":"paraphrase-multilingual-MiniLM-L12-v2"})
+
+extractor = KeywordsExtractor(backend="sentence_transformer", backend_kwargs={"model_name_or_path":"paraphrase-multilingual-MiniLM-L12-v2"})
+```
+
+## Implementation detail
+
+*You can skip this section if you are primarily interested in user experience.*
+`KeyWordExtractor` support different backends (at the moment 2). User must define the backend when he intiates `KeywordsExtractor`. allowed backends is defined in `KeywordsExtractorBackend` and validated when user instantiates `KeyWordExtractor`
+
+```python
+class KeywordsExtractorBackend(Enum, metaclass=_BackendkwEnumMeta):
+
+    SENTENCETRANSFORMER = "sentence_transformer"
+    YAKE = "yake"
+
+```
+
+Instead of considering KeyBert as a backend name *sentence_transformer* is chosen because, then it gives Haystack to add other Embedding models, such as Spacy, Gensim, etc, as a supported method.
+
+Each backend has its own Class for extracting & highlighting keywords:
+
+- `_YakeBackend(_KWExtracorBackend)`
+- `_KeyBertBackend(_KWExtracorBackend)`
+
+For being able to add different models to `KeyBert`, the model should be loaded first and then feed to the KeyBert. For example [[ref](https://github.com/MaartenGr/KeyBERT?tab=readme-ov-file#25-embedding-models)]:
+
+```python
+from keybert import KeyBERT
+from sentence_transformers import SentenceTransformer
+
+sentence_model = SentenceTransformer("all-MiniLM-L6-v2")
+kw_model = KeyBERT(model=sentence_model)
+```
+
+This brings the challenge of how impelent the component to be easy to improve. For tackling this challenge, a new 'ABC' class introduced. Any new model would be inheritated from this class and all specific implementation such as importing required package and loading the model would be handled here:
+
+```python
+class _KeyBertModel(ABC):
+    """This class represents the abstract base class for different KeyBert models."""
+
+    @abstractmethod
+    def __init__(
+        self,
+        _model_name: Optional[str] = None,
+        _model_kwargs: Optional[dict] = {},
+        _device: Optional[ComponentDevice] = None,
+        _token: Optional[Secret] = None,
+    ) -> None:
+        super().__init__()
+        self._model_name = _model_name
+        self._model_kwargs = _model_kwargs
+        self._device = _device
+        self._token = _token
+        self._model = None
+
+    @abstractmethod
+    def _initialize(self):
+        pass
+
+    @property
+    def _initialized(self) -> bool:
+        return self._model is not None
+```
+
+`KeywordsExtractor` get chosen backend and model with `_SupportedBackendModel` class. The purpose of this class is for better maintainability and easy way to add new method without need to modify `KeywordsExtractor`.
+
+```python
+class _SupportedBackendModel:
+    """
+    This class is used to get the supported models for KeyBert.
+    """
+
+    _models_dict = {KeywordsExtractorBackend.SENTENCETRANSFORMER.value: _SentenceTransformerModel}
+    _backend_dict = {
+        KeywordsExtractorBackend.SENTENCETRANSFORMER.value: _KeyBertBackend,
+        KeywordsExtractorBackend.YAKE.value: _YakeBackend,
+    }
+
+    @staticmethod
+    def get_model_type(key: str) -> _KeyBertModel:
+        return _SupportedBackendModel._models_dict.get(key, None)
+
+    @staticmethod
+    def get_backend(key: str) -> _KWExtracorBackend:
+        return _SupportedBackendModel._backend_dict[key]
+```
+
+This way for supporting new Embedding model we only need to:
+
+- Implement a new sub class of `_KeyBertModel`
+- Add desired name to `KeywordsExtractorBackend`
+- update `_models_dict` and `_backend_dict` in `_SupportedBackendModel`
+
+Following picture shows class diagram for `KeyWordExtractor`
+
+# Drawbacks
+
+This is a new component and it uses regular packages which are used in some other component, so it doesn't have breaking change. Also implementation is compatible Haystack code base.
+
+# Alternatives
+
+# Adoption strategy
+
+No adaptation strategy is needed. The implementation doesn't have any breaking change.
+
+# How we teach this
+
+*How to use the component* must be added to the documentation. However, structure design and usage follow same pattern with `NamedEntityExtractor`. So it would be easier for users and developers to use or maintain any extractor component in extroctor module.
+
+# Unresolved questions

--- a/test/components/extractors/test_keywords_extractor.py
+++ b/test/components/extractors/test_keywords_extractor.py
@@ -1,0 +1,51 @@
+import pytest
+
+from haystack import ComponentError, DeserializationError
+from haystack.components.extractors import KeywordsExtractor, KeywordsExtractorBackend
+
+
+@pytest.mark.unit
+def test_keyword_extractor_initiate():
+    _ = KeywordsExtractor(backend=KeywordsExtractorBackend.YAKE)
+
+    _ = KeywordsExtractor(backend="yake")
+
+    with pytest.raises(ComponentError, match=r"not ready yet"):
+        KeywordsExtractor(backend=KeywordsExtractorBackend.KEYBERT)
+        KeywordsExtractor(backend="keybert")
+
+    with pytest.raises(ComponentError, match=r"Invalid backend"):
+        KeywordsExtractor(backend="random_backend")
+
+
+@pytest.mark.unit
+def test_keyword_extractor_init_with_backend_kwargs():
+    backend_kwargs = {"param1": "value1", "param2": "value2"}
+    extractor = KeywordsExtractor(backend="yake", top_n=5, backend_kwargs=backend_kwargs)
+    assert extractor.type == KeywordsExtractorBackend.YAKE
+    assert extractor.top_n == 5
+    assert extractor.initialized == True
+
+
+@pytest.mark.unit
+def test_keyword_extractor_init_with_invalid_backend_kwargs():
+    backend_kwargs = "invalid_backend_kwargs"
+
+    extractor = KeywordsExtractor(backend="yake", top_n=3, backend_kwargs=backend_kwargs)
+    assert extractor._backend._backend_kwargs == {}
+
+
+@pytest.mark.unit
+def test_keywords_extractor_methods():
+    extractor = KeywordsExtractor(backend=KeywordsExtractorBackend.YAKE)
+
+    serde_data = extractor.to_dict()
+    serde_data_2 = dict(extractor)
+    assert serde_data == serde_data_2
+    new_extractor = KeywordsExtractor.from_dict(serde_data)
+
+    assert type(new_extractor._backend) == type(extractor._backend)
+
+    with pytest.raises(DeserializationError, match=r"Couldn't deserialize"):
+        serde_data["init_parameters"].pop("backend")
+        _ = KeywordsExtractor.from_dict(serde_data)

--- a/test/components/extractors/test_keywords_extractor.py
+++ b/test/components/extractors/test_keywords_extractor.py
@@ -2,6 +2,29 @@ import pytest
 
 from haystack import ComponentError, DeserializationError, Document
 from haystack.components.extractors import KeywordsExtractor, KeywordsExtractorBackend
+from haystack.utils import ComponentDevice, Secret
+
+
+@pytest.fixture
+def backend_fixture_model_name_or_path():
+    return {
+        "keyphrase_ngram_range": (1, 2),
+        "stop_words": None,
+        "model_name_or_path": "a_sentence_transformer_model",
+        "default_prompt_name": "a_prompt_name",
+        "token": "1234",
+    }
+
+
+@pytest.fixture
+def backend_fixture_model():
+    return {
+        "keyphrase_ngram_range": (1, 2),
+        "stop_words": None,
+        "model": "a_sentence_transformer_model",
+        "default_prompt_name": "a_prompt_name",
+        "token": "1234",
+    }
 
 
 @pytest.mark.unit
@@ -10,8 +33,8 @@ def test_keyword_extractor_initiate():
 
     _ = KeywordsExtractor(backend="yake")
 
-    _ = KeywordsExtractor(backend=KeywordsExtractorBackend.KEYBERT)
-    _ = KeywordsExtractor(backend="keybert")
+    _ = KeywordsExtractor(backend=KeywordsExtractorBackend.SENTENCETRANSFORMER)
+    _ = KeywordsExtractor(backend="sentence_transformer")
 
     with pytest.raises(ComponentError, match=r"Invalid backend"):
         KeywordsExtractor(backend="random_backend")
@@ -19,25 +42,35 @@ def test_keyword_extractor_initiate():
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    "backend,type,initialized",
-    [("yake", KeywordsExtractorBackend.YAKE, True), ("keybert", KeywordsExtractorBackend.KEYBERT, False)],
+    "backend,type,initialized,expected_backend_kwargs",
+    [
+        ("yake", KeywordsExtractorBackend.YAKE, True, {"candidates": "value1", "stop_words": "value2"}),
+        (
+            "sentence_transformer",
+            KeywordsExtractorBackend.SENTENCETRANSFORMER,
+            False,
+            {"candidates": "value1", "stop_words": "value2", "keyphrase_ngram_range": (3, 3)},
+        ),
+    ],
 )
-def test_keyword_extractor_init_with_backend_kwargs(backend, type, initialized):
-    backend_kwargs = {"param1": "value1", "param2": "value2"}
+def test_keyword_extractor_init_with_backend_kwargs(backend, type, initialized, expected_backend_kwargs):
+    backend_kwargs = {"candidates": "value1", "stop_words": "value2"}
     extractor = KeywordsExtractor(backend=backend, top_n=5, backend_kwargs=backend_kwargs)
     assert extractor.type == type
     assert extractor.top_n == 5
     assert extractor.initialized == initialized
-    assert extractor._backend._backend_kwargs == backend_kwargs
+    assert extractor._backend._backend_kwargs == expected_backend_kwargs
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("backend", ["yake", "keybert"])
-def test_keyword_extractor_init_with_invalid_backend_kwargs(backend):
+@pytest.mark.parametrize(
+    "backend,expected", [("yake", {}), ("sentence_transformer", {"keyphrase_ngram_range": (3, 3)})]
+)
+def test_keyword_extractor_init_with_invalid_backend_kwargs(backend, expected):
     backend_kwargs = "invalid_backend_kwargs"
 
     extractor = KeywordsExtractor(backend=backend, top_n=3, backend_kwargs=backend_kwargs)
-    assert extractor._backend._backend_kwargs == {}
+    assert extractor._backend._backend_kwargs == expected
 
 
 @pytest.mark.unit
@@ -57,14 +90,46 @@ def test_keywords_extractor_methods():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("kwargs, expected", [({"keyphrase_ngram_range": (1, 2)}, (1, 2)), ({}, (3, 3))])
+def test_keybert_model_keyphrase_init(kwargs, expected):
+    "Tests that the keyphrase_ngram_range attrib are initialized correctly when _KeyBertBackend init is called"
+    extractor = KeywordsExtractor(backend=KeywordsExtractorBackend.SENTENCETRANSFORMER, top_n=3, backend_kwargs=kwargs)
+
+    assert extractor._backend._backend_kwargs == {"keyphrase_ngram_range": expected}
+    assert extractor._backend._keybert_model._model_kwargs == {}
+    assert extractor._backend._keybert_model._model_name == "all-MiniLM-L6-v2"
+    assert extractor._backend._keybert_model._device == ComponentDevice.resolve_device(None)
+    assert extractor._backend._keybert_model._token == Secret.from_env_var("HF_API_TOKEN", strict=False)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("backend_kwargs", ["backend_fixture_model_name_or_path", "backend_fixture_model"])
+def test_keybert_model_backend_init(backend_kwargs, request: pytest.FixtureRequest):
+    "test that the _backend_kwargs and _sentence_transformer_kwargs attrib are initialized correctly when _KeyBertBackend init is called"
+    backend_kwargs = request.getfixturevalue(backend_kwargs)
+    extractor = KeywordsExtractor(
+        backend=KeywordsExtractorBackend.SENTENCETRANSFORMER, top_n=3, backend_kwargs=backend_kwargs
+    )
+
+    assert extractor._backend._backend_kwargs == {"keyphrase_ngram_range": (1, 2), "stop_words": None}
+    assert extractor._backend._keybert_model._model_kwargs == {"default_prompt_name": "a_prompt_name"}
+    assert extractor._backend._keybert_model._model_name == "a_sentence_transformer_model"
+    assert extractor._backend._keybert_model._device == ComponentDevice.resolve_device(None)
+    assert extractor._backend._keybert_model._token == "1234"
+
+
+@pytest.mark.unit
 def test_run_without_warm_up():
     """
     Tests that run method raises ComponentError if model is not warmed up
     """
-    extractor = KeywordsExtractor(backend="keybert", top_n=5)
+    extractor = KeywordsExtractor(backend="sentence_transformer", top_n=5)
 
     documents = [Document(content="doc1"), Document(content="doc2")]
 
-    error_msg = "KeywordsExtractorBackend.KEYBERT was not initialized - Did you call `warm_up()`?"
-    with pytest.raises(ComponentError, match=error_msg):
+    error_msg = "Did you call `warm_up()`?"
+    with pytest.raises(ComponentError) as exc_info:
         extractor.run(documents)
+
+    # Check if the error message contains a specific string
+    assert error_msg in str(exc_info.value)

--- a/test/components/extractors/test_keywords_extractor.py
+++ b/test/components/extractors/test_keywords_extractor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from haystack import ComponentError, DeserializationError
+from haystack import ComponentError, DeserializationError, Document
 from haystack.components.extractors import KeywordsExtractor, KeywordsExtractorBackend
 
 
@@ -10,28 +10,33 @@ def test_keyword_extractor_initiate():
 
     _ = KeywordsExtractor(backend="yake")
 
-    with pytest.raises(ComponentError, match=r"not ready yet"):
-        KeywordsExtractor(backend=KeywordsExtractorBackend.KEYBERT)
-        KeywordsExtractor(backend="keybert")
+    _ = KeywordsExtractor(backend=KeywordsExtractorBackend.KEYBERT)
+    _ = KeywordsExtractor(backend="keybert")
 
     with pytest.raises(ComponentError, match=r"Invalid backend"):
         KeywordsExtractor(backend="random_backend")
 
 
 @pytest.mark.unit
-def test_keyword_extractor_init_with_backend_kwargs():
+@pytest.mark.parametrize(
+    "backend,type,initialized",
+    [("yake", KeywordsExtractorBackend.YAKE, True), ("keybert", KeywordsExtractorBackend.KEYBERT, False)],
+)
+def test_keyword_extractor_init_with_backend_kwargs(backend, type, initialized):
     backend_kwargs = {"param1": "value1", "param2": "value2"}
-    extractor = KeywordsExtractor(backend="yake", top_n=5, backend_kwargs=backend_kwargs)
-    assert extractor.type == KeywordsExtractorBackend.YAKE
+    extractor = KeywordsExtractor(backend=backend, top_n=5, backend_kwargs=backend_kwargs)
+    assert extractor.type == type
     assert extractor.top_n == 5
-    assert extractor.initialized == True
+    assert extractor.initialized == initialized
+    assert extractor._backend._backend_kwargs == backend_kwargs
 
 
 @pytest.mark.unit
-def test_keyword_extractor_init_with_invalid_backend_kwargs():
+@pytest.mark.parametrize("backend", ["yake", "keybert"])
+def test_keyword_extractor_init_with_invalid_backend_kwargs(backend):
     backend_kwargs = "invalid_backend_kwargs"
 
-    extractor = KeywordsExtractor(backend="yake", top_n=3, backend_kwargs=backend_kwargs)
+    extractor = KeywordsExtractor(backend=backend, top_n=3, backend_kwargs=backend_kwargs)
     assert extractor._backend._backend_kwargs == {}
 
 
@@ -49,3 +54,17 @@ def test_keywords_extractor_methods():
     with pytest.raises(DeserializationError, match=r"Couldn't deserialize"):
         serde_data["init_parameters"].pop("backend")
         _ = KeywordsExtractor.from_dict(serde_data)
+
+
+@pytest.mark.unit
+def test_run_without_warm_up():
+    """
+    Tests that run method raises ComponentError if model is not warmed up
+    """
+    extractor = KeywordsExtractor(backend="keybert", top_n=5)
+
+    documents = [Document(content="doc1"), Document(content="doc2")]
+
+    error_msg = "KeywordsExtractorBackend.KEYBERT was not initialized - Did you call `warm_up()`?"
+    with pytest.raises(ComponentError, match=error_msg):
+        extractor.run(documents)


### PR DESCRIPTION
### Related Issues

- fixes #7083 

### Proposed Changes:

Introduce `KeywordExtractor` to extractor module

### How did you test it?
 - existing tests
 - additional unit test for `KeywordExtractor` component
 - additional 2e2 for testing component in `pipeline`
 - local built and test package in env with `python 3.10` and `python 3.12`

### Notes for the reviewer
##### **Design decisions**
Since this component is also an extractor, is added to extractor module and that's why tried to be compatible as much as possible to `NamedEntityExtractor`:
- from user perspective, the required parameters and name convention is exactly the same as `NamedEntityExtractor`: `extractor = KeywordsExtractor(backend="sentence_transformer")`
- From a maintainer perspective, it follows a similar design pattern

This feature use `yake` and `keyBert` package for extracting keywords. `KeyBert` supports different embedding models for extracting. In this implementation only `sentece-transformer` is added, however the design decision is based on be able to add other models easily without any refactoring main component. More detail would be found in proposal [implementation detail](https://github.com/jalesiyan-hadis/haystack/blob/feature-7083-keyword-extractor/proposals/text/0000-keyword-extractor.md#implementation-detail).

Both `yake` and `keyBert` support highlighting keywords. Having a highlighted text could give a good value to the end user. That's why Instead of returning the position of keywords, `KeywordExtractor` returns `keywords` and `highlights` as metadata for **each document**:
````python
metadata: {
"keywords": [KeyWordsSelection(entity="machine learning task", score=0.026288458458349206)],
"highlight": HighlightedText(
    text=(
        "Supervised learning is the <kw>machine learning task</kw> of learning afunction that maps an "
        "input to an output based on example input-output pairs. It infers a function from labeled "
        "training data consisting of a set of training examples. In supervised learning, each example "
        "is a pair consisting of an input object (typically a vector) and a desired output value "
        "(also called the supervisory signal). A supervised learning algorithm analyzes the training "
        "data and produces an inferred function, which can be used for mapping new examples. "
        "An optimal scenario will allow for the algorithm to correctly determine the class labels "
        "for unseen instances. This requires the learning algorithm to generalize from the training "
        "data to unseen situations in a 'reasonable' way (see inductive bias)."
    )
),
},
````
The Current implementation doesn't return highlight for `sentence-transformer`. Originally `KeyBert` print highlight to the console, for adding it to this component 1 or 2 extra days is needed. 

##### **Limitation**
If other out of box approach is going to be added to this component, highlight metadata should be also be implemented.

##### **Possible future**
- Add support for other Embedding models (at the moment it supports only `sentence-transformer`)
- Add highlight for `Keybert` method

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the doc strings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
