### PR TITLE
fix: use dunder all for ToolInvoker

### DIFF
--- a/haystack/components/tools/__init__.py
+++ b/haystack/components/tools/__init__.py
@@ -4,4 +4,4 @@
 
 from haystack.components.tools.tool_invoker import ToolInvoker
 
-_all_ = ["ToolInvoker"]
+__all__ = ["ToolInvoker"]


### PR DESCRIPTION
### Proposed Changes:

As noticed by @sjrl in the haystack-experimental repo, we are not using the proper dunder syntax in the __init__.py for the tools package.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
