### PR TITLE
chore: adding a deprecation warning on the `SentenceWindowRetriever`

### DIFF
--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import warnings
 from typing import Any, Dict, List, Optional
 

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -93,7 +93,7 @@ class SentenceWindowRetriever:
         self.document_store = document_store
 
         warnings.warn(
-            "The `context_documents` output key will be deprecated in the next release. Instead of a "
+            "The output of `context_documents` will change in the next release. Instead of a "
             "List[List[Document]], the output will be a List[Document], ordered by `split_idx_start`.",
             DeprecationWarning,
         )

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -95,7 +95,8 @@ class SentenceWindowRetriever:
 
         warnings.warn(
             "The output of `context_documents` will change in the next release. Instead of a "
-            "List[List[Document]], the output will be a List[Document], ordered by `split_idx_start`.",
+            "List[List[Document]], the output will be a List[Document], where the documents are ordered by "
+            "`split_idx_start`.",
             DeprecationWarning,
         )
 

--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-
+import warnings
 from typing import Any, Dict, List, Optional
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -91,6 +91,12 @@ class SentenceWindowRetriever:
 
         self.window_size = window_size
         self.document_store = document_store
+
+        warnings.warn(
+            "The `context_documents` output key will be deprecated in the next release. Instead of a "
+            "List[List[Document]], the output will be a List[Document], ordered by `split_idx_start`.",
+            DeprecationWarning,
+        )
 
     @staticmethod
     def merge_documents_text(documents: List[Document]) -> str:

--- a/releasenotes/notes/sentence-window-deprecation-b7db8efc56f33940.yaml
+++ b/releasenotes/notes/sentence-window-deprecation-b7db8efc56f33940.yaml
@@ -1,0 +1,3 @@
+deprecations:
+    |
+    "The output of `context_documents` will change in the next release. Instead of a List[List[Document]], the output will be a List[Document], where the documents are ordered by `split_idx_start`.",


### PR DESCRIPTION
### Proposed Changes:

- Adds a deprecation warning coming from this [PR](https://github.com/deepset-ai/haystack/pull/8590) and this [issue](https://github.com/deepset-ai/haystack/issues/8557)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
