### PR TITLE
fix: Expose `raise_on_invalid_filter_syntax` in `haystack.utils`

### DIFF
--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -7,7 +7,7 @@ from .callable_serialization import deserialize_callable, serialize_callable
 from .device import ComponentDevice, Device, DeviceMap, DeviceType
 from .docstore_deserialization import deserialize_document_store_in_init_params_inplace
 from .expit import expit
-from .filters import document_matches_filter
+from .filters import document_matches_filter, raise_on_invalid_filter_syntax
 from .jinja2_extensions import Jinja2TimeExtension
 from .jupyter import is_in_jupyter
 from .requests_utils import request_with_retry
@@ -22,6 +22,7 @@ __all__ = [
     "DeviceType",
     "expit",
     "document_matches_filter",
+    "raise_on_invalid_filter_syntax",
     "is_in_jupyter",
     "request_with_retry",
     "serialize_callable",


### PR DESCRIPTION
### Related Issues

- The utility function `raise_on_invalid_filter_syntax` introduced in this [PR](https://github.com/deepset-ai/haystack/pull/8386) is missing from `haystack/utils/__init__.py`.

### Proposed Changes:

Update `haystack/utils/__init__.py`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
