### PR TITLE
Rename variables used in Pipeline.run() for clarity

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -765,28 +765,28 @@ class PipelineBase:
 
         return {**data}
 
-    def _init_to_run(self, pipeline_inputs: Dict[str, Any]) -> List[Tuple[str, Component]]:
-        to_run: List[Tuple[str, Component]] = []
+    def _init_run_queue(self, pipeline_inputs: Dict[str, Any]) -> List[Tuple[str, Component]]:
+        run_queue: List[Tuple[str, Component]] = []
         for node_name in self.graph.nodes:
             component = self.graph.nodes[node_name]["instance"]
 
             if len(component.__haystack_input__._sockets_dict) == 0:
                 # Component has no input, can run right away
-                to_run.append((node_name, component))
+                run_queue.append((node_name, component))
                 continue
 
             if node_name in pipeline_inputs:
                 # This component is in the input data, if it has enough inputs it can run right away
-                to_run.append((node_name, component))
+                run_queue.append((node_name, component))
                 continue
 
             for socket in component.__haystack_input__._sockets_dict.values():
                 if not socket.senders or socket.is_variadic:
                     # Component has at least one input not connected or is variadic, can run right away.
-                    to_run.append((node_name, component))
+                    run_queue.append((node_name, component))
                     break
 
-        return to_run
+        return run_queue
 
     @classmethod
     def from_template(
@@ -824,9 +824,9 @@ class PipelineBase:
         self,
         component_name: str,
         component_result: Dict[str, Any],
-        inputs_by_component: Dict[str, Dict[str, Any]],
-        to_run: List[Tuple[str, Component]],
-        waiting_for_input: List[Tuple[str, Component]],
+        components_inputs: Dict[str, Dict[str, Any]],
+        run_queue: List[Tuple[str, Component]],
+        waiting_queue: List[Tuple[str, Component]],
     ) -> Dict[str, Any]:
         """
         Distributes the output of a Component to the next Components that need it.
@@ -836,9 +836,9 @@ class PipelineBase:
 
         :param component_name: Name of the Component that created the output
         :param component_result: The output of the Component
-        :paramt inputs_by_component: The current state of the inputs divided by Component name
-        :param to_run: Queue of Components to run
-        :param waiting_for_input: Queue of Components waiting for input
+        :paramt components_inputs: The current state of the inputs divided by Component name
+        :param run_queue: Queue of Components to run
+        :param waiting_queue: Queue of Components waiting for input
 
         :returns: The updated output of the Component without the keys that were distributed to other Components
         """
@@ -862,8 +862,8 @@ class PipelineBase:
                 # Though it will return only one output at a time.
                 continue
 
-            if receiver_name not in inputs_by_component:
-                inputs_by_component[receiver_name] = {}
+            if receiver_name not in components_inputs:
+                components_inputs[receiver_name] = {}
 
             # We keep track of the keys that were distributed to other Components.
             # This key will be removed from component_result at the end of the loop.
@@ -876,15 +876,15 @@ class PipelineBase:
                 # instead to receive inputs from multiple senders.
                 #
                 # To keep track of all the inputs received internally we always store them in a list.
-                if receiver_socket.name not in inputs_by_component[receiver_name]:
+                if receiver_socket.name not in components_inputs[receiver_name]:
                     # Create the list if it doesn't exist
-                    inputs_by_component[receiver_name][receiver_socket.name] = []
+                    components_inputs[receiver_name][receiver_socket.name] = []
                 else:
                     # Check if the value is actually a list
-                    assert isinstance(inputs_by_component[receiver_name][receiver_socket.name], list)
-                inputs_by_component[receiver_name][receiver_socket.name].append(value)
+                    assert isinstance(components_inputs[receiver_name][receiver_socket.name], list)
+                components_inputs[receiver_name][receiver_socket.name].append(value)
             else:
-                inputs_by_component[receiver_name][receiver_socket.name] = value
+                components_inputs[receiver_name][receiver_socket.name] = value
 
             receiver = self.graph.nodes[receiver_name]["instance"]
             pair = (receiver_name, receiver)
@@ -893,37 +893,37 @@ class PipelineBase:
             if receiver_socket.is_variadic and is_greedy:
                 # If the receiver is greedy, we can run it as soon as possible.
                 # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
-                if pair in to_run:
-                    to_run.remove(pair)
-                if pair in waiting_for_input:
-                    waiting_for_input.remove(pair)
-                to_run.append(pair)
+                if pair in run_queue:
+                    run_queue.remove(pair)
+                if pair in waiting_queue:
+                    waiting_queue.remove(pair)
+                run_queue.append(pair)
 
-            if pair not in waiting_for_input and pair not in to_run:
+            if pair not in waiting_queue and pair not in run_queue:
                 # Queue up the Component that received this input to run, only if it's not already waiting
                 # for input or already ready to run.
