### PR TITLE
bug: fix MRR and MAP calculations

### DIFF
--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -68,7 +68,7 @@ class DocumentMAPEvaluator:
         individual_scores = []
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
-            average_precision = 0
+            average_precision = 0.0
             average_precision_numerator = 0.0
             relevant_documents = 0
 

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -10,7 +10,7 @@ from haystack import Document, component
 @component
 class DocumentMAPEvaluator:
     """
-    A Mean Average Precision (MAP) evaluator for documents.
+    A Mean Average Precision (MAP) evaluator for documents. For details, please refer to the [resource](https://www.pinecone.io/learn/offline-evaluation/).
 
     Evaluator that calculates the mean average precision of the retrieved documents, a metric
     that measures how high retrieved documents are ranked.
@@ -68,22 +68,21 @@ class DocumentMAPEvaluator:
         individual_scores = []
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
-            score = 0.0
-            average_precision = 0.0
+            average_precision = 0
+            average_precision_numerator = 0.0
             relevant_documents = 0
 
-            ground_truth_content = [doc.content for doc in ground_truth if doc.content is not None]
+            ground_truth_contents = [doc.content for doc in ground_truth if doc.content is not None]
             for rank, retrieved_document in enumerate(retrieved):
                 if retrieved_document.content is None:
                     continue
 
-                if retrieved_document.content in ground_truth_content:
+                if retrieved_document.content in ground_truth_contents:
                     relevant_documents += 1
-                    average_precision += relevant_documents / (rank + 1)
+                    average_precision_numerator += relevant_documents / (rank + 1)
             if relevant_documents > 0:
-                score = average_precision / relevant_documents
-            individual_scores.append(score)
+                average_precision = average_precision_numerator / relevant_documents
+            individual_scores.append(average_precision)
 
         score = sum(individual_scores) / len(ground_truth_documents)
-
         return {"score": score, "individual_scores": individual_scores}

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -69,24 +69,26 @@ class DocumentMAPEvaluator:
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
             score = 0.0
+            average_precision = 0.0
+            relevant_documents = 0
+            ground_truth_content = []
+
             for ground_document in ground_truth:
                 if ground_document.content is None:
                     continue
+                ground_truth_content.append(ground_document.content)
 
-                average_precision = 0.0
-                relevant_documents = 0
+            for rank, retrieved_document in enumerate(retrieved):
+                if retrieved_document.content is None:
+                    continue
 
-                for rank, retrieved_document in enumerate(retrieved):
-                    if retrieved_document.content is None:
-                        continue
-
-                    if ground_document.content in retrieved_document.content:
-                        relevant_documents += 1
-                        average_precision += relevant_documents / (rank + 1)
-                if relevant_documents > 0:
-                    score = average_precision / relevant_documents
+                if retrieved_document.content in ground_truth_content:
+                    relevant_documents += 1
+                    average_precision += relevant_documents / (rank + 1)
+            if relevant_documents > 0:
+                score = average_precision / relevant_documents
             individual_scores.append(score)
 
-        score = sum(individual_scores) / len(retrieved_documents)
+        score = sum(individual_scores) / len(ground_truth_documents)
 
         return {"score": score, "individual_scores": individual_scores}

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -71,13 +71,8 @@ class DocumentMAPEvaluator:
             score = 0.0
             average_precision = 0.0
             relevant_documents = 0
-            ground_truth_content = []
 
-            for ground_document in ground_truth:
-                if ground_document.content is None:
-                    continue
-                ground_truth_content.append(ground_document.content)
-
+            ground_truth_content = [doc.content for doc in ground_truth if doc.content is not None]
             for rank, retrieved_document in enumerate(retrieved):
                 if retrieved_document.content is None:
                     continue

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -10,7 +10,7 @@ from haystack import Document, component
 @component
 class DocumentMAPEvaluator:
     """
