### PR TITLE
fix: Fix deserialization of pipelines that contain `LLMEvaluator` subclasses

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -6,9 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from numpy import mean as np_mean
 
-from haystack import default_from_dict
+from haystack import component, default_from_dict, default_to_dict
 from haystack.components.evaluators.llm_evaluator import LLMEvaluator
-from haystack.core.component import component
 from haystack.utils import Secret, deserialize_secrets_inplace
 
 # Private global variable for default examples to include in the prompt if the user does not provide any examples
@@ -34,6 +33,7 @@ _DEFAULT_EXAMPLES = [
 ]
 
 
+@component
 class ContextRelevanceEvaluator(LLMEvaluator):
     """
     Evaluator that checks if a provided context is relevant to the question.
@@ -115,7 +115,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         self.api = api
         self.api_key = api_key
 
-        super().__init__(
+        super(ContextRelevanceEvaluator, self).__init__(
             instructions=self.instructions,
             inputs=self.inputs,
             outputs=self.outputs,
@@ -141,7 +141,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
                 - `individual_scores`: A list of context relevance scores for each input question.
                 - `results`: A list of dictionaries with `statements` and `statement_scores` for each input context.
         """
-        result = super().run(questions=questions, contexts=contexts)
+        result = super(ContextRelevanceEvaluator, self).run(questions=questions, contexts=contexts)
 
         # calculate average statement relevance score per query
         for idx, res in enumerate(result["results"]):
@@ -158,6 +158,22 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         result["individual_scores"] = [res["score"] for res in result["results"]]
 
         return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns:
+            A dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            api=self.api,
+            api_key=self.api_key.to_dict() if self.api_key else None,
+            examples=self.examples,
+            progress_bar=self.progress_bar,
+            raise_on_failure=self.raise_on_failure,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ContextRelevanceEvaluator":

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -6,9 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from numpy import mean as np_mean
 
-from haystack import default_from_dict
+from haystack import component, default_from_dict, default_to_dict
 from haystack.components.evaluators.llm_evaluator import LLMEvaluator
-from haystack.core.component import component
 from haystack.utils import Secret, deserialize_secrets_inplace
 
 # Default examples to include in the prompt if the user does not provide any examples
@@ -46,6 +45,7 @@ _DEFAULT_EXAMPLES = [
 ]
 
 
+@component
 class FaithfulnessEvaluator(LLMEvaluator):
     """
     Evaluator that checks if a generated answer can be inferred from the provided contexts.
@@ -130,7 +130,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
         self.api = api
         self.api_key = api_key
 
-        super().__init__(
+        super(FaithfulnessEvaluator, self).__init__(
             instructions=self.instructions,
             inputs=self.inputs,
             outputs=self.outputs,
@@ -158,7 +158,9 @@ class FaithfulnessEvaluator(LLMEvaluator):
                 - `individual_scores`: A list of faithfulness scores for each input answer.
                 - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
         """
-        result = super().run(questions=questions, contexts=contexts, predicted_answers=predicted_answers)
+        result = super(FaithfulnessEvaluator, self).run(
+            questions=questions, contexts=contexts, predicted_answers=predicted_answers
+        )
 
         # calculate average statement faithfulness score per query
         for idx, res in enumerate(result["results"]):
@@ -175,6 +177,22 @@ class FaithfulnessEvaluator(LLMEvaluator):
         result["individual_scores"] = [res["score"] for res in result["results"]]
 
         return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns:
+            A dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            api=self.api,
+            api_key=self.api_key.to_dict() if self.api_key else None,
+            examples=self.examples,
+            progress_bar=self.progress_bar,
+            raise_on_failure=self.raise_on_failure,
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "FaithfulnessEvaluator":

--- a/releasenotes/notes/fix-llmevaluator-subclass-deserialization-c633b2f95c84fe4b.yaml
+++ b/releasenotes/notes/fix-llmevaluator-subclass-deserialization-c633b2f95c84fe4b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the deserialization of pipelines containing evaluator components that were subclasses of `LLMEvaluator`.


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/7824
- fixes https://github.com/deepset-ai/haystack/issues/7884

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

The subclass of the `LLMEvaluator` component were not using the `@component` decorator, which prevented them from being added to the internal component registry. This caused a failure when deserializing a pipeline that contained on those components. Furthermore, both subclasses were missing `to_dict` methods, which lead to the wrong base class method being invoked resulting in yet another failure.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
