### PR TITLE
feat: expose backend parameter in Sentence Transformer components for onnx and openvino models

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -30,13 +30,6 @@ class _SentenceTransformersEmbeddingBackendFactory:
         config_kwargs: Optional[Dict[str, Any]] = None,
         backend: Optional[Literal["torch", "onnx", "openvino"]] = "torch",
     ):
-        model_kwargs = model_kwargs or {}
-
-        if "backend" in model_kwargs:
-            backend = model_kwargs.pop("backend")
-            if backend not in {"torch", "onnx", "openvino"}:
-                raise ValueError(f"Invalid backend: {backend}. Supported backends: 'torch', 'onnx', 'openvino'")
-
         embedding_backend_id = f"{model}{device}{auth_token}{truncate_dim}{backend}"
 
         if embedding_backend_id in _SentenceTransformersEmbeddingBackendFactory._instances:
@@ -76,6 +69,7 @@ class _SentenceTransformersEmbeddingBackend:
         sentence_transformers_import.check()
 
         # this line is necessary to avoid an arg-type error for the type checker
+        # or we can make backend not optional
         if backend is None:
             backend = "torch"
 

--- a/haystack/components/embedders/sentence_transformers_document_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_document_embedder.py
@@ -56,6 +56,7 @@ class SentenceTransformersDocumentEmbedder:
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
         config_kwargs: Optional[Dict[str, Any]] = None,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
+        backend: Literal["torch", "onnx", "openvino"] = "torch",
     ):
         """
         Creates a SentenceTransformersDocumentEmbedder component.
@@ -123,6 +124,7 @@ class SentenceTransformersDocumentEmbedder:
         self.config_kwargs = config_kwargs
         self.embedding_backend = None
         self.precision = precision
+        self.backend = backend
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -155,6 +157,7 @@ class SentenceTransformersDocumentEmbedder:
             tokenizer_kwargs=self.tokenizer_kwargs,
             config_kwargs=self.config_kwargs,
             precision=self.precision,
+            backend=self.backend,
         )
         if serialization_dict["init_parameters"].get("model_kwargs") is not None:
             serialize_hf_model_kwargs(serialization_dict["init_parameters"]["model_kwargs"])
@@ -192,6 +195,7 @@ class SentenceTransformersDocumentEmbedder:
                 model_kwargs=self.model_kwargs,
                 tokenizer_kwargs=self.tokenizer_kwargs,
                 config_kwargs=self.config_kwargs,
+                backend=self.backend,
             )
             if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
                 self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]

--- a/haystack/components/embedders/sentence_transformers_text_embedder.py
+++ b/haystack/components/embedders/sentence_transformers_text_embedder.py
@@ -50,6 +50,7 @@ class SentenceTransformersTextEmbedder:
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
         config_kwargs: Optional[Dict[str, Any]] = None,
         precision: Literal["float32", "int8", "uint8", "binary", "ubinary"] = "float32",
+        backend: Literal["torch", "onnx", "openvino"] = "torch",
     ):
         """
         Create a SentenceTransformersTextEmbedder component.
@@ -111,6 +112,7 @@ class SentenceTransformersTextEmbedder:
         self.config_kwargs = config_kwargs
         self.embedding_backend = None
         self.precision = precision
+        self.backend = backend
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -141,6 +143,7 @@ class SentenceTransformersTextEmbedder:
             tokenizer_kwargs=self.tokenizer_kwargs,
             config_kwargs=self.config_kwargs,
             precision=self.precision,
+            backend=self.backend,
         )
         if serialization_dict["init_parameters"].get("model_kwargs") is not None:
             serialize_hf_model_kwargs(serialization_dict["init_parameters"]["model_kwargs"])
@@ -178,6 +181,7 @@ class SentenceTransformersTextEmbedder:
                 model_kwargs=self.model_kwargs,
                 tokenizer_kwargs=self.tokenizer_kwargs,
                 config_kwargs=self.config_kwargs,
