### PR TITLE
fix: deserialize Document Stores using specific `from_dict` class methods

### DIFF
--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Type, cast
+from typing import Any, Dict, List
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging
 from haystack.core.serialization import import_class_by_name

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, cast
 
 from haystack import DeserializationError, Document, component, default_from_dict, default_to_dict, logging
 from haystack.core.serialization import import_class_by_name
@@ -82,7 +82,7 @@ class CacheChecker:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
 
         return default_from_dict(cls, data)
 

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -82,7 +82,10 @@ class CacheChecker:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
+        if hasattr(doc_store_class, "from_dict"):
+            data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)
+        else:
+            data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
 
         return default_from_dict(cls, data)
 

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -88,7 +88,7 @@ class FilterRetriever:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
 
         return default_from_dict(cls, data)
 

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -88,7 +88,10 @@ class FilterRetriever:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
+        if hasattr(doc_store_class, "from_dict"):
+            data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)
+        else:
+            data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
 
         return default_from_dict(cls, data)
 

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -131,7 +131,7 @@ class SentenceWindowRetriever:
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
 
-        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
 
         # deserialize the component
         return default_from_dict(cls, data)

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -131,7 +131,10 @@ class SentenceWindowRetriever:
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
 
-        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
+        if hasattr(doc_store_class, "from_dict"):
+            data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)
+        else:
+            data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
 
         # deserialize the component
         return default_from_dict(cls, data)

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -84,7 +84,7 @@ class DocumentWriter:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
+        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
         data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
 
         return default_from_dict(cls, data)

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -84,7 +84,10 @@ class DocumentWriter:
             doc_store_class = import_class_by_name(doc_store_data["type"])
         except ImportError as e:
             raise DeserializationError(f"Class '{doc_store_data['type']}' not correctly imported") from e
-        data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)  # type: ignore[attr-defined]
+        if hasattr(doc_store_class, "from_dict"):
+            data["init_parameters"]["document_store"] = doc_store_class.from_dict(doc_store_data)
+        else:
+            data["init_parameters"]["document_store"] = default_from_dict(doc_store_class, doc_store_data)
         data["init_parameters"]["policy"] = DuplicatePolicy[data["init_parameters"]["policy"]]
 
         return default_from_dict(cls, data)

--- a/releasenotes/notes/use-document-store-from-dict-db7975d0e0e5e451.yaml
+++ b/releasenotes/notes/use-document-store-from-dict-db7975d0e0e5e451.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Use `from_dict` method of the specific Document Store class when deserializing the underlying Document Store
+    instead of the generic `default_from_dict` method.
+    This impacts the following generic components: `CacheChecker`, `DocumentWriter`, `FilterRetriever`, and
+    `SentenceWindowRetriever`.

--- a/releasenotes/notes/use-document-store-from-dict-db7975d0e0e5e451.yaml
+++ b/releasenotes/notes/use-document-store-from-dict-db7975d0e0e5e451.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Use `from_dict` method of the specific Document Store class when deserializing the underlying Document Store
-    instead of the generic `default_from_dict` method.
+    For components that support multiple Document Stores, prioritize using the specific `from_dict` class method
+    for deserialization when available. Otherwise, fall back to the generic `default_from_dict` method.
     This impacts the following generic components: `CacheChecker`, `DocumentWriter`, `FilterRetriever`, and
     `SentenceWindowRetriever`.


### PR DESCRIPTION
### Related Issues

- fixes #8204

### Proposed Changes:
Make these generic components (`SentenceWindowRetriever`, ...) deserialize a Document Store using its specific `from_dict` class method (if available) instead of `default_from_dict`.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
