### PR TITLE
chore: update sentence transformers import error message

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -9,7 +9,7 @@ import numpy as np
 from haystack.lazy_imports import LazyImport
 from haystack.utils.auth import Secret
 
-with LazyImport(message="Run 'pip install \"sentence-transformers>=2.2.0\"'") as sentence_transformers_import:
+with LazyImport(message="Run 'pip install \"sentence-transformers>=2.3.0\"'") as sentence_transformers_import:
     from sentence_transformers import SentenceTransformer
 
 

--- a/haystack/components/evaluators/sas_evaluator.py
+++ b/haystack/components/evaluators/sas_evaluator.py
@@ -11,7 +11,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, expit
 from haystack.utils.auth import Secret, deserialize_secrets_inplace
 
-with LazyImport(message="Run 'pip install scikit-learn \"sentence-transformers>=2.2.0\"'") as sas_import:
+with LazyImport(message="Run 'pip install \"sentence-transformers>=2.3.0\"'") as sas_import:
     from sentence_transformers import CrossEncoder, SentenceTransformer, util
     from transformers import AutoConfig
 

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -11,7 +11,7 @@ from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install \"sentence-transformers>=2.2.0\"'") as torch_and_sentence_transformers_import:
+with LazyImport(message="Run 'pip install \"sentence-transformers>=2.3.0\"'") as torch_and_sentence_transformers_import:
     import torch
     from sentence_transformers import SentenceTransformer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ format-check = "ruff format --check {args}"
 extra-dependencies = [
   "transformers[torch,sentencepiece]==4.41.2", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
   "huggingface_hub>=0.23.0",                   # Hugging Face API Generators and Embedders
-  "sentence-transformers>=2.2.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
+  "sentence-transformers>=2.3.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
   "openai-whisper>=20231106",                  # LocalWhisperTranscriber
 

--- a/releasenotes/notes/update-sentence-transformers-import-error-msg-895b8ed2355ae2fe.yaml
+++ b/releasenotes/notes/update-sentence-transformers-import-error-msg-895b8ed2355ae2fe.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Update the error message when the `sentence-transformers` library is not installed
+    and the used component requires it.


### PR DESCRIPTION
### Related Issues
While helping a user in #7850, I discovered that we are suggesting to install `sentence-transformers>=2.2.0`,
while the parameter `trust_remote_code` (introduced in Haystack in #7356) is only compatible with >=2.3.0 (https://github.com/UKPLab/sentence-transformers/issues/2272).

### Proposed Changes:
- update the import error message
- update also the test dependencies in pyproject

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
