### PR TITLE
fix: fix serialization of `DocumentRecallEvaluator`

### DIFF
--- a/haystack/components/evaluators/document_recall.py
+++ b/haystack/components/evaluators/document_recall.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Union
 
-from haystack.core.component import component
+from haystack import component, default_to_dict
 from haystack.dataclasses import Document
 
 
@@ -74,6 +74,7 @@ class DocumentRecallEvaluator:
 
         mode_functions = {RecallMode.SINGLE_HIT: self._recall_single_hit, RecallMode.MULTI_HIT: self._recall_multi_hit}
         self.mode_function = mode_functions[mode]
+        self.mode = mode
 
     def _recall_single_hit(self, ground_truth_documents: List[Document], retrieved_documents: List[Document]) -> float:
         unique_truths = {g.content for g in ground_truth_documents}
@@ -117,3 +118,12 @@ class DocumentRecallEvaluator:
             scores.append(score)
 
         return {"score": sum(scores) / len(retrieved_documents), "individual_scores": scores}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(self, mode=str(self.mode))

--- a/releasenotes/notes/fix-serialization-docrecallevaluator-91ad772ffed119ed.yaml
+++ b/releasenotes/notes/fix-serialization-docrecallevaluator-91ad772ffed119ed.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add `to_dict` method to `DocumentRecallEvaluator` to allow proper serialization of the component.

--- a/test/components/evaluators/test_document_recall.py
+++ b/test/components/evaluators/test_document_recall.py
@@ -2,6 +2,7 @@ import pytest
 
 from haystack.components.evaluators.document_recall import DocumentRecallEvaluator, RecallMode
 from haystack.dataclasses import Document
+from haystack import default_from_dict
 
 
 def test_init_with_unknown_mode_string():
@@ -77,6 +78,21 @@ class TestDocumentRecallEvaluatorSingleHit:
                 ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
                 retrieved_documents=[[Document(content="Berlin")]],
             )
+
+    def test_to_dict(self, evaluator):
+        data = evaluator.to_dict()
+        assert data == {
+            "type": "haystack.components.evaluators.document_recall.DocumentRecallEvaluator",
+            "init_parameters": {"mode": "single_hit"},
+        }
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack.components.evaluators.document_recall.DocumentRecallEvaluator",
+            "init_parameters": {"mode": "single_hit"},
+        }
+        new_evaluator = default_from_dict(DocumentRecallEvaluator, data)
+        assert new_evaluator.mode == RecallMode.SINGLE_HIT
 
 
 class TestDocumentRecallEvaluatorMultiHit:

--- a/test/components/evaluators/test_document_recall.py
+++ b/test/components/evaluators/test_document_recall.py
@@ -168,3 +168,18 @@ class TestDocumentRecallEvaluatorMultiHit:
                 ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
                 retrieved_documents=[[Document(content="Berlin")]],
             )
+
+    def test_to_dict(self, evaluator):
+        data = evaluator.to_dict()
+        assert data == {
+            "type": "haystack.components.evaluators.document_recall.DocumentRecallEvaluator",
+            "init_parameters": {"mode": "multi_hit"},
+        }
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack.components.evaluators.document_recall.DocumentRecallEvaluator",
+            "init_parameters": {"mode": "multi_hit"},
+        }
+        new_evaluator = default_from_dict(DocumentRecallEvaluator, data)
+        assert new_evaluator.mode == RecallMode.MULTI_HIT


### PR DESCRIPTION
### Related Issues

- similar to #7660

this fails because the `RecallMode` Enum is not YAML-serializable:
```python
from haystack import Pipeline
from haystack.components.evaluators.document_recall import DocumentRecallEvaluator

p = Pipeline()
p.add_component("eval", DocumentRecallEvaluator())
dump = p.dumps()

p2 = Pipeline.loads(dump)
```

### Proposed Changes:
- add `to_dict` method to handle the serialization

### How did you test it?
CI, new unit tests, manual test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
