### PR TITLE
fix: `InMemoryDocumentStore` not sharing some document stats with other instances

### DIFF
--- a/e2e/pipelines/test_hybrid_doc_search_pipeline.py
+++ b/e2e/pipelines/test_hybrid_doc_search_pipeline.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 
 from haystack import Document, Pipeline
 from haystack.components.embedders import SentenceTransformersDocumentEmbedder, SentenceTransformersTextEmbedder
@@ -10,7 +9,6 @@ from haystack.components.joiners.document_joiner import DocumentJoiner
 from haystack.components.rankers import TransformersSimilarityRanker
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever, InMemoryEmbeddingRetriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
-from haystack.document_stores.types import DuplicatePolicy
 
 
 def test_hybrid_doc_search_pipeline(tmp_path):
@@ -50,7 +48,6 @@ def test_hybrid_doc_search_pipeline(tmp_path):
         Document(content="My name is Mario and I live in the capital of Italy."),
         Document(content="My name is Giorgio and I live in Rome."),
     ]
-    hybrid_pipeline.get_component("bm25_retriever").document_store.write_documents(documents)
     doc_embedder = SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2")
     doc_embedder.warm_up()
     embedded_documents = doc_embedder.run(documents=documents)["documents"]

--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -46,6 +46,8 @@ class BM25DocumentStats:
 # Global storage for all InMemoryDocumentStore instances, indexed by the index name.
 _STORAGES: Dict[str, Dict[str, Document]] = {}
 _BM25_STATS_STORAGES: Dict[str, Dict[str, BM25DocumentStats]] = {}
+_AVERAGE_DOC_LEN_STORAGES: Dict[str, float] = {}
+_FREQ_VOCAB_FOR_IDF_STORAGES: Dict[str, Counter] = {}
 
 
 class InMemoryDocumentStore:
@@ -91,13 +93,15 @@ class InMemoryDocumentStore:
         self.bm25_parameters = bm25_parameters or {}
         self.embedding_similarity_function = embedding_similarity_function
 
-        # Global BM25 statistics
-        self._avg_doc_len: float = 0.0
-        self._freq_vocab_for_idf: Counter = Counter()
-
         # Per-document statistics
         if self.index not in _BM25_STATS_STORAGES:
             _BM25_STATS_STORAGES[self.index] = {}
+
+        if self.index not in _AVERAGE_DOC_LEN_STORAGES:
+            _AVERAGE_DOC_LEN_STORAGES[self.index] = 0.0
+
+        if self.index not in _FREQ_VOCAB_FOR_IDF_STORAGES:
+            _FREQ_VOCAB_FOR_IDF_STORAGES[self.index] = Counter()
 
     @property
     def storage(self) -> Dict[str, Document]:
@@ -109,6 +113,18 @@ class InMemoryDocumentStore:
     @property
     def _bm25_attr(self) -> Dict[str, BM25DocumentStats]:
         return _BM25_STATS_STORAGES.get(self.index, {})
+
+    @property
+    def _avg_doc_len(self) -> float:
+        return _AVERAGE_DOC_LEN_STORAGES.get(self.index, 0.0)
+
+    @_avg_doc_len.setter
+    def _avg_doc_len(self, value: float):
+        _AVERAGE_DOC_LEN_STORAGES[self.index] = value
+
+    @property
+    def _freq_vocab_for_idf(self) -> Counter:
+        return _FREQ_VOCAB_FOR_IDF_STORAGES.get(self.index, Counter())
 
     def _dispatch_bm25(self):
         """


### PR DESCRIPTION
### Related Issues

- fixes #7788

### Proposed Changes:

This PR fixed the `InMemoryDocumentStore` so that all the information that must be shared with other instances that use the same index is actually shared.

### How did you test it?

I fixed and ran the end to end test that was failing.

### Notes for the reviewer

I'm ignoring the release notes as this features has not be released yet.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
