### PR TITLE
chore: Use token instead of use_auth_token because of deprecation warning

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -19,7 +19,7 @@ class _SentenceTransformersEmbeddingBackendFactory:
     _instances: Dict[str, "_SentenceTransformersEmbeddingBackend"] = {}
 
     @staticmethod
-    def get_embedding_backend(  # pylint: disable=too-many-arguments
+    def get_embedding_backend(  # pylint: disable=too-many-positional-arguments
         model: str,
         device: Optional[str] = None,
         auth_token: Optional[Secret] = None,
@@ -52,7 +52,7 @@ class _SentenceTransformersEmbeddingBackend:
     Class to manage Sentence Transformers embeddings.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         model: str,
         device: Optional[str] = None,

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -19,7 +19,7 @@ class _SentenceTransformersEmbeddingBackendFactory:
     _instances: Dict[str, "_SentenceTransformersEmbeddingBackend"] = {}
 
     @staticmethod
-    def get_embedding_backend(
+    def get_embedding_backend(  # pylint: disable=too-many-arguments
         model: str,
         device: Optional[str] = None,
         auth_token: Optional[Secret] = None,
@@ -52,7 +52,7 @@ class _SentenceTransformersEmbeddingBackend:
     Class to manage Sentence Transformers embeddings.
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         model: str,
         device: Optional[str] = None,

--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -67,7 +67,7 @@ class _SentenceTransformersEmbeddingBackend:
         self.model = SentenceTransformer(
             model_name_or_path=model,
             device=device,
-            use_auth_token=auth_token.resolve_value() if auth_token else None,
+            token=auth_token.resolve_value() if auth_token else None,
             trust_remote_code=trust_remote_code,
             truncate_dim=truncate_dim,
             model_kwargs=model_kwargs,

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -37,7 +37,7 @@ def test_model_initialization(mock_sentence_transformer):
     mock_sentence_transformer.assert_called_once_with(
         model_name_or_path="model",
         device="cpu",
-        use_auth_token="fake-api-token",
+        token="fake-api-token",
         trust_remote_code=True,
         truncate_dim=256,
         model_kwargs=None,


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

There is a deprecation warning in Sentence Transformers here
https://github.com/UKPLab/sentence-transformers/blob/e156f38b1007e7860218c27223e1d577f3a021fe/sentence_transformers/SentenceTransformer.py#L194-L203

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Update Backend to use the non-deprecated parameter

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
