### PR TITLE
fix: Look through all streaming chunks for tools calls

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -337,7 +337,9 @@ class OpenAIChatGenerator:
                 finish_reason=meta["finish_reason"],
             )
 
-    def _convert_streaming_chunks_to_chat_message(self, chunk: Any, chunks: List[StreamingChunk]) -> ChatMessage:
+    def _convert_streaming_chunks_to_chat_message(
+        self, chunk: ChatCompletionChunk, chunks: List[StreamingChunk]
+    ) -> ChatMessage:
         """
         Connects the streaming chunks into a single ChatMessage.
 
@@ -348,7 +350,7 @@ class OpenAIChatGenerator:
         tool_calls = []
 
         # Process tool calls if present in any chunk
-        tool_call_data = {}  # Track tool calls by ID
+        tool_call_data: Dict[str, Dict[str, str]] = {}  # Track tool calls by ID
         for chunk_payload in chunks:
             tool_calls_meta = chunk_payload.meta.get("tool_calls")
             if tool_calls_meta:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -344,46 +344,37 @@ class OpenAIChatGenerator:
         :param chunk: The last chunk returned by the OpenAI API.
         :param chunks: The list of all `StreamingChunk` objects.
         """
-
         text = "".join([chunk.content for chunk in chunks])
         tool_calls = []
 
-        # are there any tool calls in the chunks?
-        if any(chunk.meta.get("tool_calls") for chunk in chunks):
-            payloads = {}  # Use a dict to track tool calls by ID
-            for chunk_payload in chunks:
-                deltas = chunk_payload.meta.get("tool_calls") or []
+        # Process tool calls if present in any chunk
+        tool_call_data = {}  # Track tool calls by ID
+        for chunk_payload in chunks:
+            tool_calls_meta = chunk_payload.meta.get("tool_calls")
+            if tool_calls_meta:
+                for delta in tool_calls_meta:
+                    if not delta.id in tool_call_data:
+                        tool_call_data[delta.id] = {"id": delta.id, "name": "", "arguments": ""}
 
-                # deltas is a list of ChoiceDeltaToolCall
-                for delta in deltas:
-                    if delta.id not in payloads:
-                        payloads[delta.id] = {"id": delta.id, "arguments": "", "name": "", "type": None}
-                    # ChoiceDeltaToolCall has a 'function' field of type ChoiceDeltaToolCallFunction
                     if delta.function:
-                        # For tool calls with the same ID, use the latest values
-                        if delta.function.name is not None:
-                            payloads[delta.id]["name"] = delta.function.name
-                        if delta.function.arguments is not None:
-                            # Use the latest arguments value
-                            payloads[delta.id]["arguments"] = delta.function.arguments
-                    if delta.type is not None:
-                        payloads[delta.id]["type"] = delta.type
+                        if delta.function.name:
+                            tool_call_data[delta.id]["name"] = delta.function.name
+                        if delta.function.arguments:
+                            tool_call_data[delta.id]["arguments"] = delta.function.arguments
 
