### PR TITLE
implement additional mime types

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -63,7 +63,7 @@ class FileTypeRouter:
 
         :param additional_mimetypes: A dictionary containing the MIME type to add to the mimetypes package to prevent
             unsupported or non native packages from being unclassified.
-            (for example: `{"application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"}`).
+            (for example: `{"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"}`).
         """
         if not mime_types:
             raise ValueError("The list of mime types cannot be empty.")

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -54,15 +54,23 @@ class FileTypeRouter:
     :param mime_types: A list of MIME types or regex patterns to classify the input files or byte streams.
     """
 
-    def __init__(self, mime_types: List[str]):
+    def __init__(self, mime_types: List[str], additional_mimetypes: Dict[str, str] = None):
         """
         Initialize the FileTypeRouter component.
 
         :param mime_types: A list of MIME types or regex patterns to classify the input files or byte streams.
             (for example: `["text/plain", "audio/x-wav", "image/jpeg"]`).
+
+        :param additional_mimetypes: A dictionary containing the MIME type to add to the mimetypes package to prevent
+            unsupported or non native packages from being unclassified.
+            (for example: `{"application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"}`).
         """
         if not mime_types:
             raise ValueError("The list of mime types cannot be empty.")
+
+        if additional_mimetypes:
+            for mime, ext in list(zip(additional_mimetypes.keys(), additional_mimetypes.values())):
+                mimetypes.add_type(mime, ext)
 
         self.mime_type_patterns = []
         for mime_type in mime_types:


### PR DESCRIPTION
### Related Issues

- fixes #8439 

### Proposed Changes:

Per our discussion, I have implemented additional mimetypes to be included and added to mimetypes to prevent unclassified categorization of MIME types that arent native to the particular OS in use, for instance AWS linux and docx MIME types.

### How did you test it?

Within a lambda, successful output:

```json
{
  "statusCode": 200,
  "body": "\"{'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [PosixPath('MYFILE.docx')]}\""
}
```

### Notes for the reviewer

Thanks for the correspondance!

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
