### PR TITLE
add `__eq__` method to `SparseEmbedding`

### DIFF
--- a/haystack/dataclasses/sparse_embedding.py
+++ b/haystack/dataclasses/sparse_embedding.py
@@ -20,6 +20,9 @@ class SparseEmbedding:
         self.indices = indices
         self.values = values
 
+    def __eq__(self, other):
+        return self.indices == other.indices and self.values == other.values
+
     def to_dict(self):
         """
         Convert the sparse embedding to a dictionary.

--- a/releasenotes/notes/sparse-emb-eq-773ef04ae3ed83ea.yaml
+++ b/releasenotes/notes/sparse-emb-eq-773ef04ae3ed83ea.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Add an `__eq__` method to `SparseEmbedding` to compare two `SparseEmbedding` objects.
+    Add an `__eq__` method to `SparseEmbedding` class to compare two `SparseEmbedding` objects.

--- a/releasenotes/notes/sparse-emb-eq-773ef04ae3ed83ea.yaml
+++ b/releasenotes/notes/sparse-emb-eq-773ef04ae3ed83ea.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add an `__eq__` method to `SparseEmbedding` to compare two `SparseEmbedding` objects.

--- a/test/dataclasses/test_sparse_embedding.py
+++ b/test/dataclasses/test_sparse_embedding.py
@@ -21,3 +21,11 @@ class TestSparseEmbedding:
         se = SparseEmbedding.from_dict({"indices": [0, 2, 4], "values": [0.1, 0.2, 0.3]})
         assert se.indices == [0, 2, 4]
         assert se.values == [0.1, 0.2, 0.3]
+
+    def test_eq(self):
+        se1 = SparseEmbedding(indices=[0, 2, 4], values=[0.1, 0.2, 0.3])
+        se2 = SparseEmbedding(indices=[0, 2, 4], values=[0.1, 0.2, 0.3])
+        assert se1 == se2
+
+        se3 = SparseEmbedding(indices=[0, 2, 4], values=[0.1, 0.2, 0.4])
+        assert se1 != se3


### PR DESCRIPTION
### Related Issues

While working on hybrid retrieval, I noticed we lack a proper way to compare `SparseEmbedding` objects.

### Proposed Changes:

Add an `__eq__` method to `SparseEmbedding` class to compare two `SparseEmbedding` objects.

### How did you test it?

CI, new test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
