### PR TITLE
Reorganize functions used by Pipeline.run

### DIFF
--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -15,8 +15,8 @@ from haystack.core.component import component
 from haystack.core.component.types import InputSocket, OutputSocket, Variadic
 from haystack.core.errors import PipelineConnectError, PipelineDrawingError, PipelineError
 from haystack.core.pipeline import Pipeline, PredefinedPipeline
-from haystack.core.pipeline.pipeline import _enqueue_component, _dequeue_component
-from haystack.core.pipeline.base import _add_missing_input_defaults
+from haystack.core.pipeline.base import _dequeue_component
+from haystack.core.pipeline.base import _add_missing_input_defaults, _enqueue_component
 from haystack.core.serialization import DeserializationCallbacks
 from haystack.testing.factory import component_class
 from haystack.testing.sample_components import AddFixedValue, Double, Greet


### PR DESCRIPTION
### Related Issues

- Part of #7614

### Proposed Changes:

Reorganize functions by moving most of them in `pipeline/base.py`.

### How did you test it?

Run tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
