### PR TITLE
feat: Add DocumentNDCGEvaluator component 

### DIFF
--- a/docs/pydoc/config/evaluators_api.yml
+++ b/docs/pydoc/config/evaluators_api.yml
@@ -7,7 +7,7 @@ loaders:
         "context_relevance",
         "document_map",
         "document_mrr",
-        "document_recall",
+        "document_ndcg",
         "document_recall",
         "faithfulness",
         "llm_evaluator",

--- a/haystack/components/evaluators/__init__.py
+++ b/haystack/components/evaluators/__init__.py
@@ -6,6 +6,7 @@ from .answer_exact_match import AnswerExactMatchEvaluator
 from .context_relevance import ContextRelevanceEvaluator
 from .document_map import DocumentMAPEvaluator
 from .document_mrr import DocumentMRREvaluator
+from .document_ndcg import DocumentNDCGEvaluator
 from .document_recall import DocumentRecallEvaluator
 from .faithfulness import FaithfulnessEvaluator
 from .llm_evaluator import LLMEvaluator
@@ -16,6 +17,7 @@ __all__ = [
     "ContextRelevanceEvaluator",
     "DocumentMAPEvaluator",
     "DocumentMRREvaluator",
+    "DocumentNDCGEvaluator",
     "DocumentRecallEvaluator",
     "FaithfulnessEvaluator",
     "LLMEvaluator",

--- a/haystack/components/evaluators/document_ndcg.py
+++ b/haystack/components/evaluators/document_ndcg.py
@@ -42,11 +42,12 @@ class DocumentNDCGEvaluator:
         Run the DocumentNDCGEvaluator on the given inputs.
 
         `ground_truth_documents` and `retrieved_documents` must have the same length.
+        The list items within `ground_truth_documents` and `retrieved_documents` can differ in length.
 
         :param ground_truth_documents:
-            A list of expected documents for each question with relevance scores or sorted by relevance.
+            Lists of expected documents, one list per question, either with relevance scores or sorted by relevance.
         :param retrieved_documents:
-            A list of retrieved documents for each question.
+            Lists of retrieved documents, one list per question.
         :returns:
             A dictionary with the following outputs:
             - `score` - The average of calculated scores.

--- a/haystack/components/evaluators/document_ndcg.py
+++ b/haystack/components/evaluators/document_ndcg.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from math import log2
+from typing import Any, Dict, List
+
+from haystack import Document, component
+
+
+@component
+class DocumentNDCGEvaluator:
+    """
+    Evaluator that calculates the normalized discounted cumulative gain of the retrieved documents.
+
+    Each question can have multiple ground truth documents and multiple retrieved documents.
+    If the ground truth documents have relevance scores, the NDCG is calculated using the relevance scores.
+    Otherwise, the NDCG is calculated using the document ranks.
+
+    `DocumentNDCGEvaluator` doesn't normalize its inputs, the `DocumentCleaner` component
+    should be used to clean and normalize the documents before passing them to this evaluator.
+
+    Usage example:
+    ```python
+    from haystack import Document
+    from haystack.components.evaluators import DocumentMRREvaluator
+
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[
+            [Document(content="France")],
+            [Document(content="9th century"), Document(content="9th")],
+        ],
+        retrieved_documents=[
+            [Document(content="France")],
+            [Document(content="9th century"), Document(content="10th century"), Document(content="9th")],
+        ],
+    )
+    print(result["individual_scores"])
+    #
+    print(result["score"])
+    #
+    ```
+    """
+
+    @component.output_types(score=float, individual_scores=List[float])
+    def run(
+        self, ground_truth_documents: List[List[Document]], retrieved_documents: List[List[Document]]
+    ) -> Dict[str, Any]:
+        """
+        Run the DocumentNDCGEvaluator on the given inputs.
+
+        `ground_truth_documents` and `retrieved_documents` must have the same length.
+
+        :param ground_truth_documents:
+            A list of expected documents for each question sorted by relevance.
+        :param retrieved_documents:
+            A list of retrieved documents for each question.
+        :returns:
+            A dictionary with the following outputs:
+            - `score` - The average of calculated scores.
+            - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents the NDCG for each question.
+        """
+        if len(ground_truth_documents) != len(retrieved_documents):
+            msg = "The length of ground_truth_documents and retrieved_documents must be the same."
+            raise ValueError(msg)
+
+        individual_scores = []
+
+        for gt_docs, ret_docs in zip(ground_truth_documents, retrieved_documents):
+            # Calculate discounted cumulative gain (DCG)
+            dcg = self._calculate_dcg(gt_docs, ret_docs)
+
+            # Calculate ideal discounted cumulative gain (IDCG)
+            idcg = self._calculate_idcg(gt_docs)
+
+            # Calculate NDCG
+            ndcg = dcg / idcg if idcg > 0 else 0
+            individual_scores.append(ndcg)
+
+        score = sum(individual_scores) / len(ground_truth_documents)
+
+        return {"score": score, "individual_scores": individual_scores}
+
+    def _calculate_dcg(self, gt_docs: List[Document], ret_docs: List[Document]) -> float:
+        dcg = 0
+        for i, doc in enumerate(ret_docs):
+            if doc in gt_docs:
+                # If the document has a score, use it; otherwise, use the inverse of the rank
+                relevance = getattr(doc, "score", 1 / (i + 1))
+                dcg += relevance / log2(i + 2)  # i + 2 because i is 0-indexed
+        return dcg
+
+    def _calculate_idcg(self, gt_docs: List[Document]) -> float:
+        idcg = 0
+        for i, doc in enumerate(sorted(gt_docs, key=lambda x: getattr(x, "score", 1), reverse=True)):
+            # If the document has a score, use it; otherwise, use the inverse of the rank
+            relevance = getattr(doc, "score", 1 / (i + 1))
+            idcg += relevance / log2(i + 2)
+        return idcg

--- a/haystack/components/evaluators/document_ndcg.py
+++ b/haystack/components/evaluators/document_ndcg.py
@@ -53,7 +53,7 @@ class DocumentNDCGEvaluator:
             - `score` - The average of calculated scores.
             - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents the NDCG for each question.
         """
-        self.validate_init_parameters(ground_truth_documents, retrieved_documents)
+        self.validate_inputs(ground_truth_documents, retrieved_documents)
 
         individual_scores = []
 
@@ -68,9 +68,9 @@ class DocumentNDCGEvaluator:
         return {"score": score, "individual_scores": individual_scores}
 
     @staticmethod
-    def validate_init_parameters(gt_docs: List[List[Document]], ret_docs: List[List[Document]]):
+    def validate_inputs(gt_docs: List[List[Document]], ret_docs: List[List[Document]]):
         """
-        Validate the init parameters.
+        Validate the input parameters.
 
         :param gt_docs:
             The ground_truth_documents to validate.

--- a/releasenotes/notes/document-ndcg-evaluator-d579f51dd76ae76a.yaml
+++ b/releasenotes/notes/document-ndcg-evaluator-d579f51dd76ae76a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added a new component DocumentNDCGEvaluator, which is similar to DocumentMRREvaluator and useful for retrieval evaluation. It calculates the normalized discounted cumulative gain, an evaluation metric useful when there are multiple ground truth relevant documents and the order in which they are retrieved is important.

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -40,8 +40,8 @@ def test_run_without_scores():
         ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
         retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
     )
