### PR TITLE
chore: Add release note for the upcoming v1.26.4 

### DIFF
--- a/releasenotes/notes/update-transformers-e83863bbe69ddceb.yaml
+++ b/releasenotes/notes/update-transformers-e83863bbe69ddceb.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    Upgrade the transformers dependency requirement to "transformers>=4.46,<5.0".
+
+enhancements:
+  - |
+    Updated `tokenizer.json` URL for Anthropic models as the old URL was no longer available.


### PR DESCRIPTION
Forgot to add release note to the latest commit and we need it for the successful build. 