### PR TITLE
chore: Add Zed config folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ haystack/json-schemas
 
 # ruff
 .ruff_cache
+
+# Zed configs
+.zed/*


### PR DESCRIPTION
I'm trying [Zed](https://zed.dev), it saves configs on the workspace much like VS Code.
It's good to ignore them.