### PR TITLE
fix: LinkContentFetcher html text encoding

### DIFF
--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -29,6 +29,16 @@ REQUEST_HEADERS = {
 }
 
 
+def _text_content_handler(response: Response) -> ByteStream:
+    """
+    Handles text content.
+
+    :param response: Response object from the request.
+    :return: The extracted text.
+    """
+    return ByteStream.from_string(response.text)
+
+
 def _binary_content_handler(response: Response) -> ByteStream:
     """
     Handles binary content.
@@ -84,9 +94,10 @@ class LinkContentFetcher:
         self.timeout = timeout
 
         # register default content handlers that extract data from the response
-        self.handlers: Dict[str, Callable[[Response], ByteStream]] = defaultdict(lambda: _binary_content_handler)
-        self.handlers["text/*"] = _binary_content_handler
-        self.handlers["application/json"] = _binary_content_handler
+        self.handlers: Dict[str, Callable[[Response], ByteStream]] = defaultdict(lambda: _text_content_handler)
+        self.handlers["text/*"] = _text_content_handler
+        self.handlers["text/html"] = _binary_content_handler
+        self.handlers["application/json"] = _text_content_handler
         self.handlers["application/*"] = _binary_content_handler
         self.handlers["image/*"] = _binary_content_handler
         self.handlers["audio/*"] = _binary_content_handler

--- a/haystack/components/fetchers/link_content.py
+++ b/haystack/components/fetchers/link_content.py
@@ -29,16 +29,6 @@ REQUEST_HEADERS = {
 }
 
 
-def _text_content_handler(response: Response) -> ByteStream:
-    """
-    Handles text content.
-
-    :param response: Response object from the request.
-    :return: The extracted text.
-    """
-    return ByteStream.from_string(response.text)
-
-
 def _binary_content_handler(response: Response) -> ByteStream:
     """
     Handles binary content.
@@ -94,9 +84,9 @@ class LinkContentFetcher:
         self.timeout = timeout
 
         # register default content handlers that extract data from the response
-        self.handlers: Dict[str, Callable[[Response], ByteStream]] = defaultdict(lambda: _text_content_handler)
-        self.handlers["text/*"] = _text_content_handler
-        self.handlers["application/json"] = _text_content_handler
+        self.handlers: Dict[str, Callable[[Response], ByteStream]] = defaultdict(lambda: _binary_content_handler)
+        self.handlers["text/*"] = _binary_content_handler
+        self.handlers["application/json"] = _binary_content_handler
         self.handlers["application/*"] = _binary_content_handler
         self.handlers["image/*"] = _binary_content_handler
         self.handlers["audio/*"] = _binary_content_handler

--- a/releasenotes/notes/fix-linkcontentfetcher-encoding-6c8df3c5b09fbc50.yaml
+++ b/releasenotes/notes/fix-linkcontentfetcher-encoding-6c8df3c5b09fbc50.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Encoding of LinkContentFetcher

--- a/releasenotes/notes/fix-linkcontentfetcher-encoding-6c8df3c5b09fbc50.yaml
+++ b/releasenotes/notes/fix-linkcontentfetcher-encoding-6c8df3c5b09fbc50.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Encoding of LinkContentFetcher
+    Encoding of HTML files in LinkContentFetcher

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -61,7 +61,7 @@ class TestLinkContentFetcher:
         correct_response = b"Example test response"
         with patch("haystack.components.fetchers.link_content.requests") as mock_run:
             mock_run.get.return_value = Mock(
-                status_code=200, text="Example test response", headers={"Content-Type": "text/plain"}
+                status_code=200, content=b"Example test response", headers={"Content-Type": "text/plain"}
             )
             fetcher = LinkContentFetcher()
             streams = fetcher.run(urls=["https://www.example.com"])["streams"]
@@ -73,7 +73,7 @@ class TestLinkContentFetcher:
         correct_response = b"<h1>Example test response</h1>"
         with patch("haystack.components.fetchers.link_content.requests") as mock_run:
             mock_run.get.return_value = Mock(
-                status_code=200, text="<h1>Example test response</h1>", headers={"Content-Type": "text/html"}
+                status_code=200, content=b"<h1>Example test response</h1>", headers={"Content-Type": "text/html"}
             )
             fetcher = LinkContentFetcher()
             streams = fetcher.run(urls=["https://www.example.com"])["streams"]

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -6,7 +6,12 @@ from unittest.mock import patch, Mock
 import pytest
 import requests
 
-from haystack.components.fetchers.link_content import LinkContentFetcher, _binary_content_handler, DEFAULT_USER_AGENT
+from haystack.components.fetchers.link_content import (
+    LinkContentFetcher,
+    _text_content_handler,
+    _binary_content_handler,
+    DEFAULT_USER_AGENT,
+)
 
 HTML_URL = "https://docs.haystack.deepset.ai/docs"
 TEXT_URL = "https://raw.githubusercontent.com/deepset-ai/haystack/main/README.md"
@@ -41,8 +46,9 @@ class TestLinkContentFetcher:
         assert fetcher.retry_attempts == 2
         assert fetcher.timeout == 3
         assert fetcher.handlers == {
-            "text/*": _binary_content_handler,
-            "application/json": _binary_content_handler,
+            "text/*": _text_content_handler,
+            "text/html": _binary_content_handler,
+            "application/json": _text_content_handler,
             "application/*": _binary_content_handler,
             "image/*": _binary_content_handler,
             "audio/*": _binary_content_handler,
@@ -61,7 +67,7 @@ class TestLinkContentFetcher:
         correct_response = b"Example test response"
         with patch("haystack.components.fetchers.link_content.requests") as mock_run:
             mock_run.get.return_value = Mock(
-                status_code=200, content=b"Example test response", headers={"Content-Type": "text/plain"}
+                status_code=200, text="Example test response", headers={"Content-Type": "text/plain"}
             )
             fetcher = LinkContentFetcher()
             streams = fetcher.run(urls=["https://www.example.com"])["streams"]

--- a/test/components/fetchers/test_link_content_fetcher.py
+++ b/test/components/fetchers/test_link_content_fetcher.py
@@ -6,12 +6,7 @@ from unittest.mock import patch, Mock
 import pytest
 import requests
 
-from haystack.components.fetchers.link_content import (
-    LinkContentFetcher,
-    _text_content_handler,
-    _binary_content_handler,
-    DEFAULT_USER_AGENT,
-)
+from haystack.components.fetchers.link_content import LinkContentFetcher, _binary_content_handler, DEFAULT_USER_AGENT
 
 HTML_URL = "https://docs.haystack.deepset.ai/docs"
 TEXT_URL = "https://raw.githubusercontent.com/deepset-ai/haystack/main/README.md"
@@ -46,8 +41,8 @@ class TestLinkContentFetcher:
         assert fetcher.retry_attempts == 2
         assert fetcher.timeout == 3
         assert fetcher.handlers == {
-            "text/*": _text_content_handler,
-            "application/json": _text_content_handler,
+            "text/*": _binary_content_handler,
+            "application/json": _binary_content_handler,
             "application/*": _binary_content_handler,
             "image/*": _binary_content_handler,
             "audio/*": _binary_content_handler,


### PR DESCRIPTION
### Related Issues
- fixes https://github.com/deepset-ai/haystack/issues/7976

### Proposed Changes:
- use `_binary_content_handler` for content type `text/html`

### How did you test it?
- adjusted tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
