### PR TITLE
ci: Fix `minor_version_release.yml` workflow to work with both 1.x and 2.x

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -1,7 +1,15 @@
-name: Minor Version Release (1.x)
+name: Minor Version Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
+        type: choice
+        options:
+          - v1.x
+          - v2.x
 
 env:
   PYTHON_VERSION: "3.8"
@@ -10,10 +18,20 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Get branch name
+        id: branch
+        shell: python
+        run: |
+          import os
+          version = "${{ inputs.version }}"
+          branch = "v1.x" if version == "v1.x" else "main"
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            print(f"name={branch}", file=f)
+
       - name: Checkout this repo
         uses: actions/checkout@v4
         with:
-          ref: "v1.x"
+          ref: "${{ steps.branch.outputs.name }}"
 
       - name: Define all versions
         id: versions
@@ -32,20 +50,20 @@ jobs:
           git checkout -b v${{ steps.versions.outputs.current_release_minor }}.x
           git push -u origin v${{ steps.versions.outputs.current_release_minor }}.x --tags
 
-      - name: Bump version on v1.x
+      - name: Bump version on ${{ steps.branch.outputs.name }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout v1.x
+          git checkout "${{ steps.branch.outputs.name }}"
           NEW_VERSION=$(awk -F. '/[0-9]+\./{$2++;print}' OFS=. < VERSION.txt)
           echo "$NEW_VERSION" > VERSION.txt
           cat VERSION.txt
           git add .
           git commit -m "Update unstable version to $NEW_VERSION"
           VERSION_TAG="v$NEW_VERSION"
-          git tag $VERSION_TAG -m"$VERSION_TAG"
-          git push --atomic origin v1.x $VERSION_TAG
+          git tag "$VERSION_TAG" -m"$VERSION_TAG"
+          git push --atomic origin "${{ steps.branch.outputs.name }}" "$VERSION_TAG"
 
       - uses: actions/setup-python@v5
         with:
@@ -58,5 +76,5 @@ jobs:
         env:
           RDME_API_KEY: ${{ secrets.README_API_KEY }}
         run: |
-          git checkout v1.x
+          git checkout ${{ steps.branch.outputs.name }}
           python ./.github/utils/release_docs.py --new-version ${{ steps.versions.outputs.current_release_minor }}


### PR DESCRIPTION
`minor_version_release.yml` is hardcoded to work with `v1.x`. 
This PR changes the workflow to work both for `v1.x` and `v2.x` depending on the workflow dispatch input.