### PR TITLE
fix: reno nodes dead end classifier

### DIFF
--- a/releasenotes/notes/add-dead-end-for-classifier-8c87716695efd86a.yaml
+++ b/releasenotes/notes/add-dead-end-for-classifier-8c87716695efd86a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Pipeline run error when using the FileTypeClassifier with the raise_on_error: True option.
+    Instead of returning an unexpected NoneType, we route the file to a dead-end edge.


### PR DESCRIPTION
### Related Issues

- ad-hoc

### Proposed Changes:
add correct release node

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
