### PR TITLE
Revert "fix: make pypdf converter more robust (#8427)"

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -108,10 +108,8 @@ class PyPDFToDocument:
         :returns:
             Deserialized component.
         """
-        # the converter default is `None`, check if it was defined before deserializing
-        if "converter" in data["init_parameters"]:
-            converter_class = deserialize_type(data["init_parameters"]["converter"]["type"])
-            data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])
+        converter_class = deserialize_type(data["init_parameters"]["converter"]["type"])
+        data["init_parameters"]["converter"] = converter_class.from_dict(data["init_parameters"]["converter"])
         return default_from_dict(cls, data)
 
     @component.output_types(documents=List[Document])

--- a/releasenotes/notes/pypdf-converter-robust-from-dict-35ebe6aaab944b19.yaml
+++ b/releasenotes/notes/pypdf-converter-robust-from-dict-35ebe6aaab944b19.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Make the `from_dict` method of the `PyPDFToDocument` more robust to cases when the converter is
-    not provided in the dictionary.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -40,12 +40,6 @@ class TestPyPDFToDocument:
         assert isinstance(instance, PyPDFToDocument)
         assert isinstance(instance.converter, DefaultConverter)
 
-    def test_from_dict_no_converter(self):
-        data = {"type": "haystack.components.converters.pypdf.PyPDFToDocument", "init_parameters": {}}
-        instance = PyPDFToDocument.from_dict(data)
-        assert isinstance(instance, PyPDFToDocument)
-        assert isinstance(instance.converter, DefaultConverter)
-
     @pytest.mark.integration
     def test_run(self, test_files_path, pypdf_converter):
         """


### PR DESCRIPTION
This reverts commit d234c75168dcb49866a6714aa232f37d56f72cab.

This change was already brought up months ago with #7996 and reverted #8014.

Reverting again. 