### PR TITLE
chore: Remove deprecated `ChatMessage.to_openai_format`

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -5,7 +5,6 @@
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional
-from warnings import warn
 
 
 class ChatRole(str, Enum):

--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -33,25 +33,6 @@ class ChatMessage:
     name: Optional[str]
     meta: Dict[str, Any] = field(default_factory=dict, hash=False)
 
-    def to_openai_format(self) -> Dict[str, Any]:
-        """
-        Convert the message to the format expected by OpenAI's Chat API.
-
-        See the [API reference](https://platform.openai.com/docs/api-reference/chat/create) for details.
-
-        :returns: A dictionary with the following key:
-            - `role`
-            - `content`
-            - `name` (optional)
-        """
-        warn("The `to_openai_format` method is deprecated and will be removed in Haystack 2.5.0.", DeprecationWarning)
-
-        msg = {"role": self.role.value, "content": self.content}
-        if self.name:
-            msg["name"] = self.name
-
-        return msg
-
     def is_from(self, role: ChatRole) -> bool:
         """
         Check if the message is from a specific role.

--- a/releasenotes/notes/deprecate-chatmessage-toopenaiformat-9b1b2987a568d3d7.yaml
+++ b/releasenotes/notes/deprecate-chatmessage-toopenaiformat-9b1b2987a568d3d7.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Remove `ChatMessage.to_openai_format` method. Use `haystack.components.generators.openai_utils._convert_message_to_openai_format` instead.


### PR DESCRIPTION
### Related Issues

- related to #8169

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Removes deprecated method and updates tests.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
Multiple core integrations need to be updated after this PR is merged. Details in the linked issue.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
