### PR TITLE
refactor: converting some DocumentJoiner methods to staticmethod

### DIFF
--- a/haystack/components/joiners/document_joiner.py
+++ b/haystack/components/joiners/document_joiner.py
@@ -102,10 +102,10 @@ class DocumentJoiner:
         if isinstance(join_mode, str):
             join_mode = JoinMode.from_str(join_mode)
         join_mode_functions = {
-            JoinMode.CONCATENATE: self._concatenate,
+            JoinMode.CONCATENATE: DocumentJoiner._concatenate,
             JoinMode.MERGE: self._merge,
             JoinMode.RECIPROCAL_RANK_FUSION: self._reciprocal_rank_fusion,
-            JoinMode.DISTRIBUTION_BASED_RANK_FUSION: self._distribution_based_rank_fusion,
+            JoinMode.DISTRIBUTION_BASED_RANK_FUSION: DocumentJoiner._distribution_based_rank_fusion,
         }
         self.join_mode_function = join_mode_functions[join_mode]
         self.join_mode = join_mode
@@ -149,7 +149,8 @@ class DocumentJoiner:
 
         return {"documents": output_documents}
 
-    def _concatenate(self, document_lists: List[List[Document]]) -> List[Document]:
+    @staticmethod
+    def _concatenate(document_lists: List[List[Document]]) -> List[Document]:
         """
         Concatenate multiple lists of Documents and return only the Document with the highest score for duplicates.
         """
@@ -217,7 +218,8 @@ class DocumentJoiner:
 
         return list(documents_map.values())
 
-    def _distribution_based_rank_fusion(self, document_lists: List[List[Document]]) -> List[Document]:
+    @staticmethod
+    def _distribution_based_rank_fusion(document_lists: List[List[Document]]) -> List[Document]:
         """
         Merge multiple lists of Documents and assign scores based on Distribution-Based Score Fusion.
 
@@ -243,7 +245,7 @@ class DocumentJoiner:
                 doc.score = (doc.score - min_score) / delta_score if delta_score != 0.0 else 0.0
                 # if all docs have the same score delta_score is 0, the docs are uninformative for the query
 
-        output = self._concatenate(document_lists=document_lists)
+        output = DocumentJoiner._concatenate(document_lists=document_lists)
 
         return output
 

--- a/releasenotes/notes/converting-docjoiner-methods-to-static-4668f5d227667dd5.yaml
+++ b/releasenotes/notes/converting-docjoiner-methods-to-static-4668f5d227667dd5.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  -|
+  	DocumentJoiner methods `_concatenate()` and `_distribution_based_rank_fusion()` were converted to static methods.

--- a/releasenotes/notes/converting-docjoiner-methods-to-static-4668f5d227667dd5.yaml
+++ b/releasenotes/notes/converting-docjoiner-methods-to-static-4668f5d227667dd5.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   -|
-  	DocumentJoiner methods `_concatenate()` and `_distribution_based_rank_fusion()` were converted to static methods.
+   DocumentJoiner methods `_concatenate()` and `_distribution_based_rank_fusion()` were converted to static methods.


### PR DESCRIPTION
### Proposed Changes:

`_concatenate()` and `_distribution_based_rank_fusion()` should be static methods

### How did you test it?

- local unit tests
- CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
