### PR TITLE
fix: end2end tests due to behaviour of DocumentSplitter "sentence" being replaced by "period"

### DIFF
--- a/e2e/pipelines/test_dense_doc_search.py
+++ b/e2e/pipelines/test_dense_doc_search.py
@@ -26,7 +26,7 @@ def test_dense_doc_search_pipeline(tmp_path, samples_path):
     indexing_pipeline.add_component(instance=DocumentJoiner(), name="joiner")
     indexing_pipeline.add_component(instance=DocumentCleaner(), name="cleaner")
     indexing_pipeline.add_component(
-        instance=DocumentSplitter(split_by="sentence", split_length=250, split_overlap=30), name="splitter"
+        instance=DocumentSplitter(split_by="period", split_length=250, split_overlap=30), name="splitter"
     )
     indexing_pipeline.add_component(
         instance=SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"), name="embedder"

--- a/e2e/pipelines/test_preprocessing_pipeline.py
+++ b/e2e/pipelines/test_preprocessing_pipeline.py
@@ -25,9 +25,7 @@ def test_preprocessing_pipeline(tmp_path):
         instance=MetadataRouter(rules={"en": {"field": "language", "operator": "==", "value": "en"}}), name="router"
     )
     preprocessing_pipeline.add_component(instance=DocumentCleaner(), name="cleaner")
-    preprocessing_pipeline.add_component(
-        instance=DocumentSplitter(split_by="sentence", split_length=1), name="splitter"
-    )
+    preprocessing_pipeline.add_component(instance=DocumentSplitter(split_by="period", split_length=1), name="splitter")
     preprocessing_pipeline.add_component(
         instance=SentenceTransformersDocumentEmbedder(model="sentence-transformers/all-MiniLM-L6-v2"), name="embedder"
     )


### PR DESCRIPTION
### How did you test it?

- local end2endtests + CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
