### PR TITLE
Extend Jinja Environment to allow Haystack data classes in ConditionalRouter

### DIFF
--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -52,16 +52,15 @@ class NativeSandboxedEnvironment(SandboxedEnvironment, NativeEnvironment):
             template_class = self.template_class
         return SandboxedEnvironment.from_string(self, source, template_class=template_class)
 
-    def is_safe_attribute(self, obj, attr, value):
+    def is_safe_attribute(self, obj):
         """
-        Whitelist attributes or slicing on your custom classes so the sandbox won't block them.
+        Whitelist Haystack dataclasses so the sandbox won't block them.
         """
-        # If it's a ChatMessage object, you can whitelist certain attributes:
         if isinstance(obj, haystack_dataclass_types):
             return True
 
         # Otherwise, fallback to the default sandbox behavior
-        return super().is_safe_attribute(obj, attr, value)
+        return super().is_safe_attribute(obj)
 
 
 @component


### PR DESCRIPTION
### Related Issues

- fixes #8517 

### Proposed Changes:

Currently, to use Haystack data classes as an output type in `ConditionalRouter`, users must set `unsafe=True`. This limitation arises because `SandboxedEnvironment` does not support the safe evaluation of Python objects, and extending `ast.literal_eval` to handle custom data classes is neither practical nor secure.

As a solution, this PR introduces `NativeSandboxedEnvironment`, a custom Jinja2 environment that tries to combine the sandboxing capabilities of `SandboxedEnvironment` with the native type rendering of `NativeEnvironment`. I tried to whitelist Haystack data classes in the `is_safe_attribute` method, allowing them to be safely rendered as native Python objects. Everything else should pass through default sandbox security rules.

❌  However, currently everything is being rendered as a `NativeTemplate` which possibly causes a security vulnerability.

Highlights:

- Subclass both SandboxedEnvironment and NativeEnvironment → NativeSandboxedEnvironment.

- Override `from_string` and `template_class` so the environment uses a “native” template but still enforces the sandbox.

- Use `is_safe_attribute`  to whitelist Haystack data classes.
### How did you test it?

Ran the tests
### Notes for the reviewer

As I am still evaluating the vulnerabilities of the above approach,  an alternative solution could be to check the `output_type`. If it corresponds to a Haystack data class, the `NativeSandboxedEnvironment` could be used specifically for rendering Haystack data classes, while the `SandboxedEnvironment` is retained for all other cases to enhance overall safety.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
