### PR TITLE
chore: pin `openai>=1.56.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "tqdm",
   "tenacity!=8.4.0",
   "lazy-imports",
-  "openai>=1.1.0",
+  "openai>=1.56.1",
   "Jinja2",
   "posthog",                # telemetry
   "pyyaml",

--- a/releasenotes/notes/pin-openai-1-56-1-43d50ebfbb8b5a8d.yaml
+++ b/releasenotes/notes/pin-openai-1-56-1-43d50ebfbb8b5a8d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Pin OpenAI client to >=1.56.1 to avoid issues related to changes in the httpx library.


### PR DESCRIPTION
### Related Issues

- Related: https://github.com/deepset-ai/devrel-board/issues/539
- The situation is quite complex and hard to debug. https://github.com/openai/openai-python/issues/1902
- It has been fixed in the OpenAI client with releases 1.55.3 and 1.56.1
- Unfortunately, Colab has 1.54.5, which is compatible with Haystack, but then the error pops up 

### Proposed Changes:
- pin to `openai>=1.56.1` to make sure that Haystack works and, when installed in Colab, updates the OpenAI client.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
