### PR TITLE
fix: compress pipeline graphs before sending to mermaid

### DIFF
--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -75,7 +75,7 @@ def _to_mermaid_image(graph: networkx.MultiDiGraph):
     #  Uses the DEFLATE algorithm at the highest level for smallest size
     compressor = zlib.compressobj(level=9)
     compressed_data = compressor.compress(json_string.encode("utf-8")) + compressor.flush()
-    url_safe_base64 = base64.urlsafe_b64encode(compressed_data).decode("utf-8").strip()
+    compressed_url_safe_base64 = base64.urlsafe_b64encode(compressed_data).decode("utf-8").strip()
 
     url = f"https://mermaid.ink/img/pako:{url_safe_base64}?type=png"
 

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -77,7 +77,7 @@ def _to_mermaid_image(graph: networkx.MultiDiGraph):
     compressed_data = compressor.compress(json_string.encode("utf-8")) + compressor.flush()
     compressed_url_safe_base64 = base64.urlsafe_b64encode(compressed_data).decode("utf-8").strip()
 
-    url = f"https://mermaid.ink/img/pako:{url_safe_base64}?type=png"
+    url = f"https://mermaid.ink/img/pako:{compressed_url_safe_base64}?type=png"
 
     logger.debug("Rendering graph at {url}", url=url)
     try:

--- a/haystack/core/pipeline/draw.py
+++ b/haystack/core/pipeline/draw.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+import json
+import zlib
 
 import networkx  # type:ignore
 import requests
@@ -68,11 +70,14 @@ def _to_mermaid_image(graph: networkx.MultiDiGraph):
     """
     # Copy the graph to avoid modifying the original
     graph_styled = _to_mermaid_text(graph.copy())
+    json_string = json.dumps({"code": graph_styled})
 
-    graphbytes = graph_styled.encode("ascii")
-    base64_bytes = base64.b64encode(graphbytes)
-    base64_string = base64_bytes.decode("ascii")
-    url = f"https://mermaid.ink/img/{base64_string}?type=png"
+    #  Uses the DEFLATE algorithm at the highest level for smallest size
+    compressor = zlib.compressobj(level=9)
+    compressed_data = compressor.compress(json_string.encode("utf-8")) + compressor.flush()
+    url_safe_base64 = base64.urlsafe_b64encode(compressed_data).decode("utf-8").strip()
+
+    url = f"https://mermaid.ink/img/pako:{url_safe_base64}?type=png"
 
     logger.debug("Rendering graph at {url}", url=url)
     try:

--- a/releasenotes/notes/compress-mermaid-graph-bf23918c3da6e018.yaml
+++ b/releasenotes/notes/compress-mermaid-graph-bf23918c3da6e018.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Haystack pipelines with Mermaid graphs are now compressed to reduce the size of the encoded base64 and avoid HTTP 400 errors when the graph is too large.


### PR DESCRIPTION
### Related Issues

- fixes #8089

### Proposed Changes:

When pipelines get too big, the resulting base64 output is too long when we send a request to the mermaid server leading to a HTTP 400 error. Mermaid supports compressed URLS using [Pako](https://github.com/jihchi/mermaid.ink/pull/33). With `zlib`, we are able to compress our input in the expected format and send it off to Mermaid.

### How did you test it?

I wanted to do as close to a 1:1 change so that this has 0 impact to the user. The same tests were used which *hopefully* means the changes are 1:1 as they have all passed. 

I am also asking for tests from Haystack users with big pipelines on [Discord](https://discord.com/channels/993534733298450452/993539071815200889/1332232320081592321).

### Notes for the reviewer

I will make another PR that will use this change as a foundation for:

- Extension parameters (jpg, png, webp, svg, pdf)
- Background color modifications
- Themes
- Image size

Aaaaand.... offline support! #7896

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