+                backend=self.backend,
             )
             if self.tokenizer_kwargs and self.tokenizer_kwargs.get("model_max_length"):
                 self.embedding_backend.model.max_seq_length = self.tokenizer_kwargs["model_max_length"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ extra-dependencies = [
 
   "transformers[torch,sentencepiece]==4.47.1", # ExtractiveReader, TransformersSimilarityRanker, LocalWhisperTranscriber, HFGenerators...
   "huggingface_hub>=0.27.0, <0.28.0",                   # Hugging Face API Generators and Embedders
-  "sentence-transformers>=3.0.0",              # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
+  "sentence-transformers[onnx]>=3.0.0",        # SentenceTransformersTextEmbedder and SentenceTransformersDocumentEmbedder
   "langdetect",                                # TextLanguageRouter and DocumentLanguageClassifier
   "openai-whisper>=20231106",                  # LocalWhisperTranscriber
   "arrow>=1.3.0",                              # Jinja2TimeExtension

--- a/releasenotes/notes/sentence-transformers-onnx-openvino-backends-756b6a484c1e49d3.yaml
+++ b/releasenotes/notes/sentence-transformers-onnx-openvino-backends-756b6a484c1e49d3.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Sentence Transformers components now support ONNX and OpenVINO backends through the "backend" parameter.
+    Supported backends are torch (default), onnx, and openvino. Refer to the [Sentence Transformers documentation](https://sbert.net/docs/sentence_transformer/usage/efficiency.html) for more information.

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -81,6 +81,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "tokenizer_kwargs": None,
                 "config_kwargs": None,
                 "precision": "float32",
+                "backend": "torch",
             },
         }
 
@@ -124,6 +125,7 @@ class TestSentenceTransformersDocumentEmbedder:
                 "tokenizer_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": True},
                 "precision": "int8",
+                "backend": "torch",
             },
         }
 
@@ -249,6 +251,7 @@ class TestSentenceTransformersDocumentEmbedder:
             model_kwargs=None,
             tokenizer_kwargs={"model_max_length": 512},
             config_kwargs={"use_memory_efficient_attention": True},
+            backend="torch",
         )
 
     @patch(
@@ -345,7 +348,7 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_model_onnx_quantization(self):
         documents = [Document(content="document number 0"), Document(content="document number 1")]
         onnx_embedder = SentenceTransformersDocumentEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "onnx"}
+            model="sentence-transformers/all-MiniLM-L6-v2", backend="onnx"
         )
         onnx_embedder.warm_up()
 
@@ -362,7 +365,7 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_model_openvino_quantization(self):
         documents = [Document(content="document number 0"), Document(content="document number 1")]
         openvino_embedder = SentenceTransformersDocumentEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "openvino"}
+            model="sentence-transformers/all-MiniLM-L6-v2", backend="openvino"
         )
         openvino_embedder.warm_up()
 

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -348,7 +348,11 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_model_onnx_quantization(self):
         documents = [Document(content="document number 0"), Document(content="document number 1")]
         onnx_embedder = SentenceTransformersDocumentEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", backend="onnx"
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            backend="onnx",
+            model_kwargs={
+                "file_name": "onnx/model.onnx"
+            },  # setting the path isn't necessary if the repo contains a "onnx/model.onnx" file but this is to prevent a HF warning
         )
         onnx_embedder.warm_up()
 
@@ -365,7 +369,11 @@ class TestSentenceTransformersDocumentEmbedder:
     def test_model_openvino_quantization(self):
         documents = [Document(content="document number 0"), Document(content="document number 1")]
         openvino_embedder = SentenceTransformersDocumentEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", backend="openvino"
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            backend="openvino",
+            model_kwargs={
+                "file_name": "openvino/openvino_model.xml"
+            },  # setting the path isn't necessary if the repo contains a "openvino/openvino_model.xml" file but this is to prevent a HF warning
         )
         openvino_embedder.warm_up()
 

