### PR TITLE
fix: PDFMinerToDocument initializes documents with content and meta

### DIFF
--- a/haystack/components/converters/pdfminer.py
+++ b/haystack/components/converters/pdfminer.py
@@ -98,15 +98,15 @@ class PDFMinerToDocument:
         )
         self.store_full_path = store_full_path
 
-    def _converter(self, extractor) -> Document:
+    def _converter(self, extractor) -> str:
         """
-        Extracts text from PDF pages then convert the text into Documents
+        Extracts text from PDF pages then converts the text into a single str
 
         :param extractor:
             Python generator that yields PDF pages.
 
         :returns:
-            PDF text converted to Haystack Document
+            PDF text converted to single str
         """
         pages = []
         for page in extractor:
@@ -120,7 +120,7 @@ class PDFMinerToDocument:
         # Add a page delimiter
         concat = "\f".join(pages)
 
-        return Document(content=concat)
+        return concat
 
     @component.output_types(documents=List[Document])
     def run(
@@ -157,14 +157,14 @@ class PDFMinerToDocument:
                 continue
             try:
                 pdf_reader = extract_pages(io.BytesIO(bytestream.data), laparams=self.layout_params)
-                document = self._converter(pdf_reader)
+                text = self._converter(pdf_reader)
             except Exception as e:
                 logger.warning(
                     "Could not read {source} and convert it to Document, skipping. {error}", source=source, error=e
                 )
                 continue
 
-            if document.content is None or document.content.strip() == "":
+            if text is None or text.strip() == "":
                 logger.warning(
                     "PDFMinerToDocument could not extract text from the file {source}. Returning an empty document.",
                     source=source,
@@ -174,7 +174,7 @@ class PDFMinerToDocument:
 
             if not self.store_full_path and (file_path := bytestream.meta.get("file_path")):
                 merged_metadata["file_path"] = os.path.basename(file_path)
-            document.meta = merged_metadata
+            document = Document(content=text, meta=merged_metadata)
             documents.append(document)
 
         return {"documents": documents}

--- a/test/components/converters/test_pdfminer_to_document.py
+++ b/test/components/converters/test_pdfminer_to_document.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 
+from haystack import Document
 from haystack.dataclasses import ByteStream
 from haystack.components.converters.pdfminer import PDFMinerToDocument
 
@@ -150,3 +151,7 @@ class TestPDFMinerToDocument:
             results = converter.run(sources=sources)
             assert "PDFMinerToDocument could not extract text from the file" in caplog.text
             assert results["documents"][0].content == ""
+
+            # Check that not only content is used when the returned document is initialized and doc id is generated
+            assert results["documents"][0].meta["file_path"] == "non_text_searchable.pdf"
+            assert results["documents"][0].id != Document(content="").id


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8701

- related to https://github.com/deepset-ai/haystack/issues/8692

### Proposed Changes:

- Initialize the Document returned by PDFMinerToDocument with content and meta so that both are taken into account for document ID generation. Previously only the content was used for the initialization of the Document and the meta data was updated later
- Extend a test case so that the previous behavior would fail

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Similar changes were made to PyPDFToDocument in https://github.com/deepset-ai/haystack/pull/8698

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
