### PR TITLE
feat: add default template to DynamicPromptBuilder

### DIFF
--- a/haystack/components/builders/dynamic_prompt_builder.py
+++ b/haystack/components/builders/dynamic_prompt_builder.py
@@ -91,7 +91,7 @@ class DynamicPromptBuilder:
         component.set_output_types(self, prompt=str)
 
         self.runtime_variables = runtime_variables
-        self.default_template: Template | None = None
+        self.default_template: Optional[Template] = None
         self.required_default_template_variables: Set[str] = set()
         if template:
             self.default_template = Template(template)

--- a/haystack/components/builders/dynamic_prompt_builder.py
+++ b/haystack/components/builders/dynamic_prompt_builder.py
@@ -125,8 +125,8 @@ class DynamicPromptBuilder:
         kwargs = kwargs or {}
         template_variables = template_variables or {}
         template_variables_combined = {**kwargs, **template_variables}
-        template = self._validate_template(template, set(template_variables_combined.keys()))
-        result = template.render(template_variables_combined)
+        compiled_template = self._validate_template(template, set(template_variables_combined.keys()))
+        result = compiled_template.render(template_variables_combined)
         return {"prompt": result}
 
     def _validate_template(self, template_text: Optional[str], provided_variables: Set[str]):

--- a/test/components/builders/test_dynamic_prompt_builder.py
+++ b/test/components/builders/test_dynamic_prompt_builder.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pytest
 from jinja2 import TemplateSyntaxError
@@ -14,15 +14,37 @@ class TestDynamicPromptBuilder:
         assert builder.runtime_variables == runtime_variables
 
         # regardless of the chat mode
-        # we have inputs that contain: prompt_source, template_variables + runtime_variables
-        expected_keys = set(runtime_variables + ["prompt_source", "template_variables"])
+        # we have inputs that contain: template, template_variables + runtime_variables
+        expected_keys = set(runtime_variables + ["template", "template_variables"])
         assert set(builder.__haystack_input__._sockets_dict.keys()) == expected_keys
 
         # response is always prompt regardless of chat mode
         assert set(builder.__haystack_output__._sockets_dict.keys()) == {"prompt"}
 
-        # prompt_source is a list of ChatMessage or a string
-        assert builder.__haystack_input__._sockets_dict["prompt_source"].type == str
+        # template is a list of ChatMessage or a string
+        assert builder.__haystack_input__._sockets_dict["template"].type == Optional[str]
+
+        # output is always prompt, but the type is different depending on the chat mode
+        assert builder.__haystack_output__._sockets_dict["prompt"].type == str
+
+    def test_initialization_with_default_template(self):
+        runtime_variables = ["var1", "var2"]
+        template = "Hello, {{ var1 }}, {{ var2 }}!"
+        builder = DynamicPromptBuilder(template=template, runtime_variables=runtime_variables)
+        assert builder.runtime_variables == runtime_variables
+        assert builder.default_template is not None
+        assert builder.required_default_template_variables == {"var1", "var2"}
+
+        # regardless of the chat mode
+        # we have inputs that contain: template, template_variables + runtime_variables
+        expected_keys = set(runtime_variables + ["template", "template_variables"])
+        assert set(builder.__haystack_input__._sockets_dict.keys()) == expected_keys
+
+        # response is always prompt regardless of chat mode
+        assert set(builder.__haystack_output__._sockets_dict.keys()) == {"prompt"}
+
+        # template is a list of ChatMessage or a string
+        assert builder.__haystack_input__._sockets_dict["template"].type == Optional[str]
 
         # output is always prompt, but the type is different depending on the chat mode
         assert builder.__haystack_output__._sockets_dict["prompt"].type == str
@@ -38,6 +60,29 @@ class TestDynamicPromptBuilder:
 
         assert builder.run(template, template_variables) == expected_result
 
+    def test_processing_a_simple_default_template_with_provided_variables(self):
+        runtime_variables = ["var1", "var2", "var3"]
+        template = "Hello, {{ name }}!"
+
+        builder = DynamicPromptBuilder(runtime_variables, template)
+
+        template_variables = {"name": "John"}
+        expected_result = {"prompt": "Hello, John!"}
+
+        assert builder.run(template_variables=template_variables) == expected_result
+
+    def test_overwriting_default_template(self):
+        runtime_variables = ["var1", "var2", "var3"]
+        default_template = "Hello, {{ name }}!"
+
+        builder = DynamicPromptBuilder(runtime_variables, default_template)
+
+        template = "Hello, {{ var1 }} {{ name }}!"
+        template_variables = {"name": "John"}
+        expected_result = {"prompt": "Hello, Big John!"}
+
+        assert builder.run(template, template_variables, var1="Big") == expected_result
+
     def test_processing_a_simple_template_with_invalid_template(self):
         runtime_variables = ["var1", "var2", "var3"]
         builder = DynamicPromptBuilder(runtime_variables)
