### PR TITLE
fix: make PyPDF backward compatible

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -106,8 +106,14 @@ class PyPDFToDocument:
         :returns:
             Deserialized component.
         """
-        converter_class = deserialize_type(data["init_parameters"]["converter"]["type"])
-        data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])
+
+        if converter := data["init_parameters"].get("converter"):
+            converter_class = deserialize_type(converter["type"])
+            data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])
+        else:
+            # Ensures backwards compatibility with Pipelines dumped with < 2.3.0
+            data["init_parameters"]["converter"] = DefaultConverter()
+
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/releasenotes/notes/improve-pypdf-backwards-compatibility-bcc75871005e9aba.yaml
+++ b/releasenotes/notes/improve-pypdf-backwards-compatibility-bcc75871005e9aba.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Enhanced the PyPDF converter to ensure backwards compatibility with Pipelines dumped with versions older than 2.3.0. The update includes a conditional check to automatically default to the `DefaultConverter` if a specific converter is not provided, improving the component's robustness and ease of use.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -40,6 +40,12 @@ class TestPyPDFToDocument:
         assert isinstance(instance, PyPDFToDocument)
         assert isinstance(instance.converter, DefaultConverter)
 
+    def test_from_dict_no_converter(self):
+        data = {"type": "haystack.components.converters.pypdf.PyPDFToDocument", "init_parameters": {}}
+        instance = PyPDFToDocument.from_dict(data)
+        assert isinstance(instance, PyPDFToDocument)
+        assert isinstance(instance.converter, DefaultConverter)
+
     @pytest.mark.integration
     def test_run(self, test_files_path, pypdf_converter):
         """


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- make PyPDF converter backward compatible with Pipelines pre 2.3

### How did you test it?

- added a test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
