### PR TITLE
draft: Nltk update v1.x

### DIFF
--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -120,7 +120,7 @@ class PreProcessor(BasePreProcessor):
             nltk.data.find("tokenizers/punkt")
         except LookupError:
             try:
-                nltk.download("punkt")
+                nltk.download("punkt_tab")
             except FileExistsError as error:
                 logger.debug("NLTK punkt tokenizer seems to be already downloaded. Error message: %s", error)
                 pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ crawler = [
   "selenium>=4.11.0"
 ]
 preprocessing = [
-  "nltk",
+  "nltk>=3.9",
   "langdetect",  # for language classification
 ]
 file-conversion = [

--- a/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
+++ b/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Upgrades ntlk to 3.9 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705


### PR DESCRIPTION
- Pin nltk>=3.9
- Instead of nltk.download("punkt") use nltk.download('punkt_tab')
- fixes https://github.com/deepset-ai/haystack/issues/8238