-    assert result["individual_scores"][0] == pytest.approx(0.8869, abs=1e-4)
-    assert result["score"] == pytest.approx(0.8869, abs=1e-4)
+    assert result["individual_scores"][0] == pytest.approx(0.9197, abs=1e-4)
+    assert result["score"] == pytest.approx(0.9197, abs=1e-4)
 
 
 def test_run_with_multiple_lists_of_docs():
@@ -69,9 +69,9 @@ def test_run_with_multiple_lists_of_docs():
             ],
         ],
     )
-    assert result["individual_scores"][0] == pytest.approx(0.8869, abs=1e-4)
+    assert result["individual_scores"][0] == pytest.approx(0.9197, abs=1e-4)
     assert result["individual_scores"][1] == pytest.approx(0.6592, abs=1e-4)
-    assert result["score"] == pytest.approx(0.7731, abs=1e-4)
+    assert result["score"] == pytest.approx(0.7895, abs=1e-4)
 
 
 def test_run_with_different_lengths():
@@ -163,7 +163,7 @@ def test_calculate_dcg_without_scores():
     gt_docs = [Document(content="doc1"), Document(content="doc2")]
     ret_docs = [Document(content="doc2"), Document(content="doc3"), Document(content="doc1")]
     dcg = evaluator.calculate_dcg(gt_docs, ret_docs)
