### PR TITLE
feat: Configure max_retries & timeout for AzureOpenAITextEmbedder

### DIFF
--- a/releasenotes/notes/timeout-and-retries-for-AzureOpenAITextEmbedder-b02b760e9d6f28aa.yaml
+++ b/releasenotes/notes/timeout-and-retries-for-AzureOpenAITextEmbedder-b02b760e9d6f28aa.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add `max_retries` and `timeout` parameters to the AzureOpenAITextEmbedder initializations.

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -34,6 +34,8 @@ class TestAzureOpenAITextEmbedder:
                 "organization": None,
                 "azure_endpoint": "https://example-resource.azure.openai.com/",
                 "api_version": "2023-05-15",
+                "max_retries": 5,
+                "timeout": 30.0,
                 "prefix": "",
                 "suffix": "",
             },


### PR DESCRIPTION
max_retries: if not set is read from the OPENAI_MAX_RETRIES env variable or set to 5.

timeout: if not set is read from the OPENAI_TIMEOUT env variable or set to 30.

### Related Issues

- fixes #7945 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
 AzureOpenAIChatGenerator now supports  max_retries and timeout for initialization.
timeout can also be set using the env variable OPENAI_TIMEOUT. Default: 30
max_retries can also be set using the env variable OPENAI_MAX_RETRIES. Default: 5
 
### How did you test it?
Unit tests

### Notes for the reviewer

There are a few other similar PRs for the issue. This is the 3/4 PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
