### PR TITLE
Add step to verify release notes files are correctly formatted

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -41,3 +41,8 @@ jobs:
             echo "::error::The release notes file is missing, please add one or attach the label 'ignore-for-release-notes' to this PR."
             exit 1
           fi
+
+      - name: Verify release notes formatting
+        if: steps.changed-files.outputs.any_changed == 'false' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
+        run: |
+          yamllint -d "{extends: default, rules: {line-length: {max: 1200}}}" ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -43,6 +43,6 @@ jobs:
           fi
 
       - name: Verify release notes formatting
-        if: steps.changed-files.outputs.any_changed == 'false' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
+        if: steps.changed-files.outputs.any_changed == 'true' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
         run: |
           yamllint -d "{extends: default, rules: {line-length: {max: 1200}}}" ${{ steps.changed-files.outputs.all_changed_files }}

--- a/releasenotes/notes/releasenotes-lint-4c2943da39f93876.yaml
+++ b/releasenotes/notes/releasenotes-lint-4c2943da39f93876.yaml
@@ -1,3 +1,0 @@
----
-highlights: >
-        Fake release note with an error

--- a/releasenotes/notes/releasenotes-lint-4c2943da39f93876.yaml
+++ b/releasenotes/notes/releasenotes-lint-4c2943da39f93876.yaml
@@ -1,0 +1,3 @@
+---
+highlights: >
+        Fake release note with an error 

--- a/releasenotes/notes/releasenotes-lint-4c2943da39f93876.yaml
+++ b/releasenotes/notes/releasenotes-lint-4c2943da39f93876.yaml
@@ -1,3 +1,3 @@
 ---
 highlights: >
-        Fake release note with an error 
+        Fake release note with an error


### PR DESCRIPTION
### Related Issues

- fixes #8319

### Proposed Changes:

Add a new step to prevent merging of badly formatted release notes files.

### How did you test it?

Added a fake release notes file in this PR, I'll remove it when CI is green.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
