### PR TITLE
fix: AsyncPipeline logging  name can't be overwritten

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -120,7 +120,7 @@ class AsyncPipeline(PipelineBase):
                     parent_span=parent_span,
                 ) as span:
                     span.set_content_tag("haystack.component.input", deepcopy(component_inputs))
-                    logger.info(f"Running component {component_name}", component_name=component_name)
+                    logger.info("Running component {component_name}", component_name=component_name)
 
                     if getattr(instance, "__haystack_supports_async__", False):
                         outputs = await instance.run_async(**component_inputs)  # type: ignore

--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -120,7 +120,7 @@ class AsyncPipeline(PipelineBase):
                     parent_span=parent_span,
                 ) as span:
                     span.set_content_tag("haystack.component.input", deepcopy(component_inputs))
-                    logger.info(f"Running component {component_name}", name=component_name)
+                    logger.info(f"Running component {component_name}", component_name=component_name)
 
                     if getattr(instance, "__haystack_supports_async__", False):
                         outputs = await instance.run_async(**component_inputs)  # type: ignore

--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -120,7 +120,7 @@ class AsyncPipeline(PipelineBase):
                     parent_span=parent_span,
                 ) as span:
                     span.set_content_tag("haystack.component.input", deepcopy(component_inputs))
-                    logger.info("Running component {name}", name=component_name)
+                    logger.info(f"Running component {component_name}", name=component_name)
 
                     if getattr(instance, "__haystack_supports_async__", False):
                         outputs = await instance.run_async(**component_inputs)  # type: ignore


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-experimental/issues/194

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
