### PR TITLE
chore: export `ChatPromptBuilder` and add it to pydoc config

### DIFF
--- a/docs/pydoc/config/builders_api.yml
+++ b/docs/pydoc/config/builders_api.yml
@@ -7,6 +7,7 @@ loaders:
         "prompt_builder",
         "dynamic_prompt_builder",
         "dynamic_chat_prompt_builder",
+        "chat_prompt_builder",
       ]
     ignore_when_discovered: ["__init__"]
 processors:

--- a/haystack/components/builders/__init__.py
+++ b/haystack/components/builders/__init__.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from haystack.components.builders.answer_builder import AnswerBuilder
+from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack.components.builders.dynamic_chat_prompt_builder import DynamicChatPromptBuilder
 from haystack.components.builders.dynamic_prompt_builder import DynamicPromptBuilder
 from haystack.components.builders.prompt_builder import PromptBuilder
 
-__all__ = ["AnswerBuilder", "PromptBuilder", "DynamicPromptBuilder", "DynamicChatPromptBuilder"]
+__all__ = ["AnswerBuilder", "PromptBuilder", "DynamicPromptBuilder", "DynamicChatPromptBuilder", "ChatPromptBuilder"]


### PR DESCRIPTION
### Related Issues

- fixes #7794

### Proposed Changes:
- add `ChatPromptBuilder` to `__init__.py`
- add it to pydoc configuration

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
