### PR TITLE
test: Pin `ddtrace` test dependency to fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ extra-dependencies = [
 
   # Tracing
   "opentelemetry-sdk",
-  "ddtrace",
+  "ddtrace==2.15.0rc2",
 
   # Structured logging
   "structlog",
@@ -138,7 +138,7 @@ extra-dependencies = [
   "python-multipart",
   "psutil",
   "mypy",
-  "pip",  # mypy needs pip to install missing stub packages
+  "pip",                     # mypy needs pip to install missing stub packages
   "pylint",
   "ipython",
 ]


### PR DESCRIPTION
### Proposed Changes:

Latest `ddtrace` release is causing issues with `pytest` during tests collection.

This PR pins `ddtrace` tests dependency to `2.15.0rc2` to fix the issue.

Example CI failure:
https://github.com/deepset-ai/haystack/actions/runs/11457182414/job/31876910579

### How did you test it?

I ran tests locally.

### Notes for the reviewer

I'll create an issue to remember unpinning as soon as `2.15.0` is released.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
