### PR TITLE
fix: Bring in fix from custom nodes

### DIFF
--- a/haystack/components/preprocessors/nltk_document_splitter.py
+++ b/haystack/components/preprocessors/nltk_document_splitter.py
@@ -5,7 +5,7 @@
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 from haystack import Document, component, logging
 from haystack.components.preprocessors.document_splitter import DocumentSplitter
@@ -33,6 +33,7 @@ class NLTKDocumentSplitter(DocumentSplitter):
         language: Language = "en",
         use_split_rules: bool = True,
         extend_abbreviations: bool = True,
+        splitting_function: Optional[Callable[[str], List[str]]] = None,
     ):
         """
         Splits your documents using NLTK to respect sentence boundaries.
@@ -53,10 +54,17 @@ class NLTKDocumentSplitter(DocumentSplitter):
         :param extend_abbreviations: Choose whether to extend NLTK's PunktTokenizer abbreviations with a list
             of curated abbreviations, if available.
             This is currently supported for English ("en") and German ("de").
+        :param splitting_function: Necessary when `split_by` is set to "function".
+            This is a function which must accept a single `str` as input and return a `list` of `str` as output,
+            representing the chunks after splitting.
         """
 
         super(NLTKDocumentSplitter, self).__init__(
-            split_by=split_by, split_length=split_length, split_overlap=split_overlap, split_threshold=split_threshold
+            split_by=split_by,
+            split_length=split_length,
+            split_overlap=split_overlap,
+            split_threshold=split_threshold,
+            splitting_function=splitting_function,
         )
         nltk_imports.check()
         if respect_sentence_boundary and split_by != "word":
@@ -100,9 +108,11 @@ class NLTKDocumentSplitter(DocumentSplitter):
         elif split_by == "word":
             self.split_at = " "
             units = text.split(self.split_at)
+        elif split_by == "function" and self.splitting_function is not None:
+            return self.splitting_function(text)
         else:
             raise NotImplementedError(
-                "DocumentSplitter only supports 'word', 'sentence', 'page' or 'passage' split_by options."
+                "DocumentSplitter only supports 'function', 'page', 'passage', 'sentence' or 'word' split_by options."
             )
 
         # Add the delimiter back to all units except the last one
@@ -138,6 +148,9 @@ class NLTKDocumentSplitter(DocumentSplitter):
                 raise ValueError(
                     f"DocumentSplitter only works with text documents but content for document ID {doc.id} is None."
                 )
+            if doc.content == "":
+                logger.warning("Document ID {doc_id} has an empty content. Skipping this document.", doc_id=doc.id)
+                continue
 
             if self.respect_sentence_boundary:
                 units = self._split_into_units(doc.content, "sentence")
@@ -175,7 +188,8 @@ class NLTKDocumentSplitter(DocumentSplitter):
 
         num_sentences_to_keep = 0
         num_words = 0
-        for sent in reversed(sentences):
+        # Next overlapping Document should not start exactly the same as the previous one, so we skip the first sentence
+        for sent in reversed(sentences[1:]):
             num_words += len(sent.split())
             # If the number of words is larger than the split_length then don't add any more sentences
             if num_words > split_length:

