### PR TITLE
fix: Add constraints to `set_input_type(s)` based on `run` method

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -133,8 +133,6 @@ class ChatPromptBuilder:
                     variables += list(template_variables)
 
         # setup inputs
-        static_input_slots = {"template": Optional[str], "template_variables": Optional[Dict[str, Any]]}
-        component.set_input_types(self, **static_input_slots)
         for var in variables:
             if var in self.required_variables:
                 component.set_input_type(self, var, Any)

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -177,8 +177,6 @@ class PromptBuilder:
         variables = variables or []
 
         # setup inputs
-        static_input_slots = {"template": Optional[str], "template_variables": Optional[Dict[str, Any]]}
-        component.set_input_types(self, **static_input_slots)
         for var in variables:
             if var in self.required_variables:
                 component.set_input_type(self, var, Any)

--- a/haystack/components/evaluators/context_relevance.py
+++ b/haystack/components/evaluators/context_relevance.py
@@ -161,7 +161,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
         )
 
     @component.output_types(score=float, results=List[Dict[str, Any]])
-    def run(self, questions: List[str], contexts: List[List[str]]) -> Dict[str, Any]:
+    def run(self, **inputs) -> Dict[str, Any]:
         """
         Run the LLM evaluator.
 
@@ -174,7 +174,7 @@ class ContextRelevanceEvaluator(LLMEvaluator):
                 - `score`: Mean context relevance score over all the provided input questions.
                 - `results`: A list of dictionaries with `relevant_statements` and `score` for each input context.
         """
-        result = super(ContextRelevanceEvaluator, self).run(questions=questions, contexts=contexts)
+        result = super(ContextRelevanceEvaluator, self).run(**inputs)
 
         for idx, res in enumerate(result["results"]):
             if res is None:

--- a/haystack/components/evaluators/faithfulness.py
+++ b/haystack/components/evaluators/faithfulness.py
@@ -151,7 +151,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
         )
 
     @component.output_types(individual_scores=List[int], score=float, results=List[Dict[str, Any]])
-    def run(self, questions: List[str], contexts: List[List[str]], predicted_answers: List[str]) -> Dict[str, Any]:
+    def run(self, **inputs) -> Dict[str, Any]:
         """
         Run the LLM evaluator.
 
@@ -167,9 +167,7 @@ class FaithfulnessEvaluator(LLMEvaluator):
                 - `individual_scores`: A list of faithfulness scores for each input answer.
                 - `results`: A list of dictionaries with `statements` and `statement_scores` for each input answer.
         """
-        result = super(FaithfulnessEvaluator, self).run(
-            questions=questions, contexts=contexts, predicted_answers=predicted_answers
-        )
+        result = super(FaithfulnessEvaluator, self).run(**inputs)
 
         # calculate average statement faithfulness score per query
         for idx, res in enumerate(result["results"]):

--- a/haystack/core/component/sockets.py
+++ b/haystack/core/component/sockets.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Type, Union
+from typing import Dict, Optional, Type, Union
 
 from haystack import logging
 from haystack.core.type_utils import _type_name
@@ -99,6 +99,24 @@ class Sockets:
         """
         self._sockets_dict[key] = socket
         self.__dict__[key] = socket
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._sockets_dict
+
+    def get(
+        self, key: str, default: Optional[Union[InputSocket, OutputSocket]] = None
+    ) -> Optional[Union[InputSocket, OutputSocket]]:
+        """
+        Get a socket from the Sockets object.
+
+        :param key:
+            The name of the socket to get.
+        :param default:
+            The value to return if the key is not found.
+        :returns:
+            The socket with the given key or `default` if the key is not found.
+        """
+        return self._sockets_dict.get(key, default)
 
     def _component_name(self) -> str:
         if pipeline := getattr(self._component, "__haystack_added_to_pipeline__"):

--- a/releasenotes/notes/component-set-input-type-constraints-0b1130c1b49d9648.yaml
+++ b/releasenotes/notes/component-set-input-type-constraints-0b1130c1b49d9648.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add constraints to `component.set_input_type` and `component.set_input_types` to prevent undefined behaviour
+    when the `run` method does not contain a variadic keyword argument.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -183,7 +183,7 @@ class TestContextRelevanceEvaluator:
     def test_run_missing_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator()
-        with pytest.raises(TypeError, match="missing 2 required positional arguments"):
+        with pytest.raises(ValueError, match="LLM evaluator expected input parameter"):
             component.run()
 
     def test_run_returns_nan_raise_on_failure_false(self, monkeypatch):

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -223,7 +223,7 @@ class TestFaithfulnessEvaluator:
     def test_run_missing_parameters(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator()
-        with pytest.raises(TypeError, match="missing 3 required positional arguments"):
+        with pytest.raises(ValueError, match="LLM evaluator expected input parameter"):
             component.run()
 
     def test_run_returns_nan_raise_on_failure_false(self, monkeypatch):

--- a/test/core/component/test_sockets.py
+++ b/test/core/component/test_sockets.py
@@ -45,3 +45,20 @@ class TestSockets:
         io = Sockets(component=comp, sockets_dict=comp.__haystack_input__._sockets_dict, sockets_io_type=InputSocket)
         res = repr(io)
         assert res == "Inputs:\n  - input_1: int\n  - input_2: int"
+
+    def test_get(self):
+        comp = component_class("SomeComponent", input_types={"input_1": int, "input_2": int})()
+        io = Sockets(component=comp, sockets_dict=comp.__haystack_input__._sockets_dict, sockets_io_type=InputSocket)
+
+        assert io.get("input_1") == comp.__haystack_input__._sockets_dict["input_1"]
+        assert io.get("input_2") == comp.__haystack_input__._sockets_dict["input_2"]
+        assert io.get("invalid") == None
+        assert io.get("invalid", InputSocket("input_2", int)) == InputSocket("input_2", int)
+
+    def test_contains(self):
+        comp = component_class("SomeComponent", input_types={"input_1": int, "input_2": int})()
+        io = Sockets(component=comp, sockets_dict=comp.__haystack_input__._sockets_dict, sockets_io_type=InputSocket)
+
+        assert "input_1" in io
+        assert "input_2" in io
+        assert "invalid" not in io

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -848,7 +848,7 @@ def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run():
     - The second Component has at least one default input
     """
 
-    def fake_generator_run(self, prompt: str, generation_kwargs: Optional[Dict[str, Any]] = None):
+    def fake_generator_run(self, generation_kwargs: Optional[Dict[str, Any]] = None, **kwargs):
         # Simple hack to simulate a model returning a different reply after the
         # the first time it's called
         if getattr(fake_generator_run, "called", False):
@@ -858,7 +858,7 @@ def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run():
 
     FakeGenerator = component_class(
         "FakeGenerator",
-        input_types={"prompt": str, "generation_kwargs": Optional[Dict[str, Any]]},
+        input_types={"prompt": str},
         output_types={"replies": List[str]},
         extra_fields={"run": fake_generator_run},
     )


### PR DESCRIPTION
### Related Issues

- fixes #8280

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Prevent `set_input_types`/`set_input_type` from being used when the `run` method is missing a `kwargs` parameter.
- Prevent `set_input_types`/`set_input_type` from overriding parameters in the `run` method's signature.
- Correct the handling of variadic kwargs when validating `run`/`async_run` signatures.
- Fix component string repr breaking when errors are raised during the `ComponentMeta` init phase.


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue