### PR TITLE
fix: ChatPromptBuilder from_dict if template is None

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -254,7 +254,7 @@ class ChatPromptBuilder:
             The deserialized component.
         """
         init_parameters = data["init_parameters"]
-        template = init_parameters.get("template", [])
+        template = init_parameters.get("template", []) or []
         init_parameters["template"] = [ChatMessage.from_dict(d) for d in template]
 
         return default_from_dict(cls, data)

--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -254,7 +254,8 @@ class ChatPromptBuilder:
             The deserialized component.
         """
         init_parameters = data["init_parameters"]
-        template = init_parameters.get("template", []) or []
-        init_parameters["template"] = [ChatMessage.from_dict(d) for d in template]
+        template = init_parameters.get("template")
+        if template:
+            init_parameters["template"] = [ChatMessage.from_dict(d) for d in template]
 
         return default_from_dict(cls, data)

--- a/releasenotes/notes/fix-chat-prompt-builder-from-dict-template-none-56c91effe61e823c.yaml
+++ b/releasenotes/notes/fix-chat-prompt-builder-from-dict-template-none-56c91effe61e823c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix ChatPromptBuilder from_dict method when template value is None.

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -546,4 +546,4 @@ class TestChatPromptBuilderDynamic:
 
         assert component.template == []
         assert component._variables is None
-        assert component._required_variables == []
+        assert component._required_variables is None

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -535,3 +535,15 @@ class TestChatPromptBuilderDynamic:
         ]
         assert component._variables == ["var", "required_var"]
         assert component._required_variables == ["required_var"]
+
+    def test_from_dict_template_none(self):
+        component = ChatPromptBuilder.from_dict(
+            data={
+                "type": "haystack.components.builders.chat_prompt_builder.ChatPromptBuilder",
+                "init_parameters": {"template": None},
+            }
+        )
+
+        assert component.template == []
+        assert component._variables is None
+        assert component._required_variables == []

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -544,6 +544,6 @@ class TestChatPromptBuilderDynamic:
             }
         )
 
-        assert component.template == []
+        assert component.template is None
         assert component._variables is None
         assert component._required_variables is None


### PR DESCRIPTION
### Related Issues

When initialisizing `ChatPromptBuilder` component `from_dict` with value {"template": None}, 
we receive `'NoneType' object is not iterable`.

### Proposed Changes:

Fix `from_dict` method.

### How did you test it?

Unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
