### PR TITLE
ci: remove dependency cache job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,36 +79,9 @@ jobs:
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-  install-dependencies:
-    name: Install and cache ${{ matrix.os }} dependencies
-    needs: black
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "${{ env.PYTHON_VERSION }}"
-
-      - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
-
-      - name: Install dependencies
-        # To actually install and sync the dependencies
-        run: hatch run test:pip list
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml') }}
-
   unit-tests:
     name: Unit / ${{ matrix.os }}
-    needs: install-dependencies
+    needs: black
     strategy:
       fail-fast: false
       matrix:
@@ -123,12 +96,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
-
-      - name: Restore Python dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: pip-${{ runner.os }}-${{ github.run_id }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
         run: hatch run test:unit


### PR DESCRIPTION
### Related Issues

The caching job `install-dependencies` is useless at the moment, because the downstream job `unit-tests` reinstall all the dependencies again, no matter what. 


### Proposed Changes:

I don't have the time to investigate the root cause, but in the meantime we can speed up the CI and save some CPU cycles by removing the cache steps, bringing them back later with a proper fix.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
