### PR TITLE
chore: remove unused functions `serialize_callback_handler` and `deserialize_callback_handler`

### DIFF
--- a/haystack/components/generators/utils.py
+++ b/haystack/components/generators/utils.py
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Optional
-
 from haystack.dataclasses import StreamingChunk
-from haystack.utils import deserialize_callable, serialize_callable
 
 
 def print_streaming_chunk(chunk: StreamingChunk) -> None:
@@ -15,29 +12,3 @@ def print_streaming_chunk(chunk: StreamingChunk) -> None:
     Prints the tokens of the first completion to stdout as soon as they are received
     """
     print(chunk.content, flush=True, end="")
-
-
-def serialize_callback_handler(streaming_callback: Callable[[StreamingChunk], None]) -> str:
-    """
-    Serializes the streaming callback handler.
-
-    :param streaming_callback:
-        The streaming callback handler function
-    :returns:
-        The full path of the streaming callback handler function
-    """
-    return serialize_callable(streaming_callback)
-
-
-def deserialize_callback_handler(callback_name: str) -> Optional[Callable[[StreamingChunk], None]]:
-    """
-    Deserializes the streaming callback handler.
-
-    :param callback_name:
-        The full path of the streaming callback handler function
-    :returns:
-        The streaming callback handler function
-    :raises DeserializationError:
-        If the streaming callback handler function cannot be found
-    """
-    return deserialize_callable(callback_name)

--- a/releasenotes/notes/rm-serialize-callback-handler-5c104eafc6673932.yaml
+++ b/releasenotes/notes/rm-serialize-callback-handler-5c104eafc6673932.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The `serialize_callback_handler` and `deserialize_callback_handler` utility functions have been removed.
+    Use `serialize_callable` and `deserialize_callable` instead.
+
+    For more information on `serialize_callable` and `deserialize_callable`, see the API reference:
+    https://docs.haystack.deepset.ai/reference/utils-api#module-callable_serialization


### PR DESCRIPTION
### Related Issues

These utility functions are probably a leftover.

I checked that they are not used anywhere: haystack, core-integrations, integrations page, website, tutorials, cookbook...

Some related issues (in case you are interested in history :smiley:): #6979 #6988 https://github.com/deepset-ai/haystack-core-integrations/issues/415

### Proposed Changes:
Remove these functions

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
