### PR TITLE
fix: DocumentCleaner: keep the \f in text

### DIFF
--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -114,12 +114,8 @@ class DocumentCleaner:
         :returns: The text without empty lines.
         """
         pages = text.split("\f")
-        lines_per_page = [page.split("\n") for page in pages]
-        non_empty_lines = []
-        for lines in lines_per_page:
-            non_empty_lines.append(filter(lambda line: line.strip() != "", lines))
-        lines_without_empty_lines = ["\n".join(lines) for lines in non_empty_lines]
-        return "\f".join(lines_without_empty_lines)
+        cleaned_pages = ["\n".join(line for line in page.split("\n") if line.strip()) for page in pages]
+        return "\f".join(cleaned_pages)
 
     def _remove_extra_whitespaces(self, text: str) -> str:
         """

--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -113,9 +113,13 @@ class DocumentCleaner:
         :param text: Text to clean.
         :returns: The text without empty lines.
         """
-        lines = text.split("\n")
-        non_empty_lines = filter(lambda line: line.strip() != "", lines)
-        return "\n".join(non_empty_lines)
+        pages = text.split("\f")
+        lines_per_page = [page.split("\n") for page in pages]
+        non_empty_lines = []
+        for lines in lines_per_page:
+            non_empty_lines.append(filter(lambda line: line.strip() != "", lines))
+        lines_without_empty_lines = ["\n".join(lines) for lines in non_empty_lines]
+        return "\f".join(lines_without_empty_lines)
 
     def _remove_extra_whitespaces(self, text: str) -> str:
         """
@@ -124,7 +128,9 @@ class DocumentCleaner:
         :param text: Text to clean.
         :returns: The text without extra whitespaces.
         """
-        return re.sub(r"\s\s+", " ", text).strip()
+        texts = text.split("\f")
+        cleaned_text = [re.sub(r"\s\s+", " ", text).strip() for text in texts]
+        return "\f".join(cleaned_text)
 
     def _remove_regex(self, text: str, regex: str) -> str:
         """
@@ -134,7 +140,9 @@ class DocumentCleaner:
         :param regex: Regex to match and replace substrings by "".
         :returns: The text without the substrings that match the regex.
         """
-        return re.sub(regex, "", text).strip()
+        texts = text.split("\f")
+        cleaned_text = [re.sub(regex, "", text).strip() for text in texts]
+        return "\f".join(cleaned_text)
 
     def _remove_substrings(self, text: str, substrings: List[str]) -> str:
         """

--- a/releasenotes/notes/fix-document-cleaner-page-tag-15c66d6433b82b0a.yaml
+++ b/releasenotes/notes/fix-document-cleaner-page-tag-15c66d6433b82b0a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the DocumentCleaner removing the `\f` tag from content preventing from counting page number (by Splitter for example).

--- a/test/components/preprocessors/test_document_cleaner.py
+++ b/test/components/preprocessors/test_document_cleaner.py
@@ -40,7 +40,7 @@ class TestDocumentCleaner:
         result = cleaner.run(
             documents=[
                 Document(
-                    content="This is a text with some words. "
+                    content="This is a text with some words. \f"
                     ""
                     "There is a second sentence. "
                     ""
@@ -51,7 +51,7 @@ class TestDocumentCleaner:
         assert len(result["documents"]) == 1
         assert (
             result["documents"][0].content
-            == "This is a text with some words. There is a second sentence. And there is a third sentence."
+            == "This is a text with some words. \fThere is a second sentence. And there is a third sentence."
         )
 
     def test_remove_whitespaces(self):
@@ -63,33 +63,33 @@ class TestDocumentCleaner:
                     ""
                     "There is a second sentence.  "
                     ""
-                    "And there  is a third sentence. "
+                    "And there  is a third sentence.\f "
                 )
             ]
         )
         assert len(result["documents"]) == 1
         assert result["documents"][0].content == (
-            "This is a text with some words. " "" "There is a second sentence. " "" "And there is a third sentence."
+            "This is a text with some words. " "" "There is a second sentence. " "" "And there is a third sentence.\f"
         )
 
     def test_remove_substrings(self):
         cleaner = DocumentCleaner(remove_substrings=["This", "A", "words", "🪲"])
-        result = cleaner.run(documents=[Document(content="This is a text with some words.🪲")])
+        result = cleaner.run(documents=[Document(content="This is a text with some words.\f🪲")])
         assert len(result["documents"]) == 1
-        assert result["documents"][0].content == " is a text with some ."
+        assert result["documents"][0].content == " is a text with some .\f"
 
     def test_remove_regex(self):
         cleaner = DocumentCleaner(remove_regex=r"\s\s+")
-        result = cleaner.run(documents=[Document(content="This is a  text with   some words.")])
+        result = cleaner.run(documents=[Document(content="This is a  text \f with   some words.")])
         assert len(result["documents"]) == 1
-        assert result["documents"][0].content == "This is a text with some words."
+        assert result["documents"][0].content == "This is a text\fwith some words."
 
     def test_remove_repeated_substrings(self):
         cleaner = DocumentCleaner(
             remove_empty_lines=False, remove_extra_whitespaces=False, remove_repeated_substrings=True
         )
 
-        text = """First PageThis is a header.
+        text = """First Page\fThis is a header.
         Page  of
         2
         4
@@ -109,7 +109,7 @@ class TestDocumentCleaner:
         This is a footer number 1
         This is footer number 2"""
 
-        expected_text = """First Page 2
+        expected_text = """First Page\f 2
         4
         Lorem ipsum dolor sit amet 3
         4


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8053

### Proposed Changes:

Split on "\f" before performing cleaning and join in the end.

### How did you test it?

End to end testing using it as a custom component in my pipeline. "\f" are not removed anymore and page number detection from Splitter is correct.

### Notes for the reviewer

Could be optimized probably.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
