### PR TITLE
feat: Extend YAML serialization to allow Python tuples

### DIFF
--- a/haystack/marshal/yaml.py
+++ b/haystack/marshal/yaml.py
@@ -7,6 +7,16 @@ from typing import Any, Dict, Union
 import yaml
 
 
+# Custom YAML safe loader that supports loading Python tuples
+class YamlLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
+    def construct_python_tuple(self, node: yaml.SequenceNode):
+        """Construct a Python tuple from the sequence."""
+        return tuple(self.construct_sequence(node))
+
+
+YamlLoader.add_constructor("tag:yaml.org,2002:python/tuple", YamlLoader.construct_python_tuple)
+
+
 class YamlMarshaller:
     def marshal(self, dict_: Dict[str, Any]) -> str:
         """Return a YAML representation of the given dictionary."""
@@ -14,4 +24,4 @@ class YamlMarshaller:
 
     def unmarshal(self, data_: Union[str, bytes, bytearray]) -> Dict[str, Any]:
         """Return a dictionary from the given YAML data."""
-        return yaml.safe_load(data_)
+        return yaml.load(data_, Loader=YamlLoader)

--- a/releasenotes/notes/serialization-tuple-support-ffe176417e7099f5.yaml
+++ b/releasenotes/notes/serialization-tuple-support-ffe176417e7099f5.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Pipeline serialization to YAML now supports tuples as field values.

--- a/test/marshal/__init__.py
+++ b/test/marshal/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/marshal/test_yaml.py
+++ b/test/marshal/test_yaml.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from haystack.marshal.yaml import YamlMarshaller
+
+
+@pytest.fixture
+def yaml_data():
+    return {"key": "value", 1: 0.221, "list": [1, 2, 3], "tuple": (1, None, True), "dict": {"set": {False}}}
+
+
+@pytest.fixture
+def serialized_yaml_str():
+    return """key: value
+1: 0.221
+list:
+- 1
+- 2
+- 3
+tuple: !!python/tuple
+- 1
+- null
+- true
+dict:
+  set: !!set
+    false: null
+"""
+
+
+def test_yaml_marshal(yaml_data, serialized_yaml_str):
+    marshaller = YamlMarshaller()
+    marshalled = marshaller.marshal(yaml_data)
+    assert isinstance(marshalled, str)
+    assert marshalled.strip().replace("\n", "") == serialized_yaml_str.strip().replace("\n", "")
+
+
+def test_yaml_unmarshal(yaml_data, serialized_yaml_str):
+    marshaller = YamlMarshaller()
+    unmarshalled = marshaller.unmarshal(serialized_yaml_str)
+    assert unmarshalled == yaml_data


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/694

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Currently, serialization to YAML does not support Python tuples. This PR extends support to them on the marshaller level, allowing all components and integrations to take advantage of it.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
All tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
