### PR TITLE
feat: use importlib when deserializing callables

### DIFF
--- a/releasenotes/notes/use-importlib-when-deserializing-callable-1f36f07c4518c2cf.yaml
+++ b/releasenotes/notes/use-importlib-when-deserializing-callable-1f36f07c4518c2cf.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Improved deserialization of callables by using `importlib` instead of `sys.modules`.
+    This change allows importing local functions and classes that are not in `sys.modules`
+    when deserializing callables.

--- a/test/utils/test_callable_serialization.py
+++ b/test/utils/test_callable_serialization.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 import requests
 
+from haystack import DeserializationError
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.utils import serialize_callable, deserialize_callable
 
@@ -36,3 +38,10 @@ def test_callable_deserialization_non_local():
     result = serialize_callable(requests.api.get)
     fn = deserialize_callable(result)
     assert fn is requests.api.get
+
+
+def test_callable_deserialization_error():
+    with pytest.raises(DeserializationError):
+        deserialize_callable("this.is.not.a.valid.module")
+    with pytest.raises(DeserializationError):
+        deserialize_callable("sys.foobar")


### PR DESCRIPTION
### Related Issues

- fixes #8647

### Proposed Changes:

Supports local package imports via importlib.import_module

### How did you test it?

Existing unit tests passed. I also added a new negative test for this.

### Notes for the reviewer

This is a rather small change but it is causing issues for me right now. Really hope this can be included in 2.9.0!

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
