### PR TITLE
refactor: Isolate logic that distributes Components output after run

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -870,7 +870,7 @@ class PipelineBase:
         # We keep track of which keys to remove from component_result at the end of the loop.
         # This is done after the output has been distributed to the next components, so that
         # we're sure all components that need this output have received it.
-        to_remove_from_res = set()
+        to_remove_from_component_result = set()
 
         for _, receiver_name, connection in self.graph.edges(nbunch=component_name, data=True):
             sender_socket: OutputSocket = connection["from_socket"]
@@ -890,8 +890,9 @@ class PipelineBase:
             if receiver_name not in inputs_by_component:
                 inputs_by_component[receiver_name] = {}
 
-            # We'll remove this key from the output at the end of the loop
-            to_remove_from_res.add(sender_socket.name)
+            # We keep track of the keys that were distributed to other Components.
+            # This key will be removed from component_result at the end of the loop.
+            to_remove_from_component_result.add(sender_socket.name)
 
             value = component_result[sender_socket.name]
 
@@ -928,7 +929,7 @@ class PipelineBase:
                 to_run.append(pair)
 
         # Returns the output without the keys that were distributed to other Components
-        return {k: v for k, v in component_result.items() if k not in to_remove_from_res}
+        return {k: v for k, v in component_result.items() if k not in to_remove_from_component_result}
 
 
 def _connections_status(

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -916,7 +916,7 @@ class PipelineBase:
 
             is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
             if receiver_socket.is_variadic and is_greedy:
-                # If the receiver is greedy, we can run it right away.
+                # If the receiver is greedy, we can run it as soon as possible.
                 # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
                 if pair in to_run:
                     to_run.remove(pair)

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -916,13 +916,12 @@ class PipelineBase:
 
             is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
             if receiver_socket.is_variadic and is_greedy:
-                # If the receiver is greedy, we can run it right away.
+                # If the receiver is greedy, we can run it as soon as possible.
                 # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
-                if pair in to_run:
-                    to_run.remove(pair)
                 if pair in waiting_for_input:
                     waiting_for_input.remove(pair)
-                to_run.append(pair)
+                if pair not in to_run:
+                    to_run.append(pair)
 
             if pair not in waiting_for_input and pair not in to_run:
                 # Queue up the Component that received this input to run, only if it's not already waiting

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -877,7 +877,14 @@ class PipelineBase:
             receiver_socket: InputSocket = connection["to_socket"]
 
             if sender_socket.name not in component_result:
-                # This output wasn't created by the sender, nothing we can do
+                # This output wasn't created by the sender, nothing we can do.
+                #
+                # Some Components might have conditional outputs, so we need to check if they actually returned
+                # some output while iterating over their output sockets.
+                #
+                # A perfect example of this would be the ConditionalRouter, which will have an output for each
+                # condition it has been initialized with.
+                # Though it will return only one output at a time.
                 continue
 
             if receiver_name not in inputs_by_component:

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -816,6 +816,107 @@ class PipelineBase:
         for node in self.graph.nodes:
             self.graph.nodes[node]["visits"] = 0
 
+    def _remove_components_that_received_no_input(
+        self,
+        name: str,
+        res: Dict[str, Any],
+        to_run: List[Tuple[str, Component]],
+        waiting_for_input: List[Tuple[str, Component]],
+    ):
+        """
+        Removes Components that didn't receive any input from the list of Components to run.
+
+        We can't run those Components if they didn't receive any input, even if it's optional.
+        This is mainly useful for Components that have conditional outputs.
+
+        :param name: Name of the Component that created the output
+        :param res: The output of the Component
+        :param to_run: Queue of Components to run
+        :param waiting_for_input: Queue of Components waiting for input
+        """
+        instance: Component = self.graph.nodes[name]["instance"]
+        for socket_name, socket in instance.__haystack_output__._sockets_dict.items():  # type: ignore
+            if socket_name in res:
+                continue
+            for receiver in socket.receivers:
+                receiver_instance: Component = self.graph.nodes[receiver]["instance"]
+                pair = (receiver, receiver_instance)
+                if pair in to_run:
+                    to_run.remove(pair)
+                if pair in waiting_for_input:
+                    waiting_for_input.remove(pair)
+
+    def _distribute_output(
+        self,
+        name: str,
+        res: Dict[str, Any],
+        inputs: Dict[str, Dict[str, Any]],
+        to_run: List[Tuple[str, Component]],
+        waiting_for_input: List[Tuple[str, Component]],
+    ):
+        """
+        Distributes the output of a Component to the next Components that need it.
+
+        This also updates the queues that keep track of which Components are ready to run and which are waiting for input.
+
+        :param name: Name of the Component that created the output
+        :param res: The output of the Component
+        :paramt inputs: The current state of the inputs divided by Component name
+        :param to_run: Queue of Components to run
+        :param waiting_for_input: Queue of Components waiting for input
+
+        :return: The updated output of the Component without the keys that were distributed to other Components
+        """
+        # We keep track of which keys to remove from res at the end of the loop.
+        # This is done after the output has been distributed to the next components, so that
+        # we're sure all components that need this output have received it.
+        to_remove_from_res = set()
+
+        for _, receiver_name, connection in self.graph.edges(nbunch=name, data=True):
+            sender_socket: OutputSocket = connection["from_socket"]
+            receiver_socket: InputSocket = connection["to_socket"]
+
+            if sender_socket.name not in res:
+                # This output wasn't created by the sender, nothing we can do
+                continue
+
+            if receiver_name not in inputs:
+                inputs[receiver_name] = {}
+
+            # We'll remove this key from the output at the end of the loop
+            to_remove_from_res.add(sender_socket.name)
+
+            value = res[sender_socket.name]
+
+            if receiver_socket.is_variadic:
+                # Variadic inputs are always lists
+                if receiver_socket.name not in inputs[receiver_name]:
+                    # Create the list if it doesn't exist
+                    inputs[receiver_name][receiver_socket.name] = []
+                inputs[receiver_name][receiver_socket.name].append(value)
+            else:
+                inputs[receiver_name][receiver_socket.name] = value
+
+            receiver = self.graph.nodes[receiver_name]["instance"]
+            pair = (receiver_name, receiver)
+
+            is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
+            if receiver_socket.is_variadic and is_greedy:
+                # If the receiver is greedy, we can run it right away.
+                # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
+                if pair in to_run:
+                    to_run.remove(pair)
+                if pair in waiting_for_input:
+                    waiting_for_input.remove(pair)
+                to_run.append(pair)
+            elif pair not in waiting_for_input and pair not in to_run:
+                # Queue up the Component that received this input to run, only if it's not already waiting
+                # for input or already ready to run.
+                to_run.append(pair)
+
+        # Returns the output without the keys that were distributed to other Components
+        return {k: v for k, v in res.items() if k not in to_remove_from_res}
+
 
 def _connections_status(
     sender_node: str, receiver_node: str, sender_sockets: List[OutputSocket], receiver_sockets: List[InputSocket]

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -923,7 +923,8 @@ class PipelineBase:
                 if pair in waiting_for_input:
                     waiting_for_input.remove(pair)
                 to_run.append(pair)
-            elif pair not in waiting_for_input and pair not in to_run:
+
+            if pair not in waiting_for_input and pair not in to_run:
                 # Queue up the Component that received this input to run, only if it's not already waiting
                 # for input or already ready to run.
                 to_run.append(pair)

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -896,10 +896,16 @@ class PipelineBase:
             value = component_result[sender_socket.name]
 
             if receiver_socket.is_variadic:
-                # Variadic inputs are always lists
+                # Usually Component inputs can only be received from one sender, the Variadic type allows
+                # instead to receive inputs from multiple senders.
+                #
+                # To keep track of all the inputs received internally we always store them in a list.
                 if receiver_socket.name not in inputs_by_component[receiver_name]:
                     # Create the list if it doesn't exist
                     inputs_by_component[receiver_name][receiver_socket.name] = []
+                else:
+                    # Check if the value is actually a list
+                    assert isinstance(inputs_by_component[receiver_name][receiver_socket.name], list)
                 inputs_by_component[receiver_name][receiver_socket.name].append(value)
             else:
                 inputs_by_component[receiver_name][receiver_socket.name] = value

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -853,7 +853,7 @@ class PipelineBase:
         inputs_by_component: Dict[str, Dict[str, Any]],
         to_run: List[Tuple[str, Component]],
         waiting_for_input: List[Tuple[str, Component]],
-    ):
+    ) -> Dict[str, Any]:
         """
         Distributes the output of a Component to the next Components that need it.
 

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -867,7 +867,7 @@ class PipelineBase:
 
         :return: The updated output of the Component without the keys that were distributed to other Components
         """