--- a/haystack/components/preprocessors/nltk_document_splitter.py
+++ b/haystack/components/preprocessors/nltk_document_splitter.py
@@ -25,7 +25,7 @@ Language = Literal[
 
 @component
 class NLTKDocumentSplitter(DocumentSplitter):
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         split_by: Literal["word", "sentence", "page", "passage", "function"] = "word",
         split_length: int = 200,

--- a/releasenotes/notes/fix-nltk-doc-splitter-d0864dda906c45b0.yaml
+++ b/releasenotes/notes/fix-nltk-doc-splitter-d0864dda906c45b0.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    For the NLTKDocumentSplitter we are updating how chunks are made when splitting by word and sentence boundary is respected.
+    Namely, to avoid fully subsuming the previous chunk into the next one, we ignore the first sentence from that chunk when calculating sentence overlap.
+    i.e. we want to avoid cases of Doc1 = [s1, s2], Doc2 = [s1, s2, s3].
+
+    Finished adding function support for this component by updating the _split_into_units function and added the splitting_function init parameter.
+
+    Add specific to_dict method to overwrite the underlying one from DocumentSplitter. This is needed to properly save the settings of the component to yaml.

--- a/test/components/preprocessors/test_nltk_document_splitter.py
+++ b/test/components/preprocessors/test_nltk_document_splitter.py
@@ -87,9 +87,11 @@ class TestNLTKDocumentSplitterNumberOfSentencesToKeep:
     @pytest.mark.parametrize(
         "sentences, expected_num_sentences",
         [
-            (["Moonlight shimmered softly, wolves howled nearby, night enveloped everything."], 0),
-            ([" It was a dark night ..."], 0),
-            ([" The moon was full."], 1),
+            (["The sun set.", "Moonlight shimmered softly, wolves howled nearby, night enveloped everything."], 0),
+            (["The sun set.", "It was a dark night ..."], 0),
+            (["The sun set.", " The moon was full."], 1),
+            (["The sun.", " The moon."], 1),  # Ignores the first sentence
+            (["Sun", "Moon"], 1),  # Ignores the first sentence even if its inclusion would be < split_overlap
         ],
     )
     def test_number_of_sentences_to_keep(self, sentences: List[str], expected_num_sentences: int) -> None:
@@ -304,7 +306,7 @@ class TestNLTKDocumentSplitterRespectSentenceBoundary:
     def test_run_split_by_word_respect_sentence_boundary_with_split_overlap_and_page_breaks(self) -> None:
         document_splitter = NLTKDocumentSplitter(
             split_by="word",
-            split_length=5,
+            split_length=8,
             split_overlap=1,
             split_threshold=0,
             language="en",
@@ -313,26 +315,37 @@ class TestNLTKDocumentSplitterRespectSentenceBoundary:
             respect_sentence_boundary=True,
         )
 
-        text = "Sentence on page 1.\fSentence on page 2. \fSentence on page 3. \f\f Sentence on page 5."
+        text = (
+            "Sentence on page 1. Another on page 1.\fSentence on page 2. Another on page 2.\f"
+            "Sentence on page 3. Another on page 3.\f\f Sentence on page 5."
+        )
         documents = document_splitter.run(documents=[Document(content=text)])["documents"]
 
-        assert len(documents) == 4
-        assert documents[0].content == "Sentence on page 1.\f"
+        assert len(documents) == 6
+        assert documents[0].content == "Sentence on page 1. Another on page 1.\f"
         assert documents[0].meta["page_number"] == 1
         assert documents[0].meta["split_id"] == 0
         assert documents[0].meta["split_idx_start"] == text.index(documents[0].content)
-        assert documents[1].content == "Sentence on page 1.\fSentence on page 2. \f"
+        assert documents[1].content == "Another on page 1.\fSentence on page 2. "
         assert documents[1].meta["page_number"] == 1
         assert documents[1].meta["split_id"] == 1
         assert documents[1].meta["split_idx_start"] == text.index(documents[1].content)
-        assert documents[2].content == "Sentence on page 2. \fSentence on page 3. \f\f "
+        assert documents[2].content == "Sentence on page 2. Another on page 2.\f"
         assert documents[2].meta["page_number"] == 2
         assert documents[2].meta["split_id"] == 2
         assert documents[2].meta["split_idx_start"] == text.index(documents[2].content)
-        assert documents[3].content == "Sentence on page 3. \f\f Sentence on page 5."
-        assert documents[3].meta["page_number"] == 3
+        assert documents[3].content == "Another on page 2.\fSentence on page 3. "
+        assert documents[3].meta["page_number"] == 2
         assert documents[3].meta["split_id"] == 3
         assert documents[3].meta["split_idx_start"] == text.index(documents[3].content)
+        assert documents[4].content == "Sentence on page 3. Another on page 3.\f\f "
+        assert documents[4].meta["page_number"] == 3
+        assert documents[4].meta["split_id"] == 4
+        assert documents[4].meta["split_idx_start"] == text.index(documents[4].content)
+        assert documents[5].content == "Another on page 3.\f\f Sentence on page 5."
+        assert documents[5].meta["page_number"] == 3
+        assert documents[5].meta["split_id"] == 5
+        assert documents[5].meta["split_idx_start"] == text.index(documents[5].content)
 
 
 class TestSentenceSplitter:


### PR DESCRIPTION
### Related Issues

Brings in the fix first introduced here https://github.com/deepset-ai/deepset-cloud-custom-nodes/pull/367

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- To avoid fully subsuming the previous chunk, we ignore the first sentence from that chunk when calculating sentence overlap. i.e. we want to avoid cases of: Doc1 = [s1, s2], Doc2 = [s1, s2, s3].
- Only applies when splitting by word and respecting sentence boundary.
- This mirrors the implementation in v1's PreProcessor.

Since this component was a port of the functionality of Haystack v1 I view this as a bug fix. 

A few other changes:
- While I was here I also finished adding function support for this component by updating the `_split_into_units` function and added the `splitting_function` init parameter. 
- Also fixed another bug which was caused by the introduction of the `to_dict` method of the underlying `DocumentSplitter` when adding function support. This means without defining a new `to_dict` method for this component, a number of parameters were being ignored when saving this component to yaml. So I added a `to_dict` method for this component and added a corresponding test.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Copied over tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
