### PR TITLE
fix: update Haystack version when Dynamic Builders are to be removed

### DIFF
--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -86,7 +86,7 @@ class DynamicChatPromptBuilder:
             template placeholders of a ChatMessage that is provided to the `run` method.
         """
         warnings.warn(
-            "`DynamicChatPromptBuilder` is deprecated and will be removed in Haystack 2.3.0."
+            "`DynamicChatPromptBuilder` is deprecated and will be removed in Haystack 2.4.0."
             "Use `ChatPromptBuilder` instead.",
             DeprecationWarning,
         )

--- a/haystack/components/builders/dynamic_prompt_builder.py
+++ b/haystack/components/builders/dynamic_prompt_builder.py
@@ -86,7 +86,7 @@ class DynamicPromptBuilder:
             template placeholders of a prompt text template that is provided to the `run` method.
         """
         warnings.warn(
-            "`DynamicPromptBuilder` is deprecated and will be removed in Haystack 2.3.0."
+            "`DynamicPromptBuilder` is deprecated and will be removed in Haystack 2.4.0."
             "Use `PromptBuilder` instead.",
             DeprecationWarning,
         )


### PR DESCRIPTION
### Proposed Changes:

Both Dynamic Builders are being deprecated in 2.2 and will be removed in 2.4.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
