### PR TITLE
chore: Fixing linting of `tracing/datadog.py`

### DIFF
--- a/haystack/tracing/datadog.py
+++ b/haystack/tracing/datadog.py
@@ -62,11 +62,11 @@ class DatadogTracer(Tracer):
     def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
         """Activate and return a new span that inherits from the current active span."""
         with self._tracer.trace(operation_name) as span:
-            span = DatadogSpan(span)
+            custom_span = DatadogSpan(span)
             if tags:
-                span.set_tags(tags)
+                custom_span.set_tags(tags)
 
-            yield span
+            yield custom_span
 
     def current_span(self) -> Optional[Span]:
         """Return the current active span"""


### PR DESCRIPTION
### Proposed Changes:

`mypy` is failing when linting `tracing/datadog.py`, this fixes it. 

```
❯ hatch run test:types
haystack/tracing/datadog.py:65: error: Incompatible types in assignment (expression has type "DatadogSpan", variable has type "Span")  [assignment]
haystack/tracing/datadog.py:67: error: Argument 1 to "set_tags" of "Span" has incompatible type "dict[str, Any]"; expected "dict[str | bytes, Any]"  [arg-type]
haystack/tracing/datadog.py:69: error: Incompatible types in "yield" (actual type "ddtrace._trace.span.Span", expected type "haystack.tracing.tracer.Span")  [misc]
haystack/components/converters/tika.py:30: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 3 errors in 1 file (checked 191 source files)
```

### How did you test it?

I ran `hatch run test:types` locally.

### Notes for the reviewer

We've not seen this failure in CI as we only lint modified files.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
