### PR TITLE
fix: fix release note indentation of #8302

### DIFF
--- a/releasenotes/notes/refactor_deserialize_document_store_in_init_parameters-b7f05173f0c56452.yaml
+++ b/releasenotes/notes/refactor_deserialize_document_store_in_init_parameters-b7f05173f0c56452.yaml
@@ -2,4 +2,4 @@
 enhancements:
   - |
     Refactor deserialize_document_store_in_init_parameters so that new function name
-   indicates that the operation occurs in place, with no return value. 
+    indicates that the operation occurs in place, with no return value.


### PR DESCRIPTION
### Related Issues

- releasenotes/notes/refactor_deserialize_document_store_in_init_parameters-b7f05173f0c56452.yaml has a wrong indentation and caused a release workflow to fail https://github.com/deepset-ai/haystack/actions/runs/11108077435/job/30860188401

### Proposed Changes:

- fix indentation

### How did you test it?

no tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
