### PR TITLE
feat!: tracing with concurrency

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -29,12 +29,16 @@ class Pipeline(PipelineBase):
     Orchestrates component execution according to the execution graph, one after the other.
     """
 
-    def _run_component(self, name: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def _run_component(
+        self, name: str, inputs: Dict[str, Any], parent_span: Optional[tracing.Span] = None
+    ) -> Dict[str, Any]:
         """
         Runs a Component with the given inputs.
 
         :param name: Name of the Component as defined in the Pipeline.
         :param inputs: Inputs for the Component.
+        :param parent_span: The parent span to use for the newly created span.
+            This is to allow tracing to be correctly linked to the pipeline run.
         :raises PipelineRuntimeError: If Component doesn't return a dictionary.
         :return: The output of the Component.
         """
@@ -61,6 +65,7 @@ class Pipeline(PipelineBase):
                     for key, value in instance.__haystack_output__._sockets_dict.items()  # type: ignore
                 },
             },
+            parent_span=parent_span,
         ) as span:
             span.set_content_tag("haystack.component.input", inputs)
             logger.info("Running component {component_name}", component_name=name)
@@ -207,7 +212,7 @@ class Pipeline(PipelineBase):
                 "haystack.pipeline.metadata": self.metadata,
                 "haystack.pipeline.max_runs_per_component": self._max_runs_per_component,
             },
-        ):
+        ) as span:
             # Cache for extra outputs, if enabled.
             extra_outputs: Dict[Any, Any] = {}
 
@@ -225,7 +230,7 @@ class Pipeline(PipelineBase):
                         msg = f"Maximum run count {self._max_runs_per_component} reached for component '{name}'"
                         raise PipelineMaxComponentRuns(msg)
 
-                    res: Dict[str, Any] = self._run_component(name, components_inputs[name])
+                    res: Dict[str, Any] = self._run_component(name, components_inputs[name], parent_span=span)
 
                     if name in include_outputs_from:
                         # Deepcopy the outputs to prevent downstream nodes from modifying them

--- a/haystack/tracing/datadog.py
+++ b/haystack/tracing/datadog.py
@@ -59,7 +59,9 @@ class DatadogTracer(Tracer):
         self._tracer = tracer
 
     @contextlib.contextmanager
-    def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
+    def trace(
+        self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+    ) -> Iterator[Span]:
         """Activate and return a new span that inherits from the current active span."""
         with self._tracer.trace(operation_name) as span:
             custom_span = DatadogSpan(span)

--- a/haystack/tracing/logging_tracer.py
+++ b/haystack/tracing/logging_tracer.py
@@ -49,12 +49,15 @@ class LoggingTracer(Tracer):
         self.tags_color_strings = tags_color_strings or {}
 
     @contextlib.contextmanager
-    def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
+    def trace(
+        self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+    ) -> Iterator[Span]:
         """
         Trace the execution of a block of code.
 
         :param operation_name: the name of the operation being traced.
         :param tags: tags to apply to the newly created span.
