### PR TITLE
chore: make `warm_up()` usage consistent

### DIFF
--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -113,7 +113,7 @@ class LocalWhisperTranscriber:
                 alignment data and the path to the audio file used for the transcription.
         """
         if self._model is None:
-            raise RuntimeError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
+            raise RuntimeError("The component LocalWhisperTranscriber was not warmed up. Run 'warm_up()' before calling 'run()'.")
 
         if whisper_params is None:
             whisper_params = self.whisper_params

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -158,6 +158,9 @@ class LocalWhisperTranscriber:
         return_segments = kwargs.pop("return_segments", False)
         transcriptions: Dict[Path, Any] = {}
         for source in sources:
+            if self._model is None:
+                continue
+
             if not isinstance(source, ByteStream):
                 path = Path(source)
                 source = ByteStream.from_file_path(path)
@@ -165,8 +168,8 @@ class LocalWhisperTranscriber:
             else:
                 # If we received a ByteStream instance that doesn't have the "file_path" metadata set,
                 # we dump the bytes into a temporary file.
-                path = source.meta.get("file_path")
-                if path is None:
+                path = source.meta.get("file_path", Path())
+                if path.name:
                     fp = tempfile.NamedTemporaryFile(delete=False)
                     path = Path(fp.name)
                     source.to_file(path)

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union, get_args
 
-from haystack import ComponentError, Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ByteStream
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
@@ -113,7 +113,7 @@ class LocalWhisperTranscriber:
                 alignment data and the path to the audio file used for the transcription.
         """
         if self._model is None:
-            raise ComponentError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
+            raise RuntimeError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
 
         if whisper_params is None:
             whisper_params = self.whisper_params
@@ -155,9 +155,6 @@ class LocalWhisperTranscriber:
         :returns:
             A dictionary mapping 'file_path' to 'transcription'.
         """
-        if self._model is None:
-            raise ComponentError("Model is not loaded, please run 'warm_up()' before calling 'run()'")
-
         return_segments = kwargs.pop("return_segments", False)
         transcriptions: Dict[Path, Any] = {}
         for source in sources:

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -113,7 +113,9 @@ class LocalWhisperTranscriber:
                 alignment data and the path to the audio file used for the transcription.
         """
         if self._model is None:
-            raise RuntimeError("The component LocalWhisperTranscriber was not warmed up. Run 'warm_up()' before calling 'run()'.")
+            raise RuntimeError(
+                "The component LocalWhisperTranscriber was not warmed up. Run 'warm_up()' before calling 'run()'."
+            )
 
         if whisper_params is None:
             whisper_params = self.whisper_params

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -155,12 +155,12 @@ class LocalWhisperTranscriber:
         :returns:
             A dictionary mapping 'file_path' to 'transcription'.
         """
+        if self._model is None:
+            raise RuntimeError("Model is not loaded, please run 'warm_up()' before calling 'run()'")
+
         return_segments = kwargs.pop("return_segments", False)
         transcriptions: Dict[Path, Any] = {}
         for source in sources:
-            if self._model is None:
-                continue
-
             if not isinstance(source, ByteStream):
                 path = Path(source)
                 source = ByteStream.from_file_path(path)
@@ -168,8 +168,8 @@ class LocalWhisperTranscriber:
             else:
                 # If we received a ByteStream instance that doesn't have the "file_path" metadata set,
                 # we dump the bytes into a temporary file.
-                path = source.meta.get("file_path", Path())
-                if path.name:
+                path = source.meta.get("file_path")
+                if path is None:
                     fp = tempfile.NamedTemporaryFile(delete=False)
                     path = Path(fp.name)
                     source.to_file(path)

--- a/haystack/components/evaluators/sas_evaluator.py
+++ b/haystack/components/evaluators/sas_evaluator.py
@@ -116,6 +116,9 @@ class SASEvaluator:
         """
         Initializes the component.
         """
+        if self._similarity_model:
+            return
+
         token = self._token.resolve_value() if self._token else None
         config = AutoConfig.from_pretrained(self._model, use_auth_token=token)
         cross_encoder_used = False

--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -177,7 +177,7 @@ class NamedEntityExtractor:
             If the backend fails to process a document.
         """
         if not self._warmed_up:
-            msg = "The NER backend has not been initialized. Call warm_up() before running the component."
+            msg = "The component NamedEntityExtractor was not warmed up. Call warm_up() before running the component."
             raise RuntimeError(msg)
 
         texts = [doc.content if doc.content is not None else "" for doc in documents]

