### PR TITLE
feat: Add inference mode to ExtractiveReader

### DIFF
--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -602,7 +602,8 @@ class ExtractiveReader:
             cur_input_ids = input_ids[start_index:end_index]
             cur_attention_mask = attention_mask[start_index:end_index]
 
-            output = self.model(input_ids=cur_input_ids, attention_mask=cur_attention_mask)
+            with torch.inference_mode():
+                output = self.model(input_ids=cur_input_ids, attention_mask=cur_attention_mask)
             cur_start_logits = output.start_logits
             cur_end_logits = output.end_logits
             if num_batches != 1:

--- a/releasenotes/notes/add-inf-mode-reader-e6eb79920e73c956.yaml
+++ b/releasenotes/notes/add-inf-mode-reader-e6eb79920e73c956.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds inference mode to model call of the ExtractiveReader. This prevents gradients from being calculated during inference time in pytorch.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds inference mode to model call of the ExtractiveReader. This prevents gradients from being calculated during inference time in pytorch which saves on resources. This addition does not change the output of the model.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
