### PR TITLE
fix: Fix csv document splitter when table is only one row wide

### DIFF
--- a/haystack/components/preprocessors/csv_document_splitter.py
+++ b/haystack/components/preprocessors/csv_document_splitter.py
@@ -195,7 +195,7 @@ class CSVDocumentSplitter:
         df_length = df.shape[0] if axis == "row" else df.shape[1]
         for empty_start_idx, empty_end_idx in split_indices + [(df_length, df_length)]:
             # Avoid empty splits
-            if empty_start_idx - table_start_idx > 1:
+            if empty_start_idx - table_start_idx >= 1:
                 if axis == "row":
                     sub_table = df.iloc[table_start_idx:empty_start_idx]
                 else:

--- a/test/components/preprocessors/test_csv_document_splitter.py
+++ b/test/components/preprocessors/test_csv_document_splitter.py
@@ -227,6 +227,12 @@ E,F,,,G,H
             assert table.content == expected_tables[i]
             assert table.meta == expected_meta[i]
 
+    def test_sub_table_with_one_row(self):
+        splitter = CSVDocumentSplitter(row_split_threshold=1)
+        doc = Document(content="""A,B,C\n1,2,3\n,,\n4,5,6""")
+        split_result = splitter.run([doc])
+        assert len(split_result["documents"]) == 2
+
     def test_threshold_no_effect(self, two_tables_sep_by_two_empty_rows: str) -> None:
         splitter = CSVDocumentSplitter(row_split_threshold=3)
         doc = Document(content=two_tables_sep_by_two_empty_rows)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Fix csv document splitter when table is only one row wide

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- added a test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->
- I don't think any release notes for this is needed because it's a fix for a component that hasn't been released yet
- Original PR is here: https://github.com/deepset-ai/haystack/pull/8815

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
