### PR TITLE
ci: Rework `minor_version_release.yml` to create PR that bumps version

### DIFF
--- a/.github/workflows/minor_version_release.yml
+++ b/.github/workflows/minor_version_release.yml
@@ -53,17 +53,35 @@ jobs:
       - name: Bump version on ${{ steps.branch.outputs.name }}
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # We use the HAYSTACK_BOT_TOKEN here so the PR created by the step will
+          # trigger required workflows and can be merged by anyone
+          GITHUB_TOKEN: ${{ secrets.HAYSTACK_BOT_TOKEN }}
         run: |
           git checkout "${{ steps.branch.outputs.name }}"
+
+          # Tag the base with X.Y.Z-rc0.
+          # At this point VERSION.txt still contains the previous version and not
+          # the one specified by the tag.
+          # This is good though as we just need this to make reno work properly.
           NEW_VERSION=$(awk -F. '/[0-9]+\./{$2++;print}' OFS=. < VERSION.txt)
           echo "$NEW_VERSION" > VERSION.txt
-          cat VERSION.txt
-          git add .
-          git commit -m "Update unstable version to $NEW_VERSION"
           VERSION_TAG="v$NEW_VERSION"
           git tag "$VERSION_TAG" -m"$VERSION_TAG"
-          git push --atomic origin "${{ steps.branch.outputs.name }}" "$VERSION_TAG"
+          git push --tags
+
+          # Create the branch that bump version in dev branch
+          cat VERSION.txt
+          git checkout -b bump-version
+          git add .
+          git commit -m "Update unstable version to $NEW_VERSION"
+          g push -u origin bump-version
+
+          # Create the PR
+          gh pr create -B "${{ steps.branch.outputs.name }}" \
+            -H bump-version \
+            --title 'Bump unstable version' \
+            --body 'Part of the release process' \
+            --label 'ignore-for-release-notes'
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This PR changes `minor_version_release.yml` to create a PR to bump the version in `main` or `v1.x` instead of pushing directly to those branches.

Pushing to `v1.x` is fine actually since it's not a protected branch, but `main` is so it fails. See [this workflow run](https://github.com/deepset-ai/haystack/actions/runs/8936143640/job/24545924772).

We used a similar strategy in the past that would bump the version with a PR. That was problematic as we were using the workflow GH token, opening a PR with that token doesn't trigger workflows in that PR.

To work around that I used the `HAYSTACK_BOT_TOKEN`, that will trigger workflows. 

I tested by opening PR #7641 with that token via REST API and it triggered workflows with no issues.

I'll update the release process after this is merged.