### PR TITLE
Update document_writer.py

### DIFF
--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -109,5 +109,8 @@ class DocumentWriter:
         if policy is None:
             policy = self.policy
 
+        for document in documents:
+            document.content = document.content.replace('\x00', '')
+
         documents_written = self.document_store.write_documents(documents=documents, policy=policy)
         return {"documents_written": documents_written}


### PR DESCRIPTION
### Related Issues

- fixes #7592

### Proposed Changes:

Guarding against writing null byes in `/components/document_writer.py`

### How did you test it?

Manually, it allows the pipeline to write the parsed text from pdf to my postgres db.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