--- a/haystack/components/extractors/named_entity_extractor.py
+++ b/haystack/components/extractors/named_entity_extractor.py
@@ -134,6 +134,7 @@ class NamedEntityExtractor:
             backend = NamedEntityExtractorBackend.from_str(backend)
 
         self._backend: _NerBackend
+        self._warmed_up: bool = False
         device = ComponentDevice.resolve_device(device)
 
         if backend == NamedEntityExtractorBackend.HUGGING_FACE:
@@ -150,8 +151,12 @@ class NamedEntityExtractor:
         :raises ComponentError:
             If the backend fails to initialize successfully.
         """
+        if self._warmed_up:
+            return
+
         try:
             self._backend.initialize()
+            self._warmed_up = True
         except Exception as e:
             raise ComponentError(
                 f"Named entity extractor with backend '{self._backend.type} failed to initialize."
@@ -171,6 +176,10 @@ class NamedEntityExtractor:
         :raises ComponentError:
             If the backend fails to process a document.
         """
+        if not self._warmed_up:
+            msg = "The NER backend has not been initialized. Call warm_up() before running the component."
+            raise RuntimeError(msg)
+
         texts = [doc.content if doc.content is not None else "" for doc in documents]
         annotations = self._backend.annotate(texts, batch_size=batch_size)
 

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -189,10 +189,8 @@ class HuggingFaceLocalChatGenerator:
         """
         Initializes the component.
         """
-        if self.pipeline is not None:
-            return
-
-        self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
+        if self.pipeline is None:
+            self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -176,7 +176,6 @@ class HuggingFaceLocalChatGenerator:
         self.chat_template = chat_template
         self.streaming_callback = streaming_callback
         self.pipeline = None
-        self._warmed_up: bool = False
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -190,11 +189,10 @@ class HuggingFaceLocalChatGenerator:
         """
         Initializes the component.
         """
-        if self._warmed_up:
+        if self.pipeline is not None:
             return
 
         self.pipeline = pipeline(**self.huggingface_pipeline_kwargs)
-        self._warmed_up = True
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -249,7 +247,7 @@ class HuggingFaceLocalChatGenerator:
         :returns:
             A list containing the generated responses as ChatMessage instances.
         """
-        if not self._warmed_up:
+        if self.pipeline is None:
             raise RuntimeError("The generation model has not been loaded. Please call warm_up() before running.")
 
         tokenizer = self.pipeline.tokenizer

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -235,7 +235,9 @@ class HuggingFaceTGIChatGenerator:
         :return: A list containing the generated responses as ChatMessage instances.
         """
         if not self._warmed_up:
-            raise RuntimeError("The component HuggingFaceTGIChatGenerator was not warmed up. Please call warm_up() before running.")
+            raise RuntimeError(
+                "The component HuggingFaceTGIChatGenerator was not warmed up. Please call warm_up() before running."
+            )
 
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -150,6 +150,7 @@ class HuggingFaceTGIChatGenerator:
         self.client = InferenceClient(url or model, token=token.resolve_value() if token else None)
         self.streaming_callback = streaming_callback
         self.tokenizer = None
+        self._warmed_up: bool = False
 
     def warm_up(self) -> None:
         """
@@ -158,6 +159,8 @@ class HuggingFaceTGIChatGenerator:
         If the url is not provided, check if the model is deployed on the free tier of the HF inference API.
         Load the tokenizer
         """
+        if self._warmed_up:
+            return
 
         # is this user using HF free tier inference API?
         if self.model and not self.url:
@@ -183,6 +186,8 @@ class HuggingFaceTGIChatGenerator:
                 "format, potentially leading to unexpected behavior.",
                 model=self.model,
             )
+
+        self._warmed_up = True
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -229,6 +234,8 @@ class HuggingFaceTGIChatGenerator:
         :param generation_kwargs: Additional keyword arguments for text generation.
         :return: A list containing the generated responses as ChatMessage instances.
         """
+        if not self._warmed_up:
+            raise RuntimeError("The generation model has not been loaded. Please call warm_up() before running.")
 
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -235,7 +235,7 @@ class HuggingFaceTGIChatGenerator:
         :return: A list containing the generated responses as ChatMessage instances.
         """
         if not self._warmed_up:
-            raise RuntimeError("The generation model has not been loaded. Please call warm_up() before running.")
+            raise RuntimeError("The component HuggingFaceTGIChatGenerator was not warmed up. Please call warm_up() before running.")
 
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -142,7 +142,9 @@ class HuggingFaceLocalGenerator:
 
     @property
     def _warmed_up(self) -> bool:
