### PR TITLE
fix: Prevent `Pipeline.from_dict` from modifying the dictionary parameter passed to it

### DIFF
--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -84,7 +84,6 @@ class DocumentWriter:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-
         data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
         data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
 

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging
@@ -86,11 +85,10 @@ class DocumentWriter:
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
 
-        data_copy = deepcopy(data)
-        data_copy["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
-        data_copy["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
+        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+        data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
 
-        return default_from_dict(cls, data_copy)
+        return default_from_dict(cls, data)
 
     @component.output_types(documents_written=int)
     def run(self, documents: List[Document], policy: Optional[DuplicatePolicy] = None):

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging
@@ -84,10 +85,12 @@ class DocumentWriter:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
-        data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
 
-        return default_from_dict(cls, data)
+        data_copy = deepcopy(data)
+        data_copy["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+        data_copy["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
+
+        return default_from_dict(cls, data_copy)
 
     @component.output_types(documents_written=int)
     def run(self, documents: List[Document], policy: Optional[DuplicatePolicy] = None):

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -150,12 +150,13 @@ class PipelineBase:
         :returns:
             Deserialized component.
         """
-        metadata = data.get("metadata", {})
-        max_loops_allowed = data.get("max_loops_allowed", 100)
-        debug_path = Path(data.get("debug_path", ".haystack_debug/"))
+        data_copy = deepcopy(data)  # to prevent modification of original data
+        metadata = data_copy.get("metadata", {})
+        max_loops_allowed = data_copy.get("max_loops_allowed", 100)
+        debug_path = Path(data_copy.get("debug_path", ".haystack_debug/"))
         pipe = cls(metadata=metadata, max_loops_allowed=max_loops_allowed, debug_path=debug_path)
         components_to_reuse = kwargs.get("components", {})
-        for name, component_data in data.get("components", {}).items():
+        for name, component_data in data_copy.get("components", {}).items():
             if name in components_to_reuse:
                 # Reuse an instance
                 instance = components_to_reuse[name]

--- a/releasenotes/notes/fix-pipeline-deserialization-a3909bb6b623c588.yaml
+++ b/releasenotes/notes/fix-pipeline-deserialization-a3909bb6b623c588.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    fixes deseriliaztion of components in pipelines so that the original payload is not modified.
+    Prevent `Pipeline.from_dict` from modifying the dictionary parameter passed to it.

--- a/releasenotes/notes/fix-pipeline-deserialization-a3909bb6b623c588.yaml
+++ b/releasenotes/notes/fix-pipeline-deserialization-a3909bb6b623c588.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    fixes deseriliaztion of components in pipelines so that the original payload is not modified.


### PR DESCRIPTION
### Related Issues

- fixes #7961 

### Proposed Changes:

The `from_dict` method of some components modifies the original payload during deserialization. Update these to prevent this behaviour.

### How did you test it?
- Ran the unit tests
- Manually verification with example in issue

### Notes for the reviewer
N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
