### PR TITLE
fix: route not identified files to dead end edge

### DIFF
--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -134,7 +134,7 @@ class FileTypeClassifier(BaseComponent):
                     paths[0],
                     self.supported_types,
                 )
-                return {"file_paths": [paths]}, "output_dead_end"
+                return {"file_paths": paths}, "output_dead_end"
             raise ValueError(
                 f"Files of type '{extension}' ({paths[0]}) are not supported. "
                 f"The supported types are: {self.supported_types}. "

--- a/haystack/nodes/file_classifier/file_type.py
+++ b/haystack/nodes/file_classifier/file_type.py
@@ -134,7 +134,7 @@ class FileTypeClassifier(BaseComponent):
                     paths[0],
                     self.supported_types,
                 )
-                return None, None
+                return {"file_paths": [paths]}, "output_dead_end"
             raise ValueError(
                 f"Files of type '{extension}' ({paths[0]}) are not supported. "
                 f"The supported types are: {self.supported_types}. "

--- a/test/nodes/test_filetype_classifier.py
+++ b/test/nodes/test_filetype_classifier.py
@@ -176,7 +176,8 @@ def test_filetype_classifier_raise_on_error_disabled_unsupported_file_types(tmp_
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         output, edge = node.run(test_file)
-        assert edge == output == None
+        assert edge == "output_dead_end"
+        assert output == {"file_paths": [test_file]}
         assert (
             f"Unsupported files of type '{file_type}' ({test_file!s}) found. Unsupported file types will be ignored"
             in caplog.text

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import ssl
 import json
 import platform
@@ -16,6 +17,7 @@ from haystack import __version__
 from haystack.document_stores.deepsetcloud import DeepsetCloudDocumentStore
 from haystack.document_stores.elasticsearch import ElasticsearchDocumentStore
 from haystack.document_stores.memory import InMemoryDocumentStore
+from haystack.nodes.file_classifier.file_type import FileTypeClassifier
 from haystack.nodes.other.join_docs import JoinDocuments
 from haystack.nodes.base import BaseComponent
 from haystack.nodes.retriever.sparse import BM25Retriever
@@ -2189,6 +2191,25 @@ def test_pipeline_execution_using_join_preserves_changed_query():
     assert res["_debug"]["Join"]["input"]["query"] == "This is a test."
     assert res["_debug"]["DummyNode2"]["input"]["query"] == "This is a test."
     assert res["query"] == "This is a test."
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("file_type", ["csv", "xml"])
+def test_pipeline_execution_can_handle_unknown_edge_for_classifier(file_type: str) -> None:
+    """Tests running a classifier against an unexpected file type.
+
+    We need to route not expected file types against a dead end node.
+    Simply returning "None" for a classification does not work, since
+    the pipeline will raise an error, trying to route the result to the next node
+    here: https://github.com/deepset-ai/haystack/blob/b45ecb355636c3227185e97ee595006c06d17470/haystack/pipelines/base.py#L573
+
+    See fix pr: https://github.com/deepset-ai/haystack/pull/7589
+    """
+    classifier = FileTypeClassifier(raise_on_error=False)
+    pipeline = Pipeline()
+    pipeline.add_node(component=classifier, name="FileTypeClassifier", inputs=["File"])
+    res = pipeline.run_batch(file_paths=[Path(f"./test.{file_type}")])  # By default CSVs are not supported
+    assert res["file_paths"] == [Path(f"./test.{file_type}")]
 
 
 @pytest.mark.unit

--- a/test/pipelines/test_pipeline.py
+++ b/test/pipelines/test_pipeline.py
@@ -2208,7 +2208,7 @@ def test_pipeline_execution_can_handle_unknown_edge_for_classifier(file_type: st
     classifier = FileTypeClassifier(raise_on_error=False)
     pipeline = Pipeline()
     pipeline.add_node(component=classifier, name="FileTypeClassifier", inputs=["File"])
-    res = pipeline.run_batch(file_paths=[Path(f"./test.{file_type}")])  # By default CSVs are not supported
+    res = pipeline.run_batch(file_paths=[f"./test.{file_type}"])
     assert res["file_paths"] == [Path(f"./test.{file_type}")]
 
 


### PR DESCRIPTION
### Related Issues

- followup from https://github.com/deepset-ai/haystack/pull/7542

### Proposed Changes:
- route not identified file to dead end.

### How did you test it?
- not yet. First want to validate that this is feasible solution

### Notes for the reviewer
- turned out that this does not work: https://github.com/deepset-ai/haystack/pull/7542#discussion_r1562336195. 
This results in: 
```
Failed to index because of: 'Exception while running node 'FileTypeClassifier': 'NoneType' object has no attribute 'get'
Enable debug logging to see the data that was passed when the pipeline failed.'. Skipping handling indexing requests.

AttributeError: 'NoneType' object has no attribute 'get'
/opt/venv/lib/python3.10/site-packages/haystack/pipelines/base.py, line 567, run
/opt/venv/lib/python3.10/site-packages/haystack/pipelines/base.py, line 469, _run_node
/opt/venv/lib/python3.10/site-packages/haystack/nodes/base.py, line 201, _dispatch_run
/opt/venv/lib/python3.10/site-packages/haystack/nodes/base.py, line 257, _dispatch_run_general

Caused by:
Exception: Exception while running node 'FileTypeClassifier': 'NoneType' object has no attribute 'get'
Enable debug logging to see the data that was passed when the pipeline failed.
/opt/venv/lib/python3.10/site-packages/dc_consumer_indexing/indexing_service.py, line 79, handle_indexing_queue
/opt/venv/lib/python3.10/site-packages/dc_consumer_indexing/indexing_service.py, line 216, _batch_index_file
/opt/venv/lib/python3.10/site-packages/dc_consumer_indexing/gateways/haystack/local.py, line 170, batch_index
/opt/venv/lib/python3.10/site-packages/dc_consumer_indexing/gateways/haystack/local.py, line 90, _index
/opt/venv/lib/python3.10/site-packages/haystack/pipelines/base.py, line 574, run
```


- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
