### PR TITLE
feat: Add support for multimodal on ChatMessages with ContentPart

### DIFF
--- a/haystack/dataclasses/__init__.py
+++ b/haystack/dataclasses/__init__.py
@@ -5,6 +5,7 @@
 from haystack.dataclasses.answer import Answer, ExtractedAnswer, GeneratedAnswer
 from haystack.dataclasses.byte_stream import ByteStream
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole
+from haystack.dataclasses.content_part import ContentPart, ContentType, ImageDetail
 from haystack.dataclasses.document import Document
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from haystack.dataclasses.streaming_chunk import StreamingChunk
@@ -19,4 +20,7 @@ __all__ = [
     "ChatRole",
     "StreamingChunk",
     "SparseEmbedding",
+    "ContentPart",
+    "ContentType",
+    "ImageDetail",
 ]

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -62,4 +62,6 @@ class ByteStream:
         :returns: The string representation of the ByteStream.
         :raises: UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
         """
+        if isinstance(self.data, str):
+            return self.data
         return self.data.decode(encoding)

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -4,7 +4,10 @@
 
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
+
+from .byte_stream import ByteStream
+from .content_part import ContentPart
 
 
 class ChatRole(str, Enum):
@@ -21,13 +24,13 @@ class ChatMessage:
     """
     Represents a message in a LLM chat conversation.
 
-    :param content: The text content of the message.
+    :param content: The content of the message.
     :param role: The role of the entity sending the message.
     :param name: The name of the function being called (only applicable for role FUNCTION).
     :param meta: Additional metadata associated with the message.
     """
 
-    content: str
+    content: Union[str, ContentPart, List[Union[str, ContentPart]]]
     role: ChatRole
     name: Optional[str]
     meta: Dict[str, Any] = field(default_factory=dict, hash=False)
@@ -43,9 +46,32 @@ class ChatMessage:
             - `content`
             - `name` (optional)
         """
-        msg = {"role": self.role.value, "content": self.content}
+        msg = {"role": self.role.value}
         if self.name:
             msg["name"] = self.name
+
+        if isinstance(self.content, str):
+            msg["content"] = self.content
+        elif isinstance(self.content, ContentPart):
+            msg["content"] = self.content.to_openai_format()
+        elif isinstance(self.content, list):
+            msg["content"] = []
+            for part in self.content:
+                if isinstance(part, str):
+                    msg["content"].append(ContentPart.from_text(part).to_openai_format())
+                elif isinstance(part, ContentPart):
+                    msg["content"].append(part.to_openai_format())
+                else:
+                    raise ValueError(
+                        "One of the elements of the content is not of a valid type."
+                        "Valid types: str or ContentPart. Element: {part}"
+                    )
+        else:
+            raise ValueError(
+                "The content of the message is not of a valid type."
+                "Valid types: str, ContentPart or list of str and ContentPart."
+                "Content: {self.content}"
+            )
 
         return msg
 
@@ -59,7 +85,9 @@ class ChatMessage:
         return self.role == role
 
     @classmethod
-    def from_assistant(cls, content: str, meta: Optional[Dict[str, Any]] = None) -> "ChatMessage":
+    def from_assistant(
+        cls, content: Union[str, ContentPart, List[Union[str, ContentPart]]], meta: Optional[Dict[str, Any]] = None
+    ) -> "ChatMessage":
         """
         Create a message from the assistant.
 
@@ -70,7 +98,7 @@ class ChatMessage:
         return cls(content, ChatRole.ASSISTANT, None, meta or {})
 
     @classmethod
-    def from_user(cls, content: str) -> "ChatMessage":
+    def from_user(cls, content: Union[str, ContentPart, List[Union[str, ContentPart]]]) -> "ChatMessage":
         """
         Create a message from the user.
 
@@ -80,7 +108,7 @@ class ChatMessage:
         return cls(content, ChatRole.USER, None)
 
     @classmethod