-    assert dcg == pytest.approx(1.1667, abs=1e-4)
+    assert dcg == pytest.approx(1.5, abs=1e-4)
 
 
 def test_calculate_dcg_empty():
@@ -192,7 +192,7 @@ def test_calculate_idcg_without_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
     idcg = evaluator.calculate_idcg(gt_docs)
-    assert idcg == pytest.approx(1.4821, abs=1e-4)
+    assert idcg == pytest.approx(2.1309, abs=1e-4)
 
 
 def test_calculate_idcg_empty():

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from haystack import Document
+from haystack.components.evaluators.document_ndcg import DocumentNDCGEvaluator
+
+
+def test_document_ndcg_evaluator():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[
+            [Document(content="France", score=3)],
+            [Document(content="9th century", score=2), Document(content="9th", score=1)],
+        ],
+        retrieved_documents=[
+            [Document(content="France"), Document(content="Germany")],
+            [Document(content="9th century"), Document(content="10th century"), Document(content="9th")],
+        ],
+    )
+    assert len(result["individual_scores"]) == 2
+    assert result["individual_scores"][0] == pytest.approx(1.0)
+    assert result["individual_scores"][1] == pytest.approx(0.9196, abs=1e-4)
+    assert result["score"] == pytest.approx(0.9598, abs=1e-4)
+
+
+def test_document_ndcg_evaluator_empty_retrieved():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[]])
+    assert result["individual_scores"] == [0.0]
+    assert result["score"] == 0.0
+
+
+def test_document_ndcg_evaluator_empty_ground_truth():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(ground_truth_documents=[[]], retrieved_documents=[[Document(content="France")]])
+    assert result["individual_scores"] == [0.0]
+    assert result["score"] == 0.0
+
+
+def test_document_ndcg_evaluator_without_relevance_scores():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
+        retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
+    )
+    assert result["individual_scores"][0] == pytest.approx(0.9196, abs=1e-4)
+    assert result["score"] == pytest.approx(0.9196, abs=1e-4)
+
+
+def test_document_ndcg_evaluator_with_relevance_scores():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[
+            [
+                Document(content="doc1", score=3),
+                Document(content="doc2", score=2),
+                Document(content="doc3", score=3),
+                Document(content="doc5", score=1),
+                Document(content="doc6", score=2),
+                Document(content="doc7", score=3),
+                Document(content="doc8", score=2),
+            ]
+        ],
+        retrieved_documents=[
+            [
+                Document(content="doc1"),
+                Document(content="doc2"),
+                Document(content="doc3"),
+                Document(content="doc4"),
+                Document(content="doc5"),
+                Document(content="doc6"),
+            ]
+        ],
+    )
+    assert result["individual_scores"][0] == pytest.approx(0.785, abs=1e-4)
+    assert result["score"] == pytest.approx(0.785, abs=1e-4)
+
+
+def test_document_ndcg_evaluator_different_lengths():
+    evaluator = DocumentNDCGEvaluator()
+    with pytest.raises(
+        ValueError, match="The length of ground_truth_documents and retrieved_documents must be the same."
+    ):
+        evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[])
+
+
+def test_document_ndcg_evaluator_none_content():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[Document(content=None)]]
+    )
+    assert result["individual_scores"] == [0.0]
+    assert result["score"] == 0.0
+
+
+def test_document_ndcg_evaluator_no_score():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
+        retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
+    )
+    assert result["individual_scores"][0] == pytest.approx(0.7928, abs=1e-4)
+    assert result["score"] == pytest.approx(0.7928, abs=1e-4)
+
+
+def test_calculate_dcg():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = [Document(content="doc1", score=3), Document(content="doc2", score=2)]
+    ret_docs = [Document(content="doc1"), Document(content="doc3"), Document(content="doc2")]
+    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    assert dcg == pytest.approx(2.1309, abs=1e-4)
+
+
+def test_calculate_dcg_no_scores():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = [Document(content="doc1"), Document(content="doc2")]
+    ret_docs = [Document(content="doc2"), Document(content="doc3"), Document(content="doc1")]
+    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    assert dcg == pytest.approx(1.5, abs=1e-4)
+
+
+def test_calculate_idcg():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = [Document(content="doc1", score=3), Document(content="doc2", score=2), Document(content="doc3", score=3)]
+    idcg = evaluator._calculate_idcg(gt_docs)
+    assert idcg == pytest.approx(5.4196, abs=1e-4)
+
+
+def test_calculate_idcg_no_scores():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
+    idcg = evaluator._calculate_idcg(gt_docs)
+    assert idcg == pytest.approx(2.7095, abs=1e-4)
+
+
+def test_calculate_idcg_empty():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = []
+    idcg = evaluator._calculate_idcg(gt_docs)
+    assert idcg == 0
+
+
+def test_calculate_dcg_empty():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = [Document(content="doc1")]
+    ret_docs = []
+    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    assert dcg == 0

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -111,6 +111,31 @@ def test_run_empty_ground_truth():
     assert result["score"] == 0.0
 
 
