### PR TITLE
feat : DocumentSplitter, adding the option to split_by function

### DIFF
--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Dict, List, Literal, Tuple, Optional, Callable
+from typing import Callable, Dict, List, Literal, Optional, Tuple
 
 from more_itertools import windowed
 
@@ -50,7 +50,7 @@ class DocumentSplitter:
         split_length: int = 200,
         split_overlap: int = 0,
         split_threshold: int = 0,
-        splitting_function: Optional[Callable[[str], List[str]]] = None
+        splitting_function: Optional[Callable[[str], List[str]]] = None,
     ):
         """
         Initialize DocumentSplitter.
@@ -80,7 +80,6 @@ class DocumentSplitter:
         self.split_overlap = split_overlap
         self.split_threshold = split_threshold
         self.splitting_function = splitting_function
-
 
     @component.output_types(documents=List[Document])
     def run(self, documents: List[Document]):
@@ -122,8 +121,9 @@ class DocumentSplitter:
             )
         return {"documents": split_docs}
 
-    def _split_into_units(self, text: str,
-                          split_by: Literal["function", "page", "passage", "sentence", "word"]) -> List[str]:
+    def _split_into_units(
+        self, text: str, split_by: Literal["function", "page", "passage", "sentence", "word"]
+    ) -> List[str]:
         if split_by == "page":
             self.split_at = "\f"
         elif split_by == "passage":

--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -132,7 +132,7 @@ class DocumentSplitter:
             self.split_at = "."
         elif split_by == "word":
             self.split_at = " "
-        elif split_by == "function":
+        elif split_by == "function" and self.splitting_function is not None:
             return self.splitting_function(text)
         else:
             raise NotImplementedError(

--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -136,7 +136,7 @@ class DocumentSplitter:
             return self.splitting_function(text)
         else:
             raise NotImplementedError(
-                "DocumentSplitter only supports 'word', 'sentence', 'page' or 'passage' split_by options."
+                "DocumentSplitter only supports 'function', 'page', 'passage', 'sentence' or 'word' split_by options."
             )
         units = text.split(self.split_at)
         # Add the delimiter back to all units except the last one

--- a/releasenotes/notes/feat-DocumentSplitter-add-split-by-function-77501f439b63bb49.yaml
+++ b/releasenotes/notes/feat-DocumentSplitter-add-split-by-function-77501f439b63bb49.yaml
@@ -1,0 +1,8 @@
+---
+highlights: >
+    Added the option to split text using a user-provided function in `DocumentSplitter`.
+features:
+  - |
+    Added the option to use a custom splitting function in DocumentSplitter. The function must accept a string as
+    input and return a list of strings, representing the split units. To use the feature initialise `DocumentSplitter`
+    with `split_by="function"` providing the custom splitting function as `splitting_function=custom_function`.

--- a/releasenotes/notes/feat-documentsplitter-add-split-by-function-77501f439b63bb49.yaml
+++ b/releasenotes/notes/feat-documentsplitter-add-split-by-function-77501f439b63bb49.yaml
@@ -1,6 +1,4 @@
 ---
-highlights: >
-    Added the option to split text using a user-provided function in `DocumentSplitter`.
 features:
   - |
     Added the option to use a custom splitting function in DocumentSplitter. The function must accept a string as


### PR DESCRIPTION
### Proposed Changes:

Adding the possibility to pass a function and personalise the way in which DocumentSplitter defines a unit.

This means a user can, for example, use the following to split and define units:

`splitter_function = lambda text: re.split('[\n]{2,}, text)`

(or use spacy or anything else).

### How did you test it?

Added two tests with two "mock" splitter functions.

### Notes for the reviewer

There are some issues related to document splitting #5922 . Given the fact that the current methods are very basic and the issues have been open for moths, I think it would make sense to let the user define how text is split.
