### PR TITLE
Add method to find Component with lazy variadic input or all inputs with defaults

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1006,15 +1006,9 @@ class PipelineBase:
         :returns: The name and the instance of the next Component that can be run
         """
         for name, comp in waiting_for_input:
-            is_variadic = any(
-                socket.is_variadic
-                for socket in comp.__haystack_input__._sockets_dict.values()  # type: ignore
-            )
-            has_only_defaults = all(
-                not socket.is_mandatory
-                for socket in comp.__haystack_input__._sockets_dict.values()  # type: ignore
-            )
-            if is_variadic and not comp.__haystack_is_greedy__ or has_only_defaults:  # type: ignore[attr-defined]
+            is_lazy_variadic = _is_lazy_variadic(comp)
+            has_only_defaults = _has_all_inputs_with_defaults(comp)
+            if is_lazy_variadic or has_only_defaults:  # type: ignore[attr-defined]
                 return name, comp
 
         # If we reach this point it means that we found no Component that has a lazy variadic input or all inputs with

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1008,7 +1008,7 @@ class PipelineBase:
         for name, comp in waiting_for_input:
             is_lazy_variadic = _is_lazy_variadic(comp)
             has_only_defaults = _has_all_inputs_with_defaults(comp)
-            if is_lazy_variadic or has_only_defaults:  # type: ignore[attr-defined]
+            if is_lazy_variadic or has_only_defaults:
                 return name, comp
 
         # If we reach this point it means that we found no Component that has a lazy variadic input or all inputs with

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -293,30 +293,9 @@ class Pipeline(PipelineBase):
                             warn(RuntimeWarning(msg))
                             break
 
-                        for name, comp in waiting_for_input:
-                            is_variadic = any(
-                                socket.is_variadic
-                                for socket in comp.__haystack_input__._sockets_dict.values()  # type: ignore
-                            )
-                            has_only_defaults = all(
-                                not socket.is_mandatory
-                                for socket in comp.__haystack_input__._sockets_dict.values()  # type: ignore
-                            )
-                            if is_variadic and not comp.__haystack_is_greedy__ or has_only_defaults:  # type: ignore[attr-defined]
-                                break
-
-                        # There was a lazy variadic or a component with only default waiting for input, we can run it
-                        waiting_for_input.remove((name, comp))
-                        to_run.append((name, comp))
-
-                        # Let's use the default value for the inputs that are still missing, or the component
-                        # won't run and will be put back in the waiting list, causing an infinite loop.
-                        for input_socket in comp.__haystack_input__._sockets_dict.values():  # type: ignore
-                            if input_socket.is_mandatory:
-                                continue
-                            if input_socket.name not in last_inputs[name]:
-                                last_inputs[name][input_socket.name] = input_socket.default_value
-
+                        (name, comp) = self._find_next_runnable_lazy_variadic_or_default_component(waiting_for_input)
+                        _add_missing_input_defaults(name, comp, last_inputs)
+                        _enqueue_component((name, comp), to_run, waiting_for_input)
                         continue
 
                     before_last_waiting_for_input = (


### PR DESCRIPTION
### Related Issues

- Part of #7614

### Proposed Changes:

Add a `_find_next_runnable_lazy_variadic_or_default_component` to find a Component with lazy variadic input or all inputs with default values. 

### How did you test it?

I added tests and ran them locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
