### PR TITLE
fix: Document Classifiers - fix error messages

### DIFF
--- a/haystack/components/classifiers/document_language_classifier.py
+++ b/haystack/components/classifiers/document_language_classifier.py
@@ -83,7 +83,7 @@ class DocumentLanguageClassifier:
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError(
                 "DocumentLanguageClassifier expects a list of Document as input. "
-                "In case you want to classify a text, please use the TextLanguageClassifier."
+                "In case you want to classify and route a text, please use the TextLanguageRouter."
             )
 
         output: Dict[str, List[Document]] = {language: [] for language in self.languages}

--- a/haystack/components/classifiers/zero_shot_document_classifier.py
+++ b/haystack/components/classifiers/zero_shot_document_classifier.py
@@ -211,8 +211,8 @@ class TransformersZeroShotDocumentClassifier:
 
         if not isinstance(documents, list) or documents and not isinstance(documents[0], Document):
             raise TypeError(
-                "DocumentLanguageClassifier expects a list of documents as input. "
-                "In case you want to classify a text, please use the TextLanguageClassifier."
+                "TransformerZeroShotDocumentClassifier expects a list of documents as input. "
+                "In case you want to classify and route a text, please use the TransformersZeroShotTextRouter."
             )
 
         invalid_doc_ids = []

--- a/releasenotes/notes/fix-classifiers-docstrings-messages-dcae473d2bd3cb95.yaml
+++ b/releasenotes/notes/fix-classifiers-docstrings-messages-dcae473d2bd3cb95.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix docstrings and error messages for Document Classifier components, that were suggesting to use inexistent
+    components for text classification.

--- a/releasenotes/notes/fix-classifiers-docstrings-messages-dcae473d2bd3cb95.yaml
+++ b/releasenotes/notes/fix-classifiers-docstrings-messages-dcae473d2bd3cb95.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix docstrings and error messages for Document Classifier components, that were suggesting to use inexistent
+    Fix docstrings and error messages for Document Classifier components, that suggested using nonexistent
     components for text classification.

--- a/releasenotes/notes/fix-classifiers-docstrings-messages-dcae473d2bd3cb95.yaml
+++ b/releasenotes/notes/fix-classifiers-docstrings-messages-dcae473d2bd3cb95.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix docstrings and error messages for Document Classifier components, that suggested using nonexistent
-    components for text classification.
+    Fix error messages for Document Classifier components, that suggested using nonexistent components for text
+    classification.


### PR DESCRIPTION
### Related Issues
While trying these components, I found that we were sometimes suggesting to use nonexistent components to classify text.

### Proposed Changes:
- fix error messages

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
