### PR TITLE
ci: Add code formatting checks 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,10 @@ jobs:
         run: pip install hatch==${{ env.HATCH_VERSION }}
 
       - name: Check file format
-        run: hatch run format
+        run: hatch run format-check
+
+      - name: Check linting
+        run: hatch run lint
 
       - name: Check presence of license header
         run: docker run --rm -v "$(pwd):/github/workspace" ghcr.io/korandoru/hawkeye check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: hatch run format-check
 
       - name: Check linting
-        run: hatch run lint
+        run: hatch run check
 
       - name: Check presence of license header
         run: docker run --rm -v "$(pwd):/github/workspace" ghcr.io/korandoru/hawkeye check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   rev: v0.3.0
   hooks:
   - id: ruff
-    args: [--fix, --exit-non-zero-on-fix]
+  - id: ruff-format
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5

--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -108,8 +108,8 @@ class LocalWhisperTranscriber:
             A list of paths or binary streams to transcribe.
 
         :returns: A dictionary with the following keys:
-            - `documents`: A list of Documents, one for each file. The content of the document is the transcription text,
-                while the document's metadata contains the values returned by the Whisper model, such as the
+            - `documents`: A list of Documents, one for each file. The content of the document is the transcription
+                text, while the document's metadata contains the values returned by the Whisper model, such as the
                 alignment data and the path to the audio file used for the transcription.
         """
         if self._model is None:

--- a/haystack/components/builders/answer_builder.py
+++ b/haystack/components/builders/answer_builder.py
@@ -82,7 +82,8 @@ class AnswerBuilder:
             is used as the answer. If no capture group is present, the whole match is used as the answer.
                 Examples:
                     `[^\\n]+$` finds "this is an answer" in a string "this is an argument.\\nthis is an answer".
-                    `Answer: (.*)` finds "this is an answer" in a string "this is an argument. Answer: this is an answer".
+                    `Answer: (.*)` finds "this is an answer" in a string
+                    "this is an argument. Answer: this is an answer".
         :param reference_pattern:
             The regular expression pattern to use for parsing the document references.
             We assume that references are specified as indices of the input documents and that indices start at 1.

--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -20,10 +20,10 @@ class ChatPromptBuilder:
     It is designed to construct prompts for the pipeline using static or dynamic templates: Users can change
     the prompt template at runtime by providing a new template for each pipeline run invocation if needed.
 
-    The template variables found in the init template string are used as input types for the component and are all optional,
-    unless explicitly specified. If an optional template variable is not provided as an input, it will be replaced with
-    an empty string in the rendered prompt. Use `variable` and `required_variables` to specify the input types and
-    required variables.
+    The template variables found in the init template string are used as input types for the component and are all
+    optional, unless explicitly specified. If an optional template variable is not provided as an input, it will be
+    replaced with an empty string in the rendered prompt. Use `variable` and `required_variables` to specify the input
+    types and required variables.
 
     Usage example with static prompt template:
     ```python
@@ -38,7 +38,8 @@ class ChatPromptBuilder:
     builder = ChatPromptBuilder(template=template)
     builder.run(target_language="spanish", snippet="I can't speak spanish.")
 
-    summary_template = [ChatMessage.from_user("Translate to {{ target_language }} and summarize. Context: {{ snippet }}; Summary:")]
+    msg = "Translate to {{ target_language }} and summarize. Context: {{ snippet }}; Summary:"
+    summary_template = [ChatMessage.from_user(msg)]
     builder.run(target_language="spanish", snippet="I can't speak spanish.", template=summary_template)
     ```
 
@@ -155,13 +156,14 @@ class ChatPromptBuilder:
         set directly to this method. On collision, the variables provided directly to this method take precedence.
 
         :param template:
-            An optional list of ChatMessages to overwrite ChatPromptBuilder's default template. If None, the default template
-            provided at initialization is used.
+            An optional list of ChatMessages to overwrite ChatPromptBuilder's default template. If None, the default
+            template provided at initialization is used.
         :param template_variables:
             An optional dictionary of template variables. These are additional variables users can provide directly
             to this method in contrast to pipeline variables.
         :param kwargs:
-            Pipeline variables (typically resolved from a pipeline) which are merged with the provided template variables.
+            Pipeline variables (typically resolved from a pipeline) which are merged with the provided template
+            variables.
 
         :returns: A dictionary with the following keys:
             - `prompt`: The updated list of `ChatMessage` instances after rendering the found templates.

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -14,18 +14,21 @@ class PromptBuilder:
     """
     PromptBuilder is a component that renders a prompt from a template string using Jinja2 templates.
 
-    For prompt engineering, users can switch the template at runtime by providing a template for each pipeline run invocation.
+    For prompt engineering, users can switch the template at runtime by providing a template for each pipeline run
+    invocation.
 
-    The template variables found in the default template string are used as input types for the component and are all optional,
-    unless explicitly specified. If an optional template variable is not provided as an input, it will be replaced with
-    an empty string in the rendered prompt. Use `variables` and `required_variables` to change the default variable behavior.
+    The template variables found in the default template string are used as input types for the component and are all
+    optional, unless explicitly specified. If an optional template variable is not provided as an input, it will be
+    replaced with an empty string in the rendered prompt. Use `variables` and `required_variables` to change the
+    default variable behavior.
 
     ### Usage examples
 
     #### On its own
 
-    Below is an example of using the `PromptBuilder` to render a prompt template and fill it with `target_language` and `snippet`.
-    The PromptBuilder returns a prompt with the string "Translate the following context to spanish. Context: I can't speak spanish.; Translation:".
+    Below is an example of using the `PromptBuilder` to render a prompt template and fill it with `target_language`
+    and `snippet`. The PromptBuilder returns a prompt with the string "Translate the following context to spanish.
+    Context: I can't speak spanish.; Translation:".
     ```python
     from haystack.components.builders import PromptBuilder
 
@@ -36,8 +39,8 @@ class PromptBuilder:
 
     #### In a Pipeline
 
-    Below is an example of a RAG pipeline where we use a `PromptBuilder` to render a custom prompt template and fill it with the
-    contents of retrieved Documents and a query. The rendered prompt is then sent to a Generator.
+    Below is an example of a RAG pipeline where we use a `PromptBuilder` to render a custom prompt template and fill it
+    with the contents of retrieved Documents and a query. The rendered prompt is then sent to a Generator.
     ```python
     from haystack import Pipeline, Document
     from haystack.utils import Secret
@@ -102,7 +105,8 @@ class PromptBuilder:
 
     #### Overwriting variables at runtime
 
-    In case you want to overwrite the values of variables, you can use `template_variables` during runtime as illustrated below:
+    In case you want to overwrite the values of variables, you can use `template_variables` during runtime as
+    illustrated below:
     ```python
     language_template = \"\"\"
     You are a helpful assistant.
@@ -146,9 +150,9 @@ class PromptBuilder:
         :param required_variables: An optional list of input variables that must be provided at runtime.
             If a required variable is not provided at runtime, an exception will be raised.
         :param variables:
-            An optional list of input variables to be used in prompt templates instead of the ones inferred from `template`.
-            For example, if you want to use more variables during prompt engineering than the ones present in the default
-            template, you can provide them here.
+            An optional list of input variables to be used in prompt templates instead of the ones inferred from
+            `template`. For example, if you want to use more variables during prompt engineering than the ones present
+            in the default template, you can provide them here.
         """
         self._template_string = template
         self._variables = variables

--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -32,8 +32,8 @@ class AzureOCRDocumentConverter:
     Supported file formats are: PDF, JPEG, PNG, BMP, TIFF, DOCX, XLSX, PPTX, and HTML.
 
     In order to be able to use this component, you need an active Azure account
-    and a Document Intelligence or Cognitive Services resource. Follow the steps described in the
-    [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api)
+    and a Document Intelligence or Cognitive Services resource. Follow the steps described in the [Azure documentation]
+    (https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api)
     to set up your resource.
 
     Usage example:
@@ -42,7 +42,7 @@ class AzureOCRDocumentConverter:
     from haystack.utils import Secret
 
     converter = AzureOCRDocumentConverter(endpoint="<url>", api_key=Secret.from_token("<your-api-key>"))
-    results = converter.run(sources=["path/to/document_with_images.pdf"], meta={"date_added": datetime.now().isoformat()})
+    results = converter.run(sources=["path/to/doc_with_images.pdf"], meta={"date_added": datetime.now().isoformat()})
     documents = results["documents"]
     print(documents[0].content)
     # 'This is a text from the PDF file.'
@@ -68,10 +68,10 @@ class AzureOCRDocumentConverter:
         :param api_key:
             The key of your Azure resource.
         :param model_id:
-            The model ID of the model you want to use. Please refer to
-            [Azure documentation](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/choose-model-feature)
+            The model ID of the model you want to use. Please refer to [Azure documentation]
+            (https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/choose-model-feature)
             for a list of available models. Default: `"prebuilt-read"`.
-                :param preceding_context_len: Number of lines before a table to extract as preceding context
+        :param preceding_context_len: Number of lines before a table to extract as preceding context
             (will be returned as part of metadata).
         :param following_context_len: Number of lines after a table to extract as subsequent context (
             will be returned as part of metadata).
@@ -88,7 +88,9 @@ class AzureOCRDocumentConverter:
         """
         azure_import.check()
 
-        self.document_analysis_client = DocumentAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(api_key.resolve_value()))  # type: ignore
+        self.document_analysis_client = DocumentAnalysisClient(
+            endpoint=endpoint, credential=AzureKeyCredential(api_key.resolve_value() or "")
+        )  # type: ignore
         self.endpoint = endpoint
         self.model_id = model_id
         self.api_key = api_key
@@ -111,8 +113,8 @@ class AzureOCRDocumentConverter:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
-            If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
+            If it's a list, the length of the list must match the number of sources, because the two lists will be
+            zipped. If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:
             A dictionary with the following keys:

--- a/haystack/components/converters/docx.py
+++ b/haystack/components/converters/docx.py
@@ -60,7 +60,8 @@ class DocxToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -102,7 +102,8 @@ class HTMLToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
         :param extraction_kwargs:
             Additional keyword arguments to customize the extraction process.

--- a/haystack/components/converters/markdown.py
+++ b/haystack/components/converters/markdown.py
@@ -66,7 +66,8 @@ class MarkdownToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/pdfminer.py
+++ b/haystack/components/converters/pdfminer.py
@@ -131,7 +131,8 @@ class PDFMinerToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/pptx.py
+++ b/haystack/components/converters/pptx.py
@@ -71,7 +71,8 @@ class PPTXToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -104,7 +104,8 @@ class PyPDFToDocument:
                 converter = CONVERTERS_REGISTRY[converter_name]
             except KeyError:
                 msg = (
-                    f"Invalid converter_name: {converter_name}.\n Available converters: {list(CONVERTERS_REGISTRY.keys())}"
+                    f"Invalid converter_name: {converter_name}.\n "
+                    f"Available converters: {list(CONVERTERS_REGISTRY.keys())}"
                     f"To specify a custom converter, it is recommended to use the `converter` parameter."
                 )
                 raise ValueError(msg) from KeyError
@@ -158,7 +159,8 @@ class PyPDFToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/tika.py
+++ b/haystack/components/converters/tika.py
@@ -67,7 +67,8 @@ class TikaDocumentConverter:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -55,7 +55,8 @@ class TextFileToDocument:
             Optional metadata to attach to the Documents.
             This value can be either a list of dictionaries or a single dictionary.
             If it's a single dictionary, its content is added to the metadata of all produced Documents.
-            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If it's a list, the length of the list must match the number of sources, because the two lists will
+            be zipped.
             If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
 
         :returns:

--- a/haystack/components/converters/utils.py
+++ b/haystack/components/converters/utils.py
@@ -12,8 +12,10 @@ def get_bytestream_from_source(source: Union[str, Path, ByteStream]) -> ByteStre
     """
     Creates a ByteStream object from a source.
 
-    :param source: A source to convert to a ByteStream. Can be a string (path to a file), a Path object, or a ByteStream.
-    :return: A ByteStream object.
+    :param source:
+        A source to convert to a ByteStream. Can be a string (path to a file), a Path object, or a ByteStream.
+    :return:
+        A ByteStream object.
     """
 
     if isinstance(source, ByteStream):

--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -59,7 +59,8 @@ class AzureOpenAIDocumentEmbedder:
         :param azure_deployment:
             The deployment of the model, usually matches the model name.
         :param dimensions:
-            The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+            The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3
+            and later models.
         :param api_key:
             The API key used for authentication.
         :param azure_ad_token:

--- a/haystack/components/embedders/azure_text_embedder.py
+++ b/haystack/components/embedders/azure_text_embedder.py
@@ -54,7 +54,8 @@ class AzureOpenAITextEmbedder:
         :param azure_deployment:
             The deployment of the model, usually matches the model name.
         :param dimensions:
-            The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+            The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3
+            and later models.
         :param api_key:
             The API key used for authentication.
         :param azure_ad_token:

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
+
+import numpy as np
 
 from haystack.lazy_imports import LazyImport
 from haystack.utils.auth import Secret
@@ -54,5 +56,5 @@ class _SentenceTransformersEmbeddingBackend:
         )
 
     def embed(self, data: List[str], **kwargs) -> List[List[float]]:
-        embeddings = self.model.encode(data, **kwargs).tolist()
+        embeddings = cast(np.ndarray, self.model.encode(data, **kwargs)).tolist()
         return embeddings

--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -106,7 +106,8 @@ class HuggingFaceAPIDocumentEmbedder:
         :param api_params:
             A dictionary containing the following keys:
             - `model`: model ID on the Hugging Face Hub. Required when `api_type` is `SERVERLESS_INFERENCE_API`.
-            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or `TEXT_EMBEDDINGS_INFERENCE`.
+            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or
+                `TEXT_EMBEDDINGS_INFERENCE`.
         :param token: The HuggingFace token to use as HTTP bearer authorization.
             You can find your HF token in your [account settings](https://huggingface.co/settings/tokens).
         :param prefix:
@@ -116,13 +117,15 @@ class HuggingFaceAPIDocumentEmbedder:
         :param truncate:
             Truncate input text from the end to the maximum length supported by the model.
             This parameter takes effect when the `api_type` is `TEXT_EMBEDDINGS_INFERENCE`.
-            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text Embeddings Inference.
-            This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API` (it is always set to `True` and cannot be changed).
+            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text
+            Embeddings Inference. This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API`
+            (it is always set to `True` and cannot be changed).
         :param normalize:
             Normalize the embeddings to unit length.
             This parameter takes effect when the `api_type` is `TEXT_EMBEDDINGS_INFERENCE`.
-            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text Embeddings Inference.
-            This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API` (it is always set to `False` and cannot be changed).
+            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text
+            Embeddings Inference. This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API`
+            (it is always set to `False` and cannot be changed).
         :param batch_size:
             Number of Documents to process at once.
         :param progress_bar:
@@ -150,12 +153,17 @@ class HuggingFaceAPIDocumentEmbedder:
         elif api_type in [HFEmbeddingAPIType.INFERENCE_ENDPOINTS, HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE]:
             url = api_params.get("url")
             if url is None:
-                raise ValueError(
-                    "To use Text Embeddings Inference or Inference Endpoints, you need to specify the `url` parameter in `api_params`."
+                msg = (
+                    "To use Text Embeddings Inference or Inference Endpoints, you need to specify the `url` "
+                    "parameter in `api_params`."
                 )
+                raise ValueError(msg)
             if not is_valid_http_url(url):
                 raise ValueError(f"Invalid URL: {url}")
             model_or_url = url
+        else:
+            msg = f"Unknown api_type {api_type}"
+            raise ValueError(api_type)
 
         self.api_type = api_type
         self.api_params = api_params

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -87,7 +87,8 @@ class HuggingFaceAPITextEmbedder:
         :param api_params:
             A dictionary containing the following keys:
             - `model`: model ID on the Hugging Face Hub. Required when `api_type` is `SERVERLESS_INFERENCE_API`.
-            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or `TEXT_EMBEDDINGS_INFERENCE`.
+            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or
+                `TEXT_EMBEDDINGS_INFERENCE`.
         :param token: The HuggingFace token to use as HTTP bearer authorization
             You can find your HF token in your [account settings](https://huggingface.co/settings/tokens)
         :param prefix:
@@ -97,13 +98,15 @@ class HuggingFaceAPITextEmbedder:
         :param truncate:
             Truncate input text from the end to the maximum length supported by the model.
             This parameter takes effect when the `api_type` is `TEXT_EMBEDDINGS_INFERENCE`.
-            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text Embeddings Inference.
-            This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API` (it is always set to `True` and cannot be changed).
+            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text
+            Embeddings Inference. This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API`
+            (it is always set to `True` and cannot be changed).
         :param normalize:
             Normalize the embeddings to unit length.
             This parameter takes effect when the `api_type` is `TEXT_EMBEDDINGS_INFERENCE`.
-            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text Embeddings Inference.
-            This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API` (it is always set to `False` and cannot be changed).
+            It also takes effect when the `api_type` is `INFERENCE_ENDPOINTS` and the backend is based on Text
+            Embeddings Inference. This parameter is ignored when the `api_type` is `SERVERLESS_INFERENCE_API`
+            (it is always set to `False` and cannot be changed).
         """
         huggingface_hub_import.check()
 
@@ -121,12 +124,17 @@ class HuggingFaceAPITextEmbedder:
         elif api_type in [HFEmbeddingAPIType.INFERENCE_ENDPOINTS, HFEmbeddingAPIType.TEXT_EMBEDDINGS_INFERENCE]:
             url = api_params.get("url")
             if url is None:
-                raise ValueError(
-                    "To use Text Embeddings Inference or Inference Endpoints, you need to specify the `url` parameter in `api_params`."
+                msg = (
+                    "To use Text Embeddings Inference or Inference Endpoints, you need to specify the `url` "
+                    "parameter in `api_params`."
                 )
+                raise ValueError(msg)
             if not is_valid_http_url(url):
                 raise ValueError(f"Invalid URL: {url}")
             model_or_url = url
+        else:
+            msg = f"Unknown api_type {api_type}"
+            raise ValueError()
 
         self.api_type = api_type
         self.api_params = api_params

--- a/haystack/components/embedders/openai_document_embedder.py
+++ b/haystack/components/embedders/openai_document_embedder.py
@@ -52,7 +52,8 @@ class OpenAIDocumentEmbedder:
         """
         Create a OpenAIDocumentEmbedder component.
 
