### PR TITLE
test: Fix telemetry tests so they don't fail

### DIFF
--- a/test/tracing/test_tracer.py
+++ b/test/tracing/test_tracer.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import builtins
 import sys
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import ddtrace
 import opentelemetry.trace
@@ -19,6 +18,8 @@ from haystack.tracing.opentelemetry import OpenTelemetryTracer
 from haystack.tracing.tracer import (
     NullTracer,
     NullSpan,
+    _auto_configured_opentelemetry_tracer,
+    _auto_configured_datadog_tracer,
     enable_tracing,
     Tracer,
     disable_tracing,
@@ -97,10 +98,6 @@ class TestAutoEnableTracer:
         opentelemetry.trace._TRACER_PROVIDER = None
         disable_tracing()
 
-    @pytest.fixture()
-    def uninstalled_ddtrace_package(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.setattr(ddtrace.tracer, "enabled", False)
-
     def test_skip_auto_enable_tracer_if_already_configured(self) -> None:
         my_tracker = Mock(spec=Tracer)  # anything else than `NullTracer` works for this test
         enable_tracing(my_tracker)
@@ -127,30 +124,38 @@ class TestAutoEnableTracer:
         assert isinstance(activated_tracer, OpenTelemetryTracer)
         assert is_tracing_enabled()
 
-    def test_skip_enable_opentelemetry_tracer_if_import_error(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.delitem(sys.modules, "opentelemetry", raising=False)
-        monkeypatch.setattr(builtins, "__import__", Mock(side_effect=ImportError))
-        auto_enable_tracing()
-
-        activated_tracer = tracer.actual_tracer
-        assert isinstance(activated_tracer, NullTracer)
-        assert not is_tracing_enabled()
-
-    def test_skip_add_datadog_tracer_if_import_error(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.delitem(sys.modules, "ddtrace", raising=False)
-        monkeypatch.setattr(builtins, "__import__", Mock(side_effect=ImportError))
-        auto_enable_tracing()
-
-        activated_tracer = tracer.actual_tracer
-        assert isinstance(activated_tracer, NullTracer)
-        assert not is_tracing_enabled()
-
     def test_add_datadog_tracer(self) -> None:
         auto_enable_tracing()
 
         activated_tracer = tracer.actual_tracer
         assert isinstance(activated_tracer, DatadogTracer)
         assert is_tracing_enabled()
+
+    def test__auto_configured_opentelemetry_tracer(self, configured_opentelemetry_tracing):
+        tracer = _auto_configured_opentelemetry_tracer()
+        assert isinstance(tracer, OpenTelemetryTracer)
+
+    def test__auto_configured_opentelemetry_tracer_with_failing_import(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "opentelemetry.trace", raising=False)
+        tracer = _auto_configured_opentelemetry_tracer()
+        assert tracer is None
+
+    def test__auto_configured_datadog_tracer(self):
+        tracer = _auto_configured_datadog_tracer()
+        assert isinstance(tracer, DatadogTracer)
+
+    def test__auto_configured_datadog_tracer_with_failing_import(self, monkeypatch):
+        monkeypatch.setattr(ddtrace.tracer, "enabled", False)
+        tracer = _auto_configured_datadog_tracer()
+        assert tracer is None
+
+    @patch("haystack.tracing.tracer._auto_configured_datadog_tracer")
+    @patch("haystack.tracing.tracer._auto_configured_opentelemetry_tracer")
+    def test_auto_enable_tracing_with_no_tracer(self, mock_opentelemetry_tracer, mock_datadog_tracer):
+        mock_opentelemetry_tracer.return_value = None
+        mock_datadog_tracer.return_value = None
+        auto_enable_tracing()
+        assert not is_tracing_enabled()
 
 
 class TestTracingContent:

--- a/test/tracing/test_tracer.py
+++ b/test/tracing/test_tracer.py
@@ -149,14 +149,6 @@ class TestAutoEnableTracer:
         tracer = _auto_configured_datadog_tracer()
         assert tracer is None
 
-    @patch("haystack.tracing.tracer._auto_configured_datadog_tracer")
-    @patch("haystack.tracing.tracer._auto_configured_opentelemetry_tracer")
-    def test_auto_enable_tracing_with_no_tracer(self, mock_opentelemetry_tracer, mock_datadog_tracer):
-        mock_opentelemetry_tracer.return_value = None
-        mock_datadog_tracer.return_value = None
-        auto_enable_tracing()
-        assert not is_tracing_enabled()
-
 
 class TestTracingContent:
     def test_set_content_tag_with_default_settings(self, spying_tracer: SpyingTracer) -> None:


### PR DESCRIPTION
### Proposed Changes:

Rewrite some telemetry testing that make `pytest` to not run.

Technically those tests are not causing failures since they're not technically running at all for `pytest`. Thought they might cause other plugins to fail.

Example failure:
```
ImportError:
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning

INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/silvanocerza/Library/Application Support/hatch/env/virtual/haystack-ai/ZmvGEzQW/test/lib/python3.12/site-packages/_pytest/main.py", line 285, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/silvanocerza/Library/Application Support/hatch/env/virtual/haystack-ai/ZmvGEzQW/test/lib/python3.12/site-packages/_pytest/main.py", line 339, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/Users/silvanocerza/Library/Application Support/hatch/env/virtual/haystack-ai/ZmvGEzQW/test/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/silvanocerza/Library/Application Support/hatch/env/virtual/haystack-ai/ZmvGEzQW/test/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/silvanocerza/Library/Application Support/hatch/env/virtual/haystack-ai/ZmvGEzQW/test/lib/python3.12/site-packages/pluggy/_callers.py", line 156, in _multicall
INTERNALERROR>     teardown[0].send(outcome)
INTERNALERROR>   File "/Users/silvanocerza/Library/Application Support/hatch/env/virtual/haystack-ai/ZmvGEzQW/test/lib/python3.12/site-packages/pytest_cov/plugin.py", line 345, in pytest_runtestloop
INTERNALERROR>     from coverage.misc import CoverageException
INTERNALERROR>   File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 1134, in __call__
INTERNALERROR>     return self._mock_call(*args, **kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
INTERNALERROR>     return self._execute_mock_call(*args, **kwargs)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
INTERNALERROR>     raise effect
INTERNALERROR> ImportError
```


### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
