### PR TITLE
feat: Expose default_headers and add kwargs for Azure Client

### DIFF
--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -68,6 +68,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
+        default_headers: Optional[Dict[str, str]] = None,
+        azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the Azure OpenAI Generator.
@@ -136,6 +138,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         self.model: str = azure_deployment or "gpt-35-turbo"
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", 30.0))
         self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", 5))
+        self.default_headers = default_headers or {}
+        self.azure_kwargs = azure_kwargs or {}
 
         self.client = AzureOpenAI(
             api_version=api_version,
@@ -146,6 +150,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             organization=organization,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=self.default_headers,
+            **self.azure_kwargs,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -169,6 +175,8 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             azure_ad_token=self.azure_ad_token.to_dict() if self.azure_ad_token is not None else None,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=self.default_headers,
+            azure_kwargs=self.azure_kwargs,
         )
 
     @classmethod

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -109,6 +109,9 @@ class AzureOpenAIGenerator(OpenAIGenerator):
                 Higher values make the model less likely to repeat the token.
             - `logit_bias`: Adds a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
+        :param default_headers: Default headers to use for the AzureOpenAI client.
+        :param azure_kwargs: Other parameters to use for the AzureOpenAI class. See the [AzureOpenAI class](https://github.com/openai/openai-python/blob/main/src/openai/lib/azure.py)
+            for supported parameters.
         """
         # We intentionally do not call super().__init__ here because we only need to instantiate the client to interact
         # with the API.

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -69,7 +69,6 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         max_retries: Optional[int] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         default_headers: Optional[Dict[str, str]] = None,
-        azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the Azure OpenAI Generator.
@@ -110,8 +109,6 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             - `logit_bias`: Adds a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
         :param default_headers: Default headers to use for the AzureOpenAI client.
-        :param azure_kwargs: Other parameters to use for the AzureOpenAI class. See the [AzureOpenAI class](https://github.com/openai/openai-python/blob/main/src/openai/lib/azure.py)
-            for supported parameters.
         """
         # We intentionally do not call super().__init__ here because we only need to instantiate the client to interact
         # with the API.
@@ -142,7 +139,6 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", 30.0))
         self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", 5))
         self.default_headers = default_headers or {}
-        self.azure_kwargs = azure_kwargs or {}
 
         self.client = AzureOpenAI(
             api_version=api_version,
@@ -154,7 +150,6 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             timeout=self.timeout,
             max_retries=self.max_retries,
             default_headers=self.default_headers,
-            **self.azure_kwargs,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -179,7 +174,6 @@ class AzureOpenAIGenerator(OpenAIGenerator):
             timeout=self.timeout,
             max_retries=self.max_retries,
             default_headers=self.default_headers,
-            azure_kwargs=self.azure_kwargs,
         )
 
     @classmethod

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -74,6 +74,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
+        default_headers: Optional[Dict[str, str]] = None,
+        azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the Azure OpenAI Chat Generator component.
@@ -110,6 +112,9 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
                 Higher values make the model less likely to repeat the token.
             - `logit_bias`: Adds a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
+        :param default_headers: Default headers to use for the AzureOpenAI client.
+        :param azure_kwargs: Other parameters to use for the AzureOpenAI class. See the [AzureOpenAI class](https://github.com/openai/openai-python/blob/main/src/openai/lib/azure.py)
+            for supported parameters.
         """
         # We intentionally do not call super().__init__ here because we only need to instantiate the client to interact
         # with the API.
@@ -138,6 +143,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         self.model = azure_deployment or "gpt-35-turbo"
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", 30.0))
         self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", 5))
+        self.default_headers = default_headers or {}
+        self.azure_kwargs = azure_kwargs or {}
 
         self.client = AzureOpenAI(
             api_version=api_version,
@@ -148,6 +155,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             organization=organization,
             timeout=self.timeout,
             max_retries=self.max_retries,
+            default_headers=self.default_headers,
+            **self.azure_kwargs,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -170,6 +179,8 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             max_retries=self.max_retries,
             api_key=self.api_key.to_dict() if self.api_key is not None else None,
             azure_ad_token=self.azure_ad_token.to_dict() if self.azure_ad_token is not None else None,
+            default_headers=self.default_headers,
+            azure_kwargs=self.azure_kwargs,
         )
 
     @classmethod

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -75,7 +75,6 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         max_retries: Optional[int] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,
         default_headers: Optional[Dict[str, str]] = None,
-        azure_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the Azure OpenAI Chat Generator component.
@@ -113,8 +112,6 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             - `logit_bias`: Adds a logit bias to specific tokens. The keys of the dictionary are tokens, and the
                 values are the bias to add to that token.
         :param default_headers: Default headers to use for the AzureOpenAI client.
-        :param azure_kwargs: Other parameters to use for the AzureOpenAI class. See the [AzureOpenAI class](https://github.com/openai/openai-python/blob/main/src/openai/lib/azure.py)
-            for supported parameters.
         """
         # We intentionally do not call super().__init__ here because we only need to instantiate the client to interact
         # with the API.
@@ -144,7 +141,6 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", 30.0))
         self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", 5))
         self.default_headers = default_headers or {}
-        self.azure_kwargs = azure_kwargs or {}
 
         self.client = AzureOpenAI(
             api_version=api_version,
@@ -156,7 +152,6 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             timeout=self.timeout,
             max_retries=self.max_retries,
             default_headers=self.default_headers,
-            **self.azure_kwargs,
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -180,7 +175,6 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             api_key=self.api_key.to_dict() if self.api_key is not None else None,
             azure_ad_token=self.azure_ad_token.to_dict() if self.azure_ad_token is not None else None,
             default_headers=self.default_headers,
-            azure_kwargs=self.azure_kwargs,
         )
 
     @classmethod

--- a/releasenotes/notes/add-azure-kwargs-6a5ab1358ef7f44c.yaml
+++ b/releasenotes/notes/add-azure-kwargs-6a5ab1358ef7f44c.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Expose default_headers to pass custom headers to Azure API including APIM subscription key.
+  - |
+    Add optional azure_kwargs dictionary parameter to pass in parameters undefined in Haystack but supported by AzureOpenAI.

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -57,6 +57,8 @@ class TestOpenAIChatGenerator:
                 "generation_kwargs": {},
                 "timeout": 30.0,
                 "max_retries": 5,
+                "default_headers": {},
+                "azure_kwargs": {},
             },
         }
 
