### PR TITLE
Add functions to easily update `waiting_queue`

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1161,3 +1161,25 @@ def _dequeue_component(
 
     if component_pair in run_queue:
         run_queue.remove(component_pair)
+
+
+def _enqueue_waiting_component(component_pair: Tuple[str, Component], waiting_queue: List[Tuple[str, Component]]):
+    """
+    Append a Component in the queue of Components that are waiting for inputs if not already in it.
+
+    :param component_pair: Tuple of Component name and instance
+    :param waiting_queue: Queue of Components waiting for input
+    """
+    if component_pair not in waiting_queue:
+        waiting_queue.append(component_pair)
+
+
+def _dequeue_waiting_component(component_pair: Tuple[str, Component], waiting_queue: List[Tuple[str, Component]]):
+    """
+    Removes a Component from the queue of Components that are waiting for inputs.
+
+    :param component_pair: Tuple of Component name and instance
+    :param waiting_queue: Queue of Components waiting for input
+    """
+    if component_pair in waiting_queue:
+        waiting_queue.remove(component_pair)


### PR DESCRIPTION
### Related Issues

- Part of #7614

### Proposed Changes:

Add `_enqueue_waiting_component` and `_dequeue_waiting_component` functions to easily update `waiting_queue`.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

Depends on #8009

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
