### PR TITLE
fix: failsafe for non-valid json and failed LLM calls

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -71,7 +71,6 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         api: str = "openai",
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         raise_on_failure: bool = True,
-        progress_bar: bool = True,
     ):
         """
         Creates an instance of ContextRelevanceEvaluator.
@@ -111,7 +110,6 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         self.api = api
         self.api_key = api_key
         self.raise_on_failure = raise_on_failure
-        self.progress_bar = progress_bar
 
         super().__init__(
             instructions=self.instructions,
@@ -121,7 +119,6 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             api=self.api,
             api_key=self.api_key,
             raise_on_failure=self.raise_on_failure,
-            progress_bar=self.progress_bar,
         )
 
     @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -69,6 +69,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         examples: Optional[List[Dict[str, Any]]] = None,
         api: str = "openai",
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
+        raise_on_failure: bool = True,
+        progress_bar: bool = True,
     ):
         """
         Creates an instance of ContextRelevanceEvaluator.
@@ -107,6 +109,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         self.examples = examples or _DEFAULT_EXAMPLES
         self.api = api
         self.api_key = api_key
+        self.raise_on_failure = raise_on_failure
+        self.progress_bar = progress_bar
 
         super().__init__(
             instructions=self.instructions,
@@ -115,6 +119,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             examples=self.examples,
             api=self.api,
             api_key=self.api_key,
+            raise_on_failure=self.raise_on_failure,
+            progress_bar=self.progress_bar,
         )
 
     @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from numpy import isnan
 from numpy import mean as np_mean
 
 from haystack import default_from_dict
@@ -141,7 +142,10 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         result = super().run(questions=questions, contexts=contexts)
 
         # calculate average statement relevance score per query
-        for res in result["results"]:
+        for idx, res in enumerate(result["results"]):
+            if isinstance(res, float) and isnan(res):
+                result["results"][idx] = {"statements": [], "statement_scores": [], "score": 0}
+                continue
             if not res["statements"]:
                 res["score"] = 0
             else:

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from math import isnan
 from typing import Any, Dict, List, Optional
 
-from numpy import isnan
+import numpy as np
 from numpy import mean as np_mean
 
 from haystack import default_from_dict
@@ -96,6 +97,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             Supported APIs: "openai".
         :param api_key:
             The API key.
+        :param raise_on_failure:
+            Whether to raise an exception if the API call fails.
 
         """
         self.instructions = (
@@ -109,7 +112,6 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         self.examples = examples or _DEFAULT_EXAMPLES
         self.api = api
         self.api_key = api_key
-        self.raise_on_failure = raise_on_failure
 
         super().__init__(
             instructions=self.instructions,
@@ -118,7 +120,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             examples=self.examples,
             api=self.api,
             api_key=self.api_key,
-            raise_on_failure=self.raise_on_failure,
+            raise_on_failure=raise_on_failure,
         )
 
     @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])
@@ -140,8 +142,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
 
         # calculate average statement relevance score per query
         for idx, res in enumerate(result["results"]):
-            if isinstance(res, float) and isnan(res):
-                result["results"][idx] = {"statements": [], "statement_scores": [], "score": 0}
+            if not res:
+                result["results"][idx] = {"statements": [], "statement_scores": [], "score": float("nan")}
                 continue
             if not res["statements"]:
                 res["score"] = 0

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -140,7 +140,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
 
         # calculate average statement relevance score per query
         for idx, res in enumerate(result["results"]):
-            if not res:
+            if res is None:
                 result["results"][idx] = {"statements": [], "statement_scores": [], "score": float("nan")}
                 continue
             if not res["statements"]:

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -2,10 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from math import isnan
 from typing import Any, Dict, List, Optional
 
-import numpy as np
 from numpy import mean as np_mean
 
 from haystack import default_from_dict

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -4,6 +4,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from numpy import isnan
 from numpy import mean as np_mean
 
 from haystack import default_from_dict
@@ -159,7 +160,10 @@ class FaithfulnessEvaluator(LLMEvaluator):
         result = super().run(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
 
         # calculate average statement faithfulness score per query
-        for res in result["results"]:
+        for idx, res in enumerate(result["results"]):
+            if isinstance(res, float) and isnan(res):
+                result["results"][idx] = {"statements": [], "statement_scores": [], "score": 0}
+                continue
             if not res["statements"]:
                 res["score"] = 0
             else:

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -85,7 +85,6 @@ class FaithfulnessEvaluator(LLMEvaluator):
         api: str = "openai",
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         raise_on_failure: bool = True,
-        progress_bar: bool = True,
     ):
         """
         Creates an instance of FaithfulnessEvaluator.
