### PR TITLE
Fix to tracing parent spans on loops

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -99,6 +99,7 @@ class Pipeline(PipelineBase):
         component_name: str,
         components_inputs: Dict[str, Dict[str, Any]],
         include_outputs_from: Optional[Set[str]] = None,
+        parent_span: Optional[tracing.Span] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """
         Runs a `cycle` in the Pipeline starting from `component_name`.
@@ -162,7 +163,7 @@ class Pipeline(PipelineBase):
                     msg = f"Maximum run count {self._max_runs_per_component} reached for component '{name}'"
                     raise PipelineMaxComponentRuns(msg)
 
-                res: Dict[str, Any] = self._run_component(name, components_inputs[name])
+                res: Dict[str, Any] = self._run_component(name, components_inputs[name], parent_span=parent_span)
 
                 # Delete the inputs that were consumed by the Component and are not received from
                 # the user or from Components that are part of this cycle
@@ -439,7 +440,7 @@ class Pipeline(PipelineBase):
                     # are run doesn't make a different whether we pick the first or any of the others a
                     # Component is part of.
                     subgraph_output, subgraph_extra_output = self._run_subgraph(
-                        cycles[0], name, components_inputs, include_outputs_from
+                        cycles[0], name, components_inputs, include_outputs_from, parent_span=span
                     )
 
                     # After a cycle is run the previous run_queue can't be correct anymore cause it's


### PR DESCRIPTION
### Issue - Tracing bug on circular component runs in Pipeline

This is a new issue which I will explain here with a reproducible example.

The issue is that when the pipeline has a loop in it then the tracing breaks its link with the parent span.  I am using the Langfuse Tracing plugin but this is a feature of the core code so will affect all tracing setups.  

To reproduce.   Let's say we have a very simple `Pipeline` with a loop in it.  This one takes text input and then adds `xx` onto the end of it and keeps looping until it reaches at least 8 characters long and then ends. 

```python
from haystack import Pipeline, component
from haystack.components.routers import ConditionalRouter
from haystack.components.joiners import BranchJoiner
from haystack_integrations.components.connectors.langfuse import LangfuseConnector

@component
class AppendCharacters:
    """
    Adds more characters to the text and outputs
    """

    @component.output_types(text=str)
    def run(self, text: str):
        return {"text": str(text) + "xx"}


@component
class TextInOut:

    @component.output_types(text=str)
    def run(self, text: str):
        return {"text": str(text)}


# Routes will go round the loop until the text is longer than 8 characters
routes = [
    {
        "condition": "{{text|length < 8}}",
        "output": "{{text}}",
        "output_name": "loop_text",
        "output_type": str,
    },
    {
        "condition": "{{text|length >= 8}}",
        "output": "{{text}}",
        "output_name": "final_text",
        "output_type": str,
    },
]

p = Pipeline()

p.add_component("tracer", LangfuseConnector("loop_test"))
p.add_component("text_input", TextInOut())
p.add_component("joiner", BranchJoiner(type_=str))
p.add_component("add_characters", AppendCharacters())
p.add_component("router", ConditionalRouter(routes=routes))
p.add_component("final", TextInOut())

p.connect("text_input", "joiner")
p.connect("joiner", "add_characters")
p.connect("add_characters", "router")
p.connect("router.loop_text", "joiner")
p.connect("router.final_text", "final")

p.show()
```

When we run this we get errors showing that at the point the loop starts, the parent span is lost and it starts a new trace.  

```python
p.run({"text_input": {"text": "a"}})
```

Error: `Creating a new trace without a parent span is not recommended for operation 'haystack.component.run'`


### Analysis 

In the `haystack.core.pipeline.pipeline.py`, when the `self._run_component(...)` is run on a normal component then the tracing is called correctly and DOES include the current span passed as the parent_span and this feeds into the subsequent `.trace(...)` correctly :

```
# line 523
res: Dict[str, Any] = self._run_component(
                        name, components_inputs[name], parent_span=span
                    )
```

However when the `self._run_component(...)`  hits a component that is part of a loop, the if statement on line 478 runs as it includes a cycle and then it triggers a `self._run_subgraph(...) without passing in the current span as a parent_span. 

```
# line 485
subgraph_output, subgraph_extra_output = self._run_subgraph(
                        cycles[0],
                        name,
                        components_inputs,
                        include_outputs_from,
                    )
```

Therefore when the trace is called within the `self._run_subgraph(...)` it has no `parent_span` and therefore starts a new trace.


### Proposed Fix:

There is a simple fix the we do pass `parent_span=span` into the `self._run_subgraph` and default that to `None` so that it behaves as today.

Best way to see changes is to look at the commit.  Very small changes.


### How did you test it?

I've tested locally on my machine with the Langfuse tracing.

I could not get my local dev environment working to run the unit tests with Hatch.  Sorry.


### Notes for the reviewer

