### PR TITLE
ci: add dependency cache step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.sha }}
 
   lint:
     needs: build-env
@@ -148,7 +148,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Mypy
         if: steps.files.outputs.any_changed == 'true'
@@ -221,7 +221,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Run
         run: hatch run test:unit
@@ -292,7 +292,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Install dependencies
         run: |
@@ -358,7 +358,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Install dependencies
         run: |
@@ -420,7 +420,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ github.sha }}
 
       - name: Run
         run: hatch run test:integration-windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,12 +102,13 @@ jobs:
 
       - name: Install Hatch
         id: hatch
+        shell: bash
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
           hatch env create test
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
@@ -143,7 +144,7 @@ jobs:
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
@@ -211,11 +212,12 @@ jobs:
 
       - name: Install Hatch
         id: hatch
+        shell: bash
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
@@ -281,11 +283,12 @@ jobs:
 
       - name: Install Hatch
         id: hatch
+        shell: bash
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
@@ -346,11 +349,12 @@ jobs:
 
       - name: Install Hatch
         id: hatch
+        shell: bash
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}
@@ -407,11 +411,12 @@ jobs:
 
       - name: Install Hatch
         id: hatch
+        shell: bash
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         id: cache
         with:
           path: ${{ steps.hatch.outputs.env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
         id: hatch
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
-          hatch shell test
+          hatch env create test
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache/save@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,8 +82,39 @@ jobs:
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-  lint:
+  build-env:
+    name: Build env / ${{ matrix.os }}
     needs: format
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-12
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: Install Hatch
+        id: hatch
+        run: |
+          pip install hatch==${{ env.HATCH_VERSION }}
+          hatch shell test
+          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/save@v3
+        id: cache
+        with:
+          path: ${{ steps.hatch.outputs.env }}
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
+  lint:
+    needs: build-env
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -107,7 +138,16 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        id: hatch
+        run: |
+          pip install hatch==${{ env.HATCH_VERSION }}
+          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ${{ steps.hatch.outputs.env }}
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Mypy
         if: steps.files.outputs.any_changed == 'true'
@@ -153,7 +193,7 @@ jobs:
 
   unit-tests:
     name: Unit / ${{ matrix.os }}
-    needs: lint
+    needs: build-env
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +210,16 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        id: hatch
+        run: |
+          pip install hatch==${{ env.HATCH_VERSION }}
+          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ${{ steps.hatch.outputs.env }}
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
         run: hatch run test:unit
@@ -231,7 +280,16 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        id: hatch
+        run: |
+          pip install hatch==${{ env.HATCH_VERSION }}
+          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ${{ steps.hatch.outputs.env }}
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install dependencies
         run: |
@@ -287,7 +345,16 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        id: hatch
+        run: |
+          pip install hatch==${{ env.HATCH_VERSION }}
+          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ${{ steps.hatch.outputs.env }}
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Install dependencies
         run: |
@@ -339,7 +406,16 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install Hatch
-        run: pip install hatch==${{ env.HATCH_VERSION }}
+        id: hatch
+        run: |
+          pip install hatch==${{ env.HATCH_VERSION }}
+          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ${{ steps.hatch.outputs.env }}
+          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
       - name: Run
         run: hatch run test:integration-windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,8 +82,8 @@ jobs:
                 - "branch:${{ github.ref_name }}"
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-  build-env:
-    name: Build env / ${{ matrix.os }}
+  unit-tests:
+    name: Unit / ${{ matrix.os }}
     needs: format
     strategy:
       fail-fast: false
@@ -105,8 +105,10 @@ jobs:
         shell: bash
         run: |
           pip install hatch==${{ env.HATCH_VERSION }}
-          hatch env create test
           echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
+
+      - name: Run
+        run: hatch run test:unit
 
       - uses: actions/cache/save@v4
         id: cache
@@ -114,8 +116,47 @@ jobs:
           path: ${{ steps.hatch.outputs.env }}
           key: ${{ runner.os }}-${{ github.sha }}
 
+      - name: Coveralls
+        # We upload only coverage for ubuntu as handling both os
+        # complicates the workflow too much for little to no gain
+        if: matrix.os == 'ubuntu-latest'
+        uses: coverallsapp/github-action@v2
+        with:
+          path-to-lcov: coverage.xml
+
+      - name: Calculate alert data
+        id: calculator
+        shell: bash
+        if: (success() || failure()) && github.ref_name == 'main'
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "alert_type=success" >> "$GITHUB_OUTPUT";
+          else
+            echo "alert_type=error" >> "$GITHUB_OUTPUT";
+          fi
+
+      - name: Send event to Datadog
+        if: (success() || failure()) && github.ref_name == 'main'
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
+          api-url: https://api.datadoghq.eu
+          events: |
+            - title: "${{ github.workflow }} workflow"
+              text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
+              alert_type: "${{ steps.calculator.outputs.alert_type }}"
+              source_type_name: "Github"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "project:${{ github.repository }}"
+                - "job:${{ github.job }}"
+                - "run_id:${{ github.run_id }}"
+                - "workflow:${{ github.workflow }}"
+                - "branch:${{ github.ref_name }}"
+                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   lint:
-    needs: build-env
+    needs: unit-tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -160,79 +201,6 @@ jobs:
         if: steps.files.outputs.any_changed == 'true'
         run: |
           hatch run test:lint ${{ steps.files.outputs.all_changed_files }}
-
-      - name: Calculate alert data
-        id: calculator
-        shell: bash
-        if: (success() || failure()) && github.ref_name == 'main'
-        run: |
-          if [ "${{ job.status }}" = "success" ]; then
-            echo "alert_type=success" >> "$GITHUB_OUTPUT";
-          else
-            echo "alert_type=error" >> "$GITHUB_OUTPUT";
-          fi
-
-      - name: Send event to Datadog
-        if: (success() || failure()) && github.ref_name == 'main'
-        uses: masci/datadog@v1
-        with:
-          api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
-          api-url: https://api.datadoghq.eu
-          events: |
-            - title: "${{ github.workflow }} workflow"
-              text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
-              alert_type: "${{ steps.calculator.outputs.alert_type }}"
-              source_type_name: "Github"
-              host: ${{ github.repository_owner }}
-              tags:
-                - "project:${{ github.repository }}"
-                - "job:${{ github.job }}"
-                - "run_id:${{ github.run_id }}"
-                - "workflow:${{ github.workflow }}"
-                - "branch:${{ github.ref_name }}"
-                - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-  unit-tests:
-    name: Unit / ${{ matrix.os }}
-    needs: build-env
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-12
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "${{ env.PYTHON_VERSION }}"
-
-      - name: Install Hatch
-        id: hatch
-        shell: bash
-        run: |
-          pip install hatch==${{ env.HATCH_VERSION }}
-          echo "env=$(hatch env find test)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache/restore@v4
-        id: cache
-        with:
-          path: ${{ steps.hatch.outputs.env }}
-          key: ${{ runner.os }}-${{ github.sha }}
-
-      - name: Run
-        run: hatch run test:unit
-
-      - name: Coveralls
-        # We upload only coverage for ubuntu as handling both os
-        # complicates the workflow too much for little to no gain
-        if: matrix.os == 'ubuntu-latest'
-        uses: coverallsapp/github-action@v2
-        with:
-          path-to-lcov: coverage.xml
 
       - name: Calculate alert data
         id: calculator

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -26,3 +26,5 @@ __all__ = [
     "GeneratedAnswer",
     "ExtractedAnswer",
 ]
+
+# FIXME: remove before merging PR


### PR DESCRIPTION
### Related Issues

- no issue, trying to restore the dependency cache that was removed as ineffective in #7754 

- The venv created by the unit tests is carried over and reused by the integration tests and the linting job. 
- This saves about one minute (pulling the cache vs. installing packages).
- The cache is short-lived, it's created at every commit.

### Before

<img width="1070" alt="image" src="https://github.com/deepset-ai/haystack/assets/7241/0b3b3ffa-433a-454e-ba60-a9a49df08bbd">


### After

<img width="1075" alt="image" src="https://github.com/deepset-ai/haystack/assets/7241/24a37bf2-dcad-4911-a4fb-2558c153fc96">


 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
