### PR TITLE
chore: Make openai test more robust

### DIFF
--- a/test/components/generators/test_openai.py
+++ b/test/components/generators/test_openai.py
@@ -311,10 +311,10 @@ class TestOpenAIGenerator:
         assert "teorema" in result["replies"][0].lower()
 
         result = generator.run(
-            "Can you explain the Pitagoras therom?",
+            "Can you explain the Pitagoras therom? Repeat the name of the theorem in German.",
             system_prompt="You answer in German, regardless of the language on which a question is asked.",
         )
-        assert "pythagoras" in result["replies"][0].lower()
+        assert "pythag" in result["replies"][0].lower()
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),


### PR DESCRIPTION
### Related Issues

- fixes blocking tests on this [PR](https://github.com/deepset-ai/haystack/pull/8871)

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Shortened the string check and updated prompt to more reliably get name of theorem in the answer.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
