### PR TITLE
fix: Fix `LLMEvaluator` serialization

### DIFF
--- a/releasenotes/notes/llm-evaluator-serde-fix-aa5b27d2524db9c5.yaml
+++ b/releasenotes/notes/llm-evaluator-serde-fix-aa5b27d2524db9c5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Correctly serialize tuples and types in the init parameters of the `LLMEvaluator` component and its subclasses.

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 
-import numpy as np
 import pytest
 
+from haystack import Pipeline
 from haystack.components.evaluators import LLMEvaluator
 from haystack.utils.auth import Secret
 
@@ -205,7 +205,7 @@ class TestLLMEvaluator:
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "api": "openai",
                 "instructions": "test-instruction",
-                "inputs": [("predicted_answers", List[str])],
+                "inputs": [["predicted_answers", "typing.List[str]"]],
                 "outputs": ["score"],
                 "progress_bar": True,
                 "examples": [
@@ -223,7 +223,7 @@ class TestLLMEvaluator:
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "api": "openai",
                 "instructions": "test-instruction",
-                "inputs": [("predicted_answers", List[str])],
+                "inputs": [["predicted_answers", "typing.List[str]"]],
                 "outputs": ["score"],
                 "examples": [
                     {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
@@ -266,7 +266,7 @@ class TestLLMEvaluator:
                 "api_key": {"env_vars": ["ENV_VAR"], "strict": True, "type": "env_var"},
                 "api": "openai",
                 "instructions": "test-instruction",
-                "inputs": [("predicted_answers", List[str])],
+                "inputs": [["predicted_answers", "typing.List[str]"]],
                 "outputs": ["custom_score"],
                 "progress_bar": True,
                 "examples": [
@@ -281,6 +281,20 @@ class TestLLMEvaluator:
                 ],
             },
         }
+
+    def test_serde(self):
+        pipeline = Pipeline()
+        component = LLMEvaluator(
+            instructions="test-instruction",
+            inputs=[("questions", List[str]), ("predicted_answers", List[List[str]])],
+            outputs=["score"],
+            examples=[
+                {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
+            ],
+        )
+        pipeline.add_component("evaluator", component)
+        serialized_pipeline = pipeline.dumps()
+        deserialized_pipeline = Pipeline.loads(serialized_pipeline)
 
     def test_run_with_different_lengths(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -282,7 +282,8 @@ class TestLLMEvaluator:
             },
         }
 
-    def test_serde(self):
+    def test_serde(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         pipeline = Pipeline()
         component = LLMEvaluator(
             instructions="test-instruction",


### PR DESCRIPTION
### Related Issues

- fixes #7768

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The `inputs` init parameter of the `LLMEvaluator` component accepts a list of tuples containing an input name and its corresponding type. Previously, we were saving this parameter as-is - problematic due to the serialization code supporting neither raw tuples nor raw types. This PR fixes the above issue by converting the tuples to lists and the correctly serializing the types.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
