### PR TITLE
fix: docstring for normalization

### DIFF
--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -79,7 +79,7 @@ class SentenceTransformersDocumentEmbedder:
         :param progress_bar:
             If `True`, shows a progress bar when embedding documents.
         :param normalize_embeddings:
-            If `True`, returns vectors with length 1.
+            If `True`, the embeddings are normalized using L2 normalization.
         :param meta_fields_to_embed:
             List of metadata fields to embed along with the document text.
         :param embedding_separator:

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -38,7 +38,7 @@ class SentenceTransformersDocumentEmbedder:
     ```
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913 # pylint: disable=too-many-positional-arguments
         self,
         model: str = "sentence-transformers/all-mpnet-base-v2",
         device: Optional[ComponentDevice] = None,
@@ -79,7 +79,7 @@ class SentenceTransformersDocumentEmbedder:
         :param progress_bar:
             If `True`, shows a progress bar when embedding documents.
         :param normalize_embeddings:
-            If `True`, the embeddings are normalized using L2 normalization.
+            If `True`, the embeddings are normalized using L2 normalization, so that each embedding has a norm of 1.
         :param meta_fields_to_embed:
             List of metadata fields to embed along with the document text.
         :param embedding_separator:

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -73,7 +73,7 @@ class SentenceTransformersTextEmbedder:
             If `True`, shows a progress bar for calculating embeddings.
             If `False`, disables the progress bar.
         :param normalize_embeddings:
-            If `True`, returned vectors have a length of 1.
+            If `True`, the embeddings are normalized using L2 normalization.
         :param trust_remote_code:
             If `False`, permits only Hugging Face verified model architectures.
             If `True`, permits custom models and scripts.

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -34,7 +34,7 @@ class SentenceTransformersTextEmbedder:
     ```
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913 # pylint: disable=too-many-positional-arguments
         self,
         model: str = "sentence-transformers/all-mpnet-base-v2",
         device: Optional[ComponentDevice] = None,
@@ -73,7 +73,7 @@ class SentenceTransformersTextEmbedder:
             If `True`, shows a progress bar for calculating embeddings.
             If `False`, disables the progress bar.
         :param normalize_embeddings:
-            If `True`, the embeddings are normalized using L2 normalization.
+            If `True`, the embeddings are normalized using L2 normalization, so that the embeddings have a norm of 1.
         :param trust_remote_code:
             If `False`, permits only Hugging Face verified model architectures.
             If `True`, permits custom models and scripts.

--- a/releasenotes/notes/fix-docstrings-normalize-embedding-fd2dba50ba9e51a1.yaml
+++ b/releasenotes/notes/fix-docstrings-normalize-embedding-fd2dba50ba9e51a1.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - fix docstrings for normalize_embeddings in sentence_transformers_text_embedder and sentence_transformers_document_embedder

--- a/releasenotes/notes/fix-docstrings-normalize-embedding-fd2dba50ba9e51a1.yaml
+++ b/releasenotes/notes/fix-docstrings-normalize-embedding-fd2dba50ba9e51a1.yaml
@@ -1,2 +1,3 @@
+---
 fixes:
   - fix docstrings for normalize_embeddings in sentence_transformers_text_embedder and sentence_transformers_document_embedder


### PR DESCRIPTION
### Related Issues

- wrong docstring

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
