### PR TITLE
docs: `MarkdownToDocument` example - adding missing import

### DIFF
--- a/haystack/components/converters/markdown.py
+++ b/haystack/components/converters/markdown.py
@@ -28,6 +28,7 @@ class MarkdownToDocument:
     Usage example:
     ```python
     from haystack.components.converters import MarkdownToDocument
+    from datetime import datetime
 
     converter = MarkdownToDocument()
     results = converter.run(sources=["path/to/sample.md"], meta={"date_added": datetime.now().isoformat()})


### PR DESCRIPTION
### Related Issues

missing import

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
