### PR TITLE
chore: Update indexing and rag default templates to use `InMemoryDocumentStore`

### DIFF
--- a/haystack/core/pipeline/predefined/indexing.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/indexing.yaml.jinja2
@@ -45,10 +45,12 @@ components:
     init_parameters:
       document_store:
         init_parameters:
-          collection_name: documents
-          embedding_function: default
-          persist_path: .
-        type: haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore
+          bm25_tokenization_regex: (?u)\b\w\w+\b
+          bm25_algorithm: BM25L
+          bm25_parameters: {}
+          embedding_similarity_function: dot_product
+          index: documents
+        type: haystack.document_stores.in_memory.document_store.InMemoryDocumentStore
       policy: NONE
     type: haystack.components.writers.document_writer.DocumentWriter
 

--- a/haystack/core/pipeline/predefined/rag.yaml.jinja2
+++ b/haystack/core/pipeline/predefined/rag.yaml.jinja2
@@ -34,13 +34,15 @@ components:
     init_parameters:
       document_store:
         init_parameters:
-          collection_name: documents
-          embedding_function: default
-          persist_path: .
-        type: haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore
+          bm25_tokenization_regex: (?u)\b\w\w+\b
+          bm25_algorithm: BM25L
+          bm25_parameters: {}
+          embedding_similarity_function: dot_product
+          index: documents
+        type: haystack.document_stores.in_memory.document_store.InMemoryDocumentStore
       filters: null
       top_k: 10
-    type: haystack_integrations.components.retrievers.chroma.retriever.ChromaEmbeddingRetriever
+    type: haystack.components.retrievers.in_memory.embedding_retriever.InMemoryEmbeddingRetriever
 
   text_embedder:
     init_parameters:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ extra-dependencies = [
   "langdetect",  # TextLanguageRouter and DocumentLanguageClassifier
   "sentence-transformers>=2.2.0",  # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "openai-whisper>=20231106",  # LocalWhisperTranscriber
-  "chroma-haystack",  # pipeline predefined templates
 
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -595,9 +595,8 @@ class TestPipeline:
 
     def test_from_template(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake_key")
-        with patch("haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore"):
-            pipe = Pipeline.from_template(PredefinedPipeline.INDEXING)
-            assert pipe.get_component("cleaner")
+        pipe = Pipeline.from_template(PredefinedPipeline.INDEXING)
+        assert pipe.get_component("cleaner")
 
     def test_walk_pipeline_with_no_cycles(self):
         """

--- a/test/core/pipeline/test_templates.py
+++ b/test/core/pipeline/test_templates.py
@@ -50,15 +50,14 @@ class TestPipelineTemplate:
     #  Building a pipeline directly using all default components specified in a predefined or custom template.
     def test_build_pipeline_with_default_components(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "fake_key")
-        with mock.patch("haystack_integrations.document_stores.chroma.document_store.ChromaDocumentStore"):
-            rendered = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING).render()
-            pipeline = Pipeline.loads(rendered)
+        rendered = PipelineTemplate.from_predefined(PredefinedPipeline.INDEXING).render()
+        pipeline = Pipeline.loads(rendered)
 
-            # pipeline has components
-            assert pipeline.get_component("cleaner")
-            assert pipeline.get_component("writer")
-            assert pipeline.get_component("embedder")
+        # pipeline has components
+        assert pipeline.get_component("cleaner")
+        assert pipeline.get_component("writer")
+        assert pipeline.get_component("embedder")
 
-            # pipeline should have inputs and outputs
-            assert len(pipeline.inputs()) > 0
-            assert len(pipeline.outputs()) > 0
+        # pipeline should have inputs and outputs
+        assert len(pipeline.inputs()) > 0
+        assert len(pipeline.outputs()) > 0


### PR DESCRIPTION
### Proposed Changes:

Change indexing and rag default templates to use shared `InMemoryDocumentStore` instead of `ChromaDocumentStore`.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
