### PR TITLE
Add fetch_archive_from_http to utils/__init__.py

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -1,6 +1,7 @@
 from haystack.utils.reflection import args_to_kwargs
 from haystack.utils.requests_utils import request_with_retry
 from haystack.utils.preprocessing import convert_files_to_docs, tika_convert_files_to_docs
+from haystack.utils.import_utils import fetch_archive_from_http
 from haystack.utils.cleaning import clean_wiki_text
 from haystack.utils.doc_store import launch_es, launch_opensearch, launch_weaviate, stop_opensearch, stop_service
 from haystack.utils.deepsetcloud import DeepsetCloud, DeepsetCloudError, DeepsetCloudExperiments


### PR DESCRIPTION
### Related Issues

- fixes failures in tutorials tests https://github.com/deepset-ai/haystack-tutorials/actions/runs/9392855560/job/25867859115

### Proposed Changes:

- export the `fetch_archive_from_http` utility function to utils/__init__.py

### How did you test it?

No need to test this

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
