### PR TITLE
chore: Rollback macos-latest to macos-12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
     needs: black
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -115,7 +115,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
+          - macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -234,9 +234,9 @@ jobs:
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   integration-tests-macos:
-    name: Integration / macos-latest
+    name: Integration / macos-12
     needs: unit-tests
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       HAYSTACK_MPS_ENABLED: false
 


### PR DESCRIPTION
Github macos-latest now points to M1 runners (macos-14-arm64) which is nice but that kills our python version test matrix. Let's rollback to macos-12 until we see what versions of python shall we test if we use macos-latest (has only python 3.10 and after)

More details: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
Available macos runners: https://github.com/actions/runner-images/tree/main/images/macos
Avialable python versions on macos-12: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#python 