### PR TITLE
ci: Fix `readme_sync.yml`

### DIFF
--- a/.github/workflows/readme_sync.yml
+++ b/.github/workflows/readme_sync.yml
@@ -45,9 +45,15 @@ jobs:
         id: version-getter
         run: |
           VERSION="$(hatch version | cut -d '.' -f 1,2)"
-          CURRENT_BRANCH="${{ github.ref_name }}"
-          # If we're on `main` branch we should push docs to the unstable version
-          if [ "$CURRENT_BRANCH" = "main" ]; then
+          # The first stable documentation on Readme for a version is created when
+          # the first x.x.0 version is released.
+          # Up until that point we need to push to an "-unstable" suffixed version.
+          # This also means that following RCs for patch releases are pushed to the
+          # stable docs, for the time being we're ok with that.
+          # `main` branch docs will be handled correctly too and get pushed to an
+          # unstable documentation.
+          IS_UNSTABLE=$(hatch version | grep -v -q "0-rc")
+          if [ "$IS_UNSTABLE" ]; then
             VERSION="$VERSION-unstable"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Proposed Changes:

Fix `readme_sync.yml` so that documentation is pushed to correct version before the stable version is released.

### How did you test it?

Can't test really, I tested the bash script I edited and it returns what I expect though.

### Notes for the reviewer

Example failure:
https://github.com/deepset-ai/haystack/actions/runs/11157243880/job/31011161262

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