--- a/test/components/embedders/test_sentence_transformers_document_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_document_embedder.py
@@ -340,3 +340,35 @@ class TestSentenceTransformersDocumentEmbedder:
             normalize_embeddings=False,
             precision="float32",
         )
+
+    @pytest.mark.integration
+    def test_model_onnx_quantization(self):
+        documents = [Document(content="document number 0"), Document(content="document number 1")]
+        onnx_embedder = SentenceTransformersDocumentEmbedder(
+            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "onnx"}
+        )
+        onnx_embedder.warm_up()
+
+        result = onnx_embedder.run(documents=documents)
+
+        assert len(result["documents"]) == 2
+        assert len(result["documents"][0].embedding) == 384
+        assert len(result["documents"][1].embedding) == 384
+        assert result["documents"][0].embedding[0] == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.skip(
+        reason="OpenVINO backend does not support our current transformers + sentence transformers depdenencies versions"
+    )
+    def test_model_openvino_quantization(self):
+        documents = [Document(content="document number 0"), Document(content="document number 1")]
+        openvino_embedder = SentenceTransformersDocumentEmbedder(
+            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "openvino"}
+        )
+        openvino_embedder.warm_up()
+
+        result = openvino_embedder.run(documents=documents)
+
+        assert len(result["documents"]) == 2
+        assert len(result["documents"][0].embedding) == 384
+        assert len(result["documents"][1].embedding) == 384
+        assert result["documents"][0].embedding[0] == pytest.approx(0.0, abs=0.1)

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -41,7 +41,7 @@ def test_model_initialization(mock_sentence_transformer):
         token="fake-api-token",
         trust_remote_code=True,
         truncate_dim=256,
-        model_kwargs={},
+        model_kwargs=None,
         tokenizer_kwargs=None,
         config_kwargs=None,
         backend="torch",

--- a/test/components/embedders/test_sentence_transformers_embedding_backend.py
+++ b/test/components/embedders/test_sentence_transformers_embedding_backend.py
@@ -33,6 +33,7 @@ def test_model_initialization(mock_sentence_transformer):
         auth_token=Secret.from_token("fake-api-token"),
         trust_remote_code=True,
         truncate_dim=256,
+        backend="torch",
     )
     mock_sentence_transformer.assert_called_once_with(
         model_name_or_path="model",
@@ -40,9 +41,10 @@ def test_model_initialization(mock_sentence_transformer):
         token="fake-api-token",
         trust_remote_code=True,
         truncate_dim=256,
-        model_kwargs=None,
+        model_kwargs={},
         tokenizer_kwargs=None,
         config_kwargs=None,
+        backend="torch",
     )
 
 

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -306,7 +306,11 @@ class TestSentenceTransformersTextEmbedder:
         text = "a nice text to embed"
 
         onnx_embedder_def = SentenceTransformersTextEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", backend="onnx"
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            backend="onnx",
+            model_kwargs={
+                "file_name": "onnx/model.onnx"
+            },  # setting the path isn't necessary if the repo contains a "onnx/model.onnx" file but this is to prevent a HF warning
         )
         onnx_embedder_def.warm_up()
 
@@ -323,7 +327,11 @@ class TestSentenceTransformersTextEmbedder:
         text = "a nice text to embed"
 
         openvino_embedder_def = SentenceTransformersTextEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", backend="openvino"
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            backend="openvino",
+            model_kwargs={
+                "file_name": "openvino/openvino_model.xml"
+            },  # setting the path isn't necessary if the repo contains a "openvino/openvino_model.xml" file but this is to prevent a HF warning
         )
         openvino_embedder_def.warm_up()
 

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -296,3 +296,35 @@ class TestSentenceTransformersTextEmbedder:
 
         assert len(embedding_def) == 768
         assert all(isinstance(el, int) for el in embedding_def)
