### PR TITLE
chore: `OpenAITextEmbedder` - remove unused constants

### DIFF
--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -10,9 +10,6 @@ from openai import OpenAI
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
 
-OPENAI_TIMEOUT = float(os.environ.get("OPENAI_TIMEOUT", 30))
-OPENAI_MAX_RETRIES = int(os.environ.get("OPENAI_MAX_RETRIES", 5))
-
 
 @component
 class OpenAITextEmbedder:


### PR DESCRIPTION
### Related issues

The constants below were introduced in #7653
https://github.com/deepset-ai/haystack/blob/99e7e343b28d2d076a63f9d5823d0e1cf23f68ca/haystack/components/embedders/openai_text_embedder.py#L13-L14

but the actual access to env vars happen here:
https://github.com/deepset-ai/haystack/blob/99e7e343b28d2d076a63f9d5823d0e1cf23f68ca/haystack/components/embedders/openai_text_embedder.py#L95-L99

### Proposed Changes:
- Remove the unused constants

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
