### PR TITLE
chore: Deprecate legacy filter

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from dataclasses import fields
 from datetime import datetime
 from typing import Any, Dict, List, Union
@@ -214,6 +215,12 @@ def convert(filters: Dict[str, Any]) -> Dict[str, Any]:
     }
     ```
     """
+    warnings.warn(
+        "You are using deprecated filter syntax. Please use the new filter syntax as described "
+        "in the documentation. We will attempt to convert your old filter syntax to the new one. The old syntax "
+        "support will be removed in Haystack 2.5",
+        DeprecationWarning,
+    )
     if not isinstance(filters, dict):
         msg = f"Can't convert filters from type '{type(filters)}'"
         raise ValueError(msg)

--- a/releasenotes/notes/deprecation-warning-legacy-filter-syntax-2fe61cab5e14ad8e.yaml
+++ b/releasenotes/notes/deprecation-warning-legacy-filter-syntax-2fe61cab5e14ad8e.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+ - |
+   Added deprecation warning for using old filter syntax. Users are advised to switch to the new filter syntax as the old syntax will be removed 2.5 Haystack release.


### PR DESCRIPTION
### Why:
This update aims to encourage users to transition to a new filter syntax by introducing a deprecation warning for the old syntax. This preemptive measure ensures a smoother transition before the old syntax is removed in an upcoming release, thereby maintaining code compatibility and reducing future technical debt.

### What:
- Added an import statement for the `warnings` module in `filters.py`.
- Inserted a `DeprecationWarning` in the `convert` function indicating the use of deprecated filter syntax.

### How can it be used:
- **Deprecation Warning:** When the `convert` function is called with the old filter syntax, a warning message will inform users about the deprecation, encouraging them to update their code.

### How did you test it:
- Added a deprecation warning which inherently doesn't disrupt functionality.

### Notes for the reviewer:
- Verify that the deprecation warning appropriately triggers when old syntax is used.
- Ensure the message is clear and directs users to the documentation for the new syntax.