### PR TITLE
fix: `DOCXToDocument` converter - use forward reference to `Paragraph`

### DIFF
--- a/haystack/components/converters/docx.py
+++ b/haystack/components/converters/docx.py
@@ -137,7 +137,7 @@ class DOCXToDocument:
 
         return {"documents": documents}
 
-    def _extract_paragraphs_with_page_breaks(self, paragraphs: List[Paragraph]) -> List[str]:
+    def _extract_paragraphs_with_page_breaks(self, paragraphs: List["Paragraph"]) -> List[str]:
         """
         Extracts paragraphs from a DOCX file, including page breaks.
 

--- a/releasenotes/notes/docx-para-forwardref-31941f54ab3b679f.yaml
+++ b/releasenotes/notes/docx-para-forwardref-31941f54ab3b679f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Use a forward reference for the `Paragraph`` class in the `DOCXToDocument` converter
+    to prevent import errors.

--- a/releasenotes/notes/docx-para-forwardref-31941f54ab3b679f.yaml
+++ b/releasenotes/notes/docx-para-forwardref-31941f54ab3b679f.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Use a forward reference for the `Paragraph`` class in the `DOCXToDocument` converter
+    Use a forward reference for the `Paragraph` class in the `DOCXToDocument` converter
     to prevent import errors.


### PR DESCRIPTION
### Related Issues
`from haystack.components.converters import DOCXToDocument`

this fails if `python-docx` is not installed

related to #8232
similar to  #7852

### Proposed Changes:
Use forward reference to `Paragraph`.

If the library is not installed, we will have a clear `ImportError` at init time.

### How did you test it?
Manual tests, (CI)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
