### PR TITLE
feat: hf inference support for gated repos

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod, ABC
-from typing import Union, Dict
+from typing import Optional, Union, Dict
 
 from haystack.lazy_imports import LazyImport
 
@@ -61,8 +61,10 @@ class DefaultPromptHandler:
     are within the model_max_length.
     """
 
-    def __init__(self, model_name_or_path: str, model_max_length: int, max_length: int = 100):
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+    def __init__(
+        self, model_name_or_path: str, model_max_length: int, max_length: int = 100, token: Optional[str] = None
+    ):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, token=token)
         self.tokenizer.model_max_length = model_max_length
         self.model_max_length = model_max_length
         self.max_length = max_length

--- a/haystack/nodes/prompt/invocation_layer/handlers.py
+++ b/haystack/nodes/prompt/invocation_layer/handlers.py
@@ -62,9 +62,13 @@ class DefaultPromptHandler:
     """
 
     def __init__(
-        self, model_name_or_path: str, model_max_length: int, max_length: int = 100, token: Optional[str] = None
+        self,
+        model_name_or_path: str,
+        model_max_length: int,
+        max_length: int = 100,
+        use_auth_token: Optional[Union[str, bool]] = None,
     ):
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, token=token)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, token=use_auth_token)
         self.tokenizer.model_max_length = model_max_length
         self.model_max_length = model_max_length
         self.max_length = max_length

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -104,6 +104,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
                 model_name_or_path=model_name_or_path,
                 model_max_length=model_max_length,
                 max_length=self.max_length or 100,
+                token=self.api_key,
             )
 
     def preprocess_prompt(self, prompt: str):

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -39,7 +39,14 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
 
     """
 
-    def __init__(self, api_key: str, model_name_or_path: str, max_length: Optional[int] = 100, **kwargs):
+    def __init__(
+        self,
+        api_key: str,
+        model_name_or_path: str,
+        max_length: Optional[int] = 100,
+        use_auth_token: Optional[Union[str, bool]] = None,
+        **kwargs,
+    ):
         """
          Creates an instance of HFInferenceEndpointInvocationLayer
         :param model_name_or_path: can be either:
@@ -104,7 +111,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
                 model_name_or_path=model_name_or_path,
                 model_max_length=model_max_length,
                 max_length=self.max_length or 100,
-                token=self.api_key,
+                use_auth_token=use_auth_token,
             )
 
     def preprocess_prompt(self, prompt: str):

--- a/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
+++ b/haystack/nodes/prompt/invocation_layer/hugging_face_inference.py
@@ -83,6 +83,7 @@ class HFInferenceEndpointInvocationLayer(PromptModelInvocationLayer):
                 "repetition_penalty",
                 "return_full_text",
                 "seed",
+                "stop",
                 "stream",
                 "stream_handler",
                 "temperature",

--- a/releasenotes/notes/support-hf-inference-gated-repos-c04be10438e08501.yaml
+++ b/releasenotes/notes/support-hf-inference-gated-repos-c04be10438e08501.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Support gated repos for Huggingface inference.


### PR DESCRIPTION
### Related Issues

- this allows us to use `meta-llama/Meta-Llama-3-8B-Instruct` via HF inference API

### Proposed Changes:
- pass hf token to `DefaultPromptHandler` for tokenizer
- chore: add `stop` param to `HFInferenceInvocationLayer` (for usage via model_kwargs)

### How did you test it?
- ran locally, e.g.
  ```python
  pn = PromptNode(
      model_name_or_path="meta-llama/Meta-Llama-3-8B-Instruct", 
      api_key="TOKEN",
      use_auth_token="TOKEN",
      model_kwargs={
          "stop": ["<|end_of_text|>", "<|eot_id|>"],
      }
  )
  pn("What is the capital of Germany?")
  ```

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
