### PR TITLE
chore: declare `requires-python<3.13` in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LLM framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pipelines or agents that can interact with your data."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 authors = [{ name = "deepset.ai", email = "malte.pietsch@deepset.ai" }]
 keywords = [
   "BERT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ dependencies = [
   "ruff",
   "toml",
   "reno",
+  # dulwich is a reno dependency, they pin it at >=0.15.0 so pip takes ton of time to resolve the dependency tree.
+  # We pin it here to avoid taking too much time.
+  # https://opendev.org/openstack/reno/src/branch/master/requirements.txt#L7
+  "dulwich>=0.21.0,<1.0.0",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,6 @@ dependencies = [
   "ruff",
   "toml",
   "reno",
-  # dulwich is a reno dependency, they pin it at >=0.15.0 so pip takes ton of time to resolve the dependency tree.
-  # We pin it here to avoid taking too much time.
-  # https://opendev.org/openstack/reno/src/branch/master/requirements.txt#L7
-  "dulwich>=0.21.0,<1.0.0",
 ]
 
 [tool.hatch.envs.default.scripts]


### PR DESCRIPTION
### Related Issues
As discovered by @silvanocerza and also reported in https://github.com/deepset-ai/haystack/discussions/8543, there are some incompatibiliets with python 3.13.

We should explicitly declare this in pyproject, to avoid problems when installing the project with hatch.

### Proposed Changes:
- `requires-python = ">=3.8,<3.13"`

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
