### PR TITLE
fix: prevents exception when the pipeline contains multiple nested loops

### DIFF
--- a/releasenotes/notes/fix-break-sypported-cycles-in-grapth-f8769351fe4ca706.yaml
+++ b/releasenotes/notes/fix-break-sypported-cycles-in-grapth-f8769351fe4ca706.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Prevents the pipeline from raising an exception when there are multiple nested cycles in the graph.


### PR DESCRIPTION
The cycle detection/breaking algorithm (PipelineBase::_break_supported_cycles_in_graph()) was raising exceptions in some situations for pipelines that contained nested loops. This was happening because the algorithm was trying to remove the same edge multiple times from the graph. 

### Related Issues

- fixes #8657 

### Proposed Changes:

- added a check in PipelineBase::_break_supported_cycles_in_graph() to prevent the same edge from being removed multiple times

### How did you test it?

- included unit test

### Notes for the reviewer

The current PR fixes the reported problem. However, it was clear during my tests that the current algorithm to break cycles is not deterministic (due to the undeterministic order of the dictionaries/lists it iterates on, in the presence of multiple Variadic and/or Optional inputs). I don't have enough knowledge at the moment to assess if this is really a problem, but my hunch is that in some situations, where multiple nodes with Variadic and/or Optional inputs are present, the end result of the pipeline execution might become undeterministic as well. Since this was not the point/scope of this ticket, I did not try to change that, but it might warrant a separate ticket/investigation.

### Checklist

- [x] I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- [x] I have updated the related issue with new insights and changes
- [x] I added unit tests and updated the docstrings
- [x] I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- [x] I documented my code
- [x] I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
