### PR TITLE
fix: `meta` prefix missing in the sentence window retriever filters

### DIFF
--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -24,6 +24,13 @@ class SentenceWindowRetriever:
     EmbeddingRetriever. First, use a Retriever to find documents based on a query and then use
     SentenceWindowRetriever to get the surrounding documents for context.
 
+    The SentenceWindowRetriever is compatible with the following DocumentStores:
+    - (Astra)[https://docs.haystack.deepset.ai/docs/astradocumentstore]
+    - (Elasticsearch)[https://docs.haystack.deepset.ai/docs/elasticsearch-document-store]
+    - (OpenSearch)[https://docs.haystack.deepset.ai/docs/opensearch-document-store]
+    - (Pgvector)[https://docs.haystack.deepset.ai/docs/pgvectordocumentstore]
+    - (Pinecone)[https://docs.haystack.deepset.ai/docs/pinecone-document-store]
+    - (Qdrant)[https://docs.haystack.deepset.ai/docs/qdrant-document-store]
 
     ### Usage example
 

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -172,9 +172,9 @@ class SentenceWindowRetriever:
                 {
                     "operator": "AND",
                     "conditions": [
-                        {"field": "source_id", "operator": "==", "value": source_id},
-                        {"field": "split_id", "operator": ">=", "value": min_before},
-                        {"field": "split_id", "operator": "<=", "value": max_after},
+                        {"field": "meta.source_id", "operator": "==", "value": source_id},
+                        {"field": "meta.split_id", "operator": ">=", "value": min_before},
+                        {"field": "meta.split_id", "operator": "<=", "value": max_after},
                     ],
                 }
             )

--- a/releasenotes/notes/fix-sentence-window-retriever-filter-b7b136eedf6e8488.yaml
+++ b/releasenotes/notes/fix-sentence-window-retriever-filter-b7b136eedf6e8488.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixing the filters in the `SentenceWindowRetriever` allowing now support for 3 more DocumentStores: Astra, PGVector, Qdrant


### PR DESCRIPTION
### Related Issues

- fixes [#8308](https://github.com/deepset-ai/haystack/issues/8308)

### Proposed Changes:

- added the prefix `meta` in the filter used by the `SentenceWindowRetriever`

### How did you test it?

- unit tests and integration tests from the CI
- ran locally an end2end example for the `SentenceWindowRetriever`: 
   - splitting and indexing document chunks
   - querying and making sure the full context window is returned without crashing or an empty return
- this test was run successfully for the following DBs:
   - Astra
   - ElasticSearch
   - OpenSearch
   - PGVector
   - PineCone
   - Qdrant

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
