### PR TITLE
refactor: move `Tool` to a separate package; refactor serde

### DIFF
--- a/docs/pydoc/config/tool_components_api.yml
+++ b/docs/pydoc/config/tool_components_api.yml
@@ -1,8 +1,7 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack/dataclasses]
-    modules:
-      ["answer", "byte_stream", "chat_message", "document", "streaming_chunk", "sparse_embedding",]
+    search_path: [../../../haystack/components/tools]
+    modules: ["tool_invoker"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -14,15 +13,15 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
-  excerpt: Core classes that carry data through the system.
+  excerpt: Components related to Tool Calling.
   category_slug: haystack-api
-  title: Data Classes
-  slug: data-classes-api
-  order: 30
+  title: Tool Components
+  slug: tool-components-api
+  order: 152
   markdown:
     descriptive_class_title: false
     classdef_code_block: false
     descriptive_module_title: true
     add_method_class_prefix: true
     add_member_class_prefix: false
-    filename: data_classess_api.md
+    filename: tool_components_api.md

--- a/docs/pydoc/config/tools_api.yml
+++ b/docs/pydoc/config/tools_api.yml
@@ -1,7 +1,8 @@
 loaders:
   - type: haystack_pydoc_tools.loaders.CustomPythonLoader
-    search_path: [../../../haystack/components/tools]
-    modules: ["tool_invoker"]
+    search_path: [../../../haystack/tools]
+    modules:
+      ["tool"]
     ignore_when_discovered: ["__init__"]
 processors:
   - type: filter
@@ -13,11 +14,11 @@ processors:
   - type: crossref
 renderer:
   type: haystack_pydoc_tools.renderers.ReadmeCoreRenderer
-  excerpt: Components related to Tool Calling.
+  excerpt: Unified abstractions to represent tools across the framework.
   category_slug: haystack-api
   title: Tools
   slug: tools-api
-  order: 152
+  order: 151
   markdown:
     descriptive_class_title: false
     classdef_code_block: false

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall
-from haystack.dataclasses.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.lazy_imports import LazyImport
+from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 from haystack.utils.hf import HFGenerationAPIType, HFModelType, check_valid_model, convert_message_to_hf_format
 from haystack.utils.url_validation import is_valid_http_url

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -13,7 +13,7 @@ from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall
-from haystack.dataclasses.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
 logger = logging.getLogger(__name__)

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List
 
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses.chat_message import ChatMessage, ToolCall
-from haystack.dataclasses.tool import Tool, ToolInvocationError, _check_duplicate_tool_names, deserialize_tools_inplace
+from haystack.tools.tool import Tool, ToolInvocationError, _check_duplicate_tool_names, deserialize_tools_inplace
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/dataclasses/__init__.py
+++ b/haystack/dataclasses/__init__.py
@@ -8,7 +8,6 @@ from haystack.dataclasses.chat_message import ChatMessage, ChatRole, TextContent
 from haystack.dataclasses.document import Document
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
 from haystack.dataclasses.streaming_chunk import StreamingChunk
-from haystack.dataclasses.tool import Tool
 
 __all__ = [
     "Document",
@@ -23,5 +22,4 @@ __all__ = [
     "TextContent",
     "StreamingChunk",
     "SparseEmbedding",
-    "Tool",
 ]

--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+
+__all__ = ["Tool", "_check_duplicate_tool_names", "deserialize_tools_inplace"]

--- a/releasenotes/notes/tool-refactor-7ed98e3ee4de14c3.yaml
+++ b/releasenotes/notes/tool-refactor-7ed98e3ee4de14c3.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Move `Tool` to a new dedicated `tools` package.
+    Refactor `Tool` serialization and deserialization to make it more flexible and include type information.

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -23,7 +23,8 @@ from huggingface_hub import (
 from huggingface_hub.utils import RepositoryNotFoundError
 
 from haystack.components.generators.chat.hugging_face_api import HuggingFaceAPIChatGenerator
-from haystack.dataclasses import ChatMessage, Tool, ToolCall
+from haystack.tools import Tool
+from haystack.dataclasses import ChatMessage, ToolCall
 
 
 @pytest.fixture
@@ -217,10 +218,13 @@ class TestHuggingFaceAPIChatGenerator:
         assert init_params["streaming_callback"] is None
         assert init_params["tools"] == [
             {
-                "description": "description",
-                "function": "builtins.print",
-                "name": "name",
-                "parameters": {"x": {"type": "string"}},
+                "type": "haystack.tools.tool.Tool",
+                "data": {
+                    "description": "description",
+                    "function": "builtins.print",
+                    "name": "name",
+                    "parameters": {"x": {"type": "string"}},
+                },
             }
         ]
 
@@ -276,10 +280,13 @@ class TestHuggingFaceAPIChatGenerator:
                         "streaming_callback": None,
                         "tools": [
                             {
-                                "name": "name",
-                                "description": "description",
-                                "parameters": {"x": {"type": "string"}},
-                                "function": "builtins.print",
+                                "type": "haystack.tools.tool.Tool",
+                                "data": {
+                                    "name": "name",
+                                    "description": "description",
+                                    "parameters": {"x": {"type": "string"}},
+                                    "function": "builtins.print",
+                                },
                             }
                         ],
                     },

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -18,7 +18,8 @@ from openai.types.chat import chat_completion_chunk
 from haystack.components.generators.utils import print_streaming_chunk
 from haystack.dataclasses import StreamingChunk
 from haystack.utils.auth import Secret
-from haystack.dataclasses import ChatMessage, Tool, ToolCall
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.tools import Tool
 from haystack.components.generators.chat.openai import OpenAIChatGenerator
 
 
@@ -200,10 +201,13 @@ class TestOpenAIChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "tools": [
                     {
-                        "description": "description",
-                        "function": "builtins.print",
-                        "name": "name",
-                        "parameters": {"x": {"type": "string"}},
+                        "type": "haystack.tools.tool.Tool",
+                        "data": {
+                            "description": "description",
+                            "function": "builtins.print",
+                            "name": "name",
+                            "parameters": {"x": {"type": "string"}},
+                        },
                     }
                 ],
                 "tools_strict": True,
@@ -224,10 +228,13 @@ class TestOpenAIChatGenerator:
                 "generation_kwargs": {"max_tokens": 10, "some_test_param": "test-params"},
                 "tools": [
                     {
-                        "description": "description",
-                        "function": "builtins.print",
-                        "name": "name",
-                        "parameters": {"x": {"type": "string"}},
+                        "type": "haystack.tools.tool.Tool",
+                        "data": {
+                            "description": "description",
+                            "function": "builtins.print",
+                            "name": "name",
+                            "parameters": {"x": {"type": "string"}},
+                        },
                     }
                 ],
                 "tools_strict": True,

--- a/test/components/tools/test_tool_invoker.py
+++ b/test/components/tools/test_tool_invoker.py
@@ -4,7 +4,7 @@ import datetime
 from haystack import Pipeline
 
 from haystack.dataclasses import ChatMessage, ToolCall, ToolCallResult, ChatRole
-from haystack.dataclasses.tool import Tool, ToolInvocationError
+from haystack.tools.tool import Tool, ToolInvocationError
 from haystack.components.tools.tool_invoker import ToolInvoker, ToolNotFoundException, StringConversionError
 from haystack.components.generators.chat.openai import OpenAIChatGenerator
 
@@ -238,14 +238,17 @@ class TestToolInvoker:
                     "init_parameters": {
                         "tools": [
                             {
-                                "name": "weather_tool",
-                                "description": "Provides weather information for a given location.",
-                                "parameters": {
-                                    "type": "object",
-                                    "properties": {"location": {"type": "string"}},
-                                    "required": ["location"],
+                                "type": "haystack.tools.tool.Tool",
+                                "data": {
+                                    "name": "weather_tool",
+                                    "description": "Provides weather information for a given location.",
+                                    "parameters": {
+                                        "type": "object",
+                                        "properties": {"location": {"type": "string"}},
+                                        "required": ["location"],
+                                    },
+                                    "function": "tools.test_tool_invoker.weather_function",
                                 },
-                                "function": "tools.test_tool_invoker.weather_function",
                             }
                         ],
                         "raise_on_failure": True,

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -5,7 +5,6 @@
 from typing import Literal, Optional
 
 import pytest
-import copy
 from haystack.tools.tool import (
     SchemaGenerationError,
     Tool,

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -5,8 +5,8 @@
 from typing import Literal, Optional
 
 import pytest
-
-from haystack.dataclasses.tool import (
+import copy
+from haystack.tools.tool import (
     SchemaGenerationError,
     Tool,
     ToolInvocationError,
@@ -78,18 +78,24 @@ class TestTool:
         )
 
         assert tool.to_dict() == {
-            "name": "weather",
-            "description": "Get weather report",
-            "parameters": parameters,
-            "function": "test_tool.get_weather_report",
+            "type": "haystack.tools.tool.Tool",
+            "data": {
+                "name": "weather",
+                "description": "Get weather report",
+                "parameters": parameters,
+                "function": "test_tool.get_weather_report",
+            },
         }
 
     def test_from_dict(self):
         tool_dict = {
-            "name": "weather",
-            "description": "Get weather report",
-            "parameters": parameters,
-            "function": "test_tool.get_weather_report",
+            "type": "haystack.tools.tool.Tool",
+            "data": {
+                "name": "weather",
+                "description": "Get weather report",
+                "parameters": parameters,
+                "function": "test_tool.get_weather_report",
+            },
         }
 
         tool = Tool.from_dict(tool_dict)
@@ -179,14 +185,12 @@ class TestTool:
 
 def test_deserialize_tools_inplace():
     tool = Tool(name="weather", description="Get weather report", parameters=parameters, function=get_weather_report)
-    serialized_tool = tool.to_dict()
-    print(serialized_tool)
 
-    data = {"tools": [serialized_tool.copy()]}
+    data = {"tools": [tool.to_dict()]}
     deserialize_tools_inplace(data)
     assert data["tools"] == [tool]
 
-    data = {"mytools": [serialized_tool.copy()]}
+    data = {"mytools": [tool.to_dict()]}
     deserialize_tools_inplace(data, key="mytools")
     assert data["mytools"] == [tool]
 
@@ -209,6 +213,11 @@ def test_deserialize_tools_inplace_failures():
         deserialize_tools_inplace(data)
 
     data = {"tools": ["not a dictionary"]}
+    with pytest.raises(TypeError):
+        deserialize_tools_inplace(data)
+
+    # not a subclass of Tool
+    data = {"tools": [{"type": "haystack.dataclasses.ChatMessage", "data": {"irrelevant": "irrelevant"}}]}
     with pytest.raises(TypeError):
         deserialize_tools_inplace(data)
 


### PR DESCRIPTION
### Related Issues
Since we plan to introduce some subclasses of `Tool` (`ComponentTool` etc.), we thought of moving the dataclass into a dedicated package and make serialization/deserialization more flexible.

### Proposed Changes:
- Move `Tool` to a new dedicated `tools` package.
- Refactor `Tool` serialization and deserialization to make it more flexible and include type information. (Same approach as POC in https://github.com/deepset-ai/haystack-experimental/pull/164)

### How did you test it?
CI, adapted tests

### Notes for the reviewer
@dfokina your input here is necessary for the API reference docs.
- I removed the `tool` module from `data_classes_api`.
- I renamed `tools_api` (which previously contained components related to Tools, such as `ToolInvoker`) to `tools_components_api`.
- I put the new module `tool` (from `tools` package) into `tools_api`.

LMK if this makes sense.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