+def test_run_empty_retrieved_and_empty_ground_truth():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(ground_truth_documents=[[]], retrieved_documents=[[]])
+    assert result["individual_scores"] == [0.0]
+    assert result["score"] == 0.0
+
+
+def test_run_no_retrieved():
+    evaluator = DocumentNDCGEvaluator()
+    with pytest.raises(ValueError):
+        result = evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[])
+
+
+def test_run_no_ground_truth():
+    evaluator = DocumentNDCGEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[[Document(content="France")]])
+
+
+def test_run_no_retrieved_and_no_ground_truth():
+    evaluator = DocumentNDCGEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(ground_truth_documents=[], retrieved_documents=[])
+
+
 def test_calculate_dcg_with_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [
@@ -129,7 +154,7 @@ def test_calculate_dcg_with_scores():
         Document(content="doc5"),
         Document(content="doc6"),
     ]
-    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    dcg = evaluator.calculate_dcg(gt_docs, ret_docs)
     assert dcg == pytest.approx(6.8611, abs=1e-4)
 
 
@@ -137,7 +162,7 @@ def test_calculate_dcg_without_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2")]
     ret_docs = [Document(content="doc2"), Document(content="doc3"), Document(content="doc1")]
-    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    dcg = evaluator.calculate_dcg(gt_docs, ret_docs)
     assert dcg == pytest.approx(1.1667, abs=1e-4)
 
 
@@ -145,7 +170,7 @@ def test_calculate_dcg_empty():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1")]
     ret_docs = []
-    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    dcg = evaluator.calculate_dcg(gt_docs, ret_docs)
     assert dcg == 0
 
 
@@ -159,19 +184,19 @@ def test_calculate_idcg_with_scores():
         Document(content="doc5", score=2),
         Document(content="doc6", score=2),
     ]
-    idcg = evaluator._calculate_idcg(gt_docs)
+    idcg = evaluator.calculate_idcg(gt_docs)
     assert idcg == pytest.approx(8.7403, abs=1e-4)
 
 
 def test_calculate_idcg_without_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
-    idcg = evaluator._calculate_idcg(gt_docs)
+    idcg = evaluator.calculate_idcg(gt_docs)
     assert idcg == pytest.approx(1.4821, abs=1e-4)
 
 
 def test_calculate_idcg_empty():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = []
-    idcg = evaluator._calculate_idcg(gt_docs)
+    idcg = evaluator.calculate_idcg(gt_docs)
     assert idcg == 0

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -58,6 +58,15 @@ def test_run_with_different_lengths():
         )
 
 
+def test_run_with_mixed_documents_with_and_without_scores():
+    evaluator = DocumentNDCGEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(
+            ground_truth_documents=[[Document(content="France", score=3), Document(content="Paris")]],
+            retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
+        )
+
+
 def test_run_empty_retrieved():
     evaluator = DocumentNDCGEvaluator()
     result = evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[]])

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -44,6 +44,36 @@ def test_run_without_scores():
     assert result["score"] == pytest.approx(0.8869, abs=1e-4)
 
 
