### PR TITLE
Remove `is_greedy` deprecated argument from `@component` decorator

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -487,20 +487,11 @@ class _Component:
 
         return output_types_decorator
 
-    def _component(self, cls, is_greedy: Optional[bool] = None):
+    def _component(self, cls: Any):
         """
         Decorator validating the structure of the component and registering it in the components registry.
         """
         logger.debug("Registering {component} as a component", component=cls)
-
-        if is_greedy is not None:
-            msg = (
-                "The 'is_greedy' argument is deprecated and will be removed in version '2.7.0'. "
-                "Change the 'Variadic' input of your Component to 'GreedyVariadic' instead."
-            )
-            warnings.warn(msg, DeprecationWarning)
-        else:
-            is_greedy = False
 
         # Check for required methods and fail as soon as possible
         if not hasattr(cls, "run"):
@@ -543,11 +534,11 @@ class _Component:
 
         return cls
 
-    def __call__(self, cls: Optional[type] = None, is_greedy: Optional[bool] = None):
+    def __call__(self, cls: Optional[type] = None):
         # We must wrap the call to the decorator in a function for it to work
         # correctly with or without parens
         def wrap(cls):
-            return self._component(cls, is_greedy=is_greedy)
+            return self._component(cls)
 
         if cls:
             # Decorator is called without parens

--- a/releasenotes/notes/remove-deprecated-argument-from-component-decorator-9af6940bc60795d0.yaml
+++ b/releasenotes/notes/remove-deprecated-argument-from-component-decorator-9af6940bc60795d0.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Remove 'is_greedy' deprecated argument from `@component` decorator. Change the 'Variadic' input of your Component to 'GreedyVariadic' instead.


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/issues/8575

### Proposed Changes:

Remove `is_greedy` deprecated argument from `@component` decorator.

### How did you test it?

CI

### Notes for the reviewer

Have to add `Any` type to `cls` arg in `_component` method to avoid an `annotation-unchecked` mypy error [here](https://github.com/deepset-ai/haystack/blob/d07098048417e9367287b670e8b6f357c1a03b5a/haystack/core/component/component.py#L516).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