-        # We keep track of which keys to remove from res at the end of the loop.
+        # We keep track of which keys to remove from component_result at the end of the loop.
         # This is done after the output has been distributed to the next components, so that
         # we're sure all components that need this output have received it.
         to_remove_from_res = set()

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -916,12 +916,13 @@ class PipelineBase:
 
             is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
             if receiver_socket.is_variadic and is_greedy:
-                # If the receiver is greedy, we can run it as soon as possible.
+                # If the receiver is greedy, we can run it right away.
                 # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
+                if pair in to_run:
+                    to_run.remove(pair)
                 if pair in waiting_for_input:
                     waiting_for_input.remove(pair)
-                if pair not in to_run:
-                    to_run.append(pair)
+                to_run.append(pair)
 
             if pair not in waiting_for_input and pair not in to_run:
                 # Queue up the Component that received this input to run, only if it's not already waiting

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -260,7 +260,7 @@ class Pipeline(PipelineBase):
                         # This happens when a component was put in the waiting list but we reached it from another edge.
                         waiting_for_input.remove((name, comp))
 
-                    self._remove_components_that_received_no_input(name, res, to_run, waiting_for_input)
+                    self._dequeue_components_that_received_no_input(name, res, to_run, waiting_for_input)
                     res = self._distribute_output(name, res, last_inputs, to_run, waiting_for_input)
 
                     if len(res) > 0:

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
 from haystack import logging, tracing
 from haystack.core.component import Component
