### PR TITLE
fix: truncate ByteStream string representation

### DIFF
--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -63,3 +63,10 @@ class ByteStream:
         :raises: UnicodeDecodeError: If the ByteStream data cannot be decoded with the specified encoding.
         """
         return self.data.decode(encoding)
+
+    def __str__(self) -> str:
+        """
+        Returns a string representation of the ByteStream, truncating the data to 1KB.
+        """
+        truncated = self.data[:1021] + b"..." if len(self.data) > 1024 else self.data
+        return f"ByteStream(data={truncated!r}, mime_type={self.mime_type!r}, meta={self.meta!r})"

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -68,5 +68,5 @@ class ByteStream:
         """
         Returns a string representation of the ByteStream, truncating the data to 1KB.
         """
-        truncated = self.data[:1021] + b"..." if len(self.data) > 1024 else self.data
+        truncated = self.data[:1024] + b"..." if len(self.data) > 1024 else self.data
         return f"ByteStream(data={truncated!r}, mime_type={self.mime_type!r}, meta={self.meta!r})"

--- a/haystack/dataclasses/byte_stream.py
+++ b/haystack/dataclasses/byte_stream.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 
-@dataclass
+@dataclass(repr=False)
 class ByteStream:
     """
     Base data class representing a binary object in the Haystack API.
@@ -64,9 +64,14 @@ class ByteStream:
         """
         return self.data.decode(encoding)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """
-        Returns a string representation of the ByteStream, truncating the data to 1KB.
+        Return a string representation of the ByteStream, truncating the data to 100 bytes.
         """
-        truncated = self.data[:1024] + b"..." if len(self.data) > 1024 else self.data
-        return f"ByteStream(data={truncated!r}, mime_type={self.mime_type!r}, meta={self.meta!r})"
+        fields = []
+        truncated_data = self.data[:100] + b"..." if len(self.data) > 100 else self.data
+        fields.append(f"data={truncated_data!r}")
+        fields.append(f"meta={self.meta!r}")
+        fields.append(f"mime_type={self.mime_type!r}")
+        fields_str = ", ".join(fields)
+        return f"{self.__class__.__name__}({fields_str})"

--- a/releasenotes/notes/fix-bytestream-str-8dd6d5e9a87f6aa4.yaml
+++ b/releasenotes/notes/fix-bytestream-str-8dd6d5e9a87f6aa4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ByteStream now truncates the data to 1KB in the string representation.

--- a/releasenotes/notes/fix-bytestream-str-8dd6d5e9a87f6aa4.yaml
+++ b/releasenotes/notes/fix-bytestream-str-8dd6d5e9a87f6aa4.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    ByteStream now truncates the data to 1KB in the string representation.
+    ByteStream now truncates the data to 1KB in the string representation to avoid excessive log output.

--- a/releasenotes/notes/fix-bytestream-str-8dd6d5e9a87f6aa4.yaml
+++ b/releasenotes/notes/fix-bytestream-str-8dd6d5e9a87f6aa4.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    ByteStream now truncates the data to 1KB in the string representation to avoid excessive log output.
+    ByteStream now truncates the data to 100 bytes in the string representation to avoid excessive log output.

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -74,9 +74,9 @@ def test_to_file(tmp_path, request):
 
 
 def test_str_truncation():
-    test_str = "1234567890" * 1000
+    test_str = "1234567890" * 100
     b = ByteStream.from_string(test_str, mime_type="text/plain", meta={"foo": "bar"})
     string_repr = str(b)
-    assert len(string_repr) < 1200
+    assert len(string_repr) < 200
     assert "text/plain" in string_repr
     assert "foo" in string_repr

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -78,3 +78,5 @@ def test_str_truncation():
     b = ByteStream.from_string(test_str, mime_type="text/plain", meta={"foo": "bar"})
     string_repr = str(b)
     assert len(string_repr) < 1200
+    assert "text/plain" in string_repr
+    assert "foo" in string_repr

--- a/test/dataclasses/test_byte_stream.py
+++ b/test/dataclasses/test_byte_stream.py
@@ -71,3 +71,10 @@ def test_to_file(tmp_path, request):
     ByteStream(test_str.encode()).to_file(test_path)
     with open(test_path, "rb") as fd:
         assert fd.read().decode() == test_str
+
+
+def test_str_truncation():
+    test_str = "1234567890" * 1000
+    b = ByteStream.from_string(test_str, mime_type="text/plain", meta={"foo": "bar"})
+    string_repr = str(b)
+    assert len(string_repr) < 1200


### PR DESCRIPTION
### Related Issues

- fixes logs getting too big, e.g. https://github.com/deepset-ai/haystack/blob/04fc187bc44c39fcd5d8c29ce7f27f91667065ce/haystack/components/converters/txt.py#L90

### Proposed Changes:
- truncate `data` in str representation of `ByteStream` to 1k

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
