### PR TITLE
Isolate logic to check if we're stuck in a loop when running `Pipeline`

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1011,6 +1011,8 @@ class PipelineBase:
         Checks if the Pipeline is stuck in a loop.
 
         :param waiting_for_input: Queue of Components waiting for input
+
+        :return: True if the Pipeline is stuck in a loop, False otherwise
         """
         # Are we actually stuck or there's a lazy variadic or a component with has only default inputs
         # waiting for input?

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1016,10 +1016,13 @@ class PipelineBase:
         # waiting for input?
         # This is our last resort, if there's no lazy variadic or component with only default inputs
         # waiting for input we're stuck for real and we can't make any progress.
+        component_found = False
         for _, comp in waiting_for_input:
             if _is_lazy_variadic(comp) or _has_all_inputs_with_defaults(comp):
+                component_found = True
                 break
-        else:
+
+        if not component_found:
             # We're stuck in a loop for real, we can't make any progress.
             # BAIL!
             return True

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1012,7 +1012,7 @@ class PipelineBase:
 
         :param waiting_for_input: Queue of Components waiting for input
 
-        :return: True if the Pipeline is stuck in a loop, False otherwise
+        :returns: True if the Pipeline is stuck in a loop, False otherwise
         """
         # Are we actually stuck or there's a lazy variadic or a component with has only default inputs
         # waiting for input?

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -283,10 +283,10 @@ class Pipeline(PipelineBase):
                         and last_waiting_for_input is not None
                         and before_last_waiting_for_input == last_waiting_for_input
                     ):
-                        # Are we actually stuck or there's a lazy variadic or a component with has only default inputs
-                        # waiting for input?
-                        # This is our last resort, if there's no lazy variadic or component with only default inputs
-                        # waiting for input we're stuck for real and we can't make any progress.
+                        if self._is_stuck_in_a_loop(waiting_for_input):
+                            # We're stuck! We can't make any progress.
+                            break
+
                         for name, comp in waiting_for_input:
                             is_variadic = any(
                                 socket.is_variadic
@@ -298,17 +298,6 @@ class Pipeline(PipelineBase):
                             )
                             if is_variadic and not comp.__haystack_is_greedy__ or has_only_defaults:  # type: ignore[attr-defined]
                                 break
-                        else:
-                            # We're stuck in a loop for real, we can't make any progress.
-                            # BAIL!
-                            break
-
-                        if len(waiting_for_input) == 1:
-                            # We have a single component with variadic input or only default inputs waiting for input.
-                            # If we're at this point it means it has been waiting for input for at least 2 iterations.
-                            # This will never run.
-                            # BAIL!
-                            break
 
                         # There was a lazy variadic or a component with only default waiting for input, we can run it
                         waiting_for_input.remove((name, comp))

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -4,6 +4,7 @@
 
 from copy import deepcopy
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
+from warnings import warn
 
 from haystack import logging, tracing
 from haystack.core.component import Component
@@ -285,6 +286,11 @@ class Pipeline(PipelineBase):
                     ):
                         if self._is_stuck_in_a_loop(waiting_for_input):
                             # We're stuck! We can't make any progress.
+                            msg = (
+                                "Pipeline is stuck running in a loop. Partial outputs will be returned. "
+                                "Check the Pipeline graph for possible issues."
+                            )
+                            warn(RuntimeWarning(msg))
                             break
 
                         for name, comp in waiting_for_input:

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1222,3 +1222,30 @@ class TestPipeline:
 
         assert to_run == [("document_builder", document_builder)]
         assert waiting_for_input == [("prompt_builder", prompt_builder), ("document_joiner", document_joiner)]
+
+    def test__is_stuck_in_a_loop(self):
+        document_builder = component_class(
+            "DocumentBuilder", input_types={"text": str}, output_types={"doc": Document}
+        )()
+        document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
+        prompt_builder = PromptBuilder(template="{{ questions | join('\n') }}")
+
+        pipe = Pipeline()
+
+        waiting_for_input = [("document_builder", document_builder)]
+        assert pipe._is_stuck_in_a_loop(waiting_for_input)
+
+        waiting_for_input = [("document_joiner", document_joiner)]
+        assert pipe._is_stuck_in_a_loop(waiting_for_input)
+
+        waiting_for_input = [("prompt_builder", prompt_builder)]
+        assert pipe._is_stuck_in_a_loop(waiting_for_input)
+
+        waiting_for_input = [("document_joiner", document_joiner), ("prompt_builder", prompt_builder)]
+        assert not pipe._is_stuck_in_a_loop(waiting_for_input)
+
+        waiting_for_input = [("document_builder", document_joiner), ("prompt_builder", prompt_builder)]
+        assert not pipe._is_stuck_in_a_loop(waiting_for_input)
+
+        waiting_for_input = [("document_builder", document_joiner), ("document_joiner", document_joiner)]
+        assert not pipe._is_stuck_in_a_loop(waiting_for_input)


### PR DESCRIPTION
### Related Issues

Part of #7614

### Proposed Changes:

Isolate the logic to check if `Pipeline.run()` is stuck in a loop.

### How did you test it?

Added tests and ran them locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
