### PR TITLE
docs: Add instance argument to code samples in docstrings for component.py

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -292,7 +292,7 @@ class _Component:
         class MyComponent:
 
             def __init__(self, value: int):
-                component.set_input_types(value_1=str, value_2=str)
+                component.set_input_types(self, value_1=str, value_2=str)
                 ...
 
             @component.output_types(output_1=int, output_2=str)
@@ -309,7 +309,7 @@ class _Component:
         class MyComponent:
 
             def __init__(self, value: int):
-                component.set_input_types(value_1=str, value_2=str)
+                component.set_input_types(self, value_1=str, value_2=str)
                 ...
 
             @component.output_types(output_1=int, output_2=str)
@@ -337,7 +337,7 @@ class _Component:
         class MyComponent:
 
             def __init__(self, value: int):
-                component.set_output_types(output_1=int, output_2=str)
+                component.set_output_types(self, output_1=int, output_2=str)
                 ...
 
             # no decorators here


### PR DESCRIPTION
### Related Issues

No issue opened

### Proposed Changes:

The `instance` argument was missing from the sample code in the docstrings for `component.set_output_types` and `component.set_input_types`. This caused me to write code that didn't work. I fixed my code, I would like to fix the docs.

### How did you test it?

I haven't yet. 

### Notes for the reviewer

I hope you have a nice day.

### Checklist

[X] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
[ ] I have updated the related issue with new insights and changes
[ ] I added unit tests and updated the docstrings
[X] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
[ ] I documented my code
[ ] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