@@ -127,7 +126,6 @@ class FaithfulnessEvaluator(LLMEvaluator):
         self.api = api
         self.api_key = api_key
         self.raise_on_failure = raise_on_failure
-        self.progress_bar = progress_bar
 
         super().__init__(
             instructions=self.instructions,
@@ -137,7 +135,6 @@ class FaithfulnessEvaluator(LLMEvaluator):
             api=self.api,
             api_key=self.api_key,
             raise_on_failure=self.raise_on_failure,
-            progress_bar=self.progress_bar,
         )
 
     @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -158,7 +158,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
 
         # calculate average statement faithfulness score per query
         for idx, res in enumerate(result["results"]):
-            if not res:
+            if res is None:
                 result["results"][idx] = {"statements": [], "statement_scores": [], "score": float("nan")}
                 continue
             if not res["statements"]:

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from math import isnan
 from typing import Any, Dict, List, Optional
 
 from numpy import mean as np_mean

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -83,6 +83,8 @@ class FaithfulnessEvaluator(LLMEvaluator):
         examples: Optional[List[Dict[str, Any]]] = None,
         api: str = "openai",
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
+        raise_on_failure: bool = True,
+        progress_bar: bool = True,
     ):
         """
         Creates an instance of FaithfulnessEvaluator.
@@ -123,6 +125,8 @@ class FaithfulnessEvaluator(LLMEvaluator):
         self.examples = examples or _DEFAULT_EXAMPLES
         self.api = api
         self.api_key = api_key
+        self.raise_on_failure = raise_on_failure
+        self.progress_bar = progress_bar
 
         super().__init__(
             instructions=self.instructions,
@@ -131,6 +135,8 @@ class FaithfulnessEvaluator(LLMEvaluator):
             examples=self.examples,
             api=self.api,
             api_key=self.api_key,
+            raise_on_failure=self.raise_on_failure,
+            progress_bar=self.progress_bar,
         )
 
     @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -168,10 +168,10 @@ class LLMEvaluator:
         Run the LLM evaluator.
 
         Running the LLM evaluator is done within a try-except block to catch any exceptions that may
-        occur during the run. If an exception occurs, the method will return a np.nan value for the result.
+        occur during the run. If an exception occurs, the method will return a `np.nan` value for the result.
 
-        Likewise, if the output is not a valid JSON with the expected keys, the method will return a np.nan value
-        for the result.
+        Likewise, if the output is not a valid JSON or does not have the  expected keys, the method will return a
+        `np.nan` value for the result.
 
         :param inputs:
             The input values to evaluate. The keys are the input names and the values are lists of input values.

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -4,7 +4,7 @@
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
 from warnings import warn
 
 import numpy as np

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -6,8 +6,6 @@ import json
 from typing import Any, Dict, List, Tuple, Type
 from warnings import warn
 
-import numpy as np
-
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.builders import PromptBuilder
 from haystack.components.generators import OpenAIGenerator

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import logging
 from typing import Any, Dict, List, Tuple, Type
 from warnings import warn
 

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Tuple, Type
 from warnings import warn
 
 import numpy as np
-from tqdm import tqdm
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.builders import PromptBuilder

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -55,7 +55,6 @@ class LLMEvaluator:
         outputs: List[str],
         examples: List[Dict[str, Any]],
         raise_on_failure: bool = True,
-        progress_bar: bool = True,
         *,
         api: str = "openai",
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
@@ -87,7 +86,6 @@ class LLMEvaluator:
         """
         self.validate_init_parameters(inputs, outputs, examples)
         self.raise_on_failure = raise_on_failure
-        self.progress_bar = progress_bar
         self.instructions = instructions
         self.inputs = inputs
         self.outputs = outputs
@@ -189,7 +187,7 @@ class LLMEvaluator:
 
         results = []
         errors = 0
-        for input_names_to_values in tqdm(list_of_input_names_to_values, disable=not self.progress_bar):
+        for input_names_to_values in list_of_input_names_to_values:
             prompt = self.builder.run(**input_names_to_values)
             try:
                 result = self.generator.run(prompt=prompt["prompt"])

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -170,7 +170,11 @@ class LLMEvaluator:
         """
         Run the LLM evaluator.
 
-        # ToDo: add more details about the behavior of this method and it's exceptions
+        Running the LLM evaluator is done within a try-except block to catch any exceptions that may
+        occur during the run. If an exception occurs, the method will return a np.nan value for the result.
+
+        Likewise, if the output is not a valid JSON with the expected keys, the method will return a np.nan value
+        for the result.
 
         :param inputs:
             The input values to evaluate. The keys are the input names and the values are lists of input values.

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -336,16 +336,15 @@ class LLMEvaluator:
         """
         try:
             parsed_output = json.loads(received)
