### PR TITLE
feat: Add haystack-experimental dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
   "requests",
   "numpy<2",
   "python-dateutil",
+  "haystack-experimental",
 ]
 
 [tool.hatch.envs.default]

--- a/releasenotes/notes/add-haystack-experimental-dependency-96ff02e71bc2af13.yaml
+++ b/releasenotes/notes/add-haystack-experimental-dependency-96ff02e71bc2af13.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Added haystack-experimental to the project's dependencies to enable automatic use of cutting-edge features from Haystack. Users can now access components from haystack-experimental by simply importing them from haystack_experimental instead of haystack. For more information, visit https://github.com/deepset-ai/haystack-experimental.


### PR DESCRIPTION
Adds haystack-experimental dependency so that users then don't need to manually install the experimental features via `pip install haystack-experimental` but instead automatically have them when they install Haystack.

- fixes https://github.com/deepset-ai/haystack/issues/7911