### PR TITLE
fix: Update release note for current date feat in PromptBuilder

### DIFF
--- a/releasenotes/notes/add-current-date-promptbuilder-ff60c846f5a70dc6.yaml
+++ b/releasenotes/notes/add-current-date-promptbuilder-ff60c846f5a70dc6.yaml
@@ -1,5 +1,16 @@
 ---
 enhancements:
   - |
-    Add the current date inside a template in `PromptBuilder` using the `utc_now()`.
-    Users can also specify the date format, such as `utc_now("%Y-%m-%d")`.
+    Allow the ability to add the current date inside a template in `PromptBuilder` using the following syntax:
+    
+    - `{% now 'UTC' %}`: Get the current date for the UTC timezone.
+        
+    - `{% now 'America/Chicago' + 'hours=2' %}`: Add two hours to the current date in the Chicago timezone.
+        
+    - `{% now 'Europe/Berlin' - 'weeks=2' %}`: Subtract two weeks from the current date in the Berlin timezone.
+        
+    - `{% now 'Pacific/Fiji' + 'hours=2', '%H' %}`: Display only the number of hours after adding two hours to the Fiji timezone.
+        
+    - `{% now 'Etc/GMT-4', '%I:%M %p' %}`: Change the date format to AM/PM for the GMT-4 timezone.
+    
+    Note that if no date format is provided, the default will be `%Y-%m-%d %H:%M:%S`. Please refer to [list of tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of timezones.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

Update the release note to document the correct syntax for using the current date feature in prompt builder.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
