### PR TITLE
fix: specify embedding retriever version

### DIFF
--- a/haystack/nodes/retriever/_embedding_encoder.py
+++ b/haystack/nodes/retriever/_embedding_encoder.py
@@ -135,7 +135,10 @@ class _SentenceTransformersEmbeddingEncoder(_BaseEmbeddingEncoder):
         # e.g. 'roberta-base-nli-stsb-mean-tokens'
         torch_and_transformers_import.check()
         self.embedding_model = SentenceTransformer(
-            retriever.embedding_model, device=str(retriever.devices[0]), use_auth_token=retriever.use_auth_token
+            retriever.embedding_model,
+            device=str(retriever.devices[0]),
+            use_auth_token=retriever.use_auth_token,
+            revision=retriever.model_version,
         )
         self.batch_size = retriever.batch_size
         self.embedding_model.max_seq_length = retriever.max_seq_len

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
 [project.optional-dependencies]
 inference = [
   "transformers[torch,sentencepiece]==4.39.3",
-  "sentence-transformers>=2.2.0",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
+  "sentence-transformers>=2.3.1",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
   "huggingface-hub>=0.5.0",
 ]
 elasticsearch = [

--- a/releasenotes/notes/specify-sentence-transformer-model-version-55b633e8b294189c.yaml
+++ b/releasenotes/notes/specify-sentence-transformer-model-version-55b633e8b294189c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix bug causing latest version of sentence transformer model always being downloaded, even if specific version
+    is given.


### PR DESCRIPTION
### Related Issues

- fixes #7810 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Manual testing locally. 

I would appreciate any pointers to where you might like me to include a test.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
