### PR TITLE
chore: remove deprecation warnings related to `store_full_path`

### DIFF
--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -5,7 +5,6 @@
 import copy
 import hashlib
 import os
-import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union

--- a/haystack/components/converters/azure.py
+++ b/haystack/components/converters/azure.py
@@ -143,12 +143,6 @@ class AzureOCRDocumentConverter:
             azure_output.append(result.to_dict())
 
             merged_metadata = {**bytestream.meta, **metadata}
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
 
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)

--- a/haystack/components/converters/csv.py
+++ b/haystack/components/converters/csv.py
@@ -94,13 +94,6 @@ class CSVToDocument:
 
             merged_metadata = {**bytestream.meta, **metadata}
 
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
-
             if not self.store_full_path and "file_path" in bytestream.meta:
                 file_path = bytestream.meta.get("file_path")
                 if file_path:  # Ensure the value is not None for pylint

--- a/haystack/components/converters/csv.py
+++ b/haystack/components/converters/csv.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/haystack/components/converters/docx.py
+++ b/haystack/components/converters/docx.py
@@ -5,7 +5,6 @@
 import csv
 import io
 import os
-import warnings
 from dataclasses import dataclass
 from enum import Enum
 from io import StringIO

--- a/haystack/components/converters/docx.py
+++ b/haystack/components/converters/docx.py
@@ -189,13 +189,6 @@ class DOCXToDocument:
                 )
                 continue
 
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
-
             docx_metadata = self._get_docx_metadata(document=docx_document)
             merged_metadata = {**bytestream.meta, **metadata, "docx": docx_metadata}
 

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -123,12 +123,6 @@ class HTMLToDocument:
 
             merged_metadata = {**bytestream.meta, **metadata}
 
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
             if not self.store_full_path and "file_path" in bytestream.meta:
                 file_path = bytestream.meta.get("file_path")
                 if file_path:  # Ensure the value is not None for pylint

--- a/haystack/components/converters/html.py
+++ b/haystack/components/converters/html.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/haystack/components/converters/json.py
+++ b/haystack/components/converters/json.py
@@ -280,12 +280,6 @@ class JSONConverter:
 
             data = self._get_content_and_meta(bytestream)
 
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
             for text, extra_meta in data:
                 merged_metadata = {**bytestream.meta, **metadata, **extra_meta}
 

--- a/haystack/components/converters/json.py
+++ b/haystack/components/converters/json.py
@@ -4,7 +4,6 @@
 
 import json
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 

--- a/haystack/components/converters/markdown.py
+++ b/haystack/components/converters/markdown.py
@@ -112,13 +112,6 @@ class MarkdownToDocument:
 
             merged_metadata = {**bytestream.meta, **metadata}
 
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
-
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)
 

--- a/haystack/components/converters/markdown.py
+++ b/haystack/components/converters/markdown.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/haystack/components/converters/pdfminer.py
+++ b/haystack/components/converters/pdfminer.py
@@ -172,12 +172,6 @@ class PDFMinerToDocument:
                 )
 
             merged_metadata = {**bytestream.meta, **metadata}
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
 
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)

--- a/haystack/components/converters/pdfminer.py
+++ b/haystack/components/converters/pdfminer.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/haystack/components/converters/pptx.py
+++ b/haystack/components/converters/pptx.py
@@ -104,12 +104,6 @@ class PPTXToDocument:
                 continue
 
             merged_metadata = {**bytestream.meta, **metadata}
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
 
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)

--- a/haystack/components/converters/pptx.py
+++ b/haystack/components/converters/pptx.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -220,12 +220,7 @@ class PyPDFToDocument:
                 )
 
             merged_metadata = {**bytestream.meta, **metadata}
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
+
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)
             document.meta = merged_metadata

--- a/haystack/components/converters/pypdf.py
+++ b/haystack/components/converters/pypdf.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import warnings
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/haystack/components/converters/tika.py
+++ b/haystack/components/converters/tika.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import warnings
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/haystack/components/converters/tika.py
+++ b/haystack/components/converters/tika.py
@@ -139,12 +139,6 @@ class TikaDocumentConverter:
                 continue
 
             merged_metadata = {**bytestream.meta, **metadata}
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
 
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -93,12 +93,6 @@ class TextFileToDocument:
                 continue
 
             merged_metadata = {**bytestream.meta, **metadata}
-            warnings.warn(
-                "The `store_full_path` parameter defaults to True, storing full file paths in metadata. "
-                "In the 2.9.0 release, the default value for `store_full_path` will change to False, "
-                "storing only file names to improve privacy.",
-                DeprecationWarning,
-            )
 
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)

--- a/haystack/components/converters/txt.py
+++ b/haystack/components/converters/txt.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 


### PR DESCRIPTION
### Related Issues

- follow up of #8619

### Proposed Changes:
- remove deprecation warnings

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
