### PR TITLE
feat: Add component SimilarDocumentsRetriever

### DIFF
--- a/haystack/components/retrievers/__init__.py
+++ b/haystack/components/retrievers/__init__.py
@@ -5,5 +5,6 @@
 from haystack.components.retrievers.filter_retriever import FilterRetriever
 from haystack.components.retrievers.in_memory.bm25_retriever import InMemoryBM25Retriever
 from haystack.components.retrievers.in_memory.embedding_retriever import InMemoryEmbeddingRetriever
+from haystack.components.retrievers.similar_documents_retriever import SimilarDocumentsRetriever
 
-__all__ = ["FilterRetriever", "InMemoryEmbeddingRetriever", "InMemoryBM25Retriever"]
+__all__ = ["FilterRetriever", "InMemoryEmbeddingRetriever", "InMemoryBM25Retriever", "SimilarDocumentsRetriever"]

--- a/haystack/components/retrievers/similar_documents_retriever.py
+++ b/haystack/components/retrievers/similar_documents_retriever.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+from typing import Any, Dict, List
+
+from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class SimilarDocumentsRetriever:
+    """
+    Retrieves similar documents for each of the given documents for each preset retrievers.
+
+    Usage example:
+    ```python
+    from haystack import Document
+    from haystack.components.retrievers import SimilarDocumentsRetriever
+    from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+    docs = [
+        Document(content="Javascript is a popular programming language"),
+        Document(content="Python is a popular programming language"),
+        Document(content="A chromosome is a package of DNA"),
+        Document(content="DNA carries genetic information"),
+    ]
+
+    doc_store = InMemoryDocumentStore()
+    doc_store.write_documents(docs)
+    retriever = InMemoryBM25Retriever(doc_store, top_k=1)
+    sim_docs_retriever = SimilarDocumentsRetriever(retrievers=[retriever])
+
+    result = sim_docs_retriever.run(
+        documents=[
+            Document(content="A DNA document"),
+            Document(content="A programming document"),
+        ]
+    )
+
+    print(result["document_lists"])
+    # [
+    #   [Document(..., content: 'DNA carries genetic information', ...)],
+    #   [Document(..., content: 'Javascript is a popular programming language', ...)]
+    # ]
+    ```
+    """
+
+    def __init__(self, retrievers: List):
+        """
+        Create the SimilarDocumentsRetriever component.
+
+        :param retrievers:
+            List of Retrievers to be used to retrieve similar documents.
+        """
+        if len(retrievers) == 0:
+            raise ValueError("Empty retrievers list provided")
+        self.retrievers = retrievers
+
+    @component.output_types(document_lists=List[List[Document]])
+    def run(self, documents: List[Document]):
+        """
+        Run the InMemoryBM25Retriever on the given input data.
+
+        :param documents:
+            List of Document for which to find similar documents.
+            Every retriever is run for every document provided.
+        """
+        retrieved_docs = []
+        for r in self.retrievers:
+            for d in documents:
+                retrieved_docs.append(r.run(query=d.content)["documents"])
+        return {"document_lists": retrieved_docs}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SimilarDocumentsRetriever":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        :returns:
+            The deserialized component.
+        """
+        init_params = data.get("init_parameters", {})
+        if "retrievers" not in init_params:
+            raise DeserializationError("Missing 'retrievers' in serialization data")
+        retrievers = []
+        for retriever_params in init_params["retrievers"]:
+            if "type" not in retriever_params:
+                raise DeserializationError("Missing 'type' in retriever's serialization data")
+            try:
+                module_name, type_ = retriever_params["type"].rsplit(".", 1)
+                logger.debug("Trying to import module '{module_name}'", module_name=module_name)
+                module = importlib.import_module(module_name)
+            except (ImportError, DeserializationError) as e:
+                raise DeserializationError(
+                    f"DocumentStore of type '{retriever_params['type']}' not correctly imported"
+                ) from e
+            retriever_class = getattr(module, type_)
+            retrievers.append(retriever_class.from_dict(retriever_params))
+
+        data["init_parameters"]["retrievers"] = retrievers
+
+        return default_from_dict(cls, data)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        retrievers = [r.to_dict() for r in self.retrievers]
+        return default_to_dict(self, retrievers=retrievers)

--- a/releasenotes/notes/add-similar-docs-retriever-c252b23c0eadd30f.yaml
+++ b/releasenotes/notes/add-similar-docs-retriever-c252b23c0eadd30f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add a new component `SimilarDocumentsRetriever`.
+    This component retrieves similar documents for each of the given documents for each preset retrievers. So, in a way it's simply a wrapper around multiple retrievers to be run on multiple documents as queries.

--- a/test/components/retrievers/test_similar_documents_retriever.py
+++ b/test/components/retrievers/test_similar_documents_retriever.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict, Any, List
+
+import pytest
+
+from haystack import Pipeline, DeserializationError
+from haystack.testing.factory import document_store_class
+from haystack.components.retrievers.similar_documents_retriever import SimilarDocumentsRetriever
+from haystack.dataclasses import Document
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
+
+
+@pytest.fixture()
+def sample_docs():
+    programming_docs = [
+        Document(content="Javascript is a popular programming language"),
+        Document(content="Python is a popular programming language"),
+    ]
+    dna_docs = [
+        Document(content="A chromosome is a package of DNA"),
+        Document(content="DNA carries genetic information"),
+    ]
+    all_docs = programming_docs + dna_docs
+    return {"programming_docs": programming_docs, "dna_docs": dna_docs, "all_docs": all_docs}
+
+
+@pytest.fixture()
+def sample_document_store(sample_docs):
+    doc_store = InMemoryDocumentStore()
+    doc_store.write_documents(sample_docs["all_docs"])
+    return doc_store
+
+
+@pytest.fixture()
+def mock_retrievers(sample_document_store):
+    MyFakeRetriever1 = document_store_class("MyFakeRetriever1", bases=(InMemoryBM25Retriever,))
+    retriever1 = MyFakeRetriever1(sample_document_store)
+    retriever1.to_dict = lambda: {"type": "MyFakeRetriever1", "init_parameters": {}}
+
+    MyFakeRetriever2 = document_store_class("MyFakeRetriever2", bases=(InMemoryBM25Retriever,))
+    retriever2 = MyFakeRetriever2(sample_document_store)
+    retriever2.to_dict = lambda: {"type": "MyFakeRetriever2", "init_parameters": {}}
+
+    return [retriever1, retriever2]
+
+
+class TestSimilarDocumentsRetriever:
+    @classmethod
+    def _documents_equal(cls, docs1: List[Document], docs2: List[Document]) -> bool:
+        # Order doesn't matter; we sort before comparing
+        docs1.sort(key=lambda x: x.id)
+        docs2.sort(key=lambda x: x.id)
+        return docs1 == docs2
+
+    def test_init_empty_retrievers(self):
+        with pytest.raises(ValueError):
+            SimilarDocumentsRetriever(retrievers=[])
+
+    def test_to_dict(self, mock_retrievers):
+        component = SimilarDocumentsRetriever(retrievers=mock_retrievers)
+
+        data = component.to_dict()
+        assert data == {
+            "type": "haystack.components.retrievers.similar_documents_retriever.SimilarDocumentsRetriever",
+            "init_parameters": {
+                "retrievers": [
+                    {"type": "MyFakeRetriever1", "init_parameters": {}},
+                    {"type": "MyFakeRetriever2", "init_parameters": {}},
+                ]
+            },
+        }
+
+    def test_from_dict(self):
+        data = {
+            "type": "haystack.components.retrievers.similar_documents_retriever.SimilarDocumentsRetriever",
+            "init_parameters": {
+                "retrievers": [
+                    {
+                        "type": "haystack.components.retrievers.in_memory.bm25_retriever.InMemoryBM25Retriever",
+                        "init_parameters": {
+                            "document_store": {
+                                "type": "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
+                            }
+                        },
+                    },
+                    {
+                        "type": "haystack.components.retrievers.in_memory.bm25_retriever.InMemoryBM25Retriever",
+                        "init_parameters": {
+                            "document_store": {
+                                "type": "haystack.document_stores.in_memory.document_store.InMemoryDocumentStore"
+                            }
+                        },
+                    },
+                ]
+            },
+        }
+        component = SimilarDocumentsRetriever.from_dict(data)
+        assert isinstance(component.retrievers[0], InMemoryBM25Retriever)
+        assert len(component.retrievers) == 2
+
+    def test_from_dict_without_retrievers(self):
+        data = {
+            "type": "haystack.components.retrievers.similar_documents_retriever.SimilarDocumentsRetriever",
+            "init_parameters": {},
+        }
+        with pytest.raises(DeserializationError, match="Missing 'retrievers' in serialization data"):
+            SimilarDocumentsRetriever.from_dict(data)
+
+    def test_from_dict_without_retriever_type(self):
+        data = {
+            "type": "haystack.components.retrievers.similar_documents_retriever.SimilarDocumentsRetriever",
+            "init_parameters": {"retrievers": [{"init_parameters": {}}]},
+        }
+        with pytest.raises(DeserializationError, match="Missing 'type' in retriever's serialization data"):
+            SimilarDocumentsRetriever.from_dict(data)
+
+    def test_from_dict_nonexisting_retriever(self):
+        data = {
+            "type": "haystack.components.retrievers.similar_documents_retriever.SimilarDocumentsRetriever",
+            "init_parameters": {"retrievers": [{"type": "Nonexisting.Retriever", "init_parameters": {}}]},
+        }
+        with pytest.raises(DeserializationError):
+            SimilarDocumentsRetriever.from_dict(data)
+
+    @pytest.mark.parametrize("r1_top_k, r2_top_k", [(1, 1), (2, 1), (2, 2)])
+    def test_retriever_valid_run(self, sample_document_store, r1_top_k, r2_top_k):
+        retriever1 = InMemoryBM25Retriever(document_store=sample_document_store, top_k=r1_top_k)
+        retriever2 = InMemoryBM25Retriever(document_store=sample_document_store, top_k=r2_top_k)
+        similar_docs_retriever = SimilarDocumentsRetriever(retrievers=[retriever1, retriever2])
+
+        result = similar_docs_retriever.run(
+            [Document(content="A document about DNA"), Document(content="Java is a popular programming language")]
+        )
+
+        assert "document_lists" in result
+        doc_lists = result["document_lists"]
+
+        # [retriever1-doc1, retriever1-doc2, retriever2-doc1, retriever2-doc2]
+        assert len(doc_lists) == 4
+
+        assert len(doc_lists[0]) == r1_top_k
+        assert all("DNA" in d.content for d in doc_lists[0])
+
+        assert len(doc_lists[1]) == r1_top_k
+        assert all("programming" in d.content for d in doc_lists[1])
+
+        assert len(doc_lists[2]) == r2_top_k
+        assert all("DNA" in d.content for d in doc_lists[2])
+
+        assert len(doc_lists[3]) == r2_top_k
+        assert all("programming" in d.content for d in doc_lists[3])
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("r1_top_k, r2_top_k", [(1, 1), (2, 1), (2, 2)])
+    def test_retriever_in_pipeline_valid_run(self, sample_document_store, r1_top_k, r2_top_k):
+        retriever1 = InMemoryBM25Retriever(document_store=sample_document_store, top_k=r1_top_k)
+        retriever2 = InMemoryBM25Retriever(document_store=sample_document_store, top_k=r2_top_k)
+        similar_docs_retriever = SimilarDocumentsRetriever(retrievers=[retriever1, retriever2])
+
+        pipeline = Pipeline()
+        pipeline.add_component("sim_docs_retriever", similar_docs_retriever)
+
+        result: Dict[str, Any] = pipeline.run(
+            data={
+                "documents": [
+                    Document(content="A document about DNA"),
+                    Document(content="Java is a popular programming language"),
+                ]
+            }
+        )
+
+        assert result
+        assert "sim_docs_retriever" in result
+
+        sim_docs_result = result["sim_docs_retriever"]
+        assert "document_lists" in sim_docs_result
+        doc_lists = sim_docs_result["document_lists"]
+
+        # [retriever1-doc1, retriever1-doc2, retriever2-doc1, retriever2-doc2]
+        assert len(doc_lists) == 4
+
+        assert len(doc_lists[0]) == r1_top_k
+        assert all("DNA" in d.content for d in doc_lists[0])
+
+        assert len(doc_lists[1]) == r1_top_k
+        assert all("programming" in d.content for d in doc_lists[1])
+
+        assert len(doc_lists[2]) == r2_top_k
+        assert all("DNA" in d.content for d in doc_lists[2])
+
+        assert len(doc_lists[3]) == r2_top_k
+        assert all("programming" in d.content for d in doc_lists[3])


### PR DESCRIPTION
### Related Issues

Evolved from #5629  and #5666 

### Proposed Changes:

Addition of a new component `SimilarDocumentsRetriever`. 

This component retrieves similar documents for each of the given documents for each preset retrievers. So, in a way it's simply a wrapper around multiple retrievers to be run on multiple documents as queries.

Usage Example:

  ```python
  from haystack import Document
  from haystack.components.retrievers import SimilarDocumentsRetriever
  from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
  from haystack.document_stores.in_memory import InMemoryDocumentStore

  docs = [
      Document(content="Javascript is a popular programming language"),
      Document(content="Python is a popular programming language"),
      Document(content="A chromosome is a package of DNA"),
      Document(content="DNA carries genetic information"),
  ]

  doc_store = InMemoryDocumentStore()
  doc_store.write_documents(docs)
  retriever = InMemoryBM25Retriever(doc_store, top_k=1)
  sim_docs_retriever = SimilarDocumentsRetriever(retrievers=[retriever])

  result = sim_docs_retriever.run(
      documents=[
          Document(content="A DNA document"),
          Document(content="A programming document"),
      ]
  )

  print(result["document_lists"])
  # [
  #   [Document(..., content: 'DNA carries genetic information', ...)],
  #   [Document(..., content: 'Javascript is a popular programming language', ...)]
  # ]
  ```

#### Background
It was conceptualized when considering the addition of `FileSimilarityRetriever` [here](https://github.com/deepset-ai/haystack/pull/5629#issuecomment-2104430231). There, it's one of the components that come together to provide a file similarity functionality. Route 3 in the [demonstrative Colab Notebook](https://colab.research.google.com/drive/1WlWyDb_O73jcje0zUayv6Xh-iFamkTHm?usp=sharing#scrollTo=skfIHOlxHKoL) there.

But this component by itself should possibly be useful for other use-cases too. E.g. finding similar sets of documents to the current output set from a DocSearch pipeline.

### How did you test it?

Mostly unit tests, one integration test.

### Notes for the reviewer

Open to feedback at all levels, including if there could be another way to have this functionality. 

Some concrete big and small things I'm not sure of:

**Should this be reformulated as a different component?**

- Should it be more clear from the naming that it's a wrapper for retriever(s) and not itself a retriever?
- Should this be generalized a bit more? E.g. Instead of just `List[Document]`, also accept `List[str]` for added flexibility. And rename component to something like `BatchedRetriever` or `GroupRetriever` or `MultiRetriever`, although each name seems misleading in their own way.

Related to the last point, I'm a bit unsure what's the policy for flexible input and output types right now? E.g. accepting `List[Document]` as well as `List[str]` or output format (`List[List[Document]]` vs `List[List[List[Document]]]` or something else) based on a preset init argument.

Minor: Unsure what the type hint for the init argument `retrievers` should be? As (afaik) there is no general Retriever interface. Right now it's just `List`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
