### PR TITLE
docs: fixing ContextRelevance documentation

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -38,7 +38,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
     """
     Evaluator that checks if a provided context is relevant to the question.
 
-    An LLM separates the answer into multiple statements and checks whether the statement can be inferred from the
+    An LLM breaks up the whole context into multiple statements and checks whether the statement can be inferred from the
     context or not. The final score for the full answer is a number from 0.0 to 1.0. It represents the proportion of
     statements that can be inferred from the provided contexts.
 

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -38,8 +38,9 @@ class ContextRelevanceEvaluator(LLMEvaluator):
     """
     Evaluator that checks if a provided context is relevant to the question.
 
-    An LLM breaks up the whole context into multiple statements and checks whether the statement can be inferred from the
-    context or not. The final score for the full answer is a number from 0.0 to 1.0. It represents the proportion of
+    An LLM breaks up the whole context into multiple statements and checks whether each statement
+    is relevant for answering a question.
+    The final score for the full answer is a number from 0.0 to 1.0. It represents the proportion of
     statements that can be inferred from the provided contexts.
 
     Usage example:

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -38,9 +38,9 @@ class ContextRelevanceEvaluator(LLMEvaluator):
     """
     Evaluator that checks if a provided context is relevant to the question.
 
-    An LLM breaks up the whole context into multiple statements and checks whether each statement
+    An LLM breaks up the context into multiple statements and checks whether each statement
     is relevant for answering a question.
-    The final score for the full answer is a number from 0.0 to 1.0. It represents the proportion of
+    The final score for the context relevance is a number from 0.0 to 1.0. It represents the proportion of
     statements that can be inferred from the provided contexts.
 
     Usage example:


### PR DESCRIPTION
### Proposed Changes:

The ContextRelevanceEvaluator doesn't use the answer as stated in the docstring.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
