### PR TITLE
fix: check for None in SAS eval input

### DIFF
--- a/haystack/components/evaluators/sas_evaluator.py
+++ b/haystack/components/evaluators/sas_evaluator.py
@@ -157,6 +157,9 @@ class SASEvaluator:
         if len(ground_truth_answers) != len(predicted_answers):
             raise ValueError("The number of predictions and labels must be the same.")
 
+        if any(answer is None for answer in predicted_answers):
+            raise ValueError("Predicted answers must not contain None values.")
+
         if len(predicted_answers) == 0:
             return {"score": 0.0, "individual_scores": [0.0]}
 

--- a/releasenotes/notes/check-for-None-SAS-eval-0b982ccc1491ee83.yaml
+++ b/releasenotes/notes/check-for-None-SAS-eval-0b982ccc1491ee83.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Raise ValueError if None value is passed as predicted_answers input

--- a/releasenotes/notes/check-for-None-SAS-eval-0b982ccc1491ee83.yaml
+++ b/releasenotes/notes/check-for-None-SAS-eval-0b982ccc1491ee83.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Raise ValueError if None value is passed as predicted_answers input
+    `SASEvaluator` now raises a `ValueError` if a `None` value is contained in the `predicted_answers` input.

--- a/test/components/evaluators/test_sas_evaluator.py
+++ b/test/components/evaluators/test_sas_evaluator.py
@@ -73,6 +73,21 @@ class TestSASEvaluator:
         with pytest.raises(ValueError):
             evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)
 
+    def test_run_with_none_in_predictions(self):
+        evaluator = SASEvaluator()
+        ground_truths = [
+            "A construction budget of US $2.3 billion",
+            "The Eiffel Tower, completed in 1889, symbolizes Paris's cultural magnificence.",
+            "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
+        ]
+        predictions = [
+            "A construction budget of US $2.3 billion",
+            None,
+            "The Meiji Restoration in 1868 transformed Japan into a modernized world power.",
+        ]
+        with pytest.raises(ValueError):
+            evaluator.run(ground_truth_answers=ground_truths, predicted_answers=predictions)
+
     def test_run_not_warmed_up(self):
         evaluator = SASEvaluator()
         ground_truths = [


### PR DESCRIPTION
### Related Issues

- fixes #7842

### Proposed Changes:

Properly raises ValueError if any input in input list for predicted_answers contains None.

### How did you test it?

Checked for Value Error raise.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
