### PR TITLE
fix: OutputParser when used within PromptTemplate

### DIFF
--- a/haystack/nodes/prompt/prompt_template.py
+++ b/haystack/nodes/prompt/prompt_template.py
@@ -539,8 +539,8 @@ class PromptTemplate(BasePromptTemplate, ABC):
         if self.output_parser:
             invocation_context = kwargs
             invocation_context["results"] = prompt_output
-            self.output_parser.run(invocation_context=invocation_context)
-            return invocation_context[self.output_parser.outputs[0]]
+            parser_results, _ = self.output_parser.run(invocation_context=invocation_context)
+            return parser_results[self.output_parser.outputs[0]]
         else:
             return prompt_output
 

--- a/releasenotes/notes/fix-output-parser-in-prompt-template-22975013f44c435b.yaml
+++ b/releasenotes/notes/fix-output-parser-in-prompt-template-22975013f44c435b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes OutputParser usage in PromptTemplate after making invocation context immutable in https://github.com/deepset-ai/haystack/pull/7510.

--- a/test/prompt/test_prompt_node.py
+++ b/test/prompt/test_prompt_node.py
@@ -432,7 +432,6 @@ def test_pipeline_with_prompt_template_at_query_time(prompt_model):
     )
 
 
-@pytest.mark.skip
 @pytest.mark.integration
 def test_pipeline_with_prompt_template_and_nested_shaper_yaml(tmp_path):
     # TODO: This can be a Shaper unit test?
@@ -444,7 +443,7 @@ def test_pipeline_with_prompt_template_and_nested_shaper_yaml(tmp_path):
             - name: template_with_nested_shaper
               type: PromptTemplate
               params:
-                prompt: "Given the context please answer the question. Context: {{documents}}; Question: {{query}}; Answer: "
+                prompt: "Given the context please answer the question. Context: {documents}; Question: {query}; Answer: "
                 output_parser:
                   type: AnswerParser
             - name: p1


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
- enabled and ran all skipped tests of `test_prompt_node.py`

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
