### PR TITLE
test: Check for RuntimeError instead of ComponentError in NamedEntityExtractor test

### DIFF
--- a/e2e/pipelines/test_named_entity_extractor.py
+++ b/e2e/pipelines/test_named_entity_extractor.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from haystack import ComponentError, Document, Pipeline
+from haystack import Document, Pipeline
 from haystack.components.extractors import NamedEntityAnnotation, NamedEntityExtractor, NamedEntityExtractorBackend
 
 
@@ -49,7 +49,7 @@ def spacy_annotations():
 def test_ner_extractor_init():
     extractor = NamedEntityExtractor(backend=NamedEntityExtractorBackend.HUGGING_FACE, model="dslim/bert-base-NER")
 
-    with pytest.raises(ComponentError, match=r"not initialized"):
+    with pytest.raises(RuntimeError, match=r"not warmed up"):
         extractor.run(documents=[])
 
     assert not extractor.initialized


### PR DESCRIPTION
### Related Issues

- Fixes https://github.com/deepset-ai/haystack/issues/7761

### Proposed Changes:

- Check for RuntimeError instead of ComponentError

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

I am not convinced there really is a need for an end-to-end test here. We're not testing the warm up of any of the other components with end-to-end tests. In my understanding it's also not a good end-to-end because it doesn't do more than initializing. 
I suggest we merge this fix so that the end-to-end test runs through again. We can open a separate issue about making all the tests in the fail unit or integration tests and only keep test_ner_extractor_in_pipeline as e2e test.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
