### PR TITLE
build: unpin structlog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extra-dependencies = [
   "ddtrace",
 
   # Structured logging
-  "structlog<=24.2.0",
+  "structlog",
 
   # Looking for missing imports
   "isort",

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -319,15 +319,11 @@ class TestStructuredLoggingJSONRendering:
                             "filename": str(Path.cwd() / "test" / "test_logging.py"),
                             "lineno": ANY,  # otherwise the test breaks if you add a line :-)
                             "name": "test_logging_exceptions_json",
-                            "line": "",
-                            "locals": None,
                         },
                         {
                             "filename": str(Path.cwd() / "test" / "test_logging.py"),
                             "lineno": ANY,  # otherwise the test breaks if you add a line :-)
                             "name": "function_that_raises_and_adds_to_stack_trace",
-                            "line": "",
-                            "locals": None,
                         },
                     ],
                 }


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- unpin structlog
- adapted the tests so that they pass (nothing critical was changed, seems structlog is now only omitted empty values correctly)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