-
-            if not all(output in parsed_output for output in expected):
-                msg = f"Expected response from LLM evaluator to be JSON with keys {expected}, got {received}."
-                if self.raise_on_failure:
-                    raise ValueError(msg)
-                warn(msg)
-                return False
-
         except json.JSONDecodeError:
             msg = "Response from LLM evaluator is not a valid JSON."
+            if self.raise_on_failure:
+                raise ValueError(msg)
+            warn(msg)
+            return False
+
+        if not all(output in parsed_output for output in expected):
+            msg = f"Expected response from LLM evaluator to be JSON with keys {expected}, got {received}."
             if self.raise_on_failure:
                 raise ValueError(msg)
             warn(msg)

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 from warnings import warn
 
 from haystack import component, default_from_dict, default_to_dict
@@ -177,7 +177,7 @@ class LLMEvaluator:
         input_names, values = inputs.keys(), list(zip(*inputs.values()))
         list_of_input_names_to_values = [dict(zip(input_names, v)) for v in values]
 
-        results = []
+        results: List[Optional[Dict[str, Any]]] = []
         errors = 0
         for input_names_to_values in list_of_input_names_to_values:
             prompt = self.builder.run(**input_names_to_values)

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -57,7 +57,7 @@ class LLMEvaluator:
         inputs: List[Tuple[str, Type[List]]],
         outputs: List[str],
         examples: List[Dict[str, Any]],
-        raises_on_failure: bool = True,
+        raise_on_failure: bool = True,
         progress_bar: bool = True,
         *,
         api: str = "openai",
@@ -89,7 +89,7 @@ class LLMEvaluator:
 
         """
         self.validate_init_parameters(inputs, outputs, examples)
-        self.raise_on_failure = raises_on_failure
+        self.raise_on_failure = raise_on_failure
         self.progress_bar = progress_bar
         self.instructions = instructions
         self.inputs = inputs

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -175,6 +175,9 @@ class LLMEvaluator:
             Each result is a dictionary containing the keys as defined in the `outputs` parameter of the LLMEvaluator
             and the evaluation results as the values. If an exception occurs for a particular input value, the result
             will be `None` for that entry.
+        :raises ValueError:
+            Only in the case that  `raise_on_failure` is set to True and the received inputs are not lists or have
+            different lengths, or if the output is not a valid JSON or doesn't contain the expected keys.
         """
         self.validate_input_parameters(dict(self.inputs), inputs)
 

--- a/releasenotes/notes/add-failsafe-for-LLM-based-evaluators-34cdc183ab545315.yaml
+++ b/releasenotes/notes/add-failsafe-for-LLM-based-evaluators-34cdc183ab545315.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    If an LLM-based evaluator (e.g., `Faithfulness` or `ContextRelevance`) is initialised with `raise_on_failure=False`, and if a call to an LLM fails or an LLM outputs an invalid JSON, it returns `np.nan` and continues the evaluation.
+    If an LLM-based evaluator (e.g., `Faithfulness` or `ContextRelevance`) is initialised with `raise_on_failure=False`, and if a call to an LLM fails or an LLM outputs an invalid JSON, the score of the sample is set to `NaN` instead of raising an exception.
     The user is notified with a warning indicating the number of requests that failed.

--- a/releasenotes/notes/add-failsafe-for-LLM-based-evaluators-34cdc183ab545315.yaml
+++ b/releasenotes/notes/add-failsafe-for-LLM-based-evaluators-34cdc183ab545315.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    If an LLM-based evaluator (e.g., `Faithfulness` or `ContextRelevance`) is initialised with `raise_on_failure=False`, and if a call to an LLM fails or an LLM outputs an invalid JSON, it returns `np.nan` and continues the evaluation.
+    The user is notified with a warning indicating the number of requests that failed.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -4,6 +4,8 @@
 import os
 from typing import List
 
+import math
+
 import pytest
 
 from haystack.components.evaluators import ContextRelevanceEvaluator
@@ -186,14 +188,17 @@ class TestContextRelevanceEvaluator:
             ],
         ]
         results = component.run(questions=questions, contexts=contexts)
