### PR TITLE
chore: Deprecate the `debug` parameter in `Pipeline.run`

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -48,14 +48,14 @@ class Pipeline(PipelineBase):
                 "haystack.component.input_types": {k: type(v).__name__ for k, v in inputs.items()},
                 "haystack.component.input_spec": {
                     key: {
-                        "type": value.type.__name__ if isinstance(value.type, type) else str(value.type),
+                        "type": (value.type.__name__ if isinstance(value.type, type) else str(value.type)),
                         "senders": value.senders,
                     }
                     for key, value in instance.__haystack_input__._sockets_dict.items()  # type: ignore
                 },
                 "haystack.component.output_spec": {
                     key: {
-                        "type": value.type.__name__ if isinstance(value.type, type) else str(value.type),
+                        "type": (value.type.__name__ if isinstance(value.type, type) else str(value.type)),
                         "receivers": value.receivers,
                     }
                     for key, value in instance.__haystack_output__._sockets_dict.items()  # type: ignore
@@ -155,6 +155,8 @@ class Pipeline(PipelineBase):
         The pipeline resolves inputs to the correct components, returning
         {'hello2': {'output': 'Hello, Hello, world!!'}}.
         """
+        warn("The 'debug' parameter is deprecated and will be removed in Haystack 2.5.0.", DeprecationWarning)
+
         pipeline_running(self)
 
         # Reset the visits count for each component

--- a/releasenotes/notes/deprecate-pipeline-run-debug-param-e69190338a8e041b.yaml
+++ b/releasenotes/notes/deprecate-pipeline-run-debug-param-e69190338a8e041b.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Deprecate the unused `debug` parameter in the `Pipeline.run` method.


### PR DESCRIPTION
### Related Issues

- fixes #8015

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
It's a vestigial/unused parameter in 2.x.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
