### PR TITLE
feat: Add variable to specify inputs as optional to ConditionalRouter

### DIFF
--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -107,7 +107,7 @@ class ConditionalRouter:
     ```
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         routes: List[Dict],
         custom_filters: Optional[Dict[str, Callable]] = None,

--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -208,6 +208,15 @@ class ConditionalRouter:
         # remove optional variables from mandatory input types
         mandatory_input_types = input_types - set(self.optional_variables)
 
+        # warn about unused optional variables
+        unused_optional_vars = set(self.optional_variables) - input_types if self.optional_variables else None
+        if unused_optional_vars:
+            warn(
+                f"The following optional variables are specified but not used in any route: {unused_optional_vars}. "
+                "Check if there's a typo in variable names.",
+                UserWarning,
+            )
+
         # add mandatory input types
         component.set_input_types(self, **{var: Any for var in mandatory_input_types})
 

--- a/releasenotes/notes/conditional-router-optional-parameters-f02c598d7c751868.yaml
+++ b/releasenotes/notes/conditional-router-optional-parameters-f02c598d7c751868.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Introduces optional parameters in the ConditionalRouter component, enabling default/fallback routing behavior when certain inputs are not provided at runtime. This enhancement allows for more flexible pipeline configurations with graceful handling of missing parameters.

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -524,3 +524,21 @@ class TestRouter:
         # Test pipeline with mandatory and both optionals
         result = pipe.run(data={"router": {"question": "What?", "mode": "chat", "language": "en", "source": "doc"}})
         assert result["router"] == {"en_doc_chat": "What?"}, "Pipeline should handle all parameters"
+
+    def test_warns_on_unused_optional_variables(self):
+        """
+        Test that a warning is raised when optional_variables contains variables
+        that are not used in any route conditions or outputs.
+        """
+        routes = [
+            {"condition": '{{mode == "chat"}}', "output": "{{question}}", "output_name": "chat", "output_type": str},
+            {"condition": "{{ True }}", "output": "{{question}}", "output_name": "fallback", "output_type": str},
+        ]
+
+        # Initialize with unused optional variables and capture warning
+        with pytest.warns(UserWarning, match="optional variables"):
+            router = ConditionalRouter(routes=routes, optional_variables=["unused_var1", "unused_var2"])
+
+        # Verify router still works normally
+        result = router.run(question="What?", mode="chat")
+        assert result == {"chat": "What?"}


### PR DESCRIPTION
## Why:

Enhances the ConditionalRouter component by adding support for optional parameters, enabling default/fallback routing behavior when certain inputs are not provided at runtime.

- fixes https://github.com/deepset-ai/haystack/issues/8556

## What:
Introduces `optional_variables` parameter to specify which route variables can be omitted
Improves documentation with clear examples of fallback routing patterns
Implements proper serialization/deserialization for the new field

## How can it be used:
Define routes with fallback behavior when certain parameters are missing:

```python
from haystack import Pipeline
from haystack.components.routers import ConditionalRouter

routes = [
    {
        "condition": '{{ path == "rag" }}',
        "output": "{{ question }}",
        "output_name": "rag_route",
        "output_type": str
    },
    {
        "condition": "{{ True }}",  # fallback route
        "output": "{{ question }}",
        "output_name": "default_route",
        "output_type": str
    }
]

router = ConditionalRouter(routes, optional_variables=["path"])
pipe = Pipeline()
pipe.add_component("router", router)

# When 'path' is provided in the pipeline:
result = pipe.run(data={"router": {"question": "What?", "path": "rag"}})
assert result["router"] == {"rag_route": "What?"}

# When 'path' is not provided, fallback route is taken:
result = pipe.run(data={"router": {"question": "What?"}})
assert result["router"] == {"default_route": "What?"}
```

## How did you test it:
Unit tests verify both direct component usage and pipeline integration
Tests cover simple and complex scenarios with and without optional parameters
