### PR TITLE
feat: Set ByteStream's mime_type attribute for web based resources

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -151,6 +151,7 @@ class LinkContentFetcher:
             for stream_metadata, stream in results:  # type: ignore
                 if stream_metadata is not None and stream is not None:
                     stream.meta.update(stream_metadata)
+                    stream.mime_type = stream.meta.get("content_type", None)
                     streams.append(stream)
 
         return {"streams": streams}

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -90,7 +90,7 @@ class FileTypeRouter:
             if isinstance(source, Path):
                 mime_type = self._get_mime_type(source)
             elif isinstance(source, ByteStream):
-                mime_type = source.meta.get("content_type", None)
+                mime_type = source.mime_type
             else:
                 raise ValueError(f"Unsupported data source type: {type(source).__name__}")
 

--- a/releasenotes/notes/enhanced-mime-type-handling-182fb64a0f5fb852.yaml
+++ b/releasenotes/notes/enhanced-mime-type-handling-182fb64a0f5fb852.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Improved MIME type management by directly setting MIME types on ByteStreams, enhancing the overall handling and routing of different file types. This update makes MIME type data more consistently accessible and simplifies the process of working with various document formats.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -50,7 +50,7 @@ class TestFileTypeRouter:
         byte_streams = []
         for path, mime_type in zip(file_paths, mime_types):
             stream = ByteStream(path.read_bytes())
-            stream.meta["content_type"] = mime_type
+            stream.mime_type = mime_type
             byte_streams.append(stream)
 
         # add unclassified ByteStream
@@ -81,7 +81,7 @@ class TestFileTypeRouter:
         byte_stream_sources = []
         for path, mime_type in zip(file_paths, mime_types):
             stream = ByteStream(path.read_bytes())
-            stream.meta["content_type"] = mime_type
+            stream.mime_type = mime_type
             byte_stream_sources.append(stream)
 
         mixed_sources = file_paths[:2] + byte_stream_sources[2:]
@@ -165,9 +165,12 @@ class TestFileTypeRouter:
         """
         Test if the component correctly matches mime types exactly, without regex patterns.
         """
-        txt_stream = ByteStream(io.BytesIO(b"Text file content"), meta={"content_type": "text/plain"})
-        jpg_stream = ByteStream(io.BytesIO(b"JPEG file content"), meta={"content_type": "image/jpeg"})
-        mp3_stream = ByteStream(io.BytesIO(b"MP3 file content"), meta={"content_type": "audio/mpeg"})
+        txt_stream = ByteStream(io.BytesIO(b"Text file content").read())
+        txt_stream.mime_type = "text/plain"
+        jpg_stream = ByteStream(io.BytesIO(b"JPEG file content").read())
+        jpg_stream.mime_type = "image/jpeg"
+        mp3_stream = ByteStream(io.BytesIO(b"MP3 file content").read())
+        mp3_stream.mime_type = "audio/mpeg"
 
         byte_streams = [txt_stream, jpg_stream, mp3_stream]
 


### PR DESCRIPTION
### Why:
Enhances consistency and clarity in handling MIME types in ByteStream across Haystack. ByteStream's `mime_type` attribute gets set properly for web originating ByteStreams. In web originating ByteStream's `content_type` is still left intact in meta dictionary for backward compatibility. 

- fixes https://github.com/deepset-ai/haystack/issues/7633

### What:
- Sets `mime_type` attribute of ByteStream instead of indirect storage of MIME types within a meta dictionary. This change allows direct and uniform access to MIME types, simplifying handling for both web resources and local files.

### How can it be used:
- **Fetching and Routing Based on MIME Types**: Users can now straightforwardly fetch and route documents based on their MIME types, applying specific processing or handling routines directly:
  ```python
  if stream.mime_type == "application/pdf":
      # Process PDF stream
  ```
- **Enhanced Clarity in Code**: The management of MIME types is simplified, enhancing code readability and reducing potential for errors by avoiding nested data structures.

### How did you test it:
- Unit tests in `test_file_router.py` were adjusted to reflect the direct assignment and checking of `mime_type`.
- Tests confirm correct assignment, access, and utilization of the `mime_type` attribute across components, ensuring accurate management and application for routing and processing.
- Integration testing may be conducted to verify consistent utilization across processing pathways and to confirm no impact on existing functionalities.

### Notes for the reviewer:
- Please ensure the `mime_type` attribute implementation covers all necessary cases where MIME type information is accessed or modified.
- Special attention might be required to ensure backward compatibility or migration from the previous approach using the `meta` dictionary.