### PR TITLE
docs: add deprecation warning nltk document splitter

### DIFF
--- a/haystack/components/preprocessors/nltk_document_splitter.py
+++ b/haystack/components/preprocessors/nltk_document_splitter.py
@@ -54,7 +54,7 @@ class NLTKDocumentSplitter(DocumentSplitter):
         """
 
         warnings.warn(
-            "The NLTKDocumentSplitter will deprecated and will be removed in the next release. "
+            "The NLTKDocumentSplitter is deprecated and will be removed in the next release. "
             "See DocumentSplitter which now supports the functionalities of the NLTKDocumentSplitter, i.e.: "
             "using NLTK to detect sentence boundaries.",
             DeprecationWarning,

--- a/haystack/components/preprocessors/nltk_document_splitter.py
+++ b/haystack/components/preprocessors/nltk_document_splitter.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-
+import warnings
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
@@ -51,6 +51,12 @@ class NLTKDocumentSplitter(DocumentSplitter):
             This is a function which must accept a single `str` as input and return a `list` of `str` as output,
             representing the chunks after splitting.
         """
+
+        warnings.warn(
+            "The NLTKDocumentSplitter will deprecated and will be removed in the next release. "
+            "The DocumentSplitter will instead support the functionality of the NLTKDocumentSplitter.",
+            DeprecationWarning,
+        )
 
         super(NLTKDocumentSplitter, self).__init__(
             split_by=split_by,

--- a/haystack/components/preprocessors/nltk_document_splitter.py
+++ b/haystack/components/preprocessors/nltk_document_splitter.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import warnings
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple

--- a/haystack/components/preprocessors/nltk_document_splitter.py
+++ b/haystack/components/preprocessors/nltk_document_splitter.py
@@ -55,7 +55,8 @@ class NLTKDocumentSplitter(DocumentSplitter):
 
         warnings.warn(
             "The NLTKDocumentSplitter will deprecated and will be removed in the next release. "
-            "The DocumentSplitter will instead support the functionality of the NLTKDocumentSplitter.",
+            "See DocumentSplitter which now supports the functionalities of the NLTKDocumentSplitter, i.e.: "
+            "using NLTK to detect sentence boundaries.",
             DeprecationWarning,
         )
 

--- a/releasenotes/notes/deprecating-NLTKDocumentSplitter-e9a621e025e9a49f.yaml
+++ b/releasenotes/notes/deprecating-NLTKDocumentSplitter-e9a621e025e9a49f.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The NLTKDocumentSplitter will deprecated and will be removed in the next release. The DocumentSplitter will instead support the functionality of the NLTKDocumentSplitter.


### PR DESCRIPTION
### Related Issues

- related to #8600 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
