### PR TITLE
fix: Output Adapter from_dict with custom_filters None

### DIFF
--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -139,8 +139,13 @@ class OutputAdapter:
         """
         init_params = data.get("init_parameters", {})
         init_params["output_type"] = deserialize_type(init_params["output_type"])
-        for name, filter_func in init_params.get("custom_filters", {}).items():
-            init_params["custom_filters"][name] = deserialize_callable(filter_func) if filter_func else None
+
+        custom_filters = init_params.get("custom_filters", {})
+        if custom_filters:
+            init_params["custom_filters"] = {
+                name: deserialize_callable(filter_func) if filter_func else None
+                for name, filter_func in custom_filters.items()
+            }
         return default_from_dict(cls, data)
 
     def _extract_variables(self, env: SandboxedEnvironment) -> Set[str]:

--- a/releasenotes/notes/fix-output-adapter-from_dict-custom-filters-none-70705cbb474fe982.yaml
+++ b/releasenotes/notes/fix-output-adapter-from_dict-custom-filters-none-70705cbb474fe982.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Output Adapter from_dict method when custom_filters value is None.

--- a/test/components/converters/test_output_adapter.py
+++ b/test/components/converters/test_output_adapter.py
@@ -129,6 +129,22 @@ class TestOutputAdapter:
         # invoke the custom filter to check if it is deserialized correctly
         assert deserialized_adapter.custom_filters["custom_filter"]("test") == "TEST"
 
+    def test_output_adapter_from_dict_custom_filters_none(self):
+        component = OutputAdapter.from_dict(
+            data={
+                "type": "haystack.components.converters.output_adapter.OutputAdapter",
+                "init_parameters": {
+                    "template": "{{ documents[0].content}}",
+                    "output_type": "str",
+                    "custom_filters": None,
+                },
+            }
+        )
+
+        assert component.template == "{{ documents[0].content}}"
+        assert component.output_type == str
+        assert component.custom_filters == {}
+
     def test_output_adapter_in_pipeline(self):
         @component
         class DocumentProducer:


### PR DESCRIPTION
### Related Issues

The OutputAdapter's from_dict method was failing when custom_filters = None in spite being an Optional parameter.

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
