### PR TITLE
refactor: ContextRelevanceEvaluator takes Document as input instead of str and is renamed

### DIFF
--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -7,10 +7,10 @@ from haystack import Document, Pipeline
 from haystack.components.builders import AnswerBuilder, PromptBuilder
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
 from haystack.components.evaluators import (
-    ContextRelevanceEvaluator,
     DocumentMAPEvaluator,
     DocumentMRREvaluator,
     DocumentRecallEvaluator,
+    DocumentRelevanceEvaluator,
     FaithfulnessEvaluator,
     SASEvaluator,
 )
@@ -85,7 +85,7 @@ def evaluation_pipeline():
     eval_pipeline.add_component("doc_map", DocumentMAPEvaluator())
     eval_pipeline.add_component("doc_recall_single_hit", DocumentRecallEvaluator(mode=RecallMode.SINGLE_HIT))
     eval_pipeline.add_component("doc_recall_multi_hit", DocumentRecallEvaluator(mode=RecallMode.MULTI_HIT))
-    eval_pipeline.add_component("relevance", ContextRelevanceEvaluator())
+    eval_pipeline.add_component("relevance", DocumentRelevanceEvaluator())
 
     return eval_pipeline
 
@@ -99,7 +99,7 @@ def built_eval_input(questions, truth_docs, truth_answers, retrieved_docs, conte
         "doc_map": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
         "doc_recall_single_hit": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
         "doc_recall_multi_hit": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
-        "relevance": {"questions": questions, "contexts": contexts},
+        "relevance": {"questions": questions, "retrieved_documents": retrieved_docs},
     }
 
 
@@ -156,7 +156,7 @@ def built_input_for_results_eval(rag_results):
             "individual_scores": rag_results["doc_recall_multi_hit"]["individual_scores"],
             "score": rag_results["doc_recall_multi_hit"]["score"],
         },
-        "Contextual Relevance": {
+        "Document Relevance": {
             "individual_scores": rag_results["relevance"]["individual_scores"],
             "score": rag_results["relevance"]["score"],
         },

--- a/haystack/components/evaluators/__init__.py
+++ b/haystack/components/evaluators/__init__.py
@@ -1,15 +1,15 @@
 from .answer_exact_match import AnswerExactMatchEvaluator
-from .context_relevance import ContextRelevanceEvaluator
 from .document_map import DocumentMAPEvaluator
 from .document_mrr import DocumentMRREvaluator
 from .document_recall import DocumentRecallEvaluator
+from .document_relevance import DocumentRelevanceEvaluator
 from .faithfulness import FaithfulnessEvaluator
 from .llm_evaluator import LLMEvaluator
 from .sas_evaluator import SASEvaluator
 
 __all__ = [
     "AnswerExactMatchEvaluator",
-    "ContextRelevanceEvaluator",
+    "DocumentRelevanceEvaluator",
     "DocumentMAPEvaluator",
     "DocumentMRREvaluator",
     "DocumentRecallEvaluator",

--- a/haystack/components/evaluators/document_relevance.py
+++ b/haystack/components/evaluators/document_relevance.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from numpy import mean as np_mean
 
-from haystack import default_from_dict
+from haystack import Document, default_from_dict
 from haystack.components.evaluators.llm_evaluator import LLMEvaluator
 from haystack.core.component import component
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -30,7 +30,7 @@ _DEFAULT_EXAMPLES = [
 ]
 
 
-class ContextRelevanceEvaluator(LLMEvaluator):
+class DocumentRelevanceEvaluator(LLMEvaluator):
     """
     Evaluator that checks if a provided context is relevant to the question.
 
@@ -40,17 +40,20 @@ class ContextRelevanceEvaluator(LLMEvaluator):
 
     Usage example:
     ```python
-    from haystack.components.evaluators import ContextRelevanceEvaluator
+    from haystack import Document
+    from haystack.components.evaluators import DocumentRelevanceEvaluator
 
     questions = ["Who created the Python language?"]
-    contexts = [
+    docs = [
         [
-            "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming language. Its design philosophy emphasizes code readability, and its language constructs aim to help programmers write clear, logical code for both small and large-scale software projects."
+            Document(content="Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose
+            programming language. Its design philosophy emphasizes code readability, and its language constructs aim to
+            help programmers write clear, logical code for both small and large-scale software projects.")
         ],
     ]
 
-    evaluator = ContextRelevanceEvaluator()
-    result = evaluator.run(questions=questions, contexts=contexts)
+    evaluator = DocumentRelevanceEvaluator()
+    result = evaluator.run(questions=questions, retrieved_documents=docs)
     print(result["score"])
     # 1.0
     print(result["individual_scores"])
@@ -113,14 +116,14 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             api_key=self.api_key,
         )
 
-    @component.output_types(results=List[Dict[str, Any]])
-    def run(self, questions: List[str], contexts: List[List[str]]) -> Dict[str, Any]:
+    @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])
+    def run(self, questions: List[str], retrieved_documents: List[List[Document]]) -> Dict[str, Any]:
         """
         Run the LLM evaluator.
 
         :param questions:
             A list of questions.
-        :param contexts:
+        :param retrieved_documents:
             A list of lists of contexts. Each list of contexts corresponds to one question.
         :returns:
             A dictionary with the following outputs:
@@ -128,6 +131,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
                 - `individual_scores`: A list of context relevance scores for each input question.
                 - `results`: A list of dictionaries with `statements` and `statement_scores` for each input context.
         """
+        contexts = [[doc.content for doc in doc_list] for doc_list in retrieved_documents]
         result = super().run(questions=questions, contexts=contexts)
 
         # calculate average statement relevance score per query
@@ -141,7 +145,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "ContextRelevanceEvaluator":
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentRelevanceEvaluator":
         """
         Deserialize this component from a dictionary.
 


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack/issues/7528

### Proposed Changes:

- Change expected inputs from `List[List[str]]` to `List[List[Document]]`
- Rename input param from `contexts` to `retrieved_documents`
- Rename component from `ContextRelevanceEvaluator` to `DocumentRelevanceEvaluator`

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Note that the few shot examples are still with str format and that the parameter in there is still called contexts right now.

We should update the previously created release note about this component: releasenotes/notes/context-relevance-04063b9dc9fe7379.yaml

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
