### PR TITLE
refactor: Lazy import builders, embedders, (chat)generators, retrievers

### DIFF
--- a/haystack/components/builders/__init__.py
+++ b/haystack/components/builders/__init__.py
@@ -2,8 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack.components.builders.answer_builder import AnswerBuilder
-from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
-from haystack.components.builders.prompt_builder import PromptBuilder
-
 __all__ = ["AnswerBuilder", "PromptBuilder", "ChatPromptBuilder"]
+
+
+def AnswerBuilder():  # noqa: D103
+    from haystack.components.builders.answer_builder import AnswerBuilder
+
+    return AnswerBuilder
+
+
+def ChatPromptBuilder():  # noqa: D103
+    from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
+
+    return ChatPromptBuilder
+
+
+def PromptBuilder():  # noqa: D103
+    from haystack.components.builders.prompt_builder import PromptBuilder
+
+    return PromptBuilder

--- a/haystack/components/embedders/__init__.py
+++ b/haystack/components/embedders/__init__.py
@@ -2,22 +2,63 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack.components.embedders.azure_document_embedder import AzureOpenAIDocumentEmbedder
-from haystack.components.embedders.azure_text_embedder import AzureOpenAITextEmbedder
-from haystack.components.embedders.hugging_face_api_document_embedder import HuggingFaceAPIDocumentEmbedder
-from haystack.components.embedders.hugging_face_api_text_embedder import HuggingFaceAPITextEmbedder
-from haystack.components.embedders.openai_document_embedder import OpenAIDocumentEmbedder
-from haystack.components.embedders.openai_text_embedder import OpenAITextEmbedder
-from haystack.components.embedders.sentence_transformers_document_embedder import SentenceTransformersDocumentEmbedder
-from haystack.components.embedders.sentence_transformers_text_embedder import SentenceTransformersTextEmbedder
-
 __all__ = [
-    "HuggingFaceAPITextEmbedder",
-    "HuggingFaceAPIDocumentEmbedder",
-    "SentenceTransformersTextEmbedder",
-    "SentenceTransformersDocumentEmbedder",
-    "OpenAITextEmbedder",
-    "OpenAIDocumentEmbedder",
-    "AzureOpenAITextEmbedder",
     "AzureOpenAIDocumentEmbedder",
+    "AzureOpenAITextEmbedder",
+    "HuggingFaceAPIDocumentEmbedder",
+    "HuggingFaceAPITextEmbedder",
+    "OpenAIDocumentEmbedder",
+    "OpenAITextEmbedder",
+    "SentenceTransformersDocumentEmbedder",
+    "SentenceTransformersTextEmbedder",
 ]
+
+
+def AzureOpenAIDocumentEmbedder():  # noqa: D103
+    from haystack.components.embedders.azure_document_embedder import AzureOpenAIDocumentEmbedder
+
+    return AzureOpenAIDocumentEmbedder
+
+
+def AzureOpenAITextEmbedder():  # noqa: D103
+    from haystack.components.embedders.azure_text_embedder import AzureOpenAITextEmbedder
+
+    return AzureOpenAITextEmbedder
+
+
+def HuggingFaceAPIDocumentEmbedder():  # noqa: D103
+    from haystack.components.embedders.hugging_face_api_document_embedder import HuggingFaceAPIDocumentEmbedder
+
+    return HuggingFaceAPIDocumentEmbedder
+
+
+def HuggingFaceAPITextEmbedder():  # noqa: D103
+    from haystack.components.embedders.hugging_face_api_text_embedder import HuggingFaceAPITextEmbedder
+
+    return HuggingFaceAPITextEmbedder
+
+
+def OpenAIDocumentEmbedder():  # noqa: D103
+    from haystack.components.embedders.openai_document_embedder import OpenAIDocumentEmbedder
+
+    return OpenAIDocumentEmbedder
+
+
+def OpenAITextEmbedder():  # noqa: D103
+    from haystack.components.embedders.openai_text_embedder import OpenAITextEmbedder
+
+    return OpenAITextEmbedder
+
+
+def SentenceTransformersDocumentEmbedder():  # noqa: D103
+    from haystack.components.embedders.sentence_transformers_document_embedder import (
+        SentenceTransformersDocumentEmbedder,
+    )
+
+    return SentenceTransformersDocumentEmbedder
+
+
+def SentenceTransformersTextEmbedder():  # noqa: D103
+    from haystack.components.embedders.sentence_transformers_text_embedder import SentenceTransformersTextEmbedder
+
+    return SentenceTransformersTextEmbedder

