### PR TITLE
feat: Configure max_retries and timeout for AzureOpenAIDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -88,7 +88,7 @@ class AzureOpenAIDocumentEmbedder:
             Separator used to concatenate the meta fields to the Document text.
         :param timeout: The timeout to be passed to the underlying `AzureOpenAI` client, if not set it is
             inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
-        :param max_retries: Maximum retries to establish contact with AzureOpenAI if it returns an internal error,
+        :param max_retries: Maximum retries to establish a connection with AzureOpenAI if it returns an internal error,
             if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
         """
         # if not provided as a parameter, azure_endpoint is read from the env var AZURE_OPENAI_ENDPOINT

--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -33,7 +33,7 @@ class AzureOpenAIDocumentEmbedder:
     ```
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 (too-many-arguments)
         self,
         azure_endpoint: Optional[str] = None,
         api_version: Optional[str] = "2023-05-15",
@@ -48,6 +48,8 @@ class AzureOpenAIDocumentEmbedder:
         progress_bar: bool = True,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
+        timeout: Optional[float] = None,
+        max_retries: Optional[int] = None,
     ):
         """
         Create an AzureOpenAIDocumentEmbedder component.
@@ -84,6 +86,10 @@ class AzureOpenAIDocumentEmbedder:
             List of meta fields that will be embedded along with the Document text.
         :param embedding_separator:
             Separator used to concatenate the meta fields to the Document text.
+        :param timeout: The timeout to be passed to the underlying `AzureOpenAI` client, if not set it is
+            inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
+        :param max_retries: Maximum retries to establish contact with AzureOpenAI if it returns an internal error,
+            if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
         """
         # if not provided as a parameter, azure_endpoint is read from the env var AZURE_OPENAI_ENDPOINT
         azure_endpoint = azure_endpoint or os.environ.get("AZURE_OPENAI_ENDPOINT")
@@ -106,6 +112,8 @@ class AzureOpenAIDocumentEmbedder:
         self.progress_bar = progress_bar
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
+        self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", 30.0))
+        self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", 5))
 
         self._client = AzureOpenAI(
             api_version=api_version,
@@ -114,6 +122,8 @@ class AzureOpenAIDocumentEmbedder:
             api_key=api_key.resolve_value() if api_key is not None else None,
             azure_ad_token=azure_ad_token.resolve_value() if azure_ad_token is not None else None,
             organization=organization,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
         )
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
@@ -144,6 +154,8 @@ class AzureOpenAIDocumentEmbedder:
             embedding_separator=self.embedding_separator,
             api_key=self.api_key.to_dict() if self.api_key is not None else None,
             azure_ad_token=self.azure_ad_token.to_dict() if self.azure_ad_token is not None else None,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
         )
 
     @classmethod

--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -86,7 +86,7 @@ class AzureOpenAIDocumentEmbedder:
             List of meta fields that will be embedded along with the Document text.
         :param embedding_separator:
             Separator used to concatenate the meta fields to the Document text.
-        :param timeout: The timeout to be passed to the underlying `AzureOpenAI` client, if not set it is
+        :param timeout: The timeout in seconds to be passed to the underlying `AzureOpenAI` client, if not set it is
             inferred from the `OPENAI_TIMEOUT` environment variable or set to 30.
         :param max_retries: Maximum retries to establish a connection with AzureOpenAI if it returns an internal error,
             if not set it is inferred from the `OPENAI_MAX_RETRIES` environment variable or set to 5.

--- a/releasenotes/notes/retries-and-timeout-for-AzureOpenAIDocumentEmbedder-006fd84204942e43.yaml
+++ b/releasenotes/notes/retries-and-timeout-for-AzureOpenAIDocumentEmbedder-006fd84204942e43.yaml
@@ -1,10 +1,4 @@
 ---
 enhancements:
   - |
-    Add max_retries, timeout to AzureOpenAIDocumentEmbedder init.
-    AzureOpenAIDocumentEmbedder can now be initialised by setting max_retries.
-    If max_retries is not set, it is inferred from the `OPENAI_MAX_RETRIES`
-    environment variable or set to 5.
-    AzureOpenAIDocumentEmbedder can now be initialised by setting timeout.
-    If timeout is not set, it is inferred from the `OPENAI_TIMEOUT`
-    environment variable or set to 30.
+    Add `max_retries`, `timeout` parameters to the `AzureOpenAIDocumentEmbedder` initialization.

--- a/releasenotes/notes/retries-and-timeout-for-AzureOpenAIDocumentEmbedder-006fd84204942e43.yaml
+++ b/releasenotes/notes/retries-and-timeout-for-AzureOpenAIDocumentEmbedder-006fd84204942e43.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Add max_retries, timeout to AzureOpenAIDocumentEmbedder init.
+    AzureOpenAIDocumentEmbedder can now be initialised by setting max_retries.
+    If max_retries is not set, it is inferred from the `OPENAI_MAX_RETRIES`
+    environment variable or set to 5.
+    AzureOpenAIDocumentEmbedder can now be initialised by setting timeout.
+    If timeout is not set, it is inferred from the `OPENAI_TIMEOUT`
+    environment variable or set to 30.

--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -43,6 +43,8 @@ class TestAzureOpenAIDocumentEmbedder:
                 "progress_bar": True,
                 "meta_fields_to_embed": [],
                 "embedding_separator": "\n",
+                "max_retries": 5,
+                "timeout": 30.0,
             },
         }
 


### PR DESCRIPTION
max_retries: if not set is read from the OPENAI_MAX_RETRIES env variable or set to 5.

timeout: if not set is read from the OPENAI_TIMEOUT env variable or set to 30.

### Related Issues

- fixes #7945 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
 AzureOpenAIDocumentEmbedder now supports max_retries and timeout for initialization.
timeout can also be set using the env variable OPENAI_TIMEOUT. Default: 30
max_retries can also be set using the env variable OPENAI_MAX_RETRIES. Default: 5

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests


### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
There are a few other similar PRs for the issue. This is the 4/4 PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
