### PR TITLE
Make `_add_missing_input_defaults` less error prone and add tests

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1147,6 +1147,12 @@ def _has_all_inputs_with_defaults(c: Component) -> bool:
 
 def _add_missing_input_defaults(name: str, comp: Component, inputs_by_component: Dict[str, Dict[str, Any]]):
     """Updates the inputs with the default values for the inputs that are missing"""
+    if name not in inputs_by_component:
+        inputs_by_component[name] = {}
+
     for input_socket in comp.__haystack_input__._sockets_dict.values():  # type: ignore
+        if input_socket.is_mandatory:
+            continue
+
         if input_socket.name not in inputs_by_component[name]:
             inputs_by_component[name][input_socket.name] = input_socket.default_value

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1146,7 +1146,13 @@ def _has_all_inputs_with_defaults(c: Component) -> bool:
 
 
 def _add_missing_input_defaults(name: str, comp: Component, inputs_by_component: Dict[str, Dict[str, Any]]):
-    """Updates the inputs with the default values for the inputs that are missing"""
+    """
+    Updates the inputs with the default values for the inputs that are missing
+
+    :param name: Name of the Component
+    :param comp: Instance of the Component
+    :param inputs_by_component: The current state of the inputs divided by Component name
+    """
     if name not in inputs_by_component:
         inputs_by_component[name] = {}
 

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -8,13 +8,14 @@ from unittest.mock import patch
 import pytest
 
 from haystack import Document
-from haystack.components.builders import PromptBuilder
+from haystack.components.builders import PromptBuilder, AnswerBuilder
+from haystack.components.joiners import BranchJoiner
 from haystack.components.others import Multiplexer
 from haystack.core.component import component
 from haystack.core.component.types import InputSocket, OutputSocket, Variadic
 from haystack.core.errors import PipelineConnectError, PipelineDrawingError, PipelineError
 from haystack.core.pipeline import Pipeline, PredefinedPipeline
-from haystack.core.pipeline.pipeline import _enqueue_component
+from haystack.core.pipeline.pipeline import _enqueue_component, _add_missing_input_defaults
 from haystack.core.serialization import DeserializationCallbacks
 from haystack.testing.factory import component_class
 from haystack.testing.sample_components import AddFixedValue, Double, Greet
@@ -1372,3 +1373,26 @@ class TestPipeline:
         _enqueue_component(("document_builder", document_builder), to_run, waiting_for_input)
         assert to_run == [("document_joiner", document_joiner), ("document_builder", document_builder)]
         assert waiting_for_input == []
+
+    def test__add_missing_input_defaults(self):
+        name = "prompt_builder"
+        prompt_builder = PromptBuilder(template="{{ questions | join('\n') }}")
+        inputs_by_component = {}
+        _add_missing_input_defaults(name, prompt_builder, inputs_by_component)
+        assert inputs_by_component == {
+            "prompt_builder": {"questions": "", "template": None, "template_variables": None}
+        }
+
+        name = "answer_builder"
+        answer_builder = AnswerBuilder()
+        inputs_by_component = {"answer_builder": {"query": "What is the answer?"}}
+        _add_missing_input_defaults(name, answer_builder, inputs_by_component)
+        assert inputs_by_component == {
+            "answer_builder": {
+                "query": "What is the answer?",
+                "meta": None,
+                "documents": None,
+                "pattern": None,
+                "reference_pattern": None,
+            }
+        }

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -15,7 +15,8 @@ from haystack.core.component import component
 from haystack.core.component.types import InputSocket, OutputSocket, Variadic
 from haystack.core.errors import PipelineConnectError, PipelineDrawingError, PipelineError
 from haystack.core.pipeline import Pipeline, PredefinedPipeline
-from haystack.core.pipeline.pipeline import _enqueue_component, _add_missing_input_defaults
+from haystack.core.pipeline.pipeline import _enqueue_component
+from haystack.core.pipeline.base import _add_missing_input_defaults
 from haystack.core.serialization import DeserializationCallbacks
 from haystack.testing.factory import component_class
 from haystack.testing.sample_components import AddFixedValue, Double, Greet
@@ -1396,3 +1397,9 @@ class TestPipeline:
                 "reference_pattern": None,
             }
         }
+
+        name = "branch_joiner"
+        branch_joiner = BranchJoiner(int)
+        inputs_by_component = {}
+        _add_missing_input_defaults(name, branch_joiner, inputs_by_component)
+        assert inputs_by_component == {"branch_joiner": {}}


### PR DESCRIPTION
### Related Issues

Part of #7614

### Proposed Changes:

Change `_add_missing_input_defaults` so it handles Components that have receive no inputs yet.

### How did you test it?

Added tests and ran them locally.

### Notes for the reviewer

Depends on #7925.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
