### PR TITLE
feat: The SentenceWindowRetriever has now an extra output key containing all the documents belonging to the context window

### DIFF
--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List
 
 from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import DocumentStore

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -54,7 +54,20 @@ class SentenceWindowRetriever:
 
     >> {'sentence_window_retriever': {'context_windows': ['some words. There is a second sentence.
     >> And there is also a third sentence. It also contains a fourth sentence. And a fifth sentence. And a sixth
-    >> sentence. And a']}}
+    >> sentence. And a'], 'context_documents': [[Document(id=..., content: 'some words. There is a second sentence.
+    >> And there is ', meta: {'source_id': '...', 'page_number': 1, 'split_id': 1, 'split_idx_start': 20,
+    >> '_split_overlap': [{'doc_id': '...', 'range': (20, 43)}, {'doc_id': '...', 'range': (0, 30)}]}),
+    >> Document(id=..., content: 'second sentence. And there is also a third sentence. It ',
+    >> meta: {'source_id': '74ea87deb38012873cf8c07e...f19d01a26a098447113e1d7b83efd30c02987114', 'page_number': 1,
+    >> 'split_id': 2, 'split_idx_start': 43, '_split_overlap': [{'doc_id': '...', 'range': (23, 53)}, {'doc_id': '...',
+    >> 'range': (0, 26)}]}), Document(id=..., content: 'also a third sentence. It also contains a fourth sentence. ',
+    >> meta: {'source_id': '...', 'page_number': 1, 'split_id': 3, 'split_idx_start': 73, '_split_overlap':
+    >> [{'doc_id': '...', 'range': (30, 56)}, {'doc_id': '...', 'range': (0, 33)}]}), Document(id=..., content:
+    >> 'also contains a fourth sentence. And a fifth sentence. And ', meta: {'source_id': '...', 'page_number': 1,
+    >> 'split_id': 4, 'split_idx_start': 99, '_split_overlap': [{'doc_id': '...', 'range': (26, 59)},
+    >> {'doc_id': '...', 'range': (0, 26)}]}), Document(id=..., content: 'And a fifth sentence. And a sixth sentence.
+    >> And a ', meta: {'source_id': '...', 'page_number': 1, 'split_id': 5, 'split_idx_start': 132,
+    >> '_split_overlap': [{'doc_id': '...', 'range': (33, 59)}, {'doc_id': '...', 'range': (0, 24)}]})]]}}}}
     ```
     """
 
@@ -134,8 +147,11 @@ class SentenceWindowRetriever:
         :param retrieved_documents: List of retrieved documents from the previous retriever.
         :returns:
             A dictionary with the following keys:
-            - `context_windows`:  Strings representing the concatenated text of the retrieved documents context window.
-            - `context_documents`: Documents representing the retrieved documents context window.
+                - `context_windows`: A list of strings, where each string represents the concatenated text from the
+                                     context window of the corresponding document in `retrieved_documents`.
+                - `context_documents`: A list of lists of `Document` objects, where each inner list contains the
+                                     documents that form the context window for the corresponding document in
+                                     `retrieved_documents`.
 
         """
 

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -134,8 +134,8 @@ class SentenceWindowRetriever:
         :param retrieved_documents: List of retrieved documents from the previous retriever.
         :returns:
             A dictionary with the following keys:
-            - `context_windows`:  Strings representing the context windows text of the retrieved documents.
-            - `context_documents`: The retrieved context window documents.
+            - `context_windows`:  Strings representing the concatenated text of the retrieved documents context window.
+            - `context_documents`: Documents representing the retrieved documents context window.
 
         """
 

--- a/releasenotes/notes/sentence-window-retriever-output-docs-d3de2ac4328488f1.yaml
+++ b/releasenotes/notes/sentence-window-retriever-output-docs-d3de2ac4328488f1.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The output of the `SentenceWindowRetriever` now includes the document text and the document metadata.
+    This makes it easier to understand the context of the retrieved sentences.

--- a/releasenotes/notes/sentence-window-retriever-output-docs-d3de2ac4328488f1.yaml
+++ b/releasenotes/notes/sentence-window-retriever-output-docs-d3de2ac4328488f1.yaml
@@ -1,5 +1,4 @@
 ---
 enhancements:
   - |
-    The output of the `SentenceWindowRetriever` now includes the document text and the document metadata.
-    This makes it easier to understand the context of the retrieved sentences.
+    The SentenceWindowRetriever has now an extra output key containing all the documents belonging to the context window.

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -146,16 +146,7 @@ class TestSentenceWindowRetriever:
 
     @pytest.mark.integration
     def test_serialization_deserialization_in_pipeline(self):
-        splitter = DocumentSplitter(split_length=10, split_overlap=5, split_by="word")
-        text = (
-            "This is a text with some words. There is a second sentence. And there is also a third sentence. "
-            "It also contains a fourth sentence. And a fifth sentence. And a sixth sentence. And a seventh sentence"
-        )
-        doc = Document(content=text)
-        docs = splitter.run([doc])
         doc_store = InMemoryDocumentStore()
-        doc_store.write_documents(docs["documents"])
-
         pipe = Pipeline()
         pipe.add_component("bm25_retriever", InMemoryBM25Retriever(doc_store, top_k=1))
         pipe.add_component(

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -130,19 +130,40 @@ class TestSentenceWindowRetriever:
         doc_store = InMemoryDocumentStore()
         doc_store.write_documents(docs["documents"])
 
-        rag = Pipeline()
-        rag.add_component("bm25_retriever", InMemoryBM25Retriever(doc_store, top_k=1))
-        rag.add_component("sentence_window_retriever", SentenceWindowRetriever(document_store=doc_store, window_size=2))
-        rag.connect("bm25_retriever", "sentence_window_retriever")
-        result = rag.run({"bm25_retriever": {"query": "third"}})
+        pipe = Pipeline()
+        pipe.add_component("bm25_retriever", InMemoryBM25Retriever(doc_store, top_k=1))
+        pipe.add_component(
+            "sentence_window_retriever", SentenceWindowRetriever(document_store=doc_store, window_size=2)
+        )
+        pipe.connect("bm25_retriever", "sentence_window_retriever")
+        result = pipe.run({"bm25_retriever": {"query": "third"}})
 
-        expected = {
-            "sentence_window_retriever": {
-                "context_windows": [
-                    "some words. There is a second sentence. And there is also a third sentence. It also "
-                    "contains a fourth sentence. And a fifth sentence. And a sixth sentence. And a "
-                ]
-            }
-        }
+        assert result["sentence_window_retriever"]["context_windows"] == [
+            "some words. There is a second sentence. And there is also a third sentence. It also "
+            "contains a fourth sentence. And a fifth sentence. And a sixth sentence. And a "
+        ]
+        assert len(result["sentence_window_retriever"]["context_documents"][0]) == 5
 
-        assert result == expected
+    @pytest.mark.integration
+    def test_serialization_deserialization_in_pipeline(self):
+        splitter = DocumentSplitter(split_length=10, split_overlap=5, split_by="word")
+        text = (
+            "This is a text with some words. There is a second sentence. And there is also a third sentence. "
+            "It also contains a fourth sentence. And a fifth sentence. And a sixth sentence. And a seventh sentence"
+        )
+        doc = Document(content=text)
+        docs = splitter.run([doc])
+        doc_store = InMemoryDocumentStore()
+        doc_store.write_documents(docs["documents"])
+
+        pipe = Pipeline()
+        pipe.add_component("bm25_retriever", InMemoryBM25Retriever(doc_store, top_k=1))
+        pipe.add_component(
+            "sentence_window_retriever", SentenceWindowRetriever(document_store=doc_store, window_size=2)
+        )
+        pipe.connect("bm25_retriever", "sentence_window_retriever")
+
+        serialized = pipe.to_dict()
+        deserialized = Pipeline.from_dict(serialized)
+
+        assert deserialized == pipe


### PR DESCRIPTION
### Proposed Changes:

Adds an extra key in the output of the `SentenceWindowRetriever`, returning a `List[Document]` containing all the Document objects belonging to the context window

### How did you test it?

unit tests, integration tests, manual verification

### Notes for the reviewer

I've decided for a extra output key so that there are no breaking changes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
