### PR TITLE
fix: `OpenAIChatGenerator` - do not pass tools to the OpenAI client when none are provided

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -286,12 +286,13 @@ class OpenAIChatGenerator:
         tools_strict = tools_strict if tools_strict is not None else self.tools_strict
         _check_duplicate_tool_names(tools)
 
-        openai_tools = None
+        openai_tools = {}
         if tools:
-            openai_tools = [
+            tool_definitions = [
                 {"type": "function", "function": {**t.tool_spec, **({"strict": tools_strict} if tools_strict else {})}}
                 for t in tools
             ]
+            openai_tools = {"tools": tool_definitions}
 
         is_streaming = streaming_callback is not None
         num_responses = generation_kwargs.pop("n", 1)
@@ -302,8 +303,8 @@ class OpenAIChatGenerator:
             "model": self.model,
             "messages": openai_formatted_messages,  # type: ignore[arg-type] # openai expects list of specific message types
             "stream": streaming_callback is not None,
-            "tools": openai_tools,  # type: ignore[arg-type]
             "n": num_responses,
+            **openai_tools,
             **generation_kwargs,
         }
 

--- a/releasenotes/notes/do-not-pass-tools-to-openai-if-none-1fe09e924e7fad7a.yaml
+++ b/releasenotes/notes/do-not-pass-tools-to-openai-if-none-1fe09e924e7fad7a.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    OpenAIChatGenerator no longer passes tools to the OpenAI client none are provided.
-    Previously, an empty list was passed.
+    OpenAIChatGenerator no longer passes tools to the OpenAI client if none are provided.
+    Previously, a null value was passed.
     This change improves compatibility with OpenAI-compatible APIs that do not support tools.

--- a/releasenotes/notes/do-not-pass-tools-to-openai-if-none-1fe09e924e7fad7a.yaml
+++ b/releasenotes/notes/do-not-pass-tools-to-openai-if-none-1fe09e924e7fad7a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    OpenAIChatGenerator no longer passes tools to the OpenAI client none are provided.
+    Previously, an empty list was passed.
+    This change improves compatibility with OpenAI-compatible APIs that do not support tools.


### PR DESCRIPTION
### Related Issues

In the `OpenAIChatGenerator`, when no tools are provided, we pass `None` to the client.
This is problematic for OpenAI-compatible APIs which do not support tools.
This issue was encountered in https://github.com/deepset-ai/haystack-core-integrations/pull/1274


### Proposed Changes:
- do not pass tools to the OpenAI client when none are provided

### How did you test it?
CI, adapted existing tests to check whether we pass `tools` or not

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
