### PR TITLE
test: fix HF API flaky live test with tools

### DIFF
--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -546,8 +546,6 @@ class TestHuggingFaceAPIChatGenerator:
         assert "Paris" in tool_call.arguments["city"]
         assert message.meta["finish_reason"] == "stop"
 
-        print(message)
-
         new_messages = chat_messages + [message, ChatMessage.from_tool(tool_result="22° C", origin=tool_call)]
 
         # the model tends to make tool calls if provided with tools, so we don't pass them here

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -466,6 +466,7 @@ class TestHuggingFaceAPIChatGenerator:
         not os.environ.get("HF_API_TOKEN", None),
         reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
     )
+    @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run_serverless(self):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
@@ -489,6 +490,7 @@ class TestHuggingFaceAPIChatGenerator:
         not os.environ.get("HF_API_TOKEN", None),
         reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
     )
+    @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run_serverless_streaming(self):
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
@@ -517,19 +519,18 @@ class TestHuggingFaceAPIChatGenerator:
         not os.environ.get("HF_API_TOKEN", None),
         reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
     )
-    @pytest.mark.integration
+    @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run_with_tools(self, tools):
         """
         We test the round trip: generate tool call, pass tool message, generate response.
 
-        The model used here (zephyr-7b-beta) is always available and not gated.
-        Even if it does not officially support tools, TGI+HF API make it work.
+        The model used here (Hermes-3-Llama-3.1-8B) is not gated and kept in a warm state.
         """
 
-        chat_messages = [ChatMessage.from_user("What's the weather like in Paris and Munich?")]
+        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
         generator = HuggingFaceAPIChatGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "HuggingFaceH4/zephyr-7b-beta"},
+            api_params={"model": "NousResearch/Hermes-3-Llama-3.1-8B"},
             generation_kwargs={"temperature": 0.5},
         )
 
@@ -545,7 +546,9 @@ class TestHuggingFaceAPIChatGenerator:
         assert "Paris" in tool_call.arguments["city"]
         assert message.meta["finish_reason"] == "stop"
 
-        new_messages = chat_messages + [message, ChatMessage.from_tool(tool_result="22°", origin=tool_call)]
+        print(message)
+
+        new_messages = chat_messages + [message, ChatMessage.from_tool(tool_result="22° C", origin=tool_call)]
 
         # the model tends to make tool calls if provided with tools, so we don't pass them here
         results = generator.run(new_messages, generation_kwargs={"max_tokens": 50})


### PR DESCRIPTION
### Related Issues

- failing test in main https://github.com/deepset-ai/haystack/actions/runs/12826740828/job/35767504647

### Proposed Changes:
- use a more reliable model for the test (it's not easy to find alternatives, because the model should be warm and not gated)
- add the `flaky` marker to retry the live tests in this test suite if failing (unfortunately, the LM response is cached, so the marker only helps with network issues, etc.)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
