### PR TITLE
fix: meta from ByteStream input for AzureOCRDocumentConverter

### DIFF
--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -137,7 +137,8 @@ class AzureOCRDocumentConverter:
             result = poller.result()
             azure_output.append(result.to_dict())
 
-            docs = self._convert_tables_and_text(result=result, meta=metadata)
+            merged_metadata = {**bytestream.meta, **metadata}
+            docs = self._convert_tables_and_text(result=result, meta=merged_metadata)
             documents.extend(docs)
 
         return {"documents": documents, "raw_azure_response": azure_output}

--- a/releasenotes/notes/fix-azure-ocr-bytestream-meta-0d2c8e6ea761b791.yaml
+++ b/releasenotes/notes/fix-azure-ocr-bytestream-meta-0d2c8e6ea761b791.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Meta handling of bytestreams in Azure OCR has been fixed.

--- a/test/components/converters/test_azure_ocr_doc_converter.py
+++ b/test/components/converters/test_azure_ocr_doc_converter.py
@@ -322,7 +322,7 @@ class TestAzureOCRDocumentConverter:
             azure_mock.return_value = MockPoller()
             ocr_node = AzureOCRDocumentConverter(endpoint="")
             bytes = (test_files_path / "pdf" / "sample_pdf_1.pdf").read_bytes()
-            byte_stream = ByteStream(bytes=bytes, meta={"test_from": "byte_stream"})
+            byte_stream = ByteStream(data=bytes, meta={"test_from": "byte_stream"})
             out = ocr_node.run(sources=[byte_stream], meta=[{"test": "value_1"}])
 
         docs = out["documents"]

--- a/test/components/converters/test_azure_ocr_doc_converter.py
+++ b/test/components/converters/test_azure_ocr_doc_converter.py
@@ -13,6 +13,7 @@ import pytest
 from azure.ai.formrecognizer import AnalyzeResult
 
 from haystack.components.converters.azure import AzureOCRDocumentConverter
+from haystack.dataclasses.byte_stream import ByteStream
 from haystack.utils import Secret
 
 
@@ -306,3 +307,24 @@ class TestAzureOCRDocumentConverter:
 
         # doesn't mean much, more for sanity check
         assert hash_string_1 != hash_string_2 != hash_string_3
+
+    @patch("haystack.utils.auth.EnvVarSecret.resolve_value")
+    def test_meta_from_byte_stream(self, mock_resolve_value, test_files_path) -> None:
+        mock_resolve_value.return_value = "test_api_key"
+
+        class MockPoller:
+            def result(self) -> AnalyzeResult:
+                with open(test_files_path / "json" / "azure_sample_pdf_1.json", encoding="utf-8") as azure_file:
+                    result = json.load(azure_file)
+                return AnalyzeResult.from_dict(result)
+
+        with patch("azure.ai.formrecognizer.DocumentAnalysisClient.begin_analyze_document") as azure_mock:
+            azure_mock.return_value = MockPoller()
+            ocr_node = AzureOCRDocumentConverter(endpoint="")
+            bytes = (test_files_path / "pdf" / "sample_pdf_1.pdf").read_bytes()
+            byte_stream = ByteStream(bytes=bytes, meta={"test_from": "byte_stream"})
+            out = ocr_node.run(sources=[byte_stream], meta=[{"test": "value_1"}])
+
+        docs = out["documents"]
+        assert docs[1].meta["test"] == "value_1"
+        assert docs[1].meta["test_from"] == "byte_stream"


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
