### PR TITLE
docs: clean up docstrings of OpenAITextEmbedder

### DIFF
--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -70,7 +70,7 @@ class OpenAITextEmbedder:
         :param api_base_url:
             Overrides default base URL for all HTTP requests.
         :param organization:
-            Your Organization ID. See OpenAI's
+            Your organization ID. See OpenAI's
             [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization)
             for more information.
         :param prefix:

--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -17,9 +17,12 @@ OPENAI_MAX_RETRIES = int(os.environ.get("OPENAI_MAX_RETRIES", 5))
 @component
 class OpenAITextEmbedder:
     """
-    A component for embedding strings using OpenAI models.
+    Embeds strings using OpenAI models.
 
-    Usage example:
+    You can use it to embed user query and send it to an embedding Retriever.
+
+    ### Usage example
+
     ```python
     from haystack.components.embedders import OpenAITextEmbedder
 
@@ -48,34 +51,38 @@ class OpenAITextEmbedder:
         max_retries: Optional[int] = None,
     ):
         """
-        Create an OpenAITextEmbedder component.
+        Creates an OpenAITextEmbedder component.
 
-        By setting the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES' you can change the timeout and max_retries parameters
+        Before initializing the component, you can set the 'OPENAI_TIMEOUT' and 'OPENAI_MAX_RETRIES'
+        environment variables to override the `timeout` and `max_retries` parameters respectively
         in the OpenAI client.
 
         :param api_key:
             The OpenAI API key.
+            You can set it with an environment variable `OPENAI_API_KEY`, or pass with this parameter
+            during initialization.
         :param model:
-            The name of the model to use.
+            The name of the model to use for calculating embeddings.
+            The default model is `text-embedding-ada-002`.
         :param dimensions:
-            The number of dimensions the resulting output embeddings should have. Only supported in `text-embedding-3` a
-            nd later models.
+            The number of dimensions of the resulting embeddings. Only `text-embedding-3` and
+            later models support this parameter.
         :param api_base_url:
-            Overrides default base url for all HTTP requests.
+            Overrides default base URL for all HTTP requests.
         :param organization:
-            The Organization ID. See OpenAI's
+            Your Organization ID. See OpenAI's
             [production best practices](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization)
             for more information.
         :param prefix:
-            A string to add at the beginning of each text.
+            A string to add at the beginning of each text to embed.
         :param suffix:
-            A string to add at the end of each text.
+            A string to add at the end of each text to embed.
         :param timeout:
-            Timeout for OpenAI Client calls, if not set it is inferred from the `OPENAI_TIMEOUT` environment variable
-            or set to 30.
+            Timeout for OpenAI client calls. If not set, it defaults to either the
+            `OPENAI_TIMEOUT` environment variable, or 30 seconds.
         :param max_retries:
-            Maximum retries to stablish contact with OpenAI if it returns an internal error, if not set it is inferred
-            from the `OPENAI_MAX_RETRIES` environment variable or set to 5.
+            Maximum number of retries to contact OpenAI after an internal error.
+            If not set, it defaults to either the `OPENAI_MAX_RETRIES` environment variable, or set to 5.
         """
         self.model = model
         self.dimensions = dimensions
@@ -138,7 +145,7 @@ class OpenAITextEmbedder:
     @component.output_types(embedding=List[float], meta=Dict[str, Any])
     def run(self, text: str):
         """
-        Embed a single string.
+        Embeds a single string.
 
         :param text:
             Text to embed.


### PR DESCRIPTION
### Related Issues

- fixes #8119

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