+def test_run_with_multiple_lists_of_docs():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(
+        ground_truth_documents=[
+            [Document(content="France"), Document(content="Paris")],
+            [
+                Document(content="doc1", score=3),
+                Document(content="doc2", score=2),
+                Document(content="doc3", score=3),
+                Document(content="doc6", score=2),
+                Document(content="doc7", score=3),
+                Document(content="doc8", score=2),
+            ],
+        ],
+        retrieved_documents=[
+            [Document(content="France"), Document(content="Germany"), Document(content="Paris")],
+            [
+                Document(content="doc1"),
+                Document(content="doc2"),
+                Document(content="doc3"),
+                Document(content="doc4"),
+                Document(content="doc5"),
+            ],
+        ],
+    )
+    assert result["individual_scores"][0] == pytest.approx(0.8869, abs=1e-4)
+    assert result["individual_scores"][1] == pytest.approx(0.6592, abs=1e-4)
+    assert result["score"] == pytest.approx(0.7731, abs=1e-4)
+
+
 def test_run_with_different_lengths():
     evaluator = DocumentNDCGEvaluator()
     with pytest.raises(ValueError):

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -7,24 +7,6 @@ from haystack import Document
 from haystack.components.evaluators.document_ndcg import DocumentNDCGEvaluator
 
 
-def test_document_ndcg_evaluator():
-    evaluator = DocumentNDCGEvaluator()
-    result = evaluator.run(
-        ground_truth_documents=[
-            [Document(content="France", score=3)],
-            [Document(content="9th century", score=2), Document(content="9th", score=1)],
-        ],
-        retrieved_documents=[
-            [Document(content="France"), Document(content="Germany")],
-            [Document(content="9th century"), Document(content="10th century"), Document(content="9th")],
-        ],
-    )
-    assert len(result["individual_scores"]) == 2
-    assert result["individual_scores"][0] == pytest.approx(1.0)
-    assert result["individual_scores"][1] == pytest.approx(0.9196, abs=1e-4)
-    assert result["score"] == pytest.approx(0.9598, abs=1e-4)
-
-
 def test_document_ndcg_evaluator_empty_retrieved():
     evaluator = DocumentNDCGEvaluator()
     result = evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[]])
@@ -45,8 +27,10 @@ def test_document_ndcg_evaluator_without_relevance_scores():
         ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
         retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
     )
-    assert result["individual_scores"][0] == pytest.approx(0.9196, abs=1e-4)
-    assert result["score"] == pytest.approx(0.9196, abs=1e-4)
+    # dcg = 1/log2(2) + 0.3333/log2(4)
+    # idcg = 1/log2(2) + 0.5/log2(3)
+    assert result["individual_scores"][0] == pytest.approx(0.8869, abs=1e-4)
+    assert result["score"] == pytest.approx(0.8869, abs=1e-4)
 
 
 def test_document_ndcg_evaluator_with_relevance_scores():
@@ -57,7 +41,6 @@ def test_document_ndcg_evaluator_with_relevance_scores():
                 Document(content="doc1", score=3),
                 Document(content="doc2", score=2),
                 Document(content="doc3", score=3),
-                Document(content="doc5", score=1),
                 Document(content="doc6", score=2),
                 Document(content="doc7", score=3),
                 Document(content="doc8", score=2),
@@ -70,12 +53,13 @@ def test_document_ndcg_evaluator_with_relevance_scores():
                 Document(content="doc3"),
                 Document(content="doc4"),
                 Document(content="doc5"),
-                Document(content="doc6"),
             ]
         ],
     )
-    assert result["individual_scores"][0] == pytest.approx(0.785, abs=1e-4)
-    assert result["score"] == pytest.approx(0.785, abs=1e-4)
+    # dcg = 3/log2(2) + 2/log2(3) + 3/log2(4)
+    # idcg = 8.740
+    assert result["individual_scores"][0] == pytest.approx(0.6592, abs=1e-4)
+    assert result["score"] == pytest.approx(0.6592, abs=1e-4)
 
 
 def test_document_ndcg_evaluator_different_lengths():
@@ -95,44 +79,56 @@ def test_document_ndcg_evaluator_none_content():
     assert result["score"] == 0.0
 
 
-def test_document_ndcg_evaluator_no_score():
-    evaluator = DocumentNDCGEvaluator()
-    result = evaluator.run(
-        ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
-        retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
-    )
-    assert result["individual_scores"][0] == pytest.approx(0.7928, abs=1e-4)
-    assert result["score"] == pytest.approx(0.7928, abs=1e-4)
-
-
 def test_calculate_dcg():
     evaluator = DocumentNDCGEvaluator()
