### PR TITLE
Add JSON converter and tests

### DIFF
--- a/haystack/components/converters/__init__.py
+++ b/haystack/components/converters/__init__.py
@@ -5,6 +5,7 @@
 from haystack.components.converters.azure import AzureOCRDocumentConverter
 from haystack.components.converters.docx import DOCXMetadata, DOCXToDocument
 from haystack.components.converters.html import HTMLToDocument
+from haystack.components.converters.json import JSONToDocument
 from haystack.components.converters.markdown import MarkdownToDocument
 from haystack.components.converters.openapi_functions import OpenAPIServiceToFunctions
 from haystack.components.converters.output_adapter import OutputAdapter
@@ -25,4 +26,6 @@ __all__ = [
     "OutputAdapter",
     "DOCXToDocument",
     "DOCXMetadata",
+    "JSONToDocument",
+
 ]

--- a/haystack/components/converters/json.py
+++ b/haystack/components/converters/json.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from haystack import Document, component, logging
+from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
+from haystack.dataclasses import ByteStream
+from haystack.lazy_imports import LazyImport
+from haystack.utils.type_serialization import deserialize_type
+
+with LazyImport("Run 'pip install flatten_json' Github - https://github.com/amirziai/flatten ") as flatten_import:
+    from flatten_json import flatten
+
+import json
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class JSONToDocument:
+    """ 
+    
+    Convert JSON files to Documents.
+    
+    Converts JSON files to Documents by flattening the JSON and then
+    mapping it to content field of the Document class.  The number of
+    Document objects will be the same as the number of sources provided.  The
+    assumption is that the JSON is encoded in utf-8
+
+
+    :param sources:
+    
+        List of HTML, file paths or ByteStream objects.
+        
+    :param meta:
+    
+        Optional metadata to attach to the Documents.
+        This value can be either a list of dictionaries or a single dictionary.
+        If it's a single dictionary, its content is added to the metadata of all produced Documents.
+        If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+        If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
+        
+    :returns:
+    
+    A dictionary with the following keys:
+    - `documents`: Created Documents
+
+    Usage example:
+    ```python
+    from haystack.components.converters.txt import JSONToDocument
+
+    converter = JSONToDocument()
+    results = converter.run(sources=["sample.json"])
+    documents = results["documents"]
+    print(documents[0].content)
+    # 'This is the JSON content from the JSON file.'
+
+
+    The flatten_json library is used to flatten JSON for the purposes of embedding
+    and semantic searching.  Example:
+    nested_json = {
+    "store": {
+        "book": [
+            {"category": "fiction", "price": 8.95, "title": "Book A"},
+            {"category": "non-fiction", "price": 12.99, "title": "Book B"}
+        ]
+    }
+}
+
+flattened JSON
+
+    {'store_book_0_category': 'fiction', 'store_book_0_price': 8.95, 'store_book_0_title': 'Book A', 'store_book_1_category': 'non-fiction', 'store_book_1_price': 12.99, 'store_book_1_title': 'Book B'}
+
+
+    """
+
+    
+    def __init__(self: "JSONToDocument") -> None:
+        """
+        Create a JSONToDocument component.
+        """
+
+        flatten_import.check()
+
+
+
+
+    @component.output_types(documents=List[Document])
+    def run(
+        self,
+        sources: List[Union[str, Path, ByteStream]],
+        meta: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
+    ):
+        """
+        Converts JSON files to Documents.
+
+        :param sources:
+            List of HTML file paths or ByteStream objects.
+        :param meta:
+            Optional metadata to attach to the Documents.
+            This value can be either a list of dictionaries or a single dictionary.
+            If it's a single dictionary, its content is added to the metadata of all produced Documents.
+            If it's a list, the length of the list must match the number of sources, because the two lists will be zipped.
+            If `sources` contains ByteStream objects, their `meta` will be added to the output Documents.
+
+        :returns:
+            A dictionary with the following keys:
+            - `documents`: Created Documents
+        """
+        documents = []
+
+        meta_list = normalize_metadata(meta, sources_count=len(sources))
+
+        for source, metadata in zip(sources, meta_list):
+            try:
+                bytestream = get_bytestream_from_source(source)
+            except Exception as e:
+                logger.warning("Could not read {source}. Skipping it. Error: {error}", source=source, error=e)
+                continue
+            try:
+                # Convert the ByteStream data to a string
+                json_str = bytestream.data.decode("utf-8")
+
+                # Load the string into a dictionary
+                json_dict = json.loads(json_str)
+
+                # Flatten the dictionary
+                flattened_json_dict = flatten(json_dict)
+
+                # Convert to a string
+                flattened_string = json.dumps(flattened_json_dict)
+
+
+            except Exception as e:
+                logger.warning(
+                    "Could not convert file {source}. Skipping it. Error message: {error}", source=source, error=e
+                )
+                continue
+
+
+
+            merged_metadata = {**bytestream.meta, **metadata}
+            document = Document(content=flattened_string, meta=merged_metadata)
+            documents.append(document)
+
+        return {"documents": documents}

