### PR TITLE
fix: lowercase comparison in `OpenAIGenearator` with system prompt tests

### DIFF
--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -326,10 +326,10 @@ class TestOpenAIGenerator:
             system_prompt="You answer in Portuguese, regardless of the language on which a question is asked",
         )
         result = generator.run("Can you explain the Pitagoras therom?")
-        assert "teorema" in result["replies"][0]
+        assert "teorema" in result["replies"][0].lower()
 
         result = generator.run(
             "Can you explain the Pitagoras therom?",
             system_prompt="You answer in German, regardless of the language on which a question is asked.",
         )
-        assert "Pythagoras" in result["replies"][0]
+        assert "pythagoras".lower() in result["replies"][0].lower()


### PR DESCRIPTION
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
