### PR TITLE
feat: Add completion start time timestamp to relevant generators

### DIFF
--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -275,14 +275,12 @@ class HuggingFaceAPIChatGenerator:
 
             finish_reason = choice.finish_reason
 
-            meta = {
-                "finish_reason": finish_reason if finish_reason else None,
-                "received_at": datetime.now().isoformat(),
-            }
-            chunks_meta.append(meta)
+            meta = {}
+            if finish_reason:
+                meta["finish_reason"] = finish_reason
 
             if first_chunk_time is None:
-                first_chunk_time = meta["received_at"]
+                first_chunk_time = datetime.now().isoformat()
 
             stream_chunk = StreamingChunk(text, meta)
             self.streaming_callback(stream_chunk)  # type: ignore # streaming_callback is not None (verified in the run method)

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -260,7 +260,6 @@ class HuggingFaceAPIChatGenerator:
         )
 
         generated_text = ""
-        chunks_meta = []
         first_chunk_time = None
 
         for chunk in api_output:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from openai import OpenAI, Stream
@@ -381,6 +382,7 @@ class OpenAIChatGenerator:
             "model": chunk.model,
             "index": 0,
             "finish_reason": chunk.choices[0].finish_reason,
+            "completion_start_time": chunks[0].meta.get("received_at"),  # first chunk received
             "usage": {},  # we don't have usage data for streaming responses
         }
 
@@ -444,6 +446,7 @@ class OpenAIChatGenerator:
                 "index": choice.index,
                 "tool_calls": choice.delta.tool_calls,
                 "finish_reason": choice.finish_reason,
+                "received_at": datetime.now().isoformat(),
             }
         )
         return chunk_message

--- a/haystack/components/generators/hugging_face_api.py
+++ b/haystack/components/generators/hugging_face_api.py
@@ -225,14 +225,9 @@ class HuggingFaceAPIGenerator:
             if token.special:
                 continue
 
-            chunk_metadata = {
-                **asdict(token),
-                **(asdict(chunk.details) if chunk.details else {}),
-                "received_at": datetime.now().isoformat(),
-            }
-
+            chunk_metadata = {**asdict(token), **(asdict(chunk.details) if chunk.details else {})}
             if first_chunk_time is None:
-                first_chunk_time = chunk_metadata["received_at"]
+                first_chunk_time = datetime.now().isoformat()
 
             stream_chunk = StreamingChunk(token.text, chunk_metadata)
             chunks.append(stream_chunk)

--- a/releasenotes/notes/add-streaming-completion-timestamp-c0ad3b8698a2d575.yaml
+++ b/releasenotes/notes/add-streaming-completion-timestamp-c0ad3b8698a2d575.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Added completion_start_time metadata to track time-to-first-token (TTFT) in streaming responses from Hugging Face API and OpenAI (Azure).

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
 import os
 from unittest.mock import MagicMock, Mock, patch
 
@@ -503,9 +504,13 @@ class TestHuggingFaceAPIChatGenerator:
         assert isinstance(response["replies"], list)
         assert len(response["replies"]) > 0
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert "usage" in response["replies"][0].meta
-        assert "prompt_tokens" in response["replies"][0].meta["usage"]
-        assert "completion_tokens" in response["replies"][0].meta["usage"]
+
+        response_meta = response["replies"][0].meta
+        assert "completion_start_time" in response_meta
+        assert datetime.fromisoformat(response_meta["completion_start_time"]) < datetime.now()
+        assert "usage" in response_meta
+        assert "prompt_tokens" in response_meta["usage"]
+        assert "completion_tokens" in response_meta["usage"]
 
     @pytest.mark.integration
     @pytest.mark.skipif(

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -507,7 +507,7 @@ class TestHuggingFaceAPIChatGenerator:
 
         response_meta = response["replies"][0].meta
         assert "completion_start_time" in response_meta
-        assert datetime.fromisoformat(response_meta["completion_start_time"]) < datetime.now()
+        assert datetime.fromisoformat(response_meta["completion_start_time"]) <= datetime.now()
         assert "usage" in response_meta
         assert "prompt_tokens" in response_meta["usage"]
         assert "completion_tokens" in response_meta["usage"]

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -546,6 +546,10 @@ class TestOpenAIChatGenerator:
         assert callback.counter > 1
         assert "Paris" in callback.responses
 
+        # check that the completion_start_time is set and valid ISO format
+        assert "completion_start_time" in message.meta
+        assert datetime.fromisoformat(message.meta["completion_start_time"]) < datetime.now()
+
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
         reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",

--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
 import logging
 import os
 from typing import List
@@ -285,6 +286,9 @@ class TestOpenAIGenerator:
 
         assert "gpt-4o-mini" in metadata["model"]
         assert metadata["finish_reason"] == "stop"
+
+        assert "completion_start_time" in metadata
+        assert datetime.fromisoformat(metadata["completion_start_time"]) <= datetime.now()
 
         # unfortunately, the usage is not available for streaming calls
         # we keep the key in the metadata for compatibility


### PR DESCRIPTION
### Why:
Enhances Langfuse integration to track the time-to-first-token (TTFT) in streaming responses. The new entry in chat message metadata `completion_start_time` enables TTFT tracking in Langfuse. We'll separately update all other relevant generators in https://github.com/deepset-ai/haystack-core-integrations/ 

- fixes https://github.com/deepset-ai/haystack-core-integrations/issues/1261

### What:
- Added `completion_start_time` metadata in the `Hugging Face API` and `OpenAI` chat and non-chat generators to record the TTFT.
- Modified test cases to validate the inclusion of the `completion_start_time` and its format correctness.

### How can it be used:
This change allows developers to track the exact start time of streaming completions, aiding in performance diagnostics

### How did you test it:
Included updated unit tests for both `Hugging Face API` and `OpenAI` chat and non-chat generators to ensure the presence and correct ISO format of `completion_start_time` metadata. These tests verify that the timestamps are recorded and formatted correctly during streaming responses. 

### Notes for the reviewer:
Ensure close attention to the new metadata handling and its correctness across different components. Testing has validated the format, but real integration checks are recommended for full assurance.
