### PR TITLE
fix: explicitly tell `ContextRelevanceEvaluator` that each statement should be scored

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -23,8 +23,23 @@ _DEFAULT_EXAMPLES = [
         },
     },
     {
-        "inputs": {"questions": "What is the capital of France?", "contexts": ["Berlin is the capital of Germany."]},
-        "outputs": {"statements": ["Berlin is the capital of Germany."], "statement_scores": [0]},
+        "inputs": {
+            "questions": "What is the capital of France?",
+            "contexts": [
+                "Berlin is the capital of Germany and was founded in 1244.",
+                "Europe is a continent with 44 countries.",
+                "Madrid is the capital of Spain.",
+            ],
+        },
+        "outputs": {
+            "statements": [
+                "Berlin is the capital of Germany.",
+                "Berlin was founded in 1244.",
+                "Europe is a continent with 44 countries.",
+                "Madrid is the capital of Spain.",
+            ],
+            "statement_scores": [0, 0, 0, 0],
+        },
     },
     {
         "inputs": {"questions": "What is the capital of Italy?", "contexts": ["Rome is the capital of Italy."]},
@@ -113,7 +128,8 @@ class ContextRelevanceEvaluator(LLMEvaluator):
             "Your task is to judge how relevant the provided context is for answering a question. "
             "First, please extract statements from the provided context. "
             "Second, calculate a relevance score for each statement in the context. "
-            "The score is 1 if the statement is relevant to answer the question or 0 if it is not relevant."
+            "The score is 1 if the statement is relevant to answer the question or 0 if it is not relevant. "
+            "Each statement should be scored individually."
         )
         self.inputs = [("questions", List[str]), ("contexts", List[List[str]])]
         self.outputs = ["statements", "statement_scores"]

--- a/releasenotes/notes/improve-ContextRelevance-evaluator-prompt-6b80229c99e3bc38.yaml
+++ b/releasenotes/notes/improve-ContextRelevance-evaluator-prompt-6b80229c99e3bc38.yaml
@@ -1,0 +1,5 @@
+---
+
+enhancements:
+  - |
+    Updated the ContextRelevance evaluator prompt, explicitly asking to score each statement.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -256,6 +256,11 @@ class TestContextRelevanceEvaluator:
         nested_required_fields = {"score", "statement_scores", "statements"}
         assert all(field in result["results"][0] for field in nested_required_fields)
 
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
     def test_all_statements_are_scored(self):
         from haystack.components.evaluators import ContextRelevanceEvaluator
 

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -270,7 +270,7 @@ class TestContextRelevanceEvaluator:
                 "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming "
                 "language. Its design philosophy emphasizes code readability, and its language constructs aim to help "
                 "programmers write clear, logical code for both small and large-scale software projects.",
-                "Java is a high-level, class-based, object-oriented programming language. It allows you to write once, "
+                "Java is a high-level, class-based, object-oriented programming language which allows you to write once, "
                 "run anywhere, meaning that compiled Java code can run on all platforms that support Java without the "
                 "need for recompilation.",
                 "Scala is a high-level, statically typed programming language.",
@@ -280,5 +280,5 @@ class TestContextRelevanceEvaluator:
         evaluator = ContextRelevanceEvaluator(progress_bar=False)
         result = evaluator.run(questions=questions, contexts=contexts)
 
-        assert len(result["results"][0]["statements"]) == 5
-        assert len(result["results"][0]["statement_scores"]) == 5
+        assert len(result["results"][0]["statements"]) == 4
+        assert len(result["results"][0]["statement_scores"]) == 4

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -267,8 +267,12 @@ class TestContextRelevanceEvaluator:
         questions = ["Who created the Python language?"]
         contexts = [
             [
-                "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming language. Its design philosophy emphasizes code readability, and its language constructs aim to help programmers write clear, logical code for both small and large-scale software projects.",
-                "Java is a high-level, class-based, object-oriented programming language. It allows you to write once, run anywhere, meaning that compiled Java code can run on all platforms that support Java without the need for recompilation.",
+                "Python, created by Guido van Rossum in the late 1980s, is a high-level general-purpose programming "
+                "language. Its design philosophy emphasizes code readability, and its language constructs aim to help "
+                "programmers write clear, logical code for both small and large-scale software projects.",
+                "Java is a high-level, class-based, object-oriented programming language. It allows you to write once, "
+                "run anywhere, meaning that compiled Java code can run on all platforms that support Java without the "
+                "need for recompilation.",
                 "Scala is a high-level, statically typed programming language.",
             ]
         ]

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -196,7 +196,7 @@ class TestContextRelevanceEvaluator:
 
     def test_run_missing_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        component = ContextRelevanceEvaluator(progress_bar=False)
+        component = ContextRelevanceEvaluator()
         with pytest.raises(TypeError, match="missing 2 required positional arguments"):
             component.run()
 
@@ -248,7 +248,7 @@ class TestContextRelevanceEvaluator:
         questions = ["Who created the Python language?"]
         contexts = [["Python, created by Guido van Rossum, is a high-level general-purpose programming language."]]
 
-        evaluator = ContextRelevanceEvaluator(progress_bar=False)
+        evaluator = ContextRelevanceEvaluator()
         result = evaluator.run(questions=questions, contexts=contexts)
 
         required_fields = {"individual_scores", "results", "score"}
@@ -277,7 +277,7 @@ class TestContextRelevanceEvaluator:
             ]
         ]
 
-        evaluator = ContextRelevanceEvaluator(progress_bar=False)
+        evaluator = ContextRelevanceEvaluator()
         result = evaluator.run(questions=questions, contexts=contexts)
 
         assert len(result["results"][0]["statements"]) == 4


### PR DESCRIPTION
### Related Issues

- fixes #7803

### Proposed Changes:

- added a few more examples containing multiple non-relevant statements
- added one more line to the prompt mentioning that each statement should be scored

### How did you test it?

- run unit tests and live test, also added one more live test

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
