### PR TITLE
feat: LLMEvaluator uses OpenAI API with the the `seed` parameter

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -88,7 +88,7 @@ class LLMEvaluator:
 
         if api == "openai":
             self.generator = OpenAIGenerator(
-                api_key=api_key, generation_kwargs={"response_format": {"type": "json_object"}}
+                api_key=api_key, generation_kwargs={"response_format": {"type": "json_object"}, "seed": 42}
             )
         else:
             raise ValueError(f"Unsupported API: {api}")
@@ -98,8 +98,9 @@ class LLMEvaluator:
 
         component.set_input_types(self, **dict(inputs))
 
+    @staticmethod
     def validate_init_parameters(
-        self, inputs: List[Tuple[str, Type[List]]], outputs: List[str], examples: List[Dict[str, Any]]
+        inputs: List[Tuple[str, Type[List]]], outputs: List[str], examples: List[Dict[str, Any]]
     ):
         """
         Validate the init parameters.

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -101,7 +101,7 @@ class OpenAIGenerator:
         :param timeout:
             Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
         :param max_retries:
-            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            Maximum retries to establish contact with OpenAI if it returns an internal error, if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
 
         """
         self.api_key = api_key


### PR DESCRIPTION
### Related Issues

- fixes [#7713](https://github.com/deepset-ai/haystack/issues/7713)

### Proposed Changes:

- when the LLMEvaluator uses OpenAI API make the call with the the `seed` parameter set, to force more determinism

### How did you test it?

- run several evaluations + LLMEvaluator tests