-    def from_system(cls, content: str) -> "ChatMessage":
+    def from_system(cls, content: Union[str, ContentPart, List[Union[str, ContentPart]]]) -> "ChatMessage":
         """
         Create a message from the system.
 
@@ -90,7 +118,7 @@ class ChatMessage:
         return cls(content, ChatRole.SYSTEM, None)
 
     @classmethod
-    def from_function(cls, content: str, name: str) -> "ChatMessage":
+    def from_function(cls, content: Union[str, ContentPart, List[Union[str, ContentPart]]], name: str) -> "ChatMessage":
         """
         Create a message from a function call.
 
@@ -110,6 +138,29 @@ class ChatMessage:
         data = asdict(self)
         data["role"] = self.role.value
 
+        if isinstance(self.content, str):
+            data["content"] = self.content
+        elif isinstance(self.content, ContentPart):
+            data["content"] = self.content.to_dict()
+        elif isinstance(self.content, list):
+            data["content"] = []
+            for part in self.content:
+                if isinstance(part, str):
+                    data["content"].append(part)
+                elif isinstance(part, ContentPart):
+                    data["content"].append(part.to_dict())
+                else:
+                    raise ValueError(
+                        "One of the elements of the content is not of a valid type."
+                        "Valid types: str or ContentPart. Element: {part}"
+                    )
+        else:
+            raise ValueError(
+                "The content of the message is not of a valid type."
+                "Valid types: str, ContentPart or list of str and ContentPart."
+                "Content: {self.content}"
+            )
+
         return data
 
     @classmethod
