### PR TITLE
fix: (Temporarily) Re-add suport for pre-2.6.0 YAMLs with `PyPDFConverter`

### DIFF
--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -12,6 +12,7 @@ from haystack.components.converters.utils import get_bytestream_from_source, nor
 from haystack.dataclasses import ByteStream
 from haystack.lazy_imports import LazyImport
 from haystack.utils.base_serialization import deserialize_class_instance, serialize_class_instance
+from haystack.utils.type_serialization import deserialize_type
 
 with LazyImport("Run 'pip install pypdf'") as pypdf_import:
     from pypdf import PdfReader
@@ -118,7 +119,12 @@ class PyPDFToDocument:
         """
         custom_converter_data = data["init_parameters"]["converter"]
         if custom_converter_data is not None:
-            data["init_parameters"]["converter"] = deserialize_class_instance(custom_converter_data)
+            if "data" in custom_converter_data:
+                data["init_parameters"]["converter"] = deserialize_class_instance(custom_converter_data)
+            else:
+                # TODO: Remove in 2.7.0
+                converter_class = deserialize_type(custom_converter_data["type"])
+                data["init_parameters"]["converter"] = converter_class.from_dict(custom_converter_data)
         return default_from_dict(cls, data)
 
     def _default_convert(self, reader: "PdfReader") -> Document:

--- a/releasenotes/notes/pypdf-serde-fixes-revert-22fcdad91951d3c2.yaml
+++ b/releasenotes/notes/pypdf-serde-fixes-revert-22fcdad91951d3c2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Revert change to PyPDFConverter that broke the deserialization of pre 2.6.0 YAMLs.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from haystack import Document, default_from_dict, default_to_dict
-from haystack.components.converters.pypdf import PyPDFToDocument
+from haystack.components.converters.pypdf import PyPDFToDocument, DefaultConverter
 from haystack.dataclasses import ByteStream
 
 
@@ -78,6 +78,15 @@ class TestPyPDFToDocument:
         instance = PyPDFToDocument.from_dict(data)
         assert isinstance(instance, PyPDFToDocument)
         assert isinstance(instance.converter, CustomConverter)
+
+    def test_from_dict_pre_2_6_0(self):
+        data = {
+            "type": "haystack.components.converters.pypdf.PyPDFToDocument",
+            "init_parameters": {"converter": {"type": "haystack.components.converters.pypdf.DefaultConverter"}},
+        }
+        instance = PyPDFToDocument.from_dict(data)
+        assert isinstance(instance, PyPDFToDocument)
+        assert isinstance(instance.converter, DefaultConverter)
 
     @pytest.mark.integration
     def test_run(self, test_files_path, pypdf_converter):


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/pull/8430/

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The above PR unintentionally broke the deserialization of YAMLs that were generated with Haystack < 2.6.0, so we re-add support for it. This will be removed in 2.7.0 once the default converter is merged into the component.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
