### PR TITLE
fix: `EvaluationRunResult` should compare only input keys

### DIFF
--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -120,7 +120,7 @@ class EvaluationRunResult(BaseEvaluationRunResult):
             other_name = f"{other_name}_second"
 
         if self.inputs.keys() != other.inputs.keys():
-            warn(f"The inputs keys to the two evaluation results differ; using the inputs of '{this_name}'.")
+            warn(f"The input columns differ between the results; using the input columns of '{this_name}'.")
 
         pipe_a_df = self.to_pandas()
         pipe_b_df = other.to_pandas()

--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -119,8 +119,8 @@ class EvaluationRunResult(BaseEvaluationRunResult):
             this_name = f"{this_name}_first"
             other_name = f"{other_name}_second"
 
-        if self.inputs != other.inputs:
-            warn(f"The inputs to the two evaluation results differ; using the inputs of '{this_name}'.")
+        if self.inputs.keys() != other.inputs.keys():
+            warn(f"The inputs keys to the two evaluation results differ; using the inputs of '{this_name}'.")
 
         pipe_a_df = self.to_pandas()
         pipe_b_df = other.to_pandas()


### PR DESCRIPTION
### Related Issues

- fixes #5336 

### Notes for the reviewer

- this is quick fix part of this PR: https://github.com/deepset-ai/haystack/pull/7601

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
