### PR TITLE
test: Make ContextRelevanceEvaluator integration test more robust

### DIFF
--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -135,8 +135,8 @@ class TestContextRelevanceEvaluator:
 
         evaluator = ContextRelevanceEvaluator()
         result = evaluator.run(questions=questions, contexts=contexts)
-        assert result["score"] == 1.0
-        assert result["individual_scores"] == [1.0]
-        assert result["results"][0]["score"] == 1.0
-        assert result["results"][0]["statement_scores"] == [1.0]
-        assert "Guido van Rossum" in result["results"][0]["statements"][0]
+
+        required_fields = {"individual_scores", "results", "score"}
+        assert all(field in result for field in required_fields)
+        nested_required_fields = {"score", "statement_scores", "statements"}
+        assert all(field in result["results"][0] for field in nested_required_fields)


### PR DESCRIPTION
### Related Issues

- Similar to the PR https://github.com/deepset-ai/haystack/pull/7582 for FaithfulnessEvaluator, we want to make the ContextRelevanceEvaluator integration tests more robust

### Proposed Changes:

Check only that the fields exist but not the values in the result

### How did you test it?

Ran the test locally

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
