### PR TITLE
refactor: HF API Embedders - use `InferenceClient.feature_extraction` instead of `InferenceClient.post`

### DIFF
--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -242,7 +242,7 @@ class HuggingFaceAPIDocumentEmbedder:
         ):
             batch = texts_to_embed[i : i + batch_size]
 
-            embeddings = self._client.feature_extraction(
+            np_embeddings = self._client.feature_extraction(
                 # this method does not officially support list of strings, but works as expected
                 text=batch,  # type: ignore[arg-type]
                 # Serverless Inference API does not support truncate and normalize, so we pass None in the request
@@ -250,10 +250,10 @@ class HuggingFaceAPIDocumentEmbedder:
                 normalize=self.normalize if self.api_type != HFEmbeddingAPIType.SERVERLESS_INFERENCE_API else None,
             )
 
-            if embeddings.ndim != 2 or embeddings.shape[0] != len(batch):
-                raise ValueError(f"Expected embedding shape ({batch_size}, embedding_dim), got {embeddings.shape}")
+            if np_embeddings.ndim != 2 or np_embeddings.shape[0] != len(batch):
+                raise ValueError(f"Expected embedding shape ({batch_size}, embedding_dim), got {np_embeddings.shape}")
 
-            all_embeddings.extend(embeddings.tolist())
+            all_embeddings.extend(np_embeddings.tolist())
 
         return all_embeddings
 

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -208,7 +208,6 @@ class HuggingFaceAPITextEmbedder:
         error_msg = f"Expected embedding shape (1, embedding_dim) or (embedding_dim,), got {np_embedding.shape}"
         if np_embedding.ndim > 2:
             raise ValueError(error_msg)
-
         if np_embedding.ndim == 2 and np_embedding.shape[0] != 1:
             raise ValueError(error_msg)
 

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -79,8 +80,8 @@ class HuggingFaceAPITextEmbedder:
         token: Optional[Secret] = Secret.from_env_var(["HF_API_TOKEN", "HF_TOKEN"], strict=False),
         prefix: str = "",
         suffix: str = "",
-        truncate: bool = True,
-        normalize: bool = False,
+        truncate: Optional[bool] = True,
+        normalize: Optional[bool] = False,
     ):  # pylint: disable=too-many-positional-arguments
         """
         Creates a HuggingFaceAPITextEmbedder component.
@@ -195,14 +196,22 @@ class HuggingFaceAPITextEmbedder:
                 "In case you want to embed a list of Documents, please use the HuggingFaceAPIDocumentEmbedder."
             )
 
+        truncate = self.truncate
+        normalize = self.normalize
+
+        if self.api_type == HFEmbeddingAPIType.SERVERLESS_INFERENCE_API:
+            if truncate is not None:
+                msg = "`truncate` parameter is not supported for Serverless Inference API. It will be ignored."
+                warnings.warn(msg)
+                truncate = None
+            if normalize is not None:
+                msg = "`normalize` parameter is not supported for Serverless Inference API. It will be ignored."
+                warnings.warn(msg)
+                normalize = None
+
         text_to_embed = self.prefix + text + self.suffix
 
-        np_embedding = self._client.feature_extraction(
-            text=text_to_embed,
-            # Serverless Inference API does not support truncate and normalize, so we pass None in the request
-            truncate=self.truncate if self.api_type != HFEmbeddingAPIType.SERVERLESS_INFERENCE_API else None,
-            normalize=self.normalize if self.api_type != HFEmbeddingAPIType.SERVERLESS_INFERENCE_API else None,
-        )
+        np_embedding = self._client.feature_extraction(text=text_to_embed, truncate=truncate, normalize=normalize)
 
         error_msg = f"Expected embedding shape (1, embedding_dim) or (embedding_dim,), got {np_embedding.shape}"
         if np_embedding.ndim > 2:

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 from typing import Any, Dict, List, Optional, Union
 
 from haystack import component, default_from_dict, default_to_dict, logging

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -198,19 +198,20 @@ class HuggingFaceAPITextEmbedder:
 
         text_to_embed = self.prefix + text + self.suffix
 
-        response = self._client.feature_extraction(
+        np_embedding = self._client.feature_extraction(
             text=text_to_embed,
             # Serverless Inference API does not support truncate and normalize, so we pass None in the request
             truncate=self.truncate if self.api_type != HFEmbeddingAPIType.SERVERLESS_INFERENCE_API else None,
             normalize=self.normalize if self.api_type != HFEmbeddingAPIType.SERVERLESS_INFERENCE_API else None,
         )
 
-        if response.ndim > 2:
-            raise ValueError(f"Expected embedding shape (1, embedding_dim) or (embedding_dim,), got {response.shape}")
+        error_msg = f"Expected embedding shape (1, embedding_dim) or (embedding_dim,), got {np_embedding.shape}"
+        if np_embedding.ndim > 2:
+            raise ValueError(error_msg)
 
-        if response.ndim == 2 and response.shape[0] != 1:
-            raise ValueError(f"Expected embedding shape (1, embedding_dim) or (embedding_dim,), got {response.shape}")
+        if np_embedding.ndim == 2 and np_embedding.shape[0] != 1:
+            raise ValueError(error_msg)
 
-        embedding = response.flatten().tolist()
+        embedding = np_embedding.flatten().tolist()
 
         return {"embedding": embedding}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ extra-dependencies = [
   "numba>=0.54.0", # This pin helps uv resolve the dependency tree. See https://github.com/astral-sh/uv/issues/7881
 
   "transformers[torch,sentencepiece]==4.47.1", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
-  "huggingface_hub>=0.27.0, <0.28.0",                   # Hugging Face API Generators and Embedders
+  "huggingface_hub>=0.27.0",                   # Hugging Face API Generators and Embedders
   "sentence-transformers>=3.0.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
   "openai-whisper>=20231106",                  # LocalWhisperTranscriber

--- a/releasenotes/notes/hf-embedders-feature-extraction-ea0421a8f76052f0.yaml
+++ b/releasenotes/notes/hf-embedders-feature-extraction-ea0421a8f76052f0.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    In the Hugging Face API embedders, the `InferenceClient.feature_extraction` method is now used instead of
+    `InferenceClient.post` to compute embeddings. This ensures a more robust and future-proof implementation.

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -8,6 +8,8 @@ import random
 import pytest
 from huggingface_hub.utils import RepositoryNotFoundError
 
+from numpy import array
+
 from haystack.components.embedders import HuggingFaceAPIDocumentEmbedder
 from haystack.dataclasses import Document
 from haystack.utils.auth import Secret
@@ -23,8 +25,8 @@ def mock_check_valid_model():
         yield mock
 
 
-def mock_embedding_generation(json, **kwargs):
-    response = str([[random.random() for _ in range(384)] for _ in range(len(json["inputs"]))]).encode()
+def mock_embedding_generation(text, **kwargs):
+    response = array([[random.random() for _ in range(384)] for _ in range(len(text))])
     return response
 
 
@@ -204,7 +206,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
     def test_embed_batch(self, mock_check_valid_model):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
 
-        with patch("huggingface_hub.InferenceClient.post") as mock_embedding_patch:
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
             mock_embedding_patch.side_effect = mock_embedding_generation
 
             embedder = HuggingFaceAPIDocumentEmbedder(
@@ -222,6 +224,35 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert isinstance(embedding, list)
             assert len(embedding) == 384
             assert all(isinstance(x, float) for x in embedding)
+
+    def test_embed_batch_wrong_embedding_shape(self, mock_check_valid_model):
+        texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
+
+        # embedding ndim != 2
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
+            mock_embedding_patch.return_value = array([0.1, 0.2, 0.3])
+
+            embedder = HuggingFaceAPIDocumentEmbedder(
+                api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+                api_params={"model": "BAAI/bge-small-en-v1.5"},
+                token=Secret.from_token("fake-api-token"),
+            )
+
+            with pytest.raises(ValueError):
+                embedder._embed_batch(texts_to_embed=texts, batch_size=2)
+
+        # embedding ndim == 2 but shape[0] != len(batch)
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
+            mock_embedding_patch.return_value = array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+
+            embedder = HuggingFaceAPIDocumentEmbedder(
+                api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+                api_params={"model": "BAAI/bge-small-en-v1.5"},
+                token=Secret.from_token("fake-api-token"),
+            )
+
+            with pytest.raises(ValueError):
+                embedder._embed_batch(texts_to_embed=texts, batch_size=2)
 
     def test_run_wrong_input_format(self, mock_check_valid_model):
         embedder = HuggingFaceAPIDocumentEmbedder(
@@ -252,7 +283,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
 
-        with patch("huggingface_hub.InferenceClient.post") as mock_embedding_patch:
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
             mock_embedding_patch.side_effect = mock_embedding_generation
 
             embedder = HuggingFaceAPIDocumentEmbedder(
@@ -268,16 +299,14 @@ class TestHuggingFaceAPIDocumentEmbedder:
             result = embedder.run(documents=docs)
 
             mock_embedding_patch.assert_called_once_with(
-                json={
-                    "inputs": [
-                        "prefix Cuisine | I love cheese suffix",
-                        "prefix ML | A transformer is a deep learning architecture suffix",
-                    ],
-                    "truncate": True,
-                    "normalize": False,
-                },
-                task="feature-extraction",
+                text=[
+                    "prefix Cuisine | I love cheese suffix",
+                    "prefix ML | A transformer is a deep learning architecture suffix",
+                ],
+                truncate=None,
+                normalize=None,
             )
+
         documents_with_embeddings = result["documents"]
 
         assert isinstance(documents_with_embeddings, list)
@@ -294,7 +323,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             Document(content="A transformer is a deep learning architecture", meta={"topic": "ML"}),
         ]
 
-        with patch("huggingface_hub.InferenceClient.post") as mock_embedding_patch:
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
             mock_embedding_patch.side_effect = mock_embedding_generation
 
             embedder = HuggingFaceAPIDocumentEmbedder(
@@ -322,7 +351,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert len(doc.embedding) == 384
             assert all(isinstance(x, float) for x in doc.embedding)
 
-    @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    # @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.environ.get("HF_API_TOKEN", None),

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -351,7 +351,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert len(doc.embedding) == 384
             assert all(isinstance(x, float) for x in doc.embedding)
 
-    # @pytest.mark.flaky(reruns=5, reruns_delay=5)
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.environ.get("HF_API_TOKEN", None),

--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -203,7 +203,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
             "my_prefix document number 4 my_suffix",
         ]
 
-    def test_embed_batch(self, mock_check_valid_model):
+    def test_embed_batch(self, mock_check_valid_model, recwarn):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]
 
         with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
@@ -224,6 +224,11 @@ class TestHuggingFaceAPIDocumentEmbedder:
             assert isinstance(embedding, list)
             assert len(embedding) == 384
             assert all(isinstance(x, float) for x in embedding)
+
+        # Check that warnings about ignoring truncate and normalize are raised
+        assert len(recwarn) == 2
+        assert "truncate" in str(recwarn[0].message)
+        assert "normalize" in str(recwarn[1].message)
 
     def test_embed_batch_wrong_embedding_shape(self, mock_check_valid_model):
         texts = ["text 1", "text 2", "text 3", "text 4", "text 5"]

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import random
 import pytest
 from huggingface_hub.utils import RepositoryNotFoundError
-
+from numpy import array
 from haystack.components.embedders import HuggingFaceAPITextEmbedder
 from haystack.utils.auth import Secret
 from haystack.utils.hf import HFEmbeddingAPIType
@@ -19,11 +19,6 @@ def mock_check_valid_model():
         "haystack.components.embedders.hugging_face_api_text_embedder.check_valid_model", MagicMock(return_value=None)
     ) as mock:
         yield mock
-
-
-def mock_embedding_generation(json, **kwargs):
-    response = str([[random.random() for _ in range(384)] for _ in range(len(json["inputs"]))]).encode()
-    return response
 
 
 class TestHuggingFaceAPITextEmbedder:
@@ -142,8 +137,8 @@ class TestHuggingFaceAPITextEmbedder:
             embedder.run(text=list_integers_input)
 
     def test_run(self, mock_check_valid_model):
-        with patch("huggingface_hub.InferenceClient.post") as mock_embedding_patch:
-            mock_embedding_patch.side_effect = mock_embedding_generation
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
+            mock_embedding_patch.return_value = array([[random.random() for _ in range(384)]])
 
             embedder = HuggingFaceAPITextEmbedder(
                 api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
@@ -156,12 +151,34 @@ class TestHuggingFaceAPITextEmbedder:
             result = embedder.run(text="The food was delicious")
 
             mock_embedding_patch.assert_called_once_with(
-                json={"inputs": ["prefix The food was delicious suffix"], "truncate": True, "normalize": False},
-                task="feature-extraction",
+                text="prefix The food was delicious suffix", truncate=None, normalize=None
             )
 
         assert len(result["embedding"]) == 384
         assert all(isinstance(x, float) for x in result["embedding"])
+
+    def test_run_wrong_embedding_shape(self, mock_check_valid_model):
+        # embedding ndim > 2
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
+            mock_embedding_patch.return_value = array([[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]])
+
+            embedder = HuggingFaceAPITextEmbedder(
+                api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "BAAI/bge-small-en-v1.5"}
+            )
+
+            with pytest.raises(ValueError):
+                embedder.run(text="The food was delicious")
+
+        # embedding ndim == 2 but shape[0] != 1
+        with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
+            mock_embedding_patch.return_value = array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+
+            embedder = HuggingFaceAPITextEmbedder(
+                api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "BAAI/bge-small-en-v1.5"}
+            )
+
+            with pytest.raises(ValueError):
+                embedder.run(text="The food was delicious")
 
     @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -136,7 +136,7 @@ class TestHuggingFaceAPITextEmbedder:
         with pytest.raises(TypeError):
             embedder.run(text=list_integers_input)
 
-    def test_run(self, mock_check_valid_model):
+    def test_run(self, mock_check_valid_model, recwarn):
         with patch("huggingface_hub.InferenceClient.feature_extraction") as mock_embedding_patch:
             mock_embedding_patch.return_value = array([[random.random() for _ in range(384)]])
 
@@ -156,6 +156,11 @@ class TestHuggingFaceAPITextEmbedder:
 
         assert len(result["embedding"]) == 384
         assert all(isinstance(x, float) for x in result["embedding"])
+
+        # Check that warnings about ignoring truncate and normalize are raised
+        assert len(recwarn) == 2
+        assert "truncate" in str(recwarn[0].message)
+        assert "normalize" in str(recwarn[1].message)
 
     def test_run_wrong_embedding_shape(self, mock_check_valid_model):
         # embedding ndim > 2


### PR DESCRIPTION
### Related Issues

- fixes #8791

Our HF API Embedders support 3 different HF APIs using the `huggingface_hub` client: Serverless Inference API, Text Embeddings Inference (deployed locally or elsewhere), and HF Paid Inference Endpoints.

For several reasons, in the past we have opted to use `InferenceClient.post` method, but this is fragile, subject to changes (as has happened recently) and will soon be removed (in 0.31).

This is why I'm migrating to the `InferenceClient.feature_extraction` method. This solution works but may not be ideal, as explained in the comments.

### Proposed Changes:
- Use `feature_extraction` instead of `post`.
- Add some checks on the shape of the embeddings obtained from the API.

### How did you test it?
CI; new tests

In the CI, we are only testing the Serverless Inference API.

For these reasons, I also tested the current solution with:
- a Text Embeddings Inference container deployed locally
- a Paid Inference Endpoint (deployed on HF)

### Notes for the reviewer
Since the solution identified is not ideal, I also plan to contact a `huggingface_hub` maintainer and ask for advice.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
