### PR TITLE
chore: Remove object init parameter in huggingface_hub based tests

### DIFF
--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -44,7 +44,6 @@ def mock_chat_completion():
             ],
             id="some_id",
             model="some_model",
-            object="some_object",
             system_fingerprint="some_fingerprint",
             usage={"completion_tokens": 10, "prompt_tokens": 5, "total_tokens": 15},
             created=1710498360,
@@ -215,7 +214,6 @@ class TestHuggingFaceAPIGenerator:
                 ],
                 id="some_id",
                 model="some_model",
-                object="some_object",
                 system_fingerprint="some_fingerprint",
                 created=1710498504,
             )
@@ -228,7 +226,6 @@ class TestHuggingFaceAPIGenerator:
                 ],
                 id="some_id",
                 model="some_model",
-                object="some_object",
                 system_fingerprint="some_fingerprint",
                 created=1710498504,
             )


### PR DESCRIPTION
- huggingface-hub==0.24.0 release broke some of our huggingface_hub dependent unit tests in `TestHuggingFaceAPIGenerator`