### PR TITLE
chore: Fix `codespell` config

### DIFF
--- a/code_of_conduct.txt
+++ b/code_of_conduct.txt
@@ -6,7 +6,7 @@ Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for
 everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics,
-gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance,
+gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance,
 race, caste, color, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ packages = ["haystack"]
 [tool.codespell]
 ignore-words-list = "ans,astroid,nd,ned,nin,ue,rouge,ist"
 quiet-level = 3
-skip = "test/nodes/*,test/others/*,test/samples/*,e2e/*"
+skip = "./test,./e2e"
 
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = 120


### PR DESCRIPTION
Fix `codespell` not skipping test paths.