### PR TITLE
refactor: refactor DocumentJoiner to follow enum pattern for join_mode parameter

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -6,9 +6,9 @@ import itertools
 from collections import defaultdict
 from enum import Enum
 from math import inf
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
-from haystack import Document, component, logging
+from haystack import Document, component, default_from_dict, default_to_dict, logging
 from haystack.core.component.types import Variadic
 
 logger = logging.getLogger(__name__)
@@ -231,3 +231,30 @@ class DocumentJoiner:
         output = self._concatenate(document_lists=document_lists)
 
         return output
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            join_mode=str(self.join_mode),
+            weights=self.weights,
+            top_k=self.top_k,
+            sort_by_score=self.sort_by_score,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentJoiner":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        :returns:
+            The deserialized component.
+        """
+        return default_from_dict(cls, data)

--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -4,13 +4,40 @@
 
 import itertools
 from collections import defaultdict
+from enum import Enum
 from math import inf
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from haystack import Document, component, logging
 from haystack.core.component.types import Variadic
 
 logger = logging.getLogger(__name__)
+
+
+class JoinMode(Enum):
+    """
+    Enum for join mode.
+    """
+
+    CONCATENATE = "concatenate"
+    MERGE = "merge"
+    RECIPROCAL_RANK_FUSION = "reciprocal_rank_fusion"
+    DISTRIBUTION_BASED_RANK_FUSION = "distribution_based_rank_fusion"
+
+    def __str__(self):
+        return self.value
+
+    @staticmethod
+    def from_str(string: str) -> "JoinMode":
+        """
+        Convert a string to a JoinMode enum.
+        """
+        enum_map = {e.value: e for e in JoinMode}
+        mode = enum_map.get(string)
+        if mode is None:
+            msg = f"Unknown join mode '{string}'. Supported modes in DocumentJoiner are: {list(enum_map.keys())}"
+            raise ValueError(msg)
+        return mode
 
 
 @component
@@ -45,7 +72,7 @@ class DocumentJoiner:
 
     def __init__(
         self,
-        join_mode: str = "concatenate",
+        join_mode: Union[str, JoinMode] = JoinMode.CONCATENATE,
         weights: Optional[List[float]] = None,
         top_k: Optional[int] = None,
         sort_by_score: bool = True,
@@ -68,8 +95,15 @@ class DocumentJoiner:
             If True sorts the Documents by score in descending order.
             If a Document has no score, it is handled as if its score is -infinity.
         """
-        if join_mode not in ["concatenate", "merge", "reciprocal_rank_fusion", "distribution_based_rank_fusion"]:
-            raise ValueError(f"DocumentJoiner component does not support '{join_mode}' join_mode.")
+        if isinstance(join_mode, str):
+            join_mode = JoinMode.from_str(join_mode)
+        join_mode_functions = {
+            JoinMode.CONCATENATE: self._concatenate,
+            JoinMode.MERGE: self._merge,
+            JoinMode.RECIPROCAL_RANK_FUSION: self._reciprocal_rank_fusion,
+            JoinMode.DISTRIBUTION_BASED_RANK_FUSION: self._distribution_based_rank_fusion,
+        }
+        self.join_mode_function = join_mode_functions[join_mode]
         self.join_mode = join_mode
         self.weights = [float(i) / sum(weights) for i in weights] if weights else None
         self.top_k = top_k
@@ -92,14 +126,7 @@ class DocumentJoiner:
         output_documents = []
 
         documents = list(documents)
-        if self.join_mode == "concatenate":
-            output_documents = self._concatenate(documents)
-        elif self.join_mode == "merge":
-            output_documents = self._merge(documents)
-        elif self.join_mode == "reciprocal_rank_fusion":
-            output_documents = self._reciprocal_rank_fusion(documents)
-        elif self.join_mode == "distribution_based_rank_fusion":
-            output_documents = self._distribution_based_rank_fusion(documents)
+        output_documents = self.join_mode_function(documents)
 
         if self.sort_by_score:
             output_documents = sorted(

--- a/releasenotes/notes/refactor-documentjoiner-992e662bee8ca219.yaml
+++ b/releasenotes/notes/refactor-documentjoiner-992e662bee8ca219.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Refactor DocumentJoiner to use enum pattern for the 'join_mode' parameter instead of bare string.

--- a/test/components/joiners/test_document_joiner.py
+++ b/test/components/joiners/test_document_joiner.py
@@ -25,6 +25,41 @@ class TestDocumentJoiner:
         assert joiner.top_k == 5
         assert not joiner.sort_by_score
 
+    def test_to_dict(self):
+        joiner = DocumentJoiner()
+        data = joiner.to_dict()
+        assert data == {
+            "type": "haystack.components.joiners.document_joiner.DocumentJoiner",
+            "init_parameters": {"join_mode": "concatenate", "sort_by_score": True, "top_k": None, "weights": None},
+        }
+
+    def test_to_dict_custom_parameters(self):
+        joiner = DocumentJoiner("merge", weights=[0.4, 0.6], top_k=4, sort_by_score=False)
+        data = joiner.to_dict()
+        assert data == {
+            "type": "haystack.components.joiners.document_joiner.DocumentJoiner",
+            "init_parameters": {"join_mode": "merge", "weights": [0.4, 0.6], "top_k": 4, "sort_by_score": False},
+        }
+
+    def test_from_dict(self):
+        data = {"type": "haystack.components.joiners.document_joiner.DocumentJoiner", "init_parameters": {}}
+        document_joiner = DocumentJoiner.from_dict(data)
+        assert document_joiner.join_mode == JoinMode.CONCATENATE
+        assert document_joiner.weights == None
+        assert document_joiner.top_k == None
+        assert document_joiner.sort_by_score
+
+    def test_from_dict_customs_parameters(self):
+        data = {
+            "type": "haystack.components.joiners.document_joiner.DocumentJoiner",
+            "init_parameters": {"join_mode": "merge", "weights": [0.5, 0.6], "top_k": 6, "sort_by_score": False},
+        }
+        document_joiner = DocumentJoiner.from_dict(data)
+        assert document_joiner.join_mode == JoinMode.MERGE
+        assert document_joiner.weights == pytest.approx([0.5, 0.6], rel=0.1)
+        assert document_joiner.top_k == 6
+        assert not document_joiner.sort_by_score
+
     def test_empty_list(self):
         joiner = DocumentJoiner()
         result = joiner.run([])


### PR DESCRIPTION
### Related Issues

- fixes #7922 

### Proposed Changes:
- Refactored `DocumentJoiner` to use enum pattern for its `join_mode` parameter instead of bare string.

### How did you test it?
- Unit tests
- Also tested using the below code
```python
from haystack import Document
from haystack.components.joiners.document_joiner import DocumentJoiner

docs_1 = [
    Document(content="Paris is the capital of France.", score=0.5),
    Document(content="Berlin is the capital of Germany.", score=0.4),
]
docs_2 = [
    Document(content="Paris is the capital of France.", score=0.6),
    Document(content="Rome is the capital of Italy.", score=0.5),
]

joiner = DocumentJoiner(join_mode="merge")

print(joiner.run(documents=[docs_1, docs_2]))
```

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
