### PR TITLE
fix: logs containing JSON getting lost

### DIFF
--- a/haystack/logging.py
+++ b/haystack/logging.py
@@ -190,7 +190,10 @@ def patch_make_records_to_use_kwarg_string_interpolation(original_make_records: 
     @functools.wraps(original_make_records)
     def _wrapper(name, level, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None) -> Any:
         safe_extra = extra or {}
-        interpolated_msg = msg.format(**safe_extra)
+        try:
+            interpolated_msg = msg.format(**safe_extra)
+        except (KeyError, ValueError):
+            interpolated_msg = msg
         return original_make_records(name, level, fn, lno, interpolated_msg, (), exc_info, func, extra, sinfo)
 
     return _wrapper

--- a/releasenotes/notes/fix-logs-containing-json-1393a00b4904f996.yaml
+++ b/releasenotes/notes/fix-logs-containing-json-1393a00b4904f996.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes logs containing JSON data getting lost due to string interpolation.

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -490,6 +490,28 @@ class TestCompositeLogger:
             "module": "test.test_logging",
         }
 
+    def test_log_json_content(self, capfd: LogCaptureFixture) -> None:
+        haystack_logging.configure_logging(use_json=True)
+
+        logger = haystack_logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+
+        logger.log(logging.DEBUG, 'Hello, structured: {"key": "value"}', key="logging", key1="value1", key2="value2")
+
+        output = capfd.readouterr().err
+        parsed_output = json.loads(output)
+
+        assert parsed_output == {
+            "event": 'Hello, structured: {"key": "value"}',
+            "key": "logging",
+            "key1": "value1",
+            "key2": "value2",
+            "level": "debug",
+            "timestamp": ANY,
+            "lineno": ANY,
+            "module": "test.test_logging",
+        }
+
     def test_log_with_string_cast(self, capfd: LogCaptureFixture) -> None:
         haystack_logging.configure_logging(use_json=True)
 


### PR DESCRIPTION
### Related Issues

- fixes logs getting lost if str-interpolation-like message is passed, e.g. JSON
  ```python
  from haystack.logging import getLogger
  
  logger = getLogger(__name__)
  
  # this breaks with KeyError
  logger.info('My service responed with: {"key": "value"}')
  ```

### Proposed Changes:
- try-except string interpolation
- fallback to non-interpolated msg

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
