### PR TITLE
feat: Add CSV splitter with side-by-side BFS detection

### DIFF
--- a/haystack/components/converters/csv.py
+++ b/haystack/components/converters/csv.py
@@ -2,10 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import csv
 import io
 import os
+import warnings
+from collections import deque
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from haystack import Document, component, logging
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
@@ -102,3 +105,233 @@ class CSVToDocument:
             documents.append(document)
 
         return {"documents": documents}
+
+
+@component
+class CSVSplitter:
+    """
+    A component to split a CSV document into multiple CSV documents
+
+    It is based on:
+    1) Consecutive empty rows (the "classic" approach).
+    2) Optionally detecting side-by-side tables (via a BFS search for non-empty cells).
+
+    Attributes:
+        split_threshold (int): The number of consecutive empty rows required to split the CSV. Default is 2.
+        delimiter (str): The delimiter used in the CSV. Default is ','.
+        quotechar (str): The quote character used in the CSV. Default is '"'.
+        trim_empty_rows (bool): Whether to trim leading/trailing empty rows in each block. Default is True.
+        skip_errors (bool): Whether to skip documents with parsing errors. Default is True.
+        split_index_meta_key (Optional[str]): Metadata key to store the split index. Default is 'csv_split_index'.
+        detect_side_tables (bool): Whether to detect tables that sit side-by-side in different columns.
+                                   If True, a more expensive BFS-based approach is used.
+    """
+
+    def __init__(
+        self,
+        split_threshold: int = 2,
+        delimiter: str = ",",
+        quotechar: str = '"',
+        trim_empty_rows: bool = True,
+        skip_errors: bool = True,
+        split_index_meta_key: Optional[str] = "csv_split_index",
+        detect_side_tables: bool = False,
+    ):
+        if split_threshold < 1:
+            raise ValueError("split_threshold must be at least 1")
+        self.split_threshold = split_threshold
+        self.delimiter = delimiter
+        self.quotechar = quotechar
+        self.trim_empty_rows = trim_empty_rows
+        self.skip_errors = skip_errors
+        self.split_index_meta_key = split_index_meta_key
+        self.detect_side_tables = detect_side_tables
+
+    def _split_csv_content(self, content: str) -> List[str]:
+        """Splits CSV content into blocks of CSV text."""
+        try:
+            reader = csv.reader(
+                io.StringIO(content), delimiter=self.delimiter, quotechar=self.quotechar, skipinitialspace=True
+            )
+            rows = list(reader)
+        except csv.Error as e:
+            raise ValueError(f"CSV parsing error: {str(e)}") from e
+
+        if self.detect_side_tables:
+            blocks_2d = self._split_rows_side_by_side(rows)
+        else:
+            blocks_2d = self._split_rows_into_blocks(rows)
+
+        return [self._block_to_csv(b) for b in blocks_2d]
+
+    def _split_rows_into_blocks(self, rows: List[List[str]]) -> List[List[List[str]]]:
+        """
+        "Classic" approach: identifies table blocks separated by consecutive empty rows.
+
+        Controlled by `split_threshold`.
+        """
+        blocks, current_block, empty_count = [], [], 0
+
+        for row in rows:
+            # row is considered empty if all cells are blank
+            if all(cell.strip() == "" for cell in row):
+                empty_count += 1
+            else:
+                if empty_count >= self.split_threshold and current_block:
+                    blocks.append(current_block)
+                    current_block = []
+                empty_count = 0
+                current_block.append(row)
+
+        if current_block:
+            blocks.append(current_block)
+
+        return self._clean_blocks(blocks)
+
+    def _split_rows_side_by_side(self, rows: List[List[str]]) -> List[List[List[str]]]:
+        """
+        BFS to detect *all* distinct regions of non-empty cells, including side-by-side tables.
+
+        Each connected group of cells is output as a separate block.
+        By "connected," we mean non-empty cells that touch horizontally or vertically.
+        """
+        if not rows:
+            return []
+
+        # 1) Normalize row lengths so we have a 2D grid
+        max_cols = max(len(r) for r in rows)
+        for r in rows:
+            while len(r) < max_cols:
+                r.append("")
+
+        R, C = len(rows), max_cols
+        visited = [[False] * C for _ in range(R)]
+        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+
+        blocks = []
+
+        def bfs(start_r: int, start_c: int) -> List[Tuple[int, int]]:
+            """Collect all connected (non-empty) cells using BFS starting from (start_r, start_c)."""
+            queue = deque()
+            queue.append((start_r, start_c))
+            visited[start_r][start_c] = True
+            connected_cells = [(start_r, start_c)]
+
+            while queue:
+                r0, c0 = queue.popleft()
+                for dr, dc in directions:
+                    rr, cc = r0 + dr, c0 + dc
+                    if 0 <= rr < R and 0 <= cc < C and not visited[rr][cc] and rows[rr][cc].strip() != "":
+                        visited[rr][cc] = True
+                        queue.append((rr, cc))
+                        connected_cells.append((rr, cc))
+            return connected_cells
+
+        # 2) Find connected components of non-empty cells
+        for r in range(R):
+            for c in range(C):
+                if not visited[r][c] and rows[r][c].strip() != "":
+                    cells = bfs(r, c)
+                    min_r = min(x[0] for x in cells)
+                    max_r = max(x[0] for x in cells)
+                    min_c = min(x[1] for x in cells)
+                    max_c = max(x[1] for x in cells)
+                    submatrix = []
+                    for rr in range(min_r, max_r + 1):
+                        row_slice = rows[rr][min_c : max_c + 1]
+                        submatrix.append(row_slice)
+                    blocks.append(submatrix)
+
+        cleaned_blocks = []
+        for b in blocks:
+            cb = self._clean_single_block_2d(b)
+            if cb:
+                cleaned_blocks.append(cb)
+
+        return cleaned_blocks
+
+    def _clean_blocks(self, blocks: List[List[List[str]]]) -> List[List[List[str]]]:
+        """
+        Existing row-based cleaning (trim leading/trailing empty rows).
+        """
+        cleaned = []
+        for block in blocks:
+            if not self.trim_empty_rows:
+                cleaned_block = block.copy()
+            else:
+                start, end = 0, len(block)
+                while start < end and all(cell.strip() == "" for cell in block[start]):
+                    start += 1
+                while end > start and all(cell.strip() == "" for cell in block[end - 1]):
+                    end -= 1
+                cleaned_block = block[start:end]
+
+            if cleaned_block:
+                cleaned.append(cleaned_block)
+        return cleaned
+
+    def _clean_single_block_2d(self, block_2d: List[List[str]]) -> List[List[str]]:
+        """
+        For a 2D block remove empty top/bottom rows, and empty left/right columns
+        """
+        if not block_2d:
+            return []
+
+        if self.trim_empty_rows:
+            start_r, end_r = 0, len(block_2d)
+            while start_r < end_r and all(cell.strip() == "" for cell in block_2d[start_r]):
+                start_r += 1
+            while end_r > start_r and all(cell.strip() == "" for cell in block_2d[end_r - 1]):
+                end_r -= 1
+            block_2d = block_2d[start_r:end_r]
+
+        if not block_2d:
+            return []
+
+        min_col, max_col = 0, len(block_2d[0])
+        while min_col < max_col:
+            if all(row[min_col].strip() == "" for row in block_2d):
+                min_col += 1
+            else:
+                break
+        while max_col > min_col:
+            if all(row[max_col - 1].strip() == "" for row in block_2d):
+                max_col -= 1
+            else:
+                break
+
+        if min_col >= max_col:
+            return []
+
+        cleaned = [row[min_col:max_col] for row in block_2d]
+        return cleaned
+
+    def _block_to_csv(self, block: List[List[str]]) -> str:
+        """Converts a 2D block of rows into CSV text."""
+        output = io.StringIO()
+        writer = csv.writer(output, delimiter=self.delimiter, quotechar=self.quotechar, quoting=csv.QUOTE_MINIMAL)
+        writer.writerows(block)
+        return output.getvalue().strip()
+
+    @component.output_types(documents=List[Document])
+    def run(self, documents: List[Document]):
+        """Processes documents to split CSV content."""
+        split_docs = []
+        for doc in documents:
+            if not doc.content:
+                continue
+            try:
+                blocks = self._split_csv_content(doc.content)
+            except Exception as e:
+                if not self.skip_errors:
+                    raise
+                warnings.warn(f"Skipping document {doc.id}: {str(e)}", UserWarning)
+                continue
+
+            for idx, csv_text in enumerate(blocks):
+                meta = doc.meta.copy()
+                if self.split_index_meta_key:
+                    meta[self.split_index_meta_key] = idx
+                split_docs.append(Document(content=csv_text, meta=meta))
+
+        return {"documents": split_docs}

