### PR TITLE
docs: add pydoc config for evaluation

### DIFF
--- a/docs/pydoc/config/evaluation_api.yml
+++ b/docs/pydoc/config/evaluation_api.yml
@@ -1,17 +1,9 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack/components/evaluators]
+    search_path: [../../../haystack/evaluation]
     modules:
       [
-        "answer_exact_match",
-        "context_relevance",
-        "document_map",
-        "document_mrr",
-        "document_recall",
-        "document_recall",
-        "faithfulness",
-        "llm_evaluator",
-        "sas_evaluator",
+        "eval_run_result"
       ]
     ignore_when_discovered: ["__init__"]
 processors:
@@ -24,15 +16,15 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
-  excerpt: Evaluate your pipelines or individual components.
+  excerpt: Represents the results of evaluation.
   category_slug: haystack-api
-  title: Evaluators
-  slug: evaluators-api
-  order: 63
+  title: Evaluation
+  slug: evaluation-api
+  order: 61
   markdown:
     descriptive_class_title: false
     classdef_code_block: false
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: evaluators_api.md
+    filename: evaluation_api.md


### PR DESCRIPTION
### Related Issues

- fixes Sync docs with Readme failing workflow: https://github.com/deepset-ai/haystack/actions/runs/8845590640/job/24289790847
- follows #7594

### Proposed Changes:
- remove the no longer existing `evaluation_result` module from pydoc config for Evaluators
- add pydoc config for the evaluation package

### How did you test it?
Local run of `hatch run readme:sync`; CI.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
