### PR TITLE
removing from_dict/to_dict AWS tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,11 +99,6 @@ extra-dependencies = [
   "spacy-curated-transformers>=0.2,<=0.3",
   "en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.8.0/en_core_web_trf-3.8.0-py3-none-any.whl",
 
-  # LLMetadataExtractor
-  "amazon-bedrock-haystack>=1.0.2",
-  "google-vertex-haystack>=2.0.0",
-
-
   # Converters
   "pypdf",                            # PyPDFToDocument
   "pdfminer.six",                     # PDFMinerToDocument

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -1,7 +1,6 @@
 import os
 from unittest.mock import MagicMock
 
-import boto3
 import pytest
 from haystack import Document, Pipeline
 from haystack.components.builders import PromptBuilder

--- a/test/components/extractors/test_llm_metadata_extractor.py
+++ b/test/components/extractors/test_llm_metadata_extractor.py
@@ -88,44 +88,6 @@ class TestLLMMetadataExtractor:
             },
         }
 
-    def test_to_dict_aws_bedrock(self, boto3_session_mock):
-        extractor = LLMMetadataExtractor(
-            prompt="some prompt that was used with the LLM {{document.content}}",
-            expected_keys=["key1", "key2"],
-            generator_api=LLMProvider.AWS_BEDROCK,
-            generator_api_params={"model": "meta.llama.test"},
-            raise_on_failure=True,
-        )
-        extractor_dict = extractor.to_dict()
-        assert extractor_dict == {
-            "type": "haystack.components.extractors.llm_metadata_extractor.LLMMetadataExtractor",
-            "init_parameters": {
-                "prompt": "some prompt that was used with the LLM {{document.content}}",
-                "generator_api": "aws_bedrock",
-                "generator_api_params": {
-                    "aws_access_key_id": {"type": "env_var", "env_vars": ["AWS_ACCESS_KEY_ID"], "strict": False},
-                    "aws_secret_access_key": {
-                        "type": "env_var",
-                        "env_vars": ["AWS_SECRET_ACCESS_KEY"],
-                        "strict": False,
-                    },
-                    "aws_session_token": {"type": "env_var", "env_vars": ["AWS_SESSION_TOKEN"], "strict": False},
-                    "aws_region_name": {"type": "env_var", "env_vars": ["AWS_DEFAULT_REGION"], "strict": False},
-                    "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
-                    "model": "meta.llama.test",
-                    "stop_words": [],
-                    "generation_kwargs": {},
-                    "streaming_callback": None,
-                    "boto3_config": None,
-                    "tools": None,
-                },
-                "expected_keys": ["key1", "key2"],
-                "page_range": None,
-                "raise_on_failure": True,
-                "max_workers": 3,
-            },
-        }
-
     def test_from_dict_openai(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         extractor_dict = {
@@ -150,42 +112,6 @@ class TestLLMMetadataExtractor:
         assert extractor.expected_keys == ["key1", "key2"]
         assert extractor.prompt == "some prompt that was used with the LLM {{document.content}}"
         assert extractor.generator_api == LLMProvider.OPENAI
-
-    def test_from_dict_aws_bedrock(self, boto3_session_mock):
-        extractor_dict = {
-            "type": "haystack.components.extractors.llm_metadata_extractor.LLMMetadataExtractor",
-            "init_parameters": {
-                "prompt": "some prompt that was used with the LLM {{document.content}}",
-                "generator_api": "aws_bedrock",
-                "generator_api_params": {
-                    "aws_access_key_id": {"type": "env_var", "env_vars": ["AWS_ACCESS_KEY_ID"], "strict": False},
-                    "aws_secret_access_key": {
-                        "type": "env_var",
-                        "env_vars": ["AWS_SECRET_ACCESS_KEY"],
-                        "strict": False,
-                    },
-                    "aws_session_token": {"type": "env_var", "env_vars": ["AWS_SESSION_TOKEN"], "strict": False},
-                    "aws_region_name": {"type": "env_var", "env_vars": ["AWS_DEFAULT_REGION"], "strict": False},
-                    "aws_profile_name": {"type": "env_var", "env_vars": ["AWS_PROFILE"], "strict": False},
-                    "model": "meta.llama.test",
-                    "stop_words": [],
-                    "generation_kwargs": {},
-                    "streaming_callback": None,
-                    "boto3_config": None,
-                    "tools": None,
-                },
-                "expected_keys": ["key1", "key2"],
-                "page_range": None,
-                "raise_on_failure": True,
-                "max_workers": 3,
-            },
-        }
-        extractor = LLMMetadataExtractor.from_dict(extractor_dict)
-        assert extractor.raise_on_failure is True
-        assert extractor.expected_keys == ["key1", "key2"]
-        assert extractor.prompt == "some prompt that was used with the LLM {{document.content}}"
-        assert extractor.generator_api == LLMProvider.AWS_BEDROCK
-        assert extractor.llm_provider.model == "meta.llama.test"
 
     def test_warm_up(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")


### PR DESCRIPTION
### Proposed Changes:

- removing AWS Bedrock related tests, removing extra dependencies from pyproject.toml

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
