### PR TITLE
Split `_dequeue_components_that_received_no_input` into separate functions

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1033,14 +1033,11 @@ class PipelineBase:
             # BAIL!
             return True
 
-        if len(waiting_for_input) == 1:
-            # We have a single component with no variadic input or only default inputs waiting for input.
-            # If we're at this point it means it has been waiting for input for at least 2 iterations.
-            # This will never run.
-            # BAIL!
-            return True
-
-        return False
+        # If we have a single component with no variadic input or only default inputs waiting for input
+        # it means it has been waiting for input for at least 2 iterations.
+        # This will never run.
+        # BAIL!
+        return len(waiting_for_input) == 1
 
 
 def _connections_status(

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -37,9 +37,7 @@ class Pipeline(PipelineBase):
             return False
         expected_inputs = instance.__haystack_input__._sockets_dict.keys()  # type: ignore
         current_inputs = inputs[name].keys()
-        if expected_inputs != current_inputs:
-            return False
-        return True
+        return expected_inputs == current_inputs
 
     def _run_component(self, name: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -265,7 +265,8 @@ class Pipeline(PipelineBase):
                         # This happens when a component was put in the waiting list but we reached it from another edge.
                         waiting_for_input.remove((name, comp))
 
-                    self._dequeue_components_that_received_no_input(name, res, to_run, waiting_for_input)
+                    for pair in self._find_components_that_received_no_input(name, res):
+                        _dequeue_component(pair, to_run, waiting_for_input)
                     res = self._distribute_output(name, res, last_inputs, to_run, waiting_for_input)
 
                     if len(res) > 0:
@@ -343,3 +344,22 @@ def _enqueue_component(
 
     if component_pair not in to_run:
         to_run.append(component_pair)
+
+
+def _dequeue_component(
+    component_pair: Tuple[str, Component],
+    to_run: List[Tuple[str, Component]],
+    waiting_for_input: List[Tuple[str, Component]],
+):
+    """
+    Removes a Component both from the queue of Components to run and the waiting list.
+
+    :param component_pair: Tuple of Component name and instance
+    :param to_run: Queue of Components to run
+    :param waiting_for_input: Queue of Components waiting for input
+    """
+    if component_pair in waiting_for_input:
+        waiting_for_input.remove(component_pair)
+
+    if component_pair in to_run:
+        to_run.remove(component_pair)


### PR DESCRIPTION
### Related Issues

Part of #7614

### Proposed Changes:

Split `_dequeue_components_that_received_no_input` into two separate functions, one to find the Components and one to remove them form queues.

### How did you test it?

I added tests and run them locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
