### PR TITLE
chore: Simplify `Pipeline.run` method by moving code to the base class

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -707,6 +707,11 @@ class PipelineBase:
             msg += f"Source:\n{rendered}"
             raise PipelineUnmarshalError(msg)
 
+    def _init_graph(self):
+        """Resets the visits count for each component"""
+        for node in self.graph.nodes:
+            self.graph.nodes[node]["visits"] = 0
+
 
 def _connections_status(
     sender_node: str, receiver_node: str, sender_sockets: List[OutputSocket], receiver_sockets: List[InputSocket]

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -719,6 +719,24 @@ class PipelineBase:
 
         return {**data}
 
+    def _init_to_run(self) -> List[Tuple[str, Component]]:
+        to_run: List[Tuple[str, Component]] = []
+        for node_name in self.graph.nodes:
+            component = self.graph.nodes[node_name]["instance"]
+
+            if len(component.__haystack_input__._sockets_dict) == 0:
+                # Component has no input, can run right away
+                to_run.append((node_name, component))
+                continue
+
+            for socket in component.__haystack_input__._sockets_dict.values():
+                if not socket.senders or socket.is_variadic:
+                    # Component has at least one input not connected or is variadic, can run right away.
+                    to_run.append((node_name, component))
+                    break
+
+        return to_run
+
     @classmethod
     def from_template(
         cls, predefined_pipeline: PredefinedPipeline, template_params: Optional[Dict[str, Any]] = None

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -640,7 +640,7 @@ class PipelineBase:
                         f"Input {socket_name} for component {component_name} is already sent by {socket.senders}."
                     )
 
-    def _prepare_component_input_data(self, data: Dict[str, Any]) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any]]:
+    def _prepare_component_input_data(self, data: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         """
         Prepares input data for pipeline components.
 
@@ -658,6 +658,15 @@ class PipelineBase:
              1. A dictionary mapping component names to their respective matched inputs.
              2. A dictionary of inputs that were not matched to any component, termed as unresolved keyword arguments.
         """
+        # check whether the data is a nested dictionary of component inputs where each key is a component name
+        # and each value is a dictionary of input parameters for that component
+        is_nested_component_input = all(isinstance(value, dict) for value in data.values())
+        if is_nested_component_input:
+            return data
+
+        # flat input, a dict where keys are input names and values are the corresponding values
+        # we need to convert it to a nested dictionary of component inputs and then run the pipeline
+        # just like in the previous case
         pipeline_input_data: Dict[str, Dict[str, Any]] = defaultdict(dict)
         unresolved_kwargs = {}
 
@@ -678,7 +687,13 @@ class PipelineBase:
             if not resolved_at_least_once:
                 unresolved_kwargs[input_name] = input_value
 
-        return pipeline_input_data, unresolved_kwargs
+        if unresolved_kwargs:
+            logger.warning(
+                "Inputs {input_keys} were not matched to any component inputs, please check your run parameters.",
+                input_keys=list(unresolved_kwargs.keys()),
+            )
+
+        return pipeline_input_data
 
     @classmethod
     def from_template(

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -94,8 +94,7 @@ class Pipeline(PipelineBase):
         # }
 
         # Reset the visits count for each component
-        for node in self.graph.nodes:
-            self.graph.nodes[node]["visits"] = 0
+        self._init_graph()
 
         # TODO: Remove this warmup once we can check reliably whether a component has been warmed up or not
         # As of now it's here to make sure we don't have failing tests that assume warm_up() is called in run()

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -109,11 +109,6 @@ class Pipeline(PipelineBase):
         # Raise if input is malformed in some way
         self._validate_input(data)
 
-        # deepcopying the inputs prevents the Pipeline run logic from being altered unexpectedly
-        # when the same input reference is passed to multiple components.
-        for component_name, component_inputs in data.items():
-            data[component_name] = {k: deepcopy(v) for k, v in component_inputs.items()}
-
         for component_name, component_inputs in data.items():
             if component_name not in self.graph.nodes:
                 # This is not a component name, it must be the name of one or more input sockets.

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -31,7 +31,19 @@ class Pipeline(PipelineBase):
 
         :param data:
             A dictionary of inputs for the pipeline's components. Each key is a component name
-            and its value is a dictionary of that component's input parameters.
+            and its value is a dictionary of that component's input parameters:
+            ```
+            data = {
+                "comp1": {"input1": 1, "input2": 2},
+            }
+            ```
+            For convenience, this format is also supported when input names are unique:
+            ```
+            data = {
+                "input1": 1, "input2": 2,
+            }
+            ```
+
         :param debug:
             Set to True to collect and return debug information.
         :param include_outputs_from:
@@ -83,15 +95,6 @@ class Pipeline(PipelineBase):
         {'hello2': {'output': 'Hello, Hello, world!!'}}.
         """
         pipeline_running(self)
-        # NOTE: We're assuming data is formatted like so as of now
-        # data = {
-        #     "comp1": {"input1": 1, "input2": 2},
-        # }
-        #
-        # TODO: Support also this format:
-        # data = {
-        #     "input1": 1, "input2": 2,
-        # }
 
         # Reset the visits count for each component
         self._init_graph()
@@ -100,27 +103,11 @@ class Pipeline(PipelineBase):
         # As of now it's here to make sure we don't have failing tests that assume warm_up() is called in run()
         self.warm_up()
 
-        # check whether the data is a nested dictionary of component inputs where each key is a component name
-        # and each value is a dictionary of input parameters for that component
-        is_nested_component_input = all(isinstance(value, dict) for value in data.values())
-        if not is_nested_component_input:
-            # flat input, a dict where keys are input names and values are the corresponding values
-            # we need to convert it to a nested dictionary of component inputs and then run the pipeline
-            # just like in the previous case
-            data, unresolved_inputs = self._prepare_component_input_data(data)
-            if unresolved_inputs:
-                logger.warning(
-                    "Inputs {input_keys} were not matched to any component inputs, please check your run parameters.",
-                    input_keys=list(unresolved_inputs.keys()),
-                )
+        # normalize `data`
+        data = self._prepare_component_input_data(data)
 
         # Raise if input is malformed in some way
         self._validate_input(data)
-        # NOTE: The above NOTE and TODO are technically not true.
-        # This implementation of run supports only the first format, but the second format is actually
-        # never received by this method. It's handled by the `run()` method of the `Pipeline` class
-        # defined in `haystack/pipeline.py`.
-        # As of now we're ok with this, but we'll need to merge those two classes at some point.
 
         # deepcopying the inputs prevents the Pipeline run logic from being altered unexpectedly
         # when the same input reference is passed to multiple components.

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -114,20 +114,7 @@ class Pipeline(PipelineBase):
 
         # Take all components that have at least 1 input not connected or is variadic,
         # and all components that have no inputs at all
-        to_run: List[Tuple[str, Component]] = []
-        for node_name in self.graph.nodes:
-            component = self.graph.nodes[node_name]["instance"]
-
-            if len(component.__haystack_input__._sockets_dict) == 0:
-                # Component has no input, can run right away
-                to_run.append((node_name, component))
-                continue
-
-            for socket in component.__haystack_input__._sockets_dict.values():
-                if not socket.senders or socket.is_variadic:
-                    # Component has at least one input not connected or is variadic, can run right away.
-                    to_run.append((node_name, component))
-                    break
+        to_run: List[Tuple[str, Component]] = self._init_to_run()
 
         # These variables are used to detect when we're stuck in a loop.
         # Stuck loops can happen when one or more components are waiting for input but

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1008,3 +1008,13 @@ def test_pipeline_is_not_stuck_with_components_with_only_defaults_as_first_compo
     res = pipe.run({"prompt_builder": {"query": "What is the capital of Italy?"}})
 
     assert res == {"router": {"correct_replies": ["Rome"]}}
+
+
+def test__init_graph():
+    pipe = Pipeline()
+    pipe.add_component("greet", Greet())
+    pipe.add_component("adder", AddFixedValue())
+    pipe.connect("greet", "adder")
+    pipe._init_graph()
+    for node in pipe.graph.nodes:
+        assert pipe.graph.nodes[node]["visits"] == 0

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1050,3 +1050,26 @@ def test__init_to_run():
     assert to_run[1][0] == "with_no_inputs"
     assert to_run[2][0] == "with_single_input"
     assert to_run[3][0] == "with_multiple_inputs"
+
+
+def test__init_inputs_state():
+    pipe = Pipeline()
+    template = """
+    Answer the following questions:
+    {{ questions | join("\n") }}
+    """
+    pipe.add_component("prompt_builder", PromptBuilder(template=template))
+    pipe.add_component("multiplexer", Multiplexer(type_=int))
+    questions = ["What is the capital of Italy?", "What is the capital of France?"]
+    data = {
+        "prompt_builder": {"questions": questions},
+        "multiplexer": {"value": 1},
+        "not_a_component": "some input data",
+    }
+    res = pipe._init_inputs_state(data)
+    assert res == {
+        "prompt_builder": {"questions": ["What is the capital of Italy?", "What is the capital of France?"]},
+        "multiplexer": {"value": [1]},
+        "not_a_component": "some input data",
+    }
+    assert id(questions) != id(res["prompt_builder"]["questions"])

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -175,7 +175,7 @@ def test_pipeline_resolution_duplicate_input_names_across_components():
     result = pipe.run(data={"what": "Haystack", "who": "world"})
     assert result == {"hello2": {"output": "Hello Hello world Haystack! Haystack!"}}
 
-    resolved, _ = pipe._prepare_component_input_data(data={"what": "Haystack", "who": "world"})
+    resolved = pipe._prepare_component_input_data(data={"what": "Haystack", "who": "world"})
 
     # why does hello2 have only one input? Because who of hello2 is inserted from hello.output
     assert resolved == {"hello": {"what": "Haystack", "who": "world"}, "hello2": {"what": "Haystack"}}

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1073,3 +1073,17 @@ def test__init_inputs_state():
         "not_a_component": "some input data",
     }
     assert id(questions) != id(res["prompt_builder"]["questions"])
+
+
+def test__prepare_component_input_data():
+    MockComponent = component_class("MockComponent", input_types={"x": List[str], "y": str})
+    pipe = Pipeline()
+    pipe.add_component("first_mock", MockComponent())
+    pipe.add_component("second_mock", MockComponent())
+
+    res = pipe._prepare_component_input_data({"x": ["some data"], "y": "some other data"})
+    assert res == {
+        "first_mock": {"x": ["some data"], "y": "some other data"},
+        "second_mock": {"x": ["some data"], "y": "some other data"},
+    }
+    assert id(res["first_mock"]["x"]) != id(res["second_mock"]["x"])


### PR DESCRIPTION
### Proposed Changes:

This PR has the only purpose to clean up the logic of the `run` method by moving code around, no functional changes.
It should also make the code more testable, but knowing we have #7611 pending, I'm not touching them.
There's more code to move, but I want to keep the diff small to speed up the review process.

### How did you test it?

Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
