### PR TITLE
docs: update MetaFieldGroupingRanker name in docstrings

### DIFF
--- a/haystack/components/rankers/meta_field_grouping_ranker.py
+++ b/haystack/components/rankers/meta_field_grouping_ranker.py
@@ -60,7 +60,7 @@ class MetaFieldGroupingRanker:
 
     def __init__(self, group_by: str, subgroup_by: Optional[str] = None, sort_docs_by: Optional[str] = None):
         """
-        Creates an instance of DeepsetMetadataGrouper.
+        Creates an instance of MetaFieldGroupingRanker.
 
         :param group_by: The metadata key to aggregate the documents by.
         :param subgroup_by: The metadata key to aggregate the documents within a group that was created by the


### PR DESCRIPTION
### Proposed Changes:

Noticed that we left the dC component name in the docstirngs.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
