### PR TITLE
fix: Fix running `Pipeline` with conditional branch and Component with default inputs

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -719,7 +719,7 @@ class PipelineBase:
 
         return {**data}
 
-    def _init_to_run(self, data: Dict[str, Any]) -> List[Tuple[str, Component]]:
+    def _init_to_run(self, pipeline_inputs: Dict[str, Any]) -> List[Tuple[str, Component]]:
         to_run: List[Tuple[str, Component]] = []
         for node_name in self.graph.nodes:
             component = self.graph.nodes[node_name]["instance"]
@@ -729,7 +729,7 @@ class PipelineBase:
                 to_run.append((node_name, component))
                 continue
 
-            if node_name in data:
+            if node_name in pipeline_inputs:
                 # This component is in the input data, if it has enough inputs it can run right away
                 to_run.append((node_name, component))
                 continue

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -719,13 +719,18 @@ class PipelineBase:
 
         return {**data}
 
-    def _init_to_run(self) -> List[Tuple[str, Component]]:
+    def _init_to_run(self, data: Dict[str, Any]) -> List[Tuple[str, Component]]:
         to_run: List[Tuple[str, Component]] = []
         for node_name in self.graph.nodes:
             component = self.graph.nodes[node_name]["instance"]
 
             if len(component.__haystack_input__._sockets_dict) == 0:
                 # Component has no input, can run right away
+                to_run.append((node_name, component))
+                continue
+
+            if node_name in data:
+                # This component is in the input data, if it has enough inputs it can run right away
                 to_run.append((node_name, component))
                 continue
 

--- a/releasenotes/notes/fix-conditional-branching-a0f0d65c7ac97f71.yaml
+++ b/releasenotes/notes/fix-conditional-branching-a0f0d65c7ac97f71.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix some bugs running a Pipeline that has Components with conditional outputs.
+    Some branches that were expected not to run would run anyway, even if they received no inputs.

--- a/releasenotes/notes/fix-conditional-branching-a0f0d65c7ac97f71.yaml
+++ b/releasenotes/notes/fix-conditional-branching-a0f0d65c7ac97f71.yaml
@@ -3,3 +3,5 @@ fixes:
   - |
     Fix some bugs running a Pipeline that has Components with conditional outputs.
     Some branches that were expected not to run would run anyway, even if they received no inputs.
+    Some branches instead would cause the Pipeline to get stuck waiting to run that branch, even if they received no inputs.
+    The behaviour would depend whether the Component not receiving the input has a optional input or not.

--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -34,6 +34,9 @@ Feature: Pipeline running
         | that is linear and returns intermediate outputs |
         | that has a loop and returns intermediate outputs from it |
         | that is linear and returns intermediate outputs from multiple sockets |
+        | that has a component with default inputs that doesn't receive anything from its sender |
+        | that has a component with default inputs that doesn't receive anything from its sender but receives input from user |
+        | that has a loop and a component with default inputs that doesn't receive anything from its sender but receives input from user |
 
     Scenario Outline: Running a bad Pipeline
         Given a pipeline <kind>

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -693,19 +693,23 @@ class TestPipeline:
         pipe.add_component("with_no_inputs", ComponentWithNoInputs())
         pipe.add_component("with_single_input", ComponentWithSingleInput())
         pipe.add_component("another_with_single_input", ComponentWithSingleInput())
+        pipe.add_component("yet_another_with_single_input", ComponentWithSingleInput())
         pipe.add_component("with_multiple_inputs", ComponentWithMultipleInputs())
 
+        pipe.connect("yet_another_with_single_input.out", "with_variadic.in")
         pipe.connect("with_no_inputs.out", "with_variadic.in")
         pipe.connect("with_single_input.out", "another_with_single_input.in")
         pipe.connect("another_with_single_input.out", "with_multiple_inputs.in1")
         pipe.connect("with_multiple_inputs.out", "with_variadic.in")
 
-        to_run = pipe._init_to_run()
-        assert len(to_run) == 4
+        data = {"yet_another_with_single_input": {"in": 1}}
+        to_run = pipe._init_to_run(data)
+        assert len(to_run) == 5
         assert to_run[0][0] == "with_variadic"
         assert to_run[1][0] == "with_no_inputs"
         assert to_run[2][0] == "with_single_input"
-        assert to_run[3][0] == "with_multiple_inputs"
+        assert to_run[3][0] == "yet_another_with_single_input"
+        assert to_run[4][0] == "with_multiple_inputs"
 
     def test__init_inputs_state(self):
         pipe = Pipeline()


### PR DESCRIPTION
### Related Issues

Fixes 
- #7744
- #7533.

### Proposed Changes:

This PR changes a bit how we collect the initial list of Component that can run when calling `Pipeline.run()`.

Instead of getting only Component that have no inputs, or have a least one input that is not connected or is variadic, we also get Components that receive inputs from the user.

It also changes how we handle conditional outputs. Now if a Component with a conditional output runs and doesn't send anything to a certain socket we remove from `to_run` and `waiting_for_input` all the Components connected to that socket.


### How did you test it?

I updated tests locally and ran unit, `Pipeline.run()` and e2e tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
