### PR TITLE
fix: recreate document id if certain attributes are changed

### DIFF
--- a/releasenotes/notes/document-id-update-27d2356a791fc86e.yaml
+++ b/releasenotes/notes/document-id-update-27d2356a791fc86e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Document ids are now updated upon changes of the document's attributes. Previously document ids were unchanged when adding meta data etc. to a document after its initialization

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -126,6 +126,14 @@ def test_basic_equality_id():
     assert doc1 != doc2
 
 
+def test_id_is_updated_on_property_change():
+    doc1 = Document(content="test text")
+    id_at_creation = doc1.id
+
+    doc1.content = "new content"
+    assert doc1.id != id_at_creation
+
+
 def test_to_dict():
     doc = Document()
     assert doc.to_dict() == {

--- a/test/dataclasses/test_document.py
+++ b/test/dataclasses/test_document.py
@@ -126,12 +126,32 @@ def test_basic_equality_id():
     assert doc1 != doc2
 
 
-def test_id_is_updated_on_property_change():
+@pytest.mark.parametrize(
+    "attribute, new_value",
+    [
+        ("content", "new content"),
+        ("dataframe", pd.DataFrame([10, 20, 30])),
+        ("blob", ByteStream(b"some bytes", mime_type="application/pdf")),
+        ("meta", {"date": "10-10-2023", "type": "article"}),
+        ("embedding", [0.1, 0.2, 0.3]),
+        ("sparse_embedding", SparseEmbedding(indices=[0, 2, 4], values=[0.1, 0.2, 0.3])),
+    ],
+)
+def test_id_is_updated_on_attribute_change(attribute, new_value):
     doc1 = Document(content="test text")
     id_at_creation = doc1.id
 
-    doc1.content = "new content"
+    # Update attributes "content", "dataframe", "blob", "meta", "embedding", "sparse_embedding"
+    setattr(doc1, attribute, new_value)
     assert doc1.id != id_at_creation
+
+
+def test_id_is_not_updated_on_score_change():
+    doc1 = Document(content="test text")
+    id_at_creation = doc1.id
+
+    doc1.score = 1.0
+    assert doc1.id == id_at_creation
 
 
 def test_to_dict():


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8692

### Proposed Changes:
- Re-create the document id whenever one of the document's attributes are updated or when meta is set for the first time.
- Added a test to check that changes of any document attributes except for score result in an updated document.id
- Added a test to check that changes of document.score leave the document.id unchanged

### How did you test it?

New unit tests

### Notes for the reviewer

Our documentation explicitly mentions that the id will not be updated automatically "since Haystack uses the document’s contents to create an ID, two identical documents might have identical IDs. Keep it in mind as you update your documents, as the ID will not be updated automatically."
https://docs.haystack.deepset.ai/docs/document-store#work-with-documents

Users might rely on the ids not being auto-updated and this would mean a breaking change.

There is an alternative, more complex logic we could implement. If a document is initialized with a custom id, we could decide to keep that id regardless of any future changes to other attributes.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
