### PR TITLE
feat: Update list joiner

### DIFF
--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -102,7 +102,7 @@ class ListJoiner:
             data["init_parameters"]["list_type_"] = deserialize_type(data["init_parameters"]["list_type_"])
         return default_from_dict(cls, data)
 
-    def run(self, values: Variadic[List[Any]]) -> Dict[str, Any]:
+    def run(self, values: Variadic[List[Any]]) -> Dict[str, List[Any]]:
         """
         Joins multiple lists into a single flat list.
 

--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -97,7 +97,7 @@ class ListJoiner:
         :returns: Deserialized component.
         """
         init_parameters = data.get("init_parameters")
-        if init_parameters.get("list_type_") is not None:
+        if init_parameters is not None and init_parameters.get("list_type_") is not None:
             data["init_parameters"]["list_type_"] = deserialize_type(data["init_parameters"]["list_type_"])
         return default_from_dict(cls, data)
 

--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.core.component.types import Variadic
+from haystack.core.type_utils import _types_are_compatible
 from haystack.utils import deserialize_type, serialize_type
 
 
@@ -101,7 +102,7 @@ class ListJoiner:
             data["init_parameters"]["list_type_"] = deserialize_type(data["init_parameters"]["list_type_"])
         return default_from_dict(cls, data)
 
-    def run(self, values: Variadic[Any]) -> Dict[str, Any]:
+    def run(self, values: Variadic[List[Any]]) -> Dict[str, Any]:
         """
         Joins multiple lists into a single flat list.
 

--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -69,8 +69,9 @@ class ListJoiner:
         """
         Creates a ListJoiner component.
 
-        :param list_type_: The type of list that this joiner will handle (e.g., List[ChatMessage]).
-            All input lists must be of this type.
+        :param list_type_: The expected type of the lists this component will join (e.g., List[ChatMessage]).
+            If specified, all input lists must conform to this type. If None, the component defaults to handling
+            lists of any type including mixed types.
         """
         self.list_type_ = list_type_
         if list_type_ is not None:
@@ -105,7 +106,7 @@ class ListJoiner:
         """
         Joins multiple lists into a single flat list.
 
-        :param values:The list to be joined.
+        :param values: The list to be joined.
         :returns: Dictionary with 'values' key containing the joined list.
         """
         result = list(chain(*values))

--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional, Type
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.core.component.types import Variadic
-from haystack.core.type_utils import _types_are_compatible
 from haystack.utils import deserialize_type, serialize_type
 
 

--- a/releasenotes/notes/update-list-joiner-0a068cfb058f3c35.yaml
+++ b/releasenotes/notes/update-list-joiner-0a068cfb058f3c35.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Update ListJoiner to only optionally need list_type_ to be passed. By default it uses type List which acts like List[Any].
+    - This allows the ListJoiner to combine any incoming lists into a single flattened list.
+    - Users can still pass list_type_ if they would like to have stricter type validation in their pipelines.

--- a/test/components/joiners/test_list_joiner.py
+++ b/test/components/joiners/test_list_joiner.py
@@ -3,11 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import List
+import pytest
 
-from haystack import Document
+from haystack import Document, Pipeline
 from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.answer import GeneratedAnswer
+from haystack.components.generators.chat.openai import OpenAIChatGenerator
 from haystack.components.joiners.list_joiner import ListJoiner
+from haystack.components.embedders import SentenceTransformersTextEmbedder
+from haystack.core.errors import PipelineConnectError
+from haystack.utils.auth import Secret
 
 
 class TestListJoiner:
@@ -16,7 +21,15 @@ class TestListJoiner:
         assert isinstance(joiner, ListJoiner)
         assert joiner.list_type_ == List[ChatMessage]
 
-    def test_to_dict(self):
+    def test_to_dict_defaults(self):
+        joiner = ListJoiner()
+        data = joiner.to_dict()
+        assert data == {
+            "type": "haystack.components.joiners.list_joiner.ListJoiner",
+            "init_parameters": {"list_type_": None},
+        }
+
+    def test_to_dict_non_default(self):
         joiner = ListJoiner(List[ChatMessage])
         data = joiner.to_dict()
         assert data == {
@@ -24,7 +37,13 @@ class TestListJoiner:
             "init_parameters": {"list_type_": "typing.List[haystack.dataclasses.chat_message.ChatMessage]"},
         }
 
-    def test_from_dict(self):
+    def test_from_dict_default(self):
+        data = {"type": "haystack.components.joiners.list_joiner.ListJoiner", "init_parameters": {"list_type_": None}}
+        list_joiner = ListJoiner.from_dict(data)
+        assert isinstance(list_joiner, ListJoiner)
+        assert list_joiner.list_type_ is None
+
+    def test_from_dict_non_default(self):
         data = {
             "type": "haystack.components.joiners.list_joiner.ListJoiner",
             "init_parameters": {"list_type_": "typing.List[haystack.dataclasses.chat_message.ChatMessage]"},
@@ -69,3 +88,39 @@ class TestListJoiner:
         messages = [ChatMessage.from_user("Hello")]
         result = joiner.run([messages, [], messages])
         assert result == {"values": messages + messages}
+
+    def test_pipeline_connection_validation(self):
+        joiner = ListJoiner()
+        llm = OpenAIChatGenerator(model="gpt-4o-mini", api_key=Secret.from_token("test-api-key"))
+        pipe = Pipeline()
+        pipe.add_component("joiner", joiner)
+        pipe.add_component("llm", llm)
+        pipe.connect("joiner.values", "llm.messages")
+        assert pipe is not None
+
+    def test_pipeline_connection_validation_list_chatmessage(self):
+        joiner = ListJoiner(List[ChatMessage])
+        llm = OpenAIChatGenerator(model="gpt-4o-mini", api_key=Secret.from_token("test-api-key"))
+        pipe = Pipeline()
+        pipe.add_component("joiner", joiner)
+        pipe.add_component("llm", llm)
+        pipe.connect("joiner", "llm.messages")
+        assert pipe is not None
+
+    def test_pipeline_bad_connection(self):
+        with pytest.raises(PipelineConnectError):
+            joiner = ListJoiner()
+            query_embedder = SentenceTransformersTextEmbedder()
+            pipe = Pipeline()
+            pipe.add_component("joiner", joiner)
+            pipe.add_component("query_embedder", query_embedder)
+            pipe.connect("joiner.values", "query_embedder.text")
+
+    def test_pipeline_bad_connection_different_list_types(self):
+        with pytest.raises(PipelineConnectError):
+            joiner = ListJoiner(List[str])
+            llm = OpenAIChatGenerator(model="gpt-4o-mini", api_key=Secret.from_token("test-api-key"))
+            pipe = Pipeline()
+            pipe.add_component("joiner", joiner)
+            pipe.add_component("llm", llm)
+            pipe.connect("joiner.values", "llm.messages")


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Update ListJoiner to only optionally need list_type_ to be passed. By default it uses type List which acts like List[Any].
- This allows the ListJoiner to combine any incoming lists into a single flattened list.
- Users can still pass list_type_ if they would like to have stricter type validation in their pipelines.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added type validation tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
