### PR TITLE
chore: make Stalebot workflow work

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          only-labels: 'proposal,community-triage'
+          any-of-labels: 'proposal,community-triage'
           stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           days-before-stale: 30
           days-before-close: 10


### PR DESCRIPTION
### Related Issues
The Stalebot workflow is properly running, but it never applies the `stale` label,
because the current configuration requires all the labels `proposal` and `community-triage` to be present.

logs: https://github.com/deepset-ai/haystack/actions/runs/9011090473/job/24758184788

### Proposed Changes:
Replace `only-labels` with `any-of-labels` in config.
docs: https://github.com/actions/stale?tab=readme-ov-file#any-of-labels

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