@@ -84,6 +86,8 @@ class TestOpenAIChatGenerator:
                 "timeout": 2.5,
                 "max_retries": 10,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "default_headers": {},
+                "azure_kwargs": {},
             },
         }
 

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -58,7 +58,6 @@ class TestOpenAIChatGenerator:
                 "timeout": 30.0,
                 "max_retries": 5,
                 "default_headers": {},
-                "azure_kwargs": {},
             },
         }
 
@@ -87,7 +86,6 @@ class TestOpenAIChatGenerator:
                 "max_retries": 10,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "default_headers": {},
-                "azure_kwargs": {},
             },
         }
 
@@ -102,7 +100,7 @@ class TestOpenAIChatGenerator:
 
     @pytest.mark.integration
     @pytest.mark.skipif(
-        not os.environ.get("AZURE_OPENAI_API_KEY", None) and not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
+        not os.environ.get("AZURE_OPENAI_API_KEY", None) or not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
         reason=(
             "Please export env variables called AZURE_OPENAI_API_KEY containing "
             "the Azure OpenAI key, AZURE_OPENAI_ENDPOINT containing "

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -60,6 +60,8 @@ class TestAzureOpenAIGenerator:
                 "timeout": 30.0,
                 "max_retries": 5,
                 "generation_kwargs": {},
+                "default_headers": {},
+                "azure_kwargs": {},
             },
         }
 
@@ -89,6 +91,8 @@ class TestAzureOpenAIGenerator:
                 "timeout": 3.5,
                 "max_retries": 10,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
+                "default_headers": {},
+                "azure_kwargs": {},
             },
         }
 

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -61,7 +61,6 @@ class TestAzureOpenAIGenerator:
                 "max_retries": 5,
                 "generation_kwargs": {},
                 "default_headers": {},
-                "azure_kwargs": {},
             },
         }
 
@@ -92,7 +91,6 @@ class TestAzureOpenAIGenerator:
                 "max_retries": 10,
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "default_headers": {},
-                "azure_kwargs": {},
             },
         }
 
@@ -107,7 +105,7 @@ class TestAzureOpenAIGenerator:
 
     @pytest.mark.integration
     @pytest.mark.skipif(
-        not os.environ.get("AZURE_OPENAI_API_KEY", None) and not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
+        not os.environ.get("AZURE_OPENAI_API_KEY", None) or not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
         reason=(
             "Please export env variables called AZURE_OPENAI_API_KEY containing "
             "the Azure OpenAI key, AZURE_OPENAI_ENDPOINT containing "


### PR DESCRIPTION
### Related Issues

- fixes #8243 
### Proposed Changes:
 I explicitly chose to expose default_headers and add an optional azure_kwargs for the other more niche parameters that some users might find useful. This can be condensed into azure_kwargs if preferred.

### How did you test it?

Tested with empty dictionary as we would need someone that uses an Azure Organizational Project with APIM to test.

### Notes for the reviewer

As noted above, let me know whether exposing default_headers is the preferred way.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