+
+    @pytest.mark.integration
+    def test_model_onnx_quantization(self):
+        text = "a nice text to embed"
+
+        onnx_embedder_def = SentenceTransformersTextEmbedder(
+            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "onnx"}
+        )
+        onnx_embedder_def.warm_up()
+
+        onnx_result_def = onnx_embedder_def.run(text=text)
+        onnx_embedding_def = onnx_result_def["embedding"]
+
+        assert len(onnx_embedding_def) == 384
+        assert onnx_embedding_def[0] == pytest.approx(0.0, abs=0.1)
+
+    @pytest.mark.skip(
+        reason="OpenVINO backend does not support our current transformers + sentence transformers depdenencies versions"
+    )
+    def test_model_openvino_quantization(self):
+        text = "a nice text to embed"
+
+        openvino_embedder_def = SentenceTransformersTextEmbedder(
+            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "openvino"}
+        )
+        openvino_embedder_def.warm_up()
+
+        openvino_result_def = openvino_embedder_def.run(text=text)
+        openvino_embedding_def = openvino_result_def["embedding"]
+
+        assert len(openvino_embedding_def) == 384
+        assert openvino_embedding_def[0] == pytest.approx(0.0, abs=0.1)

--- a/test/components/embedders/test_sentence_transformers_text_embedder.py
+++ b/test/components/embedders/test_sentence_transformers_text_embedder.py
@@ -72,6 +72,7 @@ class TestSentenceTransformersTextEmbedder:
                 "tokenizer_kwargs": None,
                 "config_kwargs": None,
                 "precision": "float32",
+                "backend": "torch",
             },
         }
 
@@ -110,6 +111,7 @@ class TestSentenceTransformersTextEmbedder:
                 "tokenizer_kwargs": {"model_max_length": 512},
                 "config_kwargs": {"use_memory_efficient_attention": False},
                 "precision": "int8",
+                "backend": "torch",
             },
         }
 
@@ -224,6 +226,7 @@ class TestSentenceTransformersTextEmbedder:
             model_kwargs=None,
             tokenizer_kwargs={"model_max_length": 512},
             config_kwargs=None,
+            backend="torch",
         )
 
     @patch(
@@ -302,7 +305,7 @@ class TestSentenceTransformersTextEmbedder:
         text = "a nice text to embed"
 
         onnx_embedder_def = SentenceTransformersTextEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "onnx"}
+            model="sentence-transformers/all-MiniLM-L6-v2", backend="onnx"
         )
         onnx_embedder_def.warm_up()
 
@@ -319,7 +322,7 @@ class TestSentenceTransformersTextEmbedder:
         text = "a nice text to embed"
 
         openvino_embedder_def = SentenceTransformersTextEmbedder(
-            model="sentence-transformers/all-MiniLM-L6-v2", model_kwargs={"backend": "openvino"}
+            model="sentence-transformers/all-MiniLM-L6-v2", backend="openvino"
         )
         openvino_embedder_def.warm_up()
 


### PR DESCRIPTION
### Related Issues

- fixes #8802 

### Proposed Changes:

Sentence Transformer based components now expose a backend parameter that allows the user to specify a different backend besides the default of torch. Supported backends are onnx and openvino. Documentation for these backends can be found [here](https://sbert.net/docs/sentence_transformer/usage/efficiency.html).

### How did you test it?

Integration tests were added for each of the supported backends. I am making this PR early on to have the CI assist with some tests as I can not run them locally.

### Notes for the reviewer

- There is a major dependency conflict in the test environment. We can not install both the `onnx` and `openvino` backends at the same time due to a limitation with `optimum-intel[openvino]==1.21.0` which does not support `transformers>=4.47`. The next `optimum-intel` update should add support for `transformers>=4.47`. For now, `openvino` tests are skipped.
- I am looking into implementing explicit `onnx-gpu` support
- I am looking into also implementing the changes into the `SentenceTransformersDiversityRanker`
- I am going to add tests to support torch `dtype` quantization

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
