### PR TITLE
feat (v2): Update so `model_max_length` updates `max_seq_length` for Sentence Transformers

### DIFF
--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -187,6 +187,8 @@ class SentenceTransformersDocumentEmbedder:
                 model_kwargs=self.model_kwargs,
                 tokenizer_kwargs=self.tokenizer_kwargs,
             )
+            if self.tokenizer_kwargs.get("model_max_length"):
+                self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
 
     @component.output_types(documents=List[Document])
     def run(self, documents: List[Document]):

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -187,7 +187,7 @@ class SentenceTransformersDocumentEmbedder:
                 model_kwargs=self.model_kwargs,
                 tokenizer_kwargs=self.tokenizer_kwargs,
             )
-            if self.tokenizer_kwargs.get("model_max_length"):
+            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
                 self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
 
     @component.output_types(documents=List[Document])

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -173,7 +173,7 @@ class SentenceTransformersTextEmbedder:
                 model_kwargs=self.model_kwargs,
                 tokenizer_kwargs=self.tokenizer_kwargs,
             )
-            if self.tokenizer_kwargs.get("model_max_length"):
+            if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
                 self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
 
     @component.output_types(embedding=List[float])

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -4,8 +4,6 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from sentence_transformers import SentenceTransformer
-
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -4,6 +4,8 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
+from sentence_transformers import SentenceTransformer
+
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.embedders.backends.sentence_transformers_backend import (
     _SentenceTransformersEmbeddingBackendFactory,
@@ -173,6 +175,8 @@ class SentenceTransformersTextEmbedder:
                 model_kwargs=self.model_kwargs,
                 tokenizer_kwargs=self.tokenizer_kwargs,
             )
+            if self.tokenizer_kwargs.get("model_max_length"):
+                self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]
 
     @component.output_types(embedding=List[float])
     def run(self, text: str):

--- a/releasenotes/notes/update-max-seq-lenght-st-1dc3d7a9c9a3bdcd.yaml
+++ b/releasenotes/notes/update-max-seq-lenght-st-1dc3d7a9c9a3bdcd.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Updates SentenceTransformersDocumentEmbedder and SentenceTransformersTextEmbedder so model_max_length passed through tokenizer_kwargs also updates the max_seq_length of the underly SentenceTransformer model.

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -226,10 +226,14 @@ class TestSentenceTransformersDocumentEmbedder:
     )
     def test_warmup(self, mocked_factory):
         embedder = SentenceTransformersDocumentEmbedder(
-            model="model", token=None, device=ComponentDevice.from_str("cpu")
+            model="model",
+            token=None,
+            device=ComponentDevice.from_str("cpu"),
+            tokenizer_kwargs={"model_max_length": 512},
         )
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
+        embedder.embedding_backend.model.max_seq_length = 512
         mocked_factory.get_embedding_backend.assert_called_once_with(
             model="model",
             device="cpu",
@@ -237,7 +241,7 @@ class TestSentenceTransformersDocumentEmbedder:
             trust_remote_code=False,
             truncate_dim=None,
             model_kwargs=None,
-            tokenizer_kwargs=None,
+            tokenizer_kwargs={"model_max_length": 512},
         )
 
     @patch(

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -201,9 +201,15 @@ class TestSentenceTransformersTextEmbedder:
         "haystack.components.embedders.sentence_transformers_text_embedder._SentenceTransformersEmbeddingBackendFactory"
     )
     def test_warmup(self, mocked_factory):
-        embedder = SentenceTransformersTextEmbedder(model="model", token=None, device=ComponentDevice.from_str("cpu"))
+        embedder = SentenceTransformersTextEmbedder(
+            model="model",
+            token=None,
+            device=ComponentDevice.from_str("cpu"),
+            tokenizer_kwargs={"model_max_length": 512},
+        )
         mocked_factory.get_embedding_backend.assert_not_called()
         embedder.warm_up()
+        embedder.embedding_backend.model.max_seq_length = 512
         mocked_factory.get_embedding_backend.assert_called_once_with(
             model="model",
             device="cpu",
@@ -211,7 +217,7 @@ class TestSentenceTransformersTextEmbedder:
             trust_remote_code=False,
             truncate_dim=None,
             model_kwargs=None,
-            tokenizer_kwargs=None,
+            tokenizer_kwargs={"model_max_length": 512},
         )
 
     @patch(


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This brings a change we had in v1 that updates the Sentence Transformer specific variable `max_seq_length` that allows us to change the max sequence length. Previously we though using `model_max_length` through `tokenizer_kwargs` would fix this, but a recent inveistgation from @bglearning shows it does not. So we make an update here such that `model_max_length` updates the value of `max_seq_length`. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
