### PR TITLE
chore: deprecate `dataframe` field in `Document` and `ExtractedTableAnswer`

### DIFF
--- a/haystack/dataclasses/answer.py
+++ b/haystack/dataclasses/answer.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io
+import warnings
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
@@ -97,6 +98,10 @@ class ExtractedTableAnswer:
     document_cells: List["Cell"] = field(default_factory=list)
     context_cells: List["Cell"] = field(default_factory=list)
     meta: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        msg = "The `ExtractedTableAnswer` dataclass is deprecated and will be removed in Haystack 2.11.0."
+        warnings.warn(msg, DeprecationWarning)
 
     @dataclass
     class Cell:

--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import io
+import warnings
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Dict, List, Optional
 
@@ -113,6 +114,10 @@ class Document(metaclass=_BackwardCompatible):
         """
         # Generate an id only if not explicitly set
         self.id = self.id or self._create_id()
+
+        if self.dataframe is not None:
+            msg = "The `dataframe` field is deprecated and will be removed in Haystack 2.11.0."
+            warnings.warn(msg, DeprecationWarning)
 
     def _create_id(self):
         """

--- a/releasenotes/notes/deprecate-dataframe-ExtractedTableAnswer-3d85649a4a7e222f.yaml
+++ b/releasenotes/notes/deprecate-dataframe-ExtractedTableAnswer-3d85649a4a7e222f.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    The `ExtractedTableAnswer` dataclass and the `dataframe` field in the `Document` dataclass are deprecated and
+    will be removed in Haystack 2.11.0.
+    Check out the GitHub discussion for motivation and details: https://github.com/deepset-ai/haystack/discussions/8688


### PR DESCRIPTION
### Related Issues

- part of #8738

### Proposed Changes:

- deprecate `dataframe` field in `Document`
- deprecate `ExtractedTableAnswer`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
