### PR TITLE
Fix bug in Pipeline.run() executing Components in a wrong and unexpected order

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -767,6 +767,15 @@ class PipelineBase:
 
     def _init_run_queue(self, pipeline_inputs: Dict[str, Any]) -> List[Tuple[str, Component]]:
         run_queue: List[Tuple[str, Component]] = []
+
+        if networkx.is_directed_acyclic_graph(self.graph):
+            # If the Pipeline is linear we can easily determine the order of execution with
+            # a topological sort.
+            # So use that to get the run order.
+            for node in networkx.topological_sort(self.graph):
+                run_queue.append((node, self.graph.nodes[node]["instance"]))
+            return run_queue
+
         for node_name in self.graph.nodes:
             component = self.graph.nodes[node_name]["instance"]
 

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -768,9 +768,9 @@ class PipelineBase:
     def _init_run_queue(self, pipeline_inputs: Dict[str, Any]) -> List[Tuple[str, Component]]:
         run_queue: List[Tuple[str, Component]] = []
 
-		# HACK: Quick workaround for the issue of execution order not being
-		# well-defined (NB - https://github.com/deepset-ai/haystack/issues/7985).
-		# We should fix the original execution logic instead.
+        # HACK: Quick workaround for the issue of execution order not being
+        # well-defined (NB - https://github.com/deepset-ai/haystack/issues/7985).
+        # We should fix the original execution logic instead.
         if networkx.is_directed_acyclic_graph(self.graph):
             # If the Pipeline is linear we can easily determine the order of execution with
             # a topological sort.

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -768,6 +768,9 @@ class PipelineBase:
     def _init_run_queue(self, pipeline_inputs: Dict[str, Any]) -> List[Tuple[str, Component]]:
         run_queue: List[Tuple[str, Component]] = []
 
+		# HACK: Quick workaround for the issue of execution order not being
+		# well-defined (NB - https://github.com/deepset-ai/haystack/issues/7985).
+		# We should fix the original execution logic instead.
         if networkx.is_directed_acyclic_graph(self.graph):
             # If the Pipeline is linear we can easily determine the order of execution with
             # a topological sort.

--- a/releasenotes/notes/fix-execution-order-1121cedd9c68c560.yaml
+++ b/releasenotes/notes/fix-execution-order-1121cedd9c68c560.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix bug in Pipeline.run() executing Components in a wrong and unexpected order

--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -37,6 +37,7 @@ Feature: Pipeline running
         | that has a component with default inputs that doesn't receive anything from its sender |
         | that has a component with default inputs that doesn't receive anything from its sender but receives input from user |
         | that has a loop and a component with default inputs that doesn't receive anything from its sender but receives input from user |
+        | that has multiple components with only default inputs and are added in a different order from the order of execution |
 
     Scenario Outline: Running a bad Pipeline
         Given a pipeline <kind>

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -801,12 +801,13 @@ class TestPipeline:
 
         data = {"yet_another_with_single_input": {"in": 1}}
         run_queue = pipe._init_run_queue(data)
-        assert len(run_queue) == 5
-        assert run_queue[0][0] == "with_variadic"
-        assert run_queue[1][0] == "with_no_inputs"
-        assert run_queue[2][0] == "with_single_input"
-        assert run_queue[3][0] == "yet_another_with_single_input"
+        assert len(run_queue) == 6
+        assert run_queue[0][0] == "with_no_inputs"
+        assert run_queue[1][0] == "with_single_input"
+        assert run_queue[2][0] == "yet_another_with_single_input"
+        assert run_queue[3][0] == "another_with_single_input"
         assert run_queue[4][0] == "with_multiple_inputs"
+        assert run_queue[5][0] == "with_variadic"
 
     def test__init_inputs_state(self):
         pipe = Pipeline()


### PR DESCRIPTION
### Related Issues

- fixes #7985

### Proposed Changes:

Change the `_init_run_queue` method to check if the `Pipeline` graph is a directed and acyclic.

If it is it returns a `run_queue` that is the list of Component in the `Pipeline` graph sorted topologically. This makes the Components run in the expected order.

This fixes execution order only for `Pipeline`s that are acyclic as we can't sort nodes topologically if there are cycles.

### How did you test it?

I added a new test with the Pipeline that caused the bug as reported in the original issue.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