-    gt_docs = [Document(content="doc1", score=3), Document(content="doc2", score=2)]
-    ret_docs = [Document(content="doc1"), Document(content="doc3"), Document(content="doc2")]
+    gt_docs = [
+        Document(content="doc1", score=3),
+        Document(content="doc2", score=2),
+        Document(content="doc3", score=3),
+        Document(content="doc4", score=0),
+        Document(content="doc5", score=1),
+        Document(content="doc6", score=2),
+    ]
+    ret_docs = [
+        Document(content="doc1"),
+        Document(content="doc2"),
+        Document(content="doc3"),
+        Document(content="doc4"),
+        Document(content="doc5"),
+        Document(content="doc6"),
+    ]
     dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
-    assert dcg == pytest.approx(2.1309, abs=1e-4)
+    assert dcg == pytest.approx(6.8611, abs=1e-4)
 
 
 def test_calculate_dcg_no_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2")]
+    # 1 + 0,33/log2(3)
     ret_docs = [Document(content="doc2"), Document(content="doc3"), Document(content="doc1")]
     dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
-    assert dcg == pytest.approx(1.5, abs=1e-4)
+    assert dcg == pytest.approx(1.1667, abs=1e-4)
 
 
 def test_calculate_idcg():
     evaluator = DocumentNDCGEvaluator()
-    gt_docs = [Document(content="doc1", score=3), Document(content="doc2", score=2), Document(content="doc3", score=3)]
+    gt_docs = [
+        Document(content="doc1", score=3),
+        Document(content="doc2", score=3),
+        Document(content="doc3", score=2),
+        Document(content="doc4", score=3),
+        Document(content="doc5", score=2),
+        Document(content="doc6", score=2),
+    ]
     idcg = evaluator._calculate_idcg(gt_docs)
-    assert idcg == pytest.approx(5.4196, abs=1e-4)
+    assert idcg == pytest.approx(8.7403, abs=1e-4)
 
 
 def test_calculate_idcg_no_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
     idcg = evaluator._calculate_idcg(gt_docs)
-    assert idcg == pytest.approx(2.7095, abs=1e-4)
+    assert idcg == pytest.approx(1.4821, abs=1e-4)
 
 
 def test_calculate_idcg_empty():

--- a/test/components/evaluators/test_document_ndcg.py
+++ b/test/components/evaluators/test_document_ndcg.py
@@ -7,33 +7,7 @@ from haystack import Document
 from haystack.components.evaluators.document_ndcg import DocumentNDCGEvaluator
 
 
-def test_document_ndcg_evaluator_empty_retrieved():
-    evaluator = DocumentNDCGEvaluator()
-    result = evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[]])
-    assert result["individual_scores"] == [0.0]
-    assert result["score"] == 0.0
-
-
-def test_document_ndcg_evaluator_empty_ground_truth():
-    evaluator = DocumentNDCGEvaluator()
-    result = evaluator.run(ground_truth_documents=[[]], retrieved_documents=[[Document(content="France")]])
-    assert result["individual_scores"] == [0.0]
-    assert result["score"] == 0.0
-
-
-def test_document_ndcg_evaluator_without_relevance_scores():
-    evaluator = DocumentNDCGEvaluator()
-    result = evaluator.run(
-        ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
-        retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
-    )
-    # dcg = 1/log2(2) + 0.3333/log2(4)
-    # idcg = 1/log2(2) + 0.5/log2(3)
-    assert result["individual_scores"][0] == pytest.approx(0.8869, abs=1e-4)
-    assert result["score"] == pytest.approx(0.8869, abs=1e-4)
-
-
-def test_document_ndcg_evaluator_with_relevance_scores():
+def test_run_with_scores():
     evaluator = DocumentNDCGEvaluator()
     result = evaluator.run(
         ground_truth_documents=[
@@ -56,30 +30,49 @@ def test_document_ndcg_evaluator_with_relevance_scores():
             ]
         ],
     )
-    # dcg = 3/log2(2) + 2/log2(3) + 3/log2(4)
-    # idcg = 8.740
     assert result["individual_scores"][0] == pytest.approx(0.6592, abs=1e-4)
     assert result["score"] == pytest.approx(0.6592, abs=1e-4)
 
 
