### PR TITLE
test: ensure compatibility with `huggingface_hub==0.26.0`

### DIFF
--- a/releasenotes/notes/compatibility-hh-hub-0.26.0-a5b61f7bf99a97b7.yaml
+++ b/releasenotes/notes/compatibility-hh-hub-0.26.0-a5b61f7bf99a97b7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Adjusted a test on `HuggingFaceAPIGenerator` to ensure compatibility with the `huggingface_hub==0.26.0`.

--- a/test/components/generators/test_hugging_face_api.py
+++ b/test/components/generators/test_hugging_face_api.py
@@ -250,7 +250,9 @@ class TestHuggingFaceAPIGenerator:
                 index=1,
                 generated_text=None,
                 token=TextGenerationOutputToken(id=1, text="Ok bye", logprob=0.0, special=False),
-                details=TextGenerationStreamOutputStreamDetails(finish_reason="length", generated_tokens=5, seed=None),
+                details=TextGenerationStreamOutputStreamDetails(
+                    finish_reason="length", generated_tokens=5, seed=None, input_length=10
+                ),
             )
 
         mock_response = Mock(**{"__iter__": mock_iter})


### PR DESCRIPTION
### Related Issues
- Tests failing on main https://github.com/deepset-ai/haystack/actions/runs/11399870792/job/31719542345
-  `huggingface_hub==0.26.0` introduced a new mandatory `input_length` parameter for `TextGenerationStreamOutputStreamDetails`. We were not using it in our mock.

### Proposed Changes:
- Update the mock in the test to set `input_length`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
