### PR TITLE
fix: make SerperDevWebSearch more robust

### DIFF
--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -124,7 +124,7 @@ class SerperDevWebSearch:
 
         # we get the snippet from the json result and put it in the content field of the document
         organic = [
-            Document(meta={k: v for k, v in d.items() if k != "snippet"}, content=d["snippet"])
+            Document(meta={k: v for k, v in d.items() if k != "snippet"}, content=d.get("snippet"))
             for d in json_result["organic"]
         ]
 

--- a/releasenotes/notes/serperdev-more-robust-229ba25c8fc9306d.yaml
+++ b/releasenotes/notes/serperdev-more-robust-229ba25c8fc9306d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Make the `SerperDevWebSearch` more robust when `snippet` is not present in the request response.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-tutorials/actions/runs/9187125815/job/25264156611

### Proposed Changes:

Do not assume `snippet` is always present in Serper's response

### How did you test it?

Unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
