### PR TITLE
fix: end2end evaluation pipeline failing

### DIFF
--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -223,8 +223,8 @@ def test_evaluation_pipeline(samples_path):
 
     # assert the score report has all the metrics
     assert len(df_score_report) == 7
-    assert list(df_score_report.columns) == ["score"]
-    assert list(df_score_report.index) == [
+    assert list(df_score_report.columns) == ["metrics", "score"]
+    assert list(df_score_report.metrics) == [
         "Mean Reciprocal Rank",
         "Semantic Answer Similarity",
         "Faithfulness",


### PR DESCRIPTION
### Proposed Changes:

a column `metrics` was missing

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
