### PR TITLE
perf: reduce import time - draft

### DIFF
--- a/haystack/telemetry/_environment.py
+++ b/haystack/telemetry/_environment.py
@@ -84,31 +84,9 @@ def collect_system_specs() -> Dict[str, Any]:
         "os.machine": platform.machine(),
         "python.version": platform.python_version(),
         "hardware.cpus": os.cpu_count(),
-        "hardware.gpus": 0,
-        "libraries.transformers": False,
-        "libraries.torch": False,
-        "libraries.cuda": False,
         "libraries.pytest": sys.modules["pytest"].__version__ if "pytest" in sys.modules.keys() else False,
         "libraries.ipython": sys.modules["ipython"].__version__ if "ipython" in sys.modules.keys() else False,
         "libraries.colab": sys.modules["google.colab"].__version__ if "google.colab" in sys.modules.keys() else False,
     }
 
-    # Try to find out transformer's version
-    try:
-        import transformers
-
-        specs["libraries.transformers"] = transformers.__version__
-    except ImportError:
-        pass
-
-    # Try to find out torch's version and info on potential GPU(s)
-    try:
-        import torch
-
-        specs["libraries.torch"] = torch.__version__
-        if torch.cuda.is_available():
-            specs["libraries.cuda"] = torch.version.cuda
-            specs["libraries.gpus"] = torch.cuda.device_count()
-    except ImportError:
-        pass
     return specs

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -2,33 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .auth import Secret, deserialize_secrets_inplace
-from .callable_serialization import deserialize_callable, serialize_callable
-from .device import ComponentDevice, Device, DeviceMap, DeviceType
-from .docstore_deserialization import deserialize_document_store_in_init_params_inplace
-from .expit import expit
-from .filters import document_matches_filter, raise_on_invalid_filter_syntax
-from .jinja2_extensions import Jinja2TimeExtension
-from .jupyter import is_in_jupyter
-from .requests_utils import request_with_retry
-from .type_serialization import deserialize_type, serialize_type
+import sys
 
-__all__ = [
-    "Secret",
-    "deserialize_secrets_inplace",
-    "ComponentDevice",
-    "Device",
-    "DeviceMap",
-    "DeviceType",
-    "expit",
-    "document_matches_filter",
-    "raise_on_invalid_filter_syntax",
-    "is_in_jupyter",
-    "request_with_retry",
-    "serialize_callable",
-    "deserialize_callable",
-    "serialize_type",
-    "deserialize_type",
-    "deserialize_document_store_in_init_params_inplace",
-    "Jinja2TimeExtension",
-]
+from lazy_imports import LazyImporter
+
+_import_structure = {
+    ".utils.device": ["ComponentDevice", "Device", "DeviceMap", "DeviceType"],
+    ".utils.auth": ["Secret", "deserialize_secrets_inplace"],
+    ".utils.callable_serialization": ["deserialize_callable", "serialize_callable"],
+    ".utils.docstore_deserialization": ["deserialize_document_store_in_init_params_inplace"],
+    ".utils.expit": ["expit"],
+    ".utils.filters": ["document_matches_filter", "raise_on_invalid_filter_syntax"],
+    ".utils.type_serialization": ["deserialize_type", "serialize_type"],
+    ".utils.jinja2_extensions": ["Jinja2TimeExtension"],
+    ".utils.jupyter": ["is_in_jupyter"],
+    ".utils.requests_utils": ["request_with_retry"],
+}
+
+sys.modules[__name__] = LazyImporter(__name__, globals()["__file__"], _import_structure)

--- a/measure.py
+++ b/measure.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 import statistics
 import subprocess

--- a/measure.py
+++ b/measure.py
@@ -1,0 +1,54 @@
+import re
+import statistics
+import subprocess
+
+
+def measure_import_times(n_runs=30, module="haystack"):
+    """
+    Measure the time it takes to import a module.
+    """
+    user_times = []
+    sys_times = []
+
+    print(f"Running {n_runs} measurements...")
+
+    for i in range(n_runs):
+        # Run the import command and capture output
+        result = subprocess.run(["time", "python", "-c", f"import {module}"], capture_output=True, text=True)
+
+        # Check both stdout and stderr
+        time_output = result.stderr
+
+        # Extract times using regex - matches patterns like "3.21user 0.17system"
+        time_pattern = r"([\d.]+)user\s+([\d.]+)system"
+        match = re.search(time_pattern, time_output)
+
+        if match:
+            user_time = float(match.group(1))
+            sys_time = float(match.group(2))
+
+            user_times.append(user_time)
+            sys_times.append(sys_time)
+
+        # print(user_times)
+
+        if (i + 1) % 10 == 0:
+            print(f"Completed {i + 1} runs...")
+
+    # Calculate statistics
+    avg_user = statistics.mean(user_times)
+    avg_sys = statistics.mean(sys_times)
+    avg_total = avg_user + avg_sys
+
+    # Calculate standard deviations
+    std_user = statistics.stdev(user_times)
+    std_sys = statistics.stdev(sys_times)
+
+    print("\nResults:")
+    print(f"Average user time: {avg_user:.3f}s ± {std_user:.3f}s")
+    print(f"Average sys time:  {avg_sys:.3f}s ± {std_sys:.3f}s")
+    print(f"Average total (user + sys): {avg_total:.3f}s")
+
+
+if __name__ == "__main__":
+    measure_import_times()