-        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters in the OpenAI client.
+        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters
+        in the OpenAI client.
 
 
         :param api_key:
@@ -60,7 +61,8 @@ class OpenAIDocumentEmbedder:
         :param model:
             The name of the model to use.
         :param dimensions:
-            The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.
+            The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3`
+            and later models.
         :param api_base_url:
             Overrides default base url for all HTTP requests.
         :param organization:
@@ -80,9 +82,11 @@ class OpenAIDocumentEmbedder:
         :param embedding_separator:
             Separator used to concatenate the meta fields to the Document text.
         :param timeout:
-            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
+            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable
+            or set to 30.
         :param max_retries:
-            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred
+            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
         """
         self.api_key = api_key
         self.model = model

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -50,14 +50,16 @@ class OpenAITextEmbedder:
         """
         Create an OpenAITextEmbedder component.
 
-        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters in the OpenAI client.
+        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters
+        in the OpenAI client.
 
         :param api_key:
             The OpenAI API key.
         :param model:
             The name of the model to use.
         :param dimensions:
-            The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` and later models.
+            The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` a
+            nd later models.
         :param api_base_url:
             Overrides default base url for all HTTP requests.
         :param organization:
@@ -69,9 +71,11 @@ class OpenAITextEmbedder:
         :param suffix:
             A string to add at the end of each text.
         :param timeout:
-            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
+            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable
+            or set to 30.
         :param max_retries:
-            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred
+            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
         """
         self.model = model
         self.dimensions = dimensions

--- a/haystack/components/evaluators/answer_exact_match.py
+++ b/haystack/components/evaluators/answer_exact_match.py
@@ -48,7 +48,8 @@ class AnswerExactMatchEvaluator:
             A list of predicted answers.
         :returns:
             A dictionary with the following outputs:
-            - `individual_scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the ground truth.
+            - `individual_scores` - A list of 0s and 1s, where 1 means that the predicted answer matched one of the
+                ground truth.
             - `score` - A number from 0.0 to 1.0 that represents the proportion of questions where any predicted
                          answer matched one of the ground truth answers.
         """

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -49,9 +49,11 @@ class ContextRelevanceEvaluator(LLMEvaluator):
 
     questions = ["Who created the Python language?"]
     contexts = [
-        [
-            "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming language. Its design philosophy emphasizes code readability, and its language constructs aim to help programmers write clear, logical code for both small and large-scale software projects."
-        ],
+        [(
+            "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming "
+            "language. Its design philosophy emphasizes code readability, and its language constructs aim to help "
+            "programmers write clear, logical code for both small and large-scale software projects."
+        )],
     ]
 
     evaluator = ContextRelevanceEvaluator()
@@ -61,7 +63,11 @@ class ContextRelevanceEvaluator(LLMEvaluator):
     print(result["individual_scores"])
     # [1.0]
     print(result["results"])
-    # [{'statements': ['Python, created by Guido van Rossum in the late 1980s.'], 'statement_scores': [1], 'score': 1.0}]
+    # [{
+    #   'statements': ['Python, created by Guido van Rossum in the late 1980s.'],
+    #   'statement_scores': [1],
+    #   'score': 1.0
+    # }]
     ```
     """
 

--- a/haystack/components/evaluators/document_map.py
+++ b/haystack/components/evaluators/document_map.py
@@ -59,7 +59,8 @@ class DocumentMAPEvaluator:
         :returns:
             A dictionary with the following outputs:
             - `score` - The average of calculated scores.
-            - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents how high retrieved documents are ranked.
+            - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents how high retrieved documents
+                are ranked.
         """
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."

--- a/haystack/components/evaluators/document_mrr.py
+++ b/haystack/components/evaluators/document_mrr.py
@@ -57,7 +57,8 @@ class DocumentMRREvaluator:
         :returns:
             A dictionary with the following outputs:
             - `score` - The average of calculated scores.
-            - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents how high the first retrieved document is ranked.
+            - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents how high the first retrieved
+                document is ranked.
         """
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."

--- a/haystack/components/evaluators/document_recall.py
+++ b/haystack/components/evaluators/document_recall.py
@@ -109,8 +109,8 @@ class DocumentRecallEvaluator:
             A list of retrieved documents for each question.
         A dictionary with the following outputs:
             - `score` - The average of calculated scores.
-            - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents the proportion of matching documents retrieved.
-                                    If the mode is `single_hit`, the individual scores are 0 or 1.
+            - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents the proportion of matching
+                documents retrieved. If the mode is `single_hit`, the individual scores are 0 or 1.
         """
         if len(ground_truth_documents) != len(retrieved_documents):
             msg = "The length of ground_truth_documents and retrieved_documents must be the same."

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -60,11 +60,15 @@ class FaithfulnessEvaluator(LLMEvaluator):
 
     questions = ["Who created the Python language?"]
     contexts = [
-        [
-            "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming language. Its design philosophy emphasizes code readability, and its language constructs aim to help programmers write clear, logical code for both small and large-scale software projects."
-        ],
+        [(
+            "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming "
+            "language. Its design philosophy emphasizes code readability, and its language constructs aim to help "
+            "programmers write clear, logical code for both small and large-scale software projects."
+        )],
     ]
-    predicted_answers = ["Python is a high-level general-purpose programming language that was created by George Lucas."]
+    predicted_answers = [
+        "Python is a high-level general-purpose programming language that was created by George Lucas."
+    ]
     evaluator = FaithfulnessEvaluator()
     result = evaluator.run(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
 

--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -318,7 +318,10 @@ class LLMEvaluator:
 
         # Validate that all received inputs are lists
         if not all(isinstance(_input, list) for _input in received.values()):
-            msg = f"LLM evaluator expects all input values to be lists but received {[type(_input) for _input in received.values()]}."
+            msg = (
+                "LLM evaluator expects all input values to be lists but received "
+                f"{[type(_input) for _input in received.values()]}."
+            )
             raise ValueError(msg)
 
         # Validate that all received inputs are of the same length

--- a/haystack/components/evaluators/sas_evaluator.py
+++ b/haystack/components/evaluators/sas_evaluator.py
@@ -19,11 +19,10 @@ with LazyImport(message="Run 'pip install scikit-learn \"sentence-transformers>=
 @component
 class SASEvaluator:
     """
-    SASEvaluator computes the Semantic Answer Similarity (SAS) between a list of predictions and a list of ground truths.
+    SASEvaluator computes the Semantic Answer Similarity (SAS) between a list of predictions and a one of ground truths.
 
-    It's usually used in Retrieval Augmented Generation (RAG) pipelines to evaluate the quality of the generated answers.
-
-    The SAS is computed using a pre-trained model from the Hugging Face model hub. The model can be either a
+    It's usually used in Retrieval Augmented Generation (RAG) pipelines to evaluate the quality of the generated
+    answers. The SAS is computed using a pre-trained model from the Hugging Face model hub. The model can be either a
     Bi-Encoder or a Cross-Encoder. The choice of the model is based on the `model` parameter.
 
     Usage example:
@@ -65,7 +64,8 @@ class SASEvaluator:
         Creates a new instance of SASEvaluator.
 
         :param model:
-            SentenceTransformers semantic textual similarity model, should be path or string pointing to a downloadable model.
+            SentenceTransformers semantic textual similarity model, should be path or string pointing to a downloadable
+            model.
         :param batch_size:
             Number of prediction-label pairs to encode at once.
         :param device:

--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -163,8 +163,8 @@ class LinkContentFetcher:
         :param url: The URL to fetch content from.
         :return: A tuple containing the ByteStream metadata dict and the corresponding ByteStream.
              ByteStream metadata contains the URL and the content type of the fetched content.
