### PR TITLE
chore: Make `arrow` an optional dependency

### DIFF
--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -160,8 +160,13 @@ class PromptBuilder:
         self._variables = variables
         self._required_variables = required_variables
         self.required_variables = required_variables or []
+        try:
+            # The Jinja2TimeExtension needs an optional dependency to be installed.
+            # If it's not available we can do without it and use the PromptBuilder as is.
+            self._env = SandboxedEnvironment(extensions=[Jinja2TimeExtension])
+        except ImportError:
+            self._env = SandboxedEnvironment()
 
-        self._env = SandboxedEnvironment(extensions=[Jinja2TimeExtension])
         self.template = self._env.from_string(template)
         if not variables:
             # infer variables from template

--- a/haystack/utils/jinja2_extensions.py
+++ b/haystack/utils/jinja2_extensions.py
@@ -4,7 +4,11 @@
 
 from typing import Any, List, Optional, Union
 
-import arrow
+from haystack.lazy_imports import LazyImport
+
+with LazyImport(message='Run "pip install arrow>=1.3.0"') as arrow_import:
+    import arrow
+
 from jinja2 import Environment, nodes
 from jinja2.ext import Extension
 
@@ -20,6 +24,7 @@ class Jinja2TimeExtension(Extension):
         :param environment: The Jinja2 environment to initialize the extension with.
             It provides the context where the extension will operate.
         """
+        arrow_import.check()
         super().__init__(environment)
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "numpy<2",
   "python-dateutil",
   "haystack-experimental",
-  "arrow>=1.3.0"            # Jinja2TimeExtension
 ]
 
 [tool.hatch.envs.default]
@@ -86,6 +85,7 @@ extra-dependencies = [
   "sentence-transformers>=3.0.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
   "openai-whisper>=20231106",                  # LocalWhisperTranscriber
+  "arrow>=1.3.0",                              # Jinja2TimeExtension
 
   # NamedEntityExtractor
   "spacy>=3.7,<3.8",

--- a/test/utils/test_jinja2_extensions.py
+++ b/test/utils/test_jinja2_extensions.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import patch
+
 import pytest
 from jinja2 import Environment
 import arrow
@@ -16,6 +18,12 @@ class TestJinja2TimeExtension:
     @pytest.fixture
     def jinja_extension(self, jinja_env: Environment) -> Jinja2TimeExtension:
         return Jinja2TimeExtension(jinja_env)
+
+    @patch("haystack.utils.jinja2_extensions.arrow_import")
+    def test_init_fails_without_arrow(self, arrow_import_mock) -> None:
+        arrow_import_mock.check.side_effect = ImportError
+        with pytest.raises(ImportError):
+            Jinja2TimeExtension(Environment())
 
     def test_valid_datetime(self, jinja_extension: Jinja2TimeExtension) -> None:
         result = jinja_extension._get_datetime(


### PR DESCRIPTION
### Related Issues

Relates to #8233

### Proposed Changes:

Make the recently introduced `arrow` dependency an lazily imported one.

### How did you test it?

I added unit tests and ran them locally.

### Notes for the reviewer

I won't add a release notes as this doesn't changes anything that has been released already.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
