### PR TITLE
chore: remove deprecation warning from `SentenceWindowRetriever`

### DIFF
--- a/haystack/components/retrievers/sentence_window_retriever.py
+++ b/haystack/components/retrievers/sentence_window_retriever.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from typing import Any, Dict, List, Optional
 
 from haystack import Document, component, default_from_dict, default_to_dict
@@ -92,13 +91,6 @@ class SentenceWindowRetriever:
 
         self.window_size = window_size
         self.document_store = document_store
-
-        warnings.warn(
-            "The output of `context_documents` will change in the next release. Instead of a "
-            "List[List[Document]], the output will be a List[Document], where the documents are ordered by "
-            "`split_idx_start`.",
-            DeprecationWarning,
-        )
 
     @staticmethod
     def merge_documents_text(documents: List[Document]) -> str:


### PR DESCRIPTION
### Related Issues

- the deprecation warning was added in https://github.com/deepset-ai/haystack/pull/8597 and included in 2.8.0
- (related to #8590)
- we forgot to remove it before releasing 2.9.0

### Proposed Changes:
- remove the deprecation warning

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
