### PR TITLE
feat: Add `ByteStream` `resolved_mime_type` property 

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -86,7 +86,7 @@ class FileTypeRouter:
             if isinstance(source, Path):
                 mime_type = self._get_mime_type(source)
             elif isinstance(source, ByteStream):
-                mime_type = source.meta.get("content_type", None)
+                mime_type = source.resolved_mime_type
             else:
                 raise ValueError(f"Unsupported data source type: {type(source).__name__}")
 

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -69,7 +69,7 @@ class ByteStream:
             data=text.encode(encoding),
             mime_type=mime_type,
             meta=meta or {},
-            mime_type_resolution_priority=mime_type_resolution_priority,
+            mime_type_resolution_priority=mime_type_resolution_priority or ["attribute", "meta"],
         )
 
     def to_string(self, encoding: str = "utf-8") -> str:

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -59,3 +59,16 @@ class ByteStream:
         :raises: UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
         """
         return self.data.decode(encoding)
+
+    @property
+    def resolved_mime_type(self) -> Optional[str]:
+        """
+        Returns the resolved MIME type of the ByteStream
+
+        The mime type value comes from either from the `content_type` value of the `meta` dictionary or from
+        the `mime_type` attribute.
+
+        :return: The MIME type if available, otherwise `None`.
+        :rtype: Optional[str]
+        """
+        return self.meta.get("content_type", None) or self.mime_type

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -85,10 +85,19 @@ class ByteStream:
     @property
     def resolved_mime_type(self) -> Optional[str]:
         """
-        Returns the resolved MIME type of the ByteStream based on the `mime_type_resolution_priority` priority.
+        Returns the resolved MIME type of the ByteStream based on the `mime_type_resolution_priority` property.
+
+        The MIME type is consolidated using two different contexts:
+        - `content_type`: Used for resources fetched from the web and stored in the `meta` field.
+        - `mime_type`: Used for local files.
+
+        The `mime_type_resolution_priority` property prioritizes the resolution of the MIME type based on the order
+        of preference, picking one of the two sources of truth. The default order is `["attribute", "meta"]`.
+
+        This property is useful because it can be used with any `ByteStream` instance, regardless of the origin of
+        creation, to conveniently determine the MIME type instead of checking both sources of truth separately.
 
         :return: The MIME type if available, otherwise `None`.
-        :rtype: Optional[str]
         """
         sources = {"meta": self.meta.get("content_type", None), "attribute": self.mime_type}
 

--- a/releasenotes/notes/byte-stream-mime-type-resolution-b646183d54806319.yaml
+++ b/releasenotes/notes/byte-stream-mime-type-resolution-b646183d54806319.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Improved MIME type resolution in ByteStream dataclass to allow priority-based MIME type determination. Users can now specify a priority order for resolving the MIME type of a ByteStream, utilizing either the explicitly set mime_type attribute or the content_type found within the ByteStream's metadata. This enhancement simplifies handling of MIME types, especially when dealing with ByteStreams originating from various sources.

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -68,3 +68,41 @@ def test_to_file(tmp_path, request):
     ByteStream(test_str.encode()).to_file(test_path)
     with open(test_path, "rb") as fd:
         assert fd.read().decode() == test_str
+
+
+# tests resolved_mime_type with different priority orders
+def test_resolved_mime_type_priority():
+    test_string = "Hello, world!"
+
+    b = ByteStream(
+        data=test_string.encode(),
+        mime_type="application/octet-stream",
+        meta={"content_type": "text/plain"},
+        mime_type_resolution_priority=["meta", "attribute"],
+    )
+    assert b.resolved_mime_type == "text/plain"
+
+    b.mime_type_resolution_priority = ["attribute", "meta"]
+    assert b.resolved_mime_type == "application/octet-stream"
+
+    b = ByteStream(
+        data=test_string.encode(), mime_type=None, meta={}, mime_type_resolution_priority=["meta", "attribute"]
+    )
+    assert b.resolved_mime_type is None
+
+
+# test resolved_mime_type with default priority which is ["attribute", "meta"]
+def test_resolved_mime_type_no_priority():
+    test_string = "Hello, world!"
+
+    b = ByteStream(data=test_string.encode(), mime_type="application/octet-stream", meta={"content_type": "text/plain"})
+    assert b.resolved_mime_type == "application/octet-stream"
+
+    b = ByteStream(data=test_string.encode(), mime_type=None, meta={"content_type": "text/plain"})
+    assert b.resolved_mime_type == "text/plain"
+
+    b = ByteStream(data=test_string.encode(), mime_type="application/octet-stream", meta={})
+    assert b.resolved_mime_type == "application/octet-stream"
+
+    b = ByteStream(data=test_string.encode(), mime_type=None, meta={})
+    assert b.resolved_mime_type is None


### PR DESCRIPTION
### Why:
Enhance the MIME type resolution process for the `ByteStream` data class. It introduces a more flexible and priority-based approach to determine the MIME type of a `ByteStream`, crucial for handling data from diverse sources with varying MIME type declarations. 

- fixes https://github.com/deepset-ai/haystack/issues/7633

### What:
- Introduce new feature (see diff) without breaking any existing clients

### How can it be used:
- **MIME Type Resolution Flexibility**: Users can now specify a custom priority for MIME type resolution when creating a `ByteStream` instance. This is particularly useful for applications that process both local files and streams of data fetched from the web
- **Enhanced Data Processing**: With the improved MIME type resolution, applications can more accurately and easily determine the type of the data they are processing regardless of the origin of `ByteStream` (local, web resource etc etc)
 
### How did you test it:
- **Unit Testing**: Tests were added to verify the correct resolution of MIME types based on various prioritization scenarios, including cases with and without explicitly set MIME types and metadata.
- No regressions were found

### Notes for the reviewer:
- NA