### PR TITLE
fix: huggingface embedder error messages not being displayed

### DIFF
--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -102,7 +102,7 @@ class HuggingFaceAPIDocumentEmbedder:
         progress_bar: bool = True,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-positional-arguments
         """
         Creates a HuggingFaceAPIDocumentEmbedder component.
 

--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -102,7 +102,7 @@ class HuggingFaceAPIDocumentEmbedder:
         progress_bar: bool = True,
         meta_fields_to_embed: Optional[List[str]] = None,
         embedding_separator: str = "\n",
-    ):
+    ):  # pylint: disable=too-many-arguments
         """
         Creates a HuggingFaceAPIDocumentEmbedder component.
 

--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -168,7 +168,7 @@ class HuggingFaceAPIDocumentEmbedder:
             model_or_url = url
         else:
             msg = f"Unknown api_type {api_type}"
-            raise ValueError(api_type)
+            raise ValueError(msg)
 
         self.api_type = api_type
         self.api_params = api_params

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -82,7 +82,7 @@ class HuggingFaceAPITextEmbedder:
         suffix: str = "",
         truncate: bool = True,
         normalize: bool = False,
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-positional-arguments
         """
         Creates a HuggingFaceAPITextEmbedder component.
 

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -82,7 +82,7 @@ class HuggingFaceAPITextEmbedder:
         suffix: str = "",
         truncate: bool = True,
         normalize: bool = False,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """
         Creates a HuggingFaceAPITextEmbedder component.
 

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -138,7 +138,7 @@ class HuggingFaceAPITextEmbedder:
             model_or_url = url
         else:
             msg = f"Unknown api_type {api_type}"
-            raise ValueError()
+            raise ValueError(msg)
 
         self.api_type = api_type
         self.api_params = api_params

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -162,7 +162,7 @@ class HuggingFaceAPIChatGenerator:
             model_or_url = url
         else:
             msg = f"Unknown api_type {api_type}"
-            raise ValueError(api_type)
+            raise ValueError(msg)
 
         # handle generation kwargs setup
         generation_kwargs = generation_kwargs.copy() if generation_kwargs else {}

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -104,7 +104,7 @@ class HuggingFaceAPIChatGenerator:
     ```
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         api_type: Union[HFGenerationAPIType, str],
         api_params: Dict[str, str],

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -104,7 +104,7 @@ class HuggingFaceAPIChatGenerator:
     ```
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         api_type: Union[HFGenerationAPIType, str],
         api_params: Dict[str, str],

--- a/haystack/components/generators/hugging_face_api.py
+++ b/haystack/components/generators/hugging_face_api.py
@@ -134,7 +134,7 @@ class HuggingFaceAPIGenerator:
             model_or_url = url
         else:
             msg = f"Unknown api_type {api_type}"
-            raise ValueError(api_type)
+            raise ValueError(msg)
 
         # handle generation kwargs setup
         generation_kwargs = generation_kwargs.copy() if generation_kwargs else {}


### PR DESCRIPTION
### Proposed Changes:

- Error messages not being displayed
- Needed to add pylint disable too-many-arguments, since the file is changed, it's now checked

### How did you test it?

- CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
