### PR TITLE
chore: deprecate SentenceWindowRetrieval

### DIFF
--- a/docs/pydoc/config/retrievers_api.yml
+++ b/docs/pydoc/config/retrievers_api.yml
@@ -7,6 +7,7 @@ loaders:
         "in_memory/embedding_retriever",
         "filter_retriever",
         "sentence_window_retriever",
+        "sentence_window_retrieval"
       ]
     ignore_when_discovered: ["__init__"]
 processors:

--- a/haystack/components/retrievers/__init__.py
+++ b/haystack/components/retrievers/__init__.py
@@ -5,6 +5,13 @@
 from haystack.components.retrievers.filter_retriever import FilterRetriever
 from haystack.components.retrievers.in_memory.bm25_retriever import InMemoryBM25Retriever
 from haystack.components.retrievers.in_memory.embedding_retriever import InMemoryEmbeddingRetriever
+from haystack.components.retrievers.sentence_window_retrieval import SentenceWindowRetrieval
 from haystack.components.retrievers.sentence_window_retriever import SentenceWindowRetriever
 
-__all__ = ["FilterRetriever", "InMemoryEmbeddingRetriever", "InMemoryBM25Retriever", "SentenceWindowRetriever"]
+__all__ = [
+    "FilterRetriever",
+    "InMemoryEmbeddingRetriever",
+    "InMemoryBM25Retriever",
+    "SentenceWindowRetriever",
+    "SentenceWindowRetrieval",
+]

--- a/haystack/components/retrievers/sentence_window_retrieval.py
+++ b/haystack/components/retrievers/sentence_window_retrieval.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+
+from .sentence_window_retriever import SentenceWindowRetriever
+
+
+class SentenceWindowRetrieval(SentenceWindowRetriever):
+    """
+    This class is deprecated. Please use `SentenceWindowRetriever` instead.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The class `SentenceWindowRetrieval` is deprecated and will be removed in a future release. "
+            "Please use `SentenceWindowRetriever` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/releasenotes/notes/deprecate-sentence-window-retrieval-9d7f8a61429a514b.yaml
+++ b/releasenotes/notes/deprecate-sentence-window-retrieval-9d7f8a61429a514b.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    `SentenceWindowRetrieval` is deprecated and will be removed in future. Use `SentenceWindowRetriever` instead.

--- a/test/components/retrievers/test_sentence_window_retrieval.py
+++ b/test/components/retrievers/test_sentence_window_retrieval.py
@@ -1,0 +1,16 @@
+from haystack.components.retrievers.sentence_window_retrieval import SentenceWindowRetrieval
+from haystack.components.retrievers.sentence_window_retriever import SentenceWindowRetriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from unittest.mock import patch
+
+
+class TestSentenceWindowRetrieval:
+    def test_init_default(self):
+        retriever = SentenceWindowRetrieval(InMemoryDocumentStore())
+        assert retriever.window_size == 3
+
+    def test_init_calls_parent(self):
+        with patch.object(SentenceWindowRetriever, "__init__", return_value=None) as mock_init:
+            document_store = InMemoryDocumentStore()
+            retriever = SentenceWindowRetrieval(document_store)
+            mock_init.assert_called_once_with(document_store)


### PR DESCRIPTION

### Proposed Changes:

Created a stub class named SentenceWindowRetrieval that inherits from SentenceWindowRetriever. This stub issues a deprecation warning to guide users to transition to the SentenceWindowRetriever class while maintaining backward compatibility.
### How did you test it?

- Ran the existing tests
- Added new tests to check inheritance in SentenceWindowRetrieval

### Notes for the reviewer

NA
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
