### PR TITLE
fix: Adjust serialization to handle PEP-585 generic types

### DIFF
--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -34,15 +34,12 @@ def serialize_type(target: Any) -> str:
     type_obj = target if is_type_or_typing else type(target)
     type_obj_repr = repr(type_obj)
 
-    # get the origin (base type of the parameterized generic type)
-    origin = get_origin(type_obj)
-    # get the arguments of the generic type
-    args = get_args(type_obj)
-
     if type_obj_repr.startswith("typing."):
         # e.g., typing.List[int] -> List[int], we'll add the module below
         type_name = type_obj_repr.split(".", 1)[1]
-    elif origin:
+    elif origin := get_origin(type_obj):  # get the origin (base type of the parameterized generic type)
+        # get the arguments of the generic type
+        args = get_args(type_obj)
         args_repr = ", ".join(serialize_type(arg) for arg in args)
         type_name = f"{origin.__name__}[{args_repr}]"
     elif hasattr(type_obj, "__name__"):

--- a/releasenotes/notes/improve-type-serialization-support-18822a5b978b1e77.yaml
+++ b/releasenotes/notes/improve-type-serialization-support-18822a5b978b1e77.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Improves/fixes type serialization of PEP 585 types (e.g. list[Document], and their nested version). This improvement enables better serialization of generics and nested types and improves/fixes matching of list[X] and List[X] types in component connections after serialization.

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -2,8 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import copy
+import sys
 import typing
 from typing import List, Dict
+
+import pytest
 
 from haystack.dataclasses import ChatMessage
 from haystack.components.routers.conditional_router import serialize_type, deserialize_type
@@ -23,6 +26,10 @@ def test_output_type_serialization():
     assert serialize_type(int) == "int"
     assert serialize_type(ChatMessage.from_user("ciao")) == "haystack.dataclasses.chat_message.ChatMessage"
 
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="PEP 585 types are only available in Python 3.9+")
+def test_output_type_serialization_pep585():
+    # Only Python 3.9+ supports PEP 585 types and can serialize them
     # PEP 585 types
     assert serialize_type(list[int]) == "list[int]"
     assert serialize_type(list[list[int]]) == "list[list[int]]"
@@ -47,9 +54,14 @@ def test_output_type_deserialization():
     assert deserialize_type("haystack.dataclasses.chat_message.ChatMessage") == ChatMessage
     assert deserialize_type("int") == int
 
-    # PEP 585 types
-    assert deserialize_type("list[int]") == list[int]
-    assert deserialize_type("dict[str, int]") == dict[str, int]
+
+def test_output_type_deserialization_pep585():
+    is_pep585 = sys.version_info >= (3, 9)
+
+    # Although only Python 3.9+ supports PEP 585 types, we can still deserialize them in older Python versions
+    # as their typing equivalents
+    assert deserialize_type("list[int]") == list[int] if is_pep585 else List[int]
+    assert deserialize_type("dict[str, int]") == dict[str, int] if is_pep585 else Dict[str, int]
     # more nested types
-    assert deserialize_type("list[list[int]]") == list[list[int]]
-    assert deserialize_type("list[list[list[int]]]") == list[list[list[int]]]
+    assert deserialize_type("list[list[int]]") == list[list[int]] if is_pep585 else List[List[int]]
+    assert deserialize_type("list[list[list[int]]]") == list[list[list[int]]] if is_pep585 else List[List[List[int]]]

--- a/test/utils/test_type_serialization.py
+++ b/test/utils/test_type_serialization.py
@@ -23,6 +23,14 @@ def test_output_type_serialization():
     assert serialize_type(int) == "int"
     assert serialize_type(ChatMessage.from_user("ciao")) == "haystack.dataclasses.chat_message.ChatMessage"
 
+    # PEP 585 types
+    assert serialize_type(list[int]) == "list[int]"
+    assert serialize_type(list[list[int]]) == "list[list[int]]"
+
+    # more nested types
+    assert serialize_type(list[list[list[int]]]) == "list[list[list[int]]]"
+    assert serialize_type(dict[str, int]) == "dict[str, int]"
+
 
 def test_output_type_deserialization():
     assert deserialize_type("str") == str
@@ -38,3 +46,10 @@ def test_output_type_deserialization():
     )
     assert deserialize_type("haystack.dataclasses.chat_message.ChatMessage") == ChatMessage
     assert deserialize_type("int") == int
+
+    # PEP 585 types
+    assert deserialize_type("list[int]") == list[int]
+    assert deserialize_type("dict[str, int]") == dict[str, int]
+    # more nested types
+    assert deserialize_type("list[list[int]]") == list[list[int]]
+    assert deserialize_type("list[list[list[int]]]") == list[list[list[int]]]


### PR DESCRIPTION
### Why:
Improves type serialization, particularly focusing on better support for PEP 585 types (e.g., `list[Document]`, including nested versions). This enhancement is crucial for enabling more accurate serialization of generics and nested types, which directly impacts the ability to match types like `list[X]` and `List[X]` in component connections after serialization. 

- fixes https://github.com/deepset-ai/haystack/issues/7609

### What:
- **`haystack/utils/type_serialization.py` modification:** Introduced better handling of PEP 585 types 
- **Test enhancements:** Added multiple test cases in `test/utils/test_type_serialization.py` to verify the serialization and deserialization of PEP 585 types, including more complex nested types like `list[list[int]]`.

### How can it be used:
- **Serialization of PEP 585 and nested types:** Now users can serialize types like `list[int]` or more complex nested structures like `list[list[str]]` directly.
  ```python
  # Example: Serializing a nested list type
  serialized_type = serialize_type(list[list[int]])
  ```
- **Deserialization for advanced type checks:** Following serialization, types can be accurately deserialized, maintaining their structure for further type checks or processing.
  ```python
  # Example: Deserializing nested types back to their original form
  original_type = deserialize_type("list[list[int]]")
  ```

### How did you test it:
- Added unit tests for both serialization and deserialization processes.
- Verified the serialization of PEP 585 types like `list[int]`, including deeply nested types (e.g., `list[list[list[int]]]`).
- Ensured the deserialization process could accurately reconstruct the original types from their serialized form.
- These tests validate the changes by ensuring that both serialization and deserialization work as expected with PEP 585 types and their nested versions.

### Notes for the reviewer:
- **Impact on existing serialization:** Reviewers should consider how these changes might interact with existing serialized types, particularly in edge cases not covered by the test scenarios.