### PR TITLE
chore: fix linting of `MetaFieldGroupingRanker`

### DIFF
--- a/haystack/components/rankers/meta_field_grouping_ranker.py
+++ b/haystack/components/rankers/meta_field_grouping_ranker.py
@@ -106,9 +106,8 @@ class MetaFieldGroupingRanker:
                 no_group_docs.append(doc)
 
         ordered_docs = []
-        for group in document_groups:
-            for subgroup in document_groups[group]:
-                docs = document_groups[group][subgroup]
+        for subgroups in document_groups.values():
+            for docs in subgroups.values():
                 if self.sort_docs_by:
                     docs.sort(key=lambda d: d.meta.get(cast(str, self.sort_docs_by), float("inf")))
                 ordered_docs.extend(docs)


### PR DESCRIPTION
### Related Issues

- tests failing in unrelated PRs: https://github.com/deepset-ai/haystack/actions/runs/11971004264/job/33374908224?pr=8568
- probably because of a ruff update

### Proposed Changes:
Simplify the code to make the linter happy

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
