### PR TITLE
chore: Fix `codespell` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+        args: ["--toml", "pyproject.toml"]
         additional_dependencies:
           - tomli
 


### PR DESCRIPTION
Fix `codespell` pre-commit hook not using configs from `pyproject.toml.`