### PR TITLE
fix: Pin nltk version for sentence tokenizer

### DIFF
--- a/haystack/components/preprocessors/sentence_tokenizer.py
+++ b/haystack/components/preprocessors/sentence_tokenizer.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Tuple
 from haystack import logging
 from haystack.lazy_imports import LazyImport
 
-with LazyImport("Run 'pip install nltk==3.9.1'") as nltk_imports:
+with LazyImport("Run 'pip install nltk>=3.9.1'") as nltk_imports:
     import nltk
 
 logger = logging.getLogger(__name__)

--- a/haystack/components/preprocessors/sentence_tokenizer.py
+++ b/haystack/components/preprocessors/sentence_tokenizer.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Tuple
 from haystack import logging
 from haystack.lazy_imports import LazyImport
 
-with LazyImport("Run 'pip install nltk'") as nltk_imports:
+with LazyImport("Run 'pip install nltk==3.9.1'") as nltk_imports:
     import nltk
 
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extra-dependencies = [
   "openpyxl",                         # XLSXToDocument
   "tabulate",                         # XLSXToDocument
 
-  "nltk==3.9.1", # NLTKDocumentSplitter
+  "nltk>=3.9.1", # NLTKDocumentSplitter
 
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extra-dependencies = [
   "openpyxl",                         # XLSXToDocument
   "tabulate",                         # XLSXToDocument
 
-  "nltk", # NLTKDocumentSplitter
+  "nltk==3.9.1", # NLTKDocumentSplitter
 
   # OpenAPI
   "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions


### PR DESCRIPTION
### Related Issues

- fixes: using `DocumentSplitter` with nltk==3.8.1 or lower versions raises the below error
`nltk.find:No such file or directory: '/root/nltk_data/tokenizers/punkt/PY3_tab'
`Related issue in nltk: https://github.com/nltk/nltk/issues/3305

### Proposed Changes:
Pin `nltk==3.9.1` for `SentenceTokenizer` and `DocumentSplitter`.
This PR is a suggestion, open to discussion.

### How did you test it?

Ran the tests
Tested an example.
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
