### PR TITLE
fix: Fix infinite loop when running Pipeline

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -927,21 +927,23 @@ class PipelineBase:
             pair = (receiver_name, receiver)
 
             is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
-            if receiver_socket.is_variadic and is_greedy:
-                # If the receiver is greedy, we can run it as soon as possible.
-                # First we remove it from the status lists it's in if it's there or we risk running it multiple times.
-                if pair in run_queue:
-                    run_queue.remove(pair)
-                if pair in waiting_queue:
-                    waiting_queue.remove(pair)
-                run_queue.append(pair)
-
-            if receiver_socket.is_variadic and not is_greedy and pair not in waiting_queue:
-                # If the receiver Component has a variadic input that is not greedy
-                # we put it in the waiting queue.
-                # This make sure that we don't run it earlier than necessary and we can collect
-                # as many inputs as we can before running it.
-                waiting_queue.append(pair)
+            if receiver_socket.is_variadic:
+                if is_greedy:
+                    # If the receiver is greedy, we can run it as soon as possible.
+                    # First we remove it from the status lists it's in if it's there or
+                    # we risk running it multiple times.
+                    if pair in run_queue:
+                        run_queue.remove(pair)
+                    if pair in waiting_queue:
+                        waiting_queue.remove(pair)
+                    run_queue.append(pair)
+                else:
+                    # If the receiver Component has a variadic input that is not greedy
+                    # we put it in the waiting queue.
+                    # This make sure that we don't run it earlier than necessary and we can collect
+                    # as many inputs as we can before running it.
+                    if pair not in waiting_queue:
+                        waiting_queue.append(pair)
 
             if pair not in waiting_queue and pair not in run_queue:
                 # Queue up the Component that received this input to run, only if it's not already waiting

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -245,7 +245,7 @@ class Pipeline(PipelineBase):
                     # This happens when a component was put in the waiting list but we reached it from another edge.
                     _dequeue_waiting_component((name, comp), waiting_queue)
 
-                    for pair in self._find_components_that_received_no_input(name, res):
+                    for pair in self._find_components_that_will_receive_no_input(name, res):
                         _dequeue_component(pair, run_queue, waiting_queue)
                     res = self._distribute_output(name, res, components_inputs, run_queue, waiting_queue)
 

--- a/releasenotes/notes/fix-run-loop-63bf0ffc26887e66.yaml
+++ b/releasenotes/notes/fix-run-loop-63bf0ffc26887e66.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a bug in `Pipeline.run()` that would cause it to get stuck in an infinite loop and never return.
+
+    This was caused by Components waiting forever for their inputs when parts of the Pipeline graph are skipped
+    cause of a "decision" Component not returning outputs for that side of the Pipeline.

--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -38,6 +38,7 @@ Feature: Pipeline running
         | that has a component with default inputs that doesn't receive anything from its sender but receives input from user |
         | that has a loop and a component with default inputs that doesn't receive anything from its sender but receives input from user |
         | that has multiple components with only default inputs and are added in a different order from the order of execution |
+        | that is linear with conditional branching and multiple joins |
 
     Scenario Outline: Running a bad Pipeline
         Given a pipeline <kind>


### PR DESCRIPTION
### Related Issues

- fixes #8059

### Proposed Changes:

This changes a bit the internal run logic in two ways:

Components that have variadic input and not greedy will be put in the `waiting_queue` when outputs are distributed, previously they would have been put in the `run_queue`. This will prevent them from running before they're supposed to.

It also changes which Components we remove from the `run_queue` and `waiting_queue` when a Component produces only parts of its output, like the `ConditionalRouter`. Now we remove from the queues Components that directly would have received that output, but also their descendants. This prevents the Pipeline to get stuck in a loop waiting for inputs for Components that will never receive it.

### How did you test it?

I added a new Pipeline in the behavioural tests similar to the one reported in the above issue and updated another test.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
