### PR TITLE
feat: allow passing `meta` in the `run` method of `FileTypeRouter`

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -94,7 +94,7 @@ class FileTypeRouter:
             **{mime_type: List[Union[str, Path, ByteStream]] for mime_type in mime_types},
         )
         self.mime_types = mime_types
-        self.additional_mimetypes = additional_mimetypes
+        self._additional_mimetypes = additional_mimetypes
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -103,7 +103,7 @@ class FileTypeRouter:
         :returns:
             Dictionary with serialized data.
         """
-        return default_to_dict(self, mime_types=self.mime_types, additional_mimetypes=self.additional_mimetypes)
+        return default_to_dict(self, mime_types=self.mime_types, additional_mimetypes=self._additional_mimetypes)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "FileTypeRouter":

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -87,8 +87,8 @@ class FileTypeRouter:
 
         component.set_output_types(
             self,
-            unclassified=List[Union[Path, ByteStream]],
-            **{mime_type: List[Union[Path, ByteStream]] for mime_type in mime_types},
+            unclassified=List[Union[str, Path, ByteStream]],
+            **{mime_type: List[Union[str, Path, ByteStream]] for mime_type in mime_types},
         )
         self.mime_types = mime_types
 

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -86,6 +86,8 @@ class FileTypeRouter:
                 raise ValueError(f"Invalid regex pattern '{mime_type}'.")
             self.mime_type_patterns.append(pattern)
 
+        # the actual output type is List[Union[Path, ByteStream]],
+        # but this would cause PipelineConnectError with Converters
         component.set_output_types(
             self,
             unclassified=List[Union[str, Path, ByteStream]],

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, logging
+from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 from haystack.dataclasses import ByteStream
 
@@ -92,6 +92,28 @@ class FileTypeRouter:
             **{mime_type: List[Union[str, Path, ByteStream]] for mime_type in mime_types},
         )
         self.mime_types = mime_types
+        self.additional_mimetypes = additional_mimetypes
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return default_to_dict(self, mime_types=self.mime_types, additional_mimetypes=self.additional_mimetypes)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FileTypeRouter":
+        """
+        Deserializes the component from a dictionary.
+
+        :param data:
+            The dictionary to deserialize from.
+        :returns:
+            The deserialized component.
+        """
+        return default_from_dict(cls, data)
 
     def run(
         self,

--- a/releasenotes/notes/meta-in-filetyperouter-d3cf007f940ce324.yaml
+++ b/releasenotes/notes/meta-in-filetyperouter-d3cf007f940ce324.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The `FiletypeRouter` now supports passing metadata (`meta`) in the `run` method.
+    When metadata is provided, the sources are internally converted to `ByteStream` objects and the metadata is added.
+    This new parameter simplifies working with preprocessing/indexing pipelines.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -24,14 +24,14 @@ class TestFileTypeRouter:
         """
         router = FileTypeRouter(mime_types=["text/plain", "audio/x-wav", "image/jpeg"])
         assert router.mime_types == ["text/plain", "audio/x-wav", "image/jpeg"]
-        assert router.additional_mimetypes is None
+        assert router._additional_mimetypes is None
 
         router = FileTypeRouter(
             mime_types=["text/plain"],
             additional_mimetypes={"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"},
         )
         assert router.mime_types == ["text/plain"]
-        assert router.additional_mimetypes == {
+        assert router._additional_mimetypes == {
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx"
         }
 
@@ -76,7 +76,7 @@ class TestFileTypeRouter:
         )
 
         assert loaded_router.mime_types == expected_router.mime_types
-        assert loaded_router.additional_mimetypes == expected_router.additional_mimetypes
+        assert loaded_router._additional_mimetypes == expected_router._additional_mimetypes
 
     def test_run(self, test_files_path):
         """

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -283,13 +283,11 @@ class TestFileTypeRouter:
         Test if the component runs correctly in a pipeline with converters and passes metadata correctly.
         """
         file_type_router = FileTypeRouter(mime_types=["text/plain", "application/pdf"])
-        text_file_converter = TextFileToDocument()
-        pdf_converter = PyPDFToDocument()
 
         pipe = Pipeline()
         pipe.add_component(instance=file_type_router, name="file_type_router")
-        pipe.add_component(instance=text_file_converter, name="text_file_converter")
-        pipe.add_component(instance=pdf_converter, name="pypdf_converter")
+        pipe.add_component(instance=TextFileToDocument(), name="text_file_converter")
+        pipe.add_component(instance=PyPDFToDocument(), name="pypdf_converter")
         pipe.connect("file_type_router.text/plain", "text_file_converter.sources")
         pipe.connect("file_type_router.application/pdf", "pypdf_converter.sources")
 


### PR DESCRIPTION
### Related Issues

- fixes #8465

### Proposed Changes:
- allow passing `meta` in the `run` method of `FileTypeRouter`: when metadata is provided, the sources are internally converted to `ByteStream` objects and the metadata is added.
- general refactoring of the component

### How did you test it?
CI, several new tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
