### PR TITLE
chore: update ruff version in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.9.2
     hooks:
       - id: ruff
       - id: ruff-format


### PR DESCRIPTION
### Related Issues
While investigating formatting issues in https://github.com/deepset-ai/haystack/pull/8745,
I noticed an inconsistency:
- we are pinning ruff in our pre-commit hook
- our `format` job in test workflow uses the latest version of ruff

This can sometimes create this cycle:
- the `format` job fails
- you manually try to fix the format using `hatch run format` (because pre-commit hook did not take care of it)
- the pre-commit hook reverts changes
- ♾️

### Proposed Changes:
- pin ruff to 0.9.2 in the pre-commit hook
- unfortunately, there is no way to depend on the latest version ([pre-commit docs](https://pre-commit.com/#using-the-latest-version-for-a-repository))

### Notes for the reviewer
In the long run, there could be better ways to fix this problem, such as running `pre-commit autoupdate` in the CI or pinning ruff also in our pyproject file.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
