### PR TITLE
fix: Fix `NamedEntityExtractor` crashing in Python 3.12 if constructed using a string backend argument

### DIFF
--- a/releasenotes/notes/fix-named-entity-entity-extractor-backend-enum-2e64e25f8d7f1b08.yaml
+++ b/releasenotes/notes/fix-named-entity-entity-extractor-backend-enum-2e64e25f8d7f1b08.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `NamedEntityExtractor` crashing in Python 3.12 if constructed using a string backend argument.


### PR DESCRIPTION
### Proposed Changes:

Change `NamedEntityExtractorBackend` to better handle conversion of strings to enum values.

This fixes a crash in `NamedEntityExtractor` when using a string as `backend` argument when creating the Component in Python 3.12.

### How did you test it?

I ran tests locally using Python 3.12.

### Notes for the reviewer

CI runs tests using Python 3.8 so this won't fail, I recommend running tests locally with Python 3.12 just to be sure.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
