### PR TITLE
test: Add new behavioral test

### DIFF
--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -41,6 +41,7 @@ Feature: Pipeline running
         | that is linear with conditional branching and multiple joins |
         | that has a variadic component that receives partial inputs |
         | that has an answer joiner variadic component |
+        | that has a builder and retriever and doc joiner variadic component |
 
     Scenario Outline: Running a bad Pipeline
         Given a pipeline <kind>


### PR DESCRIPTION
### Related Issues

Adds a new behavorial test based on this issue https://github.com/deepset-ai/haystack/issues/8389

@silvanocerza this is also fixed by the subgraphs branch. 

**Note:** This test will still fail currently with the subgraphs branch b/c Doc comparison is fragile when Documents have scores. By this I mean a Doc is assigned a float score by the Retriever and the Doc `__eq__` method only does an exact comparison. This breaks when comparing floats due to the imprecision with long decimals. 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
