### PR TITLE
chore: remove `base` from evaluation pydoc config

### DIFF
--- a/docs/pydoc/config/evaluation_api.yml
+++ b/docs/pydoc/config/evaluation_api.yml
@@ -3,7 +3,6 @@ loaders:
     search_path: [../../../haystack/evaluation]
     modules:
       [
-        "base",
         "eval_run_result",
       ]
     ignore_when_discovered: ["__init__"]


### PR DESCRIPTION
### Related Issues

- "Sync docs with Readme" workflow is failing in main: https://github.com/deepset-ai/haystack/actions/runs/13371679839/job/37341382104

### Proposed Changes:
- remove `base` from evaluation pydoc config: the module was removed in #8838

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
