### PR TITLE
Fix `DocumentCleaner not preserving `Document` fields

### DIFF
--- a/haystack/components/preprocessors/document_cleaner.py
+++ b/haystack/components/preprocessors/document_cleaner.py
@@ -38,7 +38,7 @@ class DocumentCleaner:
     ```
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         remove_empty_lines: bool = True,
         remove_extra_whitespaces: bool = True,
@@ -131,7 +131,17 @@ class DocumentCleaner:
             if self.remove_repeated_substrings:
                 text = self._remove_repeated_substrings(text)
 
-            cleaned_docs.append(Document(content=text, meta=deepcopy(doc.meta), id=doc.id if self.keep_id else ""))
+            clean_doc = Document(
+                id=doc.id if self.keep_id else "",
+                content=text,
+                dataframe=doc.dataframe,
+                blob=doc.blob,
+                meta=deepcopy(doc.meta),
+                score=doc.score,
+                embedding=doc.embedding,
+                sparse_embedding=doc.sparse_embedding,
+            )
+            cleaned_docs.append(clean_doc)
 
         return {"documents": cleaned_docs}
 

--- a/releasenotes/notes/fix-document-cleaner-4e18a63fd7dc2bd9.yaml
+++ b/releasenotes/notes/fix-document-cleaner-4e18a63fd7dc2bd9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix `DocumentCleaner` not preserving all `Document` fields when run


### PR DESCRIPTION
### Related Issues

- fixes #8571

### Proposed Changes:

Change `DocumentCleaner` to keep all fields for cleaned `Document`s.

### How did you test it?

Added a new unit test.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
