### PR TITLE
chore: Deprecate connecting a Component to itself

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -454,7 +454,7 @@ class PipelineBase:
         receiver_component_name, receiver_socket_name = parse_connect_string(receiver)
 
         if sender_component_name == receiver_component_name:
-            msg = "Connecting a Component to itself is deprecated and will be removed in version '2.7.0'."
+            msg = "Connecting a Component to itself is deprecated and will raise an error from version '2.7.0' onwards."
             warnings.warn(msg, DeprecationWarning)
 
         # Get the nodes data.

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -428,7 +428,7 @@ class PipelineBase:
 
         return instance
 
-    def connect(self, sender: str, receiver: str) -> "PipelineBase":
+    def connect(self, sender: str, receiver: str) -> "PipelineBase":  # noqa: PLR0915
         """
         Connects two components together.
 
@@ -452,6 +452,10 @@ class PipelineBase:
         # Edges may be named explicitly by passing 'node_name.edge_name' to connect().
         sender_component_name, sender_socket_name = parse_connect_string(sender)
         receiver_component_name, receiver_socket_name = parse_connect_string(receiver)
+
+        if sender_component_name == receiver_component_name:
+            msg = "Connecting a Component to itself is deprecated and will be removed in version '2.7.0'."
+            warnings.warn(msg, DeprecationWarning)
 
         # Get the nodes data.
         try:

--- a/releasenotes/notes/deprecate-self-connection-665647384ae2792b.yaml
+++ b/releasenotes/notes/deprecate-self-connection-665647384ae2792b.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Deprecate connecting a Component to itself when calling `Pipeline.connect()`, it will raise in version `2.7.0`

--- a/releasenotes/notes/deprecate-self-connection-665647384ae2792b.yaml
+++ b/releasenotes/notes/deprecate-self-connection-665647384ae2792b.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    Deprecate connecting a Component to itself when calling `Pipeline.connect()`, it will raise in version `2.7.0`
+    Deprecate connecting a Component to itself when calling `Pipeline.connect()`, it will raise an error from version `2.7.0` onwards


### PR DESCRIPTION
Calling `Pipeline.connect()` with the same Component both as `sender` and `receiver` will now emit a warning.

This will change in `2.7.0` and raise an exception. This change will come together with the internal `Pipeline.run()` rework release.