### PR TITLE
feat: `Pipeline.connect()` will now raise a `PipelineConnectError` if `sender` and `receiver` are the same Component

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -453,6 +453,8 @@ class PipelineBase:
         sender_component_name, sender_socket_name = parse_connect_string(sender)
         receiver_component_name, receiver_socket_name = parse_connect_string(receiver)
 
+        if sender_component_name == receiver_component_name:
+            raise PipelineConnectError("Connecting a Component to itself is not supported.")
         # Get the nodes data.
         try:
             from_sockets = self.graph.nodes[sender_component_name]["output_sockets"]

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -981,9 +981,8 @@ class PipelineBase:
             receiver = self.graph.nodes[receiver_name]["instance"]
             pair = (receiver_name, receiver)
 
-            is_greedy = getattr(receiver, "__haystack_is_greedy__", False)
             if receiver_socket.is_variadic:
-                if is_greedy:
+                if receiver_socket.is_greedy:
                     # If the receiver is greedy, we can run it as soon as possible.
                     # First we remove it from the status lists it's in if it's there or
                     # we risk running it multiple times.
@@ -1217,7 +1216,7 @@ def _connections_status(
 
 def _is_lazy_variadic(c: Component) -> bool:
     """
-    Small utility function to check if a Component has a Variadic input that is not greedy
+    Small utility function to check if a Component has at least a Variadic input and no GreedyVariadic input.
     """
     is_variadic = any(
         socket.is_variadic
@@ -1225,7 +1224,10 @@ def _is_lazy_variadic(c: Component) -> bool:
     )
     if not is_variadic:
         return False
-    return not getattr(c, "__haystack_is_greedy__", False)
+    return not any(
+        socket.is_greedy
+        for socket in c.__haystack_input__._sockets_dict.values()  # type: ignore
+    )
 
 
 def _has_all_inputs_with_defaults(c: Component) -> bool:

--- a/releasenotes/notes/remove-support-to-connect-component-to-self-6eedfb287f2a2a02.yaml
+++ b/releasenotes/notes/remove-support-to-connect-component-to-self-6eedfb287f2a2a02.yaml
@@ -1,0 +1,3 @@
+---
+preview:
+  - Remove Pipeline ability to a component to itself

--- a/releasenotes/notes/remove-support-to-connect-component-to-self-6eedfb287f2a2a02.yaml
+++ b/releasenotes/notes/remove-support-to-connect-component-to-self-6eedfb287f2a2a02.yaml
@@ -1,3 +1,5 @@
 ---
-preview:
-  - Remove Pipeline ability to a component to itself
+upgrade:
+  - |
+    `Pipeline.connect()` will now raise a `PipelineConnectError` if `sender` and `receiver` are the same Component.
+    We do not support this use case anymore.

--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -27,8 +27,6 @@ Feature: Pipeline running
         | that has components added in a different order from the order of execution |
         | that has a component with only default inputs |
         | that has a component with only default inputs as first to run |
-        | that has only a single component that sends one of its outputs to itself |
-        | that has a component that sends one of its outputs to itself |
         | that has multiple branches that merge into a component with a single variadic input |
         | that has multiple branches of different lengths that merge into a component with a single variadic input |
         | that is linear and returns intermediate outputs |

--- a/test/core/pipeline/features/test_run.py
+++ b/test/core/pipeline/features/test_run.py
@@ -912,58 +912,6 @@ def pipeline_that_has_a_component_with_only_default_inputs_as_first_to_run():
 
 
 @given(
-    "a pipeline that has only a single component that sends one of its outputs to itself",
-    target_fixture="pipeline_data",
-)
-def pipeline_that_has_a_single_component_that_send_one_of_outputs_to_itself():
-    pipeline = Pipeline(max_runs_per_component=10)
-    pipeline.add_component("self_loop", SelfLoop())
-    pipeline.connect("self_loop.current_value", "self_loop.values")
-
-    return (
-        pipeline,
-        [
-            PipelineRunData(
-                inputs={"self_loop": {"values": 5}},
-                expected_outputs={"self_loop": {"final_result": 0}},
-                expected_run_order=["self_loop", "self_loop", "self_loop", "self_loop", "self_loop"],
-            )
-        ],
-    )
-
-
-@given("a pipeline that has a component that sends one of its outputs to itself", target_fixture="pipeline_data")
-def pipeline_that_has_a_component_that_sends_one_of_its_outputs_to_itself():
-    pipeline = Pipeline(max_runs_per_component=10)
-    pipeline.add_component("add_1", AddFixedValue())
-    pipeline.add_component("self_loop", SelfLoop())
-    pipeline.add_component("add_2", AddFixedValue())
-    pipeline.connect("add_1", "self_loop.values")
-    pipeline.connect("self_loop.current_value", "self_loop.values")
-    pipeline.connect("self_loop.final_result", "add_2.value")
-
-    return (
-        pipeline,
-        [
-            PipelineRunData(
-                inputs={"add_1": {"value": 5}},
-                expected_outputs={"add_2": {"result": 1}},
-                expected_run_order=[
-                    "add_1",
-                    "self_loop",
-                    "self_loop",
-                    "self_loop",
-                    "self_loop",
-                    "self_loop",
-                    "self_loop",
-                    "add_2",
-                ],
-            )
-        ],
-    )
-
-
-@given(
     "a pipeline that has multiple branches that merge into a component with a single variadic input",
     target_fixture="pipeline_data",
 )

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -907,9 +907,12 @@ class TestPipeline:
 
         pipeline = Pipeline()
         hello = Hello()
+        hello_again = Hello()
         pipeline.add_component("hello", hello)
-        pipeline.connect("hello.intermediate", "hello.intermediate")
-        assert [("hello", hello)] == list(pipeline.walk())
+        pipeline.add_component("hello_again", hello_again)
+        pipeline.connect("hello.intermediate", "hello_again.intermediate")
+        pipeline.connect("hello_again.intermediate", "hello.intermediate")
+        assert {("hello", hello), ("hello_again", hello_again)} == set(pipeline.walk())
 
     def test__init_graph(self):
         pipe = Pipeline()

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -914,18 +914,6 @@ class TestPipeline:
         pipeline.connect("hello_again.intermediate", "hello.intermediate")
         assert {("hello", hello), ("hello_again", hello_again)} == set(pipeline.walk())
 
-    def test_component_connecting_to_itself(self):
-        """
-        This pipeline consists of one component, which would be connected to itself.
-        Connecting a component to itself is supposed to raise PipelineConnectError.
-        """
-
-        pipe = Pipeline()
-        single_component = FakeComponent()
-        pipe.add_component("single_component", single_component)
-        with pytest.raises(PipelineConnectError):
-            pipe.connect("single_component.out", "single_component.in")
-
     def test__init_graph(self):
         pipe = Pipeline()
         pipe.add_component("greet", Greet())
@@ -1199,6 +1187,17 @@ class TestPipeline:
         assert comp2.__haystack_output__.value.receivers == ["comp3"]
         assert comp3.__haystack_input__.value.senders == ["comp1", "comp2"]
         assert list(pipe.graph.edges) == [("comp1", "comp3", "value/value"), ("comp2", "comp3", "value/value")]
+
+    def test_connect_same_component_as_sender_and_receiver(self):
+        """
+        This pipeline consists of one component, which would be connected to itself.
+        Connecting a component to itself is raises PipelineConnectError.
+        """
+        pipe = Pipeline()
+        single_component = FakeComponent()
+        pipe.add_component("single_component", single_component)
+        with pytest.raises(PipelineConnectError):
+            pipe.connect("single_component.out", "single_component.in")
 
     def test__run_component(self, spying_tracer, caplog):
         caplog.set_level(logging.INFO)

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -886,8 +886,8 @@ class TestPipeline:
 
     def test_walk_pipeline_with_cycles(self):
         """
-        This pipeline consists of one component, which would run three times in a loop.
-        pipeline.walk() should return this component exactly once. The order is not guaranteed.
+        This pipeline consists of two components, which would run three times in a loop.
+        pipeline.walk() should return these components exactly once. The order is not guaranteed.
         """
 
         @component
@@ -913,6 +913,18 @@ class TestPipeline:
         pipeline.connect("hello.intermediate", "hello_again.intermediate")
         pipeline.connect("hello_again.intermediate", "hello.intermediate")
         assert {("hello", hello), ("hello_again", hello_again)} == set(pipeline.walk())
+
+    def test_component_connecting_to_itself(self):
+        """
+        This pipeline consists of one component, which would be connected to itself.
+        Connecting a component to itself is supposed to raise PipelineConnectError.
+        """
+
+        pipe = Pipeline()
+        single_component = FakeComponent()
+        pipe.add_component("single_component", single_component)
+        with pytest.raises(PipelineConnectError):
+            pipe.connect("single_component.out", "single_component.in")
 
     def test__init_graph(self):
         pipe = Pipeline()


### PR DESCRIPTION
### Related Issues

- fixes #8369

### Proposed Changes:
 As described in the issue to remove support for connecting a component to self , we now raise an error instead of a deprecating warning