### PR TITLE
fix: renaming vars that use built-in names

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -114,8 +114,8 @@ class LLMEvaluator:
         # Validate inputs
         if (
             not isinstance(inputs, list)
-            or not all(isinstance(input, tuple) for input in inputs)
-            or not all(isinstance(input[0], str) and input[1] is not list and len(input) == 2 for input in inputs)
+            or not all(isinstance(_input, tuple) for _input in inputs)
+            or not all(isinstance(_input[0], str) and _input[1] is not list and len(_input) == 2 for _input in inputs)
         ):
             msg = (
                 f"LLM evaluator expects inputs to be a list of tuples. Each tuple must contain an input name and "
@@ -272,17 +272,17 @@ class LLMEvaluator:
                 raise ValueError(msg)
 
         # Validate that all received inputs are lists
-        if not all(isinstance(input, list) for input in received.values()):
-            msg = f"LLM evaluator expects all input values to be lists but received {[type(input) for input in received.values()]}."
+        if not all(isinstance(_input, list) for _input in received.values()):
+            msg = f"LLM evaluator expects all input values to be lists but received {[type(_input) for _input in received.values()]}."
             raise ValueError(msg)
 
         # Validate that all received inputs are of the same length
         inputs = received.values()
         length = len(next(iter(inputs)))
-        if not all(len(input) == length for input in inputs):
+        if not all(len(_input) == length for _input in inputs):
             msg = (
                 f"LLM evaluator expects all input lists to have the same length but received {inputs} with lengths "
-                f"{[len(input) for input in inputs]}."
+                f"{[len(_input) for _input in inputs]}."
             )
             raise ValueError(msg)
 

--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -22,7 +22,7 @@ class _BackendEnumMeta(EnumMeta):
     Metaclass for fine-grained error handling of backend enums.
     """
 
-    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1):
+    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1):  # noqa: A002
         if names is None:
             try:
                 return EnumMeta.__call__(cls, value, names, module=module, qualname=qualname, type=type, start=start)
@@ -244,13 +244,13 @@ class _NerBackend(ABC):
 
     def __init__(
         self,
-        type: NamedEntityExtractorBackend,
+        _type: NamedEntityExtractorBackend,
         device: ComponentDevice,
         pipeline_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
 
-        self._type = type
+        self._type = _type
         self._device = device
         self._pipeline_kwargs = pipeline_kwargs if pipeline_kwargs is not None else {}
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -155,8 +155,8 @@ class DocumentJoiner:
 
         # Normalize scores. Note: len(results) / k is the maximum possible score,
         # achieved by being ranked first in all doc lists with non-zero weight.
-        for id in scores_map:
-            scores_map[id] /= len(document_lists) / k
+        for _id in scores_map:
+            scores_map[_id] /= len(document_lists) / k
 
         for doc in documents_map.values():
             doc.score = scores_map[doc.id]

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -268,7 +268,7 @@ class _Component:
     def __init__(self):
         self.registry = {}
 
-    def set_input_type(self, instance, name: str, type: Any, default: Any = _empty):
+    def set_input_type(self, instance, name: str, type: Any, default: Any = _empty):  # noqa: A002
         """
         Add a single input socket to the component instance.
 


### PR DESCRIPTION
### Related Issues

fixing all issues raised by A002, e.g.: `Argument "type" is shadowing a Python builtin`

### How did you test it?

run `ruff` with the appropriate config locally