-from haystack.core.component.types import InputSocket, OutputSocket
 from haystack.core.errors import PipelineMaxLoops, PipelineRuntimeError
 from haystack.telemetry import pipeline_running
 
@@ -22,107 +21,6 @@ class Pipeline(PipelineBase):
 
     Orchestrates component execution according to the execution graph, one after the other.
     """
-
-    def _remove_components_that_received_no_input(
-        self,
-        name: str,
-        res: Dict[str, Any],
-        to_run: List[Tuple[str, Component]],
-        waiting_for_input: List[Tuple[str, Component]],
-    ):
-        """
-        Removes Components that didn't receive any input from the list of Components to run.
-
-        We can't run those Components if they didn't receive any input, even if it's optional.
-        This is mainly useful for Components that have conditional outputs.
-
-        :param name: Name of the Component that created the output
-        :param res: The output of the Component
-        :param to_run: Queue of Components to run
-        :param waiting_for_input: Queue of Components waiting for input
-        """
-        instance: Component = self.graph.nodes[name]["instance"]
-        for socket_name, socket in instance.__haystack_output__._sockets_dict.items():  # type: ignore
-            if socket_name in res:
-                continue
-            for receiver in socket.receivers:
-                receiver_instance: Component = self.graph.nodes[receiver]["instance"]
-                pair = (receiver, receiver_instance)
-                if pair in to_run:
-                    to_run.remove(pair)
-                if pair in waiting_for_input:
-                    waiting_for_input.remove(pair)
-
-    def _distribute_output(
-        self,
-        name: str,
-        res: Dict[str, Any],
-        inputs: Dict[str, Dict[str, Any]],
-        to_run: List[Tuple[str, Component]],
-        waiting_for_input: List[Tuple[str, Component]],
-    ):
-        """
-        Distributes the output of a Component to the next Components that need it.
-
-        This also updates the queues that keep track of which Components are ready to run and which are waiting for input.
-
-        :param name: Name of the Component that created the output
-        :param res: The output of the Component
-        :paramt inputs: The current state of the inputs divided by Component name
-        :param to_run: Queue of Components to run
-        :param waiting_for_input: Queue of Components waiting for input
-
-        :return: The updated output of the Component without the keys that were distributed to other Components
-        """
-        # We keep track of which keys to remove from res at the end of the loop.
-        # This is done after the output has been distributed to the next components, so that
-        # we're sure all components that need this output have received it.
-        to_remove_from_res = set()
-
-        for _, receiver_name, connection in self.graph.edges(nbunch=name, data=True):
-            sender_socket: OutputSocket = connection["from_socket"]
-            receiver_socket: InputSocket = connection["to_socket"]
-
-            if sender_socket.name not in res:
-                # This output wasn't created by the sender, nothing we can do
-                continue
-
-            if receiver_name not in inputs:
-                inputs[receiver_name] = {}
-
-            # We'll remove this key from the output at the end of the loop
-            to_remove_from_res.add(sender_socket.name)
-
-            value = res[sender_socket.name]
-
-            if receiver_socket.is_variadic:
-                # Variadic inputs are always lists
-                if receiver_socket.name not in inputs[receiver_name]:
-                    # Create the list if it doesn't exist
-                    inputs[receiver_name][receiver_socket.name] = []
-                inputs[receiver_name][receiver_socket.name].append(value)
-            else:
-                inputs[receiver_name][receiver_socket.name] = value
-
-            receiver = self.graph.nodes[receiver_name]["instance"]
-            pair = (receiver_name, receiver)
-
-            is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
-            if receiver_socket.is_variadic and is_greedy:
-                # If the receiver is greedy, we can run it right away.
-                # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
-                if pair in to_run:
-                    to_run.remove(pair)
-                if pair in waiting_for_input:
-                    waiting_for_input.remove(pair)
-                to_run.append(pair)
-            elif pair not in waiting_for_input and pair not in to_run:
-                # Queue up the Component that received this input to run, only if it's not already waiting
-                # for input or already ready to run.
-                to_run.append(pair)
-
-        # Returns the output without the keys that were distributed to other Components
-        return {k: v for k, v in res.items() if k not in to_remove_from_res}
 
     def _component_has_enough_inputs_to_run(self, name: str, inputs: Dict[str, Dict[str, Any]]) -> bool:
         """

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1043,6 +1043,15 @@ class TestPipeline:
 
         assert caplog.messages == ["Running component document_builder"]
 
+    def test__run_component_with_variadic_input(self):
+        document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
+
+        pipe = Pipeline()
+        pipe.add_component("document_joiner", document_joiner)
+        inputs = {"docs": [Document(content="doc1"), Document(content="doc2")]}
+        pipe._run_component("document_joiner", inputs)
+        assert inputs == {"docs": []}
+
     def test__component_has_enough_inputs_to_run(self):
         sentence_builder = component_class("SentenceBuilder", input_types={"words": List[str]})()
         pipe = Pipeline()

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1055,3 +1055,58 @@ class TestPipeline:
         assert pipe._component_has_enough_inputs_to_run(
             "sentence_builder", {"sentence_builder": {"words": ["blah blah"]}}
         )
+
+    def test__remove_components_that_received_no_input(self):
+        sentence_builder = component_class(
+            "SentenceBuilder", input_types={"words": List[str]}, output={"text": "some words"}
+        )()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output={"doc": Document(content="some words")}
+        )()
+
+        pipe = Pipeline()
+        pipe.add_component("sentence_builder", sentence_builder)
+        pipe.add_component("document_builder", document_builder)
+        pipe.connect("sentence_builder.text", "document_builder.text")
+
+        to_run = [("document_builder", document_builder)]
+        waiting_for_input = [("document_builder", document_builder)]
+        pipe._remove_components_that_received_no_input("sentence_builder", {}, to_run, waiting_for_input)
+        assert to_run == []
+        assert waiting_for_input == []
+
+    def test__distribute_output(self):
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document, "another_doc": Document}
+        )()
+        document_cleaner = component_class(
+            "DocumentCleaner", input_types={"doc": Document}, output_types={"cleaned_doc": Document}
+        )()
+        document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
+
+        pipe = Pipeline()
+        pipe.add_component("document_builder", document_builder)
+        pipe.add_component("document_cleaner", document_cleaner)
+        pipe.add_component("document_joiner", document_joiner)
+        pipe.connect("document_builder.doc", "document_cleaner.doc")
+        pipe.connect("document_builder.another_doc", "document_joiner.docs")
+
+        inputs = {"document_builder": {"text": "some text"}}
+        to_run = []
+        waiting_for_input = [("document_joiner", document_joiner)]
+        res = pipe._distribute_output(
+            "document_builder",
+            {"doc": Document("some text"), "another_doc": Document()},
+            inputs,
+            to_run,
+            waiting_for_input,
+        )
+
+        assert res == {}
+        assert inputs == {
+            "document_builder": {"text": "some text"},
+            "document_cleaner": {"doc": Document("some text")},
+            "document_joiner": {"docs": [Document()]},
+        }
+        assert to_run == [("document_cleaner", document_cleaner)]
+        assert waiting_for_input == [("document_joiner", document_joiner)]

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1065,7 +1065,7 @@ class TestPipeline:
             "sentence_builder", {"sentence_builder": {"words": ["blah blah"]}}
         )
 
-    def test__remove_components_that_received_no_input(self):
+    def test__dequeue_components_that_received_no_input(self):
         sentence_builder = component_class(
             "SentenceBuilder", input_types={"words": List[str]}, output={"text": "some words"}
         )()
@@ -1080,7 +1080,7 @@ class TestPipeline:
 
         to_run = [("document_builder", document_builder)]
         waiting_for_input = [("document_builder", document_builder)]
-        pipe._remove_components_that_received_no_input("sentence_builder", {}, to_run, waiting_for_input)
+        pipe._dequeue_components_that_received_no_input("sentence_builder", {}, to_run, waiting_for_input)
         assert to_run == []
         assert waiting_for_input == []
 


### PR DESCRIPTION
### Related Issues

- Part of #7614

### Proposed Changes:

Isolate logic that distributes Components output after run.

This also slightly changes the `_run_component()` method to resetting variadics as it was done in the wrong place.

### How did you test it?

I added tests and ran them locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
