### PR TITLE
test: Add utility then step in feature testing to draw pipeline to file

### DIFF
--- a/test/core/pipeline/features/conftest.py
+++ b/test/core/pipeline/features/conftest.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass, field
 from typing import Tuple, List, Dict, Any, Set, Union
+from pathlib import Path
+import re
 
 from pytest_bdd import when, then, parsers
 
 from haystack import Pipeline
+
+PIPELINE_NAME_REGEX = re.compile(r"\[(.*)\]")
 
 
 @dataclass
@@ -58,6 +62,19 @@ def run_pipeline(
         except Exception as e:
             return e
     return [e for e in zip(results, pipeline_run_data)]
+
+
+@then("draw it to file")
+def draw_pipeline(pipeline_data: Tuple[Pipeline, List[PipelineRunData]], request):
+    """
+    Draw the pipeline to a file with the same name as the test.
+    """
+    if m := PIPELINE_NAME_REGEX.search(request.node.name):
+        name = m.group(1).replace(" ", "_")
+        pipeline = pipeline_data[0]
+        graphs_dir = Path(request.config.rootpath) / "test_pipeline_graphs"
+        graphs_dir.mkdir(exist_ok=True)
+        pipeline.draw(graphs_dir / f"{name}.png")
 
 
 @then("it should return the expected result")


### PR DESCRIPTION
### Proposed Changes:

Small utility that ease visualization of a Pipeline graph.

To use it we just need to add a new `Then` step in a scenario like so:
```
    Scenario Outline: Running a correct Pipeline
        Given a pipeline <kind>
        When I run the Pipeline
        Then draw it to file
        Then it should return the expected result
        And components ran in the expected order
```

The images will be saved in a `test_pipeline_graphs` folder in the project's root.
This just an utility step meant to be used locally to ease some debugging.

### How did you test it?

I added a `Then` step to a scenario and run it.


### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
