### PR TITLE
feat: add custom jinja filter handling to ConditionalRouter

### DIFF
--- a/releasenotes/notes/add-custom-filters-to-conditional-router-631eba8bab3c2ae7.yaml
+++ b/releasenotes/notes/add-custom-filters-to-conditional-router-631eba8bab3c2ae7.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added custom filters support to ConditionalRouter. Users can now pass in
+    one or more custom Jinja2 filter callables and be able to access those
+    filters when defining condition expressions in routes.

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -322,16 +322,16 @@ class TestRouter:
         routes = [
             {
                 "condition": "{{ test|custom_filter_to_sede == 123 }}",
-                "output": "true",
+                "output": "123",
                 "output_name": "test",
-                "output_type": str,
+                "output_type": int,
             }
         ]
         custom_filters = {"custom_filter_to_sede": custom_filter_to_sede}
         router = ConditionalRouter(routes, custom_filters=custom_filters)
         kwargs = {"test": "123-456-789"}
         result = router.run(**kwargs)
-        assert result == {"test": "true"}
+        assert result == {"test": 123}
         serialized_router = router.to_dict()
         deserialized_router = ConditionalRouter.from_dict(serialized_router)
         assert deserialized_router.custom_filters == router.custom_filters


### PR DESCRIPTION
### Related Issues

- fixes #7940 

### Proposed Changes:

Added a `custom_filters: Optional[Dict[str, Callable]]` field to the `ConditionalRouter` constructor to allow users to pass in and use custom Jinja2 filters when creating route conditions.  Also added the same field to `from_dict` to allow users to provide callables when de-serializing a `ConditionalRouter` that was serialized with custom filters.

### How did you test it?

Added 3 unit tests to `test/components/routers/test_conditional_router.py`:
- `test_custom_filter` - ensures a custom test filter works with the router
- `test_custom_filter_serialization` - ensures the router with the custom filter attribute can be serialized and de-serialized
- `test_custom_filter_bad_deserialization` - ensures that a custom exception is generated when a router with custom filers is deserialized without providing callables

### Notes for the reviewer

I updated the docstring with usage information, but not sure what your documentation requirements are otherwise.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
