### PR TITLE
fix: Document object dict #8251

### DIFF
--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -4,9 +4,9 @@
 
 import hashlib
 import io
-from datetime import datetime
 import json
 from dataclasses import asdict, dataclass, field, fields
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from numpy import ndarray
@@ -139,12 +139,13 @@ class Document(metaclass=_BackwardCompatible):
         :param flatten:
             Whether to flatten `meta` field or not. Defaults to `True` to be backward-compatible with Haystack 1.x.
         """
+
         def json_serial(obj):
             """JSON serializer for objects not serializable by default json code"""
             if isinstance(obj, datetime):
                 return obj.isoformat()
             raise TypeError(f"Type {type(obj)} not serializable")
-    
+
         data = asdict(self)
         if (dataframe := data.get("dataframe")) is not None:
             data["dataframe"] = dataframe.to_json()


### PR DESCRIPTION
### Related Issues

- Fixes #8251

### Proposed Changes:

This PR addresses the TypeError that occurs when trying to insert DocX converted document objects into PGVector or when using `json.dumps()` on `docs.to_dict()` output. The issue is caused by datetime objects not being JSON serializable.

Changes made:
- Modified the `to_dict()` method in the Document class to handle datetime serialization.
- Implemented a custom JSON encoder to convert datetime objects to ISO format strings during serialization.
- Updated the `from_dict()` method to properly deserialize the ISO format strings back to datetime objects.

### How did you test it?

- Verified that `json.dumps()` works correctly on the output of `docs.to_dict()` from DocXToDocument Converter.

### Notes for the reviewer

My thoughts are to fix this in a two PR effort. This being the first and a separate PR in haystack-core-integrations to address the problem there. Potentially the default_to_dict() function. 

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue