### PR TITLE
fix: Remove cycle handling

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -990,7 +990,7 @@ class PipelineBase:
         first_default_lazy_variadic = next(
             (
                 (name, comp)
-                for (name, comp, lazy_variadic, num_inputs) in waiting_queue
+                for (name, comp, lazy_variadic, num_inputs) in queue
                 if lazy_variadic and num_inputs is not None
             ),
             None,
@@ -1001,7 +1001,7 @@ class PipelineBase:
         first_default = next(
             (
                 (name, comp)
-                for (name, comp, lazy_variadic, num_inputs) in waiting_queue
+                for (name, comp, lazy_variadic, num_inputs) in queue
                 if not lazy_variadic and num_inputs is not None
             ),
             None,

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -943,7 +943,7 @@ class PipelineBase:
         :param components_inputs: The current state of the inputs divided by Component name
         :param waiting_queue: Queue of Components waiting for input
 
-        :returns: The name and the instance of the next Component that can be run
+        :returns: None or the name and the instance of the next Component that can be run
         """
 
         def count_inputs(name, comp):
@@ -962,14 +962,12 @@ class PipelineBase:
                     num_inputs += 1
             return num_inputs
 
-        waiting_queue = [
-            (name, comp, _is_lazy_variadic(comp), count_inputs(name, comp)) for name, comp in waiting_queue
-        ]
+        queue = [(name, comp, _is_lazy_variadic(comp), count_inputs(name, comp)) for name, comp in waiting_queue]
 
         first_runnable = next(
             (
                 (name, comp)
-                for (name, comp, lazy_variadic, num_inputs) in waiting_queue
+                for (name, comp, lazy_variadic, num_inputs) in queue
                 if not lazy_variadic and num_inputs is not None and num_inputs > 0
             ),
             None,
@@ -980,7 +978,7 @@ class PipelineBase:
         first_lazy_variadic = next(
             (
                 (name, comp)
-                for (name, comp, lazy_variadic, num_inputs) in waiting_queue
+                for (name, comp, lazy_variadic, num_inputs) in queue
                 if lazy_variadic and num_inputs is not None and num_inputs > 0
             ),
             None,

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -94,7 +94,7 @@ class Pipeline(PipelineBase):
             return res
 
     def run(  # noqa: PLR0915, PLR0912
-        self, data: Dict[str, Any], include_outputs_from: Optional[Set[str]] = None
+        self, data: Dict[str, Any], include_outputs_from: Set[str] = set()
     ) -> Dict[str, Any]:
         """
         Runs the Pipeline with given input data.
@@ -172,7 +172,7 @@ class Pipeline(PipelineBase):
             output is included.
         :returns:
             A dictionary where each entry corresponds to a component name
-            and its output. If `include_outputs_from` is `None`, this dictionary
+            and its output. If `include_outputs_from` is empty, this dictionary
             will only contain the outputs of leaf components, i.e., components
             without outgoing connections.
 
@@ -200,8 +200,6 @@ class Pipeline(PipelineBase):
 
         # Normalize the input data
         components_inputs: Dict[str, Dict[str, Any]] = self._normalize_varidiac_input_data(data)
-
-        include_outputs_from = set() if include_outputs_from is None else include_outputs_from
 
         # This is what we'll return at the end
         final_outputs: Dict[Any, Any] = {}

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -93,170 +93,6 @@ class Pipeline(PipelineBase):
 
             return res
 
-    def _run_subgraph(  # noqa: PLR0915
-        self,
-        cycle: List[str],
-        component_name: str,
-        components_inputs: Dict[str, Dict[str, Any]],
-        *,
-        include_outputs_from: Optional[Set[str]] = None,
-        parent_span: Optional[tracing.Span] = None,
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """
-        Runs a `cycle` in the Pipeline starting from `component_name`.
-
-        This will return once there are no inputs for the Components in `cycle`.
-
-        This is an internal method meant to be used in `Pipeline.run()` only.
-
-        :param cycle:
-            List of Components that are part of the cycle being run
-        :param component_name:
-            Name of the Component that will start execution of the cycle
-        :param components_inputs:
-            Components inputs, this might include inputs for Components that are not part
-            of the cycle but part of the wider Pipeline's graph
-        :param include_outputs_from:
-            Set of component names whose individual outputs are to be
-            included in the cycle's output. In case a Component is executed multiple times
-            only the last-produced output is included.
-        :returns:
-            Outputs of all the Components that are not connected to other Components in `cycle`.
-            If `include_outputs_from` is set those Components' outputs will be included.
-        :raises PipelineMaxComponentRuns:
-            If a Component reaches the maximum number of times it can be run in this Pipeline
-        """
-        waiting_queue: List[Tuple[str, Component]] = []
-        run_queue: List[Tuple[str, Component]] = []
-
-        # Create the run queue starting with the component that needs to run first
-        start_index = cycle.index(component_name)
-        for node in cycle[start_index:]:
-            run_queue.append((node, self.graph.nodes[node]["instance"]))
-
-        include_outputs_from = set() if include_outputs_from is None else include_outputs_from
-
-        before_last_waiting_queue: Optional[Set[str]] = None
-        last_waiting_queue: Optional[Set[str]] = None
-
-        subgraph_outputs = {}
-        # These are outputs that are sent to other Components but the user explicitly
-        # asked to include them in the final output.
-        extra_outputs = {}
-
-        # This variable is used to keep track if we still need to run the cycle or not.
-        # When a Component doesn't send outputs to another Component
-        # that's inside the subgraph, we stop running this subgraph.
-        cycle_received_inputs = False
-
-        while not cycle_received_inputs:
-            # Here we run the Components
-            name, comp = run_queue.pop(0)
-            if _is_lazy_variadic(comp) and not all(_is_lazy_variadic(comp) for _, comp in run_queue):
-                # We run Components with lazy variadic inputs only if there only Components with
-                # lazy variadic inputs left to run
-                _enqueue_waiting_component((name, comp), waiting_queue)
-                continue
-
-            # As soon as a Component returns only output that is not part of the cycle, we can stop
-            if self._component_has_enough_inputs_to_run(name, components_inputs):
-                if self.graph.nodes[name]["visits"] > self._max_runs_per_component:
-                    msg = f"Maximum run count {self._max_runs_per_component} reached for component '{name}'"
-                    raise PipelineMaxComponentRuns(msg)
-
-                res: Dict[str, Any] = self._run_component(name, components_inputs[name], parent_span=parent_span)
-
-                # Delete the inputs that were consumed by the Component and are not received from
-                # the user or from Components that are part of this cycle
-                sockets = list(components_inputs[name].keys())
-                for socket_name in sockets:
-                    senders = comp.__haystack_input__._sockets_dict[socket_name].senders  # type: ignore
-                    if not senders:
-                        # We keep inputs that came from the user
-                        continue
-                    all_senders_in_cycle = all(sender in cycle for sender in senders)
-                    if all_senders_in_cycle:
-                        # All senders are in the cycle, we can remove the input.
-                        # We'll receive it later at a certain point.
-                        del components_inputs[name][socket_name]
-
-                if name in include_outputs_from:
-                    # Deepcopy the outputs to prevent downstream nodes from modifying them
-                    # We don't care about loops - Always store the last output.
-                    extra_outputs[name] = deepcopy(res)
-
-                # Reset the waiting for input previous states, we managed to run a component
-                before_last_waiting_queue = None
-                last_waiting_queue = None
-
-                # Check if a component doesn't send any output to components that are part of the cycle
-                final_output_reached = False
-                for output_socket in res.keys():
-                    for receiver in comp.__haystack_output__._sockets_dict[output_socket].receivers:  # type: ignore
-                        if receiver in cycle:
-                            final_output_reached = True
-                            break
-                    if final_output_reached:
-                        break
-
-                if not final_output_reached:
-                    # We stop only if the Component we just ran doesn't send any output to sockets that
-                    # are part of the cycle
-                    cycle_received_inputs = True
-
-                # We manage to run this component that was in the waiting list, we can remove it.
-                # This happens when a component was put in the waiting list but we reached it from another edge.
-                _dequeue_waiting_component((name, comp), waiting_queue)
-                for pair in self._find_components_that_will_receive_no_input(name, res, components_inputs):
-                    _dequeue_component(pair, run_queue, waiting_queue)
-
-                receivers = [item for item in self._find_receivers_from(name) if item[0] in cycle]
-
-                res = self._distribute_output(receivers, res, components_inputs, run_queue, waiting_queue)
-
-                # We treat a cycle as a completely independent graph, so we keep track of output
-                # that is not sent inside the cycle.
-                # This output is going to get distributed to the wider graph after we finish running
-                # a cycle.
-                # All values that are left at this point go outside the cycle.
-                if len(res) > 0:
-                    subgraph_outputs[name] = res
-            else:
-                # This component doesn't have enough inputs so we can't run it yet
-                _enqueue_waiting_component((name, comp), waiting_queue)
-
-            if len(run_queue) == 0 and len(waiting_queue) > 0:
-                # Check if we're stuck in a loop.
-                # It's important to check whether previous waitings are None as it could be that no
-                # Component has actually been run yet.
-                if (
-                    before_last_waiting_queue is not None
-                    and last_waiting_queue is not None
-                    and before_last_waiting_queue == last_waiting_queue
-                ):
-                    if self._is_stuck_in_a_loop(waiting_queue):
-                        # We're stuck! We can't make any progress.
-                        msg = (
-                            "Pipeline is stuck running in a loop. Partial outputs will be returned. "
-                            "Check the Pipeline graph for possible issues."
-                        )
-                        warn(RuntimeWarning(msg))
-                        break
-
-                    (name, comp) = self._find_next_runnable_lazy_variadic_or_default_component(waiting_queue)
-                    _add_missing_input_defaults(name, comp, components_inputs)
-                    _enqueue_component((name, comp), run_queue, waiting_queue)
-                    continue
-
-                before_last_waiting_queue = last_waiting_queue.copy() if last_waiting_queue is not None else None
-                last_waiting_queue = {item[0] for item in waiting_queue}
-
-                (name, comp) = self._find_next_runnable_component(components_inputs, waiting_queue)
-                _add_missing_input_defaults(name, comp, components_inputs)
-                _enqueue_component((name, comp), run_queue, waiting_queue)
-
-        return subgraph_outputs, extra_outputs
-
     def run(  # noqa: PLR0915, PLR0912
         self, data: Dict[str, Any], include_outputs_from: Optional[Set[str]] = None
     ) -> Dict[str, Any]:
@@ -365,34 +201,10 @@ class Pipeline(PipelineBase):
         # Normalize the input data
         components_inputs: Dict[str, Dict[str, Any]] = self._normalize_varidiac_input_data(data)
 
-        # These variables are used to detect when we're stuck in a loop.
-        # Stuck loops can happen when one or more components are waiting for input but
-        # no other component is going to run.
-        # This can happen when a whole branch of the graph is skipped for example.
-        # When we find that two consecutive iterations of the loop where the waiting_queue is the same,
-        # we know we're stuck in a loop and we can't make any progress.
-        #
-        # They track the previous two states of the waiting_queue. So if waiting_queue would n,
-        # before_last_waiting_queue would be n-2 and last_waiting_queue would be n-1.
-        # When we run a component, we reset both.
-        before_last_waiting_queue: Optional[Set[str]] = None
-        last_waiting_queue: Optional[Set[str]] = None
-
-        # The waiting_for_input list is used to keep track of components that are waiting for input.
-        waiting_queue: List[Tuple[str, Component]] = []
-
         include_outputs_from = set() if include_outputs_from is None else include_outputs_from
 
         # This is what we'll return at the end
         final_outputs: Dict[Any, Any] = {}
-
-        # Break cycles in case there are, this is a noop if no cycle is found.
-        # This will raise if a cycle can't be broken.
-        graph_without_cycles, components_in_cycles = self._break_supported_cycles_in_graph()
-
-        run_queue: List[Tuple[str, Component]] = []
-        for node in nx.topological_sort(graph_without_cycles):
-            run_queue.append((node, self.graph.nodes[node]["instance"]))
 
         # Set defaults inputs for those sockets that don't receive input neither from the user
         # nor from other Components.
@@ -410,6 +222,17 @@ class Pipeline(PipelineBase):
                     if socket.is_variadic:
                         value = [value]
                     components_inputs[name][socket_name] = value
+
+        # Contains only those nodes that have all their inputs
+        run_queue: List[Tuple[str, Component]] = []
+        # The waiting_for_input list is used to keep track of components that are waiting for input.
+        waiting_queue: List[Tuple[str, Component]] = []
+
+        for name, comp in self.graph.nodes(data="instance"):
+            if self._component_has_enough_inputs_to_run(name, components_inputs):
+                run_queue.append((name, comp))
+            else:
+                waiting_queue.append((name, comp))
 
         with tracing.tracer.trace(
             "haystack.pipeline.run",
@@ -431,41 +254,7 @@ class Pipeline(PipelineBase):
                     # lazy variadic inputs left to run
                     _enqueue_waiting_component((name, comp), waiting_queue)
                     continue
-                if self._component_has_enough_inputs_to_run(name, components_inputs) and components_in_cycles.get(
-                    name, []
-                ):
-                    cycles = components_in_cycles.get(name, [])
-
-                    # This component is part of one or more cycles, let's get the first one and run it.
-                    # We can reliably pick any of the cycles if there are multiple ones, the way cycles
-                    # are run doesn't make a different whether we pick the first or any of the others a
-                    # Component is part of.
-                    subgraph_output, subgraph_extra_output = self._run_subgraph(
-                        cycles[0], name, components_inputs, include_outputs_from=include_outputs_from, parent_span=span
-                    )
-
-                    # After a cycle is run the previous run_queue can't be correct anymore cause it's
-                    # not modified when running the subgraph.
-                    # So we reset it given the output returned by the subgraph.
-                    run_queue = []
-
-                    # Reset the waiting for input previous states, we managed to run at least one component
-                    before_last_waiting_queue = None
-                    last_waiting_queue = None
-
-                    # Merge the extra outputs
-                    extra_outputs.update(subgraph_extra_output)
-
-                    for component_name, component_output in subgraph_output.items():
-                        receivers = self._find_receivers_from(component_name)
-                        component_output = self._distribute_output(
-                            receivers, component_output, components_inputs, run_queue, waiting_queue
-                        )
-
-                        if len(component_output) > 0:
-                            final_outputs[component_name] = component_output
-
-                elif self._component_has_enough_inputs_to_run(name, components_inputs):
+                if self._component_has_enough_inputs_to_run(name, components_inputs):
                     if self.graph.nodes[name]["visits"] > self._max_runs_per_component:
                         msg = f"Maximum run count {self._max_runs_per_component} reached for component '{name}'"
                         raise PipelineMaxComponentRuns(msg)
@@ -486,16 +275,10 @@ class Pipeline(PipelineBase):
                         # We don't care about loops - Always store the last output.
                         extra_outputs[name] = deepcopy(res)
 
-                    # Reset the waiting for input previous states, we managed to run a component
-                    before_last_waiting_queue = None
-                    last_waiting_queue = None
-
                     # We manage to run this component that was in the waiting list, we can remove it.
                     # This happens when a component was put in the waiting list but we reached it from another edge.
                     _dequeue_waiting_component((name, comp), waiting_queue)
 
-                    for pair in self._find_components_that_will_receive_no_input(name, res, components_inputs):
-                        _dequeue_component(pair, run_queue, waiting_queue)
                     receivers = self._find_receivers_from(name)
                     res = self._distribute_output(receivers, res, components_inputs, run_queue, waiting_queue)
 
@@ -506,34 +289,11 @@ class Pipeline(PipelineBase):
                     _enqueue_waiting_component((name, comp), waiting_queue)
 
                 if len(run_queue) == 0 and len(waiting_queue) > 0:
-                    # Check if we're stuck in a loop.
-                    # It's important to check whether previous waitings are None as it could be that no
-                    # Component has actually been run yet.
-                    if (
-                        before_last_waiting_queue is not None
-                        and last_waiting_queue is not None
-                        and before_last_waiting_queue == last_waiting_queue
-                    ):
-                        if self._is_stuck_in_a_loop(waiting_queue):
-                            # We're stuck! We can't make any progress.
-                            msg = (
-                                "Pipeline is stuck running in a loop. Partial outputs will be returned. "
-                                "Check the Pipeline graph for possible issues."
-                            )
-                            warn(RuntimeWarning(msg))
-                            break
-
-                        (name, comp) = self._find_next_runnable_lazy_variadic_or_default_component(waiting_queue)
+                    result = self._find_next_runnable_component(components_inputs, waiting_queue)
+                    if result:
+                        (name, comp) = result
                         _add_missing_input_defaults(name, comp, components_inputs)
                         _enqueue_component((name, comp), run_queue, waiting_queue)
-                        continue
-
-                    before_last_waiting_queue = last_waiting_queue.copy() if last_waiting_queue is not None else None
-                    last_waiting_queue = {item[0] for item in waiting_queue}
-
-                    (name, comp) = self._find_next_runnable_component(components_inputs, waiting_queue)
-                    _add_missing_input_defaults(name, comp, components_inputs)
-                    _enqueue_component((name, comp), run_queue, waiting_queue)
 
             if len(include_outputs_from) > 0:
                 for name, output in extra_outputs.items():

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -177,9 +177,7 @@ class Pipeline(PipelineBase):
             without outgoing connections.
 
         :raises PipelineRuntimeError:
-            If the Pipeline contains cycles with unsupported connections that would cause
-            it to get stuck and fail running.
-            Or if a Component fails or returns output in an unsupported type.
+            If a Component fails or returns output in an unsupported type.
         :raises PipelineMaxComponentRuns:
             If a Component reaches the maximum number of times it can be run in this Pipeline.
         """

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -1214,7 +1214,7 @@ class TestPipeline:
         components_inputs = {}
         waiting_queue = [("document_builder", document_builder)]
         pair = pipe._find_next_runnable_component(components_inputs, waiting_queue)
-        assert pair == ("document_builder", document_builder)
+        assert pair == None
 
     def test__find_next_runnable_component_with_component_with_only_variadic_non_greedy_input(self):
         document_joiner = component_class("DocumentJoiner", input_types={"docs": Variadic[Document]})()
@@ -1280,7 +1280,7 @@ class TestPipeline:
         ]
         pair = pipe._find_next_runnable_component(components_inputs, waiting_queue)
 
-        assert pair == ("document_builder", document_builder)
+        assert pair == ("document_joiner", document_joiner)
 
     def test__is_stuck_in_a_loop(self):
         document_builder = component_class(


### PR DESCRIPTION
### Related Issues

- fixes #8657 
- same goal as #8677 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Remove the cycle check completely in pipeline. By ensuring that `find_next_runnable_node` only returns nodes that can actually be run, we don't need the check: Everything in the `run_queue` will be run and once its empty, we are done.

Instead of previously splitting the graph up into acyclic subgraphs, we maintain a `run_queue` which only contains nodes that can be run as is. Once we execute a node from the `run_queue`, we remove it and add all its runnable successors. That way, cycles don't need any special handling. If a backedge supplies all necessary inputs to a node at the top of a loop, it will also be added. This restarts the loop.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Unit tests and manual verification in my project.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Note that similar concerns about non-determinism from #8677 apply. For example, nodes with only default input may run in any order. #8680 addresses that specific issue. Nodes within the run_queue are still run in a non-deterministic order but they should be independent anyway.

I might also have found an error in a test: Instead of returning a document_builder (which expects but doesn't get any inputs), we now expect the document_joiner (which is variadic and thus okay with not getting any inputs).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