-        return (self.pipeline is not None) and (self.stopping_criteria_list is not None)
+        if self.stop_words:
+            return (self.pipeline is not None) and (self.stopping_criteria_list is not None)
+        return self.pipeline is not None
 
     def warm_up(self):
         """

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -219,7 +219,7 @@ class HuggingFaceLocalGenerator:
             - replies: A list of strings representing the generated replies.
         """
         if not self._warmed_up:
-            raise RuntimeError("The generation model has not been loaded. Please call warm_up() before running.")
+            raise RuntimeError("The component HuggingFaceLocalGenerator was not warmed up. Please call warm_up() before running.")
 
         if not prompt:
             return {"replies": []}

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -219,7 +219,9 @@ class HuggingFaceLocalGenerator:
             - replies: A list of strings representing the generated replies.
         """
         if not self._warmed_up:
-            raise RuntimeError("The component HuggingFaceLocalGenerator was not warmed up. Please call warm_up() before running.")
+            raise RuntimeError(
+                "The component HuggingFaceLocalGenerator was not warmed up. Please call warm_up() before running."
+            )
 
         if not prompt:
             return {"replies": []}

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -135,11 +135,14 @@ class HuggingFaceTGIGenerator:
         self.client = InferenceClient(url or model, token=token.resolve_value() if token else None)
         self.streaming_callback = streaming_callback
         self.tokenizer = None
+        self._warmed_up: bool = False
 
     def warm_up(self) -> None:
         """
         Initializes the component.
         """
+        if self._warmed_up:
+            return
 
         # is this user using HF free tier inference API?
         if self.model and not self.url:
@@ -155,6 +158,8 @@ class HuggingFaceTGIGenerator:
         self.tokenizer = AutoTokenizer.from_pretrained(
             self.model, token=self.token.resolve_value() if self.token else None
         )
+
+        self._warmed_up = True
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -205,6 +210,9 @@ class HuggingFaceTGIGenerator:
             A dictionary containing the generated replies and metadata. Both are lists of length n.
             - replies: A list of strings representing the generated replies.
         """
+        if not self._warmed_up:
+            raise RuntimeError("Please call warm_up() before running LLM inference.")
+
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]
         check_generation_params(generation_kwargs, additional_params)
@@ -213,9 +221,6 @@ class HuggingFaceTGIGenerator:
         generation_kwargs = {**self.generation_kwargs, **(generation_kwargs or {})}
         num_responses = generation_kwargs.pop("n", 1)
         generation_kwargs.setdefault("stop_sequences", []).extend(generation_kwargs.pop("stop_words", []))
-
-        if self.tokenizer is None:
-            raise RuntimeError("Please call warm_up() before running LLM inference.")
 
         prompt_token_count = len(self.tokenizer.encode(prompt, add_special_tokens=False))
 

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -135,13 +135,12 @@ class HuggingFaceTGIGenerator:
         self.client = InferenceClient(url or model, token=token.resolve_value() if token else None)
         self.streaming_callback = streaming_callback
         self.tokenizer = None
-        self._warmed_up: bool = False
 
     def warm_up(self) -> None:
         """
         Initializes the component.
         """
-        if self._warmed_up:
+        if self.tokenizer is not None:
             return
 
         # is this user using HF free tier inference API?
@@ -158,8 +157,6 @@ class HuggingFaceTGIGenerator:
         self.tokenizer = AutoTokenizer.from_pretrained(
             self.model, token=self.token.resolve_value() if self.token else None
         )
-
-        self._warmed_up = True
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -210,7 +207,7 @@ class HuggingFaceTGIGenerator:
             A dictionary containing the generated replies and metadata. Both are lists of length n.
             - replies: A list of strings representing the generated replies.
         """
-        if not self._warmed_up:
+        if not self.tokenizer:
             raise RuntimeError("Please call warm_up() before running LLM inference.")
 
         # check generation kwargs given as parameters to override the default ones

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -208,7 +208,7 @@ class HuggingFaceTGIGenerator:
             - replies: A list of strings representing the generated replies.
         """
         if not self.tokenizer:
-            raise RuntimeError("Please call warm_up() before running LLM inference.")
+            raise RuntimeError("The component HuggingFaceTGIGenerator was not warmed up. Please call warm_up() before running LLM inference.")
 
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -208,7 +208,9 @@ class HuggingFaceTGIGenerator:
             - replies: A list of strings representing the generated replies.
         """
         if not self.tokenizer:
-            raise RuntimeError("The component HuggingFaceTGIGenerator was not warmed up. Please call warm_up() before running LLM inference.")
+            raise RuntimeError(
+                "The component HuggingFaceTGIGenerator was not warmed up. Please call warm_up() before running LLM inference."
+            )
 
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -4,7 +4,7 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from haystack import ComponentError, Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
 
@@ -231,13 +231,14 @@ class SentenceTransformersDiversityRanker:
             - `documents`: List of Document objects that have been selected based on the diversity ranking.
 
         :raises ValueError: If the top_k value is less than or equal to 0.
+        :raises RuntimeError: If the component has not been warmed up.
         """
         if self.model is None:
             error_msg = (
                 "The component SentenceTransformersDiversityRanker wasn't warmed up. "
                 "Run 'warm_up()' before calling 'run()'."
             )
