### PR TITLE
fix: fix broken serialization of HFAPI components

### DIFF
--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -175,7 +175,7 @@ class HuggingFaceAPIDocumentEmbedder:
         """
         return default_to_dict(
             self,
-            api_type=self.api_type,
+            api_type=str(self.api_type),
             api_params=self.api_params,
             prefix=self.prefix,
             suffix=self.suffix,

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -142,7 +142,7 @@ class HuggingFaceAPITextEmbedder:
         """
         return default_to_dict(
             self,
-            api_type=self.api_type,
+            api_type=str(self.api_type),
             api_params=self.api_params,
             prefix=self.prefix,
             suffix=self.suffix,

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -158,7 +158,7 @@ class HuggingFaceAPIChatGenerator:
         callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
         return default_to_dict(
             self,
-            api_type=self.api_type,
+            api_type=str(self.api_type),
             api_params=self.api_params,
             token=self.token.to_dict() if self.token else None,
             generation_kwargs=self.generation_kwargs,

--- a/haystack/components/generators/hugging_face_api.py
+++ b/haystack/components/generators/hugging_face_api.py
@@ -142,7 +142,7 @@ class HuggingFaceAPIGenerator:
         callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
         return default_to_dict(
             self,
-            api_type=self.api_type,
+            api_type=str(self.api_type),
             api_params=self.api_params,
             token=self.token.to_dict() if self.token else None,
             generation_kwargs=self.generation_kwargs,

--- a/releasenotes/notes/fix-hf-api-serialization-026b84de29827c57.yaml
+++ b/releasenotes/notes/fix-hf-api-serialization-026b84de29827c57.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the broken serialization of HuggingFaceAPITextEmbedder, HuggingFaceAPIDocumentEmbedder,
+    HuggingFaceAPIGenerator, and HuggingFaceAPIChatGenerator.

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -109,7 +109,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
         assert data == {
             "type": "haystack.components.embedders.hugging_face_api_document_embedder.HuggingFaceAPIDocumentEmbedder",
             "init_parameters": {
-                "api_type": HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+                "api_type": "serverless_inference_api",
                 "api_params": {"model": "BAAI/bge-small-en-v1.5"},
                 "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "prefix": "prefix",

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -95,7 +95,7 @@ class TestHuggingFaceAPITextEmbedder:
         assert data == {
             "type": "haystack.components.embedders.hugging_face_api_text_embedder.HuggingFaceAPITextEmbedder",
             "init_parameters": {
-                "api_type": HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+                "api_type": "serverless_inference_api",
                 "api_params": {"model": "BAAI/bge-small-en-v1.5"},
                 "token": {"env_vars": ["HF_API_TOKEN"], "strict": False, "type": "env_var"},
                 "prefix": "prefix",

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -138,7 +138,7 @@ class TestHuggingFaceAPIGenerator:
         result = generator.to_dict()
         init_params = result["init_parameters"]
 
-        assert init_params["api_type"] == HFGenerationAPIType.SERVERLESS_INFERENCE_API
+        assert init_params["api_type"] == "serverless_inference_api"
         assert init_params["api_params"] == {"model": "HuggingFaceH4/zephyr-7b-beta"}
         assert init_params["token"] == {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"}
         assert init_params["generation_kwargs"] == {"temperature": 0.6, "stop": ["stop", "words"], "max_tokens": 512}

--- a/test/components/generators/test_hugging_face_api.py
+++ b/test/components/generators/test_hugging_face_api.py
@@ -131,7 +131,7 @@ class TestHuggingFaceAPIGenerator:
         result = generator.to_dict()
         init_params = result["init_parameters"]
 
-        assert init_params["api_type"] == HFGenerationAPIType.SERVERLESS_INFERENCE_API
+        assert init_params["api_type"] == "serverless_inference_api"
         assert init_params["api_params"] == {"model": "HuggingFaceH4/zephyr-7b-beta"}
         assert init_params["token"] == {"env_vars": ["ENV_VAR"], "strict": False, "type": "env_var"}
         assert init_params["generation_kwargs"] == {


### PR DESCRIPTION
### Related Issues

- fixes #7660

### Proposed Changes:

In `to_dict` methods, replace the Enum with its string representation.

### How did you test it?

CI, manual test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
