### PR TITLE
feat: Deprecate `@component` decorator `is_greedy` argument

### DIFF
--- a/haystack/components/joiners/branch.py
+++ b/haystack/components/joiners/branch.py
@@ -5,13 +5,13 @@
 from typing import Any, Dict, Type
 
 from haystack import component, default_from_dict, default_to_dict, logging
-from haystack.core.component.types import Variadic
+from haystack.core.component.types import GreedyVariadic
 from haystack.utils import deserialize_type, serialize_type
 
 logger = logging.getLogger(__name__)
 
 
-@component(is_greedy=True)
+@component()
 class BranchJoiner:
     """
     A component to join different branches of a pipeline into one single output.
@@ -100,7 +100,7 @@ class BranchJoiner:
         """
         self.type_ = type_
         # type_'s type can't be determined statically
-        component.set_input_types(self, value=Variadic[type_])  # type: ignore
+        component.set_input_types(self, value=GreedyVariadic[type_])  # type: ignore
         component.set_output_types(self, value=type_)
 
     def to_dict(self):

--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -25,7 +25,7 @@ Variadic: TypeAlias = Annotated[Iterable[T], HAYSTACK_VARIADIC_ANNOTATION]
 # in a socket with this type.
 # Instead of waiting for other inputs to be received, Components that have a GreedyVariadic
 # input will be run right after receiving the first input.
-# Even if there multiple connection to that socket.
+# Even if there are multiple connections to that socket.
 GreedyVariadic: TypeAlias = Annotated[Iterable[T], HAYSTACK_GREEDY_VARIADIC_ANNOTATION]
 
 

--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, List, Type, TypeVar, get_args
 from typing_extensions import Annotated, TypeAlias  # Python 3.8 compatibility
 
 HAYSTACK_VARIADIC_ANNOTATION = "__haystack__variadic_t"
+HAYSTACK_GREEDY_VARIADIC_ANNOTATION = "__haystack__greedy_variadic_t"
 
 # # Generic type variable used in the Variadic container
 T = TypeVar("T")
@@ -16,8 +17,16 @@ T = TypeVar("T")
 # Variadic is a custom annotation type we use to mark input types.
 # This type doesn't do anything else than "marking" the contained
 # type so it can be used in the `InputSocket` creation where we
-# check that its annotation equals to CANALS_VARIADIC_ANNOTATION
+# check that its annotation equals to HAYSTACK_VARIADIC_ANNOTATION
 Variadic: TypeAlias = Annotated[Iterable[T], HAYSTACK_VARIADIC_ANNOTATION]
+
+# GreedyVariadic type is similar to Variadic.
+# The only difference is the way it's treated by the Pipeline when input is received
+# in a socket with this type.
+# Instead of waiting for other inputs to be received, Components that have a GreedyVariadic
+# input will be run right after receiving the first input.
+# Even if there multiple connection to that socket.
+GreedyVariadic: TypeAlias = Annotated[Iterable[T], HAYSTACK_GREEDY_VARIADIC_ANNOTATION]
 
 
 class _empty:
@@ -37,6 +46,8 @@ class InputSocket:
         The default value of the input. If not set, the input is mandatory.
     :param is_variadic:
         Whether the input is variadic or not.
+    :param is_greedy
+        Whether the input is a greedy variadic or not.
     :param senders:
         The list of components that send data to this input.
     """
@@ -45,6 +56,7 @@ class InputSocket:
     type: Type
     default_value: Any = _empty
     is_variadic: bool = field(init=False)
+    is_greedy: bool = field(init=False)
     senders: List[str] = field(default_factory=list)
 
     @property
@@ -55,9 +67,14 @@ class InputSocket:
     def __post_init__(self):
         try:
             # __metadata__ is a tuple
-            self.is_variadic = self.type.__metadata__[0] == HAYSTACK_VARIADIC_ANNOTATION
+            self.is_variadic = self.type.__metadata__[0] in [
+                HAYSTACK_VARIADIC_ANNOTATION,
+                HAYSTACK_GREEDY_VARIADIC_ANNOTATION,
+            ]
+            self.is_greedy = self.type.__metadata__[0] == HAYSTACK_GREEDY_VARIADIC_ANNOTATION
         except AttributeError:
             self.is_variadic = False
+            self.is_greedy = False
         if self.is_variadic:
             # We need to "unpack" the type inside the Variadic annotation,
             # otherwise the pipeline connection api will try to match

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -978,9 +978,8 @@ class PipelineBase:
             receiver = self.graph.nodes[receiver_name]["instance"]
             pair = (receiver_name, receiver)
 
-            is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
             if receiver_socket.is_variadic:
-                if is_greedy:
+                if receiver_socket.is_greedy:
                     # If the receiver is greedy, we can run it as soon as possible.
                     # First we remove it from the status lists it's in if it's there or
                     # we risk running it multiple times.
@@ -1214,7 +1213,7 @@ def _connections_status(
 
 def _is_lazy_variadic(c: Component) -> bool:
     """