--- a/haystack/components/generators/__init__.py
+++ b/haystack/components/generators/__init__.py
@@ -2,14 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack.components.generators.openai import (  # noqa: I001 (otherwise we end up with partial imports)
-    OpenAIGenerator,
-)
-from haystack.components.generators.azure import AzureOpenAIGenerator
-from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator
-from haystack.components.generators.hugging_face_api import HuggingFaceAPIGenerator
-from haystack.components.generators.openai_dalle import DALLEImageGenerator
-
 __all__ = [
     "HuggingFaceLocalGenerator",
     "HuggingFaceAPIGenerator",
@@ -17,3 +9,35 @@ __all__ = [
     "AzureOpenAIGenerator",
     "DALLEImageGenerator",
 ]
+
+
+def HuggingFaceLocalGenerator():  # noqa: D103
+    from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator
+
+    return HuggingFaceLocalGenerator
+
+
+def HuggingFaceAPIGenerator():  # noqa: D103
+    from haystack.components.generators.hugging_face_api import HuggingFaceAPIGenerator
+
+    return HuggingFaceAPIGenerator
+
+
+def OpenAIGenerator():  # noqa: D103
+    from haystack.components.generators.openai import (  # noqa: I001 (otherwise we end up with partial imports)
+        OpenAIGenerator,
+    )
+
+    return OpenAIGenerator
+
+
+def AzureOpenAIGenerator():  # noqa: D103
+    from haystack.components.generators.azure import AzureOpenAIGenerator
+
+    return AzureOpenAIGenerator
+
+
+def DALLEImageGenerator():  # noqa: D103
+    from haystack.components.generators.openai_dalle import DALLEImageGenerator
+
+    return DALLEImageGenerator

--- a/haystack/components/generators/chat/__init__.py
+++ b/haystack/components/generators/chat/__init__.py
@@ -2,16 +2,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack.components.generators.chat.openai import (  # noqa: I001 (otherwise we end up with partial imports)
-    OpenAIChatGenerator,
-)
-from haystack.components.generators.chat.azure import AzureOpenAIChatGenerator
-from haystack.components.generators.chat.hugging_face_local import HuggingFaceLocalChatGenerator
-from haystack.components.generators.chat.hugging_face_api import HuggingFaceAPIChatGenerator
-
 __all__ = [
     "HuggingFaceLocalChatGenerator",
     "HuggingFaceAPIChatGenerator",
     "OpenAIChatGenerator",
     "AzureOpenAIChatGenerator",
 ]
+
+
+def AzureOpenAIChatGenerator():  # noqa: D103
+    from haystack.components.generators.chat.azure import AzureOpenAIChatGenerator
+
+    return AzureOpenAIChatGenerator
+
+
+def HuggingFaceLocalChatGenerator():  # noqa: D103
+    from haystack.components.generators.chat.hugging_face_local import HuggingFaceLocalChatGenerator
+
+    return HuggingFaceLocalChatGenerator
+
+
+def HuggingFaceAPIChatGenerator():  # noqa: D103
+    from haystack.components.generators.chat.hugging_face_api import HuggingFaceAPIChatGenerator
+
+    return HuggingFaceAPIChatGenerator
+
+
+def OpenAIChatGenerator():  # noqa: D103
+    from haystack.components.generators.chat.openai import (  # noqa: I001 (otherwise we end up with partial imports)
+        OpenAIChatGenerator,
+    )
+
+    return OpenAIChatGenerator

--- a/haystack/components/retrievers/__init__.py
+++ b/haystack/components/retrievers/__init__.py
@@ -2,9 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from haystack.components.retrievers.filter_retriever import FilterRetriever
-from haystack.components.retrievers.in_memory.bm25_retriever import InMemoryBM25Retriever
-from haystack.components.retrievers.in_memory.embedding_retriever import InMemoryEmbeddingRetriever
-from haystack.components.retrievers.sentence_window_retriever import SentenceWindowRetriever
-
 __all__ = ["FilterRetriever", "InMemoryEmbeddingRetriever", "InMemoryBM25Retriever", "SentenceWindowRetriever"]
+
+
+def FilterRetriever():  # noqa: D103
+    from haystack.components.retrievers.filter_retriever import FilterRetriever
+
+    return FilterRetriever
+
+
+def InMemoryBM25Retriever():  # noqa: D103
+    from haystack.components.retrievers.in_memory.bm25_retriever import InMemoryBM25Retriever
+
+    return InMemoryBM25Retriever
+
+
+def InMemoryEmbeddingRetriever():  # noqa: D103
+    from haystack.components.retrievers.in_memory.embedding_retriever import InMemoryEmbeddingRetriever
+
+    return InMemoryEmbeddingRetriever
+
+
+def SentenceWindowRetriever():  # noqa: D103
+    from haystack.components.retrievers.sentence_window_retriever import SentenceWindowRetriever
+
+    return SentenceWindowRetriever


### PR DESCRIPTION
### Related Issues

- fixes #8650 

### Proposed Changes:

- Add lazy imports for builders, embedders, (chat)generators, retrievers

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
I just added the lazy import for a small selection of components in this draft. All components used in our "first RAG pipeline" tutorial are covered, which comes down to:
```python
from haystack.document_stores.in_memory import InMemoryDocumentStore
from haystack.components.embedders import SentenceTransformersTextEmbedder
from haystack.components.embedders import SentenceTransformersDocumentEmbedder
from datasets import load_dataset
from haystack import Document
from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever
from haystack.components.builders import ChatPromptBuilder, AnswerBuilder
from haystack.dataclasses import ChatMessage
import os
from getpass import getpass
from haystack.components.generators.chat import OpenAIChatGenerator
from haystack import Pipeline
```

Tests are failing with TypeErrors. We also need to check whether type hints or auto completion in IDEs are affected in a bad way by the lazy import. For example, when add an `AnswerBuilder`, I get two suggestions about importing either the class or the function `AnswerBuilder`
<img width="677" alt="Screenshot 2024-12-17 at 17 41 05" src="https://github.com/user-attachments/assets/7f0f248d-2a6c-46bd-b3ce-eb850bfde6c7" />

Here is a comparison first without and then with lazy imports. Created with
```bash
 python -X importtime 27_first_rag_pipeline.py 2> lazy-import.log
 tuna lazy-import.log
 ```
**without lazy imports**
<img width="1168" alt="Screenshot 2024-12-17 at 18 16 02" src="https://github.com/user-attachments/assets/c8754761-ea9e-4003-b01f-8afd3959bbfa" />
**with lazy imports**
<img width="1159" alt="Screenshot 2024-12-17 at 18 16 13" src="https://github.com/user-attachments/assets/2416db72-30d4-4d95-a41d-e3bc46a36bed" />

An alternative to lazy imports would be to require users to know and always use the full path of the component they want to import.
`from haystack.components.generators.hugging_face_local import HuggingFaceLocalGenerator` for example, instead of just `from haystack.components.generators import HuggingFaceLocalGenerator`
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
