### PR TITLE
docs: clean up docstrings of FileTypeRouter

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -19,13 +19,9 @@ class FileTypeRouter:
     """
     Categorizes files or byte streams by their MIME types, helping in context-based routing.
 
-    FileTypeRouter sorts data sources (file paths or byte streams) by MIME types.
-    This helps route files based on their content type.
     FileTypeRouter supports both exact MIME type matching and regex patterns.
 
     For file paths, MIME types come from extensions, while byte streams use metadata.
-    This helps classify files and data streams for specific tasks.
-
     You can use regex patterns in the `mime_types` parameter to set broad categories
     (such as 'audio/*' or 'text/*') or specific types.
     MIME types without regex patterns are treated as exact matches.

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -17,21 +17,21 @@ logger = logging.getLogger(__name__)
 @component
 class FileTypeRouter:
     """
-    Groups a list of data sources by their MIME types.
+    Categorizes files or byte streams according to their MIME types.
 
-    FileTypeRouter groups a list of data sources (file paths or byte streams) by their MIME types, allowing
-    for flexible routing of files to different components based on their content type. It supports both exact MIME type
-    matching and pattern matching using regular expressions.
+    FileTypeRouter sorts data sources (file paths or byte streams) by MIME types.
+    This helps route files based on their content type.
+    FileTypeRouter supports both exact MIME type matching and pattern matching using regular expressions (regex).
 
-    For file paths, MIME types are inferred from their extensions, while for byte streams, MIME types are determined
-    from the provided metadata. This enables the router to classify a diverse collection of files and data streams for
-    specialized processing.
+    For file paths, MIME types come from extensions. For byte streams, they come from metadata.
+    This helps classify files and data streams for specific tasks.
 
-    The router's flexibility is enhanced by the support for regex patterns in the `mime_types` parameter, allowing users
-    to specify broad categories (e.g., 'audio/*' or 'text/*') or more specific types with regex patterns. This feature
-    is designed to be backward compatible, treating MIME types without regex patterns as exact matches.
+    FileTypeRouter supports regex patterns in the `mime_types` parameter. You can set broad categories
+    (such as 'audio/*' or 'text/*') or more specific types.
+    MIME types without regex patterns are treated as exact matches.
 
-    Usage example:
+    ### Usage example
+
     ```python
     from haystack.components.routers import FileTypeRouter
     from pathlib import Path
@@ -55,15 +55,15 @@ class FileTypeRouter:
     # ]}
     ```
 
-    :param mime_types: A list of MIME types or regex patterns to classify the incoming files or data streams.
+    :param mime_types: A list of MIME types or regex patterns to classify the input files or byte streams.
     """
 
     def __init__(self, mime_types: List[str]):
         """
         Initialize the FileTypeRouter component.
 
-        :param mime_types: A list of file mime types to consider when routing files
-            (e.g. `["text/plain", "audio/x-wav", "image/jpeg"]`).
+        :param mime_types: A list of MIME types or regex patterns to classify the input files or byte streams.
+            (for example: `["text/plain", "audio/x-wav", "image/jpeg"]`).
         """
         if not mime_types:
             raise ValueError("The list of mime types cannot be empty.")
@@ -80,7 +80,7 @@ class FileTypeRouter:
 
     def run(self, sources: List[Union[str, Path, ByteStream]]) -> Dict[str, List[Union[ByteStream, Path]]]:
         """
-        Categorizes the provided data sources by their MIME types.
+        Categorize files or byte streams according to their MIME types.
 
         :param sources: A list of file paths or byte streams to categorize.
 

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -17,17 +17,17 @@ logger = logging.getLogger(__name__)
 @component
 class FileTypeRouter:
     """
-    Categorizes files or byte streams according to their MIME types.
+    Categorizes files or byte streams by their MIME types, helping in context-based routing.
 
     FileTypeRouter sorts data sources (file paths or byte streams) by MIME types.
     This helps route files based on their content type.
-    FileTypeRouter supports both exact MIME type matching and pattern matching using regular expressions (regex).
+    FileTypeRouter supports both exact MIME type matching and regex patterns.
 
-    For file paths, MIME types come from extensions. For byte streams, they come from metadata.
+    For file paths, MIME types come from extensions, while byte streams use metadata.
     This helps classify files and data streams for specific tasks.
 
-    FileTypeRouter supports regex patterns in the `mime_types` parameter. You can set broad categories
-    (such as 'audio/*' or 'text/*') or more specific types.
+    You can use regex patterns in the `mime_types` parameter to set broad categories
+    (such as 'audio/*' or 'text/*') or specific types.
     MIME types without regex patterns are treated as exact matches.
 
     ### Usage example


### PR DESCRIPTION
### Related Issues

- fixes #8097

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
