### PR TITLE
chore: Change trafilatura dependency to use lazy import

### DIFF
--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -6,13 +6,15 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from trafilatura import extract
-
 from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 from haystack.dataclasses import ByteStream
+from haystack.lazy_imports import LazyImport
 
 logger = logging.getLogger(__name__)
+
+with LazyImport("Run 'pip install trafilatura'") as trafilatura_import:
+    from trafilatura import extract
 
 
 @component
@@ -49,6 +51,7 @@ class HTMLToDocument:
             are passed to the underlying Trafilatura `extract` function. For the full list of available arguments, see
             the [Trafilatura documentation](https://trafilatura.readthedocs.io/en/latest/corefunctions.html#extract).
         """
+        trafilatura_import.check()
         if extractor_type is not None:
             warnings.warn(
                 "The `extractor_type` parameter is ignored and will be removed in Haystack 2.4.0. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "more-itertools",  # TextDocumentSplitter
   "networkx", # Pipeline graphs
   "typing_extensions>=4.7", # typing support for Python 3.8
-  "trafilatura", # Fulltext extraction from HTML pages
   "requests",
   "numpy",
   "python-dateutil",
@@ -117,6 +116,7 @@ extra-dependencies = [
   "langdetect",  # TextLanguageRouter and DocumentLanguageClassifier
   "sentence-transformers>=2.2.0",  # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "openai-whisper>=20231106",  # LocalWhisperTranscriber
+  "trafilatura", # Fulltext extraction from HTML pages
 
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions

--- a/releasenotes/notes/change-trafilatura-dependency-575985a2271c8370.yaml
+++ b/releasenotes/notes/change-trafilatura-dependency-575985a2271c8370.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    `trafilatura` must now be manually installed with `pip install trafilatura` to use the `HTMLToDocument` Component.
+enhancements:
+  - |
+    Remove `trafilatura` as direct dependency and make it a lazily imported one


### PR DESCRIPTION
### Proposed Changes:

This PR removes `trafilatura` as a direct dependency and adds it as a lazily imported one.

The dependency has been added as a test dependency.

This is done because `trafilatura` is not a package available on Conda. Having it as a direct dependency prevents us from releasing Haystack on Conda.

See failures on conda-forge/haystack-ai-feedstock#10

### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
