### PR TITLE
ci: Install hatch in testing jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
+
       - name: Run
         run: hatch run test:unit
 
@@ -155,6 +158,9 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -208,6 +214,9 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
+
       - name: Install dependencies
         run: |
           brew install ffmpeg  # for local Whisper tests
@@ -256,6 +265,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: Install Hatch
+        run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Run
         run: hatch run test:integration-windows


### PR DESCRIPTION
CI was broken with #7754 cause we're not installing `hatch`, this fixes it.

Example failure: https://github.com/deepset-ai/haystack/actions/runs/9270808762/job/25504796874
