### PR TITLE
fix: PyPDFToDocument initializes documents with content and meta

### DIFF
--- a/releasenotes/notes/pypdf-docid-293dac08ea5f8491.yaml
+++ b/releasenotes/notes/pypdf-docid-293dac08ea5f8491.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    PyPDFToDocument now creates documents with id based on converted text and meta data. Before it didn't take the meta data into account.

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -209,3 +209,7 @@ class TestPyPDFToDocument:
             output = PyPDFToDocument().run(sources=paths)
             assert "PyPDFToDocument could not extract text from the file" in caplog.text
             assert output["documents"][0].content == ""
+
+            # Check that meta is used when the returned document is initialized and thus when doc id is generated
+            assert output["documents"][0].meta["file_path"] == "non_text_searchable.pdf"
+            assert output["documents"][0].id != Document(content="").id

--- a/test/components/converters/test_pypdf_to_document.py
+++ b/test/components/converters/test_pypdf_to_document.py
@@ -113,8 +113,8 @@ class TestPyPDFToDocument:
             layout_mode_font_height_weight=1.5,
         )
 
-        doc = converter._default_convert(mock_reader)
-        assert doc.content == "Page 1 content\fPage 2 content"
+        text = converter._default_convert(mock_reader)
+        assert text == "Page 1 content\fPage 2 content"
 
         expected_params = {
             "extraction_mode": "layout",


### PR DESCRIPTION
### Related Issues

- related to https://github.com/deepset-ai/haystack/issues/8692

### Proposed Changes:

- Initialize the Document returned by PyPDFToDocument with content and meta so that both are taken into account for document ID generation. Previously only the content was used for the initialization of the Document and the meta data was updated later

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
