### PR TITLE
test: Make faithfulness live run test more robust

### DIFF
--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -152,9 +152,7 @@ class TestFaithfulnessEvaluator:
         evaluator = FaithfulnessEvaluator()
         result = evaluator.run(questions=questions, contexts=contexts, responses=responses)
 
-        assert result["score"] == 0.5
-        assert result["individual_scores"] == [0.5]
-        assert result["results"][0]["score"] == 0.5
-        assert result["results"][0]["statement_scores"] == [1, 0]
-        assert "programming language" in result["results"][0]["statements"][0]
-        assert "George Lucas" in result["results"][0]["statements"][1]
+        required_fields = {"individual_scores", "results", "score"}
+        assert all(field in result for field in required_fields)
+        nested_required_fields = {"score", "statement_scores", "statements"}
+        assert all(field in result["results"][0] for field in nested_required_fields)


### PR DESCRIPTION
### Related Issues

- Tests failing due to differing response from OpenAI model: https://github.com/deepset-ai/haystack/actions/runs/8801507342/job/24155854332

### Proposed Changes:

Check only that the fields exist but not the values in the result

### How did you test it?

Ran the test locally

### Notes for the reviewer

We could extend the test to check the type of the returned values if we want to be more thorough.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
