### PR TITLE
fix: 1.x - nltk upgrade, use `nltk.download('punkt_tab')`

### DIFF
--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -120,7 +120,7 @@ class PreProcessor(BasePreProcessor):
             nltk.data.find("tokenizers/punkt")
         except LookupError:
             try:
-                nltk.download("punkt")
+                nltk.download("punkt_tab")
             except FileExistsError as error:
                 logger.debug("NLTK punkt tokenizer seems to be already downloaded. Error message: %s", error)
                 pass

--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 with LazyImport("Run 'pip install farm-haystack[preprocessing]' or 'pip install nltk'") as nltk_import:
     import nltk
+    from nltk.tokenize.punkt import PunktTokenizer
 
 iso639_to_nltk = {
     "ru": "russian",
@@ -929,14 +930,14 @@ class PreProcessor(BasePreProcessor):
 
         # Use a default NLTK model
         elif language_name is not None:
-            sentence_tokenizer = nltk.data.load(f"tokenizers/punkt/{language_name}.pickle")
+            sentence_tokenizer = PunktTokenizer(language_name)
         else:
             logger.error(
                 "PreProcessor couldn't find the default sentence tokenizer model for %s. "
                 " Using English instead. You may train your own model and use the 'tokenizer_model_folder' parameter.",
                 self.language,
             )
-            sentence_tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
+            sentence_tokenizer = PunktTokenizer()  # default english model
 
         return sentence_tokenizer
 

--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -131,7 +131,7 @@ class PreProcessor(BasePreProcessor):
                 "The 'tokenizer_model_folder' parameter will be ignored. "
                 "Please use the built-in nltk tokenizers instead by specifying the `language` parameter."
             )
-
+        self.tokenizer_model_folder = None
         self.clean_whitespace = clean_whitespace
         self.clean_header_footer = clean_header_footer
         self.clean_empty_lines = clean_empty_lines

--- a/haystack/nodes/preprocessor/preprocessor.py
+++ b/haystack/nodes/preprocessor/preprocessor.py
@@ -124,6 +124,14 @@ class PreProcessor(BasePreProcessor):
             except FileExistsError as error:
                 logger.debug("NLTK punkt tokenizer seems to be already downloaded. Error message: %s", error)
                 pass
+
+        if tokenizer_model_folder is not None:
+            warnings.warn(
+                "Custom NLTK tokenizers are no longer allowed. "
+                "The 'tokenizer_model_folder' parameter will be ignored. "
+                "Please use the built-in nltk tokenizers instead by specifying the `language` parameter."
+            )
+
         self.clean_whitespace = clean_whitespace
         self.clean_header_footer = clean_header_footer
         self.clean_empty_lines = clean_empty_lines
@@ -134,7 +142,6 @@ class PreProcessor(BasePreProcessor):
         self.split_respect_sentence_boundary = split_respect_sentence_boundary
         self.tokenizer = tokenizer
         self.language = language
-        self.tokenizer_model_folder = tokenizer_model_folder
         self.print_log: Set[str] = set()
         self.id_hash_keys = id_hash_keys
         self.progress_bar = progress_bar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ crawler = [
   "selenium>=4.11.0"
 ]
 preprocessing = [
-  "nltk>=3.9",
+  "nltk>=3.9.1",
   "langdetect",  # for language classification
 ]
 file-conversion = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
+  "urllib3<2.0.0",
   "requests",
   "httpx",
   "pydantic<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ preprocessing = [
 file-conversion = [
   "azure-ai-formrecognizer>=3.2.0b2",  # Microsoft Azure's Form Recognizer service (text and table exctrator)
   "python-docx",
-  "python-pptx",
+  "python-pptx<=1.0",
   "tika",  # Apache Tika (text & metadata extractor)
   "beautifulsoup4",
   "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,6 @@ colab = [
 dev = [
   "pre-commit",
   # Type check
-  "types-requests<2.31.0.7", # use urllib3 < 2.0
   "mypy==1.10.0",
   # Test
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "urllib3<2.0.0",
   "requests",
   "httpx",
   "pydantic<2",
@@ -192,7 +191,8 @@ colab = [
 dev = [
   "pre-commit",
   # Type check
-  "mypy",
+  "types-requests<2.31.0.7", # use urllib3 < 2.0
+  "mypy==1.10.0",
   # Test
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ crawler = [
   "selenium>=4.11.0"
 ]
 preprocessing = [
-  "nltk",
+  "nltk>=3.9",
   "langdetect",  # for language classification
 ]
 file-conversion = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
 [project.optional-dependencies]
 inference = [
   "transformers[torch,sentencepiece]==4.39.3",
-  "sentence-transformers>=2.3.1",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
+  "sentence-transformers<=3.0.0,>=2.3.1",  # See haystack/nodes/retriever/_embedding_encoder.py, _SentenceTransformersEmbeddingEncoder
   "huggingface-hub>=0.5.0",
 ]
 elasticsearch = [

--- a/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
+++ b/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
@@ -1,5 +1,9 @@
 fixes:
-  - Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705.
+  - |
+    Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705.
 upgrade:
   - |
     Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705. Due to these security vulnerabilities, it is not possible to use custom NLTK tokenizer models with the new version (for example in PreProcessor). Users can still use built-in nltk tokenizers by specifying the language parameter in the PreProcessor. See PreProcessor documentation for more details.
+enhancements:
+  - |
+    Pins sentence-transformers<=3.0.0,>=2.3.1 and python-pptx<=1.0 to avoid some minor typing incompatibilities with the newer version of the respective libraries.

--- a/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
+++ b/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
@@ -1,2 +1,5 @@
 fixes:
-  - Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705. Due to these security vulnerabilities, it is not possible to use custom NLTK tokenizer models with the new version (for example in PreProcessor).
+  - Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705.
+upgrade:
+  - |
+    Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705. Due to these security vulnerabilities, it is not possible to use custom NLTK tokenizer models with the new version (for example in PreProcessor). Users can still use built-in nltk tokenizers by specifying the language parameter in the PreProcessor. See PreProcessor documentation for more details.

--- a/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
+++ b/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
@@ -1,2 +1,2 @@
 fixes:
-  - Upgrades ntlk to 3.9 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705
+  - Upgrades ntlk to 3.9.1 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705. Due to these security vulnerabilities, it is not possible to use custom NLTK tokenizer models with the new version (for example in PreProcessor).

--- a/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
+++ b/releasenotes/notes/upgrade-ntlk-1e94de2d6f5dd3b6.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Upgrades ntlk to 3.9 as prior versions are affect by https://nvd.nist.gov/vuln/detail/CVE-2024-39705

--- a/test/nodes/test_preprocessor.py
+++ b/test/nodes/test_preprocessor.py
@@ -175,6 +175,7 @@ def test_preprocess_sentence_split_custom_models_non_default_language(split_leng
 
 @pytest.mark.unit
 @pytest.mark.parametrize("split_length_and_results", [(1, 8), (8, 1)])
+@pytest.mark.skip(reason="Skipped after upgrade to nltk 3.9, can't load this model pt anymore")
 def test_preprocess_sentence_split_custom_models(split_length_and_results, samples_path):
     split_length, expected_documents_count = split_length_and_results
 


### PR DESCRIPTION
- We needed to update a few more deps to get a green CI
- We needed to skip nltk preprocessing tests that load pickle models (seems to be forbidden in nltk 3.9)
- fixes https://github.com/deepset-ai/haystack/issues/8238
