### PR TITLE
chore: normalise the use of `importlib` in getting an object from a qualified name string across the codebase

### DIFF
--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
 from typing import Any, Dict, List
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -78,28 +78,11 @@ class CacheChecker:
         if "type" not in init_params["document_store"]:
             raise DeserializationError("Missing 'type' in document store's serialization data")
 
-        """
-        try:
-            module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
-            logger.debug("Trying to import module '{module_name}'", module_name=module_name)
-            module = importlib.import_module(module_name)
-        except (ImportError, DeserializationError) as e:
-            raise DeserializationError(
-                f"DocumentStore of type '{init_params['document_store']['type']}' not correctly imported"
-            ) from e
-
-        docstore_class = getattr(module, type_)
-        docstore = docstore_class.from_dict(init_params["document_store"])
-        data["init_parameters"]["document_store"] = docstore
-        """
-
-        # deserialize the document store
         doc_store_data = data["init_parameters"]["document_store"]
         try:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-
         data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
 
         return default_from_dict(cls, data)

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -6,6 +6,7 @@ import importlib
 from typing import Any, Dict, List
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging
+from haystack.core.serialization import import_class_by_name
 from haystack.document_stores.types import DocumentStore
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,7 @@ class CacheChecker:
         if "type" not in init_params["document_store"]:
             raise DeserializationError("Missing 'type' in document store's serialization data")
 
+        """
         try:
             module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
             logger.debug("Trying to import module '{module_name}'", module_name=module_name)
@@ -88,8 +90,18 @@ class CacheChecker:
 
         docstore_class = getattr(module, type_)
         docstore = docstore_class.from_dict(init_params["document_store"])
-
         data["init_parameters"]["document_store"] = docstore
+        """
+
+        # deserialize the document store
+        doc_store_data = data["init_parameters"]["document_store"]
+        try:
+            doc_store_class = import_class_by_name(doc_store_data["type"])
+        except ImportError as e:
+            raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
+
+        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+
         return default_from_dict(cls, data)
 
     @component.output_types(hits=List[Document], misses=List)

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -83,27 +83,11 @@ class FilterRetriever:
         if "type" not in init_params["document_store"]:
             raise DeserializationError("Missing 'type' in document store's serialization data")
 
-        """""
-        try:
-            module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
-            logger.debug("Trying to import module '{module_name}'", module_name=module_name)
-            module = importlib.import_module(module_name)
-        except (ImportError, DeserializationError) as e:
-            raise DeserializationError(
-                f"DocumentStore of type '{init_params['document_store']['type']}' not correctly imported"
-            ) from e
-
-        docstore_class = getattr(module, type_)
-        data["init_parameters"]["document_store"] = docstore_class.from_dict(data["init_parameters"]["document_store"])
-        """
-
-        # deserialize the document store
         doc_store_data = data["init_parameters"]["document_store"]
         try:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-
         data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
 
         return default_from_dict(cls, data)

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
 from typing import Any, Dict, List, Optional
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -80,30 +80,14 @@ class DocumentWriter:
         if "type" not in init_params["document_store"]:
             raise DeserializationError("Missing 'type' in document store's serialization data")
 
-        """
-        try:
-            module_name, type_ = init_params["document_store"]["type"].rsplit(".", 1)
-            logger.debug("Trying to import module '{module_name}'", module_name=module_name)
-            module = importlib.import_module(module_name)
-        except (ImportError, DeserializationError) as e:
-            raise DeserializationError(
-                f"DocumentStore of type '{init_params['document_store']['type']}' not correctly imported"
-            ) from e
-
-        docstore_class = getattr(module, type_)
-        docstore = docstore_class.from_dict(init_params["document_store"])
-                data["init_parameters"]["document_store"] = docstore
-        """
-
-        # deserialize the document store
         doc_store_data = data["init_parameters"]["document_store"]
         try:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-
         data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
         data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
+
         return default_from_dict(cls, data)
 
     @component.output_types(documents_written=int)

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
 from typing import Any, Dict, List, Optional
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging


### PR DESCRIPTION
### Related Issues

- fixes #8011

### Proposed Changes:

- reuse a utility function to import a generic DocumentStore (or any other component) based on it's fully qualified name

### How did you test it?

- unit test
- integration tests
- end2end tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
