### PR TITLE
chore: pin numpy<2; tenacity!=8.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "networkx", # Pipeline graphs
   "typing_extensions>=4.7", # typing support for Python 3.8
   "requests",
-  "numpy",
+  "numpy<2",
   "python-dateutil",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
   "pandas",
   "tqdm",
-  "tenacity",
+  "tenacity!=8.4.0",
   "lazy-imports",
   "openai>=1.1.0",
   "Jinja2",

--- a/releasenotes/notes/pin-numpy-2304f88504d5041a.yaml
+++ b/releasenotes/notes/pin-numpy-2304f88504d5041a.yaml
@@ -2,3 +2,4 @@
 fixes:
   - |
     Pin numpy<2 to avoid breaking changes that cause several core integrations to fail.
+    Pin tenacity too (8.4.0 is broken).

--- a/releasenotes/notes/pin-numpy-2304f88504d5041a.yaml
+++ b/releasenotes/notes/pin-numpy-2304f88504d5041a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Pin numpy<2 to avoid breaking changes that cause several core integrations to fail.


### PR DESCRIPTION
### Related Issues

Several failures in core integrations: Chroma, Fastembed, Optimum and Qdrant.

### Proposed Changes:

Pin numpy<2

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
