### PR TITLE
chore: Deprecate legacy document/metadata filters

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from dataclasses import fields
 from datetime import datetime
 from typing import Any, Dict, List, Union
@@ -103,7 +104,8 @@ def _less_than_equal(document_value: Any, filter_value: Any) -> bool:
 def _in(document_value: Any, filter_value: Any) -> bool:
     if not isinstance(filter_value, list):
         msg = (
-            f"Filter value must be a `list` when using operator 'in' or 'not in', received type '{type(filter_value)}'"
+            f"Filter value must be a `list` when using operator 'in' or 'not in', "
+            f"received type '{type(filter_value)}'"
         )
         raise FilterError(msg)
     return any(_equal(e, document_value) for e in filter_value)
@@ -214,6 +216,13 @@ def convert(filters: Dict[str, Any]) -> Dict[str, Any]:
     }
     ```
     """
+    warnings.warn(
+        "The use of legacy (Haystack 1.x) filters is deprecated and will be removed in the future. "
+        "Please use the new filter style as described in the documentation - "
+        "https://docs.haystack.deepset.ai/docs/metadata-filtering",
+        DeprecationWarning,
+    )
+
     if not isinstance(filters, dict):
         msg = f"Can't convert filters from type '{type(filters)}'"
         raise ValueError(msg)

--- a/releasenotes/notes/deprecate-legacy-filters-7c9530644d972089.yaml
+++ b/releasenotes/notes/deprecate-legacy-filters-7c9530644d972089.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Haystack 1.x legacy filters are deprecated and will be removed in a future release. Please use the new
+    filter style as described in the documentation - https://docs.haystack.deepset.ai/docs/metadata-filtering


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/875, https://github.com/deepset-ai/haystack-core-integrations/issues/876, https://github.com/deepset-ai/haystack-core-integrations/issues/877, https://github.com/deepset-ai/haystack-core-integrations/issues/878, https://github.com/deepset-ai/haystack-core-integrations/issues/879, https://github.com/deepset-ai/haystack-core-integrations/issues/880, https://github.com/deepset-ai/haystack-core-integrations/issues/881, https://github.com/deepset-ai/haystack-core-integrations/issues/882, https://github.com/deepset-ai/haystack-core-integrations/issues/882

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add a deprecation notice for legacy metadata filters.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
