### PR TITLE
Add Distribution based rank fusion mode

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -5,7 +5,7 @@
 import itertools
 from collections import defaultdict
 from math import inf
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from haystack import Document, component, logging
 from haystack.core.component.types import Variadic
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: list) -> list:
+    def _concatenate(self, document_lists: List[Any]) -> List[Any]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: list) -> list:
+    def _merge(self, document_lists: List[Any]) -> List[Any]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: list) -> list:
+    def _reciprocal_rank_fusion(self, document_lists: List[Any]) -> List[Any]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: list) -> list:
+    def _distribution_based_rank_fusion(self, document_lists: List[Any]) -> List[Any]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists):
+    def _concatenate(self, document_lists: list) -> list:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists):
+    def _merge(self, document_lists: list) -> list:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists):
+    def _reciprocal_rank_fusion(self, document_lists: list) -> list:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists):
+    def _distribution_based_rank_fusion(self, document_lists: list) -> list:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -5,7 +5,7 @@
 import itertools
 from collections import defaultdict
 from math import inf
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from haystack import Document, component, logging
 from haystack.core.component.types import Variadic
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _merge(self, document_lists: Variadic[List[Document]]) -> Dict[str, Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _reciprocal_rank_fusion(self, document_lists: List[Document]) -> Dict[str, Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists) -> Dict[str, Document]:
+    def _merge(self, document_lists) -> List[Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists) -> Dict[str, Document]:
+    def _reciprocal_rank_fusion(self, document_lists) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -66,7 +66,7 @@ class DocumentJoiner:
             If True sorts the Documents by score in descending order.
             If a Document has no score, it is handled as if its score is -infinity.
         """
-        if join_mode not in ["concatenate", "merge", "reciprocal_rank_fusion"]:
+        if join_mode not in ["concatenate", "merge", "reciprocal_rank_fusion", "distribution_based_rank_fusion"]:
             raise ValueError(
                 f"DocumentJoiner component does not support '{join_mode}' join_mode."
             )
@@ -97,7 +97,7 @@ class DocumentJoiner:
         elif self.join_mode == "reciprocal_rank_fusion":
             output_documents = self._reciprocal_rank_fusion(documents)
         elif self.join_mode == "distribution_based_rank_fusion":
-            output_documents = self._ditribution_based_rank_fusion(documents)
+            output_documents = self._distribution_based_rank_fusion(documents)
 
         if self.sort_by_score:
             output_documents = sorted(
@@ -188,7 +188,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _ditribution_based_rank_fusion(self, document_lists):
+    def _distribution_based_rank_fusion(self, document_lists):
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
         (https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18)

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists):
+    def _concatenate(self, document_lists: List[Document]) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists):
+    def _merge(self, document_lists: List[Document]) -> List[Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists):
+    def _reciprocal_rank_fusion(self, document_lists: List[Document]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists):
+    def _distribution_based_rank_fusion(self, document_lists: List[Document]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -8,7 +8,7 @@ from math import inf
 from typing import List, Optional
 
 from haystack import Document, component, logging
-from haystack.core.component.types import Iterable, Variadic
+from haystack.core.component.types import Variadic
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: Iterable[List[Document]]) -> List[Document]:
+    def _concatenate(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: Iterable[List[Document]]) -> List[Document]:
+    def _merge(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: Iterable[List[Document]]) -> List[Document]:
+    def _reciprocal_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: Iterable[List[Document]]) -> List[Document]:
+    def _distribution_based_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _concatenate(self, document_lists):
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _merge(self, document_lists):
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _reciprocal_rank_fusion(self, document_lists):
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _distribution_based_rank_fusion(self, document_lists):
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _concatenate(self, document_lists) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: Variadic[List[Document]]) -> Dict[str, Document]:
+    def _merge(self, document_lists) -> Dict[str, Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: List[Document]) -> Dict[str, Document]:
+    def _reciprocal_rank_fusion(self, document_lists) -> Dict[str, Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
+    def _distribution_based_rank_fusion(self, document_lists) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -180,7 +180,7 @@ class DocumentJoiner:
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 
         (https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18)
-        If a Document is in more than one retriever, the sone with the highest score is used.
+        If a Document is in more than one retriever, the one with the highest score is used.
         """
         for documents in document_lists:
             scores_list = []

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -189,7 +189,8 @@ class DocumentJoiner:
         return documents_map.values()
 
     def _ditribution_based_rank_fusion(self, document_lists):
-        """Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
+        """
+        Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
         (https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18)
 
         If a Document is in more than one retriever, the sone with the highest score is used.

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -22,6 +22,7 @@ class DocumentJoiner:
     - concatenate: Keeps the highest scored Document in case of duplicates.
     - merge: Merge a calculate a weighted sum of the scores of duplicate Documents.
     - reciprocal_rank_fusion: Merge and assign scores based on reciprocal rank fusion.
+    - distribution_based_rank_fusion: Merge and assign scores based on scores distribution in each retriever
 
     Usage example:
     ```python
@@ -60,7 +61,7 @@ class DocumentJoiner:
             - `distribution_based_rank_fusion`
         :param weights:
             Weight for each list of Documents received, must have the same length as the number of inputs.
-            If `join_mode` is `concatenate` this parameter is ignored.
+            If `join_mode` is `concatenate` or `distribution_based_rank_fusion` this parameter is ignored.
         :param top_k:
             The maximum number of Documents to return.
         :param sort_by_score:

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -5,10 +5,10 @@
 import itertools
 from collections import defaultdict
 from math import inf
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from haystack import Document, component, logging
-from haystack.core.component.types import Variadic
+from haystack.core.component.types import Iterable, Variadic
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: List[Document]) -> List[Any]:
+    def _concatenate(self, document_lists: Iterable[List[Document]]) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: List[Document]) -> List[Any]:
+    def _merge(self, document_lists: Iterable[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: List[Document]) -> List[Any]:
+    def _reciprocal_rank_fusion(self, document_lists: Iterable[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: List[Document]) -> List[Any]:
+    def _distribution_based_rank_fusion(self, document_lists: Iterable[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists) -> List[Document]:
+    def _concatenate(self, document_lists):
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists) -> List[Document]:
+    def _merge(self, document_lists):
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists) -> List[Document]:
+    def _reciprocal_rank_fusion(self, document_lists):
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists) -> List[Document]:
+    def _distribution_based_rank_fusion(self, document_lists):
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: List[Document]) -> List[Document]:
+    def _concatenate(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: List[Document]) -> List[Document]:
+    def _merge(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: List[Document]) -> List[Document]:
+    def _reciprocal_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: List[Document]) -> List[Document]:
+    def _distribution_based_rank_fusion(self, document_lists: Variadic[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -116,7 +116,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: List[Any]) -> List[Any]:
+    def _concatenate(self, document_lists: List[Document]) -> List[Any]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,7 +129,7 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists: List[Any]) -> List[Any]:
+    def _merge(self, document_lists: List[Document]) -> List[Any]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
@@ -147,7 +147,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _reciprocal_rank_fusion(self, document_lists: List[Any]) -> List[Any]:
+    def _reciprocal_rank_fusion(self, document_lists: List[Document]) -> List[Any]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -176,7 +176,7 @@ class DocumentJoiner:
 
         return documents_map.values()
 
-    def _distribution_based_rank_fusion(self, document_lists: List[Any]) -> List[Any]:
+    def _distribution_based_rank_fusion(self, document_lists: List[Document]) -> List[Any]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -90,6 +90,8 @@ class DocumentJoiner:
             - `documents`: Merged list of Documents
         """
         output_documents = []
+
+        documents = list(documents)
         if self.join_mode == "concatenate":
             output_documents = self._concatenate(documents)
         elif self.join_mode == "merge":
@@ -116,7 +118,7 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists):
+    def _concatenate(self, document_lists: List[List[Document]]) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -129,11 +131,11 @@ class DocumentJoiner:
             output.append(doc_with_best_score)
         return output
 
-    def _merge(self, document_lists):
+    def _merge(self, document_lists: List[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and calculate a weighted sum of the scores of duplicate Documents.
         """
-        scores_map = defaultdict(int)
+        scores_map: dict = defaultdict(int)
         documents_map = {}
         weights = self.weights if self.weights else [1 / len(document_lists)] * len(document_lists)
 
@@ -145,9 +147,9 @@ class DocumentJoiner:
         for doc in documents_map.values():
             doc.score = scores_map[doc.id]
 
-        return documents_map.values()
+        return list(documents_map.values())
 
-    def _reciprocal_rank_fusion(self, document_lists):
+    def _reciprocal_rank_fusion(self, document_lists: List[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on reciprocal rank fusion.
 
@@ -156,7 +158,7 @@ class DocumentJoiner:
         """
         k = 61
 
-        scores_map = defaultdict(int)
+        scores_map: dict = defaultdict(int)
         documents_map = {}
         weights = self.weights if self.weights else [1 / len(document_lists)] * len(document_lists)
 
@@ -174,9 +176,9 @@ class DocumentJoiner:
         for doc in documents_map.values():
             doc.score = scores_map[doc.id]
 
-        return documents_map.values()
+        return list(documents_map.values())
 
-    def _distribution_based_rank_fusion(self, document_lists):
+    def _distribution_based_rank_fusion(self, document_lists: List[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 
@@ -187,7 +189,7 @@ class DocumentJoiner:
             scores_list = []
 
             for doc in documents:
-                scores_list.append(doc.score)
+                scores_list.append(doc.score if doc.score is not None else 0)
 
             mean_score = sum(scores_list) / len(scores_list)
             std_dev = (sum((x - mean_score) ** 2 for x in scores_list) / len(scores_list)) ** 0.5

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -5,7 +5,7 @@
 import itertools
 from collections import defaultdict
 from math import inf
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from haystack import Document, component, logging
 from haystack.core.component.types import Variadic

--- a/releasenotes/notes/add-distribution-based-rank-fusion-mode-JoinDocuments-6fca30b82fd535ce.yaml
+++ b/releasenotes/notes/add-distribution-based-rank-fusion-mode-JoinDocuments-6fca30b82fd535ce.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a new mode in JoinDocuments,
+    Distribution-based rank fusion as
+    [the article](https://medium.com/plain-simple-software/distribution-based-score-fusion-dbsf-a-new-approach-to-vector-search-ranking-f87c37488b18)

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -18,9 +18,7 @@ class TestDocumentJoiner:
         assert joiner.sort_by_score
 
     def test_init_with_custom_parameters(self):
-        joiner = DocumentJoiner(
-            join_mode="merge", weights=[0.4, 0.6], top_k=5, sort_by_score=False
-        )
+        joiner = DocumentJoiner(join_mode="merge", weights=[0.4, 0.6], top_k=5, sort_by_score=False)
         assert joiner.join_mode == "merge"
         assert joiner.weights == [0.4, 0.6]
         assert joiner.top_k == 5
@@ -38,28 +36,17 @@ class TestDocumentJoiner:
 
     def test_list_with_one_empty_list(self):
         joiner = DocumentJoiner()
-        documents = [
-            Document(content="a"),
-            Document(content="b"),
-            Document(content="c"),
-        ]
+        documents = [Document(content="a"), Document(content="b"), Document(content="c")]
         result = joiner.run([[], documents])
         assert result == {"documents": documents}
 
     def test_unsupported_join_mode(self):
-        with pytest.raises(
-            ValueError,
-            match="DocumentJoiner component does not support 'unsupported_mode' join_mode.",
-        ):
+        with pytest.raises(ValueError, match="DocumentJoiner component does not support 'unsupported_mode' join_mode."):
             DocumentJoiner(join_mode="unsupported_mode")
 
     def test_run_with_concatenate_join_mode_and_top_k(self):
         joiner = DocumentJoiner(top_k=6)
-        documents_1 = [
-            Document(content="a"),
-            Document(content="b"),
-            Document(content="c"),
-        ]
+        documents_1 = [Document(content="a"), Document(content="b"), Document(content="c")]
         documents_2 = [
             Document(content="d"),
             Document(content="e"),
@@ -74,11 +61,7 @@ class TestDocumentJoiner:
 
     def test_run_with_concatenate_join_mode_and_duplicate_documents(self):
         joiner = DocumentJoiner()
-        documents_1 = [
-            Document(content="a", score=0.3),
-            Document(content="b"),
-            Document(content="c"),
-        ]
+        documents_1 = [Document(content="a", score=0.3), Document(content="b"), Document(content="c")]
         documents_2 = [
             Document(content="a", score=0.2),
             Document(content="a"),
@@ -92,10 +75,7 @@ class TestDocumentJoiner:
 
     def test_run_with_merge_join_mode(self):
         joiner = DocumentJoiner(join_mode="merge", weights=[1.5, 0.5])
-        documents_1 = [
-            Document(content="a", score=1.0),
-            Document(content="b", score=2.0),
-        ]
+        documents_1 = [Document(content="a", score=1.0), Document(content="b", score=2.0)]
         documents_2 = [
             Document(content="a", score=0.5),
             Document(content="b", score=3.0),
@@ -115,11 +95,7 @@ class TestDocumentJoiner:
 
     def test_run_with_reciprocal_rank_fusion_join_mode(self):
         joiner = DocumentJoiner(join_mode="reciprocal_rank_fusion")
-        documents_1 = [
-            Document(content="a"),
-            Document(content="b"),
-            Document(content="c"),
-        ]
+        documents_1 = [Document(content="a"), Document(content="b"), Document(content="c")]
         documents_2 = [
             Document(content="b", score=1000.0),
             Document(content="c"),
@@ -171,16 +147,8 @@ class TestDocumentJoiner:
 
     def test_run_with_top_k_in_run_method(self):
         joiner = DocumentJoiner()
-        documents_1 = [
-            Document(content="a"),
-            Document(content="b"),
-            Document(content="c"),
-        ]
-        documents_2 = [
-            Document(content="d"),
-            Document(content="e"),
-            Document(content="f"),
-        ]
+        documents_1 = [Document(content="a"), Document(content="b"), Document(content="c")]
+        documents_2 = [Document(content="d"), Document(content="e"), Document(content="f")]
         top_k = 4
         output = joiner.run([documents_1, documents_2], top_k=top_k)
         assert len(output["documents"]) == top_k
@@ -190,10 +158,7 @@ class TestDocumentJoiner:
         with caplog.at_level(logging.INFO):
             documents = [Document(content="a"), Document(content="b", score=0.5)]
             output = joiner.run([documents])
-            assert (
-                "those with score=None were sorted as if they had a score of -infinity"
-                in caplog.text
-            )
+            assert "those with score=None were sorted as if they had a score of -infinity" in caplog.text
             assert output["documents"] == documents[::-1]
 
     def test_output_documents_not_sorted_by_score(self):
@@ -220,19 +185,13 @@ class TestDocumentJoiner:
         docs_2 = [docs[0], docs[4], docs[2], docs[5], docs[1]]
         document_lists = [docs, docs_2]
 
-        joiner_1 = DocumentJoiner(
-            join_mode="reciprocal_rank_fusion", weights=[0.5, 0.5]
-        )
+        joiner_1 = DocumentJoiner(join_mode="reciprocal_rank_fusion", weights=[0.5, 0.5])
 
         joiner_2 = DocumentJoiner(join_mode="reciprocal_rank_fusion", weights=[7, 7])
 
-        joiner_3 = DocumentJoiner(
-            join_mode="reciprocal_rank_fusion", weights=[0.7, 0.3]
-        )
+        joiner_3 = DocumentJoiner(join_mode="reciprocal_rank_fusion", weights=[0.7, 0.3])
 
-        joiner_4 = DocumentJoiner(
-            join_mode="reciprocal_rank_fusion", weights=[0.6, 0.4]
-        )
+        joiner_4 = DocumentJoiner(join_mode="reciprocal_rank_fusion", weights=[0.6, 0.4])
 
         joiner_5 = DocumentJoiner(join_mode="reciprocal_rank_fusion", weights=[1, 0])
 
@@ -241,8 +200,7 @@ class TestDocumentJoiner:
         for index, joiner in enumerate(joiners):
             join_results = joiner.run(documents=document_lists)
             is_sorted = all(
-                join_results["documents"][i].score
-                >= join_results["documents"][i + 1].score
+                join_results["documents"][i].score >= join_results["documents"][i + 1].score
                 for i in range(len(join_results["documents"]) - 1)
             )
 


### PR DESCRIPTION
### Related Issues

- fixes #7914 

### Proposed Changes:
How it works:

```
from haystack import Document
from haystack.components.joiners.document_joiner import DocumentJoiner

joiner = DocumentJoiner(join_mode="distribution_based_rank_fusion")
        documents_1 = [
            Document(content="a", score=0.6),
            Document(content="b", score=0.2),
            Document(content="c", score=0.5),
        ]
        documents_2 = [
            Document(content="d", score=0.5),
            Document(content="e", score=0.8),
            Document(content="f", score=1.1, meta={"key": "value"}),
            Document(content="g", score=0.3),
            Document(content="a", score=0.3),
        ]
        output = joiner.run([documents_1, documents_2])

# output
# [
#               Document(content="a", score=0.66),
#               Document(content="b", score=0.27),
#               Document(content="c", score=0.56),
#               Document(content="d", score=0.44),
#               Document(content="e", score=0.60),
#               Document(content="f", score=0.76, meta={"key": "value"}),
#               Document(content="g", score=0.33),
#  ]
```

### How did you test it?

unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