-                to_run.append(pair)
+                run_queue.append(pair)
 
         # Returns the output without the keys that were distributed to other Components
         return {k: v for k, v in component_result.items() if k not in to_remove_from_component_result}
 
     def _find_next_runnable_component(
-        self, inputs_by_component: Dict[str, Dict[str, Any]], waiting_for_input: List[Tuple[str, Component]]
+        self, components_inputs: Dict[str, Dict[str, Any]], waiting_queue: List[Tuple[str, Component]]
     ) -> Tuple[str, Component]:
         """
         Finds the next Component that can be run and returns it.
 
-        :param inputs_by_component: The current state of the inputs divided by Component name
-        :param waiting_for_input: Queue of Components waiting for input
+        :param components_inputs: The current state of the inputs divided by Component name
+        :param waiting_queue: Queue of Components waiting for input
 
         :returns: The name and the instance of the next Component that can be run
         """
         all_lazy_variadic = True
         all_with_default_inputs = True
 
-        filtered_waiting_for_input = []
+        filtered_waiting_queue = []
 
-        for name, comp in waiting_for_input:
+        for name, comp in waiting_queue:
             if not _is_lazy_variadic(comp):
                 # Components with variadic inputs that are not greedy must be removed only if there's nothing else to
                 # run at this stage.
@@ -934,7 +934,7 @@ class PipelineBase:
                 # Components that have defaults for all their inputs must be treated the same identical way as we treat
                 # lazy variadic components. If there are only components with defaults we can run them.
                 # If we don't do this the order of execution of the Pipeline's Components will be affected cause we
-                # enqueue the Components in `to_run` at the start using the order they are added in the Pipeline.
+                # enqueue the Components in `run_queue` at the start using the order they are added in the Pipeline.
                 # If a Component A with defaults is added before a Component B that has no defaults, but in the Pipeline
                 # logic A must be executed after B. However, B could run before A if we don't do this check.
                 all_with_default_inputs = False
@@ -942,17 +942,17 @@ class PipelineBase:
             if not _is_lazy_variadic(comp) and not _has_all_inputs_with_defaults(comp):
                 # Keep track of the Components that are not lazy variadic and don't have all inputs with defaults.
                 # We'll handle these later if necessary.
-                filtered_waiting_for_input.append((name, comp))
+                filtered_waiting_queue.append((name, comp))
 
         # If all Components are lazy variadic or all Components have all inputs with defaults we can get one to run
         if all_lazy_variadic or all_with_default_inputs:
-            return waiting_for_input[0]
+            return waiting_queue[0]
 
-        for name, comp in filtered_waiting_for_input:
+        for name, comp in filtered_waiting_queue:
             # Find the first component that has all the inputs it needs to run
             has_enough_inputs = True
             for input_socket in comp.__haystack_input__._sockets_dict.values():  # type: ignore
-                if input_socket.name not in inputs_by_component.get(name, {}) and input_socket.is_mandatory:
+                if input_socket.name not in components_inputs.get(name, {}) and input_socket.is_mandatory:
                     has_enough_inputs = False
                     break
 
@@ -962,20 +962,20 @@ class PipelineBase:
         # If we reach this point it means that we found no Component that has enough inputs to run.
         # Ideally we should never reach this point, though we can't raise an exception either as
         # existing use cases rely on this behavior.
-        # So we return the last Component, that could be the last from waiting_for_input or filtered_waiting_for_input.
+        # So we return the last Component, that could be the last from waiting_queue or filtered_waiting_queue.
         return name, comp
 
     def _find_next_runnable_lazy_variadic_or_default_component(
-        self, waiting_for_input: List[Tuple[str, Component]]
+        self, waiting_queue: List[Tuple[str, Component]]
     ) -> Tuple[str, Component]:
         """
         Finds the next Component that can be run and has a lazy variadic input or all inputs with default values.
 
-        :param waiting_for_input: Queue of Components waiting for input
+        :param waiting_queue: Queue of Components waiting for input
 
         :returns: The name and the instance of the next Component that can be run
         """
-        for name, comp in waiting_for_input:
+        for name, comp in waiting_queue:
             is_lazy_variadic = _is_lazy_variadic(comp)
             has_only_defaults = _has_all_inputs_with_defaults(comp)
             if is_lazy_variadic or has_only_defaults:
@@ -1010,11 +1010,11 @@ class PipelineBase:
                 components.add((receiver, receiver_instance))
         return components
 
-    def _is_stuck_in_a_loop(self, waiting_for_input: List[Tuple[str, Component]]) -> bool:
+    def _is_stuck_in_a_loop(self, waiting_queue: List[Tuple[str, Component]]) -> bool:
         """
         Checks if the Pipeline is stuck in a loop.
 
-        :param waiting_for_input: Queue of Components waiting for input
+        :param waiting_queue: Queue of Components waiting for input
 
         :returns: True if the Pipeline is stuck in a loop, False otherwise
         """
@@ -1023,7 +1023,7 @@ class PipelineBase:
         # This is our last resort, if there's no lazy variadic or component with only default inputs
         # waiting for input we're stuck for real and we can't make any progress.
         component_found = False
-        for _, comp in waiting_for_input:
+        for _, comp in waiting_queue:
             if _is_lazy_variadic(comp) or _has_all_inputs_with_defaults(comp):
                 component_found = True
                 break
@@ -1037,7 +1037,7 @@ class PipelineBase:
         # it means it has been waiting for input for at least 2 iterations.
         # This will never run.
         # BAIL!
-        return len(waiting_for_input) == 1
+        return len(waiting_queue) == 1
 
     def _component_has_enough_inputs_to_run(self, name: str, inputs: Dict[str, Dict[str, Any]]) -> bool:
         """
@@ -1104,29 +1104,29 @@ def _has_all_inputs_with_defaults(c: Component) -> bool:
     )
 
 
-def _add_missing_input_defaults(name: str, comp: Component, inputs_by_component: Dict[str, Dict[str, Any]]):
+def _add_missing_input_defaults(name: str, comp: Component, components_inputs: Dict[str, Dict[str, Any]]):
     """
     Updates the inputs with the default values for the inputs that are missing
 
     :param name: Name of the Component
     :param comp: Instance of the Component
-    :param inputs_by_component: The current state of the inputs divided by Component name
+    :param components_inputs: The current state of the inputs divided by Component name
     """
-    if name not in inputs_by_component:
-        inputs_by_component[name] = {}
+    if name not in components_inputs:
+        components_inputs[name] = {}
 
     for input_socket in comp.__haystack_input__._sockets_dict.values():  # type: ignore
         if input_socket.is_mandatory:
             continue
 
-        if input_socket.name not in inputs_by_component[name]:
-            inputs_by_component[name][input_socket.name] = input_socket.default_value
+        if input_socket.name not in components_inputs[name]:
+            components_inputs[name][input_socket.name] = input_socket.default_value
 
 
 def _enqueue_component(
     component_pair: Tuple[str, Component],
-    to_run: List[Tuple[str, Component]],
-    waiting_for_input: List[Tuple[str, Component]],
+    run_queue: List[Tuple[str, Component]],
+    waiting_queue: List[Tuple[str, Component]],
 ):
     """
     Append a Component in the queue of Components to run if not already in it.
@@ -1134,30 +1134,30 @@ def _enqueue_component(
     Remove it from the waiting list if it's there.
 
     :param component_pair: Tuple of Component name and instance
-    :param to_run: Queue of Components to run
-    :param waiting_for_input: Queue of Components waiting for input
+    :param run_queue: Queue of Components to run
+    :param waiting_queue: Queue of Components waiting for input
     """
-    if component_pair in waiting_for_input:
-        waiting_for_input.remove(component_pair)
+    if component_pair in waiting_queue:
+        waiting_queue.remove(component_pair)
 
-    if component_pair not in to_run:
-        to_run.append(component_pair)
+    if component_pair not in run_queue:
+        run_queue.append(component_pair)
 
 
 def _dequeue_component(
     component_pair: Tuple[str, Component],
-    to_run: List[Tuple[str, Component]],
-    waiting_for_input: List[Tuple[str, Component]],
+    run_queue: List[Tuple[str, Component]],
+    waiting_queue: List[Tuple[str, Component]],
 ):
     """
     Removes a Component both from the queue of Components to run and the waiting list.
 
     :param component_pair: Tuple of Component name and instance
-    :param to_run: Queue of Components to run
-    :param waiting_for_input: Queue of Components waiting for input
+    :param run_queue: Queue of Components to run
+    :param waiting_queue: Queue of Components waiting for input
     """
-    if component_pair in waiting_for_input:
-        waiting_for_input.remove(component_pair)
+    if component_pair in waiting_queue:
+        waiting_queue.remove(component_pair)
 
-    if component_pair in to_run:
-        to_run.remove(component_pair)
+    if component_pair in run_queue:
+        run_queue.remove(component_pair)

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -179,8 +179,12 @@ class Pipeline(PipelineBase):
         # Stuck loops can happen when one or more components are waiting for input but
         # no other component is going to run.
         # This can happen when a whole branch of the graph is skipped for example.
-        # When we find that two consecutive iterations of the loop where the waiting_for_input list is the same,
+        # When we find that two consecutive iterations of the loop where the waiting_queue is the same,
         # we know we're stuck in a loop and we can't make any progress.
+        #
+        # They track the previous two states of the waiting_queue. So if waiting_queue would n,
+        # before_last_waiting_queue would be n-2 and last_waiting_queue would be n-1.
+        # When we run a component, we reset both.
         before_last_waiting_queue: Optional[Set[str]] = None
         last_waiting_queue: Optional[Set[str]] = None
 


### PR DESCRIPTION
### Related Issues

- Part of #7614

### Proposed Changes:

This only changes variables and functions names in Pipeline and its tests, logic has been left untouched.

Variables have been renamed like so:

* `to_run` -> `run_queue`
* `waiting_for_input` -> `waiting_queue`
* `before_last_waiting_for_input` -> `before_last_waiting_queue`
* `last_waiting_for_input` -> `last_waiting_queue`
* `last_inputs` -> `components_inputs`
* `inputs_by_component` -> `components_inputs`

Only one function has been renamed:
* `_init_to_run` -> `_init_run_queue`

### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
