### PR TITLE
fix: `HuggingFaceAPIGenerator` - use forward references

### DIFF
--- a/releasenotes/notes/hfapigen-forwardref-5c06090282557195.yaml
+++ b/releasenotes/notes/hfapigen-forwardref-5c06090282557195.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Use forward references for Hugging Face Hub types in the `HuggingFaceAPIGenerator` component
+    to prevent import errors.


### PR DESCRIPTION
### Related Issues

- After the changes in #8406, we started to see some failures in tests using Haystack main branch: https://github.com/deepset-ai/haystack-tutorials/actions/runs/11584421300/job/32251536345
- We should use forward references when types in methods signature come from a lazy import block

### Proposed Changes:
- use forward references
- small refactoring to remove `type: ignore` blocks

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
