### PR TITLE
docs: correcting CONTRIBUTING hatch commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ hatch run test:lint
 If the linters spot any error, you can fix it before checking in your code:
 
 ```sh
-hatch run test:lint-fix
+hatch run test:fix
 ```
 
 ## Requirements for Pull Requests


### PR DESCRIPTION
### Related Issues

Updating `CONTRIBUTING.MD` hatch commands
 
### How did you test it?

Run the `hatch run test:lint-fix` resulted in an error, run `hatch run test:fix` works 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
