### PR TITLE
fix: Update license-header.txt with breaking changes from hawkeye

### DIFF
--- a/license-header.txt
+++ b/license-header.txt
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: ${inceptionYear}-present ${copyrightOwner}
+SPDX-FileCopyrightText: {{ props["inceptionYear"] }}-present {{ props["copyrightOwner"] }}
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Related Issues

- Causes github CI to fail for this PR https://github.com/deepset-ai/haystack/pull/8775

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Newest version of [hawkeye](https://github.com/korandoru/hawkeye/releases/tag/v6.0.0) was released earlier today. it contains breaking changes for how templates work. Check out release notes [here](https://github.com/korandoru/hawkeye/releases/tag/v6.0.0).  

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Trying to test in the PR https://github.com/deepset-ai/haystack/pull/8775 since it will trigger the license header check. The changes in this PR don't seem to trigger it. 

**Update:** The change does fix the failing `Tests / format` in the PR https://github.com/deepset-ai/haystack/pull/8775

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
