### PR TITLE
test: Add matrix for test env

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,34 +25,34 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "${{ env.PYTHON_VERSION }}"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
 
-    - name: Install Hatch
-      run: pip install hatch==${{ env.HATCH_VERSION }}
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
-    - name: Run tests
-      run: hatch run test:e2e
+      - name: Run tests
+        run: hatch run +python=${{ env.PYTHON_VERSION }} test:e2e
 
-    - name: Send event to Datadog
-      if: failure() && github.event_name == 'schedule'
-      uses: masci/datadog@v1
-      with:
-        api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
-        api-url: https://api.datadoghq.eu
-        events: |
-          - title: "${{ github.workflow }} workflow"
-            text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
-            alert_type: "error"
-            source_type_name: "Github"
-            host: ${{ github.repository_owner }}
-            tags:
-              - "project:${{ github.repository }}"
-              - "job:${{ github.job }}"
-              - "run_id:${{ github.run_id }}"
-              - "workflow:${{ github.workflow }}"
-              - "branch:${{ github.ref_name }}"
-              - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send event to Datadog
+        if: failure() && github.event_name == 'schedule'
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.workflow }} workflow"
+              text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
+              alert_type: "error"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -53,7 +53,7 @@ jobs:
         if: steps.files.outputs.any_changed == 'true'
         run: |
           mkdir .mypy_cache
-          hatch run test:types ${{ steps.files.outputs.all_changed_files }}
+          hatch run +python=${{ env.PYTHON_VERSION }} test:types ${{ steps.files.outputs.all_changed_files }}
 
   pylint:
     runs-on: ubuntu-latest
@@ -82,4 +82,4 @@ jobs:
       - name: Pylint
         if: steps.files.outputs.any_changed == 'true'
         run: |
-          hatch run test:lint ${{ steps.files.outputs.all_changed_files }}
+          hatch run +python=${{ env.PYTHON_VERSION }} test:lint ${{ steps.files.outputs.all_changed_files }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install dependencies
         # To actually install and sync the dependencies
-        run: hatch run test:pip list
+        run: hatch run +python=${{ env.PYTHON_VERSION }} test:pip list
 
       - uses: actions/cache@v4
         with:
@@ -131,7 +131,7 @@ jobs:
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
-        run: hatch run test:unit
+        run: hatch run +python=${{ env.PYTHON_VERSION }} test:unit
 
       - name: Coveralls
         # We upload only coverage for ubuntu as handling both os
@@ -200,7 +200,7 @@ jobs:
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
-        run: hatch run test:integration
+        run: hatch run +python=${{ env.PYTHON_VERSION }} test:integration
 
       - name: Calculate alert data
         id: calculator
@@ -258,7 +258,7 @@ jobs:
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
-        run: hatch run test:integration-mac
+        run: hatch run +python=${{ env.PYTHON_VERSION }} test:integration-mac
 
       - name: Calculate alert data
         id: calculator
@@ -309,7 +309,7 @@ jobs:
           key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
-        run: hatch run test:integration-windows
+        run: hatch run +python=${{ env.PYTHON_VERSION }} test:integration-windows
 
       - name: Calculate alert data
         id: calculator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ dependencies = [
   "black[jupyter]~=23.0",
 ]
 
+[[tool.hatch.envs.test.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
 [tool.hatch.envs.default.scripts]
 format = "black ."
 format-check = "black --check ."


### PR DESCRIPTION
### Proposed Changes:

Add a matrix for the `test` env so we can easily run tests on a different Python version.
As of now there's no easy way to run tests on a certain version as Hatch automatically picks Python 3.12 cause of the `default` env Python version costraint `>=3.8`.

After this change we can run tests like so:

```
$ hatch run +python=3.8 test:unit
```

Or:

```
$ hatch run test.py3.8:unit
```

Calling `hatch run test:unit` will run unit tests on all the Python versions specified in the matrix.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

I had to change some workflows to run only a single version of Python.

In the future we can change our workflows so that the `pyproject.toml` matrix is actually used to generate a job matrix and tests are run for all supported versions.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
