### PR TITLE
fix: adding deprecation warning ContextEvaluator

### DIFF
--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from typing import Any, Dict, List, Optional
 
 from numpy import mean as np_mean
@@ -136,6 +137,13 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         self.examples = examples or _DEFAULT_EXAMPLES
         self.api = api
         self.api_key = api_key
+
+        warnings.warn(
+            "The output of the ContextRelevanceEvaluator will change in Haystack 2.4.0. "
+            "Contexts will be scored as a whole instead of individual statements and only the relevant sentences "
+            "will be returned. A score of 1 is now returned if a relevant sentence is found, and 0 otherwise.",
+            DeprecationWarning,
+        )
 
         super(ContextRelevanceEvaluator, self).__init__(
             instructions=self.instructions,

--- a/releasenotes/notes/add-deprecation-warning-context-relevance-937df7e807ac1a8d.yaml
+++ b/releasenotes/notes/add-deprecation-warning-context-relevance-937df7e807ac1a8d.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    "The output of the ContextRelevanceEvaluator will change in Haystack 2.4.0. Contexts will be scored as a whole instead of individual statements and only the relevant sentences will be returned. A score of 1 is now returned if a relevant sentence is found, and 0 otherwise."

--- a/releasenotes/notes/add-deprecation-warning-context-relevance-937df7e807ac1a8d.yaml
+++ b/releasenotes/notes/add-deprecation-warning-context-relevance-937df7e807ac1a8d.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    "The output of the ContextRelevanceEvaluator will change in Haystack 2.4.0. Contexts will be scored as a whole instead of individual statements and only the relevant sentences will be returned. A score of 1 is now returned if a relevant sentence is found, and 0 otherwise."
+    The output of the ContextRelevanceEvaluator will change in Haystack 2.4.0. Contexts will be scored as a whole instead of individual statements and only the relevant sentences will be returned. A score of 1 is now returned if a relevant sentence is found, and 0 otherwise.


### PR DESCRIPTION
### Proposed Changes:

- Adding a deprecation warning when the ContextEvaluator is initialized


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