-    A Mean Average Precision (MAP) evaluator for documents. For details, please refer to the [resource](https://www.pinecone.io/learn/offline-evaluation/).
+    A Mean Average Precision (MAP) evaluator for documents.
 
     Evaluator that calculates the mean average precision of the retrieved documents, a metric
     that measures how high retrieved documents are ranked.
@@ -43,6 +43,7 @@ class DocumentMAPEvaluator:
     ```
     """
 
+    # Refer to https://www.pinecone.io/learn/offline-evaluation/ for the algorithm.
     @component.output_types(score=float, individual_scores=List[float])
     def run(
         self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -67,13 +67,8 @@ class DocumentMRREvaluator:
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
             score = 0.0
-            ground_truth_content = []
 
-            for ground_document in ground_truth:
-                if ground_document.content is None:
-                    continue
-                ground_truth_content.append(ground_document.content)
-
+            ground_truth_content = [doc.content for doc in ground_truth if doc.content is not None]
             for rank, retrieved_document in enumerate(retrieved):
                 if retrieved_document.content is None:
                     continue

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -67,7 +67,6 @@ class DocumentMRREvaluator:
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
             score = 0.0
-            flag = False
             ground_truth_content = []
 
             for ground_document in ground_truth:
@@ -76,13 +75,10 @@ class DocumentMRREvaluator:
                 ground_truth_content.append(ground_document.content)
 
             for rank, retrieved_document in enumerate(retrieved):
-                if flag:
-                    break
                 if retrieved_document.content is None:
                     continue
                 if retrieved_document.content in ground_truth_content:
                     score = 1 / (rank + 1)
-                    flag = True
                     break
             individual_scores.append(score)
 

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -67,17 +67,23 @@ class DocumentMRREvaluator:
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
             score = 0.0
+            flag = False
+            ground_truth_content = []
+
             for ground_document in ground_truth:
                 if ground_document.content is None:
                     continue
+                ground_truth_content.append(ground_document.content)
 
-                for rank, retrieved_document in enumerate(retrieved):
-                    if retrieved_document.content is None:
-                        continue
-
-                    if ground_document.content in retrieved_document.content:
-                        score = 1 / (rank + 1)
-                        break
+            for rank, retrieved_document in enumerate(retrieved):
+                if flag:
+                    break
+                if retrieved_document.content is None:
+                    continue
+                if retrieved_document.content in ground_truth_content:
+                    score = 1 / (rank + 1)
+                    flag = True
+                    break
             individual_scores.append(score)
 
         score = sum(individual_scores) / len(retrieved_documents)

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -10,7 +10,7 @@ from haystack import Document, component
 @component
 class DocumentMRREvaluator:
     """
-    Evaluator that calculates the mean reciprocal rank of the retrieved documents. For details, please refer to the [resource](https://www.pinecone.io/learn/offline-evaluation/).
+    Evaluator that calculates the mean reciprocal rank of the retrieved documents.
 
     MRR measures how high the first retrieved document is ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
@@ -41,6 +41,7 @@ class DocumentMRREvaluator:
     ```
     """
 
+    # Refer to https://www.pinecone.io/learn/offline-evaluation/ for the algorithm.
     @component.output_types(score=float, individual_scores=List[float])
     def run(
         self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -10,7 +10,7 @@ from haystack import Document, component
 @component
 class DocumentMRREvaluator:
     """
-    Evaluator that calculates the mean reciprocal rank of the retrieved documents.
+    Evaluator that calculates the mean reciprocal rank of the retrieved documents. For details, please refer to the [resource](https://www.pinecone.io/learn/offline-evaluation/).
 
     MRR measures how high the first retrieved document is ranked.
     Each question can have multiple ground truth documents and multiple retrieved documents.
@@ -66,17 +66,17 @@ class DocumentMRREvaluator:
         individual_scores = []
 
         for ground_truth, retrieved in zip(ground_truth_documents, retrieved_documents):
-            score = 0.0
+            reciprocal_rank = 0.0
 
-            ground_truth_content = [doc.content for doc in ground_truth if doc.content is not None]
+            ground_truth_contents = [doc.content for doc in ground_truth if doc.content is not None]
             for rank, retrieved_document in enumerate(retrieved):
                 if retrieved_document.content is None:
                     continue
-                if retrieved_document.content in ground_truth_content:
-                    score = 1 / (rank + 1)
+                if retrieved_document.content in ground_truth_contents:
+                    reciprocal_rank = 1 / (rank + 1)
                     break
-            individual_scores.append(score)
+            individual_scores.append(reciprocal_rank)
 
-        score = sum(individual_scores) / len(retrieved_documents)
+        score = sum(individual_scores) / len(ground_truth_documents)
 
         return {"score": score, "individual_scores": individual_scores}

--- a/releasenotes/notes/fix-issue-7758-d35b687ca226a707.yaml
+++ b/releasenotes/notes/fix-issue-7758-d35b687ca226a707.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the calculation for MRR and MAP scores.

--- a/test/components/evaluators/test_document_map.py
+++ b/test/components/evaluators/test_document_map.py
@@ -62,7 +62,17 @@ def test_run_with_complex_data():
             ],
         ],
     )
-    assert result == {"individual_scores": [1.0, 0.8333333333333333, 1.0, 0.5, 0.0, 1.0], "score": 0.7222222222222222}
+    assert result == {
+        "individual_scores": [
+            1.0,
+            pytest.approx(0.8333333333333333),
+            1.0,
+            pytest.approx(0.5833333333333333),
+            0.0,
+            pytest.approx(0.8055555555555555),
+        ],
+        "score": pytest.approx(0.7037037037037037),
+    }
 
 
 def test_run_with_different_lengths():


### PR DESCRIPTION
### Related Issues

- fixes #7758

### Proposed Changes:

Fixed errors of MRREvaluator:
* Corrected the logic for calculation of MRR 
* Added a flag to break the loop when condition is fulfilled
* Optimized the loops

Fixed errors of MAPEvaluator:
* Corrected the logic for calculation of MAP
* Optimized the loops

Fixed errors in pytest file of `test_document_map.py`:
* Corrected values for `test_run_with_complex_data()`

### How did you test it?

Ran unit tests for both evaluators

### Notes for the reviewer

Verify the correctness of the calculated scores for an example.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
