### PR TITLE
fix: `EvaluationRunResult.score_report()` is missing the `metrics` column 

### DIFF
--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -97,7 +97,9 @@ class EvaluationRunResult(BaseEvaluationRunResult):
 
     def score_report(self) -> DataFrame:  # noqa: D102
         results = {k: v["score"] for k, v in self.results.items()}
-        return DataFrame.from_dict(results, orient="index", columns=["score"])
+        df = DataFrame.from_dict(results, orient="index", columns=["score"]).reset_index()
+        df.columns = ["metrics", "score"]
+        return df
 
     def to_pandas(self) -> DataFrame:  # noqa: D102
         inputs_columns = list(self.inputs.keys())

--- a/test/evaluation/test_eval_run_result.py
+++ b/test/evaluation/test_eval_run_result.py
@@ -88,10 +88,11 @@ def test_score_report():
 
     result = EvaluationRunResult("testing_pipeline_1", inputs=data["inputs"], results=data["metrics"])
     report = result.score_report().to_json()
+
     assert report == (
-        '{"score":{"reciprocal_rank":0.476932,"single_hit":0.75,"multi_hit":0.46428375,'
-        '"context_relevance":0.58177975,"faithfulness":0.40585375,'
-        '"semantic_answer_similarity":0.53757075}}'
+        '{"metrics":{"0":"reciprocal_rank","1":"single_hit","2":"multi_hit","3":"context_relevance",'
+        '"4":"faithfulness","5":"semantic_answer_similarity"},'
+        '"score":{"0":0.476932,"1":0.75,"2":0.46428375,"3":0.58177975,"4":0.40585375,"5":0.53757075}}'
     )
 
 


### PR DESCRIPTION
### Related Issues

The DataFrame generated by the EvaluationRunResult.score_report() is missing the column `metrics`.
 
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
