### PR TITLE
refactor: Rename FaithfulnessEvaluator input `responses` to `predicted_answers`

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -113,7 +113,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             api_key=self.api_key,
         )
 
-    @component.output_types(results=List[Dict[str, Any]])
+    @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])
     def run(self, questions: List[str], contexts: List[List[str]]) -> Dict[str, Any]:
         """
         Run the LLM evaluator.

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -23,18 +23,18 @@ class LLMEvaluator:
     from haystack.components.evaluators import LLMEvaluator
     evaluator = LLMEvaluator(
         instructions="Is this answer problematic for children?",
-        inputs=[("responses", List[str])],
+        inputs=[("predicted_answers", List[str])],
         outputs=["score"],
         examples=[
-            {"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"score": 1}},
-            {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}},
+            {"inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"}, "outputs": {"score": 1}},
+            {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}},
         ],
     )
-    RESPONSES = [
+    predicted_answers = [
         "Football is the most popular sport with around 4 billion followers worldwide",
         "Python language was created by Guido van Rossum.",
     ]
-    results = evaluator.run(responses=RESPONSES)
+    results = evaluator.run(predicted_answers=predicted_answers)
     print(results)
     # {'results': [{'score': 0}, {'score': 0}]}
     ```
@@ -199,7 +199,7 @@ class LLMEvaluator:
             The prompt template.
         """
         inputs_section = (
-            "{" + ",".join([f'"{input_socket[0]}": {{{{ {input_socket[0]} }}}}' for input_socket in self.inputs]) + "}"
+            "{" + ", ".join([f'"{input_socket[0]}": {{{{ {input_socket[0]} }}}}' for input_socket in self.inputs]) + "}"
         )
 
         examples_section = "\n".join(

--- a/haystack/components/evaluators/sas_evaluator.py
+++ b/haystack/components/evaluators/sas_evaluator.py
@@ -183,7 +183,7 @@ class SASEvaluator:
 
             # Compute cosine-similarities
             similarity_scores = [
-                util.cos_sim(p, l).cpu().numpy() for p, l in zip(predictions_embeddings, label_embeddings)
+                float(util.cos_sim(p, l).cpu().numpy()) for p, l in zip(predictions_embeddings, label_embeddings)
             ]
 
         sas_score = np_mean(similarity_scores)

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -11,17 +11,19 @@ class TestLLMEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["score"],
-            examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
         )
         assert component.api == "openai"
         assert component.generator.client.api_key == "test-api-key"
         assert component.instructions == "test-instruction"
