### PR TITLE
fix: Fix issue that could lead to RCE if using unsecure Jinja templates in dynamic prompt builders

### DIFF
--- a/haystack/components/builders/dynamic_chat_prompt_builder.py
+++ b/haystack/components/builders/dynamic_chat_prompt_builder.py
@@ -5,7 +5,8 @@
 import warnings
 from typing import Any, Dict, List, Optional, Set
 
-from jinja2 import Template, meta
+from jinja2 import meta
+from jinja2.sandbox import SandboxedEnvironment
 
 from haystack import component, logging
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole
@@ -177,8 +178,8 @@ class DynamicChatPromptBuilder:
         :raises ValueError:
             If all the required template variables are not provided.
         """
-        template = Template(template_text)
-        ast = template.environment.parse(template_text)
+        env = SandboxedEnvironment()
+        ast = env.parse(template_text)
         required_template_variables = meta.find_undeclared_variables(ast)
         filled_template_vars = required_template_variables.intersection(provided_variables)
         if len(filled_template_vars) != len(required_template_variables):
@@ -187,4 +188,4 @@ class DynamicChatPromptBuilder:
                 f"Required variables: {required_template_variables}. Only the following variables were "
                 f"provided: {provided_variables}. Please provide all the required template variables."
             )
-        return template
+        return env.from_string(template_text)

--- a/haystack/components/builders/dynamic_prompt_builder.py
+++ b/haystack/components/builders/dynamic_prompt_builder.py
@@ -5,7 +5,8 @@
 import warnings
 from typing import Any, Dict, List, Optional, Set
 
-from jinja2 import Template, meta
+from jinja2 import meta
+from jinja2.sandbox import SandboxedEnvironment
 
 from haystack import component, logging
 
@@ -156,8 +157,8 @@ class DynamicPromptBuilder:
         :raises ValueError:
             If all the required template variables are not provided.
         """
-        template = Template(template_text)
-        ast = template.environment.parse(template_text)
+        env = SandboxedEnvironment()
+        ast = env.parse(template_text)
         required_template_variables = meta.find_undeclared_variables(ast)
         filled_template_vars = required_template_variables.intersection(provided_variables)
         if len(filled_template_vars) != len(required_template_variables):
@@ -166,4 +167,4 @@ class DynamicPromptBuilder:
                 f"Required variables: {required_template_variables}. Only the following variables were "
                 f"provided: {provided_variables}. Please provide all the required template variables."
             )
-        return template
+        return env.from_string(template_text)

--- a/releasenotes/notes/fix-jinja-env-81c98225b22dc827.yaml
+++ b/releasenotes/notes/fix-jinja-env-81c98225b22dc827.yaml
@@ -8,6 +8,8 @@ security:
 
     - `PromptBuilder`
     - `ChatPromptBuilder`
+    - `DynamicPromptBuilder`
+    - `DynamicChatPromptBuilder`
     - `OutputAdapter`
     - `ConditionalRouter`
 


### PR DESCRIPTION
### Proposed Changes:

Brings fix from #8095 in for dynamic prompt builders.

### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
