### PR TITLE
feat: Add memory sharing between different instances of `InMemoryDocumentStore`

### DIFF
--- a/releasenotes/notes/in-memory-docstore-memory-share-82b75d018b3545fc.yaml
+++ b/releasenotes/notes/in-memory-docstore-memory-share-82b75d018b3545fc.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    Add memory sharing between different instances of InMemoryDocumentStore.
+    Setting the same `index` argument as another instance will make sure that the memory is shared.
+    e.g.
+    ```python
+    index = "my_personal_index"
+    document_store_1 = InMemoryDocumentStore(index=index)
+    document_store_2 = InMemoryDocumentStore(index=index)
+
+    assert document_store_1.count_documents() == 0
+    assert document_store_2.count_documents() == 0
+
+    document_store_1.write_documents([Document(content="Hello world")])
+
+    assert document_store_1.count_documents() == 1
+    assert document_store_2.count_documents() == 1
+    ```

--- a/test/components/retrievers/test_filter_retriever.py
+++ b/test/components/retrievers/test_filter_retriever.py
@@ -63,10 +63,13 @@ class TestFilterRetriever:
         }
 
     def test_to_dict_with_custom_init_parameters(self):
-        ds = InMemoryDocumentStore()
+        ds = InMemoryDocumentStore(index="test_to_dict_with_custom_init_parameters")
         serialized_ds = ds.to_dict()
 
-        component = FilterRetriever(document_store=InMemoryDocumentStore(), filters={"lang": "en"})
+        component = FilterRetriever(
+            document_store=InMemoryDocumentStore(index="test_to_dict_with_custom_init_parameters"),
+            filters={"lang": "en"},
+        )
         data = component.to_dict()
         assert data == {
             "type": "haystack.components.retrievers.filter_retriever.FilterRetriever",

--- a/test/components/retrievers/test_in_memory_bm25_retriever.py
+++ b/test/components/retrievers/test_in_memory_bm25_retriever.py
@@ -60,11 +60,14 @@ class TestMemoryBM25Retriever:
         }
 
     def test_to_dict_with_custom_init_parameters(self):
-        ds = InMemoryDocumentStore()
+        ds = InMemoryDocumentStore(index="test_to_dict_with_custom_init_parameters")
         serialized_ds = ds.to_dict()
 
         component = InMemoryBM25Retriever(
-            document_store=InMemoryDocumentStore(), filters={"name": "test.txt"}, top_k=5, scale_score=True
+            document_store=InMemoryDocumentStore(index="test_to_dict_with_custom_init_parameters"),
+            filters={"name": "test.txt"},
+            top_k=5,
+            scale_score=True,
         )
         data = component.to_dict()
         assert data == {


### PR DESCRIPTION
### Proposed Changes:

This PR adds the `index` argument in `InMemoryDocumentStore`.

If two or more different instances of `InMemoryDocumentStore` use the same `index` they will use the same memory, so writing or deleting a document from one will affect the others too.

### How did you test it?

I added some tests and run all existing tests.

### Notes for the reviewer

This will bring two extra possibile enhancements. We can change the default `Pipeline` templates to use `InMemoryDocumentStore` with the same index, thus removing the dependency to `chroma-haystack`. This will also make it possible to remove some steps from the [Pipeline templates](https://docs.haystack.deepset.ai/docs/pipeline-templates) documentation. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
