### PR TITLE
chore: update test dependency and `LazyImport` block to make compatibility with `sentence-transformers>=3.0.0` explicit

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -9,7 +9,7 @@ import numpy as np
 from haystack.lazy_imports import LazyImport
 from haystack.utils.auth import Secret
 
-with LazyImport(message="Run 'pip install \"sentence-transformers>=2.3.0\"'") as sentence_transformers_import:
+with LazyImport(message="Run 'pip install \"sentence-transformers>=3.0.0\"'") as sentence_transformers_import:
     from sentence_transformers import SentenceTransformer
 
 

--- a/haystack/components/evaluators/sas_evaluator.py
+++ b/haystack/components/evaluators/sas_evaluator.py
@@ -11,7 +11,7 @@ from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, expit
 from haystack.utils.auth import Secret, deserialize_secrets_inplace
 
-with LazyImport(message="Run 'pip install \"sentence-transformers>=2.3.0\"'") as sas_import:
+with LazyImport(message="Run 'pip install \"sentence-transformers>=3.0.0\"'") as sas_import:
     from sentence_transformers import CrossEncoder, SentenceTransformer, util
     from transformers import AutoConfig
 

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -11,7 +11,7 @@ from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
 logger = logging.getLogger(__name__)
 
 
-with LazyImport(message="Run 'pip install \"sentence-transformers>=2.3.0\"'") as torch_and_sentence_transformers_import:
+with LazyImport(message="Run 'pip install \"sentence-transformers>=3.0.0\"'") as torch_and_sentence_transformers_import:
     import torch
     from sentence_transformers import SentenceTransformer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ format-check = "ruff format --check {args}"
 extra-dependencies = [
   "transformers[torch,sentencepiece]==4.41.2", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
   "huggingface_hub>=0.23.0",                   # Hugging Face API Generators and Embedders
-  "sentence-transformers>=2.3.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
+  "sentence-transformers>=3.0.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
   "openai-whisper>=20231106",                  # LocalWhisperTranscriber
 

--- a/releasenotes/notes/update-sentence-transformers-3-3bca4e3f3ad3e7ba.yaml
+++ b/releasenotes/notes/update-sentence-transformers-3-3bca4e3f3ad3e7ba.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    Starting from `haystack-ai==2.4.0`, Haystack is compatible with `sentence-transformers>=3.0.0`.
+    Starting from `haystack-ai==2.4.0`, Haystack is compatible with `sentence-transformers>=3.0.0`;
+    earlier versions of `sentence-transformers` are not supported.
     We are updating the test dependency and the LazyImport messages to reflect that.

--- a/releasenotes/notes/update-sentence-transformers-3-3bca4e3f3ad3e7ba.yaml
+++ b/releasenotes/notes/update-sentence-transformers-3-3bca4e3f3ad3e7ba.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Starting from `haystack-ai==2.4.0`, Haystack is compatible with `sentence-transformers>=3.0.0`.
+    We are updating the test dependency and the LazyImport messages to reflect that.


### PR DESCRIPTION
### Related Issues
Starting from `haystack-ai==2.4.0`, Haystack is only compatible with `sentence-transformers>=3.0.0`, due to `model_kwargs` parameter.

- https://github.com/deepset-ai/haystack/issues/8248#issuecomment-2312689180

### Proposed Changes:
- update the test dependency pin
- update the `LazyImport` message to suggest installing `sentence-transformers>=3.0.0`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
