### PR TITLE
chore: Pin structlog to 24.2.0 due to unit test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extra-dependencies = [
   "ddtrace",
 
   # Structured logging
-  "structlog",
+  "structlog==24.2.0",
 
   # Looking for missing imports
   "isort",


### PR DESCRIPTION
- The title says it all. Let's unblock PR train to main
- We'll fix structlog==24.4.0 failing `TestStructuredLoggingJSONRendering` unit tests when time permitting 