### PR TITLE
fix: make from dict conditional router more resilient

### DIFF
--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -12,12 +12,7 @@ from jinja2.nativetypes import NativeEnvironment
 from jinja2.sandbox import SandboxedEnvironment
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.utils import (
-    deserialize_callable,
-    deserialize_type,
-    serialize_callable,
-    serialize_type,
-)
+from haystack.utils import deserialize_callable, deserialize_type, serialize_callable, serialize_type
 
 logger = logging.getLogger(__name__)
 
@@ -112,12 +107,7 @@ class ConditionalRouter:
     ```
     """
 
-    def __init__(
-        self,
-        routes: List[Dict],
-        custom_filters: Optional[Dict[str, Callable]] = None,
-        unsafe: bool = False,
-    ):
+    def __init__(self, routes: List[Dict], custom_filters: Optional[Dict[str, Callable]] = None, unsafe: bool = False):
         """
         Initializes the `ConditionalRouter` with a list of routes detailing the conditions for routing.
 
@@ -155,16 +145,12 @@ class ConditionalRouter:
 
         self._validate_routes(routes)
         # Inspect the routes to determine input and output types.
-        input_types: Set[str] = (
-            set()
-        )  # let's just store the name, type will always be Any
+        input_types: Set[str] = set()  # let's just store the name, type will always be Any
         output_types: Dict[str, str] = {}
 
         for route in routes:
             # extract inputs
-            route_input_names = self._extract_variables(
-                self._env, [route["output"], route["condition"]]
-            )
+            route_input_names = self._extract_variables(self._env, [route["output"], route["condition"]])
             input_types.update(route_input_names)
 
             # extract outputs
@@ -183,13 +169,8 @@ class ConditionalRouter:
         for route in self.routes:
             # output_type needs to be serialized to a string
             route["output_type"] = serialize_type(route["output_type"])
-        se_filters = {
-            name: serialize_callable(filter_func)
-            for name, filter_func in self.custom_filters.items()
-        }
-        return default_to_dict(
-            self, routes=self.routes, custom_filters=se_filters, unsafe=self._unsafe
-        )
+        se_filters = {name: serialize_callable(filter_func) for name, filter_func in self.custom_filters.items()}
+        return default_to_dict(self, routes=self.routes, custom_filters=se_filters, unsafe=self._unsafe)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ConditionalRouter":
@@ -212,9 +193,7 @@ class ConditionalRouter:
         custom_filters = init_params.get("custom_filters", {})
         if custom_filters is not None:
             for name, filter_func in custom_filters.items():
-                init_params["custom_filters"][name] = (
-                    deserialize_callable(filter_func) if filter_func else None
-                )
+                init_params["custom_filters"][name] = deserialize_callable(filter_func) if filter_func else None
         return default_from_dict(cls, data)
 
     def run(self, **kwargs):
@@ -256,9 +235,7 @@ class ConditionalRouter:
                     # and return the output as a dictionary under the output_name key
                     return {route["output_name"]: output}
             except Exception as e:
-                raise RouteConditionException(
-                    f"Error evaluating condition for route '{route}': {e}"
-                ) from e
+                raise RouteConditionException(f"Error evaluating condition for route '{route}': {e}") from e
 
         raise NoRouteSelectedException(f"No route fired. Routes: {self.routes}")
 
@@ -282,9 +259,7 @@ class ConditionalRouter:
                 )
             for field in ["condition", "output"]:
                 if not self._validate_template(self._env, route[field]):
-                    raise ValueError(
-                        f"Invalid template for field '{field}': {route[field]}"
-                    )
+                    raise ValueError(f"Invalid template for field '{field}': {route[field]}")
 
     def _extract_variables(self, env: Environment, templates: List[str]) -> Set[str]:
         """

--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -12,7 +12,12 @@ from jinja2.nativetypes import NativeEnvironment
 from jinja2.sandbox import SandboxedEnvironment
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.utils import deserialize_callable, deserialize_type, serialize_callable, serialize_type
+from haystack.utils import (
+    deserialize_callable,
+    deserialize_type,
+    serialize_callable,
+    serialize_type,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +112,12 @@ class ConditionalRouter:
     ```
     """
 
-    def __init__(self, routes: List[Dict], custom_filters: Optional[Dict[str, Callable]] = None, unsafe: bool = False):
+    def __init__(
+        self,
+        routes: List[Dict],
+        custom_filters: Optional[Dict[str, Callable]] = None,
+        unsafe: bool = False,
+    ):
         """
         Initializes the `ConditionalRouter` with a list of routes detailing the conditions for routing.
 
