### PR TITLE
feat: add ListJoiner

### DIFF
--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, List, Generic, TypeVar, Optional
+
+from haystack import component, logging
+from haystack.core.component.types import Variadic
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T')
+
+@component
+class ListJoiner(Generic[T]):
+    """
+    Joins multiple lists into a single flat list, preserving the order of inputs.
+
+    Use this component when you need to merge multiple lists (e.g., `List[ChatMessage]`)
+    into a single list while maintaining the sequence of inputs.
+
+    ### Usage example:
+
+    ```python
+    from haystack import Pipeline
+    from haystack.dataclasses import ChatMessage
+    from haystack.components.joiners import ListJoiner
+
+    messages1 = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi there")]
+    messages2 = [ChatMessage.from_user("How are you?")]
+
+    p = Pipeline()
+    p.add_component("joiner", ListJoiner())
+    result = p.run(data={"lists": [messages1, messages2]})
+    # result.messages will be [messages1[0], messages1[1], messages2[0]]
+    ```
+    """
+
+    def __init__(self):
+        """
+        Creates a new ListJoiner instance.
+        The joiner preserves the order of inputs, adding earlier inputs first.
+        """
+
+    @component.output_types(joined_list=List[Any])
+    def run(self, lists: Variadic[List[T]]) -> Dict[str, List[T]]:
+        """
+        Join multiple input lists into a single flat list.
+
+        :param lists: Multiple lists to be joined.
+        
+        :returns:
+        A dictionary with the following key:
+            - `joined_list`: A single list containing all elements from input lists in order.
+        """
+        output: List[T] = []
+        for input_list in lists:
+            output.extend(input_list)
+        return {"joined_list": output}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns:
+            Dictionary with serialized data.
+        """
+        return {}

--- a/test/components/joiners/test_list_joiner.py
+++ b/test/components/joiners/test_list_joiner.py
@@ -1,0 +1,79 @@
+import pytest
+
+from haystack import Pipeline
+from haystack.dataclasses import ChatMessage
+from haystack.components.joiners import ListJoiner
+
+
+def test_list_joiner_empty():
+    """
+    Test that ListJoiner correctly handles an empty list of inputs
+    """
+    joiner = ListJoiner()
+    result = joiner.run([])
+    assert result["joined_list"] == []
+
+
+def test_list_joiner_single_list():
+    """
+    Test that ListJoiner correctly handles a single list input
+    """
+    input_list = [1, 2, 3]
+    joiner = ListJoiner()
+    result = joiner.run([input_list])
+    assert result["joined_list"] == input_list
+
+
+def test_list_joiner_multiple_lists():
+    """
+    Test that ListJoiner correctly merges multiple lists maintaining order
+    """
+    list1 = [1, 2]
+    list2 = [3, 4]
+    list3 = [5]
+    
+    joiner = ListJoiner()
+    result = joiner.run([list1, list2, list3])
+    
+    # Input order should be preserved
+    assert result["joined_list"] == [1, 2, 3, 4, 5]
+
+
+def test_list_joiner_chat_messages():
+    """
+    Test that ListJoiner correctly handles ChatMessage lists
+    """
+    messages1 = [
+        ChatMessage.from_user("Hello"),
+        ChatMessage.from_assistant("Hi there")
+    ]
+    messages2 = [ChatMessage.from_user("How are you?")]
+    
+    joiner = ListJoiner()
+    result = joiner.run([messages1, messages2])
+    
+    assert len(result["joined_list"]) == 3
+    assert all(isinstance(msg, ChatMessage) for msg in result["joined_list"])
+    # Order should be preserved
+    assert result["joined_list"][0].text == "Hello"
+    assert result["joined_list"][1].text == "Hi there"
+    assert result["joined_list"][2].text == "How are you?"
+
+
+def test_list_joiner_in_pipeline():
+    """
+    Test that ListJoiner works correctly in a Pipeline
+    """
+    messages1 = [
+        ChatMessage.from_user("Hello"),
+        ChatMessage.from_assistant("Hi there")
+    ]
+    messages2 = [ChatMessage.from_user("How are you?")]
+    
+    p = Pipeline()
+    p.add_component("joiner", ListJoiner())
+    
+    result = p.run(data={"lists": [messages1, messages2]})
+    
+    assert len(result["joiner"]["joined_list"]) == 3
+    assert all(isinstance(msg, ChatMessage) for msg in result["joiner"]["joined_list"])


### PR DESCRIPTION
### Related Issues

- fixes #8714 

### Proposed Changes:

 This PR adds a new ListJoiner component that allows merging multiple lists into a single flat list while preserving the order of inputs. This is particularly useful for scenarios where multiple List[ChatMessage] need to be consolidated into one unified list.

Changes
Add ListJoiner component in haystack/components/joiners/list_joiner.py
Add comprehensive test suite in test/components/joiners/test_list_joiner.py
Key Features
Generic implementation that works with any list type (e.g., List[ChatMessage], List[int], etc.)
Preserves input order (earlier inputs appear first in the output)
Simple interface that works with Haystack's Pipeline
Type-safe implementation using Python's generics
Example usage with ChatMessages:
from haystack import Pipeline
from haystack.dataclasses import ChatMessage
from haystack.components.joiners import ListJoiner

messages1 = [ChatMessage.from_user("Hello"), ChatMessage.from_assistant("Hi there")]
messages2 = [ChatMessage.from_user("How are you?")]

p = Pipeline()
p.add_component("joiner", ListJoiner())
result = p.run(data={"lists": [messages1, messages2]})
# result.messages will be [messages1[0], messages1[1], messages2[0]]


### How did you test it?

The test suite checks:

Empty list handling
Single list input
Multiple list inputs
ChatMessage list handling
Pipeline integration


### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
