### PR TITLE
Add the missing parameter for serialization

### DIFF
--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -146,6 +146,7 @@ class OpenAIGenerator:
             model=self.model,
             streaming_callback=callback_name,
             api_base_url=self.api_base_url,
+            organization=self.organization,
             generation_kwargs=self.generation_kwargs,
             system_prompt=self.system_prompt,
             api_key=self.api_key.to_dict(),

--- a/releasenotes/notes/fix-serialization-openai-generator-cf7e9a04562dde75.yaml
+++ b/releasenotes/notes/fix-serialization-openai-generator-cf7e9a04562dde75.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Adds the missing 'organization' parameter to the serialization function.

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -137,6 +137,7 @@ class TestOpenAIGenerator:
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "system_prompt": None,
+                "organization": None,
                 "api_base_url": "test-base-url",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -78,6 +78,7 @@ class TestOpenAIGenerator:
                 "streaming_callback": None,
                 "system_prompt": None,
                 "api_base_url": None,
+                "organization": None,
                 "generation_kwargs": {},
             },
         }
@@ -89,6 +90,7 @@ class TestOpenAIGenerator:
             model="gpt-4",
             streaming_callback=print_streaming_chunk,
             api_base_url="test-base-url",
+            organization="org-1234567",
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
         data = component.to_dict()
@@ -99,6 +101,7 @@ class TestOpenAIGenerator:
                 "model": "gpt-4",
                 "system_prompt": None,
                 "api_base_url": "test-base-url",
+                "organization": "org-1234567",
                 "streaming_callback": "haystack.components.generators.utils.print_streaming_chunk",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
@@ -119,6 +122,7 @@ class TestOpenAIGenerator:
                 "api_key": {"env_vars": ["OPENAI_API_KEY"], "strict": True, "type": "env_var"},
                 "model": "gpt-4",
                 "system_prompt": None,
+                "organization": None,
                 "api_base_url": "test-base-url",
                 "streaming_callback": "test_openai.<lambda>",
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},


### PR DESCRIPTION
### Related Issues

- fixes #7903 

### Proposed Changes:

Add the missing `organization` parameter to the serialization function.

### How did you test it?

Updated the unit tests to check `organization` parameter during serialization and deserialization.

### Notes for the reviewer

Though about it , but makes sense to not serialize `timeout` and `max_retries` parameters to allow dynamic configuration as also mentioned in the issue.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
