### PR TITLE
refactor: Isolate logic to check if a Component can run

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -25,13 +25,18 @@ class Pipeline(PipelineBase):
     def _component_has_enough_inputs_to_run(self, name: str, last_inputs: Dict[str, Dict[str, Any]]) -> bool:
         """
         Returns True if the Component has all the inputs it needs to run.
+
+        :param name: Name of the Component as defined in the Pipeline.
+        :param last_inputs: The current state of the inputs divided by Component name.
+
+        :return: Whether the Component can run or not.
         """
         instance: Component = self.graph.nodes[name]["instance"]
         if name not in last_inputs:
             return False
-        expected_inputs = set(instance.__haystack_input__._sockets_dict.keys())  # type: ignore
-        current_inputs = set(last_inputs[name].keys())
-        if expected_inputs != current_inputs:  # type: ignore
+        expected_inputs = instance.__haystack_input__._sockets_dict.keys()  # type: ignore
+        current_inputs = last_inputs[name].keys()
+        if expected_inputs != current_inputs:
             return False
         return True
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -22,20 +22,20 @@ class Pipeline(PipelineBase):
     Orchestrates component execution according to the execution graph, one after the other.
     """
 
-    def _component_has_enough_inputs_to_run(self, name: str, last_inputs: Dict[str, Dict[str, Any]]) -> bool:
+    def _component_has_enough_inputs_to_run(self, name: str, inputs: Dict[str, Dict[str, Any]]) -> bool:
         """
         Returns True if the Component has all the inputs it needs to run.
 
         :param name: Name of the Component as defined in the Pipeline.
-        :param last_inputs: The current state of the inputs divided by Component name.
+        :param inputs: The current state of the inputs divided by Component name.
 
         :return: Whether the Component can run or not.
         """
         instance: Component = self.graph.nodes[name]["instance"]
-        if name not in last_inputs:
+        if name not in inputs:
             return False
         expected_inputs = instance.__haystack_input__._sockets_dict.keys()  # type: ignore
-        current_inputs = last_inputs[name].keys()
+        current_inputs = inputs[name].keys()
         if expected_inputs != current_inputs:
             return False
         return True

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1042,3 +1042,16 @@ class TestPipeline:
         }
 
         assert caplog.messages == ["Running component document_builder"]
+
+    def test__component_has_enough_inputs_to_run(self):
+        sentence_builder = component_class("SentenceBuilder", input_types={"words": List[str]})()
+        pipe = Pipeline()
+        pipe.add_component("sentence_builder", sentence_builder)
+
+        assert not pipe._component_has_enough_inputs_to_run("sentence_builder", {})
+        assert not pipe._component_has_enough_inputs_to_run(
+            "sentence_builder", {"sentence_builder": {"wrong_input_name": "blah blah"}}
+        )
+        assert pipe._component_has_enough_inputs_to_run(
+            "sentence_builder", {"sentence_builder": {"words": ["blah blah"]}}
+        )


### PR DESCRIPTION
### Related Issues

Part of #7614

### Proposed Changes:

Isolate and make slightly safer the logic to check if a Component can run.

### How did you test it?

Added a new unit test and run test.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
