### PR TITLE
fix: `OpenAIChatGenerator` and `OpenAIGenerator` crashing when streaming with usage tracking

### DIFF
--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -222,15 +222,17 @@ class OpenAIGenerator:
             if num_responses > 1:
                 raise ValueError("Cannot stream multiple responses, please set n=1.")
             chunks: List[StreamingChunk] = []
-            chunk = None
+            completion_chunk: Optional[ChatCompletionChunk] = None
 
             # pylint: disable=not-an-iterable
-            for chunk in completion:
-                if chunk.choices and streaming_callback:
-                    chunk_delta: StreamingChunk = self._build_chunk(chunk)
+            for completion_chunk in completion:
+                if completion_chunk.choices and streaming_callback:
+                    chunk_delta: StreamingChunk = self._build_chunk(completion_chunk)
                     chunks.append(chunk_delta)
                     streaming_callback(chunk_delta)  # invoke callback with the chunk_delta
-            completions = [self._connect_chunks(chunk, chunks)]
+            # Makes type checkers happy
+            assert completion_chunk is not None
+            completions = [self._create_message_from_chunks(completion_chunk, chunks)]
         elif isinstance(completion, ChatCompletion):
             completions = [self._build_message(completion, choice) for choice in completion.choices]
 
@@ -244,17 +246,21 @@ class OpenAIGenerator:
         }
 
     @staticmethod
-    def _connect_chunks(chunk: Any, chunks: List[StreamingChunk]) -> ChatMessage:
+    def _create_message_from_chunks(
+        completion_chunk: ChatCompletionChunk, streamed_chunks: List[StreamingChunk]
+    ) -> ChatMessage:
         """
-        Connects the streaming chunks into a single ChatMessage.
+        Creates a single ChatMessage from the streamed chunks. Some data is retrieved from the completion chunk.
         """
-        complete_response = ChatMessage.from_assistant("".join([chunk.content for chunk in chunks]))
+        complete_response = ChatMessage.from_assistant("".join([chunk.content for chunk in streamed_chunks]))
+        finish_reason = streamed_chunks[-1].meta["finish_reason"]
         complete_response.meta.update(
             {
-                "model": chunk.model,
+                "model": completion_chunk.model,
                 "index": 0,
-                "finish_reason": chunk.choices[0].finish_reason,
-                "usage": {},  # we don't have usage data for streaming responses
+                "finish_reason": finish_reason,
+                # Usage is available when streaming only if the user explicitly requests it
+                "usage": dict(completion_chunk.usage or {}),
             }
         )
         return complete_response

--- a/haystack/components/generators/openai.py
+++ b/haystack/components/generators/openai.py
@@ -49,7 +49,7 @@ class OpenAIGenerator:
     ```
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         api_key: Secret = Secret.from_env_var("OPENAI_API_KEY"),
         model: str = "gpt-4o-mini",

--- a/releasenotes/notes/fix-openai-streaming-usage-c3dbad63fd9a8020.yaml
+++ b/releasenotes/notes/fix-openai-streaming-usage-c3dbad63fd9a8020.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `OpenAIChatGenerator` and `OpenAIGenerator` crashing when using a `streaming_callback` and `generation_kwargs` contain `{"stream_options": {"include_usage": True}}`.

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -333,3 +333,42 @@ class TestOpenAIGenerator:
             system_prompt="You answer in German, regardless of the language on which a question is asked.",
         )
         assert "pythagoras" in result["replies"][0].lower()
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    def test_live_run_streaming_with_include_usage(self):
+        class Callback:
+            def __init__(self):
+                self.responses = ""
+                self.counter = 0
+
+            def __call__(self, chunk: StreamingChunk) -> None:
+                self.counter += 1
+                self.responses += chunk.content if chunk.content else ""
+
+        callback = Callback()
+        component = OpenAIGenerator(
+            streaming_callback=callback, generation_kwargs={"stream_options": {"include_usage": True}}
+        )
+        results = component.run("What's the capital of France?")
+
+        assert len(results["replies"]) == 1
+        assert len(results["meta"]) == 1
+        response: str = results["replies"][0]
+        assert "Paris" in response
+
+        metadata = results["meta"][0]
+
+        assert "gpt-4o-mini" in metadata["model"]
+        assert metadata["finish_reason"] == "stop"
+
+        assert "usage" in metadata
+        assert "prompt_tokens" in metadata["usage"] and metadata["usage"]["prompt_tokens"] > 0
+        assert "completion_tokens" in metadata["usage"] and metadata["usage"]["completion_tokens"] > 0
+        assert "total_tokens" in metadata["usage"] and metadata["usage"]["total_tokens"] > 0
+
+        assert callback.counter > 1
+        assert "Paris" in callback.responses


### PR DESCRIPTION
### Related Issues

- fixes #8507

### Proposed Changes:

Fix `OpenAIChatGenerator` and `OpenAIGenerator` to correctly return usage when using a `streaming_callback` and `generation_kwargs` contain `{"stream_options": {"include_usage": True}}`.

Previously that would cause it to crash.

### How did you test it?

I added new integration tests.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
