### PR TITLE
chore: Deprecate `Pipeline` init argument `debug_path`

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -59,7 +59,7 @@ class PipelineBase:
         self,
         metadata: Optional[Dict[str, Any]] = None,
         max_loops_allowed: Optional[int] = None,
-        debug_path: Union[Path, str] = Path(".haystack_debug/"),
+        debug_path: Optional[Union[Path, str]] = None,
         max_runs_per_component: int = 100,
     ):
         """
@@ -83,7 +83,13 @@ class PipelineBase:
         self.metadata = metadata or {}
         self.graph = networkx.MultiDiGraph()
         self._debug: Dict[int, Dict[str, Any]] = {}
-        self._debug_path = Path(debug_path)
+        if debug_path is None:
+            self._debug_path = Path(".haystack_debug/")
+        else:
+            warnings.warn(
+                "The 'debug_path' argument is deprecated and will be removed in version '2.7.0'.", DeprecationWarning
+            )
+            self._debug_path = Path(debug_path)
 
         if max_loops_allowed is not None:
             warnings.warn(_MAX_LOOPS_ALLOWED_DEPRECATION_MESSAGE, DeprecationWarning)

--- a/releasenotes/notes/deprecate-debug-path-976bb5a851365233.yaml
+++ b/releasenotes/notes/deprecate-debug-path-976bb5a851365233.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    `Pipeline` init argument `debug_path` is deprecated and will be remove in version `2.7.0`.


### PR DESCRIPTION
### Related Issues

- fixes #8352

### Proposed Changes:

Deprecate `Pipeline` init argument `debug_path` as it's unused.
 
### How did you test it?

I ran tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
