### PR TITLE
fix: `ChatPromptBuilder` Fails to JSON Serialize due to `ChatMessage` class

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Set
 from jinja2 import Template, meta
 
 from haystack import component, logging
+from haystack.core.serialization import default_from_dict, default_to_dict
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole
 
 logger = logging.getLogger(__name__)
@@ -221,3 +222,28 @@ class ChatPromptBuilder:
                 f"Missing required input variables in ChatPromptBuilder: {missing_vars_str}. "
                 f"Required variables: {self.required_variables}. Provided variables: {provided_variables}."
             )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        template = [message.__dict__ for message in self.template]
+        return default_to_dict(self, template=template)
+
+    @classmethod
+    def from_dict(cls, data) -> "ChatPromptBuilder":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        :returns:
+            The deserialized component.
+        """
+        data["init_parameters"]["template"] = [
+            ChatMessage(**message_dict) for message_dict in data["init_parameters"]["template"]
+        ]
+        return default_from_dict(cls, data)


### PR DESCRIPTION
### Related Issues

- fixes #7844

### Proposed Changes:

Added `to_dict` and `from_dict` to `ChatPromptBuilder` fixing the issue. Differently from pr #7849 I didn't change `ChatMessage`.

Not sure which solution is better (I think his), keeping this here just in case :)

### How did you test it?

Empirically

### Notes for the reviewer


### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [ ] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
