### PR TITLE
fix: ComponentTool description should not be truncated

### DIFF
--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -152,9 +152,7 @@ class ComponentTool(Tool):
                 ]
             ).lstrip("_")
 
-        # Generate a description for the tool if not provided and truncate to 512 characters
-        # as most LLMs have a limit for the description length
-        description = (description or component.__doc__ or name)[:512]
+        description = description or component.__doc__ or name
 
         # Create the Tool instance with the component invoker as the function to be called and the schema
         super().__init__(name, description, tool_schema, component_invoker)

--- a/releasenotes/notes/fix-tool-description-truncation-011e8275fea4ccb0.yaml
+++ b/releasenotes/notes/fix-tool-description-truncation-011e8275fea4ccb0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ComponentTool does not truncate 'description' anymore.

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -142,6 +142,12 @@ class TestToolComponent:
         assert "reply" in result
         assert result["reply"] == "Hello, world!"
 
+    def test_from_component_long_description(self):
+        component = SimpleComponent()
+        tool = ComponentTool(component=component, description="".join(["A"] * 1024))
+
+        assert len(tool.description) == 1024
+
     def test_from_component_with_dataclass(self):
         component = UserGreeter()
 


### PR DESCRIPTION

### Proposed Changes:

`ComponentTool` truncates the tool description to 512 characters. This leads to unexpected results where because the user is not warned about it. Additionally, models support longer descriptions.

This led to a problem where the model would not even follow the schema because the description was cut too early. It makes ComponentTool not useful for many more complex use cases.

Ideally, we could get a patch release for this.

### How did you test it?

- unit tests, manual tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