-             The content type is a string indicating the type of content fetched (for example, "text/html", "application/pdf").
-             The ByteStream object contains the fetched content as binary data.
+             The content type is a string indicating the type of content fetched (for example, "text/html",
+             "application/pdf"). The ByteStream object contains the fetched content as binary data.
 
         :raises: If an error occurs during content retrieval and `raise_on_failure` is set to True, this method will
         raise an exception. Otherwise, all fetching errors are logged, and an empty ByteStream is returned.

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -21,8 +21,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
     """
     A Chat Generator component that uses the Azure OpenAI API to generate text.
 
-    Enables text generation using OpenAI's large language models (LLMs) on Azure. It supports `gpt-4` and `gpt-3.5-turbo`
-    family of models accessed through the chat completions API endpoint.
+    Enables text generation using OpenAI's large language models (LLMs) on Azure. It supports `gpt-4` and
+    `gpt-3.5-turbo` family of models accessed through the chat completions API endpoint.
 
     Users can pass any text generation parameters valid for the `openai.ChatCompletion.create` method
     directly to this component via the `generation_kwargs` parameter in `__init__` or the `generation_kwargs`
@@ -62,7 +62,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
     ```
     {'replies':
         [ChatMessage(content='Natural Language Processing (NLP) is a branch of artificial intelligence that focuses on
-         enabling computers to understand, interpret, and generate human language in a way that is meaningful and useful.',
+         enabling computers to understand, interpret, and generate human language in a way that is useful.',
          role=<ChatRole.ASSISTANT: 'assistant'>, name=None,
          meta={'model': 'gpt-3.5-turbo-0613', 'index': 0, 'finish_reason': 'stop',
          'usage': {'prompt_tokens': 15, 'completion_tokens': 36, 'total_tokens': 51}})]

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -105,7 +105,8 @@ class HuggingFaceAPIChatGenerator:
         :param api_params:
             A dictionary containing the following keys:
             - `model`: model ID on the Hugging Face Hub. Required when `api_type` is `SERVERLESS_INFERENCE_API`.
-            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or `TEXT_GENERATION_INFERENCE`.
+            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or
+            `TEXT_GENERATION_INFERENCE`.
         :param token: The HuggingFace token to use as HTTP bearer authorization
             You can find your HF token in your [account settings](https://huggingface.co/settings/tokens)
         :param generation_kwargs:
@@ -132,12 +133,17 @@ class HuggingFaceAPIChatGenerator:
         elif api_type in [HFGenerationAPIType.INFERENCE_ENDPOINTS, HFGenerationAPIType.TEXT_GENERATION_INFERENCE]:
             url = api_params.get("url")
             if url is None:
-                raise ValueError(
-                    "To use Text Generation Inference or Inference Endpoints, you need to specify the `url` parameter in `api_params`."
+                msg = (
+                    "To use Text Generation Inference or Inference Endpoints, you need to specify the `url` parameter "
+                    "in `api_params`."
                 )
+                raise ValueError(msg)
             if not is_valid_http_url(url):
                 raise ValueError(f"Invalid URL: {url}")
             model_or_url = url
+        else:
+            msg = f"Unknown api_type {api_type}"
+            raise ValueError(api_type)
 
         # handle generation kwargs setup
         generation_kwargs = generation_kwargs.copy() if generation_kwargs else {}

--- a/haystack/components/generators/chat/hugging_face_tgi.py
+++ b/haystack/components/generators/chat/hugging_face_tgi.py
@@ -37,14 +37,16 @@ class HuggingFaceTGIChatGenerator:
     Inference API tier.
 
     Key Features and Compatibility:
-     - Primary Compatibility: designed to work seamlessly with any chat-based model deployed using the TGI
+    - Primary Compatibility: designed to work seamlessly with any chat-based model deployed using the TGI
        framework. For more information on TGI, visit [text-generation-inference](https://github.com/huggingface/text-generation-inference)
+
     - Hugging Face Inference Endpoints: Supports inference of TGI chat LLMs deployed on Hugging Face
        inference endpoints. For more details, refer to [inference-endpoints](https://huggingface.co/inference-endpoints)
 
     - Inference API Support: supports inference of TGI chat LLMs hosted on the rate-limited Inference
       API tier. Learn more about the Inference API at [inference-api](https://huggingface.co/inference-api).
-      Discover available chat models using the following command: `wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference | grep chat`
+      Discover available chat models using the following command:
+      `wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference | grep chat`
       and simply use the model ID as the model parameter for this component. You'll also need to provide a valid
       Hugging Face API token as the token parameter.
 
@@ -66,7 +68,7 @@ class HuggingFaceTGIChatGenerator:
                 ChatMessage.from_user("What's Natural Language Processing?")]
 
 
-    client = HuggingFaceTGIChatGenerator(model="HuggingFaceH4/zephyr-7b-beta", token=Secret.from_token("<your-api-key>"))
+    client = HuggingFaceTGIChatGenerator(model="HuggingFaceH4/zephyr-7b-beta", token=Secret.from_token("<api-key>"))
     client.warm_up()
     response = client.run(messages, generation_kwargs={"max_new_tokens": 120})
     print(response)

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -48,8 +48,8 @@ class OpenAIChatGenerator:
     ```
     {'replies':
         [ChatMessage(content='Natural Language Processing (NLP) is a branch of artificial intelligence
-                              that focuses on enabling computers to understand, interpret, and generate human language in
-                              a way that is meaningful and useful.',
+            that focuses on enabling computers to understand, interpret, and generate human language in
+            a way that is meaningful and useful.',
          role=<ChatRole.ASSISTANT: 'assistant'>, name=None,
          meta={'model': 'gpt-3.5-turbo-0613', 'index': 0, 'finish_reason': 'stop',
          'usage': {'prompt_tokens': 15, 'completion_tokens': 36, 'total_tokens': 51}})
@@ -58,7 +58,8 @@ class OpenAIChatGenerator:
     ```
 
      Key Features and Compatibility:
-      - Primary Compatibility: designed to work seamlessly with the OpenAI API Chat Completion endpoint and `gpt-4` and `gpt-3.5-turbo` family of models.
+      - Primary Compatibility: designed to work seamlessly with the OpenAI API Chat Completion endpoint and `gpt-4`
+        and `gpt-3.5-turbo` family of models.
       - Streaming Support: supports streaming responses from the OpenAI API Chat Completion endpoint.
       - Customizability: supports all parameters supported by the OpenAI API Chat Completion endpoint.
 
@@ -85,7 +86,8 @@ class OpenAIChatGenerator:
         Creates an instance of OpenAIChatGenerator. Unless specified otherwise in the `model`, this is for OpenAI's
         GPT-3.5 model.
 
-        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters in the OpenAI client.
+        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters
+        in the OpenAI client.
 
         :param api_key: The OpenAI API key.
         :param model: The name of the model to use.
@@ -114,9 +116,11 @@ class OpenAIChatGenerator:
             - `logit_bias`: Add a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
         :param timeout:
-            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
+            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable
+            or set to 30.
         :param max_retries:
-            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred
+            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
         """
         self.api_key = api_key
         self.model = model

--- a/haystack/components/generators/hugging_face_api.py
+++ b/haystack/components/generators/hugging_face_api.py
@@ -89,13 +89,15 @@ class HuggingFaceAPIGenerator:
         :param api_params:
             A dictionary containing the following keys:
             - `model`: model ID on the Hugging Face Hub. Required when `api_type` is `SERVERLESS_INFERENCE_API`.
