### PR TITLE
test: Rename `responses` and use preds instead of ground truth answers in e2e eval test

### DIFF
--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -94,7 +94,7 @@ def built_eval_input(questions, truth_docs, truth_answers, retrieved_docs, conte
     """Helper function to build the input for the evaluation pipeline"""
     return {
         "doc_mrr": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
-        "groundness": {"questions": questions, "contexts": contexts, "responses": truth_answers},
+        "groundedness": {"questions": questions, "contexts": contexts, "predicted_answers": pred_answers},
         "sas": {"predicted_answers": pred_answers, "ground_truth_answers": truth_answers},
         "doc_map": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
         "doc_recall_single_hit": {"ground_truth_documents": truth_docs, "retrieved_documents": retrieved_docs},
@@ -141,8 +141,8 @@ def built_input_for_results_eval(rag_results):
             "score": rag_results["sas"]["score"],
         },
         "Faithfulness": {
-            "individual_scores": rag_results["groundness"]["individual_scores"],
-            "score": rag_results["groundness"]["score"],
+            "individual_scores": rag_results["groundedness"]["individual_scores"],
+            "score": rag_results["groundedness"]["score"],
         },
         "Document MAP": {
             "individual_scores": rag_results["doc_map"]["individual_scores"],

--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -80,7 +80,7 @@ def evaluation_pipeline():
     """
     eval_pipeline = Pipeline()
     eval_pipeline.add_component("doc_mrr", DocumentMRREvaluator())
-    eval_pipeline.add_component("groundness", FaithfulnessEvaluator())
+    eval_pipeline.add_component("groundedness", FaithfulnessEvaluator())
     eval_pipeline.add_component("sas", SASEvaluator(model=EMBEDDINGS_MODEL))
     eval_pipeline.add_component("doc_map", DocumentMAPEvaluator())
     eval_pipeline.add_component("doc_recall_single_hit", DocumentRecallEvaluator(mode=RecallMode.SINGLE_HIT))


### PR DESCRIPTION
### Related Issues

- e2e eval test failed because the FaithfulnessEvaluator expects `predicted_answers` but received only `responses`: https://github.com/deepset-ai/haystack/actions/runs/8932162279/job/24535543678
- The renaming was done in https://github.com/deepset-ai/haystack/pull/7621

### Proposed Changes:

- Rename the input  when it is sent to FaithfulnessEvaluator from responses to predicted_answers
- Use predicted answers instead of ground truth answers as input for FaithfulnessEvaluator
- Fixed typo in component name groundness - groundedness

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
