### PR TITLE
feat: allow DocumentJoiner to accept top_k parameter in run method

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -74,12 +74,14 @@ class DocumentJoiner:
         self.sort_by_score = sort_by_score
 
     @component.output_types(documents=List[Document])
-    def run(self, documents: Variadic[List[Document]]):
+    def run(self, documents: Variadic[List[Document]], top_k: Optional[int] = None):
         """
         Joins multiple lists of Documents into a single list depending on the `join_mode` parameter.
 
         :param documents:
             List of list of Documents to be merged.
+        :param top_k:
+            The maximum number of Documents to return. Overrides the instance's `top_k` if provided.
 
         :returns:
             A dictionary with the following keys:
@@ -103,8 +105,11 @@ class DocumentJoiner:
                     "score, so those with score=None were sorted as if they had a score of -infinity."
                 )
 
-        if self.top_k:
+        if top_k:
+            output_documents = output_documents[:top_k]
+        elif self.top_k:
             output_documents = output_documents[: self.top_k]
+
         return {"documents": output_documents}
 
     def _concatenate(self, document_lists):

--- a/releasenotes/notes/fix-documentjoiner-topk-173141a894e5c093.yaml
+++ b/releasenotes/notes/fix-documentjoiner-topk-173141a894e5c093.yaml
@@ -1,0 +1,5 @@
+---
+
+enhancements:
+  - |
+     The `DocumentJoiner` component's `run` method now accepts a `top_k` parameter, allowing users to specify the maximum number of documents to return at query time. This fixes issue #7702.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -115,6 +115,14 @@ class TestDocumentJoiner:
         ]
         assert all(doc.id in expected_document_ids for doc in output["documents"])
 
+    def test_run_with_top_k_in_run_method(self):
+        joiner = DocumentJoiner()
+        documents_1 = [Document(content="a"), Document(content="b"), Document(content="c")]
+        documents_2 = [Document(content="d"), Document(content="e"), Document(content="f")]
+        top_k = 4
+        output = joiner.run([documents_1, documents_2], top_k=top_k)
+        assert len(output["documents"]) == top_k
+
     def test_sort_by_score_without_scores(self, caplog):
         joiner = DocumentJoiner()
         with caplog.at_level(logging.INFO):


### PR DESCRIPTION
### Related Issues

- fixes #7702

### Proposed Changes:

The issue was caused by the `DocumentJoiner` component's `run` method not accepting the `top_k` parameter. This resulted in a `ValueError` when trying to pass `top_k` at query time using `pipe.run("DocumentJoiner": {"top_k": top_k})`.

To solve this issue, I updated the `run` method to accept the `top_k` parameter and use it to limit the number of returned documents. The relevant lines in the `run` method were modified to check for the `top_k` parameter and apply it accordingly.

### How did you test it?

I added a unit test to the `test_document_joiner.py` file to ensure the `top_k` parameter works correctly when provided in the `run` method. The test verifies that the `run` method limits the number of returned documents to the specified `top_k` value.

### Notes for the reviewer

None

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
- I have added a release note file using `reno`