+        :param parent_span: the parent span to use for the newly created span. Not used in this simple tracer.
         :returns: the newly created span.
         """
 

--- a/haystack/tracing/opentelemetry.py
+++ b/haystack/tracing/opentelemetry.py
@@ -48,7 +48,9 @@ class OpenTelemetryTracer(Tracer):
         self._tracer = tracer
 
     @contextlib.contextmanager
-    def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
+    def trace(
+        self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+    ) -> Iterator[Span]:
         """Activate and return a new span that inherits from the current active span."""
         with self._tracer.start_as_current_span(operation_name) as raw_span:
             span = OpenTelemetrySpan(raw_span)

--- a/releasenotes/notes/tracing-with-concurrency-5daadfde0a36f94a.yaml
+++ b/releasenotes/notes/tracing-with-concurrency-5daadfde0a36f94a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Each tracing span of a component run is now attached with the pipeline run span object. This allows users to trace
+    the execution of multiple pipeline runs concurrently.

--- a/test/core/pipeline/test_tracing.py
+++ b/test/core/pipeline/test_tracing.py
@@ -39,7 +39,7 @@ class TestTracing:
         assert len(spying_tracer.spans) == 3
 
         assert spying_tracer.spans == [
-            SpyingSpan(
+            pipeline_span := SpyingSpan(
                 operation_name="haystack.pipeline.run",
                 tags={
                     "haystack.pipeline.input_data": {"hello": {"word": "world"}},
@@ -47,6 +47,7 @@ class TestTracing:
                     "haystack.pipeline.metadata": {},
                     "haystack.pipeline.max_runs_per_component": 100,
                 },
+                parent_span=None,
                 trace_id=ANY,
                 span_id=ANY,
             ),
@@ -60,6 +61,7 @@ class TestTracing:
                     "haystack.component.output_spec": {"output": {"type": "str", "receivers": ["hello2"]}},
                     "haystack.component.visits": 1,
                 },
+                parent_span=pipeline_span,
                 trace_id=ANY,
                 span_id=ANY,
             ),
@@ -73,6 +75,7 @@ class TestTracing:
                     "haystack.component.output_spec": {"output": {"type": "str", "receivers": []}},
                     "haystack.component.visits": 1,
                 },
+                parent_span=pipeline_span,
                 trace_id=ANY,
                 span_id=ANY,
             ),
@@ -95,7 +98,7 @@ class TestTracing:
 
         assert len(spying_tracer.spans) == 3
         assert spying_tracer.spans == [
-            SpyingSpan(
+            pipeline_span := SpyingSpan(
                 operation_name="haystack.pipeline.run",
                 tags={
                     "haystack.pipeline.metadata": {},
@@ -118,6 +121,7 @@ class TestTracing:
                     "haystack.component.visits": 1,
                     "haystack.component.output": {"output": "Hello, world!"},
                 },
+                parent_span=pipeline_span,
                 trace_id=ANY,
                 span_id=ANY,
             ),
@@ -133,6 +137,7 @@ class TestTracing:
                     "haystack.component.visits": 1,
                     "haystack.component.output": {"output": "Hello, Hello, world!!"},
                 },
+                parent_span=pipeline_span,
                 trace_id=ANY,
                 span_id=ANY,
             ),

--- a/test/tracing/utils.py
+++ b/test/tracing/utils.py
@@ -12,6 +12,7 @@ from haystack.tracing import Span, Tracer
 @dataclasses.dataclass
 class SpyingSpan(Span):
     operation_name: str
+    parent_span: Optional[Span] = None
     tags: Dict[str, Any] = dataclasses.field(default_factory=dict)
 
     trace_id: Optional[str] = dataclasses.field(default_factory=lambda: str(uuid.uuid4()))
@@ -32,8 +33,10 @@ class SpyingTracer(Tracer):
         self.spans: List[SpyingSpan] = []
 
     @contextlib.contextmanager
-    def trace(self, operation_name: str, tags: Optional[Dict[str, Any]] = None) -> Iterator[Span]:
-        new_span = SpyingSpan(operation_name)
+    def trace(
+        self, operation_name: str, tags: Optional[Dict[str, Any]] = None, parent_span: Optional[Span] = None
+    ) -> Iterator[Span]:
+        new_span = SpyingSpan(operation_name, parent_span)
 
         for key, value in (tags or {}).items():
             new_span.set_tag(key, value)


### PR DESCRIPTION
### Related Issues

- fixes #8488

### Proposed Changes:

Issue: I ran into some issues after deploying a pipeline as a service with tracing enabled. If there are concurrent calls to run the pipeline, the structure of spans kinda messed up due to the fact that the "haystack.component.run" spans are attached to the "haystack.pipeline.run" span. I experimented primarily with Langfuse, and this gave me a giant span with nested pipeline runs overlapping each other, which is definitely not ideal.

Purposed solution: I have come up with a solution by adding an optional `parent_span` parameter in the trace context. Furthermore, I tweaked the Langfuse tracer integration such that it creates a new span/generation on top of the parent span if it is provided, or create a root span if not.

### How did you test it?

1. unit test
2. I also tried running concurrent pipeline runs with Langfuse setup that it seem to work correctly.
<img width="1687" alt="Screenshot 2024-10-24 at 12 16 08" src="https://github.com/user-attachments/assets/9449bef9-4c99-4fed-b2da-6a2bfeff8749">


### Notes for the reviewer

1. I am not very familiar with datadog/opentelemetry so I am not confident there.
2. This could be related to async logic and please let me know if you have any better solutions in mind.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