@@ -145,12 +155,16 @@ class ConditionalRouter:
 
         self._validate_routes(routes)
         # Inspect the routes to determine input and output types.
-        input_types: Set[str] = set()  # let's just store the name, type will always be Any
+        input_types: Set[str] = (
+            set()
+        )  # let's just store the name, type will always be Any
         output_types: Dict[str, str] = {}
 
         for route in routes:
             # extract inputs
-            route_input_names = self._extract_variables(self._env, [route["output"], route["condition"]])
+            route_input_names = self._extract_variables(
+                self._env, [route["output"], route["condition"]]
+            )
             input_types.update(route_input_names)
 
             # extract outputs
@@ -169,8 +183,13 @@ class ConditionalRouter:
         for route in self.routes:
             # output_type needs to be serialized to a string
             route["output_type"] = serialize_type(route["output_type"])
-        se_filters = {name: serialize_callable(filter_func) for name, filter_func in self.custom_filters.items()}
-        return default_to_dict(self, routes=self.routes, custom_filters=se_filters, unsafe=self._unsafe)
+        se_filters = {
+            name: serialize_callable(filter_func)
+            for name, filter_func in self.custom_filters.items()
+        }
+        return default_to_dict(
+            self, routes=self.routes, custom_filters=se_filters, unsafe=self._unsafe
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ConditionalRouter":
@@ -188,14 +207,14 @@ class ConditionalRouter:
             # output_type needs to be deserialized from a string to a type
             route["output_type"] = deserialize_type(route["output_type"])
 
-        # Since the custom_filters are typed as optional in the init signature, we catch the 
+        # Since the custom_filters are typed as optional in the init signature, we catch the
         # case where they are not present in the serialized data and set them to an empty dict.
         custom_filters = init_params.get("custom_filters", {})
         if custom_filters is not None:
             for name, filter_func in custom_filters.items():
-                init_params["custom_filters"][name] = deserialize_callable(filter_func) if filter_func else None
-        else:
-            init_params["custom_filters"] = {}
+                init_params["custom_filters"][name] = (
+                    deserialize_callable(filter_func) if filter_func else None
+                )
         return default_from_dict(cls, data)
 
     def run(self, **kwargs):
@@ -237,7 +256,9 @@ class ConditionalRouter:
                     # and return the output as a dictionary under the output_name key
                     return {route["output_name"]: output}
             except Exception as e:
-                raise RouteConditionException(f"Error evaluating condition for route '{route}': {e}") from e
+                raise RouteConditionException(
+                    f"Error evaluating condition for route '{route}': {e}"
+                ) from e
 
         raise NoRouteSelectedException(f"No route fired. Routes: {self.routes}")
 
@@ -261,7 +282,9 @@ class ConditionalRouter:
                 )
             for field in ["condition", "output"]:
                 if not self._validate_template(self._env, route[field]):
-                    raise ValueError(f"Invalid template for field '{field}': {route[field]}")
+                    raise ValueError(
+                        f"Invalid template for field '{field}': {route[field]}"
+                    )
 
     def _extract_variables(self, env: Environment, templates: List[str]) -> Set[str]:
         """

--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -187,8 +187,15 @@ class ConditionalRouter:
         for route in routes:
             # output_type needs to be deserialized from a string to a type
             route["output_type"] = deserialize_type(route["output_type"])
-        for name, filter_func in init_params.get("custom_filters", {}).items():
-            init_params["custom_filters"][name] = deserialize_callable(filter_func) if filter_func else None
+
+        # Since the custom_filters are typed as optional in the init signature, we catch the 
+        # case where they are not present in the serialized data and set them to an empty dict.
+        custom_filters = init_params.get("custom_filters", {})
+        if custom_filters is not None:
+            for name, filter_func in custom_filters.items():
+                init_params["custom_filters"][name] = deserialize_callable(filter_func) if filter_func else None
+        else:
+            init_params["custom_filters"] = {}
         return default_from_dict(cls, data)
 
     def run(self, **kwargs):

--- a/releasenotes/notes/make-from-dict-more-robust-for-conditionalrouter-c6ed6f841ad8e58d.yaml
+++ b/releasenotes/notes/make-from-dict-more-robust-for-conditionalrouter-c6ed6f841ad8e58d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The `from_dict` method of `ConditionalRouter` now correctly handles
+    the case where the `dict` passed to it contains the key `custom_filters` explicitly
+    set to `None`. Previously this was causing an `AttributeError`

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -21,7 +21,12 @@ class TestRouter:
     @pytest.fixture
     def routes(self):
         return [
-            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"},
+            {
+                "condition": "{{streams|length < 2}}",
+                "output": "{{query}}",
+                "output_type": str,
+                "output_name": "query",
+            },
             {
                 "condition": "{{streams|length >= 2}}",
                 "output": "{{streams}}",
@@ -50,7 +55,14 @@ class TestRouter:
         ConditionalRouter init raises a ValueError if one of the routes contains invalid condition
         """
         # invalid condition field
