### PR TITLE
ci: Disable tracing when running tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,9 @@ from haystack.testing.test_utils import set_all_seeds
 
 set_all_seeds(0)
 
+# Tracing is disable by default to avoid failures in CI
+tracing.disable_tracing()
+
 
 @pytest.fixture()
 def mock_tokenizer():


### PR DESCRIPTION
### Related Issues

- fixes #7923

### Proposed Changes:

Disable tracing in CI to fix failures like these:

```
ERROR    ddtrace.internal.writer.writer:writer.py:399 failed to send, dropping 12 traces to intake at http://localhost:8126/v0.5/traces after 3 retries
```

https://github.com/deepset-ai/haystack/actions/runs/9664504239/job/26659322073#step:5:117

### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
