### PR TITLE
ci: add `pip` to `test` dependencies

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -14,6 +14,9 @@ from haystack.dataclasses import ByteStream
 logger = logging.getLogger(__name__)
 
 
+# COMMENT TO TRIGGER THE LINT/TYPING WORKFLOW
+
+
 @component
 class FileTypeRouter:
     """

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -14,9 +14,6 @@ from haystack.dataclasses import ByteStream
 logger = logging.getLogger(__name__)
 
 
-# COMMENT TO TRIGGER THE LINT/TYPING WORKFLOW
-
-
 @component
 class FileTypeRouter:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ extra-dependencies = [
   "python-multipart",
   "psutil",
   "mypy",
+  "pip",  # mypy needs pip to install missing stub packages
   "pylint",
   "ipython",
 ]

--- a/releasenotes/notes/pip-test-dep-b797879f1d73b3eb.yaml
+++ b/releasenotes/notes/pip-test-dep-b797879f1d73b3eb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add `pip` to test dependencies: `mypy` needs it to install missing stub packages.


### PR DESCRIPTION
### Related Issues

- After the introduction of `uv`, [some typing tests are failing](https://github.com/deepset-ai/haystack/actions/runs/11443115369/job/31835396458?pr=8473).
- This happens because `pip` is no longer installed by default and it is needed by `mypy` for installing missing stub packages.

### Proposed Changes:
Add `pip` to `test` dependencies

### How did you test it?
CI. In https://github.com/deepset-ai/haystack/pull/8475/commits/875c4133f422ee62968fa48795255d5d4a31b367, I modified a python file to trigger the `lint` workflow.

See [lint/typing tests passing](https://github.com/deepset-ai/haystack/actions/runs/11455951671/job/31873387408?pr=8475).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
