### PR TITLE
fix: `TransformersZeroShotTextRouter` and `TransformersTextRouter` from_dict to work with default value for huggingface_pipeline_kwargs

### DIFF
--- a/haystack/components/generators/hugging_face_local.py
+++ b/haystack/components/generators/hugging_face_local.py
@@ -196,12 +196,13 @@ class HuggingFaceLocalGenerator:
             The deserialized component.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
-        deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:
             data["init_parameters"]["streaming_callback"] = deserialize_callable(serialized_callback_handler)
 
+        huggingface_pipeline_kwargs = init_params.get("huggingface_pipeline_kwargs", {})
+        deserialize_hf_model_kwargs(huggingface_pipeline_kwargs)
         return default_from_dict(cls, data)
 
     @component.output_types(replies=List[str])

--- a/haystack/components/routers/transformers_text_router.py
+++ b/haystack/components/routers/transformers_text_router.py
@@ -177,7 +177,8 @@ class TransformersTextRouter:
             Deserialized component.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
-        deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
+        if data["init_parameters"].get("huggingface_pipeline_kwargs") is not None:
+            deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
         return default_from_dict(cls, data)
 
     @component.output_types(documents=Dict[str, str])

--- a/haystack/components/routers/zero_shot_text_router.py
+++ b/haystack/components/routers/zero_shot_text_router.py
@@ -188,7 +188,8 @@ class TransformersZeroShotTextRouter:
             Deserialized component.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
-        deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
+        if data["init_parameters"].get("huggingface_pipeline_kwargs") is not None:
+            deserialize_hf_model_kwargs(data["init_parameters"]["huggingface_pipeline_kwargs"])
         return default_from_dict(cls, data)
 
     @component.output_types(documents=Dict[str, str])

--- a/releasenotes/notes/transformer-router-from-dict-fix-04cb41b38ca61043.yaml
+++ b/releasenotes/notes/transformer-router-from-dict-fix-04cb41b38ca61043.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix TransformersZeroShotTextRouter and TransformersTextRouter from_dict methods to work with default value for huggingface_pipeline_kwargs.
+    So now if huggingface_pipeline_kwargs is left out or set to None, from_dict will correct load the components.

--- a/releasenotes/notes/transformer-router-from-dict-fix-04cb41b38ca61043.yaml
+++ b/releasenotes/notes/transformer-router-from-dict-fix-04cb41b38ca61043.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    Fix TransformersZeroShotTextRouter and TransformersTextRouter from_dict methods to work with default value for huggingface_pipeline_kwargs.
-    So now if huggingface_pipeline_kwargs is left out or set to None, from_dict will correct load the components.
+    Fix `TransformersZeroShotTextRouter` and `TransformersTextRouter` `from_dict` methods to work when `init_parameters` only contain required variables.

--- a/test/components/routers/test_transformers_text_router.py
+++ b/test/components/routers/test_transformers_text_router.py
@@ -81,15 +81,12 @@ class TestTransformersTextRouter:
         }
 
     @patch("haystack.components.routers.transformers_text_router.AutoConfig.from_pretrained")
-    def test_from_dict_no_huggingface_pipeline_kwargs(self, mock_auto_config_from_pretrained, monkeypatch):
+    def test_from_dict_no_default_parameters(self, mock_auto_config_from_pretrained, monkeypatch):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         monkeypatch.delenv("HF_API_TOKEN", raising=False)
         data = {
             "type": "haystack.components.routers.transformers_text_router.TransformersTextRouter",
-            "init_parameters": {
-                "model": "papluca/xlm-roberta-base-language-detection",
-                "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
-            },
+            "init_parameters": {"model": "papluca/xlm-roberta-base-language-detection"},
         }
         component = TransformersTextRouter.from_dict(data)
         assert component.labels == ["en", "de"]