-        assert component.inputs == [("responses", List[str])]
+        assert component.inputs == [("predicted_answers", List[str])]
         assert component.outputs == ["score"]
         assert component.examples == [
-            {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
         ]
 
     def test_init_fail_wo_openai_api_key(self, monkeypatch):
@@ -30,31 +32,39 @@ class TestLLMEvaluator:
             LLMEvaluator(
                 api="openai",
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=["score"],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
 
     def test_init_with_parameters(self):
         component = LLMEvaluator(
             instructions="test-instruction",
             api_key=Secret.from_token("test-api-key"),
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["custom_score"],
             api="openai",
             examples=[
-                {"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
-                {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"custom_score": 0}},
+                {
+                    "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
+                    "outputs": {"custom_score": 1},
+                },
+                {
+                    "inputs": {"predicted_answers": "Football is the most popular sport."},
+                    "outputs": {"custom_score": 0},
+                },
             ],
         )
         assert component.generator.client.api_key == "test-api-key"
         assert component.api == "openai"
         assert component.examples == [
-            {"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
-            {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"custom_score": 0}},
+            {"inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
+            {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"custom_score": 0}},
         ]
         assert component.instructions == "test-instruction"
-        assert component.inputs == [("responses", List[str])]
+        assert component.inputs == [("predicted_answers", List[str])]
         assert component.outputs == ["custom_score"]
 
     def test_init_with_invalid_parameters(self, monkeypatch):
@@ -63,85 +73,105 @@ class TestLLMEvaluator:
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs={("responses", List[str])},
+                inputs={("predicted_answers", List[str])},
                 outputs=["score"],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[(List[str], "responses")],
+                inputs=[(List[str], "predicted_answers")],
                 outputs=["score"],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
                 inputs=[List[str]],
                 outputs=["score"],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs={("responses", str)},
+                inputs={("predicted_answers", str)},
                 outputs=["score"],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
 
         # Invalid outputs
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs="score",
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=[["score"]],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )
 
         # Invalid examples
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=["score"],
                 examples={
-                    "inputs": {"responses": "Damn, this is straight outta hell!!!"},
+                    "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
                     "outputs": {"custom_score": 1},
                 },
             )
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=["score"],
                 examples=[
-                    [{"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}}]
+                    [
+                        {
+                            "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
+                            "outputs": {"custom_score": 1},
+                        }
+                    ]
                 ],
             )
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
-                outputs=["score"],
-                examples=[
-                    {"wrong_key": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}}
-                ],
-            )
-        with pytest.raises(ValueError):
-            LLMEvaluator(
-                instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=["score"],
                 examples=[
                     {
-                        "inputs": [{"responses": "Damn, this is straight outta hell!!!"}],
+                        "wrong_key": {"predicted_answers": "Damn, this is straight outta hell!!!"},
+                        "outputs": {"custom_score": 1},
+                    }
+                ],
+            )
+        with pytest.raises(ValueError):
+            LLMEvaluator(
+                instructions="test-instruction",
+                inputs=[("predicted_answers", List[str])],
+                outputs=["score"],
+                examples=[
+                    {
+                        "inputs": [{"predicted_answers": "Damn, this is straight outta hell!!!"}],
                         "outputs": [{"custom_score": 1}],
                     }
                 ],
@@ -149,7 +179,7 @@ class TestLLMEvaluator:
         with pytest.raises(ValueError):
             LLMEvaluator(
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=["score"],
                 examples=[{"inputs": {1: "Damn, this is straight outta hell!!!"}, "outputs": {2: 1}}],
             )
@@ -158,9 +188,11 @@ class TestLLMEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["score"],
-            examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
         )
         data = component.to_dict()
         assert data == {
@@ -169,9 +201,11 @@ class TestLLMEvaluator:
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "api": "openai",
                 "instructions": "test-instruction",
-                "inputs": [("responses", List[str])],
+                "inputs": [("predicted_answers", List[str])],
                 "outputs": ["score"],
-                "examples": [{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                "examples": [
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             },
         }
 
@@ -184,19 +218,21 @@ class TestLLMEvaluator:
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "api": "openai",
                 "instructions": "test-instruction",
-                "inputs": [("responses", List[str])],
+                "inputs": [("predicted_answers", List[str])],
                 "outputs": ["score"],
-                "examples": [{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                "examples": [
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             },
         }
         component = LLMEvaluator.from_dict(data)
         assert component.api == "openai"
         assert component.generator.client.api_key == "test-api-key"
         assert component.instructions == "test-instruction"
-        assert component.inputs == [("responses", List[str])]
+        assert component.inputs == [("predicted_answers", List[str])]
         assert component.outputs == ["score"]
         assert component.examples == [
-            {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
         ]
 
     def test_to_dict_with_parameters(self, monkeypatch):
@@ -204,12 +240,18 @@ class TestLLMEvaluator:
         component = LLMEvaluator(
             instructions="test-instruction",
             api_key=Secret.from_env_var("ENV_VAR"),
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["custom_score"],
             api="openai",
             examples=[
-                {"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
-                {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"custom_score": 0}},
+                {
+                    "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
+                    "outputs": {"custom_score": 1},
+                },
+                {
+                    "inputs": {"predicted_answers": "Football is the most popular sport."},
+                    "outputs": {"custom_score": 0},
+                },
             ],
         )
         data = component.to_dict()
@@ -219,11 +261,17 @@ class TestLLMEvaluator:
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
                 "api": "openai",
                 "instructions": "test-instruction",
-                "inputs": [("responses", List[str])],
+                "inputs": [("predicted_answers", List[str])],
                 "outputs": ["custom_score"],
                 "examples": [
-                    {"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
-                    {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"custom_score": 0}},
+                    {
+                        "inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"},
+                        "outputs": {"custom_score": 1},
+                    },
+                    {
+                        "inputs": {"predicted_answers": "Football is the most popular sport."},
+                        "outputs": {"custom_score": 0},
+                    },
                 ],
             },
         }
@@ -232,9 +280,11 @@ class TestLLMEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("questions", List[str]), ("responses", List[List[str]])],
+            inputs=[("questions", List[str]), ("predicted_answers", List[List[str]])],
             outputs=["score"],
-            examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
         )
 
         def generator_run(self, *args, **kwargs):
@@ -243,20 +293,23 @@ class TestLLMEvaluator:
         monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
 
         with pytest.raises(ValueError):
-            component.run(questions=["What is the capital of Germany?"], responses=[["Berlin"], ["Paris"]])
+            component.run(questions=["What is the capital of Germany?"], predicted_answers=[["Berlin"], ["Paris"]])
 
         with pytest.raises(ValueError):
             component.run(
-                questions=["What is the capital of Germany?", "What is the capital of France?"], responses=[["Berlin"]]
+                questions=["What is the capital of Germany?", "What is the capital of France?"],
+                predicted_answers=[["Berlin"]],
             )
 
     def test_run_returns_parsed_result(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("questions", List[str]), ("responses", List[List[str]])],
