### PR TITLE
fix: Enforce basic Python types restriction on serialized component data and improve related errors

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -111,7 +111,7 @@ class PipelineBase:
         """
         components = {}
         for name, instance in self.graph.nodes(data="instance"):  # type:ignore
-            components[name] = component_to_dict(instance)
+            components[name] = component_to_dict(instance, name)
 
         connections = []
         for sender, receiver, edge_data in self.graph.edges.data():

--- a/releasenotes/notes/enforce-python-types-serde-0c5cd0a716bab7d0.yaml
+++ b/releasenotes/notes/enforce-python-types-serde-0c5cd0a716bab7d0.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Improved serialization/deserialization errors to provide extra context about the delinquent components when possible.
+
+fixes:
+  - |
+    Serialized data of components are now explicitly enforced to be one of the following basic Python datatypes: str, int, float, bool, list, dict, set, tuple or None.

--- a/test/marshal/test_yaml.py
+++ b/test/marshal/test_yaml.py
@@ -6,9 +6,21 @@ import pytest
 from haystack.marshal.yaml import YamlMarshaller
 
 
+class InvalidClass:
+    def __init__(self) -> None:
+        self.a = 1
+        self.b = None
+        self.c = "string"
+
+
 @pytest.fixture
 def yaml_data():
     return {"key": "value", 1: 0.221, "list": [1, 2, 3], "tuple": (1, None, True), "dict": {"set": {False}}}
+
+
+@pytest.fixture
+def invalid_yaml_data():
+    return {"key": "value", 1: 0.221, "list": [1, 2, 3], "tuple": (1, InvalidClass(), True), "dict": {"set": {False}}}
 
 
 @pytest.fixture
@@ -34,6 +46,12 @@ def test_yaml_marshal(yaml_data, serialized_yaml_str):
     marshalled = marshaller.marshal(yaml_data)
     assert isinstance(marshalled, str)
     assert marshalled.strip().replace("\n", "") == serialized_yaml_str.strip().replace("\n", "")
+
+
+def test_yaml_marshal_invalid_type(invalid_yaml_data):
+    with pytest.raises(TypeError, match="basic Python types"):
+        marshaller = YamlMarshaller()
+        marshalled = marshaller.marshal(invalid_yaml_data)
 
 
 def test_yaml_unmarshal(yaml_data, serialized_yaml_str):


### PR DESCRIPTION
### Related Issues

- fixes #8458

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The pipeline serialization code now explicitly restricts the usage of custom types in serialized component data. Previously, custom types were serialized to a generic Python object representation by the YAML marshaller even though the loader did not support them.

Additionally, errors related to serde have been expanded to provide information about the problematic component whenever possible.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
All tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