@@ -47,12 +92,26 @@ class TestDynamicPromptBuilder:
         with pytest.raises(TemplateSyntaxError):
             builder.run(template, template_variables)
 
+    def test_processing_a_simple_default_template_with_invalid_template(self):
+        runtime_variables = ["var1", "var2", "var3"]
+        template = "Hello, {{ name }!"
+        with pytest.raises(TemplateSyntaxError):
+            DynamicPromptBuilder(runtime_variables, template)
+
     def test_processing_a_simple_template_with_missing_variables(self):
         runtime_variables = ["var1", "var2", "var3"]
         builder = DynamicPromptBuilder(runtime_variables)
 
         with pytest.raises(ValueError):
-            builder.run("Hello, {{ name }}!", {})
+            builder.run("Hello, {{ name }}!")
+
+    def test_processing_a_simple_default_template_with_missing_variables(self):
+        runtime_variables = ["var1", "var2", "var3"]
+        template = "Hello, {{ name }}!"
+        builder = DynamicPromptBuilder(runtime_variables, template)
+
+        with pytest.raises(ValueError):
+            builder.run()
 
     def test_missing_template_variables(self):
         prompt_builder = DynamicPromptBuilder(runtime_variables=["documents"])
@@ -79,7 +138,8 @@ class TestDynamicPromptBuilder:
         prompt_builder._validate_template("Hello, I'm {{ name }}, and I live in {{ city }}.", {"name", "city", "age"})
 
     def test_example_in_pipeline(self):
-        prompt_builder = DynamicPromptBuilder(runtime_variables=["documents"])
+        default_template = "Here is the document: {{documents[0].content}} \\n Answer: {{query}}"
+        prompt_builder = DynamicPromptBuilder(runtime_variables=["documents"], template=default_template)
 
         @component
         class DocumentProducer:
@@ -92,12 +152,12 @@ class TestDynamicPromptBuilder:
         pipe.add_component("prompt_builder", prompt_builder)
         pipe.connect("doc_producer.documents", "prompt_builder.documents")
 
-        template = "Here is the document: {{documents[0].content}} \\n Answer: {{query}}"
+        template = "Here is the document: {{documents[0].content}} \\n Query: {{query}}"
         result = pipe.run(
             data={
                 "doc_producer": {"doc_input": "Hello world, I live in Berlin"},
                 "prompt_builder": {
-                    "prompt_source": template,
+                    "template": template,
                     "template_variables": {"query": "Where does the speaker live?"},
                 },
             }
@@ -105,6 +165,6 @@ class TestDynamicPromptBuilder:
 
         assert result == {
             "prompt_builder": {
-                "prompt": "Here is the document: Hello world, I live in Berlin \\n Answer: Where does the speaker live?"
+                "prompt": "Here is the document: Hello world, I live in Berlin \\n Query: Where does the speaker live?"
             }
         }


### PR DESCRIPTION
### Related Issues

Currently we cannot have both:
- a default prompt template defined (PromptBuilder)
- dynamically change prompt templates at runtime (DynamicPromptBuilder)

There are two options:
- **A** we extend `DynamicPromptBuilder` and leave `PromptBuilder` as is
- **B** we extend `PromptBuilder` and deprecate `DynamicPromptBuilder`

This is Option **A** 
See https://github.com/deepset-ai/haystack/pull/7655 for Option **B**

### Proposed Changes:
This extends DynamicPromptBuilder to have a default prompt template that is specified at init time.
```python
default_template = "This is the default prompt: \\n Query: {{query}}"
prompt_builder = DynamicPromptBuilder(runtime_variables=["query"], template=default_template)

pipe = Pipeline()
pipe.add_component("prompt_builder", prompt_builder)

# using the default prompt
result = pipe.run(
    data={
        "prompt_builder": {
            "query": "Where does the speaker live?",
        },
    }
)
#  "This is the default prompt: \n Query: Where does the speaker live?"

# using the dynamic prompt
result = pipe.run(
    data={
        "prompt_builder": {
            "template": "This is the dynamic prompt:\\n Query: {{query}}",
            "query": "Where does the speaker live?",
        },
    }
)
#  "This is the dynamic prompt: \n Query: Where does the speaker live?"
```

### How did you test it?
- added tests

### Notes for the reviewer
- There is a breaking change: `prompt_source` param has been renamed to `template` for consistency. We can undo that if necessary.
- Given that `PromptBuilder` only has a subset of `DynamicPromptBuilder`'s and no additional functionality, I would prefer Option **B**
- A `Chat` counterpart to `DynamicPromptBuilder` would still need to be implemented

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