-            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or `TEXT_GENERATION_INFERENCE`.
+            - `url`: URL of the inference endpoint. Required when `api_type` is `INFERENCE_ENDPOINTS` or
+            `TEXT_GENERATION_INFERENCE`.
         :param token: The HuggingFace token to use as HTTP bearer authorization.
             You can find your HF token in your [account settings](https://huggingface.co/settings/tokens).
         :param generation_kwargs:
-            A dictionary containing keyword arguments to customize text generation.
-                Some examples: `max_new_tokens`, `temperature`, `top_k`, `top_p`,...
-                See Hugging Face's [documentation](https://huggingface.co/docs/huggingface_hub/en/package_reference/inference_client#huggingface_hub.InferenceClient.text_generation) for more information.
+            A dictionary containing keyword arguments to customize text generation. Some examples: `max_new_tokens`,
+            `temperature`, `top_k`, `top_p`,...
+            See Hugging Face's [documentation](https://huggingface.co/docs/huggingface_hub/en/package_reference/inference_client#huggingface_hub.InferenceClient.text_generation)
+            for more information.
         :param stop_words: An optional list of strings representing the stop words.
         :param streaming_callback: An optional callable for handling streaming responses.
         """
@@ -116,12 +118,17 @@ class HuggingFaceAPIGenerator:
         elif api_type in [HFGenerationAPIType.INFERENCE_ENDPOINTS, HFGenerationAPIType.TEXT_GENERATION_INFERENCE]:
             url = api_params.get("url")
             if url is None:
-                raise ValueError(
-                    "To use Text Generation Inference or Inference Endpoints, you need to specify the `url` parameter in `api_params`."
+                msg = (
+                    "To use Text Generation Inference or Inference Endpoints, you need to specify the `url` "
+                    "parameter in `api_params`."
                 )
+                raise ValueError(msg)
             if not is_valid_http_url(url):
                 raise ValueError(f"Invalid URL: {url}")
             model_or_url = url
+        else:
+            msg = f"Unknown api_type {api_type}"
+            raise ValueError(api_type)
 
         # handle generation kwargs setup
         generation_kwargs = generation_kwargs.copy() if generation_kwargs else {}

--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -241,7 +241,9 @@ class HuggingFaceLocalGenerator:
                 updated_generation_kwargs["num_return_sequences"] = 1
             # streamer parameter hooks into HF streaming, HFTokenStreamingHandler is an adapter to our streaming
             updated_generation_kwargs["streamer"] = HFTokenStreamingHandler(
-                self.pipeline.tokenizer, self.streaming_callback, self.stop_words  # type: ignore
+                self.pipeline.tokenizer,  # type: ignore
+                self.streaming_callback,
+                self.stop_words,  # type: ignore
             )
 
         output = self.pipeline(prompt, stopping_criteria=self.stopping_criteria_list, **updated_generation_kwargs)  # type: ignore

--- a/haystack/components/generators/hugging_face_tgi.py
+++ b/haystack/components/generators/hugging_face_tgi.py
@@ -37,19 +37,23 @@ class HuggingFaceTGIGenerator:
 
     Key Features and Compatibility:
      - Primary Compatibility: designed to work seamlessly with any non-based model deployed using the TGI
-       framework. For more information on TGI, visit [text-generation-inference](https://github.com/huggingface/text-generation-inference)
+       framework. For more information on TGI, visit
+       [text-generation-inference](https://github.com/huggingface/text-generation-inference)
 
     - Hugging Face Inference Endpoints: Supports inference of TGI chat LLMs deployed on Hugging Face
-       inference endpoints. For more details, refer to [inference-endpoints](https://huggingface.co/inference-endpoints)
+       inference endpoints. For more details, refer to
+       [inference-endpoints](https://huggingface.co/inference-endpoints)
 
     - Inference API Support: supports inference of TGI LLMs hosted on the rate-limited Inference
       API tier. Learn more about the Inference API at [inference-api](https://huggingface.co/inference-api).
-      Discover available chat models using the following command: `wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference | grep chat`
+      Discover available chat models using the following command:
+      `wget -qO- https://api-inference.huggingface.co/framework/text-generation-inference | grep chat`
       and simply use the model ID as the model parameter for this component. You'll also need to provide a valid
       Hugging Face API token as the token parameter.
 
     - Custom TGI Endpoints: supports inference of TGI chat LLMs deployed on custom TGI endpoints. Anyone can
-      deploy their own TGI endpoint using the TGI framework. For more details, refer to [inference-endpoints](https://huggingface.co/inference-endpoints)
+      deploy their own TGI endpoint using the TGI framework. For more details, refer to
+      [inference-endpoints](https://huggingface.co/inference-endpoints)
 
      Input and Output Format:
       - String Format: This component uses the str format for structuring both input and output,
@@ -101,7 +105,8 @@ class HuggingFaceTGIGenerator:
         :param generation_kwargs:
             A dictionary containing keyword arguments to customize text generation.
                 Some examples: `max_new_tokens`, `temperature`, `top_k`, `top_p`,...
-                See Hugging Face's documentation for more information at: [TextGenerationParameters](https://huggingface.co/docs/huggingface_hub/v0.18.0.rc0/en/package_reference/inference_client#huggingface_hub.inference._text_generation.TextGenerationParameters
+                See Hugging Face's documentation for more information at:
+                [TextGenerationParameters](https://huggingface.co/docs/huggingface_hub/v0.18.0.rc0/en/package_reference/inference_client#huggingface_hub.inference._text_generation.TextGenerationParameters
         :param stop_words: An optional list of strings representing the stop words.
         :param streaming_callback: An optional callable for handling streaming responses.
         """
@@ -208,9 +213,11 @@ class HuggingFaceTGIGenerator:
             - replies: A list of strings representing the generated replies.
         """
         if not self.tokenizer:
-            raise RuntimeError(
-                "The component HuggingFaceTGIGenerator was not warmed up. Please call warm_up() before running LLM inference."
+            msg = (
+                "The component HuggingFaceTGIGenerator was not warmed up. Please call warm_up() before "
+                "running LLM inference."
             )
+            raise RuntimeError(msg)
 
         # check generation kwargs given as parameters to override the default ones
         additional_params = ["n", "stop_words"]

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -65,18 +65,17 @@ class OpenAIGenerator:
         max_retries: Optional[int] = None,
     ):
         """
-        Creates an instance of OpenAIGenerator. Unless specified otherwise in the `model`, this is for OpenAI's GPT-3.5 model.
+        Creates an instance of OpenAIGenerator. Unless specified otherwise in the `model`, OpenAI's GPT-3.5 is used.
 
-        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters in the OpenAI client.
-
+        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters
+        in the OpenAI client.
 
         :param api_key: The OpenAI API key.
         :param model: The name of the model to use.
         :param streaming_callback: A callback function that is called when a new token is received from the stream.
             The callback function accepts StreamingChunk as an argument.
         :param api_base_url: An optional base URL.
-        :param organization: The Organization ID, defaults to `None`. See
-        [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization).
+        :param organization: The Organization ID, defaults to `None`.
         :param system_prompt: The system prompt to use for text generation. If not provided, the system prompt is
         omitted, and the default system prompt of the model is used.
         :param generation_kwargs: Other parameters to use for the model. These parameters are all sent directly to
@@ -99,9 +98,11 @@ class OpenAIGenerator:
             - `logit_bias`: Add a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
         :param timeout:
-            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
+            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable
+            or set to 30.
         :param max_retries:
-            Maximum retries to establish contact with OpenAI if it returns an internal error, if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            Maximum retries to establish contact with OpenAI if it returns an internal error, if not set it is inferred
+            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
 
         """
         self.api_key = api_key
@@ -176,8 +177,8 @@ class OpenAIGenerator:
             The string prompt to use for text generation.
         :param generation_kwargs:
             Additional keyword arguments for text generation. These parameters will potentially override the parameters
-            passed in the `__init__` method. For more details on the parameters supported by the OpenAI API, refer to the
-            OpenAI [documentation](https://platform.openai.com/docs/api-reference/chat/create).
+            passed in the `__init__` method. For more details on the parameters supported by the OpenAI API, refer to
+            the OpenAI [documentation](https://platform.openai.com/docs/api-reference/chat/create).
         :returns:
             A list of strings containing the generated responses and a list of dictionaries containing the metadata
         for each response.

--- a/haystack/components/joiners/branch.py
+++ b/haystack/components/joiners/branch.py
@@ -72,7 +72,7 @@ class BranchJoiner:
     pipe.connect("validator.validation_error", "joiner")
 
     result = pipe.run(data={"fc_llm": {"generation_kwargs": {"response_format": {"type": "json_object"}}},
-                            "adapter": {"chat_message": [ChatMessage.from_user("Create json object from Peter Parker")]}})
+                            "adapter": {"chat_message": [ChatMessage.from_user("Create json from Peter Parker")]}})
 
     print(json.loads(result["validator"]["validated"][0].content))
 
@@ -81,9 +81,9 @@ class BranchJoiner:
     >> 'Superhero', 'age': 23, 'location': 'New York City'}
     ```
 
-    Note that `BranchJoiner` can manage only one data type at a time. In this case, `BranchJoiner` is created for passing
-    `List[ChatMessage]`. This determines the type of data that `BranchJoiner` will receive from the upstream connected
-    components and also the type of data that `BranchJoiner` will send through its output.
+    Note that `BranchJoiner` can manage only one data type at a time. In this case, `BranchJoiner` is created for
+    passing `List[ChatMessage]`. This determines the type of data that `BranchJoiner` will receive from the upstream
+    connected components and also the type of data that `BranchJoiner` will send through its output.
 
     In the code example, `BranchJoiner` receives a looped back `List[ChatMessage]` from the `JsonSchemaValidator` and
     sends it down to the `OpenAIChatGenerator` for re-generation. We can have multiple loopback connections in the

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -114,7 +114,7 @@ class DocumentJoiner:
 
     def _concatenate(self, document_lists):
         """
-        Concatenate multiple lists of Documents and return only the Document with the highest score for duplicate Documents.
+        Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
         output = []
         docs_per_id = defaultdict(list)

--- a/haystack/components/others/multiplexer.py
+++ b/haystack/components/others/multiplexer.py
@@ -31,11 +31,12 @@ class Multiplexer:
     `Multiplexer` is important for spreading outputs from a single source like a Large Language Model (LLM) across
     different branches of a pipeline. It is especially valuable in error correction loops by rerouting data for
     reevaluation if errors are detected. For instance, in an example pipeline below, `Multiplexer` helps create
-    a schema valid JSON object (given a person's data) with the help of an `OpenAIChatGenerator` and a `JsonSchemaValidator`.
+    a schema valid JSON object (given a person's data) with the help of an `OpenAIChatGenerator` and a
+    `JsonSchemaValidator`.
     In case the generated JSON object fails schema validation, `JsonSchemaValidator` starts a correction loop, sending
     the data back through the `Multiplexer` to the `OpenAIChatGenerator` until it passes schema validation. If we didn't
-    have `Multiplexer`, we wouldn't be able to loop back the data to `OpenAIChatGenerator` for re-generation, as components
-    accept only one input connection for the declared run method parameters.
+    have `Multiplexer`, we wouldn't be able to loop back the data to `OpenAIChatGenerator` for re-generation, as
+    components accept only one input connection for the declared run method parameters.
 
     Usage example:
 
@@ -75,7 +76,7 @@ class Multiplexer:
     pipe.connect("validator.validation_error", "mx")
 
     result = pipe.run(data={"fc_llm": {"generation_kwargs": {"response_format": {"type": "json_object"}}},
-                            "adapter": {"chat_message": [ChatMessage.from_user("Create json object from Peter Parker")]}})
+                            "adapter": {"chat_message": [ChatMessage.from_user("Create json from Peter Parker")]}})
 
     print(json.loads(result["validator"]["validated"][0].content))
 
@@ -93,8 +94,8 @@ class Multiplexer:
 
     In the code example, `Multiplexer` receives a looped back `List[ChatMessage]` from the `JsonSchemaValidator` and
     sends it down to the `OpenAIChatGenerator` for re-generation. We can have multiple loop back connections in the
-    pipeline. In this instance, the downstream component is only one – the `OpenAIChatGenerator` – but the pipeline can have more
-    than one downstream component.
+    pipeline. In this instance, the downstream component is only one – the `OpenAIChatGenerator` – but the pipeline can
+    have more than one downstream component.
     """
 
     def __init__(self, type_: TypeAlias):

--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -83,7 +83,8 @@ class DocumentCleaner:
         for doc in documents:
             if doc.content is None:
                 logger.warning(
-                    "DocumentCleaner only cleans text documents but document.content for document ID %{document_id} is None.",
+                    "DocumentCleaner only cleans text documents but document.content for document ID"
+                    " %{document_id} is None.",
                     document_id=doc.id,
                 )
                 cleaned_docs.append(doc)
@@ -171,7 +172,8 @@ class DocumentCleaner:
          but won't detect "Page 3 of 4" or similar.
 
         :param n_chars: The number of first/last characters where the header/footer shall be searched in.
-        :param n_first_pages_to_ignore: The number of first pages to ignore (e.g. TOCs often don't contain footer/header).
+        :param n_first_pages_to_ignore: The number of first pages to ignore
+            (e.g. TOCs often don't contain footer/header).
         :param n_last_pages_to_ignore: The number of last pages to ignore.
         :returns: The text without the found headers and footers.
         """

--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -45,7 +45,8 @@ class DocumentSplitter:
             "sentence" for splitting by ".", "page" for splitting by "\\f" or "passage" for splitting by "\\n\\n".
         :param split_length: The maximum number of units in each split.
         :param split_overlap: The number of units that each split should overlap.
-        :param split_threshold: The minimum number of units that the split should have. If the split has fewer units than the threshold, it will be attached to the previous split.
+        :param split_threshold: The minimum number of units that the split should have. If the split has fewer units
+            than the threshold, it will be attached to the previous split.
         """
 
         self.split_by = split_by
@@ -71,8 +72,9 @@ class DocumentSplitter:
 
         :returns: A dictionary with the following key:
             - `documents`: List of documents with the split texts. A metadata field "source_id" is added to each
-            document to keep track of the original document that was split. Another metadata field "page_number" is added to each number to keep track of the page it belonged to in the original document. Other metadata are copied from the original
-            document.
+            document to keep track of the original document that was split. Another metadata field "page_number"
+            is added to each number to keep track of the page it belonged to in the original document. Other metadata
+            are copied from the original document.
 
         :raises TypeError: if the input is not a list of Documents.
         :raises ValueError: if the content of a document is None.
@@ -85,7 +87,7 @@ class DocumentSplitter:
         for doc in documents:
             if doc.content is None:
                 raise ValueError(
-                    f"DocumentSplitter only works with text documents but document.content for document ID {doc.id} is None."
+                    f"DocumentSplitter only works with text documents but content for document ID {doc.id} is None."
                 )
             units = self._split_into_units(doc.content, self.split_by)
             text_splits, splits_pages = self._concatenate_units(
@@ -121,9 +123,11 @@ class DocumentSplitter:
         self, elements: List[str], split_length: int, split_overlap: int, split_threshold: int
     ) -> Tuple[List[str], List[int]]:
         """
-        Concatenates the elements into parts of split_length units keeping track of the original page number that each element belongs.
+        Concatenates the elements into parts of split_length units.
 
-        If the length of the current units is less than the pre-defined `split_threshold`, it does not create a new split. Instead, it concatenates the current units with the last split, preventing the creation of excessively small splits.
+        Keeps track of the original page number that each element belongs. If the length of the current units is less
+        than the pre-defined `split_threshold`, it does not create a new split. Instead, it concatenates the current
+        units with the last split, preventing the creation of excessively small splits.
         """
 
         text_splits: List[str] = []
@@ -151,7 +155,7 @@ class DocumentSplitter:
     @staticmethod
     def _create_docs_from_splits(text_splits: List[str], splits_pages: List[int], meta: Dict) -> List[Document]:
         """
-        Creates Document objects from text splits enriching them with page number and the metadata of the original document.
+        Creates Document objects from splits enriching them with page number and the metadata of the original document.
         """
         documents: List[Document] = []
 

--- a/haystack/components/rankers/meta_field.py
+++ b/haystack/components/rankers/meta_field.py
@@ -250,7 +250,8 @@ class MetaFieldRanker:
         # If all docs are missing self.meta_field return original documents
         if len(docs_with_meta_field) == 0:
             logger.warning(
-                "The parameter <meta_field> is currently set to '{meta_field}', but none of the provided Documents with IDs {document_ids} have this meta key.\n"
+                "The parameter <meta_field> is currently set to '{meta_field}', but none of the provided "
+                "Documents with IDs {document_ids} have this meta key.\n"
                 "Set <meta_field> to the name of a field that is present within the provided Documents.\n"
                 "Returning the <top_k> of the original Documents since there are no values to rank.",
                 meta_field=self.meta_field,
@@ -266,17 +267,20 @@ class MetaFieldRanker:
 
             if missing_meta == "bottom":
                 logger.warning(
-                    "{warning_start}Because the parameter <missing_meta> is set to 'bottom', these Documents will be placed at the end of the sorting order.",
+                    "{warning_start}Because the parameter <missing_meta> is set to 'bottom', these Documents will be "
+                    "placed at the end of the sorting order.",
                     warning_start=warning_start,
                 )
             elif missing_meta == "top":
                 logger.warning(
-                    "{warning_start}Because the parameter <missing_meta> is set to 'top', these Documents will be placed at the top of the sorting order.",
+                    "{warning_start}Because the parameter <missing_meta> is set to 'top', these Documents will be "
+                    "placed at the top of the sorting order.",
                     warning_start=warning_start,
                 )
             else:
                 logger.warning(
-                    "{warning_start}Because the parameter <missing_meta> is set to 'drop', these Documents will be removed from the list of retrieved Documents.",
+                    "{warning_start}Because the parameter <missing_meta> is set to 'drop', these Documents will be "
+                    "removed from the list of retrieved Documents.",
                     warning_start=warning_start,
                 )
 
@@ -345,7 +349,8 @@ class MetaFieldRanker:
             meta_values = [parse_fn(d.meta[self.meta_field]) for d in docs_with_meta_field]
         except ValueError as error:
             logger.warning(
-                "Tried to parse the meta values of Documents with IDs {document_ids}, but got ValueError with the message: {error}\n"
+                "Tried to parse the meta values of Documents with IDs {document_ids}, but got ValueError with the "
+                "message: {error}\n"
                 "Skipping parsing of the meta values.",
                 document_ids=",".join([doc.id for doc in docs_with_meta_field]),
                 error=error,

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -251,9 +251,7 @@ class TransformersSimilarityRanker:
             text_to_embed = self.embedding_separator.join(meta_values_to_embed + [doc.content or ""])
             query_doc_pairs.append([self.query_prefix + query, self.document_prefix + text_to_embed])
 
-        features = self.tokenizer(
-            query_doc_pairs, padding=True, truncation=True, return_tensors="pt"
-        ).to(  # type: ignore
+        features = self.tokenizer(query_doc_pairs, padding=True, truncation=True, return_tensors="pt").to(  # type: ignore
             self.device.first_device.to_torch()
         )
         with torch.inference_mode():

--- a/haystack/components/retrievers/in_memory/bm25_retriever.py
+++ b/haystack/components/retrievers/in_memory/bm25_retriever.py
@@ -53,7 +53,8 @@ class InMemoryBM25Retriever:
         :param top_k:
             The maximum number of documents to retrieve.
         :param scale_score:
-            Scales the BM25 score to a unit interval in the range of 0 to 1, where 1 means extremely relevant. If set to `False`, uses raw similarity scores.
+            Scales the BM25 score to a unit interval in the range of 0 to 1, where 1 means extremely relevant.
+            If set to `False`, uses raw similarity scores.
         :param filter_policy: The filter policy to apply during retrieval.
         :raises ValueError:
             If the specified `top_k` is not > 0.
@@ -134,8 +135,9 @@ class InMemoryBM25Retriever:
         :param top_k:
             The maximum number of documents to return.
         :param scale_score:
-            Scales the BM25 score to a unit interval in the range of 0 to 1, where 1 means extremely relevant. If set to `False`, uses raw similarity scores.
-            If not specified, the value provided at initialization is used.
+            Scales the BM25 score to a unit interval in the range of 0 to 1, where 1 means extremely relevant.
+            If set to `False`, uses raw similarity scores. If not specified, the value provided at initialization
+            is used.
         :returns:
             The retrieved documents.
 

--- a/haystack/components/retrievers/in_memory/embedding_retriever.py
+++ b/haystack/components/retrievers/in_memory/embedding_retriever.py
@@ -63,7 +63,8 @@ class InMemoryEmbeddingRetriever:
         :param top_k:
             The maximum number of documents to retrieve.
         :param scale_score:
-            Scales the BM25 score to a unit interval in the range of 0 to 1, where 1 means extremely relevant. If set to `False`, uses raw similarity scores.
+            Scales the BM25 score to a unit interval in the range of 0 to 1, where 1 means extremely relevant. If set
+            to `False`, uses raw similarity scores.
         :param return_embedding:
             Whether to return the embedding of the retrieved Documents.
         :param filter_policy: The filter policy to apply during retrieval.
@@ -149,8 +150,9 @@ class InMemoryEmbeddingRetriever:
         :param top_k:
             The maximum number of documents to return.
         :param scale_score:
-            Scales the similarity score to a unit interval in the range of 0 to 1, where 1 means extremely relevant. If set to `False`, uses raw similarity scores.
-            If not specified, the value provided at initialization is used.
+            Scales the similarity score to a unit interval in the range of 0 to 1, where 1 means extremely relevant.
+            If set to `False`, uses raw similarity scores. If not specified, the value provided at initialization
+            is used.
         :param return_embedding:
             Whether to return the embedding of the retrieved Documents.
         :returns:

--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -111,8 +111,8 @@ class ConditionalRouter:
             - `condition`: A Jinja2 string expression that determines if the route is selected.
             - `output`: A Jinja2 expression defining the route's output value.
             - `output_type`: The type of the output data (e.g., str, List[int]).
-            - `output_name`: The name under which the `output` value of the route is published. This name is used to connect
-            the router to other components in the pipeline.
+            - `output_name`: The name under which the `output` value of the route is published. This name is used to
+                connect the router to other components in the pipeline.
         """
         self._validate_routes(routes)
         self.routes: List[dict] = routes
@@ -169,8 +169,9 @@ class ConditionalRouter:
         """
         Executes the routing logic.
 
-        Executes the routing logic by evaluating the specified boolean condition expressions for each route in the order they are listed.
-        The method directs the flow of data to the output specified in the first route whose `condition` is True.
+        Executes the routing logic by evaluating the specified boolean condition expressions for each route in the
+        order they are listed. The method directs the flow of data to the output specified in the first route whose
+        `condition` is True.
 
         :param kwargs: All variables used in the `condition` expressed in the routes. When the component is used in a
             pipeline, these variables are passed from the previous component's output.
@@ -179,7 +180,8 @@ class ConditionalRouter:
             of the selected route.
 
         :raises NoRouteSelectedException: If no `condition' in the routes is `True`.
-        :raises RouteConditionException: If there is an error parsing or evaluating the `condition` expression in the routes.
+        :raises RouteConditionException: If there is an error parsing or evaluating the `condition` expression in the
+            routes.
         """
         # Create a Jinja native environment to evaluate the condition templates as Python expressions
         env = NativeEnvironment()

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -23,8 +23,8 @@ class FileTypeRouter:
     for flexible routing of files to different components based on their content type. It supports both exact MIME type
     matching and pattern matching using regular expressions.
 
-    For file paths, MIME types are inferred from their extensions, while for byte streams, MIME types are determined from
-    the provided metadata. This enables the router to classify a diverse collection of files and data streams for
+    For file paths, MIME types are inferred from their extensions, while for byte streams, MIME types are determined
+    from the provided metadata. This enables the router to classify a diverse collection of files and data streams for
     specialized processing.
 
     The router's flexibility is enhanced by the support for regex patterns in the `mime_types` parameter, allowing users
@@ -47,8 +47,12 @@ class FileTypeRouter:
     print(router_with_regex.run(sources=sources))
 
     # Expected output:
-    # {'text/plain': [PosixPath('file.txt')], 'application/pdf': [PosixPath('document.pdf')], 'unclassified': [PosixPath('song.mp3')]}
-    # {'audio/.*': [PosixPath('song.mp3')], 'text/plain': [PosixPath('file.txt')], 'unclassified': [PosixPath('document.pdf')]}
+    # {'text/plain': [
+    #   PosixPath('file.txt')], 'application/pdf': [PosixPath('document.pdf')], 'unclassified': [PosixPath('song.mp3')
+    # ]}
+    # {'audio/.*': [
+    #   PosixPath('song.mp3')], 'text/plain': [PosixPath('file.txt')], 'unclassified': [PosixPath('document.pdf')
+    # ]}
     ```
 
     :param mime_types: A list of MIME types or regex patterns to classify the incoming files or data streams.
@@ -80,7 +84,8 @@ class FileTypeRouter:
 
         :param sources: A list of file paths or byte streams to categorize.
 
-        :returns: A dictionary where the keys are MIME types (or `"unclassified"`) and the values are lists of data sources.
+        :returns: A dictionary where the keys are MIME types (or `"unclassified"`) and the values are lists of data
+            sources.
         """
 
         mime_types = defaultdict(list)

--- a/haystack/components/routers/metadata_router.py
+++ b/haystack/components/routers/metadata_router.py
@@ -26,7 +26,7 @@ class MetadataRouter:
     print(router.run(documents=docs))
 
     # {'en': [Document(id=..., content: 'Paris is the capital of France.', meta: {'language': 'en'})],
-    #  'unmatched': [Document(id=..., content: 'Berlin ist die Haupststadt von Deutschland.', meta: {'language': 'de'})]}
+    # 'unmatched': [Document(id=..., content: 'Berlin ist die Haupststadt von Deutschland.', meta: {'language': 'de'})]}
     ```
     """
 
@@ -34,9 +34,10 @@ class MetadataRouter:
         """
         Initialize the MetadataRouter.
 
-        :param rules: A dictionary of rules that specify which output connection to route a document to based on its metadata.
-            The keys of the dictionary are the names of the output connections, and the values are dictionaries that
-            follow the [format of filtering expressions in Haystack](https://docs.haystack.deepset.ai/v2.0/docs/metadata-filtering).
+        :param rules: A dictionary of rules that specify which output connection to route a document to based on its
+            metadata. The keys of the dictionary are the names of the output connections, and the values are
+            dictionaries that follow the format of
+            [filtering expressions in Haystack](https://docs.haystack.deepset.ai/v2.0/docs/metadata-filtering).
             For example:
             ```python
             {
@@ -78,8 +79,8 @@ class MetadataRouter:
         """
         Route the documents.
 
-        Route the documents to different edges based on their fields content and the rules specified during initialization.
-        If a document does not match any of the rules, it is routed to a connection named "unmatched".
+        Route the documents to different edges based on their fields content and the rules specified during
+        initialization. If a document does not match any of the rules, it is routed to a connection named "unmatched".
 
         :param documents: A list of documents to route to different edges.
 

--- a/haystack/components/routers/text_language_router.py
+++ b/haystack/components/routers/text_language_router.py
@@ -51,7 +51,8 @@ class TextLanguageRouter:
         Initialize the TextLanguageRouter component.
 
         :param languages: A list of languages in ISO code, each corresponding to a different output connection.
-            For supported languages, see the [`langdetect` documentation](https://github.com/Mimino666/langdetect#languages).
+            For supported languages, see the
+            [`langdetect` documentation](https://github.com/Mimino666/langdetect#languages).
             If not specified, the default is `["en"]`.
         """
         langdetect_import.check()
@@ -75,9 +76,11 @@ class TextLanguageRouter:
         :raises TypeError: If the input is not a string.
         """
         if not isinstance(text, str):
-            raise TypeError(
-                "TextLanguageRouter expects a str as input. In case you want to classify a document, please use the DocumentLanguageClassifier and MetaDataRouter."
+            msg = (
+                "TextLanguageRouter expects a string as input. In case you want to classify a document, please use "
+                "the DocumentLanguageClassifier and MetaDataRouter."
             )
+            raise TypeError(msg)
 
         output: Dict[str, str] = {}
 

--- a/haystack/components/validators/json_schema.py
+++ b/haystack/components/validators/json_schema.py
@@ -56,11 +56,18 @@ class JsonSchemaValidator:
     p.connect("llm.replies", "schema_validator.messages")
     p.connect("schema_validator.validation_error", "mx_for_llm")
 
-    result = p.run(
-        data={"message_producer": {"messages":[ChatMessage.from_user("Generate JSON for person with name 'John' and age 30")]},
-              "schema_validator": {"json_schema": {"type": "object",
-                                                   "properties": {"name": {"type": "string"},
-                                                                  "age": {"type": "integer"}}}}})
+    result = p.run(data={
+        "message_producer": {
+            "messages":[ChatMessage.from_user("Generate JSON for person with name 'John' and age 30")]},
+            "schema_validator": {
+                "json_schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"},
+                    "age": {"type": "integer"}
+                }
+            }
+        }
+    })
     print(result)
     >> {'schema_validator': {'validated': [ChatMessage(content='\\n{\\n  "name": "John",\\n  "age": 30\\n}',
     role=<ChatRole.ASSISTANT: 'assistant'>, name=None, meta={'model': 'gpt-4-1106-preview', 'index': 0,

--- a/haystack/components/websearch/searchapi.py
+++ b/haystack/components/websearch/searchapi.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 SEARCHAPI_BASE_URL = "https://www.searchapi.io/api/v1/search"
 
 
-class SearchApiError(ComponentError):
-    ...
+class SearchApiError(ComponentError): ...
 
 
 @component

--- a/haystack/components/websearch/serper_dev.py
+++ b/haystack/components/websearch/serper_dev.py
@@ -16,8 +16,7 @@ logger = logging.getLogger(__name__)
 SERPERDEV_BASE_URL = "https://google.serper.dev/search"
 
 
-class SerperDevError(ComponentError):
-    ...
+class SerperDevError(ComponentError): ...
 
 
 @component

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -3,69 +3,69 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-    Attributes:
+Attributes:
 
-        component: Marks a class as a component. Any class decorated with `@component` can be used by a Pipeline.
+    component: Marks a class as a component. Any class decorated with `@component` can be used by a Pipeline.
 
-    All components must follow the contract below. This docstring is the source of truth for components contract.
+All components must follow the contract below. This docstring is the source of truth for components contract.
 
-    <hr>
+<hr>
 
-    `@component` decorator
+`@component` decorator
 
-    All component classes must be decorated with the `@component` decorator. This allows Canals to discover them.
+All component classes must be decorated with the `@component` decorator. This allows Canals to discover them.
 
-    <hr>
+<hr>
 
-    `__init__(self, **kwargs)`
+`__init__(self, **kwargs)`
 
-    Optional method.
+Optional method.
 
-    Components may have an `__init__` method where they define:
+Components may have an `__init__` method where they define:
 
-    - `self.init_parameters = {same parameters that the __init__ method received}`:
-        In this dictionary you can store any state the components wish to be persisted when they are saved.
-        These values will be given to the `__init__` method of a new instance when the pipeline is loaded.
-        Note that by default the `@component` decorator saves the arguments automatically.
-        However, if a component sets their own `init_parameters` manually in `__init__()`, that will be used instead.
-        Note: all of the values contained here **must be JSON serializable**. Serialize them manually if needed.
+- `self.init_parameters = {same parameters that the __init__ method received}`:
+    In this dictionary you can store any state the components wish to be persisted when they are saved.
+    These values will be given to the `__init__` method of a new instance when the pipeline is loaded.
+    Note that by default the `@component` decorator saves the arguments automatically.
+    However, if a component sets their own `init_parameters` manually in `__init__()`, that will be used instead.
+    Note: all of the values contained here **must be JSON serializable**. Serialize them manually if needed.
 
-    Components should take only "basic" Python types as parameters of their `__init__` function, or iterables and
-    dictionaries containing only such values. Anything else (objects, functions, etc) will raise an exception at init
-    time. If there's the need for such values, consider serializing them to a string.
+Components should take only "basic" Python types as parameters of their `__init__` function, or iterables and
+dictionaries containing only such values. Anything else (objects, functions, etc) will raise an exception at init
+time. If there's the need for such values, consider serializing them to a string.
 
-    _(TODO explain how to use classes and functions in init. In the meantime see `test/components/test_accumulate.py`)_
+_(TODO explain how to use classes and functions in init. In the meantime see `test/components/test_accumulate.py`)_
 
-    The `__init__` must be extremely lightweight, because it's a frequent operation during the construction and
-    validation of the pipeline. If a component has some heavy state to initialize (models, backends, etc...) refer to
-    the `warm_up()` method.
+The `__init__` must be extremely lightweight, because it's a frequent operation during the construction and
+validation of the pipeline. If a component has some heavy state to initialize (models, backends, etc...) refer to
+the `warm_up()` method.
 
-    <hr>
+<hr>
 
-    `warm_up(self)`
+`warm_up(self)`
 
-    Optional method.
+Optional method.
 
-    This method is called by Pipeline before the graph execution. Make sure to avoid double-initializations,
-    because Pipeline will not keep track of which components it called `warm_up()` on.
+This method is called by Pipeline before the graph execution. Make sure to avoid double-initializations,
+because Pipeline will not keep track of which components it called `warm_up()` on.
 
-    <hr>
+<hr>
 
-    `run(self, data)`
+`run(self, data)`
 
-    Mandatory method.
+Mandatory method.
 
-    This is the method where the main functionality of the component should be carried out. It's called by
-    `Pipeline.run()`.
+This is the method where the main functionality of the component should be carried out. It's called by
+`Pipeline.run()`.
 
-    When the component should run, Pipeline will call this method with an instance of the dataclass returned by the
-    method decorated with `@component.input`. This dataclass contains:
+When the component should run, Pipeline will call this method with an instance of the dataclass returned by the
+method decorated with `@component.input`. This dataclass contains:
 
-    - all the input values coming from other components connected to it,
-    - if any is missing, the corresponding value defined in `self.defaults`, if it exists.
+- all the input values coming from other components connected to it,
+- if any is missing, the corresponding value defined in `self.defaults`, if it exists.
 
-    `run()` must return a single instance of the dataclass declared through the method decorated with
-    `@component.output`.
+`run()` must return a single instance of the dataclass declared through the method decorated with
+`@component.output`.
 
 """
 
@@ -416,7 +416,8 @@ class _Component:
         if class_path in self.registry:
             # Corner case, but it may occur easily in notebooks when re-running cells.
             logger.debug(
-                "Component {component} is already registered. Previous imported from '{module_name}', new imported from '{new_module_name}'",
+                "Component {component} is already registered. Previous imported from '{module_name}', \
+                new imported from '{new_module_name}'",
                 component=class_path,
                 module_name=self.registry[class_path],
                 new_module_name=cls,

--- a/haystack/core/component/sockets.py
+++ b/haystack/core/component/sockets.py
@@ -49,7 +49,7 @@ class Sockets:
     >>>   - documents: Any
 
     inputs.question
-    >>> InputSocket(name='question', type=typing.Any, default_value=<class 'haystack.core.component.types._empty'>, is_variadic=False, senders=[])
+    >>> InputSocket(name='question', type=typing.Any, default_value=<class 'haystack.core.component.types._empty'>, ...
     ```
     """
 

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -23,9 +23,9 @@ def _prepare_for_drawing(graph: networkx.MultiDiGraph) -> networkx.MultiDiGraph:
     """
     # Label the edges
     for inp, outp, key, data in graph.edges(keys=True, data=True):
-        data[
-            "label"
-        ] = f"{data['from_socket'].name} -> {data['to_socket'].name}{' (opt.)' if not data['mandatory'] else ''}"
+        data["label"] = (
+            f"{data['from_socket'].name} -> {data['to_socket'].name}{' (opt.)' if not data['mandatory'] else ''}"
+        )
         graph.add_edge(inp, outp, key=key, **data)
 
     # Add inputs fake node
@@ -124,7 +124,7 @@ def _to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
     }
 
     states = {
-        comp: f"{comp}[\"<b>{comp}</b><br><small><i>{type(data['instance']).__name__}{optional_inputs[comp]}</i></small>\"]:::component"
+        comp: f"{comp}[\"<b>{comp}</b><br><small><i>{type(data['instance']).__name__}{optional_inputs[comp]}</i></small>\"]:::component"  # noqa
         for comp, data in graph.nodes(data=True)
         if comp not in ["input", "output"]
     }

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -86,13 +86,17 @@ class Pipeline(PipelineBase):
                     inputs[socket.name] = []
 
             if not isinstance(res, Mapping):
-                raise PipelineRuntimeError(f"Component '{name}' didn't return a dictionary. " "Components must always return dictionaries: check the the documentation.")
+                raise PipelineRuntimeError(
+                    f"Component '{name}' didn't return a dictionary. "
+                    "Components must always return dictionaries: check the the documentation."
+                )
             span.set_tag("haystack.component.visits", self.graph.nodes[name]["visits"])
             span.set_content_tag("haystack.component.output", res)
 
             return res
 
-    # TODO: We're ignoring these linting rules for the time being, after we properly optimize this function we'll remove the noqa
+    # TODO: We're ignoring these linting rules for the time being, after we properly optimize this function we'll
+    # remove the noqa
     def run(  # noqa: C901, PLR0912, PLR0915 pylint: disable=too-many-branches,too-many-locals
         self, data: Dict[str, Any], debug: bool = False, include_outputs_from: Optional[Set[str]] = None
     ) -> Dict[str, Any]:
@@ -227,7 +231,9 @@ class Pipeline(PipelineBase):
                 ):
                     there_are_non_variadics = False
                     for _, other_comp in to_run:
-                        if not any(socket.is_variadic for socket in other_comp.__haystack_input__._sockets_dict.values()):  # type: ignore
+                        if not any(
+                            socket.is_variadic for socket in other_comp.__haystack_input__._sockets_dict.values()
+                        ):  # type: ignore
                             there_are_non_variadics = True
                             break
 
@@ -271,12 +277,19 @@ class Pipeline(PipelineBase):
                     # Check if we're stuck in a loop.
                     # It's important to check whether previous waitings are None as it could be that no
                     # Component has actually been run yet.
-                    if before_last_waiting_for_input is not None and last_waiting_for_input is not None and before_last_waiting_for_input == last_waiting_for_input:
-                        # Are we actually stuck or there's a lazy variadic or a component with has only default inputs waiting for input?
-                        # This is our last resort, if there's no lazy variadic or component with only default inputs waiting for input
-                        # we're stuck for real and we can't make any progress.
+                    if (
+                        before_last_waiting_for_input is not None
+                        and last_waiting_for_input is not None
+                        and before_last_waiting_for_input == last_waiting_for_input
+                    ):
+                        # Are we actually stuck or there's a lazy variadic or a component with has only default inputs
+                        # waiting for input?
+                        # This is our last resort, if there's no lazy variadic or component with only default inputs
+                        # waiting for input we're stuck for real and we can't make any progress.
                         for name, comp in waiting_for_input:
-                            is_variadic = any(socket.is_variadic for socket in comp.__haystack_input__._sockets_dict.values())  # type: ignore
+                            is_variadic = any(
+                                socket.is_variadic for socket in comp.__haystack_input__._sockets_dict.values()
+                            )  # type: ignore
                             has_only_defaults = all(
                                 not socket.is_mandatory
                                 for socket in comp.__haystack_input__._sockets_dict.values()  # type: ignore
@@ -309,7 +322,9 @@ class Pipeline(PipelineBase):
 
                         continue
 
-                    before_last_waiting_for_input = last_waiting_for_input.copy() if last_waiting_for_input is not None else None
+                    before_last_waiting_for_input = (
+                        last_waiting_for_input.copy() if last_waiting_for_input is not None else None
+                    )
                     last_waiting_for_input = {item[0] for item in waiting_for_input}
 
                     self._enqueue_next_runnable_component(last_inputs, to_run, waiting_for_input)

--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -23,9 +23,10 @@ logger = logging.getLogger(__name__)
 # document scores are essentially unbounded and will be scaled to values between 0 and 1 if scale_score is set to
 # True (default). Scaling uses the expit function (inverse of the logit function) after applying a scaling factor
 # (e.g., BM25_SCALING_FACTOR for the bm25_retrieval method).
-# Larger scaling factor decreases scaled scores. For example, an input of 10 is scaled to 0.99 with BM25_SCALING_FACTOR=2
-# but to 0.78 with BM25_SCALING_FACTOR=8 (default). The defaults were chosen empirically. Increase the default if most
-# unscaled scores are larger than expected (>30) and otherwise would incorrectly all be mapped to scores ~1.
+# Larger scaling factor decreases scaled scores. For example, an input of 10 is scaled to 0.99 with
+# BM25_SCALING_FACTOR=2 but to 0.78 with BM25_SCALING_FACTOR=8 (default). The defaults were chosen empirically.
+# Increase the default if most unscaled scores are larger than expected (>30) and otherwise would incorrectly all be
+# mapped to scores ~1.
 BM25_SCALING_FACTOR = 8
 DOT_PRODUCT_SCALING_FACTOR = 100
 
@@ -69,14 +70,13 @@ class InMemoryDocumentStore:
         :param bm25_tokenization_regex: The regular expression used to tokenize the text for BM25 retrieval.
         :param bm25_algorithm: The BM25 algorithm to use. One of "BM25Okapi", "BM25L", or "BM25Plus".
         :param bm25_parameters: Parameters for BM25 implementation in a dictionary format.
-                                For example: {'k1':1.5, 'b':0.75, 'epsilon':0.25}
-                                You can learn more about these parameters by visiting https://github.com/dorianbrown/rank_bm25.
-                                By default, no parameters are set.
+            For example: {'k1':1.5, 'b':0.75, 'epsilon':0.25}
+            You can learn more about these parameters by visiting https://github.com/dorianbrown/rank_bm25.
         :param embedding_similarity_function: The similarity function used to compare Documents embeddings.
-                                              One of "dot_product" (default) or "cosine".
-                                              To choose the most appropriate function, look for information about your embedding model.
-        :param index: If specified uses a specific index to store the documents. If not specified, a random UUID is used.
-                      Using the same index allows you to store documents across multiple InMemoryDocumentStore instances.
+            One of "dot_product" (default) or "cosine". To choose the most appropriate function, look for information
+            about your embedding model.
+        :param index: A specific index to store the documents. If not specified, a random UUID is used.
+            Using the same index allows you to store documents across multiple InMemoryDocumentStore instances.
         """
         self.bm25_tokenization_regex = bm25_tokenization_regex
         self.tokenizer = re.compile(bm25_tokenization_regex).findall
@@ -349,7 +349,8 @@ class InMemoryDocumentStore:
         """
         Returns the documents that match the filters provided.
 
-        For a detailed specification of the filters, refer to the DocumentStore.filter_documents() protocol documentation.
+        For a detailed specification of the filters, refer to the DocumentStore.filter_documents() protocol
+        documentation.
 
         :param filters: The filters to apply to the document list.
         :returns: A list of Documents that match the given filters.

--- a/haystack/document_stores/types/protocol.py
+++ b/haystack/document_stores/types/protocol.py
@@ -122,7 +122,8 @@ class DocumentStore(Protocol):
             - `DuplicatePolicy.SKIP`: If a Document with the same id already exists, it is skipped and not written.
             - `DuplicatePolicy.OVERWRITE`: If a Document with the same id already exists, it is overwritten.
             - `DuplicatePolicy.FAIL`: If a Document with the same id already exists, an error is raised.
-        :raises DuplicateError: If `policy` is set to `DuplicatePolicy.FAIL` and a Document with the same id already exists.
+        :raises DuplicateError: If `policy` is set to `DuplicatePolicy.FAIL` and a Document with the same id already
+            exists.
         :returns: The number of Documents written.
             If `DuplicatePolicy.OVERWRITE` is used, this number is always equal to the number of documents in input.
             If `DuplicatePolicy.SKIP` is used, this number can be lower than the number of documents in the input list.

--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -144,9 +144,7 @@ class EvaluationRunResult(BaseEvaluationRunResult):
 
         pipe_b_df.drop(columns=ignore, inplace=True, errors="ignore")
         pipe_b_df.columns = [f"{other_name}_{column}" for column in pipe_b_df.columns]  # type: ignore
-        pipe_a_df.columns = [
-            f"{this_name}_{col}" if col not in ignore else col for col in pipe_a_df.columns
-        ]  # type: ignore
+        pipe_a_df.columns = [f"{this_name}_{col}" if col not in ignore else col for col in pipe_a_df.columns]  # type: ignore
 
         results_df = pd_concat([pipe_a_df, pipe_b_df], axis=1)
         return results_df

--- a/haystack/telemetry/_telemetry.py
+++ b/haystack/telemetry/_telemetry.py
@@ -80,7 +80,8 @@ class Telemetry:
                 "Haystack sends anonymous usage data to understand the actual usage and steer dev efforts "
                 "towards features that are most meaningful to users. You can opt-out at anytime by manually "
                 "setting the environment variable HAYSTACK_TELEMETRY_ENABLED as described for different "
-                "operating systems in the [documentation page](https://docs.haystack.deepset.ai/docs/telemetry#how-can-i-opt-out). "
+                "operating systems in the "
+                "[documentation page](https://docs.haystack.deepset.ai/docs/telemetry#how-can-i-opt-out). "
                 "More information at [Telemetry](https://docs.haystack.deepset.ai/docs/telemetry)."
             )
             CONFIG_PATH.parents[0].mkdir(parents=True, exist_ok=True)

--- a/haystack/testing/document_store.py
+++ b/haystack/testing/document_store.py
@@ -137,7 +137,8 @@ class DeleteDocumentsTest:
     Utility class to test a Document Store `delete_documents` method.
 
     To use it create a custom test class and override the `document_store` fixture to return your Document Store.
-    The Document Store `write_documents` and `count_documents` methods must be implemented for this tests to work correctly.
+    The Document Store `write_documents` and `count_documents` methods must be implemented for this tests to work
+    correctly.
     Example usage:
 
     ```python
@@ -689,7 +690,7 @@ class LegacyFilterDocumentsLessThanEqualTest(AssertDocumentsEqualMixin, Filterab
 
 class LegacyFilterDocumentsSimpleLogicalTest(AssertDocumentsEqualMixin, FilterableDocsFixtureMixin):
     """
-    Utility class to test a Document Store `filter_documents` method using logical '$and', '$or' and '$not' legacy filters
+    Utility class to test a Document Store `filter_documents` method using '$and', '$or' and '$not' legacy filters
 
     To use it create a custom test class and override the `document_store` fixture to return your Document Store.
     Example usage:
@@ -761,7 +762,7 @@ class LegacyFilterDocumentsSimpleLogicalTest(AssertDocumentsEqualMixin, Filterab
 
 class LegacyFilterDocumentsNestedLogicalTest(AssertDocumentsEqualMixin, FilterableDocsFixtureMixin):
     """
-    Utility class to test a Document Store `filter_documents` method using multiple nested logical '$and', '$or' and '$not' legacy filters
+    Utility class to test `filter_documents` using multiple nested logical '$and', '$or' and '$not' legacy filters
 
     To use it create a custom test class and override the `document_store` fixture to return your Document Store.
     Example usage:

--- a/haystack/testing/sample_components/concatenate.py
+++ b/haystack/testing/sample_components/concatenate.py
@@ -26,4 +26,6 @@ class Concatenate:
             res = first + [second]
         elif isinstance(first, str) and isinstance(second, list):
             res = [first] + second
+        else:
+            res = None
         return {"value": res}

--- a/haystack/utils/device.py
+++ b/haystack/utils/device.py
@@ -13,7 +13,8 @@ from haystack.lazy_imports import LazyImport
 logger = logging.getLogger(__name__)
 
 with LazyImport(
-    message="PyTorch must be installed to use torch.device or use GPU support in HuggingFace transformers. Run 'pip install transformers[torch]'"
+    message="PyTorch must be installed to use torch.device or use GPU support in HuggingFace transformers. "
+    "Run 'pip install transformers[torch]'"
 ) as torch_import:
     import torch
 

--- a/haystack/utils/hf.py
+++ b/haystack/utils/hf.py
@@ -136,7 +136,7 @@ def deserialize_hf_model_kwargs(kwargs: Dict[str, Any]):
 
 def resolve_hf_device_map(device: Optional[ComponentDevice], model_kwargs: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """
-    Update `model_kwargs` to include the keyword argument `device_map` based on `device` if `device_map` is not already present in `model_kwargs`.
+    Update `model_kwargs` to include the keyword argument `device_map`.
 
     This method is useful you want to force loading a transformers model when using `AutoModel.from_pretrained` to
     use `device_map`.
@@ -260,6 +260,9 @@ def check_valid_model(model_id: str, model_type: HFModelType, token: Optional[Se
     elif model_type == HFModelType.GENERATION:
         allowed_model = model_info.pipeline_tag in ["text-generation", "text2text-generation"]
         error_msg = f"Model {model_id} is not a text generation model. Please provide a text generation model."
+    else:
+        allowed_model = False
+        error_msg = f"Unknown model type for {model_id}"
 
     if not allowed_model:
         raise ValueError(error_msg)

--- a/haystack/utils/type_serialization.py
+++ b/haystack/utils/type_serialization.py
@@ -68,7 +68,8 @@ def deserialize_type(type_str: str) -> Any:
     Deserializes a type given its full import path as a string, including nested generic types.
 
     This function will dynamically import the module if it's not already imported
-    and then retrieve the type object from it. It also handles nested generic types like `typing.List[typing.Dict[int, str]]`.
+    and then retrieve the type object from it. It also handles nested generic types like
+    `typing.List[typing.Dict[int, str]]`.
 
     :param type_str:
         The string representation of the type's full import path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 
 [tool.hatch.envs.default.scripts]
 release-note = "reno new {args}"
-lint = "ruff check {args}"
+check = "ruff check {args}"
 fix = "ruff check --fix"
 format = "ruff format {args}"
 format-check = "ruff format --check {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,15 @@
 [build-system]
-requires = [
-  "hatchling>=1.8.0",
-]
+requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
 [project]
 name = "haystack-ai"
-dynamic = [
-  "version",
-]
+dynamic = ["version"]
 description = "LLM framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pipelines or agents that can interact with your data."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.8"
-authors = [
-  { name = "deepset.ai", email = "malte.pietsch@deepset.ai" },
-]
+authors = [{ name = "deepset.ai", email = "malte.pietsch@deepset.ai" }]
 keywords = [
   "BERT",
   "QA",
@@ -52,10 +46,10 @@ dependencies = [
   "lazy-imports",
   "openai>=1.1.0",
   "Jinja2",
-  "posthog",  # telemetry
+  "posthog",                # telemetry
   "pyyaml",
-  "more-itertools",  # TextDocumentSplitter
-  "networkx", # Pipeline graphs
+  "more-itertools",         # TextDocumentSplitter
+  "networkx",               # Pipeline graphs
   "typing_extensions>=4.7", # typing support for Python 3.8
   "requests",
   "numpy<2",
@@ -76,15 +70,18 @@ dependencies = [
 
 [tool.hatch.envs.default.scripts]
 release-note = "reno new {args}"
-format = "ruff check {args:haystack} --fix"
+lint = "ruff check {args}"
+fix = "ruff check --fix"
+format = "ruff format {args}"
+format-check = "ruff format --check {args}"
 
 [tool.hatch.envs.test]
 extra-dependencies = [
-  "transformers[torch,sentencepiece]==4.41.2",  # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
-  "huggingface_hub>=0.23.0", # Hugging Face API Generators and Embedders
-  "sentence-transformers>=2.2.0",  # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
-  "langdetect",  # TextLanguageRouter and DocumentLanguageClassifier
-  "openai-whisper>=20231106",  # LocalWhisperTranscriber
+  "transformers[torch,sentencepiece]==4.41.2", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
+  "huggingface_hub>=0.23.0",                   # Hugging Face API Generators and Embedders
+  "sentence-transformers>=2.2.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
+  "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
+  "openai-whisper>=20231106",                  # LocalWhisperTranscriber
 
   # NamedEntityExtractor
   "spacy>=3.7,<3.8",
@@ -92,15 +89,15 @@ extra-dependencies = [
   "en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.7.3/en_core_web_trf-3.7.3-py3-none-any.whl",
 
   # Converters
-  "pypdf",  # PyPDFToDocument
-  "pdfminer.six", # PDFMinerToDocument
-  "markdown-it-py",  # MarkdownToDocument
-  "mdit_plain",  # MarkdownToDocument
-  "tika",  # TikaDocumentConverter
-  "azure-ai-formrecognizer>=3.2.0b2",  # AzureOCRDocumentConverter
-  "trafilatura", # HTMLToDocument
-  "python-pptx",  # PPTXToDocument
-  "python-docx", # DocxToDocument
+  "pypdf",                            # PyPDFToDocument
+  "pdfminer.six",                     # PDFMinerToDocument
+  "markdown-it-py",                   # MarkdownToDocument
+  "mdit_plain",                       # MarkdownToDocument
+  "tika",                             # TikaDocumentConverter
+  "azure-ai-formrecognizer>=3.2.0b2", # AzureOCRDocumentConverter
+  "trafilatura",                      # HTMLToDocument
+  "python-pptx",                      # PPTXToDocument
+  "python-docx",                      # DocxToDocument
 
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions
@@ -124,7 +121,7 @@ extra-dependencies = [
   "pytest",
   "pytest-bdd",
   "pytest-cov",
-  "pytest-custom_exit_code",  # used in the CI
+  "pytest-custom_exit_code", # used in the CI
   "pytest-asyncio",
   "pytest-rerunfailures",
   "responses",
@@ -147,10 +144,8 @@ types = "mypy --install-types --non-interactive --cache-dir=.mypy_cache/ {args:h
 lint = "pylint -ry -j 0 {args:haystack}"
 
 [tool.hatch.envs.readme]
-detached = true  # To avoid installing the dependencies from the default environment
-dependencies = [
-  "haystack-pydoc-tools",
-]
+detached = true                         # To avoid installing the dependencies from the default environment
+dependencies = ["haystack-pydoc-tools"]
 
 [tool.hatch.envs.readme.scripts]
 sync = "./.github/utils/pydoc-markdown.sh"
@@ -171,15 +166,10 @@ pattern = "(?P<version>.+)"
 allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
-include = [
-  "/haystack",
-  "/VERSION.txt",
-]
+include = ["/haystack", "/VERSION.txt"]
 
 [tool.hatch.build.targets.wheel]
-packages = [
-  "haystack",
-]
+packages = ["haystack"]
 
 [tool.codespell]
 ignore-words-list = "ans,astroid,nd,ned,nin,ue,rouge,ist"
@@ -187,7 +177,7 @@ quiet-level = 3
 skip = "test/nodes/*,test/others/*,test/samples/*,e2e/*"
 
 [tool.pylint.'MESSAGES CONTROL']
-max-line-length=120
+max-line-length = 120
 disable = [
 
   # To keep
@@ -237,15 +227,15 @@ disable = [
   "deprecated-method",
 ]
 [tool.pylint.'DESIGN']
-max-args = 38  # Default is 5
-max-attributes = 28  # Default is 7
-max-branches = 34  # Default is 12
-max-locals = 45  # Default is 15
-max-module-lines = 2468  # Default is 1000
-max-nested-blocks = 9  # Default is 5
-max-statements = 206  # Default is 50
+max-args = 38           # Default is 5
+max-attributes = 28     # Default is 7
+max-branches = 34       # Default is 12
+max-locals = 45         # Default is 15
+max-module-lines = 2468 # Default is 1000
+max-nested-blocks = 9   # Default is 5
+max-statements = 206    # Default is 50
 [tool.pylint.'SIMILARITIES']
-min-similarity-lines=6
+min-similarity-lines = 6
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -277,55 +267,59 @@ warn_unused_configs = true
 ignore_missing_imports = true
 
 [tool.ruff]
-line-length = 301
+line-length = 120
 target-version = "py38"
-exclude= ["test"]
+exclude = [".github", "proposals"]
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
+isort.split-on-trailing-comma = false
+exclude = ["test/**", "e2e/**"]
 select = [
-  "ASYNC",  # flake8-async
-  "C4",     # flake8-comprehensions
-  "C90",    # McCabe cyclomatic complexity
-  "E501",   # Long lines
-  "EXE",    # flake8-executable
-  "F",      # Pyflakes
-  "INT",    # flake8-gettext
-  "PERF",   # Perflint
-  "PL",     # Pylint
-  "Q",      # flake8-quotes
-  "SIM",    # flake8-simplify
-  "SLOT",   # flake8-slots
-  "T10",    # flake8-debugger
-  "W",      # pycodestyle
-  "YTT",    # flake8-2020
-  "I",       # isort
+  "ASYNC", # flake8-async
+  "C4",    # flake8-comprehensions
+  "C90",   # McCabe cyclomatic complexity
+  "E501",  # Long lines
+  "EXE",   # flake8-executable
+  "F",     # Pyflakes
+  "INT",   # flake8-gettext
+  "PERF",  # Perflint
+  "PL",    # Pylint
+  "Q",     # flake8-quotes
+  "SIM",   # flake8-simplify
+  "SLOT",  # flake8-slots
+  "T10",   # flake8-debugger
+  "W",     # pycodestyle
+  "YTT",   # flake8-2020
+  "I",     # isort
   # built-in shadowing
-  "A001",	# builtin-variable-shadowing
-  "A002",	# builtin-argument-shadowing
-  "A003",	# builtin-attribute-shadowing
+  "A001", # builtin-variable-shadowing
+  "A002", # builtin-argument-shadowing
+  "A003", # builtin-attribute-shadowing
   # docstring rules
-  "D102",   # Missing docstring in public method
-  "D103",   # Missing docstring in public function
-  "D209",   # Closing triple quotes go to new line
-  "D205",   # 1 blank line required between summary line and description
-  "D213",   # summary lines must be positioned on the second physical line of the docstring
-  "D417",   # undocumented-parameter
-  "D419",   # undocumented-returns
+  "D102", # Missing docstring in public method
+  "D103", # Missing docstring in public function
+  "D209", # Closing triple quotes go to new line
+  "D205", # 1 blank line required between summary line and description
+  "D213", # summary lines must be positioned on the second physical line of the docstring
+  "D417", # undocumented-parameter
+  "D419", # undocumented-returns
 ]
 
 ignore = [
-  "F401",     # unused-import
-  "PERF203",	# `try`-`except` within a loop incurs performance overhead
-  "PERF401",	# Use a list comprehension to create a transformed list
-  "PLR1714",  # repeated-equality-comparison
-  "PLR5501",  # collapsible-else-if
-  "PLW0603",  # global-statement
-  "PLW1510",  # subprocess-run-without-check
-  "PLW2901",  # redefined-loop-name
-  "SIM108",   # if-else-block-instead-of-if-exp
-  "SIM115",   # open-file-with-context-handler
-  "SIM118",   # in-dict-keys
+  "F401",    # unused-import
+  "PERF203", # `try`-`except` within a loop incurs performance overhead
+  "PERF401", # Use a list comprehension to create a transformed list
+  "PLR1714", # repeated-equality-comparison
+  "PLR5501", # collapsible-else-if
+  "PLW0603", # global-statement
+  "PLW1510", # subprocess-run-without-check
+  "PLW2901", # redefined-loop-name
+  "SIM108",  # if-else-block-instead-of-if-exp
+  "SIM115",  # open-file-with-context-handler
+  "SIM118",  # in-dict-keys
 ]
 
 [tool.ruff.lint.mccabe]
@@ -338,13 +332,11 @@ max-complexity = 28
 
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["float", "int", "str"]
-max-args = 14  # Default is 5
-max-branches = 21  # Default is 12
-max-public-methods = 20  # Default is 20
-max-returns = 7  # Default is 6
-max-statements = 60  # Default is 50
+max-args = 14                                     # Default is 5
+max-branches = 21                                 # Default is 12
+max-public-methods = 20                           # Default is 20
+max-returns = 7                                   # Default is 6
+max-statements = 60                               # Default is 50
 
 [tool.coverage.run]
-omit = [
-    "haystack/testing/*",
-]
+omit = ["haystack/testing/*"]

--- a/test/components/preprocessors/test_document_splitter.py
+++ b/test/components/preprocessors/test_document_splitter.py
@@ -10,7 +10,7 @@ from haystack.components.preprocessors import DocumentSplitter
 class TestDocumentSplitter:
     def test_non_text_document(self):
         with pytest.raises(
-            ValueError, match="DocumentSplitter only works with text documents but document.content for document ID"
+            ValueError, match="DocumentSplitter only works with text documents but content for document ID"
         ):
             splitter = DocumentSplitter()
             splitter.run(documents=[Document()])

--- a/test/components/routers/test_text_language_router.py
+++ b/test/components/routers/test_text_language_router.py
@@ -11,12 +11,12 @@ from haystack.components.routers import TextLanguageRouter
 
 class TestTextLanguageRouter:
     def test_non_string_input(self):
-        with pytest.raises(TypeError, match="TextLanguageRouter expects a str as input."):
+        with pytest.raises(TypeError, match="TextLanguageRouter expects a string as input."):
             classifier = TextLanguageRouter()
             classifier.run(text=Document(content="This is an english sentence."))
 
     def test_list_of_string(self):
-        with pytest.raises(TypeError, match="TextLanguageRouter expects a str as input."):
+        with pytest.raises(TypeError, match="TextLanguageRouter expects a string as input."):
             classifier = TextLanguageRouter()
             classifier.run(text=["This is an english sentence."])
 

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -691,7 +691,10 @@ def pipeline_that_has_a_greedy_and_variadic_component_after_a_component_with_def
 @given("a pipeline that has a component that doesn't return a dictionary", target_fixture="pipeline_data")
 def pipeline_that_has_a_component_that_doesnt_return_a_dictionary():
     BrokenComponent = component_class(
-        "BrokenComponent", input_types={"a": int}, output_types={"b": int}, output=1  # type:ignore
+        "BrokenComponent",
+        input_types={"a": int},
+        output_types={"b": int},
+        output=1,  # type:ignore
     )
 
     pipe = Pipeline(max_loops_allowed=10)

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -77,7 +77,9 @@ class TestPipeline:
     @patch("haystack.core.pipeline.base.is_in_jupyter")
     @patch("IPython.display.Image")
     @patch("IPython.display.display")
-    def test_show_in_notebook(self, mock_ipython_display, mock_ipython_image, mock_is_in_jupyter, mock_to_mermaid_image):
+    def test_show_in_notebook(
+        self, mock_ipython_display, mock_ipython_image, mock_is_in_jupyter, mock_to_mermaid_image
+    ):
         pipe = Pipeline()
 
         mock_to_mermaid_image.return_value = b"some_image_data"
@@ -161,7 +163,9 @@ class TestPipeline:
 
         assert component_2.__haystack_added_to_pipeline__ is None
         assert component_2.__haystack_input__._sockets_dict == {"in": InputSocket(name="in", type=int, senders=[])}
-        assert component_2.__haystack_output__._sockets_dict == {"out": OutputSocket(name="out", type=int, receivers=[])}
+        assert component_2.__haystack_output__._sockets_dict == {
+            "out": OutputSocket(name="out", type=int, receivers=[])
+        }
 
         pipe2 = Pipeline()
         pipe2.add_component("component_4", Some())
@@ -171,8 +175,12 @@ class TestPipeline:
         pipe2.connect("component_4", "component_2")
         pipe2.connect("component_2", "component_5")
         assert component_2.__haystack_added_to_pipeline__ is pipe2
-        assert component_2.__haystack_input__._sockets_dict == {"in": InputSocket(name="in", type=int, senders=["component_4"])}
-        assert component_2.__haystack_output__._sockets_dict == {"out": OutputSocket(name="out", type=int, receivers=["component_5"])}
+        assert component_2.__haystack_input__._sockets_dict == {
+            "in": InputSocket(name="in", type=int, senders=["component_4"])
+        }
+        assert component_2.__haystack_output__._sockets_dict == {
+            "out": OutputSocket(name="out", type=int, receivers=["component_5"])
+        }
 
         # instance = pipe2.get_component("some")
         # assert instance == component
@@ -202,7 +210,16 @@ class TestPipeline:
         pipe.connect("double", "add_default")
 
         expected_repr = (
-            f"{object.__repr__(pipe)}\n" "🧱 Metadata\n" "  - test: test\n" "🚅 Components\n" "  - add_two: AddFixedValue\n" "  - add_default: AddFixedValue\n" "  - double: Double\n" "🛤️ Connections\n" "  - add_two.result -> double.value (int)\n" "  - double.value -> add_default.value (int)\n"
+            f"{object.__repr__(pipe)}\n"
+            "🧱 Metadata\n"
+            "  - test: test\n"
+            "🚅 Components\n"
+            "  - add_two: AddFixedValue\n"
+            "  - add_default: AddFixedValue\n"
+            "  - double: Double\n"
+            "🛤️ Connections\n"
+            "  - add_two.result -> double.value (int)\n"
+            "  - double.value -> add_default.value (int)\n"
         )
 
         assert repr(pipe) == expected_repr
@@ -362,7 +379,9 @@ class TestPipeline:
 
             components_seen_in_callback.append(name)
 
-        pipe = Pipeline.from_dict(data, callbacks=DeserializationCallbacks(component_pre_init=component_pre_init_callback))
+        pipe = Pipeline.from_dict(
+            data, callbacks=DeserializationCallbacks(component_pre_init=component_pre_init_callback)
+        )
         assert components_seen_in_callback == ["add_two", "add_default", "double", "greet"]
         add_two = pipe.graph.nodes["add_two"]["instance"]
         assert add_two.add == 2
@@ -384,7 +403,9 @@ class TestPipeline:
                 init_params["message"] = "modified test"
                 init_params["log_level"] = "DEBUG"
 
-        pipe = Pipeline.from_dict(data, callbacks=DeserializationCallbacks(component_pre_init=component_pre_init_callback_modify))
+        pipe = Pipeline.from_dict(
+            data, callbacks=DeserializationCallbacks(component_pre_init=component_pre_init_callback_modify)
+        )
         add_two = pipe.graph.nodes["add_two"]["instance"]
         assert add_two.add == 3
         add_default = pipe.graph.nodes["add_default"]["instance"]
@@ -537,7 +558,9 @@ class TestPipeline:
         p.connect("a.x", "c.x")
         p.connect("b.y", "c.y")
         assert p.inputs() == {}
-        assert p.inputs(include_components_with_connected_inputs=True) == {"c": {"x": {"type": int, "is_mandatory": True}, "y": {"type": int, "is_mandatory": True}}}
+        assert p.inputs(include_components_with_connected_inputs=True) == {
+            "c": {"x": {"type": int, "is_mandatory": True}, "y": {"type": int, "is_mandatory": True}}
+        }
 
     def test_describe_input_some_components_with_no_inputs(self):
         A = component_class("A", input_types={}, output={"x": 0})
@@ -719,10 +742,16 @@ class TestPipeline:
             assert pipe.graph.nodes[node]["visits"] == 0
 
     def test__init_to_run(self):
-        ComponentWithVariadic = component_class("ComponentWithVariadic", input_types={"in": Variadic[int]}, output_types={"out": int})
+        ComponentWithVariadic = component_class(
+            "ComponentWithVariadic", input_types={"in": Variadic[int]}, output_types={"out": int}
+        )
         ComponentWithNoInputs = component_class("ComponentWithNoInputs", input_types={}, output_types={"out": int})
-        ComponentWithSingleInput = component_class("ComponentWithSingleInput", input_types={"in": int}, output_types={"out": int})
-        ComponentWithMultipleInputs = component_class("ComponentWithMultipleInputs", input_types={"in1": int, "in2": int}, output_types={"out": int})
+        ComponentWithSingleInput = component_class(
+            "ComponentWithSingleInput", input_types={"in": int}, output_types={"out": int}
+        )
+        ComponentWithMultipleInputs = component_class(
+            "ComponentWithMultipleInputs", input_types={"in1": int, "in2": int}, output_types={"out": int}
+        )
 
         pipe = Pipeline()
         pipe.add_component("with_variadic", ComponentWithVariadic())
@@ -783,7 +812,9 @@ class TestPipeline:
         assert id(res["first_mock"]["x"]) != id(res["second_mock"]["x"])
 
     def test__prepare_component_input_data_with_connected_inputs(self):
-        MockComponent = component_class("MockComponent", input_types={"x": List[str], "y": str}, output_types={"z": str})
+        MockComponent = component_class(
+            "MockComponent", input_types={"x": List[str], "y": str}, output_types={"z": str}
+        )
         pipe = Pipeline()
         pipe.add_component("first_mock", MockComponent())
         pipe.add_component("second_mock", MockComponent())
@@ -797,7 +828,10 @@ class TestPipeline:
         pipe = Pipeline()
         res = pipe._prepare_component_input_data({"input_name": 1})
         assert res == {}
-        assert "Inputs ['input_name'] were not matched to any component inputs, " "please check your run parameters." in caplog.text
+        assert (
+            "Inputs ['input_name'] were not matched to any component inputs, "
+            "please check your run parameters." in caplog.text
+        )
 
     def test_connect(self):
         comp1 = component_class("Comp1", output_types={"value": int})()
@@ -973,8 +1007,12 @@ class TestPipeline:
 
     def test__run_component(self, spying_tracer, caplog):
         caplog.set_level(logging.INFO)
-        sentence_builder = component_class("SentenceBuilder", input_types={"words": List[str]}, output={"text": "some words"})()
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output={"doc": Document(content="some words")})()
+        sentence_builder = component_class(
+            "SentenceBuilder", input_types={"words": List[str]}, output={"text": "some words"}
+        )()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output={"doc": Document(content="some words")}
+        )()
         document_cleaner = component_class(
             "DocumentCleaner",
             input_types={"doc": Document},
@@ -1020,12 +1058,20 @@ class TestPipeline:
         pipe.add_component("sentence_builder", sentence_builder)
 
         assert not pipe._component_has_enough_inputs_to_run("sentence_builder", {})
-        assert not pipe._component_has_enough_inputs_to_run("sentence_builder", {"sentence_builder": {"wrong_input_name": "blah blah"}})
-        assert pipe._component_has_enough_inputs_to_run("sentence_builder", {"sentence_builder": {"words": ["blah blah"]}})
+        assert not pipe._component_has_enough_inputs_to_run(
+            "sentence_builder", {"sentence_builder": {"wrong_input_name": "blah blah"}}
+        )
+        assert pipe._component_has_enough_inputs_to_run(
+            "sentence_builder", {"sentence_builder": {"words": ["blah blah"]}}
+        )
 
     def test__dequeue_components_that_received_no_input(self):
-        sentence_builder = component_class("SentenceBuilder", input_types={"words": List[str]}, output={"text": "some words"})()
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output={"doc": Document(content="some words")})()
+        sentence_builder = component_class(
+            "SentenceBuilder", input_types={"words": List[str]}, output={"text": "some words"}
+        )()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output={"doc": Document(content="some words")}
+        )()
 
         pipe = Pipeline()
         pipe.add_component("sentence_builder", sentence_builder)
@@ -1039,8 +1085,12 @@ class TestPipeline:
         assert waiting_for_input == []
 
     def test__distribute_output(self):
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output_types={"doc": Document, "another_doc": Document})()
-        document_cleaner = component_class("DocumentCleaner", input_types={"doc": Document}, output_types={"cleaned_doc": Document})()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document, "another_doc": Document}
+        )()
+        document_cleaner = component_class(
+            "DocumentCleaner", input_types={"doc": Document}, output_types={"cleaned_doc": Document}
+        )()
         document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
 
         pipe = Pipeline()
@@ -1071,7 +1121,9 @@ class TestPipeline:
         assert waiting_for_input == [("document_joiner", document_joiner)]
 
     def test__enqueue_next_runnable_component(self):
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output_types={"doc": Document})()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document}
+        )()
         pipe = Pipeline()
         inputs_by_component = {"document_builder": {"text": "some text"}}
         to_run = []
@@ -1082,7 +1134,9 @@ class TestPipeline:
         assert waiting_for_input == []
 
     def test__enqueue_next_runnable_component_without_component_inputs(self):
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output_types={"doc": Document})()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document}
+        )()
         pipe = Pipeline()
         inputs_by_component = {}
         to_run = []
@@ -1130,32 +1184,41 @@ class TestPipeline:
         assert waiting_for_input == [("prompt_builder", prompt_builder)]
 
     def test__enqueue_next_runnable_component_with_different_components_inputs(self):
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output_types={"doc": Document})()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document}
+        )()
         document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
         prompt_builder = PromptBuilder(template="{{ questions | join('\n') }}")
 
         pipe = Pipeline()
         inputs_by_component = {"document_builder": {"text": "some text"}}
         to_run = []
-        waiting_for_input = [("prompt_builder", prompt_builder), ("document_builder", document_builder), ("document_joiner", document_joiner)]
+        waiting_for_input = [
+            ("prompt_builder", prompt_builder),
+            ("document_builder", document_builder),
+            ("document_joiner", document_joiner),
+        ]
         pipe._enqueue_next_runnable_component(inputs_by_component, to_run, waiting_for_input)
 
         assert to_run == [("document_builder", document_builder)]
         assert waiting_for_input == [("prompt_builder", prompt_builder), ("document_joiner", document_joiner)]
 
     def test__enqueue_next_runnable_component_with_different_components_without_any_input(self):
-        document_builder = component_class("DocumentBuilder", input_types={"text": str}, output_types={"doc": Document})()
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document}
+        )()
         document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
         prompt_builder = PromptBuilder(template="{{ questions | join('\n') }}")
 
         pipe = Pipeline()
         inputs_by_component = {}
         to_run = []
-        waiting_for_input = [("prompt_builder", prompt_builder), ("document_builder", document_builder), ("document_joiner", document_joiner)]
+        waiting_for_input = [
+            ("prompt_builder", prompt_builder),
+            ("document_builder", document_builder),
+            ("document_joiner", document_joiner),
+        ]
         pipe._enqueue_next_runnable_component(inputs_by_component, to_run, waiting_for_input)
 
         assert to_run == [("document_builder", document_builder)]
-        assert waiting_for_input == [
-            ("prompt_builder", prompt_builder),
-            ("document_joiner", document_joiner),
-        ]
+        assert waiting_for_input == [("prompt_builder", prompt_builder), ("document_joiner", document_joiner)]

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -75,7 +75,11 @@ def test_init_with_parameters():
 
 def test_init_with_legacy_fields():
     doc = Document(
-        content="test text", content_type="text", id_hash_keys=["content"], score=0.812, embedding=[0.1, 0.2, 0.3]  # type: ignore
+        content="test text",
+        content_type="text",
+        id_hash_keys=["content"],
+        score=0.812,
+        embedding=[0.1, 0.2, 0.3],  # type: ignore
     )
     assert doc.id == "18fc2c114825872321cf5009827ca162f54d3be50ab9e9ffa027824b6ec223af"
     assert doc.content == "test text"
@@ -233,7 +237,11 @@ def test_from_dict_with_legacy_fields():
             "embedding": [0.1, 0.2, 0.3],
         }
     ) == Document(
-        content="test text", content_type="text", id_hash_keys=["content"], score=0.812, embedding=[0.1, 0.2, 0.3]  # type: ignore
+        content="test text",
+        content_type="text",
+        id_hash_keys=["content"],
+        score=0.812,
+        embedding=[0.1, 0.2, 0.3],  # type: ignore
     )
 
 


### PR DESCRIPTION
### Proposed Changes:

- Add `hatch run format` and `hatch run check` to use `ruff format` and `ruff check` respectively
- Add `hatch run format-check` to fail the CI if files would need formatting
- Enable `ruff format` in the pre-commit hook
- Run `format` on the `test` folder but skip it for linting
- Configure `ruff format` with the same rules as the old Black setup
- Reformat the offending files

### How did you test it?

Unit tests

### Notes for the reviewer



### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