@@ -123,5 +174,17 @@ class ChatMessage:
             The created object.
         """
         data["role"] = ChatRole(data["role"])
+
+        if "content" in data:
+            if isinstance(data["content"], dict):  # Assume it is a ContentPart
+                data["content"] = ContentPart.from_dict(data["content"])
+            elif isinstance(data["content"], list):
+                content = data.pop("content")
+                data["content"] = []
+                for part in content:
+                    if isinstance(part, str):
+                        data["content"].append(part)
+                    else:
+                        data["content"].append(ContentPart.from_dict(part))
 
         return cls(**data)

--- a/haystack/dataclasses/content_part.py
+++ b/haystack/dataclasses/content_part.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+
+from haystack.dataclasses import ByteStream
+
+
+class ContentType(str, Enum):
+    """Enumeration representing the possible content types of a ChatMessage."""
+
+    TEXT = "text"
+    IMAGE_URL = "image_url"
+    IMAGE_BASE64 = "image_base64"
+
+    def to_openai_format(self) -> str:
+        """
+        Returns the string that OpenAI expects inside the 'type' key on the dictionary.
+
+        :returns: The string expected by OpenAI.
+        """
+
+        return {ContentType.TEXT: "text", ContentType.IMAGE_URL: "image_url", ContentType.IMAGE_BASE64: "image_url"}[
+            self
+        ]
+
+
+class ImageDetail(str, Enum):
+    """Enumeration representing the possible image quality options in OpenAI Chat API."""
+
+    HIGH = "high"
+    LOW = "low"
+    AUTO = "auto"
+
+
+@dataclass
+class ContentPart:
+    """
+    Represents a part of the content on a message in a LLM chat conversation.
+
+    :param type: The content type of the message, weather it is regular text, an image url, ...
+    :param content: The actual content of this part of the message.
+    """
+
+    type: ContentType
+    content: Union[str, ByteStream]
+    image_detail: Optional[ImageDetail] = None
+
+    def to_openai_format(self) -> Dict[str, Any]:
+        """
+        Convert the content part to the format expected by OpenAI's Chat API.
+
+        See the [API reference](https://platform.openai.com/docs/api-reference/chat/create) for details.
+
+        :returns: A dictionary representation of the content part.
+        """
+
+        content = {"type": self.type.to_openai_format()}
+
+        if self.type is ContentType.TEXT:
+            content["text"] = self.content
+
+        elif self.type is ContentType.IMAGE_URL:
+            content["image_url"] = {"url": self.content}
+
+            if self.image_detail is not None:
+                content["image_url"]["detail"] = self.image_detail.value
+
+        elif self.type is ContentType.IMAGE_BASE64:
+            content["image_url"] = {  # TODO: check if png images work as well
+                "url": f"data:image/jpeg;base64,{self.content.to_string()}"
+            }
+
+            if self.image_detail is not None:
+                content["image_url"]["detail"] = self.image_detail.value
+
+        return content
+
+    @classmethod
+    def from_text(cls, text: str) -> "ContentPart":
+        """
+        Create a ContentPart from a string of text.
+
+        :param text: The text content.
+        :returns: A new ContentPart instance.
+        """
+        return cls(type=ContentType.TEXT, content=text)
+
+    @classmethod
+    def from_image_url(cls, url: str, image_detail: Optional[ImageDetail] = None) -> "ContentPart":
+        """
+        Create a ContentPart from an image url.
+
+        :param text: The url of the image.
+        :returns: A new ContentPart instance.
+        """
+        return cls(type=ContentType.IMAGE_URL, content=url, image_detail=image_detail)
+
+    @classmethod
+    def from_base64_image(cls, image: ByteStream, image_detail: Optional[ImageDetail] = None) -> "ContentPart":
+        """
+        Create a ContentPart from a base64 encoded image.
+
+        :param text: The base64 byte representation of the image.
+        :returns: A new ContentPart instance.
+        """
+        # TODO: add support for input str?
+        return cls(type=ContentType.IMAGE_BASE64, content=image, image_detail=image_detail)

--- a/haystack/dataclasses/content_part.py
+++ b/haystack/dataclasses/content_part.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union

--- a/releasenotes/notes/feat-content-part-and-multimodal-chat-message-ca3b3dc63d60b766.yaml
+++ b/releasenotes/notes/feat-content-part-and-multimodal-chat-message-ca3b3dc63d60b766.yaml
@@ -1,0 +1,13 @@
+---
+highlights: >
+    Added multi modal support for 'ChatMessage' content through 'ContentPart'
+features:
+  - |
+    Added a new data class, 'ContentPart', it is designed to store any kind of data type related to the content of a 'ChatMessage'.
+    For now, it just supports images (as image urls or base64 encoded images) and text.
+    It has OpenAI Chat API specific formatting.
+
+    Now 'ChatMessage' allows you to add 'ContentPart' as content or a list of 'str' and 'ContentPart', OpenAI Chat API
+    specific formatting and serialization was updated to support this feature.
+
+    Finally, 'ChatPromptBuilder' has been updated to support the multi modal capabilities of 'ChatMessage'.

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -5,7 +5,7 @@ import pytest
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack import component
 from haystack.core.pipeline.pipeline import Pipeline
-from haystack.dataclasses.chat_message import ChatMessage
+from haystack.dataclasses.chat_message import ChatMessage, ContentPart, ByteStream
 from haystack.dataclasses.document import Document
 
 
@@ -535,3 +535,31 @@ class TestChatPromptBuilderDynamic:
         ]
         assert component._variables == ["var", "required_var"]
         assert component._required_variables == ["required_var"]
+
+
+def test_init_with_template_using_content_part():
+    messages = [
+        ChatMessage.from_system(ContentPart.from_text("This is {{content}}")),
+        ChatMessage.from_user(ContentPart.from_image_url("image.com/{{image}}")),
+        ChatMessage.from_user(ContentPart.from_base64_image(ByteStream.from_string("Hello {{world}}!"))),
+    ]
+
+    component = ChatPromptBuilder(template=messages)
+
+    assert component.template == messages
+
+
+def test_init_with_template_using_list_of_str_and_content_part():
+    messages = [
+        ChatMessage.from_system(
+            content=[
+                ContentPart.from_text("Your name is {{name}}"),
+                ContentPart.from_base64_image(ByteStream.from_string("image:{{bytes}}")),
+                "Random {{content}}",
+            ]
+        )
+    ]
+
+    component = ChatPromptBuilder(template=messages)
+
+    assert component.template == messages

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -45,6 +45,9 @@ def test_to_string():
     b = ByteStream.from_string(test_string)
     assert b.to_string() == test_string
 
+    b = ByteStream(test_string)
+    assert b.to_string() == test_string
+
 
 def test_to_from_string_encoding():
     test_string = "Hello Baščaršija!"

--- a/test/dataclasses/test_content_part.py
+++ b/test/dataclasses/test_content_part.py
@@ -1,0 +1,87 @@
+import pytest
+
+import base64
+
+from haystack.dataclasses import ContentPart, ContentType, ImageDetail, ByteStream
+
+
+def test_from_text_with_valid_content():
+    content = "This is some text."
+    content_part = ContentPart.from_text(content)
+    assert content_part.content == content
+    assert content_part.type == ContentType.TEXT
+
+
+def test_from_image_url_with_valid_content():
+    content = "image.com/sample.jpg"
+    content_part = ContentPart.from_image_url(content)
+    assert content_part.content == content
+    assert content_part.type == ContentType.IMAGE_URL
+
+    content_part = ContentPart.from_image_url(url=content, image_detail=ImageDetail.LOW)
+    assert content_part.content == content
+    assert content_part.type == ContentType.IMAGE_URL
+    assert content_part.image_detail == ImageDetail.LOW
+
+
+def test_from_base64_with_valid_content(test_files_path):
+    # Function to encode the image
+    def encode_image(image_path) -> ByteStream:
+        with open(image_path, "rb") as image_file:
+            return ByteStream(base64.b64encode(image_file.read()))
+
+    image_path = test_files_path / "images" / "apple.jpg"
+
+    base64_image = encode_image(image_path=image_path)
+
+    content_part = ContentPart.from_base64_image(base64_image)
+    assert content_part.content == base64_image
+    assert content_part.type == ContentType.IMAGE_BASE64
+
+    content_part = ContentPart.from_base64_image(image=base64_image, image_detail=ImageDetail.HIGH)
+    assert content_part.content == base64_image
+    assert content_part.type == ContentType.IMAGE_BASE64
+    assert content_part.image_detail == ImageDetail.HIGH
+
+
+def test_content_type_to_openai_format():
+    assert (ContentType.TEXT).to_openai_format() == "text"
+    assert (ContentType.IMAGE_URL).to_openai_format() == "image_url"
+    assert (ContentType.IMAGE_BASE64).to_openai_format() == "image_url"
+
+
+def test_to_openai_format_with_text():
+    assert ContentPart.from_text("Text").to_openai_format() == {"type": "text", "text": "Text"}
+
+
+def test_to_openai_format_with_image_url():
+    assert ContentPart.from_image_url("image.com/test.jpg").to_openai_format() == {
+        "type": "image_url",
+        "image_url": {"url": "image.com/test.jpg"},
+    }
+
+    assert ContentPart.from_image_url(url="image.com/test.jpg", image_detail=ImageDetail.HIGH).to_openai_format() == {
+        "type": "image_url",
+        "image_url": {"url": "image.com/test.jpg", "detail": "high"},
+    }
+
+
+def test_to_openai_format_with_base64_image(test_files_path):
+    # Function to encode the image
+    def encode_image(image_path) -> ByteStream:
+        with open(image_path, "rb") as image_file:
+            return ByteStream(base64.b64encode(image_file.read()))
+
+    image_path = test_files_path / "images" / "apple.jpg"
+
+    base64_image = encode_image(image_path=image_path)
+
+    assert ContentPart.from_base64_image(base64_image).to_openai_format() == {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/jpeg;base64,{base64_image.to_string()}"},
+    }
+
+    assert ContentPart.from_base64_image(image=base64_image, image_detail=ImageDetail.LOW).to_openai_format() == {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/jpeg;base64,{base64_image.to_string()}", "detail": "low"},
+    }

--- a/test/dataclasses/test_content_part.py
+++ b/test/dataclasses/test_content_part.py
@@ -85,3 +85,75 @@ def test_to_openai_format_with_base64_image(test_files_path):
         "type": "image_url",
         "image_url": {"url": f"data:image/jpeg;base64,{base64_image.to_string()}", "detail": "low"},
     }
+
+
+def test_to_dict_with_text():
+    assert ContentPart.from_text("Text").to_dict() == {"type": "text", "content": "Text"}
+
+
+def test_from_dict_with_text():
+    assert ContentPart.from_dict({"type": "text", "content": "content"}) == ContentPart.from_text("content")
+
+
+def test_to_dict_With_image_url():
+    assert ContentPart.from_image_url("image.com/test.jpg").to_dict() == {
+        "type": "image_url",
+        "content": "image.com/test.jpg",
+    }
+
+    assert ContentPart.from_image_url(url="image.com/test.jpg", image_detail=ImageDetail.HIGH).to_dict() == {
+        "type": "image_url",
+        "content": "image.com/test.jpg",
+        "image_detail": "high",
+    }
+
+
+def test_from_dict_with_image_url():
+    assert ContentPart.from_dict({"type": "image_url", "content": "image.com/test.jpg"}) == ContentPart.from_image_url(
+        "image.com/test.jpg"
+    )
+
+    assert ContentPart.from_dict(
+        {"type": "image_url", "content": "image.com/test.jpg", "image_detail": "high"}
+    ) == ContentPart.from_image_url(url="image.com/test.jpg", image_detail=ImageDetail.HIGH)
+
+
+def test_to_dict_with_base64_image(test_files_path):
+    # Function to encode the image
+    def encode_image(image_path) -> ByteStream:
+        with open(image_path, "rb") as image_file:
+            return ByteStream(base64.b64encode(image_file.read()))
+
+    image_path = test_files_path / "images" / "apple.jpg"
+
+    base64_image = encode_image(image_path=image_path)
+
+    assert ContentPart.from_base64_image(base64_image).to_dict() == {
+        "type": "image_base64",
+        "content": base64_image.to_string(),
+    }
+
+    assert ContentPart.from_base64_image(image=base64_image, image_detail=ImageDetail.LOW).to_dict() == {
+        "type": "image_base64",
+        "content": base64_image.to_string(),
+        "image_detail": "low",
+    }
+
+
+def test_from_dict_with_base64_image(test_files_path):
+    # Function to encode the image
+    def encode_image(image_path) -> ByteStream:
+        with open(image_path, "rb") as image_file:
+            return ByteStream(base64.b64encode(image_file.read()))
+
+    image_path = test_files_path / "images" / "apple.jpg"
+
+    base64_image = encode_image(image_path=image_path)
+
+    assert ContentPart.from_dict(
+        {"type": "image_base64", "content": base64_image.to_string()}
+    ) == ContentPart.from_base64_image(base64_image)
+
+    assert ContentPart.from_dict(
+        {"type": "image_base64", "content": base64_image.to_string(), "image_detail": "low"}
+    ) == ContentPart.from_base64_image(image=base64_image, image_detail=ImageDetail.LOW)


### PR DESCRIPTION
### Related Issues

- fixes #7848

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I have added a new data class called 'ContentPart' as suggested in #7848 that holds any kind of content you might want to add to a 'ChatMessage', now only text, image urls and image in base 64 are implemented, as the original goal of this PR was to support Image passing to the OpenAI Chat API. This class allows for serialization and OpenAI specific formatting.

Added support for different content types on 'ChatMessage': 'str', 'ContentPart' and 'List[Union[str, ContentPart]]'. All serialization and OpenAI specific formatting was addressed. 

Added support for these new content types for 'ChatMessage' on 'ChatPromptBuilder'. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit test for any new functionality for both 'ChatMessage' and 'ChatPromptBuilder', and created a new file containing unit tests for 'ContentPart'.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
- I have stumbled upon that some of the 'from_user' kind of methods on 'ChatMessage' allow the passing of metadata and others don't, should we add it to all of them?
- Do not know if you want me to support any other of content type such as Audio or Video.
- 'ByteStream' does not ensure that the content it has are bytes, we can pass it a string, and it breaks when calling the 'to_string' method, I patched it, but I believe we should think of a better solution.
- When working with base64 images, the 'from_base64' image method just accepts 'ByteStream', but we could make it accept str also and convert it to 'ByteStream' internally.
- The OpenAI API Vision documentation ([here](https://platform.openai.com/docs/guides/vision/what-type-of-files-can-i-upload)) says that it supports for other formats different from JPEG, but it does not provide any examples on how to encode the base64 image, see the 'to_openai_format' method of 'ContentPart' for context, I do not know how to check if it works.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt) ✅
- I have updated the related issue with new insights and changes ✅
- I added unit tests and updated the docstrings ✅
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`. ✅
- I documented my code ✅
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue ✅
