### PR TITLE
feat: InMemoryDocumentStore serialization

### DIFF
--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import math
 import re
 import uuid
 from collections import Counter
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
 import numpy as np
@@ -338,6 +340,38 @@ class InMemoryDocumentStore:
             The deserialized component.
         """
         return default_from_dict(cls, data)
+
+    def save_to_disk(self, path: str) -> None:
+        """
+        Write the database and its' data to disk as a JSON file.
+
+        :param path: The path to the JSON file.
+        """
+        data: Dict[str, Any] = self.to_dict()
+        data["documents"] = [doc.to_dict(flatten=False) for doc in self.storage.values()]
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    @classmethod
+    def load_from_disk(cls, path: str) -> "InMemoryDocumentStore":
+        """
+        Load the database and its' data from disk as a JSON file.
+
+        :param path: The path to the JSON file.
+        :returns: The loaded InMemoryDocumentStore.
+        """
+        if Path(path).exists():
+            try:
+                with open(path, "r") as f:
+                    data = json.load(f)
+                documents = data.pop("documents")
+                cls_object = default_from_dict(cls, data)
+                cls_object.write_documents(documents=[Document(**doc) for doc in documents])
+                return cls_object
+            except Exception as e:
+                raise Exception(f"Error loading InMemoryDocumentStore from disk. error: {e}")
+        else:
+            return cls()
 
     def count_documents(self) -> int:
         """

--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -364,12 +364,16 @@ class InMemoryDocumentStore:
             try:
                 with open(path, "r") as f:
                     data = json.load(f)
-                documents = data.pop("documents")
-                cls_object = default_from_dict(cls, data)
-                cls_object.write_documents(documents=[Document(**doc) for doc in documents])
-                return cls_object
             except Exception as e:
                 raise Exception(f"Error loading InMemoryDocumentStore from disk. error: {e}")
+
+            documents = data.pop("documents")
+            cls_object = default_from_dict(cls, data)
+            cls_object.write_documents(
+                documents=[Document(**doc) for doc in documents], policy=DuplicatePolicy.OVERWRITE
+            )
+            return cls_object
+
         else:
             raise FileNotFoundError(f"File {path} not found.")
 

--- a/haystack/document_stores/in_memory/document_store.py
+++ b/haystack/document_stores/in_memory/document_store.py
@@ -371,7 +371,7 @@ class InMemoryDocumentStore:
             except Exception as e:
                 raise Exception(f"Error loading InMemoryDocumentStore from disk. error: {e}")
         else:
-            return cls()
+            raise FileNotFoundError(f"File {path} not found.")
 
     def count_documents(self) -> int:
         """

--- a/releasenotes/notes/add-serialization-to-inmemorydocumentstore-2aa4d9ac85b961c5.yaml
+++ b/releasenotes/notes/add-serialization-to-inmemorydocumentstore-2aa4d9ac85b961c5.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Added serialization methods save_to_disk and write_to_disk to InMemoryDocumentStore.

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+import tempfile
 
 from haystack import Document
 from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
@@ -73,6 +74,20 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert store.bm25_algorithm == "BM25Plus"
         assert store.bm25_parameters == {"key": "value"}
         assert store.index == "my_cool_index"
+
+    def test_save_to_disk_and_load_from_disk(self, document_store: InMemoryDocumentStore):
+        docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
+        document_store = InMemoryDocumentStore()
+        document_store.write_documents(docs)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = tmp_dir + "/tmp.json"
+            document_store.save_to_disk(tmp_dir)
+            document_store_loaded = InMemoryDocumentStore.load_from_disk(tmp_dir)
+
+        assert document_store_loaded.count_documents() == 2
+        assert document_store_loaded.storage.values() == docs
+        assert document_store_loaded.to_dict() == document_store.to_dict()
 
     def test_invalid_bm25_algorithm(self):
         with pytest.raises(ValueError, match="BM25 algorithm 'invalid' is not supported"):

--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -20,6 +20,11 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
     """
 
     @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yield tmp_dir
+
+    @pytest.fixture
     def document_store(self) -> InMemoryDocumentStore:
         return InMemoryDocumentStore(bm25_algorithm="BM25L")
 
@@ -75,18 +80,16 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         assert store.bm25_parameters == {"key": "value"}
         assert store.index == "my_cool_index"
 
-    def test_save_to_disk_and_load_from_disk(self, document_store: InMemoryDocumentStore):
+    def test_save_to_disk_and_load_from_disk(self, tmp_dir: str):
         docs = [Document(content="Hello world"), Document(content="Haystack supports multiple languages")]
         document_store = InMemoryDocumentStore()
         document_store.write_documents(docs)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_dir = tmp_dir + "/tmp.json"
-            document_store.save_to_disk(tmp_dir)
-            document_store_loaded = InMemoryDocumentStore.load_from_disk(tmp_dir)
+        tmp_dir = tmp_dir + "/document_store.json"
+        document_store.save_to_disk(tmp_dir)
+        document_store_loaded = InMemoryDocumentStore.load_from_disk(tmp_dir)
 
         assert document_store_loaded.count_documents() == 2
-        assert document_store_loaded.storage.values() == docs
+        assert list(document_store_loaded.storage.values()) == docs
         assert document_store_loaded.to_dict() == document_store.to_dict()
 
     def test_invalid_bm25_algorithm(self):


### PR DESCRIPTION
### Related Issues

- fixes #7887 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Added two `save_to_disk` and `load_from_disk` functions.

### How did you test it?

Added a test `test_save_to_disk_and_load_from_disk`

### Notes for the reviewer

The test has an issue due to `cls.from_dict` methods somehow caching `InMemoryDocumentStore.values()`. I added an overwrite policy to avoid this but it is not the cleanest way. Not sure what is happening.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
