### PR TITLE
build: add `jsonschema` library to core dependencies

### DIFF
--- a/haystack/components/validators/json_schema.py
+++ b/haystack/components/validators/json_schema.py
@@ -5,12 +5,10 @@
 import json
 from typing import Any, Dict, List, Optional
 
+from jsonschema import ValidationError, validate
+
 from haystack import component
 from haystack.dataclasses import ChatMessage
-from haystack.lazy_imports import LazyImport
-
-with LazyImport(message="Run 'pip install jsonschema'") as jsonschema_import:
-    from jsonschema import ValidationError, validate
 
 
 def is_valid_json(s: str) -> bool:
@@ -110,7 +108,6 @@ class JsonSchemaValidator:
             the messages' content is validated.
         :param error_template: A custom template string for formatting the error message in case of validation failure.
         """
-        jsonschema_import.check()
         self.json_schema = json_schema
         self.error_template = error_template
 

--- a/haystack/tools/tool.py
+++ b/haystack/tools/tool.py
@@ -5,14 +5,12 @@
 from dataclasses import asdict, dataclass
 from typing import Any, Callable, Dict, List, Optional
 
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
 from haystack.core.serialization import generate_qualified_class_name, import_class_by_name
-from haystack.lazy_imports import LazyImport
 from haystack.tools.errors import ToolInvocationError
 from haystack.utils import deserialize_callable, serialize_callable
-
-with LazyImport(message="Run 'pip install jsonschema'") as jsonschema_import:
-    from jsonschema import Draft202012Validator
-    from jsonschema.exceptions import SchemaError
 
 
 @dataclass
@@ -39,7 +37,6 @@ class Tool:
     function: Callable
 
     def __post_init__(self):
-        jsonschema_import.check()
         # Check that the parameters define a valid JSON schema
         try:
             Draft202012Validator.check_schema(self.parameters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
   "requests",
   "numpy",
   "python-dateutil",
+  "jsonschema",             # JsonSchemaValidator, Tool
   "haystack-experimental",
 ]
 
@@ -115,9 +116,6 @@ extra-dependencies = [
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions
   "openapi3",
-
-  # JsonSchemaValidator, Tool
-  "jsonschema",
 
   # Tracing
   "opentelemetry-sdk",

--- a/releasenotes/notes/jsonschema-core-dependency-d38645d819eb0d2d.yaml
+++ b/releasenotes/notes/jsonschema-core-dependency-d38645d819eb0d2d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add jsonschema library as a core dependency. It is used in Tool and JsonSchemaValidator.


### PR DESCRIPTION
### Related Issues

- the `jsonschema` library is used in our `Tool` implementation. The library is lightweight, and having it as a core dependency would mean making life easier for our users.
- I had previously decided not to add it as a core dependency because in the past we had some issues with testing it in the CI (see #7353 and linked PRs). These issues are fixed now.
- Many big and small projects [depend on this library](https://github.com/python-jsonschema/jsonschema/network/dependents); it is also installed by default in Colab. So I would say it's pretty safe to add it as a core dependency.

### Proposed Changes:
- add `jsonschema` to core dependencies and remove related lazy imports.

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
