### PR TITLE
fix: Fix filters to handle date times with timezones (loading and comparison)

### DIFF
--- a/haystack/components/routers/metadata_router.py
+++ b/haystack/components/routers/metadata_router.py
@@ -76,6 +76,11 @@ class MetadataRouter:
             ```
         """
         self.rules = rules
+        for rule in self.rules.values():
+            if "operator" not in rule:
+                raise ValueError(
+                    "Invalid filter syntax. See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
+                )
         component.set_output_types(self, unmatched=List[Document], **{edge: List[Document] for edge in rules})
 
     def run(self, documents: List[Document]):
@@ -95,11 +100,6 @@ class MetadataRouter:
         for document in documents:
             cur_document_matched = False
             for edge, rule in self.rules.items():
-                if "operator" not in rule:
-                    raise ValueError(
-                        "Invalid filter syntax. "
-                        "See https://docs.haystack.deepset.ai/docs/metadata-filtering for details."
-                    )
                 if document_matches_filter(rule, document):
                     output[edge].append(document)
                     cur_document_matched = True

--- a/releasenotes/notes/fix-date-comparison-ced1d6ef64534951.yaml
+++ b/releasenotes/notes/fix-date-comparison-ced1d6ef64534951.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Enhancements to Date Filtering in MetadataRouter
+    - Improved date parsing in filter utilities by introducing `_parse_date`, which first attempts `datetime.fromisoformat(value)` for backward compatibility and then falls back to dateutil.parser.parse() for broader ISO 8601 support.
+    - Resolved a common issue where comparing naive and timezone-aware datetimes resulted in TypeError. Added `_ensure_both_dates_naive_or_aware`, which ensures both datetimes are either naive or aware. If one is missing a timezone, it is assigned the timezone of the other for consistency.

--- a/test/components/routers/test_metadata_router.py
+++ b/test/components/routers/test_metadata_router.py
@@ -35,3 +35,30 @@ class TestMetadataRouter:
         assert output["edge_1"][0].meta["created_at"] == "2023-02-01"
         assert output["edge_2"][0].meta["created_at"] == "2023-05-01"
         assert output["unmatched"][0].meta["created_at"] == "2023-08-01"
+
+    def test_run_wrong_filter(self):
+        rules = {
+            "edge_1": {"field": "meta.created_at", "operator": ">=", "value": "2023-01-01"},
+            "wrong_filter": {"wrong_value": "meta.created_at == 2023-04-01"},
+        }
+        with pytest.raises(ValueError):
+            MetadataRouter(rules=rules)
+
+    def test_run_datetime_with_timezone(self):
+        rules = {
+            "edge_1": {
+                "operator": "AND",
+                "conditions": [{"field": "meta.created_at", "operator": ">=", "value": "2025-02-01"}],
+            }
+        }
+        router = MetadataRouter(rules=rules)
+        documents = [
+            Document(meta={"created_at": "2025-02-03T12:45:46.435816Z"}),
+            Document(meta={"created_at": "2025-02-01T12:45:46.435816Z"}),
+            Document(meta={"created_at": "2025-01-03T12:45:46.435816Z"}),
+        ]
+        output = router.run(documents=documents)
+        assert len(output["edge_1"]) == 2
+        assert output["edge_1"][0].meta["created_at"] == "2025-02-03T12:45:46.435816Z"
+        assert output["edge_1"][1].meta["created_at"] == "2025-02-01T12:45:46.435816Z"
+        assert output["unmatched"][0].meta["created_at"] == "2025-01-03T12:45:46.435816Z"

--- a/test/utils/test_filters.py
+++ b/test/utils/test_filters.py
@@ -485,6 +485,18 @@ document_matches_filter_data = [
         True,
         id="NOT operator with Document matching no condition",
     ),
+    pytest.param(
+        {"field": "meta.date", "operator": "==", "value": "2025-02-03T12:45:46.435816Z"},
+        Document(meta={"date": "2025-02-03T12:45:46.435816Z"}),
+        True,
+        id="== operator with ISO 8601 datetime Document value",
+    ),
+    pytest.param(
+        {"field": "meta.date", "operator": ">=", "value": "2025-02-01"},
+        Document(meta={"date": "2025-02-03T12:45:46.435816Z"}),
+        True,
+        id=">= operator with naive and aware ISO 8601 datetime Document value",
+    ),
 ]
 
 
@@ -552,159 +564,3 @@ def test_document_matches_filter_raises_error(filter):
     with pytest.raises(FilterError):
         document = Document(meta={"page": 10})
         document_matches_filter(filter, document)
-
-
-filters_data = [
-    pytest.param(
-        {
-            "$and": {
-                "type": {"$eq": "article"},
-                "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
-                "rating": {"$gte": 3},
-                "$or": {"genre": {"$in": ["economy", "politics"]}, "publisher": {"$eq": "nytimes"}},
-            }
-        },
-        {
-            "operator": "AND",
-            "conditions": [
-                {"field": "type", "operator": "==", "value": "article"},
-                {"field": "date", "operator": ">=", "value": "2015-01-01"},
-                {"field": "date", "operator": "<", "value": "2021-01-01"},
-                {"field": "rating", "operator": ">=", "value": 3},
-                {
-                    "operator": "OR",
-                    "conditions": [
-                        {"field": "genre", "operator": "in", "value": ["economy", "politics"]},
-                        {"field": "publisher", "operator": "==", "value": "nytimes"},
-                    ],
-                },
-            ],
-        },
-        id="All operators explicit",
-    ),
-    pytest.param(
-        {
-            "type": "article",
-            "date": {"$gte": "2015-01-01", "$lt": "2021-01-01"},
-            "rating": {"$gte": 3},
-            "$or": {"genre": ["economy", "politics"], "publisher": "nytimes"},
-        },
-        {
-            "operator": "AND",
-            "conditions": [
-                {"field": "type", "operator": "==", "value": "article"},
-                {"field": "date", "operator": ">=", "value": "2015-01-01"},
-                {"field": "date", "operator": "<", "value": "2021-01-01"},
-                {"field": "rating", "operator": ">=", "value": 3},
-                {
-                    "operator": "OR",
-                    "conditions": [
-                        {"field": "genre", "operator": "in", "value": ["economy", "politics"]},
-                        {"field": "publisher", "operator": "==", "value": "nytimes"},
-                    ],
-                },
-            ],
-        },
-        id="Root $and implicit",
-    ),
-    pytest.param(
-        {
-            "$or": [
-                {"Type": "News Paper", "Date": {"$lt": "2019-01-01"}},
-                {"Type": "Blog Post", "Date": {"$gte": "2019-01-01"}},
-            ]
-        },
-        {
-            "operator": "OR",
-            "conditions": [
-                {
-                    "operator": "AND",
-                    "conditions": [
-                        {"field": "Type", "operator": "==", "value": "News Paper"},
-                        {"field": "Date", "operator": "<", "value": "2019-01-01"},
-                    ],
-                },
-                {
-                    "operator": "AND",
-                    "conditions": [
-                        {"field": "Type", "operator": "==", "value": "Blog Post"},
-                        {"field": "Date", "operator": ">=", "value": "2019-01-01"},
-                    ],
-                },
-            ],
-        },
-        id="Root $or with list and multiple comparisons",
-    ),
-    pytest.param(
-        {"text": "A Foo Document 1"},
-        {"operator": "AND", "conditions": [{"field": "text", "operator": "==", "value": "A Foo Document 1"}]},
-        id="Implicit root $and and field $eq",
-    ),
-    pytest.param(
-        {"$or": {"name": {"$or": [{"$eq": "name_0"}, {"$eq": "name_1"}]}, "number": {"$lt": 1.0}}},
-        {
-            "operator": "OR",
-            "conditions": [
-                {
-                    "operator": "OR",
-                    "conditions": [
-                        {"field": "name", "operator": "==", "value": "name_0"},
-                        {"field": "name", "operator": "==", "value": "name_1"},
-                    ],
-                },
-                {"field": "number", "operator": "<", "value": 1.0},
-            ],
-        },
-        id="Root $or with dict and field $or with list",
-    ),
-    pytest.param(
-        {"number": {"$lte": 2, "$gte": 0}, "name": ["name_0", "name_1"]},
-        {
-            "operator": "AND",
-            "conditions": [
-                {"field": "number", "operator": "<=", "value": 2},
-                {"field": "number", "operator": ">=", "value": 0},
-                {"field": "name", "operator": "in", "value": ["name_0", "name_1"]},
-            ],
-        },
-        id="Implicit $and and field $in",
-    ),
-    pytest.param(
-        {"number": {"$and": [{"$lte": 2}, {"$gte": 0}]}},
-        {
-            "operator": "AND",
-            "conditions": [
-                {"field": "number", "operator": "<=", "value": 2},
-                {"field": "number", "operator": ">=", "value": 0},
-            ],
-        },
-        id="Implicit root $and and field $and with list",
-    ),
-    pytest.param(
-        {
-            "$not": {
-                "number": {"$lt": 1.0},
-                "$and": {"name": {"$in": ["name_0", "name_1"]}, "$not": {"chapter": {"$eq": "intro"}}},
-            }
-        },
-        {
-            "operator": "NOT",
-            "conditions": [
-                {"field": "number", "operator": "<", "value": 1.0},
-                {
-                    "operator": "AND",
-                    "conditions": [
-                        {"field": "name", "operator": "in", "value": ["name_0", "name_1"]},
-                        {"operator": "NOT", "conditions": [{"field": "chapter", "operator": "==", "value": "intro"}]},
-                    ],
-                },
-            ],
-        },
-        id="Root explicit $not",
-    ),
-    pytest.param(
-        {"page": {"$not": 102}},
-        {"operator": "NOT", "conditions": [{"field": "page", "operator": "==", "value": 102}]},
-        id="Explicit $not with implicit $eq",
-    ),
-]


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I tried using the `MetadataRouter` in an indexing pipeline to only consider files uploaded after a certain date `2025-02-01`. I ran into two issues:
- Our filters utils uses `datetime.fromisoformat(value)` which doesn't support all types of ISO formatted strings resulting in an error. See more info [here](https://stackoverflow.com/questions/55542280/why-does-python-3-find-this-iso8601-date-2019-04-05t165526z-invalid). So I created a `_parse_date` function which first uses `datetime.fromisoformat(value)` for backwards compatibility and then tries to use `dateutil.parse` which is the recommended solution to handle all types of ISO formatted strings. 
- After fixing the above I tried to compare two date times `2025-02-01` and `2025-02-03T12:45:46.435816Z` where I ran into the error `TypeError: can't compare offset-naive and offset-aware datetimes`. Basically the first date time needs to be given a timezone (or the second date have it's time zone removed) for this comparison to work. I think running into this mismatch can be a fairly common scenario so I created a function called `_ensure_both_dates_naive_or_aware` which checks that both date times are comparable. In the edge case where one has a timezone and one is missing it, I assign the date missing the timezone the same timezone as the other one. 


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added new filter tests
- I also added some more tests to the `MetadataRouter` to cover these cases as well.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