-def test_document_ndcg_evaluator_different_lengths():
-    evaluator = DocumentNDCGEvaluator()
-    with pytest.raises(
-        ValueError, match="The length of ground_truth_documents and retrieved_documents must be the same."
-    ):
-        evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[])
-
-
-def test_document_ndcg_evaluator_none_content():
+def test_run_without_scores():
     evaluator = DocumentNDCGEvaluator()
     result = evaluator.run(
-        ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[Document(content=None)]]
+        ground_truth_documents=[[Document(content="France"), Document(content="Paris")]],
+        retrieved_documents=[[Document(content="France"), Document(content="Germany"), Document(content="Paris")]],
     )
+    assert result["individual_scores"][0] == pytest.approx(0.8869, abs=1e-4)
+    assert result["score"] == pytest.approx(0.8869, abs=1e-4)
+
+
+def test_run_with_different_lengths():
+    evaluator = DocumentNDCGEvaluator()
+    with pytest.raises(ValueError):
+        evaluator.run(
+            ground_truth_documents=[[Document(content="Berlin")]],
+            retrieved_documents=[[Document(content="Berlin")], [Document(content="London")]],
+        )
+    with pytest.raises(ValueError):
+        evaluator.run(
+            ground_truth_documents=[[Document(content="Berlin")], [Document(content="Paris")]],
+            retrieved_documents=[[Document(content="Berlin")]],
+        )
+
+
+def test_run_empty_retrieved():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(ground_truth_documents=[[Document(content="France")]], retrieved_documents=[[]])
     assert result["individual_scores"] == [0.0]
     assert result["score"] == 0.0
 
 
-def test_calculate_dcg():
+def test_run_empty_ground_truth():
+    evaluator = DocumentNDCGEvaluator()
+    result = evaluator.run(ground_truth_documents=[[]], retrieved_documents=[[Document(content="France")]])
+    assert result["individual_scores"] == [0.0]
+    assert result["score"] == 0.0
+
+
+def test_calculate_dcg_with_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [
         Document(content="doc1", score=3),
@@ -101,16 +94,23 @@ def test_calculate_dcg():
     assert dcg == pytest.approx(6.8611, abs=1e-4)
 
 
-def test_calculate_dcg_no_scores():
+def test_calculate_dcg_without_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2")]
-    # 1 + 0,33/log2(3)
     ret_docs = [Document(content="doc2"), Document(content="doc3"), Document(content="doc1")]
     dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
     assert dcg == pytest.approx(1.1667, abs=1e-4)
 
 
-def test_calculate_idcg():
+def test_calculate_dcg_empty():
+    evaluator = DocumentNDCGEvaluator()
+    gt_docs = [Document(content="doc1")]
+    ret_docs = []
+    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
+    assert dcg == 0
+
+
+def test_calculate_idcg_with_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [
         Document(content="doc1", score=3),
@@ -124,7 +124,7 @@ def test_calculate_idcg():
     assert idcg == pytest.approx(8.7403, abs=1e-4)
 
 
-def test_calculate_idcg_no_scores():
+def test_calculate_idcg_without_scores():
     evaluator = DocumentNDCGEvaluator()
     gt_docs = [Document(content="doc1"), Document(content="doc2"), Document(content="doc3")]
     idcg = evaluator._calculate_idcg(gt_docs)
@@ -136,11 +136,3 @@ def test_calculate_idcg_empty():
     gt_docs = []
     idcg = evaluator._calculate_idcg(gt_docs)
     assert idcg == 0
-
-
-def test_calculate_dcg_empty():
-    evaluator = DocumentNDCGEvaluator()
-    gt_docs = [Document(content="doc1")]
-    ret_docs = []
-    dcg = evaluator._calculate_dcg(gt_docs, ret_docs)
-    assert dcg == 0


### PR DESCRIPTION
### Related Issues

- fixes #8415 

### Proposed Changes:

* Adding a new DocumentNDCGEvaluator component and corresponding unit tests

### How did you test it?

* New unit tests

### Notes for the reviewer

* The implementation of this component could benefit from any work on https://github.com/deepset-ai/haystack/issues/8412 In this PR, I am simply comparing document ids to evaluate whether two documents are equal.
* I can recommend reading https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Example for understanding the calculations and the values used in the test assertions

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