-        routes = [{"condition": "{{streams|length < 2", "output": "query", "output_type": str, "output_name": "test"}]
+        routes = [
+            {
+                "condition": "{{streams|length < 2",
+                "output": "query",
+                "output_type": str,
+                "output_name": "test",
+            }
+        ]
         with pytest.raises(ValueError, match="Invalid template"):
             ConditionalRouter(routes)
 
@@ -84,7 +96,11 @@ class TestRouter:
                 "output_name": "test",
                 "bla": "bla",
             },
-            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str},
+            {
+                "condition": "{{streams|length < 2}}",
+                "output": "{{query}}",
+                "output_type": str,
+            },
         ]
 
         with pytest.raises(ValueError):
@@ -94,8 +110,14 @@ class TestRouter:
         router = ConditionalRouter(routes)
 
         assert router.routes == routes
-        assert set(router.__haystack_input__._sockets_dict.keys()) == {"query", "streams"}
-        assert set(router.__haystack_output__._sockets_dict.keys()) == {"query", "streams"}
+        assert set(router.__haystack_input__._sockets_dict.keys()) == {
+            "query",
+            "streams",
+        }
+        assert set(router.__haystack_output__._sockets_dict.keys()) == {
+            "query",
+            "streams",
+        }
 
     def test_router_evaluate_condition_expressions(self):
         router = ConditionalRouter(
@@ -194,7 +216,12 @@ class TestRouter:
         Router raises a ValueError if each route is not a dictionary
         """
         routes = [
-            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"},
+            {
+                "condition": "{{streams|length < 2}}",
+                "output": "{{query}}",
+                "output_type": str,
+                "output_name": "query",
+            },
             ["{{streams|length >= 2}}", "streams", List[int]],
         ]
 
@@ -215,7 +242,12 @@ class TestRouter:
 
     def test_router_de_serialization(self):
         routes = [
-            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"},
+            {
+                "condition": "{{streams|length < 2}}",
+                "output": "{{query}}",
+                "output_type": str,
+                "output_name": "query",
+            },
             {
                 "condition": "{{streams|length >= 2}}",
                 "output": "{{streams}}",
@@ -242,6 +274,36 @@ class TestRouter:
 
         # check that the result is the same and correct
         assert result1 == result2 and result1 == {"streams": [1, 2, 3]}
+
+    def test_router_de_serialization_with_none_argument(self):
+        new_router = ConditionalRouter.from_dict(
+            {
+                "type": "haystack.components.routers.conditional_router.ConditionalRouter",
+                "init_parameters": {
+                    "routes": [
+                        {
+                            "condition": "{{streams|length < 2}}",
+                            "output": "{{query}}",
+                            "output_type": "str",
+                            "output_name": "query",
+                        },
+                        {
+                            "condition": "{{streams|length >= 2}}",
+                            "output": "{{streams}}",
+                            "output_type": "typing.List[int]",
+                            "output_name": "streams",
+                        },
+                    ],
+                    "custom_filters": None,
+                    "unsafe": False,
+                },
+            }
+        )
+
+        # now use both routers with the same input
+        kwargs = {"streams": [1, 2, 3], "query": "Haystack"}
+        result2 = new_router.run(**kwargs)
+        assert result2 == {"streams": [1, 2, 3]}
 
     def test_router_serialization_idempotence(self):
         routes = [
@@ -280,7 +342,9 @@ class TestRouter:
             },
         ]
 
-        router = ConditionalRouter(routes, custom_filters={"get_area_code": custom_filter_to_sede})
+        router = ConditionalRouter(
+            routes, custom_filters={"get_area_code": custom_filter_to_sede}
+        )
         kwargs = {"phone_num": "123-456-7890"}
         result = router.run(**kwargs)
         assert result == {"good_phone_num": "Phone number has a 123 area code"}
@@ -305,7 +369,10 @@ class TestRouter:
         serialized_router = router.to_dict()
         deserialized_router = ConditionalRouter.from_dict(serialized_router)
         assert deserialized_router.custom_filters == router.custom_filters
-        assert deserialized_router.custom_filters["custom_filter_to_sede"]("123-456-789") == 123
+        assert (
+            deserialized_router.custom_filters["custom_filter_to_sede"]("123-456-789")
+            == 123
+        )
         assert result == deserialized_router.run(**kwargs)
 
     def test_unsafe(self):

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -21,12 +21,7 @@ class TestRouter:
     @pytest.fixture
     def routes(self):
         return [
-            {
-                "condition": "{{streams|length < 2}}",
-                "output": "{{query}}",
-                "output_type": str,
-                "output_name": "query",
-            },
+            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"},
             {
                 "condition": "{{streams|length >= 2}}",
                 "output": "{{streams}}",
@@ -55,14 +50,7 @@ class TestRouter:
         ConditionalRouter init raises a ValueError if one of the routes contains invalid condition
         """
         # invalid condition field
-        routes = [
-            {
-                "condition": "{{streams|length < 2",
-                "output": "query",
-                "output_type": str,
-                "output_name": "test",
-            }
-        ]
+        routes = [{"condition": "{{streams|length < 2", "output": "query", "output_type": str, "output_name": "test"}]
         with pytest.raises(ValueError, match="Invalid template"):
             ConditionalRouter(routes)
 
@@ -96,11 +84,7 @@ class TestRouter:
                 "output_name": "test",
                 "bla": "bla",
             },
