### PR TITLE
ci: reintroduce `macos-latest` in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-12
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -305,9 +305,9 @@ jobs:
                 - "url:https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   integration-tests-macos:
-    name: Integration / macos-12
+    name: Integration / macos-latest
     needs: unit-tests
-    runs-on: macos-12
+    runs-on: macos-latest
     env:
       HAYSTACK_MPS_ENABLED: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
+# trigger
+
 [project]
 name = "haystack-ai"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
-# trigger
-
 [project]
 name = "haystack-ai"
 dynamic = ["version"]


### PR DESCRIPTION
### Related Issues

In #7597, we introduced `macos-12` (instead of `macos-latest`) because the CI was broken.

After several months, `haystack-core-integrations` and `haystack-experimental` use `macos-latest`.
I also found out that our CI works properly with `macos-latest` (it also seems faster than `macos-12`).

### Proposed Changes:
Reintroduce `macos-latest`.

### How did you test it?
CI (triggered with a temporary change to pyproject -> https://github.com/deepset-ai/haystack/actions/runs/11029975901)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