-        assert results == {
-            "individual_scores": [1, 0],
-            "results": [
-                {"score": 1, "statement_scores": [1, 1], "statements": ["c", "d"]},
-                {"score": 0, "statement_scores": [], "statements": []},
-            ],
-            "score": 0.5,
-        }
+
+        assert math.isnan(results["score"])
+
+        assert results["individual_scores"][0] == 1.0
+        assert math.isnan(results["individual_scores"][1])
+
+        assert results["results"][0] == {"statements": ["c", "d"], "statement_scores": [1, 1], "score": 1.0}
+
+        assert results["results"][1]["statements"] == []
+        assert results["results"][1]["statement_scores"] == []
+        assert math.isnan(results["results"][1]["score"])
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -161,7 +161,7 @@ class TestContextRelevanceEvaluator:
 
     def test_run_handles_nan(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        component = ContextRelevanceEvaluator(progress_bar=False, raise_on_failure=False)
+        component = ContextRelevanceEvaluator(raise_on_failure=False)
 
         def generator_run(self, *args, **kwargs):
             if "Python" in kwargs["prompt"]:

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -161,7 +161,7 @@ class TestContextRelevanceEvaluator:
         with pytest.raises(TypeError, match="missing 2 required positional arguments"):
             component.run()
 
-    def test_run_handles_nan(self, monkeypatch):
+    def test_run_returns_nan_raise_on_failure_false(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator(raise_on_failure=False)
 

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -4,6 +4,7 @@
 import os
 from typing import List
 
+import numpy as np
 import pytest
 
 from haystack.components.evaluators import FaithfulnessEvaluator
@@ -190,6 +191,46 @@ class TestFaithfulnessEvaluator:
         component = FaithfulnessEvaluator()
         with pytest.raises(TypeError, match="missing 3 required positional arguments"):
             component.run()
+
+    def test_run_handles_nan(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = FaithfulnessEvaluator(progress_bar=False, raise_on_failure=False)
+
+        def generator_run(self, *args, **kwargs):
+            if "Python" in kwargs["prompt"]:
+                raise Exception("OpenAI API request failed.")
+            else:
+                return {"replies": ['{"statements": ["c", "d"], "statement_scores": [1, 1]}']}
+
+        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+
+        questions = ["Which is the most popular global sport?", "Who created the Python language?"]
+        contexts = [
+            [
+                "The popularity of sports can be measured in various ways, including TV viewership, social media "
+                "presence, number of participants, and economic impact. Football is undoubtedly the world's most "
+                "popular sport with major events like the FIFA World Cup and sports personalities like Ronaldo and "
+                "Messi, drawing a followership of more than 4 billion people."
+            ],
+            [
+                "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming "
+                "language. Its design philosophy emphasizes code readability, and its language constructs aim to help "
+                "programmers write clear, logical code for both small and large-scale software projects."
+            ],
+        ]
+        predicted_answers = [
+            "Football is the most popular sport with around 4 billion followers worldwide.",
+            "Guido van Rossum.",
+        ]
+        results = component.run(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
+        assert results == {
+            "individual_scores": [1, 0],
+            "results": [
+                {"score": 1, "statement_scores": [1, 1], "statements": ["c", "d"]},
+                {"score": 0, "statement_scores": [], "statements": []},
+            ],
+            "score": 0.5,
+        }
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -223,13 +223,14 @@ class TestFaithfulnessEvaluator:
             "Guido van Rossum.",
         ]
         results = component.run(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
+
         assert results == {
-            "individual_scores": [1, 0],
+            "individual_scores": [1.0, float(nan)],
             "results": [
-                {"score": 1, "statement_scores": [1, 1], "statements": ["c", "d"]},
-                {"score": 0, "statement_scores": [], "statements": []},
+                {"statements": ["c", "d"], "statement_scores": [1, 1], "score": 1.0},
+                {"statements": [], "statement_scores": [], "score": float(nan)},
             ],
-            "score": 0.5,
+            "score": float(nan),
         }
 
     @pytest.mark.skipif(

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -193,7 +193,7 @@ class TestFaithfulnessEvaluator:
         with pytest.raises(TypeError, match="missing 3 required positional arguments"):
             component.run()
 
-    def test_run_handles_nan(self, monkeypatch):
+    def test_run_returns_nan_raise_on_failure_false(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator(raise_on_failure=False)
 

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -194,7 +194,7 @@ class TestFaithfulnessEvaluator:
 
     def test_run_handles_nan(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        component = FaithfulnessEvaluator(progress_bar=False, raise_on_failure=False)
+        component = FaithfulnessEvaluator(raise_on_failure=False)
 
         def generator_run(self, *args, **kwargs):
             if "Python" in kwargs["prompt"]:

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+import math
 from typing import List
 
 import numpy as np
@@ -224,14 +225,16 @@ class TestFaithfulnessEvaluator:
         ]
         results = component.run(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
 
-        assert results == {
-            "individual_scores": [1.0, float(nan)],
-            "results": [
-                {"statements": ["c", "d"], "statement_scores": [1, 1], "score": 1.0},
-                {"statements": [], "statement_scores": [], "score": float(nan)},
-            ],
-            "score": float(nan),
-        }
+        assert math.isnan(results["score"])
+
+        assert results["individual_scores"][0] == 1.0
+        assert math.isnan(results["individual_scores"][1])
+
+        assert results["results"][0] == {"statements": ["c", "d"], "statement_scores": [1, 1], "score": 1.0}
+
+        assert results["results"][1]["statements"] == []
+        assert results["results"][1]["statement_scores"] == []
+        assert math.isnan(results["results"][1]["score"])
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -392,7 +392,7 @@ class TestLLMEvaluator:
             examples=[
                 {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
             ],
-            raises_on_failure=False,
+            raise_on_failure=False,
         )
         result = component.validate_outputs(expected=["score"], received="some_invalid_json_output")
         assert np.isnan(result)

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -378,10 +378,12 @@ class TestLLMEvaluator:
             ],
         )
         with pytest.raises(ValueError):
-            component.is_valid_json(expected=["score", "another_expected_output"], received='{"score": 1.0}')
+            component.is_valid_json_and_has_expected_keys(
+                expected=["score", "another_expected_output"], received='{"score": 1.0}'
+            )
 
         with pytest.raises(ValueError):
-            component.is_valid_json(expected=["score"], received='{"wrong_name": 1.0}')
+            component.is_valid_json_and_has_expected_keys(expected=["score"], received='{"wrong_name": 1.0}')
 
     def test_output_invalid_json_raise_on_failure_false(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
@@ -394,7 +396,10 @@ class TestLLMEvaluator:
             ],
             raise_on_failure=False,
         )
-        assert component.is_valid_json(expected=["score"], received="some_invalid_json_output") is False
+        assert (
+            component.is_valid_json_and_has_expected_keys(expected=["score"], received="some_invalid_json_output")
+            is False
+        )
 
     def test_output_invalid_json_raise_on_failure_true(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
@@ -407,7 +412,7 @@ class TestLLMEvaluator:
             ],
         )
         with pytest.raises(ValueError):
-            component.is_valid_json(expected=["score"], received="some_invalid_json_output")
+            component.is_valid_json_and_has_expected_keys(expected=["score"], received="some_invalid_json_output")
 
     def test_unsupported_api(self):
         with pytest.raises(ValueError):

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -378,10 +378,10 @@ class TestLLMEvaluator:
             ],
         )
         with pytest.raises(ValueError):
-            component.validate_outputs(expected=["score", "another_expected_output"], received='{"score": 1.0}')
+            component.is_valid_json(expected=["score", "another_expected_output"], received='{"score": 1.0}')
 
         with pytest.raises(ValueError):
-            component.validate_outputs(expected=["score"], received='{"wrong_name": 1.0}')
+            component.is_valid_json(expected=["score"], received='{"wrong_name": 1.0}')
 
     def test_output_invalid_json_raise_on_failure_false(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
@@ -394,8 +394,7 @@ class TestLLMEvaluator:
             ],
             raise_on_failure=False,
         )
-        result = component.validate_outputs(expected=["score"], received="some_invalid_json_output")
-        assert np.isnan(result)
+        assert component.is_valid_json(expected=["score"], received="some_invalid_json_output") is False
 
     def test_output_invalid_json_raise_on_failure_true(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
@@ -408,7 +407,7 @@ class TestLLMEvaluator:
             ],
         )
         with pytest.raises(ValueError):
-            component.validate_outputs(expected=["score"], received="some_invalid_json_output")
+            component.is_valid_json(expected=["score"], received="some_invalid_json_output")
 
     def test_unsupported_api(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Related Issues

- fixes [#7712](https://github.com/deepset-ai/haystack/issues/7712)

### Proposed Changes:

The LLM-based evaluators can fail due to:
- an error when making a call the LLM 
- an output returned by the LLM which is an invalid JSON

This PR adds safeguards to LLM-based evaluators:
- If an LLM-based evaluator (e.g., `Faithfulness` or `ContextRelevance`) is initialised with `raise_on_failure=False`, and if a call to an LLM fails or an LLM outputs an invalid JSON, it returns `np.nan` and continues the evaluation. 
- The user being notified with a warning, and with the number of requests that failed.