-    Small utility function to check if a Component has a Variadic input that is not greedy
+    Small utility function to check if a Component has a Variadic input
     """
     is_variadic = any(
         socket.is_variadic
@@ -1222,7 +1221,10 @@ def _is_lazy_variadic(c: Component) -> bool:
     )
     if not is_variadic:
         return False
-    return not getattr(c, "__haystack_is_greedy__", False)
+    return not any(
+        socket.is_greedy
+        for socket in c.__haystack_input__._sockets_dict.values()  # type: ignore
+    )
 
 
 def _has_all_inputs_with_defaults(c: Component) -> bool:

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -1213,7 +1213,7 @@ def _connections_status(
 
 def _is_lazy_variadic(c: Component) -> bool:
     """
-    Small utility function to check if a Component has a Variadic input
+    Small utility function to check if a Component has at least a Variadic input and no GreedyVariadic input.
     """
     is_variadic = any(
         socket.is_variadic

--- a/releasenotes/notes/deprecate-greedy-argument-4b8c39572f5df25c.yaml
+++ b/releasenotes/notes/deprecate-greedy-argument-4b8c39572f5df25c.yaml
@@ -1,0 +1,13 @@
+---
+enhancements:
+  - |
+    Add new `GreedyVariadic` input type. This has a similar behaviour to `Variadic` input type
+    as it can be connected to multiple output sockets, though the Pipeline will run it as soon
+    as it receives an input without waiting for others.
+    This replaces the `is_greedy` argument in the `@component` decorator.
+    If you had a Component with a `Variadic` input type and `@component(is_greedy=True)` you need
+    to change the type to `GreedyVariadic` and remove `is_greedy=true` from `@component`.
+deprecations:
+  - |
+    `@component` decorator `is_greedy` argument is deprecated and will be remove in version `2.7.0`.
+    Use `GreedyVariadic` type instead.

--- a/releasenotes/notes/deprecate-greedy-argument-4b8c39572f5df25c.yaml
+++ b/releasenotes/notes/deprecate-greedy-argument-4b8c39572f5df25c.yaml
@@ -9,5 +9,5 @@ enhancements:
     to change the type to `GreedyVariadic` and remove `is_greedy=true` from `@component`.
 deprecations:
   - |
-    `@component` decorator `is_greedy` argument is deprecated and will be remove in version `2.7.0`.
+    `@component` decorator `is_greedy` argument is deprecated and will be removed in version `2.7.0`.
     Use `GreedyVariadic` type instead.

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -430,57 +430,6 @@ def test_repr_added_to_pipeline():
     assert repr(comp) == f"{object.__repr__(comp)}\nmy_component\nInputs:\n  - value: int\nOutputs:\n  - value: int"
 
 
-def test_is_greedy_default_with_variadic_input():
-    @component
-    class MockComponent:
-        @component.output_types(value=int)
-        def run(self, value: Variadic[int]):
-            return {"value": value}
-
-    assert not MockComponent.__haystack_is_greedy__
-    assert not MockComponent().__haystack_is_greedy__
-
-
-def test_is_greedy_default_without_variadic_input():
-    @component
-    class MockComponent:
-        @component.output_types(value=int)
-        def run(self, value: int):
-            return {"value": value}
-
-    assert not MockComponent.__haystack_is_greedy__
-    assert not MockComponent().__haystack_is_greedy__
-
-
-def test_is_greedy_flag_with_variadic_input():
-    @component(is_greedy=True)
-    class MockComponent:
-        @component.output_types(value=int)
-        def run(self, value: Variadic[int]):
-            return {"value": value}
-
-    assert MockComponent.__haystack_is_greedy__
-    assert MockComponent().__haystack_is_greedy__
-
-
-def test_is_greedy_flag_without_variadic_input(caplog):
-    caplog.set_level(logging.WARNING)
-
-    @component(is_greedy=True)
-    class MockComponent:
-        @component.output_types(value=int)
-        def run(self, value: int):
-            return {"value": value}
-
-    assert MockComponent.__haystack_is_greedy__
-    assert caplog.text == ""
-    assert MockComponent().__haystack_is_greedy__
-    assert (
-        "Component 'MockComponent' has no variadic input, but it's marked as greedy."
-        " This is not supported and can lead to unexpected behavior.\n" in caplog.text
-    )
-
-
 def test_pre_init_hooking():
     @component
     class MockComponent:


### PR DESCRIPTION
### Related Issues

- fixes #7871

### Proposed Changes:

Deprecate `@component` decorator `is_greedy` argument and add a new `GreedyVariadic` input type in its place.

### How did you test it?

I ran unit tests locally.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
