### PR TITLE
fix: `DocxToDocument` - use forward reference

### DIFF
--- a/haystack/components/converters/docx.py
+++ b/haystack/components/converters/docx.py
@@ -25,7 +25,7 @@ class DocxToDocument:
     Converts Docx files to Documents.
 
     Uses `python-docx` library to convert the Docx file to a document.
-    This component does not preserve page brakes in the original document.
+    This component does not preserve page breaks in the original document.
 
     Usage example:
     ```python
@@ -115,7 +115,7 @@ class DocxToDocument:
 
         return {"documents": documents}
 
-    def _get_docx_metadata(self, document: DocxDocument) -> Dict[str, Union[str, int, datetime]]:
+    def _get_docx_metadata(self, document: "DocxDocument") -> Dict[str, Union[str, int, datetime]]:
         """
         Get all relevant data from the 'core_properties' attribute from a Docx Document.
 

--- a/test/components/converters/test_docx_file_to_document.py
+++ b/test/components/converters/test_docx_file_to_document.py
@@ -27,12 +27,11 @@ class TestDocxToDocument:
         assert len(docs) == 1
         assert "History" in docs[0].content
 
+    @pytest.mark.integration
     def test_run_with_meta(self, test_files_path, docx_converter):
-        with patch("haystack.components.converters.docx.DocxToDocument"):
-            output = docx_converter.run(
-                sources=[test_files_path / "docx" / "sample_docx_1.docx"],
-                meta={"language": "it", "author": "test_author"},
-            )
+        output = docx_converter.run(
+            sources=[test_files_path / "docx" / "sample_docx_1.docx"], meta={"language": "it", "author": "test_author"}
+        )
 
         # check that the metadata from the bytestream is merged with that from the meta parameter
         assert output["documents"][0].meta["author"] == "test_author"


### PR DESCRIPTION
### Related Issues

- fixes errors like this: https://github.com/deepset-ai/haystack-core-integrations/actions/runs/9491529913/job/26157131998
- `python-docx` is an optional dependency, but we are explicitly using its `DocxDocument` type in the signature of `_get_docx_metadata`

### Proposed Changes:
- use forward reference

### How did you test it?
CI, local tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
