### PR TITLE
fix: update component registration to use new class reference

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -512,10 +512,12 @@ class _Component:
         # We must explicitly redefine the type of the class to make sure language servers
         # and type checkers understand that the class is of the correct type.
         # mypy doesn't like that we do this though so we explicitly ignore the type check.
-        cls: cls.__name__ = new_class(cls.__name__, cls.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace)  # type: ignore[no-redef]
+        new_cls: cls.__name__ = new_class(
+            cls.__name__, cls.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace
+        )  # type: ignore[no-redef]
 
         # Save the component in the class registry (for deserialization)
-        class_path = f"{cls.__module__}.{cls.__name__}"
+        class_path = f"{new_cls.__module__}.{new_cls.__name__}"
         if class_path in self.registry:
             # Corner case, but it may occur easily in notebooks when re-running cells.
             logger.debug(
@@ -523,15 +525,15 @@ class _Component:
                 new imported from '{new_module_name}'",
                 component=class_path,
                 module_name=self.registry[class_path],
-                new_module_name=cls,
+                new_module_name=new_cls,
             )
-        self.registry[class_path] = cls
-        logger.debug("Registered Component {component}", component=cls)
+        self.registry[class_path] = new_cls
+        logger.debug("Registered Component {component}", component=new_cls)
 
         # Override the __repr__ method with a default one
-        cls.__repr__ = _component_repr
+        new_cls.__repr__ = _component_repr
 
-        return cls
+        return new_cls
 
     def __call__(self, cls: Optional[type] = None):
         # We must wrap the call to the decorator in a function for it to work

--- a/releasenotes/notes/component-registration-052467bb409d2e4c.yaml
+++ b/releasenotes/notes/component-registration-052467bb409d2e4c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug that causes pyright type checker to fail for all component objects.


### PR DESCRIPTION
The pyright language server is now able to resolve the import and provide completions for the component.

### Related Issues

- fixes #8624
 
### Proposed Changes:

Reuse of the name of the newly created class caused a type error and the type checker did not recognize the parameters. Renaming the newly created class to `new_class` seems to fix the problem.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