--- a/test/components/converters/test_json_to_document.py
+++ b/test/components/converters/test_json_to_document.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from pathlib import Path
+import json
+import pytest
+
+from haystack.dataclasses import ByteStream
+from haystack.components.converters.json import JSONToDocument
+
+
+class TestJSONToDocument:
+    def test_run(self, test_files_path):
+        """
+        Test if the component runs correctly.
+        """
+        sample_json = {
+            "store": {
+                "book": [
+                    {"category": "fiction", "price": 8.95, "title": "Book A"},
+                    {"category": "non-fiction", "price": 12.99, "title": "Book B"}
+                ]
+            }
+        }
+
+        # Save JSON content to a file
+        file_path = test_files_path / "json" / "sample.json"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w") as f:
+            json.dump(sample_json, f)
+
+        converter = JSONToDocument()
+        bytestream = ByteStream.from_file_path(file_path, meta={"file_path": str(file_path)})
+        output = converter.run(sources=[bytestream])
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert "store_book_0_category" in docs[0].content
+        assert docs[0].meta["file_path"] == str(file_path)
+
+    def test_run_error_handling(self, test_files_path, caplog):
+        """
+        Test if the component correctly handles errors.
+        """
+        paths = [test_files_path / "json" / "sample.json", "non_existing_file.json"]
+        converter = JSONToDocument()
+        with caplog.at_level(logging.WARNING):
+            output = converter.run(sources=paths)
+            assert "non_existing_file.json" in caplog.text
+        docs = output["documents"]
+        assert len(docs) == 1
+        assert docs[0].meta["file_path"] == str(paths[0])
+
+    def test_run_with_meta(self, test_files_path):
+        """
+        Test if the component correctly merges metadata.
+        """
+        sample_json = {
+            "store": {
+                "book": [
+                    {"category": "fiction", "price": 8.95, "title": "Book A"},
+                    {"category": "non-fiction", "price": 12.99, "title": "Book B"}
+                ]
+            }
+        }
+
+        # Save JSON content to a file
+        file_path = test_files_path / "json" / "sample.json"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w") as f:
+            json.dump(sample_json, f)
+
+        converter = JSONToDocument()
+        bytestream = ByteStream.from_file_path(file_path, meta={"author": "test_author"})
+        output = converter.run(sources=[bytestream], meta={"language": "en"})
+        document = output["documents"][0]
+
+        # Validate the metadata merge
+        assert document.meta["author"] == "test_author"
+        assert document.meta["language"] == "en"


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

[Json to document converter ](https://github.com/deepset-ai/haystack/issues/7784) modeled after the text and PDF converters.
Json is read from a file, flattened and returned as the content of a Haystack document.

### How did you test it?

Pytest unit test -test/components/converters/test_json_to_document.py. I followed the convention for the other converter tests

### Notes for the reviewer

Not able to get the pre-commit hooks to pass.  Get a Ruff D205  error.  Bypassed it for now so I could commit.  Will continue to debug.  
I will also extend the functionality to have a JSON string as a source.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
