### PR TITLE
feat: Add utility function to check metadata filter syntax

### DIFF
--- a/haystack/utils/filters.py
+++ b/haystack/utils/filters.py
@@ -4,12 +4,21 @@
 
 from dataclasses import fields
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
 from haystack.dataclasses import Document
 from haystack.errors import FilterError
+
+
+def raise_on_invalid_filter_syntax(filters: Optional[Dict[str, Any]] = None):
+    """
+    Raise an error if the filter syntax is invalid.
+    """
+    if filters and "operator" not in filters and "conditions" not in filters:
+        msg = "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
+        raise ValueError(msg)
 
 
 def document_matches_filter(filters: Dict[str, Any], document: Document) -> bool:


### PR DESCRIPTION
### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Now that legacy filters are disabled, we need a centralized check for basic filter syntax.


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
