### PR TITLE
feat: Improve LinkContentFetcher content type handling

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -98,6 +98,7 @@ class LinkContentFetcher:
         self.handlers["text/*"] = _text_content_handler
         self.handlers["application/json"] = _text_content_handler
         self.handlers["application/*"] = _binary_content_handler
+        self.handlers["image/*"] = _binary_content_handler
         self.handlers["audio/*"] = _binary_content_handler
         self.handlers["video/*"] = _binary_content_handler
 

--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -4,6 +4,7 @@
 
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from fnmatch import fnmatch
 from typing import Callable, Dict, List, Optional, Tuple
 
 import requests
@@ -94,10 +95,11 @@ class LinkContentFetcher:
 
         # register default content handlers that extract data from the response
         self.handlers: Dict[str, Callable[[Response], ByteStream]] = defaultdict(lambda: _text_content_handler)
-        self.handlers["text/html"] = _text_content_handler
-        self.handlers["text/plain"] = _text_content_handler
-        self.handlers["application/pdf"] = _binary_content_handler
-        self.handlers["application/octet-stream"] = _binary_content_handler
+        self.handlers["text/*"] = _text_content_handler
+        self.handlers["application/json"] = _text_content_handler
+        self.handlers["application/*"] = _binary_content_handler
+        self.handlers["audio/*"] = _binary_content_handler
+        self.handlers["video/*"] = _binary_content_handler
 
         @retry(
             reraise=True,
@@ -175,7 +177,7 @@ class LinkContentFetcher:
         try:
             response = self._get_response(url)
             content_type = self._get_content_type(response)
-            handler: Callable = self.handlers[content_type]
+            handler: Callable = self._resolve_handler(content_type)
             stream = handler(response)
         except Exception as e:
             if self.raise_on_failure:
@@ -216,6 +218,29 @@ class LinkContentFetcher:
         """
         content_type = response.headers.get("Content-Type", "")
         return content_type.split(";")[0]
+
+    def _resolve_handler(self, content_type: str) -> Callable[[Response], ByteStream]:
+        """
+        Resolves the handler for the given content type.
+
+        First, it tries to find a direct match for the content type in the handlers dictionary.
+        If no direct match is found, it tries to find a pattern match using the fnmatch function.
+        If no pattern match is found, it returns the default handler for text/plain.
+
+        :param content_type: The content type to resolve the handler for.
+        :returns: The handler for the given content type, if found. Otherwise, the default handler for text/plain.
+        """
+        # direct match
+        if content_type in self.handlers:
+            return self.handlers[content_type]
+
+        # pattern matches
+        for pattern, handler in self.handlers.items():
+            if fnmatch(content_type, pattern):
+                return handler
+
+        # default handler
+        return self.handlers["text/plain"]
 
     def _switch_user_agent(self, retry_state: RetryCallState) -> None:
         """

--- a/releasenotes/notes/link-content-fetcher-enhancements-49babe1c60888043.yaml
+++ b/releasenotes/notes/link-content-fetcher-enhancements-49babe1c60888043.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Improve LinkContentFetcher to support a broader range of content types, including glob patterns for text, application, audio, and video types. This update introduces a more flexible content handler resolution mechanism, allowing for direct matches and pattern matching, thereby greatly improving the handler's adaptability to various content types encountered on the web.

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -49,6 +49,7 @@ class TestLinkContentFetcher:
             "text/*": _text_content_handler,
             "application/json": _text_content_handler,
             "application/*": _binary_content_handler,
+            "image/*": _binary_content_handler,
             "audio/*": _binary_content_handler,
             "video/*": _binary_content_handler,
         }

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -46,10 +46,11 @@ class TestLinkContentFetcher:
         assert fetcher.retry_attempts == 2
         assert fetcher.timeout == 3
         assert fetcher.handlers == {
-            "text/html": _text_content_handler,
-            "text/plain": _text_content_handler,
-            "application/pdf": _binary_content_handler,
-            "application/octet-stream": _binary_content_handler,
+            "text/*": _text_content_handler,
+            "application/json": _text_content_handler,
+            "application/*": _binary_content_handler,
+            "audio/*": _binary_content_handler,
+            "video/*": _binary_content_handler,
         }
         assert hasattr(fetcher, "_get_response")
 
@@ -191,3 +192,11 @@ class TestLinkContentFetcher:
         fetcher = LinkContentFetcher()
         with pytest.raises(requests.exceptions.ConnectionError):
             fetcher.run(["https://non_existent_website_dot.com/"])
+
+    @pytest.mark.integration
+    def test_link_content_fetcher_audio(self):
+        fetcher = LinkContentFetcher()
+        streams = fetcher.run(["https://download.samplelib.com/mp3/sample-3s.mp3"])["streams"]
+        first_stream = streams[0]
+        assert first_stream.meta["content_type"] == "audio/mpeg"
+        assert len(first_stream.data) > 0


### PR DESCRIPTION
### Why:
Enhances `LinkContentFetcher` to broaden its content handling capabilities. The primary motivation behind these changes is to allow more content type support utilizing pattern matching for content types and allow fetching web content that includes text, applications, audio, and video files.

Direct motivation for this enhancement was an experiment to fetch an audio file and transcribe it via Groq i.e:

```
from haystack.components.audio import RemoteWhisperTranscriber
from haystack.components.fetchers import LinkContentFetcher
from haystack import Pipeline
from haystack.utils import Secret

transcriber = RemoteWhisperTranscriber(Secret.from_env_var("GROQ_API_KEY"),
                                       api_base_url="https://api.groq.com/openai/v1",
                                       model="whisper-large-v3")

pipe = Pipeline()
pipe.add_component("fetcher", LinkContentFetcher())
pipe.add_component("transcriber", RemoteWhisperTranscriber(Secret.from_env_var("GROQ_API_KEY"),
                                                           api_base_url="https://api.groq.com/openai/v1",
                                                           model="whisper-large-v3"))

pipe.connect("fetcher", "transcriber")
result = pipe.run(
    data={"fetcher": {"urls": ["https://ia601309.us.archive.org/29/items/jfks19610427/jfk_1961_0427_press_64kb.mp3"]}})
print(result["transcriber"]["documents"])
```

We couldn't however do this out-of-the box because we didn't have content type handler registered for audio files. 
This PR remedies this oversight. And adds more flexibility by adding pattern matching for content types


### What:
- Simplified and expanded content type handling by implementing wildcard patterns (e.g., `text/*`, `application/*`, `audio/*`, `video/*`) in the fetcher's handlers to efficiently map multiple content types to their appropriate handlers.
- Added support for `application/json` as a text content type.
- Introduced a `_resolve_handler` method to dynamically determine the correct handler for a content type, utilizing the `fnmatch` module for pattern matching.
- Adjusted existing tests and added a new integration test to cover the handling of an `audio/mpeg` content type.

### How can it be used:
- All previous use cases are still supported
- The above audio transcription example works out of the box
 
### How did you test it:
- Modified unit tests to assert the correct mapping of MIME types to handlers according to the new pattern matching logic.
- Added an integration test (`test_link_content_fetcher_audio`) which specifically tests fetching an MP3 file, asserting both the `content_type` to be `audio/mpeg` and that the data stream is correctly retrieved and non-empty.

### Notes for the reviewer:
- Pay special attention to the pattern matching implementation in the `_resolve_handler` method to ensure that it properly covers all anticipated content types and does not inadvertently match undesired types.
- Review the added integration test for audio content