### PR TITLE
fix: fix Pipeline rendering by replacing `*` with `&ast;`

### DIFF
--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -139,11 +139,11 @@ def _to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
             connections_list.append(conn_string)
 
     input_connections = [
-        f"i{{*}} -- \"{conn_data['label']}<br><small><i>{conn_data['conn_type']}</i></small>\" --> {states[to_comp]}"
+        f"i{{&ast;}}--\"{conn_data['label']}<br><small><i>{conn_data['conn_type']}</i></small>\"--> {states[to_comp]}"
         for _, to_comp, conn_data in graph.out_edges("input", data=True)
     ]
     output_connections = [
-        f"{states[from_comp]} -- \"{conn_data['label']}<br><small><i>{conn_data['conn_type']}</i></small>\"--> o{{*}}"
+        f"{states[from_comp]}--\"{conn_data['label']}<br><small><i>{conn_data['conn_type']}</i></small>\"--> o{{&ast;}}"
         for from_comp, _, conn_data in graph.in_edges("output", data=True)
     ]
     connections = "\n".join(connections_list + input_connections + output_connections)

--- a/releasenotes/notes/fix-pipe-rendering-50261e0472f0d267.yaml
+++ b/releasenotes/notes/fix-pipe-rendering-50261e0472f0d267.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the Pipeline visualization issue due to changes in the new release of Mermaid.


### PR DESCRIPTION
### Related Issues

- fixes #8348 

### Proposed Changes:

Simply replace the not allowed `*` character with `&ast;` in Pipeline drawing.

### How did you test it?
Manual tests.

With this fix, the Pipeline visualization is working properly again.

![image](https://github.com/user-attachments/assets/9dee9e3f-8128-4fb6-a398-6e3b3eab13dd)


### Notes for the reviewer

See the original issue for details.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