--- a/test/components/routers/test_transformers_text_router.py
+++ b/test/components/routers/test_transformers_text_router.py
@@ -81,6 +81,30 @@ class TestTransformersTextRouter:
         }
 
     @patch("haystack.components.routers.transformers_text_router.AutoConfig.from_pretrained")
+    def test_from_dict_no_huggingface_pipeline_kwargs(self, mock_auto_config_from_pretrained, monkeypatch):
+        mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)
+        data = {
+            "type": "haystack.components.routers.transformers_text_router.TransformersTextRouter",
+            "init_parameters": {
+                "model": "papluca/xlm-roberta-base-language-detection",
+                "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
+            },
+        }
+        component = TransformersTextRouter.from_dict(data)
+        assert component.labels == ["en", "de"]
+        assert component.pipeline is None
+        assert component.token == Secret.from_dict(
+            {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"}
+        )
+        assert component.huggingface_pipeline_kwargs == {
+            "model": "papluca/xlm-roberta-base-language-detection",
+            "device": ComponentDevice.resolve_device(None).to_hf(),
+            "task": "text-classification",
+            "token": None,
+        }
+
+    @patch("haystack.components.routers.transformers_text_router.AutoConfig.from_pretrained")
     def test_from_dict_with_cpu_device(self, mock_auto_config_from_pretrained, monkeypatch):
         mock_auto_config_from_pretrained.return_value = MagicMock(label2id={"en": 0, "de": 1})
         monkeypatch.delenv("HF_API_TOKEN", raising=False)

--- a/test/components/routers/test_zero_shot_text_router.py
+++ b/test/components/routers/test_zero_shot_text_router.py
@@ -54,14 +54,11 @@ class TestTransformersZeroShotTextRouter:
             "token": None,
         }
 
-    def test_from_dict_no_huggingface_pipeline_kwargs(self, monkeypatch):
+    def test_from_dict_no_default_parameters(self, monkeypatch):
         monkeypatch.delenv("HF_API_TOKEN", raising=False)
         data = {
             "type": "haystack.components.routers.zero_shot_text_router.TransformersZeroShotTextRouter",
-            "init_parameters": {
-                "labels": ["query", "passage"],
-                "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
-            },
+            "init_parameters": {"labels": ["query", "passage"]},
         }
         component = TransformersZeroShotTextRouter.from_dict(data)
         assert component.labels == ["query", "passage"]

--- a/test/components/routers/test_zero_shot_text_router.py
+++ b/test/components/routers/test_zero_shot_text_router.py
@@ -54,6 +54,28 @@ class TestTransformersZeroShotTextRouter:
             "token": None,
         }
 
+    def test_from_dict_no_huggingface_pipeline_kwargs(self, monkeypatch):
+        monkeypatch.delenv("HF_API_TOKEN", raising=False)
+        data = {
+            "type": "haystack.components.routers.zero_shot_text_router.TransformersZeroShotTextRouter",
+            "init_parameters": {
+                "labels": ["query", "passage"],
+                "token": {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"},
+            },
+        }
+        component = TransformersZeroShotTextRouter.from_dict(data)
+        assert component.labels == ["query", "passage"]
+        assert component.pipeline is None
+        assert component.token == Secret.from_dict(
+            {"env_vars": ["HF_API_TOKEN", "HF_TOKEN"], "strict": False, "type": "env_var"}
+        )
+        assert component.huggingface_pipeline_kwargs == {
+            "model": "MoritzLaurer/deberta-v3-base-zeroshot-v1.1-all-33",
+            "device": ComponentDevice.resolve_device(None).to_hf(),
+            "task": "zero-shot-classification",
+            "token": None,
+        }
+
     @patch("haystack.components.routers.zero_shot_text_router.pipeline")
     def test_warm_up(self, hf_pipeline_mock):
         router = TransformersZeroShotTextRouter(labels=["query", "passage"])


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Update `TransformersZeroShotTextRouter` and `TransformersTextRouter` from_dict methods to work when `init_parameters` only contains required parameters.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
