### PR TITLE
fix: adjusting code due to new ruff version enforcing more strict linting

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -36,7 +36,7 @@ class Pipeline(PipelineBase):
             return False
         expected_inputs = instance.__haystack_input__._sockets_dict.keys()  # type: ignore
         current_inputs = inputs[name].keys()
-        return expected_inputs != current_inputs
+        return expected_inputs == current_inputs
 
     def _run_component(self, name: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -36,9 +36,7 @@ class Pipeline(PipelineBase):
             return False
         expected_inputs = instance.__haystack_input__._sockets_dict.keys()  # type: ignore
         current_inputs = inputs[name].keys()
-        if expected_inputs != current_inputs:
-            return False
-        return True
+        return expected_inputs != current_inputs
 
     def _run_component(self, name: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """


### PR DESCRIPTION
### Related Issues

Adjusting code due to new ruff version enforces more strict linting.

### Proposed Changes:

```python
        if expected_inputs != current_inputs:
            return False
        return True
```

now has to be:

```python
return expected_inputs == current_inputs
```

### How did you test it?

run local tests + linting and typing


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
