### PR TITLE
fix: use correct output annotation for pdfminer converter

### DIFF
--- a/haystack/components/converters/pdfminer.py
+++ b/haystack/components/converters/pdfminer.py
@@ -116,7 +116,7 @@ class PDFMinerToDocument:
 
         return Document(content=concat)
 
-    @component.output_types(document=List[Document])
+    @component.output_types(documents=List[Document])
     def run(
         self,
         sources: List[Union[str, Path, ByteStream]],

--- a/releasenotes/notes/fix-pdfminer-converter-54e6d7e1a82d6e7b.yaml
+++ b/releasenotes/notes/fix-pdfminer-converter-54e6d7e1a82d6e7b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the PdfMinerToDocument converter's outputs to be properly wired up to 'documents'.


### PR DESCRIPTION
### Related Issues

- fixes #7749

### Proposed Changes:
changed the PDFMinerToDocument converter output_type to 'documents'

### How did you test it?
manually ran my repro from the issue

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
