### PR TITLE
refactor: `ChatMessage` - introduce `text` property and deprecate `content`

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional
@@ -31,6 +32,26 @@ class ChatMessage:
     role: ChatRole
     name: Optional[str]
     meta: Dict[str, Any] = field(default_factory=dict, hash=False)
+
+    @property
+    def text(self) -> Optional[str]:
+        """
+        Returns the textual content of the message.
+        """
+        # Currently, this property mirrors the `content` attribute. This will change in 2.9.0.
+        # The current actual return type is str. We are using Optional[str] to be ready for 2.9.0,
+        # when None will be a valid value for `text`.
+        return object.__getattribute__(self, "content")
+
+    def __getattribute__(self, name):
+        # this method is reimplemented to warn about the deprecation of the `content` attribute
+        if name == "content":
+            msg = (
+                "The `content` attribute of `ChatMessage` will be removed in Haystack 2.9.0. "
+                "Use the `text` property to access the textual value."
+            )
+            warnings.warn(msg, DeprecationWarning)
+        return object.__getattribute__(self, name)
 
     def is_from(self, role: ChatRole) -> bool:
         """

--- a/releasenotes/notes/chatmessage-text-5bd06f6ac70ac649.yaml
+++ b/releasenotes/notes/chatmessage-text-5bd06f6ac70ac649.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    In Haystack 2.9.0, the `ChatMessage` dataclass will be refactored to make it more flexible and future-proof.
+    As part of this change, the `content` attribute will be removed.
+    A new `text` property has been introduced to provide access to the textual value of the `ChatMessage`.
+    To ensure a smooth transition, start using the `text` property now in place of `content`.

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -36,6 +36,7 @@ def test_with_empty_content():
     message = ChatMessage.from_user("")
     assert message.content == ""
     assert message.text == ""
+    assert message.role == ChatRole.USER
 
 
 def test_from_function_with_empty_name():
@@ -44,6 +45,7 @@ def test_from_function_with_empty_name():
     assert message.content == content
     assert message.text == content
     assert message.name == ""
+    assert message.role == ChatRole.FUNCTION
 
 
 def test_to_openai_format():
@@ -94,11 +96,15 @@ def test_apply_custom_chat_templating_on_chat_message():
 
 
 def test_to_dict():
-    message = ChatMessage.from_user("content")
-    message.meta["some"] = "some"
+    content = "content"
+    role = "user"
+    meta = {"some": "some"}
 
-    assert message.to_dict() == {"content": "content", "role": "user", "name": None, "meta": {"some": "some"}}
-    assert message.text == "content"
+    message = ChatMessage.from_user(content)
+    message.meta.update(meta)
+
+    assert message.text == content
+    assert message.to_dict() == {"content": content, "role": role, "name": None, "meta": meta}
 
 
 def test_from_dict():

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -12,6 +12,7 @@ def test_from_assistant_with_valid_content():
     content = "Hello, how can I assist you?"
     message = ChatMessage.from_assistant(content)
     assert message.content == content
+    assert message.text == content
     assert message.role == ChatRole.ASSISTANT
 
 
@@ -19,6 +20,7 @@ def test_from_user_with_valid_content():
     content = "I have a question."
     message = ChatMessage.from_user(content)
     assert message.content == content
+    assert message.text == content
     assert message.role == ChatRole.USER
 
 
@@ -26,18 +28,21 @@ def test_from_system_with_valid_content():
     content = "System message."
     message = ChatMessage.from_system(content)
     assert message.content == content
+    assert message.text == content
     assert message.role == ChatRole.SYSTEM
 
 
 def test_with_empty_content():
     message = ChatMessage.from_user("")
     assert message.content == ""
+    assert message.text == ""
 
 
 def test_from_function_with_empty_name():
     content = "Function call"
     message = ChatMessage.from_function(content, "")
     assert message.content == content
+    assert message.text == content
     assert message.name == ""
 
 
@@ -93,6 +98,7 @@ def test_to_dict():
     message.meta["some"] = "some"
 
     assert message.to_dict() == {"content": "content", "role": "user", "name": None, "meta": {"some": "some"}}
+    assert message.text == "content"
 
 
 def test_from_dict():
@@ -105,3 +111,17 @@ def test_from_dict_with_meta():
     assert ChatMessage.from_dict(
         data={"content": "text", "role": "user", "name": None, "meta": {"something": "something"}}
     ) == ChatMessage(content="text", role=ChatRole("user"), name=None, meta={"something": "something"})
+
+
+def test_content_deprecation_warning(recwarn):
+    message = ChatMessage.from_user("my message")
+
+    # accessing the content attribute triggers the deprecation warning
+    _ = message.content
+    assert len(recwarn) == 1
+    wrn = recwarn.pop(DeprecationWarning)
+    assert "`content` attribute" in wrn.message.args[0]
+
+    # accessing the text property does not trigger a warning
+    assert message.text == "my message"
+    assert len(recwarn) == 0


### PR DESCRIPTION
### Related Issues

- part of #8587 (see #8583 for the motivation)

### Proposed Changes:
- Introduce a `text` property that mirrors `content`
- If users/applications directly access the `content` attribute, show a deprecation warning telling that `content` will be removed in 2.9.0 and to use `text` instead

### How did you test it?
CI, new tests

### Notes for the reviewer
Adaptation of all Haystack components to use `text` instead of `content` will be done in a future PR.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
