### PR TITLE
test: Reenable collection of `test_json_schema.py`

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -85,11 +85,3 @@ def spying_tracer() -> Generator[SpyingTracer, None, None]:
 
     # Make sure to disable tracing after the test to avoid affecting other tests
     tracing.disable_tracing()
-
-
-# Collecting this test is causing issues when running tests in CI
-# as it's indirectly importing jsonschema which for some reason
-# is causing collection to fail.
-# See this issue:
-# https://github.com/python-jsonschema/jsonschema/issues/1236
-collect_ignore = ["components/validators/test_json_schema.py"]


### PR DESCRIPTION
### Proposed Changes:

Reenable collection of `test_json_schema.py` that we previously removed with #7353 cause of python-jsonschema/jsonschema#1236.

### How did you test it?

Can't test locally, this happens only in CI.

### Notes for the reviewer

This is just an attempt to see if the problem has actually been solved.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
