### PR TITLE
fix: Fix NamedEntityExtractor serde

### DIFF
--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -197,7 +197,7 @@ class NamedEntityExtractor:
         """
         return default_to_dict(
             self,
-            backend=self._backend.type,
+            backend=self._backend.type.name,
             model=self._backend.model_name,
             device=self._backend.device.to_dict(),
             pipeline_kwargs=self._backend._pipeline_kwargs,
@@ -216,6 +216,7 @@ class NamedEntityExtractor:
         try:
             init_params = data["init_parameters"]
             init_params["device"] = ComponentDevice.from_dict(init_params["device"])
+            init_params["backend"] = NamedEntityExtractorBackend[init_params["backend"]]
             return default_from_dict(cls, data)
         except Exception as e:
             raise DeserializationError(f"Couldn't deserialize {cls.__name__} instance") from e

--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -214,7 +214,7 @@ class NamedEntityExtractor:
             Deserialized component.
         """
         try:
-            init_params = data["init_parameters"]            
+            init_params = data["init_parameters"]
             if init_params["device"] is not None:
                 init_params["device"] = ComponentDevice.from_dict(init_params["device"])
             init_params["backend"] = NamedEntityExtractorBackend[init_params["backend"]]

--- a/releasenotes/notes/named-entity-extractor-serde-improvements-28b594be5a38f175.yaml
+++ b/releasenotes/notes/named-entity-extractor-serde-improvements-28b594be5a38f175.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed (de)serialization of NamedEntityExtractor. Includes updated tests verifying these fixes when NamedEntityExtractor is used in pipelines.

--- a/test/components/extractors/test_named_entity_extractor.py
+++ b/test/components/extractors/test_named_entity_extractor.py
@@ -8,7 +8,6 @@ from haystack.components.extractors import NamedEntityExtractor, NamedEntityExtr
 from haystack.utils.device import ComponentDevice
 
 
-@pytest.mark.unit
 def test_named_entity_extractor_backend():
     _ = NamedEntityExtractor(backend=NamedEntityExtractorBackend.HUGGING_FACE, model="dslim/bert-base-NER")
 
@@ -22,7 +21,6 @@ def test_named_entity_extractor_backend():
         NamedEntityExtractor(backend="random_backend", model="dslim/bert-base-NER")
 
 
-@pytest.mark.unit
 def test_named_entity_extractor_serde():
     extractor = NamedEntityExtractor(
         backend=NamedEntityExtractorBackend.HUGGING_FACE,
@@ -54,9 +52,8 @@ def test_named_entity_extractor_pipeline_serde(tmp_path):
         q = Pipeline.load(f)
 
     assert p.to_dict() == q.to_dict(), "Pipeline serialization/deserialization with NamedEntityExtractor failed."
-    
-    
-@pytest.mark.unit
+
+
 def test_named_entity_extractor_serde_none_device():
     extractor = NamedEntityExtractor(
         backend=NamedEntityExtractorBackend.HUGGING_FACE, model="dslim/bert-base-NER", device=None


### PR DESCRIPTION
### Why:
Fixes serialization and deserialization (serde) in the `NamedEntityExtractor` component. Important for usecases where  `NamedEntityExtractor` needs to be serialized to a pipeline yaml file.

- fixes https://github.com/deepset-ai/haystack/issues/7666

### What:
- Modified the serialization method to correctly serialize the backend type by calling `.name` on the `_backend.type` attribute, ensuring that it is stored as a string rather than an object reference.
- Adjusted the deserialization method to transform the `backend` string back into the correct `NamedEntityExtractorBackend` enumeration before attempting to use it in constructing a `NamedEntityExtractor` instance.
- Included a new test ensuring that the `NamedEntityExtractor` can be serialized and deserialized correctly, particularly when used within a pipeline configuration.

### How can it be used:
- Saving the configuration of a `NamedEntityExtractor` to a yaml file 
- Loading a previously saved `NamedEntityExtractor` configuration to resume processing or to replicate a specific setup across different environments or applications.

Example of serializing and deserializing a pipeline including a `NamedEntityExtractor`:
```python
from haystack import Pipeline
from haystack.components.extractors import NamedEntityExtractor, NamedEntityExtractorBackend

# Create an extractor and add it to a pipeline
extractor = NamedEntityExtractor(backend=NamedEntityExtractorBackend.HUGGING_FACE, model="dslim/bert-base-NER")
pipeline = Pipeline()
pipeline.add_component(instance=extractor, name="extractor")

# Serialize the pipeline to a file
with open("path_to_file/test_pipeline.yaml", "w") as f:
    pipeline.dump(f)

# Later or elsewhere, deserialize the pipeline from the file
with open("path_to_file/test_pipeline.yaml", "r") as f:
    loaded_pipeline = Pipeline.load(f)
```

### How did you test it:
- Updated the unit test for the `NamedEntityExtractor` to include checks for both serialization and deserialization functionality, confirming that the process retains the correct component configurations.
- Added a new test that incorporates the `NamedEntityExtractor` within a pipeline configuration, ensuring that the entire pipeline can be serialized and deserialized correctly. This test verifies that the pipeline's dictionary representation remains consistent before and after the serde.

### Notes for the reviewer:
- Pay special attention to the changes in the serialization and deserialization methods, ensuring that the implementation aligns with standard practices for handling enumeration types in Python.