### PR TITLE
fix: `Pipeline.run` correctly returns all outputs when the `include_outputs_from` parameter is used

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -23,7 +23,7 @@ class Pipeline(PipelineBase):
     """
 
     # TODO: We're ignoring these linting rules for the time being, after we properly optimize this function we'll remove the noqa
-    def run(  # noqa: C901, PLR0912, PLR0915 pylint: disable=too-many-branches
+    def run(  # noqa: C901, PLR0912, PLR0915 pylint: disable=too-many-branches,too-many-locals
         self, data: Dict[str, Any], debug: bool = False, include_outputs_from: Optional[Set[str]] = None
     ) -> Dict[str, Any]:
         """
@@ -431,7 +431,16 @@ class Pipeline(PipelineBase):
 
             if len(include_outputs_from) > 0:
                 for name, output in extra_outputs.items():
-                    if name not in final_outputs:
+                    inner = final_outputs.get(name)
+                    if inner is None:
                         final_outputs[name] = output
+                    else:
+                        # Let's not override any keys that are already
+                        # in the final_outputs as they might be different
+                        # from what we cached in extra_outputs, e.g. when loops
+                        # are involved.
+                        for k, v in output.items():
+                            if k not in inner:
+                                inner[k] = v
 
             return final_outputs

--- a/releasenotes/notes/pipeline-run-fix-extra-outputs-a6c750a91faaa8fd.yaml
+++ b/releasenotes/notes/pipeline-run-fix-extra-outputs-a6c750a91faaa8fd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The `include_outputs_from` parameter in `Pipeline.run` correctly returns outputs of components with multiple outputs.


### PR DESCRIPTION
### Related Issues

- fixes #7695

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Previously, we wouldn't add the accumulated outputs of intermediate components to the final pipeline output if the latter contained the name of the former. This approach was not fined-grained enough to account for components that returned multiple outputs and only some which were used as inputs to the other components. 

The PR fixes this by iterating over the individual outputs of each intermediate component and adding any missing ones to the final output.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit test, repro code

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