-            {
-                "condition": "{{streams|length < 2}}",
-                "output": "{{query}}",
-                "output_type": str,
-            },
+            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str},
         ]
 
         with pytest.raises(ValueError):
@@ -110,14 +94,8 @@ class TestRouter:
         router = ConditionalRouter(routes)
 
         assert router.routes == routes
-        assert set(router.__haystack_input__._sockets_dict.keys()) == {
-            "query",
-            "streams",
-        }
-        assert set(router.__haystack_output__._sockets_dict.keys()) == {
-            "query",
-            "streams",
-        }
+        assert set(router.__haystack_input__._sockets_dict.keys()) == {"query", "streams"}
+        assert set(router.__haystack_output__._sockets_dict.keys()) == {"query", "streams"}
 
     def test_router_evaluate_condition_expressions(self):
         router = ConditionalRouter(
@@ -216,12 +194,7 @@ class TestRouter:
         Router raises a ValueError if each route is not a dictionary
         """
         routes = [
-            {
-                "condition": "{{streams|length < 2}}",
-                "output": "{{query}}",
-                "output_type": str,
-                "output_name": "query",
-            },
+            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"},
             ["{{streams|length >= 2}}", "streams", List[int]],
         ]
 
@@ -242,12 +215,7 @@ class TestRouter:
 
     def test_router_de_serialization(self):
         routes = [
-            {
-                "condition": "{{streams|length < 2}}",
-                "output": "{{query}}",
-                "output_type": str,
-                "output_name": "query",
-            },
+            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"},
             {
                 "condition": "{{streams|length >= 2}}",
                 "output": "{{streams}}",
@@ -342,9 +310,7 @@ class TestRouter:
             },
         ]
 
-        router = ConditionalRouter(
-            routes, custom_filters={"get_area_code": custom_filter_to_sede}
-        )
+        router = ConditionalRouter(routes, custom_filters={"get_area_code": custom_filter_to_sede})
         kwargs = {"phone_num": "123-456-7890"}
         result = router.run(**kwargs)
         assert result == {"good_phone_num": "Phone number has a 123 area code"}
@@ -369,10 +335,7 @@ class TestRouter:
         serialized_router = router.to_dict()
         deserialized_router = ConditionalRouter.from_dict(serialized_router)
         assert deserialized_router.custom_filters == router.custom_filters
-        assert (
-            deserialized_router.custom_filters["custom_filter_to_sede"]("123-456-789")
-            == 123
-        )
+        assert deserialized_router.custom_filters["custom_filter_to_sede"]("123-456-789") == 123
         assert result == deserialized_router.run(**kwargs)
 
     def test_unsafe(self):


### PR DESCRIPTION
### Related Issues

- fixes from_dict for conditional router to be resilient against explicit "None" mappings

### Proposed Changes:
- parse explicit None mappings for deserialization as empty dict

### How did you test it?
- unit test

### Notes for the reviewer
although this can't happen if you call from_dict(to_dict) it can still happen if you change the yaml and (maybe by accident) set the key `custom_filters` to "None" based on the function signature. 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
