### PR TITLE
fix: make pypdf converter more robust

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -40,7 +40,8 @@ class DefaultConverter:
     The default converter class that extracts text from a PdfReader object's pages and returns a Document.
     """
 
-    def convert(self, reader: "PdfReader") -> Document:
+    @staticmethod
+    def convert(reader: "PdfReader") -> Document:
         """Extract text from the PDF and return a Document object with the text content."""
         text = "\f".join(page.extract_text() for page in reader.pages)
         return Document(content=text)
@@ -108,8 +109,7 @@ class PyPDFToDocument:
         :returns:
             Deserialized component.
         """
-        # the constructor has a default value for the converter of `None`. To keep the `from_dict` method in line with
-        # that default value, we need to check if the key is present.
+        # the converter default is `None`, check if it was defined before deserializing
         if "converter" in data["init_parameters"]:
             converter_class = deserialize_type(data["init_parameters"]["converter"]["type"])
             data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -40,8 +40,7 @@ class DefaultConverter:
     The default converter class that extracts text from a PdfReader object's pages and returns a Document.
     """
 
-    @staticmethod
-    def convert(reader: "PdfReader") -> Document:
+    def convert(self, reader: "PdfReader") -> Document:
         """Extract text from the PDF and return a Document object with the text content."""
         text = "\f".join(page.extract_text() for page in reader.pages)
         return Document(content=text)

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -108,8 +108,11 @@ class PyPDFToDocument:
         :returns:
             Deserialized component.
         """
-        converter_class = deserialize_type(data["init_parameters"]["converter"]["type"])
-        data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])
+        # the constructor has a default value for the converter of `None`. To keep the `from_dict` method in line with
+        # that default value, we need to check if the key is present.
+        if "converter" in data["init_parameters"]:
+            converter_class = deserialize_type(data["init_parameters"]["converter"]["type"])
+            data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/releasenotes/notes/pypdf-converter-robust-from-dict-35ebe6aaab944b19.yaml
+++ b/releasenotes/notes/pypdf-converter-robust-from-dict-35ebe6aaab944b19.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Make the `from_dict` method of the `PyPDFToDocument` more robust to cases when the converter is 
+    Make the `from_dict` method of the `PyPDFToDocument` more robust to cases when the converter is
     not provided in the dictionary.

--- a/releasenotes/notes/pypdf-converter-robust-from-dict-35ebe6aaab944b19.yaml
+++ b/releasenotes/notes/pypdf-converter-robust-from-dict-35ebe6aaab944b19.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Make the `from_dict` method of the `PyPDFToDocument` more robust to cases when the converter is 
+    not provided in the dictionary.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -40,6 +40,12 @@ class TestPyPDFToDocument:
         assert isinstance(instance, PyPDFToDocument)
         assert isinstance(instance.converter, DefaultConverter)
 
+    def test_from_dict_no_converter(self):
+        data = {"type": "haystack.components.converters.pypdf.PyPDFToDocument", "init_parameters": {}}
+        instance = PyPDFToDocument.from_dict(data)
+        assert isinstance(instance, PyPDFToDocument)
+        assert isinstance(instance.converter, DefaultConverter)
+
     @pytest.mark.integration
     def test_run(self, test_files_path, pypdf_converter):
         """


### PR DESCRIPTION

### Related Issues

- main version of https://github.com/deepset-ai/haystack/pull/8422

### Proposed Changes:

- **fix: make `from_dict` of `PyPDFToDocument` more robust**
- **chore: drop trailing space**
- **converting method to static and making the comment shorter**
- **reverting method to static**


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
