### PR TITLE
fix: Prevent `set_output_types` from being called when the `output_types` decorator is used

### DIFF
--- a/haystack/components/classifiers/zero_shot_document_classifier.py
+++ b/haystack/components/classifiers/zero_shot_document_classifier.py
@@ -121,7 +121,6 @@ class TransformersZeroShotDocumentClassifier:
         self.token = token
         self.labels = labels
         self.multi_label = multi_label
-        component.set_output_types(self, **{label: str for label in labels})
 
         huggingface_pipeline_kwargs = resolve_hf_pipeline_kwargs(
             huggingface_pipeline_kwargs=huggingface_pipeline_kwargs or {},
@@ -229,7 +228,7 @@ class TransformersZeroShotDocumentClassifier:
             )
 
         texts = [
-            doc.content if self.classification_field is None else doc.meta[self.classification_field]
+            (doc.content if self.classification_field is None else doc.meta[self.classification_field])
             for doc in documents
         ]
 

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -449,6 +449,13 @@ class _Component:
                 return {"output_1": 1, "output_2": "2"}
         ```
         """
+        has_decorator = hasattr(instance.run, "_output_types_cache")
+        if has_decorator:
+            raise ComponentError(
+                "Cannot call `set_output_types` on a component that already has "
+                "the 'output_types' decorator on its `run` method"
+            )
+
         instance.__haystack_output__ = Sockets(
             instance, {name: OutputSocket(name=name, type=type_) for name, type_ in types.items()}, OutputSocket
         )

--- a/releasenotes/notes/component-set-output-type-override-852a19b3f0621fb0.yaml
+++ b/releasenotes/notes/component-set-output-type-override-852a19b3f0621fb0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Prevent `set_output_types`` from being called when the `output_types`` decorator is used.

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -315,6 +315,20 @@ def test_output_types_decorator_wrong_method():
                 return cls()
 
 
+def test_output_types_decorator_and_set_output_types():
+    @component
+    class MockComponent:
+        def __init__(self) -> None:
+            component.set_output_types(self, value=int)
+
+        @component.output_types(value=int)
+        def run(self, value: int):
+            return {"value": 1}
+
+    with pytest.raises(ComponentError, match="Cannot call `set_output_types`"):
+        comp = MockComponent()
+
+
 def test_output_types_decorator_mismatch_run_async_run():
     @component
     class MockComponent:


### PR DESCRIPTION

### Related Issues

- fixes #8372

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