--- a/torch_tracker.py
+++ b/torch_tracker.py
@@ -1,0 +1,60 @@
+import importlib.abc
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class ImportTracker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        """
+        If the module name contains "torch", print the full name and the stack trace.
+        """
+        if "torch" in fullname:
+            print(f"\nAttempting to import: {fullname}")
+            import traceback
+
+            for frame in traceback.extract_stack()[:-1]:  # Exclude this frame
+                if "haystack" in frame.filename:
+                    print(f"  In Haystack file: {frame.filename}:{frame.lineno}")
+                    print(f"    {frame.line}")
+
+
+# Install the import tracker
+sys.meta_path.insert(0, ImportTracker())
+
+# Record modules before import
+print("Recording initial modules...")
+modules_before = set(sys.modules.keys())
+
+# Import haystack
+print("Importing haystack...")
+import haystack
+
+# Find new modules after import
+print("Analyzing new modules...")
+modules_after = set(sys.modules.keys())
+new_modules = modules_after - modules_before
+
+# Filter for haystack modules that imported torch
+haystack_importers = {}
+
+for name in new_modules:
+    if name.startswith("haystack"):
+        module = sys.modules[name]
+        # Check if this module uses torch
+        module_dict = getattr(module, "__dict__", {})
+        for value in module_dict.values():
+            if isinstance(value, types.ModuleType) and "torch" in value.__name__:
+                if name not in haystack_importers:
+                    haystack_importers[name] = set()
+                haystack_importers[name].add(value.__name__)
+
+if haystack_importers:
+    print("\nFound haystack modules that imported torch:")
+    for module_name, torch_modules in sorted(haystack_importers.items()):
+        print(f"\n{module_name}:")
+        for torch_module in sorted(torch_modules):
+            print(f"  - {torch_module}")
+else:
+    print("\nNo haystack modules imported torch")

--- a/torch_tracker.py
+++ b/torch_tracker.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import importlib.abc
 import importlib.util
 import sys


### PR DESCRIPTION
### Motivation

Motivated by recent issues (#8649, #8650, and #8704), I investigated the import times of Haystack.

I used some raw scripts (attached in this draft PR) and commands like
`python -X importtime -c "import haystack"` to analyze cumulative import times of packages.

### Findings
- Our `LazyImport` context manager behaves like a `DeferImportError` context manager. If a package you import is available, it gets imported immediately. If not, the import error is caught and only raised later when calling  `.check()`. Maybe this is something known, but it was surprising to me.
- As a result the more libraries installed, the slower the imports (since more packages get loaded).
- Our telemetry surprisingly imports heavy dependencies like `torch` and `transformers`.

### An exploratory solution

I explored low-effort ways to improve this:
- remove heavy imports from telemetry
- make modules import in `__init__.py` of packages *actually lazy*
  - I only did this for the `utils` package, that triggered the `torch` import

#### Results

Tested on Ubuntu 22.04, Python 3.10.12, averaged over 30 runs.

I focus on User time and System time, as they capture actual CPU time, irrespective of parallelism and system load ([reference](https://stackoverflow.com/questions/556405/what-do-real-user-and-sys-mean-in-the-output-of-time1)).

*Dependencies*
- Minimal = `pip install haystack-ai`
- Test = All dependencies required for tests ([pyproject](https://github.com/deepset-ai/haystack/blob/e5b9bdeb66b8e459a269a91ad922c6045dc2ad79/pyproject.toml#L85))

| Haystack | Dependencies   | User Time | Sys Time | Total Time |
|----------|--------|-----------|----------|------------|
| Current (https://github.com/deepset-ai/haystack/commit/35788a2d060d58b901b8d10237f23273399998e5)  | Minimal | 2.114s    | 0.031s   | 2.145s     |
| Current (https://github.com/deepset-ai/haystack/commit/35788a2d060d58b901b8d10237f23273399998e5)  | Test    | 3.236s    | 0.185s   | **3.420s**     |
| This PR       | Minimal | 2.098s    | 0.036s   | 2.134s     |
| This PR       | Test    | 2.265s    | 0.050s   | **2.316s**     |


### Next Steps
I believe that these results can encourage discussion.

- Should we rename `LazyImport` or transform it into a truly lazy importer (difficult if we want to keep its API unchanged)?
- Do we want to use *real* lazy imports in the `__init__.py` of packages?