-            raise ComponentError(error_msg)
+            raise RuntimeError(error_msg)
 
         if not documents:
             return {"documents": []}

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -232,6 +232,13 @@ class SentenceTransformersDiversityRanker:
 
         :raises ValueError: If the top_k value is less than or equal to 0.
         """
+        if self.model is None:
+            error_msg = (
+                "The component SentenceTransformersDiversityRanker wasn't warmed up. "
+                "Run 'warm_up()' before calling 'run()'."
+            )
+            raise ComponentError(error_msg)
+
         if not documents:
             return {"documents": []}
 
@@ -239,13 +246,6 @@ class SentenceTransformersDiversityRanker:
             top_k = self.top_k
         elif top_k <= 0:
             raise ValueError(f"top_k must be > 0, but got {top_k}")
-
-        if self.model is None:
-            error_msg = (
-                "The component SentenceTransformersDiversityRanker wasn't warmed up. "
-                "Run 'warm_up()' before calling 'run()'."
-            )
-            raise ComponentError(error_msg)
 
         diversity_sorted = self._greedy_diversity_order(query=query, documents=documents)
 

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -224,7 +224,7 @@ class TransformersSimilarityRanker:
         # If a model path is provided but the model isn't loaded
         if self.model is None:
             raise RuntimeError(
-                f"The component TransformersSimilarityRanker wasn't warmed up. Run 'warm_up()' before calling 'run()'."
+                "The component TransformersSimilarityRanker wasn't warmed up. Run 'warm_up()' before calling 'run()'."
             )
 
         if not documents:

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -5,7 +5,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import ComponentError, Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, DeviceMap, Secret, deserialize_secrets_inplace
 from haystack.utils.hf import deserialize_hf_model_kwargs, resolve_hf_device_map, serialize_hf_model_kwargs
@@ -218,9 +218,15 @@ class TransformersSimilarityRanker:
         :raises ValueError:
             If `top_k` is not > 0.
             If `scale_score` is True and `calibration_factor` is not provided.
-        :raises ComponentError:
+        :raises RuntimeError:
             If the model is not loaded because `warm_up()` was not called before.
         """
+        # If a model path is provided but the model isn't loaded
+        if self.model is None:
+            raise RuntimeError(
+                f"The component {self.__class__.__name__} wasn't warmed up. Run 'warm_up()' before calling 'run()'."
+            )
+
         if not documents:
             return {"documents": []}
 
@@ -235,12 +241,6 @@ class TransformersSimilarityRanker:
         if scale_score and calibration_factor is None:
             raise ValueError(
                 f"scale_score is True so calibration_factor must be provided, but got {calibration_factor}"
-            )
-
-        # If a model path is provided but the model isn't loaded
-        if self.model is None:
-            raise ComponentError(
-                f"The component {self.__class__.__name__} wasn't warmed up. Run 'warm_up()' before calling 'run()'."
             )
 
         query_doc_pairs = []

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -224,7 +224,7 @@ class TransformersSimilarityRanker:
         # If a model path is provided but the model isn't loaded
         if self.model is None:
             raise RuntimeError(
-                f"The component {self.__class__.__name__} wasn't warmed up. Run 'warm_up()' before calling 'run()'."
+                f"The component TransformersSimilarityRanker wasn't warmed up. Run 'warm_up()' before calling 'run()'."
             )
 
         if not documents:

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -571,17 +571,17 @@ class ExtractiveReader:
         :returns:
             List of answers sorted by (desc.) answer score.
 
-        :raises ComponentError:
+        :raises RuntimeError:
             If the component was not warmed up by calling 'warm_up()' before.
         """
+        if self.model is None:
+            raise RuntimeError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
+
         if not documents:
             return {"answers": []}
 
         queries = [query]  # Temporary solution until we have decided what batching should look like in v2
         nested_documents = [documents]
-        if self.model is None:
-            raise ComponentError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
-
         top_k = top_k or self.top_k
         score_threshold = score_threshold or self.score_threshold
         max_seq_length = max_seq_length or self.max_seq_length

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -575,7 +575,9 @@ class ExtractiveReader:
             If the component was not warmed up by calling 'warm_up()' before.
         """
         if self.model is None:
