### PR TITLE
fix: Adding missing `component` decorator to AzureOpenAIGenerator

### DIFF
--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Optional
 # pylint: disable=import-error
 from openai.lib.azure import AzureOpenAI
 
-from haystack import default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators import OpenAIGenerator
 from haystack.dataclasses import StreamingChunk
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
@@ -16,6 +16,7 @@ from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inp
 logger = logging.getLogger(__name__)
 
 
+@component
 class AzureOpenAIGenerator(OpenAIGenerator):
     """
     A Generator component that uses OpenAI's large language models (LLMs) on Azure to generate text.

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Optional
 # pylint: disable=import-error
 from openai.lib.azure import AzureOpenAI
 
-from haystack import default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingChunk
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
@@ -16,6 +16,7 @@ from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inp
 logger = logging.getLogger(__name__)
 
 
+@component
 class AzureOpenAIChatGenerator(OpenAIChatGenerator):
     """
     A Chat Generator component that uses the Azure OpenAI API to generate text.

--- a/releasenotes/notes/fix-azure-generators-serialization-18fcdc9cbcb3732e.yaml
+++ b/releasenotes/notes/fix-azure-generators-serialization-18fcdc9cbcb3732e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixes the (de)serialization of Azure generators.
+    Azure generators components fixed, they were missing the `@component` decorator.

--- a/releasenotes/notes/fix-azure-generators-serialization-18fcdc9cbcb3732e.yaml
+++ b/releasenotes/notes/fix-azure-generators-serialization-18fcdc9cbcb3732e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes the (de)serialization of Azure generators.

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -86,13 +86,8 @@ class TestOpenAIChatGenerator:
         generator = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")
         p = Pipeline()
         p.add_component(instance=generator, name="generator")
-
-        with open(tmp_path / "test_pipeline.yaml", "w") as f:
-            p.dump(f)
-
-        with open(tmp_path / "test_pipeline.yaml", "r") as f:
-            q = Pipeline.load(f)
-
+        p_str = p.dumps()
+        q = Pipeline.loads(p_str)
         assert p.to_dict() == q.to_dict(), "Pipeline serialization/deserialization w/ AzureOpenAIChatGenerator failed."
 
     @pytest.mark.integration

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -6,6 +6,7 @@ import os
 import pytest
 from openai import OpenAIError
 
+from haystack import Pipeline
 from haystack.components.generators.chat import AzureOpenAIChatGenerator
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import ChatMessage
@@ -79,6 +80,20 @@ class TestOpenAIChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
+
+    def test_pipeline_serialization_deserialization(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        generator = AzureOpenAIChatGenerator(azure_endpoint="some-non-existing-endpoint")
+        p = Pipeline()
+        p.add_component(instance=generator, name="generator")
+
+        with open(tmp_path / "test_pipeline.yaml", "w") as f:
+            p.dump(f)
+
+        with open(tmp_path / "test_pipeline.yaml", "r") as f:
+            q = Pipeline.load(f)
+
+        assert p.to_dict() == q.to_dict(), "Pipeline serialization/deserialization w/ AzureOpenAIChatGenerator failed."
 
     @pytest.mark.integration
     @pytest.mark.skipif(

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+
+from haystack import Pipeline
 from haystack.utils.auth import Secret
 
 import pytest
@@ -82,6 +84,20 @@ class TestAzureOpenAIGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }
+
+    def test_pipeline_serialization_deserialization(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")
+        generator = AzureOpenAIGenerator(azure_endpoint="some-non-existing-endpoint")
+        p = Pipeline()
+        p.add_component(instance=generator, name="generator")
+
+        with open(tmp_path / "test_pipeline.yaml", "w") as f:
+            p.dump(f)
+
+        with open(tmp_path / "test_pipeline.yaml", "r") as f:
+            q = Pipeline.load(f)
+
+        assert p.to_dict() == q.to_dict(), "Pipeline serialization/deserialization with AzureOpenAIGenerator failed."
 
     @pytest.mark.integration
     @pytest.mark.skipif(

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -90,13 +90,8 @@ class TestAzureOpenAIGenerator:
         generator = AzureOpenAIGenerator(azure_endpoint="some-non-existing-endpoint")
         p = Pipeline()
         p.add_component(instance=generator, name="generator")
-
-        with open(tmp_path / "test_pipeline.yaml", "w") as f:
-            p.dump(f)
-
-        with open(tmp_path / "test_pipeline.yaml", "r") as f:
-            q = Pipeline.load(f)
-
+        p_str = p.dumps()
+        q = Pipeline.loads(p_str)
         assert p.to_dict() == q.to_dict(), "Pipeline serialization/deserialization with AzureOpenAIGenerator failed."
 
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #7693

### Proposed Changes:

- adding the missing `@component` decorator

### How did you test it?

- run all unit and integration tests