### PR TITLE
fix: `SentenceWindowRetriever` convert metadata fields back to int

### DIFF
--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -118,14 +118,12 @@ class SentenceWindowRetriever:
         Convert metadata original int values back to integers again, since PineCone store numbers as float.
         """
 
-        values_to_convert = ["split_id", "split_idx_start"]
+        values_to_convert = ["split_id", "split_idx_start", "page_number"]
 
         for doc in context_docs:
             for value in values_to_convert:
                 if value in doc.meta:
-                    print("before: ", doc.meta[value])
                     doc.meta[value] = int(doc.meta[value]) if isinstance(doc.meta[value], float) else doc.meta[value]
-                    print("after: ", doc.meta[value])
 
         return context_docs
 

--- a/test/components/retrievers/test_sentence_window_retriever.py
+++ b/test/components/retrievers/test_sentence_window_retriever.py
@@ -159,7 +159,7 @@ class TestSentenceWindowRetriever:
 
         assert deserialized == pipe
 
-    def test_metadata_invalid_but_still_return_documents(self):
+    def test_metadata_float_but_still_return_documents(self):
         splitter = DocumentSplitter(split_length=10, split_overlap=5, split_by="word")
         text = (
             "This is a text with some words. There is a second sentence. And there is also a third sentence. "
@@ -167,6 +167,13 @@ class TestSentenceWindowRetriever:
         )
         doc = Document(content=text)
         docs = splitter.run([doc])
+
+        # convert to float
+        for doc in docs["documents"]:
+            doc.meta["split_id"] = float(doc.meta["split_id"])
+            doc.meta["split_idx_start"] = float(doc.meta["split_idx_start"])
+            doc.meta["page_number"] = float(doc.meta["page_number"])
+
         doc_store = InMemoryDocumentStore()
         doc_store.write_documents(docs["documents"])
 


### PR DESCRIPTION
### Proposed Changes:

Pinecone converts all meta numbers in the meta field to float (https://docs.pinecone.io/guides/data/filter-with-metadata). This causes the `SentenceWindowRetriever` to crash completely. 

This PR checks if the metadata values are floats and converts them back to integers making `PineCone` supported by the `SentenceWindowRetriever`


### How did you test it?

- unit tests, 
- integration tests
- manual verification


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