-            raise RuntimeError("The component ExtractiveReader was not warmed up. Run 'warm_up()' before calling 'run()'.")
+            raise RuntimeError(
+                "The component ExtractiveReader was not warmed up. Run 'warm_up()' before calling 'run()'."
+            )
 
         if not documents:
             return {"answers": []}

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -575,7 +575,7 @@ class ExtractiveReader:
             If the component was not warmed up by calling 'warm_up()' before.
         """
         if self.model is None:
-            raise RuntimeError("The component was not warmed up. Run 'warm_up()' before calling 'run()'.")
+            raise RuntimeError("The component ExtractiveReader was not warmed up. Run 'warm_up()' before calling 'run()'.")
 
         if not documents:
             return {"answers": []}

--- a/haystack/components/readers/extractive.py
+++ b/haystack/components/readers/extractive.py
@@ -7,7 +7,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from haystack import ComponentError, Document, ExtractedAnswer, component, default_from_dict, default_to_dict, logging
+from haystack import Document, ExtractedAnswer, component, default_from_dict, default_to_dict, logging
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, DeviceMap, Secret, deserialize_secrets_inplace
 from haystack.utils.hf import deserialize_hf_model_kwargs, resolve_hf_device_map, serialize_hf_model_kwargs

--- a/releasenotes/notes/make-warm-up-consistent-0247da81b155b136.yaml
+++ b/releasenotes/notes/make-warm-up-consistent-0247da81b155b136.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Make `warm_up()` usage consistent across the codebase.

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -385,7 +385,7 @@ class TestHuggingFaceLocalGenerator:
             model="google/flan-t5-base", task="text2text-generation", generation_kwargs={"max_new_tokens": 100}
         )
 
-        with pytest.raises(RuntimeError, match="The generation model has not been loaded."):
+        with pytest.raises(RuntimeError, match="The component HuggingFaceLocalGenerator was not warmed up"):
             generator.run(prompt="irrelevant")
 
     def test_stop_words_criteria_with_a_mocked_tokenizer(self):

--- a/test/components/generators/test_hugging_face_local_generator.py
+++ b/test/components/generators/test_hugging_face_local_generator.py
@@ -424,6 +424,7 @@ class TestHuggingFaceLocalGenerator:
             model="google/flan-t5-small", task="text2text-generation", stop_words=["world"]
         )
         generator.pipeline = Mock(return_value=[{"generated_text": "Hello world"}])
+        generator.stopping_criteria_list = Mock()
         results = generator.run(prompt="irrelevant")
         assert results == {"replies": ["Hello"]}
 

--- a/test/components/rankers/test_sentence_transformers_diversity.py
+++ b/test/components/rankers/test_sentence_transformers_diversity.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 import torch
 
-from haystack import ComponentError, Document
+from haystack import Document
 from haystack.components.rankers import SentenceTransformersDiversityRanker
 from haystack.utils import ComponentDevice
 from haystack.utils.auth import Secret
@@ -228,7 +228,7 @@ class TestSentenceTransformersDiversityRanker:
         documents = [Document(content="doc1"), Document(content="doc2")]
 
         error_msg = "The component SentenceTransformersDiversityRanker wasn't warmed up."
-        with pytest.raises(ComponentError, match=error_msg):
+        with pytest.raises(RuntimeError, match=error_msg):
             ranker.run(query="test query", documents=documents)
 
     @pytest.mark.parametrize("similarity", ["dot_product", "cosine"])

--- a/test/components/rankers/test_transformers_similarity.py
+++ b/test/components/rankers/test_transformers_similarity.py
@@ -343,7 +343,7 @@ class TestSimilarityRanker:
     @pytest.mark.integration
     def test_raises_component_error_if_model_not_warmed_up(self):
         sampler = TransformersSimilarityRanker()
-        with pytest.raises(ComponentError):
+        with pytest.raises(RuntimeError):
             sampler.run(query="query", documents=[Document(content="document")])
 
     @pytest.mark.integration


### PR DESCRIPTION
### Related Issues

- fixes #7021 

### Proposed Changes:

Make the usage of `warm_up` consistent according to these criteria:
- Calling `run()` on a component that has not been warmed up raises a `RuntimeError`
- The warmup check is performed first thing in the `run()` method

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Sometimes the "warm up" state cannot be determined by evaluating a single field (e.g. `self._model is not None`). In those cases I introduced a boolean field `self._warmed_up`.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
