### PR TITLE
test: Support multiple runs for Pipeline run tests

### DIFF
--- a/test/core/pipeline/features/README.md
+++ b/test/core/pipeline/features/README.md
@@ -49,9 +49,9 @@ def pipeline_that_is_linear():
     )
 ```
 
-Some kind of `Pipeline`s requires multiple runs to correctly verify their correct working, e.g those with multiple branches.
-Because of this we also support functions that return lists of inputs, expected outputs and expected run orders.
-If we would have needed to run the above `Pipeline` multiple times we could do something like this:
+Some kinds of `Pipeline`s require multiple runs to verify they work correctly, for example those with multiple branches.
+For this reason we also support functions returning a "list of inputs", a "list of expected outputs" and a "list of expected run orders" (all the lists have the same size).
+For example, we could test two different runs of the same pipeline like this:
 
 ```python
 @given("a pipeline that is linear", target_fixture="pipeline_data")

--- a/test/core/pipeline/features/README.md
+++ b/test/core/pipeline/features/README.md
@@ -49,6 +49,28 @@ def pipeline_that_is_linear():
     )
 ```
 
+Some kind of `Pipeline`s requires multiple runs to correctly verify their correct working, e.g those with multiple branches.
+Because of this we also support functions that return lists of inputs, expected outputs and expected run orders.
+If we would have needed to run the above `Pipeline` multiple times we could do something like this:
+
+```python
+@given("a pipeline that is linear", target_fixture="pipeline_data")
+def pipeline_that_is_linear():
+    pipeline = Pipeline()
+    pipeline.add_component("first_addition", AddFixedValue(add=2))
+    pipeline.add_component("second_addition", AddFixedValue())
+    pipeline.add_component("double", Double())
+    pipeline.connect("first_addition", "double")
+    pipeline.connect("double", "second_addition")
+
+    return (
+        pipeline,
+        [{"first_addition": {"value": 1}}, {"first_addition": {"value": 100}}],
+        [{"second_addition": {"result": 7}}, {"first_addition": {"value": 206}}],
+        [["first_addition", "double", "second_addition"], ["first_addition", "double", "second_addition"]],
+    )
+```
+
 ### Bad Pipeline
 
 The second case is similar to the first one, but we can also specify the expected exception.

--- a/test/core/pipeline/features/conftest.py
+++ b/test/core/pipeline/features/conftest.py
@@ -1,8 +1,16 @@
+from typing import Tuple, List, Dict, Any
+
 from pytest_bdd import when, then, parsers
+
+from haystack import Pipeline
+
+
+PipelineData = Tuple[Pipeline, List[Dict[str, Any]], List[Dict[str, Any]], List[List[str]]]
+PipelineResult = Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[List[str]], List[List[str]]]
 
 
 @when("I run the Pipeline", target_fixture="pipeline_result")
-def run_pipeline(pipeline_data, spying_tracer):
+def run_pipeline(pipeline_data: PipelineData, spying_tracer):
     """
     Attempts to run a pipeline with the given inputs.
     `pipeline_data` is a tuple that must contain:
@@ -17,31 +25,44 @@ def run_pipeline(pipeline_data, spying_tracer):
     In case an exceptions is raised returns that.
     """
     pipeline, inputs, expected_outputs = pipeline_data[0], pipeline_data[1], pipeline_data[2]
+    expected_order = []
     if len(pipeline_data) == 4:
         expected_order = pipeline_data[3]
 
-    try:
-        res = pipeline.run(inputs)
-        run_order = [
-            span.tags["haystack.component.name"]
-            for span in spying_tracer.spans
-            if "haystack.component.name" in span.tags
-        ]
-        return res, expected_outputs, run_order, expected_order
-    except Exception as e:
-        return e
+    if not isinstance(inputs, list):
+        inputs = [inputs]
+        expected_outputs = [expected_outputs]
+        expected_order = [expected_order]
+
+    results = []
+    run_orders = []
+
+    for i in inputs:
+        try:
+            res = pipeline.run(i)
+            run_order = [
+                span.tags["haystack.component.name"]
+                for span in spying_tracer.spans
+                if "haystack.component.name" in span.tags
+            ]
+            results.append(res)
+            run_orders.append(run_order)
+            spying_tracer.spans.clear()
+        except Exception as e:
+            return e
+    return results, expected_outputs, run_orders, expected_order
 
 
 @then("it should return the expected result")
-def check_pipeline_result(pipeline_result):
+def check_pipeline_result(pipeline_result: PipelineResult):
     assert pipeline_result[0] == pipeline_result[1]
 
 
 @then("components ran in the expected order")
-def check_pipeline_run_order(pipeline_result):
+def check_pipeline_run_order(pipeline_result: PipelineResult):
     assert pipeline_result[2] == pipeline_result[3]
 
 
 @then(parsers.parse("it must have raised {exception_class_name}"))
-def check_pipeline_raised(pipeline_result, exception_class_name):
+def check_pipeline_raised(pipeline_result: Exception, exception_class_name: str):
     assert pipeline_result.__class__.__name__ == exception_class_name


### PR DESCRIPTION
This PR changes a bit the boilerplate functions that handle running the `Pipeline` in the `run` tests.

While I was migrating the other tests I noticed that some tests run a `Pipeline` multiple times, mostly when it has conditional branching, loops, and the likes. I thought of just running a `Pipeline` once but some actually require to be run with different inputs to actually verify their correct behaviour.

I tried using `@pytest.mark.parametrize` on the `@given` steps that define the `Pipeline` to test but that doesn't work, `pytest-bdd` forbids that.

Another option would have been to define the function that returns the `Pipeline` multiple times as different `@given` steps, one for each different input. That would be more error prone in my opinion as the `Pipeline` would be defined multiple times.

Best solution would be defining these parameters in the gherkin file, but that's not possible as that would have to be Python code. That would complicate things too much as we'd have to `eval`uate parts of the steps, making the gherkin less readable, more frustrating to work with, and ton of othe problems.

This is the simplest and fastest solution and is good enough for the time being .