--- a/test/components/converters/test_csv_splitter.py
+++ b/test/components/converters/test_csv_splitter.py
@@ -1,0 +1,235 @@
+import pytest
+from haystack import Document
+from haystack.components.converters.csv import CSVSplitter
+
+
+class TestCSVSplitter:
+    def test_empty_file(self) -> None:
+        """
+        Completely empty CSV content should produce zero documents.
+        """
+        splitter = CSVSplitter(detect_side_tables=True)
+        result = splitter.run([Document(content="")])
+        docs = result["documents"]
+        assert len(docs) == 0
+
+    def test_minimal_single_row(self) -> None:
+        """
+        Single row CSV to confirm we get exactly one block.
+        """
+        csv_data = "OnlyCol1,OnlyCol2,OnlyCol3"
+        splitter = CSVSplitter(detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 1
+        assert docs[0].content.strip() == csv_data
+
+    def test_side_tables_false_no_split_on_side(self) -> None:
+        """
+        detect_side_tables=False => everything in a single row remains one block.
+        """
+        csv_data = """LeftCol1,LeftCol2,,,RightCol1,RightCol2
+L1A,L1B,,,R1A,R1B
+L2A,L2B,,,R2A,R2B
+"""
+        splitter = CSVSplitter(detect_side_tables=False)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 1
+        assert "LeftCol1" in docs[0].content
+        assert "RightCol1" in docs[0].content
+
+    def test_side_tables_false_with_empty_rows(self) -> None:
+        """
+        detect_side_tables=False with multiple empty rows => classic row-based splits only.
+        """
+        csv_data = """A1,A2,,,B1,B2
+C1,C2,,,D1,D2
+
+
+X1,X2,,,Y1,Y2
+"""
+        splitter = CSVSplitter(split_threshold=2, detect_side_tables=False)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 2
+        block_texts = [doc.content for doc in docs]
+        assert any("A1,A2,,,B1,B2" in block for block in block_texts)
+        assert any("X1,X2,,,Y1,Y2" in block for block in block_texts)
+
+    def test_side_by_side_basic(self) -> None:
+        """
+        Simple case of left and right tables with detect_side_tables=True => split horizontally.
+        """
+        csv_data = """LeftCol1,LeftCol2,,,RightCol1,RightCol2
+L1A,L1B,,,R1A,R1B
+L2A,L2B,,,R2A,R2B
+"""
+        splitter = CSVSplitter(detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 2
+        left_table = docs[0].content
+        right_table = docs[1].content
+        assert "LeftCol1" in left_table
+        assert "RightCol1" in right_table
+
+    def test_empty_rows_and_side_tables(self) -> None:
+        """
+        Multiple blocks (side-by-side columns + empty lines) => 4 total splits.
+        """
+        csv_data = """A1,A2,,,B1,B2
+A3,A4,,,B3,B4
+
+
+X1,X2,,,Y1,Y2
+X3,X4,,,Y3,Y4
+"""
+        splitter = CSVSplitter(split_threshold=2, detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 4
+        block_texts = [d.content for d in docs]
+        assert any("A1,A2" in text for text in block_texts)
+        assert any("B3,B4" in text for text in block_texts)
+        assert any("X1,X2" in text for text in block_texts)
+        assert any("Y3,Y4" in text for text in block_texts)
+
+    def test_complex_bridging(self) -> None:
+        """
+        Rows bridging from left to right => BFS splits each row into left block & right block.
+        """
+        csv_data = """ID,LeftVal,,,RightVal,Extra
+1,Hello,,,World,Joined
+2,StillLeft,,,StillRight,Bridge
+
+A,B,,,C,D
+E,F,,,G,H
+"""
+        splitter = CSVSplitter(split_threshold=1, detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 4
+        block_texts = [doc.content for doc in docs]
+        assert any("ID,LeftVal" in text for text in block_texts)
+        assert any("Hello" in text for text in block_texts)
+        assert any("World,Joined" in text for text in block_texts)
+        assert any("StillLeft" in text for text in block_texts)
+        assert any("StillRight,Bridge" in text for text in block_texts)
+        assert any("A,B" in text for text in block_texts)
+        assert any("C,D" in text for text in block_texts)
+        assert any("E,F" in text for text in block_texts)
+        assert any("G,H" in text for text in block_texts)
+
+    def test_multiline_fields(self) -> None:
+        """
+        CSV with quoted multiline fields to ensure BFS or row-based approach parses them safely.
+        """
+        csv_data = """ID,Description
+1,"This is a
+multiline description"
+2,"Side-by-side
+But still single
+field",,RightCol,Yes
+"""
+        splitter = CSVSplitter(detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) >= 1
+        combined_csv = "\n".join(d.content for d in docs)
+        assert "multiline description" in combined_csv
+        assert "Side-by-side\nBut still single\nfield" in combined_csv
+
+    def test_large_empty_section(self) -> None:
+        """
+        Large stretch of empty rows => multiple blocks if over split_threshold.
+        """
+        csv_data = """ColA,ColB
+1,2
+3,4
+
+
+
+
+
+5,6
+7,8
+"""
+        splitter = CSVSplitter(split_threshold=2, detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 2
+
+    def test_edge_case_column_padding(self) -> None:
+        """
+        BFS splits row '7,,,,8,9' into two clusters: left (7) and right (8,9).
+        """
+        csv_data = """A,B,C
+1,2
+3,4,5,6
+7,,,,8,9
+10
+"""
+        splitter = CSVSplitter(detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) >= 1
+        combined = "\n".join(d.content for d in docs)
+        assert "A,B,C" in combined
+        assert "7,,," in combined or "7,," in combined
+        assert "8,9" in combined
+
+    def test_single_column_many_rows(self) -> None:
+        """
+        Single column with blank lines => multiple vertical blocks by BFS.
+        Checks that Val3 and Val4 appear together.
+        """
+        csv_data = """OnlyCol
+Val1
+
+Val2
+
+Val3
+Val4
+"""
+        splitter = CSVSplitter(split_threshold=1, detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) == 3
+        block_texts = [d.content for d in docs]
+        assert any("Val1" in txt for txt in block_texts)
+        assert any("Val2" in txt for txt in block_texts)
+        normalized_blocks = [b.replace("\r", "") for b in block_texts]
+        assert any("Val3\nVal4" in b for b in normalized_blocks)
+
+    def test_multiple_side_tables_and_skipped_errors(self) -> None:
+        """
+        Default Python CSV won't raise error on "Broken,Row => BFS sees a multiline cell, not an error.
+        """
+        csv_data = """Left1,Left2,,,Right1,Right2
+A,B,,,C,D
+"Broken,Row
+X,Y,,,Z,W
+"""
+        splitter = CSVSplitter(skip_errors=True, detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) > 0
+
+    def test_multiple_side_tables_and_no_skipped_errors(self) -> None:
+        """
+        Same broken CSV row, skip_errors=False => no error is raised unless we set strict=True.
+        """
+        csv_data = """Left1,Left2,,,Right1,Right2
+A,B,,,C,D
+"Broken,Row
+X,Y,,,Z,W
+"""
+        splitter = CSVSplitter(skip_errors=False, detect_side_tables=True)
+        result = splitter.run([Document(content=csv_data)])
+        docs = result["documents"]
+        assert len(docs) > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
### Related Issues

- Fixes #8784 (Add CSV document splitter with side-by-side table detection)

### Proposed Changes
- Introduce a `CSVSplitter` that can separate a single CSV into multiple smaller “table” blocks (each block will be returned as a `Document`)
- **Row-based splitting** is controlled by `split_threshold`: if you have purely vertical tables separated by empty rows, the splitter works in a straightforward way, just select how many empty spaces are required to consider for separating the blocks
- **Optional side-by-side detection** can be enabled via `detect_side_tables=True`. This uses BFS to find horizontally adjacent blocks of non-empty cells (i.e., multiple tables in the same row).
- By default, BFS is disabled, preserving a classic “vertical only” splitting approach based on empty rows.
- Added tests in `test_csv_splitter.py` for both vertical-only and side-by-side scenarios
<img width="200" alt="image" src="https://github.com/user-attachments/assets/eb0a171f-792a-41be-8c41-7b74d469a8ab" />

For reference, in CSVs with side-by-side tables (`CSV3`), `detect_side_tables` should be `True`, and BFS is used to detect the connected components. For a CSV with tables separated only vertically, `detect_side_tables` should be `False` and the component would run much faster.

### How did you test it?

- Created multiple tests in `test_csv_splitter.py` with different CSV layouts
- Verified locally by running:
  ```bash
  hatch run test:unit
  pytest test_csv_splitter.py

### Notes for the reviewer
- **Performance**: BFS over large CSVs can be costly, but it can be disabled (if no side tables are present) or optimized. 
- **Unintended merging**: A single bridging cell merges two blocks, i.e. the side tables need to be completely separated with blank cells in order to not merge them with other cells
- **Component category**: I've decided to place the component in the `converters` category, but it might be more suitable in `preprocessors`
- **`split_index_meta_key` removal (?)** = "csv_split_index" is a little bit useless, just a value in `meta` to tag each newly generated `Document` with its positional index after splitting. `CSVSplitter` already has many params, so we can get rid of it if you decide so 

Checklist
 I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt).
 I have updated the related issue with new insights and changes.
 I added unit tests and updated docstrings.
 I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title, for example feat: CSV splitter with side-by-side.
 I documented my code (docstrings & comments).
 I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issues.