### PR TITLE
feat: HuggingFaceAPIChatGenerator add token `usage` data

### DIFF
--- a/releasenotes/notes/add-usage-huggingfaceapi-generators-de8979cad6b6ec45.yaml
+++ b/releasenotes/notes/add-usage-huggingfaceapi-generators-de8979cad6b6ec45.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
  - |
-   Adds 'usage' meta field with 'prompt_tokens' and 'completion_tokens' keys to HuggingFaceAPIGenerator and HuggingFaceAPIChatGenerator.
+   Adds 'usage' meta field with 'prompt_tokens' and 'completion_tokens' keys to HuggingFaceAPIChatGenerator.

--- a/releasenotes/notes/add-usage-huggingfaceapi-generators-de8979cad6b6ec45.yaml
+++ b/releasenotes/notes/add-usage-huggingfaceapi-generators-de8979cad6b6ec45.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Adds 'usage' meta field with 'prompt_tokens' and 'completion_tokens' keys to HuggingFaceAPIGenerator and HuggingFaceAPIChatGenerator.

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -287,3 +287,31 @@ class TestHuggingFaceAPIGenerator:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert "usage" in response["replies"][0].meta
+        assert "prompt_tokens" in response["replies"][0].meta["usage"]
+        assert "completion_tokens" in response["replies"][0].meta["usage"]
+
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    @pytest.mark.integration
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
+    def test_run_serverless_streaming(self):
+        generator = HuggingFaceAPIChatGenerator(
+            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": "HuggingFaceH4/zephyr-7b-beta"},
+            generation_kwargs={"max_tokens": 20},
+            streaming_callback=streaming_callback_handler,
+        )
+
+        messages = [ChatMessage.from_user("What is the capital of France?")]
+        response = generator.run(messages=messages)
+
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) > 0
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert "usage" in response["replies"][0].meta
+        assert "prompt_tokens" in response["replies"][0].meta["usage"]
+        assert "completion_tokens" in response["replies"][0].meta["usage"]


### PR DESCRIPTION
### Why:
Adds  token `usage` metadata to responses from HuggingFaceAPIChatGenerator. `usage` dictionary response meta field has the following two keys `prompt_tokens` and `completion_tokens` matching OpenAI format in token counting. 

This feature, i.e. OpenAI token usage format compatibility, aside from chat generators interchangeability benefits, is needed for full support of Langfuse GENERATION token usage renderings in traces. See https://github.com/deepset-ai/haystack-private/issues/82 for more details. 

### What:
- Added a new `usage` meta field with the keys `prompt_tokens` and `completion_tokens` to `HuggingFaceAPIChatGenerator`.
- Modified the streaming and non-streaming response generation code to include the new `usage` information in the message metadata.

### How can it be used:

```python
# Get the usage information from the first reply
usage_info = response["replies"][0].meta["usage"]
prompt_tokens_used = usage_info["prompt_tokens"]
completion_tokens_used = usage_info["completion_tokens"]

print(f"Prompt tokens used: {prompt_tokens_used}, Completion tokens used: {completion_tokens_used}")
```

### How did you test it:
- Updated unit tests are included to ensure the presence of the `usage` meta field and its contained `prompt_tokens` and `completion_tokens` keys in the reply messages.
- Tests cover non-streaming and streaming scenarios, ensuring compatibility with different API types.

### Notes for the reviewer:
- After this PR is merged ensure https://github.com/deepset-ai/haystack-private/issues/82 is closed as well
- Support for HuggingFaceAPIGenerator hasn't been added intentionally as it is, as other non-chat generators, in the process of deprecation and eventual removal. 
