### PR TITLE
chore: Remove emojis from release notes config

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -38,10 +38,10 @@ template: |
 
 sections:
   # The prelude section is implicitly included.
-  - [upgrade, ⬆️ Upgrade Notes]
-  - [features, 🚀 New Features]
-  - [enhancements, ⚡️ Enhancement Notes]
+  - [upgrade, Upgrade Notes]
+  - [features, New Features]
+  - [enhancements, Enhancement Notes]
   - [issues, Known Issues]
-  - [deprecations, ⚠️ Deprecation Notes]
+  - [deprecations, Deprecation Notes]
   - [security, Security Notes]
-  - [fixes, 🐛 Bug Fixes]
+  - [fixes, Bug Fixes]


### PR DESCRIPTION
### Related Issues

- fixes #7315 

### Proposed Changes:

- Remove emojis from release notes config

### How did you test it?

no tests

### Notes for the reviewer

The issue is a bit old already. I didn't try to reproduce it and I wonder why there were not more complaints about problems on Windows. I am not convinced that emojis caused frequent trouble in the past but I also don't see a reason to keep them. One alternative could be to close the issue as won't fix.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