+            inputs=[("questions", List[str]), ("predicted_answers", List[List[str]])],
             outputs=["score"],
-            examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
         )
 
         def generator_run(self, *args, **kwargs):
@@ -264,42 +317,46 @@ class TestLLMEvaluator:
 
         monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
 
-        results = component.run(questions=["What is the capital of Germany?"], responses=["Berlin"])
+        results = component.run(questions=["What is the capital of Germany?"], predicted_answers=["Berlin"])
         assert results == {"results": [{"score": 0.5}]}
 
     def test_prepare_template(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["score"],
             examples=[
-                {"inputs": {"responses": "Damn, this is straight outta hell!!!"}, "outputs": {"score": 1}},
-                {"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}},
+                {"inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"}, "outputs": {"score": 1}},
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}},
             ],
         )
         template = component.prepare_template()
         assert (
             template
-            == 'Instructions:\ntest-instruction\n\nGenerate the response in JSON format with the following keys:\n["score"]\nConsider the instructions and the examples below to determine those values.\n\nExamples:\nInputs:\n{"responses": "Damn, this is straight outta hell!!!"}\nOutputs:\n{"score": 1}\nInputs:\n{"responses": "Football is the most popular sport."}\nOutputs:\n{"score": 0}\n\nInputs:\n{"responses": {{ responses }}}\nOutputs:\n'
+            == 'Instructions:\ntest-instruction\n\nGenerate the response in JSON format with the following keys:\n["score"]\nConsider the instructions and the examples below to determine those values.\n\nExamples:\nInputs:\n{"predicted_answers": "Damn, this is straight outta hell!!!"}\nOutputs:\n{"score": 1}\nInputs:\n{"predicted_answers": "Football is the most popular sport."}\nOutputs:\n{"score": 0}\n\nInputs:\n{"predicted_answers": {{ predicted_answers }}}\nOutputs:\n'
         )
 
     def test_invalid_input_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["score"],
-            examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
         )
         # None of the expected parameters are received
         with pytest.raises(ValueError):
-            component.validate_input_parameters(expected={"responses": List[str]}, received={"questions": List[str]})
+            component.validate_input_parameters(
+                expected={"predicted_answers": List[str]}, received={"questions": List[str]}
+            )
 
         # Only one but not all the expected parameters are received
         with pytest.raises(ValueError):
             component.validate_input_parameters(
-                expected={"responses": List[str], "questions": List[str]}, received={"questions": List[str]}
+                expected={"predicted_answers": List[str], "questions": List[str]}, received={"questions": List[str]}
             )
 
         # Received inputs are not lists
@@ -310,9 +367,11 @@ class TestLLMEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = LLMEvaluator(
             instructions="test-instruction",
-            inputs=[("responses", List[str])],
+            inputs=[("predicted_answers", List[str])],
             outputs=["score"],
-            examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
         )
         with pytest.raises(ValueError):
             component.validate_outputs(expected=["score", "another_expected_output"], received='{"score": 1.0}')
@@ -325,7 +384,9 @@ class TestLLMEvaluator:
             LLMEvaluator(
                 api="unsupported_api",
                 instructions="test-instruction",
-                inputs=[("responses", List[str])],
+                inputs=[("predicted_answers", List[str])],
                 outputs=["score"],
-                examples=[{"inputs": {"responses": "Football is the most popular sport."}, "outputs": {"score": 0}}],
+                examples=[
+                    {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+                ],
             )


### PR DESCRIPTION
### Related Issues

- fixes #7620 
- fixes #7528 

### Proposed Changes:

- Make SASEvaluator output format for bi-encoder models consistent with its output format for cross-encoder models fixing #7620 
- Rename FaithfulnessEvaluator input `responses` to `predicted_answers`. This renaming makes the parameter name consistent with the parameter name of SASEvaluator and AnswerExactMatchEvaluator. Downside is that it's a different name than in the integrations of Ragas and DeepEval. These two use `responses` as the input parameter name.
- Minor change of the prompt for LLMEvaluator adding a whitespace

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

I decided to keep the `contexts` input param of `FaithfulnessEvaluator` and `ContextRelevanceEvaluator` unchanged. Changing its type from str to Document and the name from `contexts` to `retrieved_documents` doesn't work well with how we pass all the data in a prompt to an LLM. I suggest the model-based evaluators keep str as input and to make that more visible keep also the different input names `contexts` for model-based evaluators and `retrieved_documents` for statistical evaluators.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
