### PR TITLE
feat: Add `fetch_archive_from_http` to fetch zip or gzip archives

### DIFF
--- a/haystack/utils/import_utils.py
+++ b/haystack/utils/import_utils.py
@@ -1,13 +1,18 @@
-import logging
+import gzip
 import importlib
 import importlib.util
-from typing import Optional, Tuple, List
-from urllib.parse import urlparse, unquote
-from os.path import splitext, basename
+import io
+import logging
+import zipfile
+from os.path import basename, splitext
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+from urllib.parse import unquote, urlparse
+
+import requests
 
 from haystack.errors import DatasetsError
 from haystack.schema import Document
-
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +58,55 @@ def get_filename_extension_from_url(url: str) -> Tuple[str, str]:
     archive_extension = extension[1:]
     file_name = unquote(basename(root[1:]))
     return file_name, archive_extension
+
+
+def fetch_archive_from_http(
+    url: str,
+    output_dir: str,
+    proxies: Optional[Dict[str, str]] = None,
+    timeout: Union[float, Tuple[float, float]] = 10.0,
+) -> bool:
+    """
+    Fetch an archive (zip or gz) from a url via http and extract content to an output directory.
+    :param url: http address
+    :param output_dir: local path
+    :param proxies: proxies details as required by requests library
+    :param timeout: How many seconds to wait for the server to send data before giving up,
+        as a float, or a :ref:`(connect timeout, read timeout) <timeouts>` tuple.
+        Defaults to 10 seconds.
+    :return: if anything got fetched
+    """
+    # verify & prepare local directory
+    path = Path(output_dir)
+    if not path.exists():
+        path.mkdir(parents=True)
+
+    is_not_empty = len(list(Path(path).rglob("*"))) > 0
+    if is_not_empty:
+        logger.info("Found data stored in '%s'. Delete this first if you really want to fetch new data.", output_dir)
+        return False
+    else:
+        logger.info("Fetching from %s to '%s'", url, output_dir)
+
+        file_name, archive_extension = get_filename_extension_from_url(url)
+        request_data = requests.get(url, proxies=proxies, timeout=timeout)
+
+        if archive_extension == "zip":
+            zip_archive = zipfile.ZipFile(io.BytesIO(request_data.content))
+            zip_archive.extractall(output_dir)
+        elif archive_extension == "gz" and not "tar.gz" in url:
+            gzip_archive = gzip.GzipFile(fileobj=io.BytesIO(request_data.content))
+            file_content = gzip_archive.read()
+            with open(f"{output_dir}/{file_name}", "wb") as file:
+                file.write(file_content)
+        else:
+            logger.warning(
+                "Skipped url %s as file type is not supported here. "
+                "See haystack documentation for support of more file types",
+                url,
+            )
+
+        return True
 
 
 def is_whisper_available():

--- a/releasenotes/notes/safe-fetch-4ba829def3241eec.yaml
+++ b/releasenotes/notes/safe-fetch-4ba829def3241eec.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add previously removed `fetch_archive_from_http` util function to fetch zip and gzip archives from url


### PR DESCRIPTION
### Related Issues

- fixes deepset-ai/haystack-tutorials#326

### Proposed Changes:

Add `fetch_archive_from_http` to fetch zip or gzip archives.
This function has been previously removed for security reasons as it also supported tar files unpacking via `tarfile` module.
This version drops support for tar files so it's safe to use.

### How did you test it?

I didn't ran any test, this function wasn't tested previously.

### Notes for the reviewer

I'll make a new release after this is merged.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
