### PR TITLE
chore: Remove DocumentSplitter warning - split_by='sentence'

### DIFF
--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 

--- a/haystack/components/preprocessors/document_splitter.py
+++ b/haystack/components/preprocessors/document_splitter.py
@@ -112,14 +112,6 @@ class DocumentSplitter:
             nltk_imports.check()
             self.sentence_splitter = None
 
-        if split_by == "sentence":
-            # ToDo: remove this warning in the next major release
-            msg = (
-                "The `split_by='sentence'` no longer splits by '.' and now relies on custom sentence tokenizer "
-                "based on NLTK. To achieve the previous behaviour use `split_by='period'."
-            )
-            warnings.warn(msg)
-
     def _init_checks(
         self,
         *,


### PR DESCRIPTION
### Related Issues

- fixes #8755

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