-            for payload in payloads.values():
-                arguments_str = payload["arguments"]
-                try:
-                    # Try to parse the concatenated arguments string as JSON
-                    arguments = json.loads(arguments_str)
-                    tool_calls.append(ToolCall(id=payload["id"], tool_name=payload["name"], arguments=arguments))
-                except json.JSONDecodeError:
-                    logger.warning(
-                        "OpenAI returned a malformed JSON string for tool call arguments. This tool call "
-                        "will be skipped. To always generate a valid JSON, set `tools_strict` to `True`. "
-                        "Tool call ID: {_id}, Tool name: {_name}, Arguments: {_arguments}",
-                        _id=payload["id"],
-                        _name=payload["name"],
-                        _arguments=arguments_str,
-                    )
+        # Convert accumulated tool call data into ToolCall objects
+        for call_data in tool_call_data.values():
+            try:
+                arguments = json.loads(call_data["arguments"])
+                tool_calls.append(ToolCall(id=call_data["id"], tool_name=call_data["name"], arguments=arguments))
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping malformed tool call due to invalid JSON. Set `tools_strict=True` for valid JSON. "
+                    "Tool call ID: {_id}, Tool name: {_name}, Arguments: {_arguments}",
+                    _id=call_data["id"],
+                    _name=call_data["name"],
+                    _arguments=call_data["arguments"],
+                )
 
         meta = {
             "model": chunk.model,

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -348,9 +348,11 @@ class OpenAIChatGenerator:
         text = "".join([chunk.content for chunk in chunks])
         tool_calls = []
 
-        # if it's a tool call , we need to build the payload dict from all the chunks
-        if bool(chunks[0].meta.get("tool_calls")):
-            tools_len = len(chunks[0].meta.get("tool_calls", []))
+        # are there any tool calls in the chunks?
+        if any(chunk.meta.get("tool_calls") for chunk in chunks):
+            ## get the index of the first chunk with tool calls
+            tool_call_index = next((i for i, chunk in enumerate(chunks) if chunk.meta.get("tool_calls")), None)
+            tools_len = len(chunks[tool_call_index].meta.get("tool_calls", []))
 
             payloads = [{"arguments": "", "name": ""} for _ in range(tools_len)]
             for chunk_payload in chunks:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -351,7 +351,7 @@ class OpenAIChatGenerator:
         # are there any tool calls in the chunks?
         if any(chunk.meta.get("tool_calls") for chunk in chunks):
             ## get the index of the first chunk with tool calls
-            tool_call_index = next((i for i, chunk in enumerate(chunks) if chunk.meta.get("tool_calls")), None)
+            tool_call_index = next((i for i, chunk in enumerate(chunks) if chunk.meta.get("tool_calls")), 0)
             tools_len = len(chunks[tool_call_index].meta.get("tool_calls", []))
 
             payloads = [{"arguments": "", "name": ""} for _ in range(tools_len)]

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -359,7 +359,7 @@ class OpenAIChatGenerator:
                     if delta.id not in payloads:
                         payloads[delta.id] = {"id": delta.id, "arguments": "", "name": "", "type": None}
                     # ChoiceDeltaToolCall has a 'function' field of type ChoiceDeltaToolCallFunction
-                    if delta.function:  # type: ChoiceDeltaToolCallFunction
+                    if delta.function:
                         # For tool calls with the same ID, use the latest values
                         if delta.function.name is not None:
                             payloads[delta.id]["name"] = delta.function.name

--- a/releasenotes/notes/improve-tool-call-chunk-search-986474e814af17a7.yaml
+++ b/releasenotes/notes/improve-tool-call-chunk-search-986474e814af17a7.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Improved openai streaming response tool call processing: The logic now scans all chunks to correctly identify the first chunk with tool calls, ensuring accurate payload construction and preventing errors when tool call data isn’t confined to the initial chunk.
+    Improved `OpenAIChatGenerator` streaming response tool call processing: The logic now scans all chunks to correctly identify the first chunk with tool calls, ensuring accurate payload construction and preventing errors when tool call data isn’t confined to the initial chunk.

--- a/releasenotes/notes/improve-tool-call-chunk-search-986474e814af17a7.yaml
+++ b/releasenotes/notes/improve-tool-call-chunk-search-986474e814af17a7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Improved openai streaming response tool call processing: The logic now scans all chunks to correctly identify the first chunk with tool calls, ensuring accurate payload construction and preventing errors when tool call data isn’t confined to the initial chunk.


### PR DESCRIPTION
### Why:
Enhances the processing logic to support various LLM platforms—not just OpenAI. Testing with the OpenAI Python package using the Mistral platform revealed that some platforms may place `tool_calls` in any streamed chunk (not only in the first). This change ensures that all chunks are scanned for the  `tool_calls` payload.

### What:
- Refined detection of tool calls across all streaming chunks.
- Changed the assumption that `tool_calls` appear only in the first chunk to a search that finds them anywhere.

### How can it be used:
This update ensures robust tool call tracking in streaming messages, accurately constructing payloads regardless of where the `tool_calls` appear:
```python
# Updated logic to search for tool_calls in all chunks
tool_call_index = next((i for i, chunk in enumerate(chunks) if chunk.meta.get("tool_calls")), None)
tools_len = len(chunks[tool_call_index].meta.get("tool_calls", []))
```

### How did you test it:
- No tests were added, using old tests

### Notes for the reviewer:
N/A