### PR TITLE
chore: Remove deprecated init paramters from `HTMLToDocument`

### DIFF
--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -34,34 +33,15 @@ class HTMLToDocument:
     ```
     """
 
-    def __init__(
-        self,
-        extractor_type: Optional[str] = None,
-        try_others: Optional[bool] = None,
-        extraction_kwargs: Optional[Dict[str, Any]] = None,
-    ):
+    def __init__(self, extraction_kwargs: Optional[Dict[str, Any]] = None):
         """
         Create an HTMLToDocument component.
 
-        :param extractor_type: Ignored. This parameter is kept for compatibility with previous versions. It will be
-            removed in Haystack 2.4.0. To customize the extraction, use the `extraction_kwargs` parameter.
-        :param try_others: Ignored. This parameter is kept for compatibility with previous versions. It will be
-            removed in Haystack 2.4.0.
         :param extraction_kwargs: A dictionary containing keyword arguments to customize the extraction process. These
             are passed to the underlying Trafilatura `extract` function. For the full list of available arguments, see
             the [Trafilatura documentation](https://trafilatura.readthedocs.io/en/latest/corefunctions.html#extract).
         """
         trafilatura_import.check()
-        if extractor_type is not None:
-            warnings.warn(
-                "The `extractor_type` parameter is ignored and will be removed in Haystack 2.4.0. "
-                "To customize the extraction, use the `extraction_kwargs` parameter.",
-                DeprecationWarning,
-            )
-        if try_others is not None:
-            warnings.warn(
-                "The `try_others` parameter is ignored and will be removed in Haystack 2.4.0. ", DeprecationWarning
-            )
 
         self.extraction_kwargs = extraction_kwargs or {}
 

--- a/releasenotes/notes/remove-htmltodocument-deprecated-init-params-2f81cf6a3b13710d.yaml
+++ b/releasenotes/notes/remove-htmltodocument-deprecated-init-params-2f81cf6a3b13710d.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Removed deprecated init parameters `extractor_type` and `try_again` from `HTMLToDocument`.

--- a/releasenotes/notes/remove-htmltodocument-deprecated-init-params-2f81cf6a3b13710d.yaml
+++ b/releasenotes/notes/remove-htmltodocument-deprecated-init-params-2f81cf6a3b13710d.yaml
@@ -1,4 +1,4 @@
 ---
-deprecations:
+upgrade:
   - |
-    Removed deprecated init parameters `extractor_type` and `try_again` from `HTMLToDocument`.
+    Removed deprecated init parameters `extractor_type` and `try_others` from `HTMLToDocument`.


### PR DESCRIPTION
### Related Issues

- fixes #7710 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Removes deprecated init paramters from `HTMLToDocument`. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
