### PR TITLE
fix: handle removed `converter_name` parameter in `PyPDFToDocument`

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -106,7 +106,9 @@ class PyPDFToDocument:
         :returns:
             Deserialized component.
         """
-
+        # Old versions of this component used to have a `converter_name` parameter. To ensure backwards compatibility,
+        # we remove it.
+        data["init_parameters"].pop("converter_name", None)
         if converter := data["init_parameters"].get("converter"):
             converter_class = deserialize_type(converter["type"])
             data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -46,6 +46,15 @@ class TestPyPDFToDocument:
         assert isinstance(instance, PyPDFToDocument)
         assert isinstance(instance.converter, DefaultConverter)
 
+    def test_from_dict_with_converter_name(self):
+        data = {
+            "type": "haystack.components.converters.pypdf.PyPDFToDocument",
+            "init_parameters": {"converter_name": "DefaultConverter"},
+        }
+        instance = PyPDFToDocument.from_dict(data)
+        assert isinstance(instance, PyPDFToDocument)
+        assert isinstance(instance.converter, DefaultConverter)
+
     @pytest.mark.integration
     def test_run(self, test_files_path, pypdf_converter):
         """


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- handle removed parameter

### How did you test it?

- add unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
