### PR TITLE
chore: Remove deprecated `debug` param from `Pipeline.run`

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -85,7 +85,7 @@ class Pipeline(PipelineBase):
             return res
 
     def run(  # noqa: PLR0915
-        self, data: Dict[str, Any], debug: bool = False, include_outputs_from: Optional[Set[str]] = None
+        self, data: Dict[str, Any], include_outputs_from: Optional[Set[str]] = None
     ) -> Dict[str, Any]:
         """
         Runs the pipeline with given input data.
@@ -105,8 +105,6 @@ class Pipeline(PipelineBase):
             }
             ```
 
-        :param debug:
-            Set to True to collect and return debug information.
         :param include_outputs_from:
             Set of component names whose individual outputs are to be
             included in the pipeline's output. For components that are
@@ -155,8 +153,6 @@ class Pipeline(PipelineBase):
         The pipeline resolves inputs to the correct components, returning
         {'hello2': {'output': 'Hello, Hello, world!!'}}.
         """
-        warn("The 'debug' parameter is deprecated and will be removed in Haystack 2.5.0.", DeprecationWarning)
-
         pipeline_running(self)
 
         # Reset the visits count for each component
@@ -208,7 +204,6 @@ class Pipeline(PipelineBase):
             tags={
                 "haystack.pipeline.input_data": data,
                 "haystack.pipeline.output_data": final_outputs,
-                "haystack.pipeline.debug": debug,
                 "haystack.pipeline.metadata": self.metadata,
                 "haystack.pipeline.max_loops_allowed": self.max_loops_allowed,
             },

--- a/releasenotes/notes/remove-deprecated-pipeline-run-debug-eab0c31ea0ce513d.yaml
+++ b/releasenotes/notes/remove-deprecated-pipeline-run-debug-eab0c31ea0ce513d.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Remove unused `debug` parameter from `Pipeline.run` method.

--- a/test/core/pipeline/test_tracing.py
+++ b/test/core/pipeline/test_tracing.py
@@ -44,7 +44,6 @@ class TestTracing:
                 tags={
                     "haystack.pipeline.input_data": {"hello": {"word": "world"}},
                     "haystack.pipeline.output_data": {"hello2": {"output": "Hello, Hello, world!!"}},
-                    "haystack.pipeline.debug": False,
                     "haystack.pipeline.metadata": {},
                     "haystack.pipeline.max_loops_allowed": 100,
                 },
@@ -99,7 +98,6 @@ class TestTracing:
             SpyingSpan(
                 operation_name="haystack.pipeline.run",
                 tags={
-                    "haystack.pipeline.debug": False,
                     "haystack.pipeline.metadata": {},
                     "haystack.pipeline.max_loops_allowed": 100,
                     "haystack.pipeline.input_data": {"hello": {"word": "world"}},


### PR DESCRIPTION
### Related Issues

- fixes #8076 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Removes deprecated parameter from `Pipeline.run`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
