### PR TITLE
feat: Add max_retries to AzureOpenAIGenerator

### DIFF
--- a/releasenotes/notes/max-retries-for-AzureOpenAIGenerator-0f1a1807dd2af041.yaml
+++ b/releasenotes/notes/max-retries-for-AzureOpenAIGenerator-0f1a1807dd2af041.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Add max_retries to AzureOpenAIGenerator.
+    AzureOpenAIGenerator can now be initialised by setting max_retries.
+    If not set, it is inferred from the `OPENAI_MAX_RETRIES`
+    environment variable or set to 5.
+    The timeout for AzureOpenAIGenerator, if not set, it is inferred
+    from the `OPENAI_TIMEOUT` environment variable or set to 30.

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -39,7 +39,7 @@ class TestAzureOpenAIGenerator:
         assert component.client.api_key == "fake-api-key"
         assert component.azure_deployment == "gpt-35-turbo"
         assert component.streaming_callback is print_streaming_chunk
-        assert component.timeout is None
+        assert component.timeout == 30.0
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
 
     def test_to_dict_default(self, monkeypatch):
@@ -57,7 +57,8 @@ class TestAzureOpenAIGenerator:
                 "azure_endpoint": "some-non-existing-endpoint",
                 "organization": None,
                 "system_prompt": None,
-                "timeout": None,
+                "timeout": 30.0,
+                "max_retries": 5,
                 "generation_kwargs": {},
             },
         }
@@ -69,6 +70,7 @@ class TestAzureOpenAIGenerator:
             azure_ad_token=Secret.from_env_var("ENV_VAR1", strict=False),
             azure_endpoint="some-non-existing-endpoint",
             timeout=3.5,
+            max_retries=10,
             generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
         )
 
@@ -85,6 +87,7 @@ class TestAzureOpenAIGenerator:
                 "organization": None,
                 "system_prompt": None,
                 "timeout": 3.5,
+                "max_retries": 10,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
             },
         }


### PR DESCRIPTION
### Related Issues

- fixes #7945

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
AzureOpenAIGenerator can be initiated using `max_retries`.

### How did you test it?

Unit tests

### Notes for the reviewer

I thought it'd be a good idea also to return `max_retries` when `to_dict` is called since we are doing it for `timeout` as well. Let me know if this is not required.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
