### PR TITLE
Add `run_async` to `OpenAIChatGenerator`

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -282,7 +282,10 @@ class OpenAIChatGenerator:
         tools_strict: Optional[bool] = None,
     ):
         """
-        Invokes chat completion asynchronously based on the provided messages and generation parameters.
+        Asynchronously invokes chat completion based on the provided messages and generation parameters.
+
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
 
         :param messages:
             A list of ChatMessage instances representing the input messages.

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -310,7 +310,8 @@ class OpenAIChatGenerator:
             If set, it will override the `tools_strict` parameter set during component initialization.
 
         :returns:
-            A list containing the generated responses as ChatMessage instances.
+            A dictionary with the following key:
+            - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         # validate and select the streaming callback
         streaming_callback = select_streaming_callback(self.streaming_callback, streaming_callback, requires_async=True)  # type: ignore

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -5,7 +5,7 @@
 import json
 import os
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from openai import AsyncOpenAI, AsyncStream, OpenAI, Stream
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage

--- a/haystack/dataclasses/__init__.py
+++ b/haystack/dataclasses/__init__.py
@@ -7,7 +7,13 @@ from haystack.dataclasses.byte_stream import ByteStream
 from haystack.dataclasses.chat_message import ChatMessage, ChatRole, TextContent, ToolCall, ToolCallResult
 from haystack.dataclasses.document import Document
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
-from haystack.dataclasses.streaming_chunk import StreamingChunk
+from haystack.dataclasses.streaming_chunk import (
+    AsyncStreamingCallbackT,
+    StreamingCallbackT,
+    StreamingChunk,
+    SyncStreamingCallbackT,
+    select_streaming_callback,
+)
 
 __all__ = [
     "Document",
@@ -22,4 +28,8 @@ __all__ = [
     "TextContent",
     "StreamingChunk",
     "SparseEmbedding",
+    "select_streaming_callback",
+    "StreamingCallbackT",
+    "SyncStreamingCallbackT",
+    "AsyncStreamingCallbackT",
 ]

--- a/haystack/dataclasses/streaming_chunk.py
+++ b/haystack/dataclasses/streaming_chunk.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Awaitable, Callable, Dict, Optional, Union
+
+from haystack.utils.asynchronous import is_callable_async_compatible
 
 
 @dataclass
@@ -19,3 +21,41 @@ class StreamingChunk:
 
     content: str
     meta: Dict[str, Any] = field(default_factory=dict, hash=False)
+
+
+SyncStreamingCallbackT = Callable[[StreamingChunk], None]
+AsyncStreamingCallbackT = Callable[[StreamingChunk], Awaitable[None]]
+
+StreamingCallbackT = Union[SyncStreamingCallbackT, AsyncStreamingCallbackT]
+
+
+def select_streaming_callback(
+    init_callback: Optional[StreamingCallbackT], runtime_callback: Optional[StreamingCallbackT], requires_async: bool
+) -> Optional[StreamingCallbackT]:
+    """
+    Picks the correct streaming callback given an optional initial and runtime callback.
+
+    The runtime callback takes precedence over the initial callback.
+
+    :param init_callback:
+        The initial callback.
+    :param runtime_callback:
+        The runtime callback.
+    :param requires_async:
+        Whether the selected callback must be async compatible.
+    :returns:
+        The selected callback.
+    """
+    if init_callback is not None:
+        if requires_async and not is_callable_async_compatible(init_callback):
+            raise ValueError("The init callback must be async compatible.")
+        if not requires_async and is_callable_async_compatible(init_callback):
+            raise ValueError("The init callback cannot be a coroutine.")
+
+    if runtime_callback is not None:
+        if requires_async and not is_callable_async_compatible(runtime_callback):
+            raise ValueError("The runtime callback must be async compatible.")
+        if not requires_async and is_callable_async_compatible(runtime_callback):
+            raise ValueError("The runtime callback cannot be a coroutine.")
+
+    return runtime_callback or init_callback

--- a/haystack/utils/asynchronous.py
+++ b/haystack/utils/asynchronous.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+from typing import Callable
+
+
+def is_callable_async_compatible(func: Callable) -> bool:
+    """
+    Returns if the given callable is usable inside a component's `run_async` method.
+
+    :param callable:
+        The callable to check.
+    :returns:
+        True if the callable is compatible, False otherwise.
+    """
+    return inspect.iscoroutinefunction(func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,7 @@ markers = [
   "document_store",
 ]
 log_cli = true
+asyncio_mode = "auto"
 
 [tool.mypy]
 warn_return_any = false

--- a/releasenotes/notes/add-run-async-to-openai-chat-generator-3b4724af4fe4707a.yaml
+++ b/releasenotes/notes/add-run-async-to-openai-chat-generator-3b4724af4fe4707a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add `run_async` method to OpenAIChatGenerator. This method internally uses the async version of the OpenAI client
+    to generate chat completions and supports the same parameters as the `run` method. It returns a coroutine
+    that can be awaited.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -299,18 +299,6 @@ class TestOpenAIChatGenerator:
         assert len(response["replies"]) == 1
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
 
-    @pytest.mark.asyncio
-    async def test_run_async(self, chat_messages, openai_mock_async_chat_completion):
-        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
-        response = await component.run_async(chat_messages)
-
-        # check that the component returns the correct ChatMessage response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-
     def test_run_with_params(self, chat_messages, openai_mock_chat_completion):
         component = OpenAIChatGenerator(
             api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
@@ -319,28 +307,6 @@ class TestOpenAIChatGenerator:
 
         # check that the component calls the OpenAI API with the correct parameters
         _, kwargs = openai_mock_chat_completion.call_args
-        assert kwargs["max_tokens"] == 10
-        assert kwargs["temperature"] == 0.5
-
-        # check that the tools are not passed to the OpenAI API (the generator is initialized without tools)
-        assert "tools" not in kwargs
-
-        # check that the component returns the correct response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-
-    @pytest.mark.asyncio
-    async def test_run_with_params_async(self, chat_messages, openai_mock_async_chat_completion):
-        component = OpenAIChatGenerator(
-            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
-        )
-        response = await component.run_async(chat_messages)
-
-        # check that the component calls the OpenAI API with the correct parameters
-        _, kwargs = openai_mock_async_chat_completion.call_args
         assert kwargs["max_tokens"] == 10
         assert kwargs["temperature"] == 0.5
 
@@ -377,30 +343,6 @@ class TestOpenAIChatGenerator:
         assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
         assert "Hello" in response["replies"][0].text  # see openai_mock_chat_completion_chunk
 
-    @pytest.mark.asyncio
-    async def test_run_with_params_streaming_async(self, chat_messages, openai_mock_async_chat_completion_chunk):
-        streaming_callback_called = False
-
-        def streaming_callback(chunk: StreamingChunk) -> None:
-            nonlocal streaming_callback_called
-            streaming_callback_called = True
-
-        component = OpenAIChatGenerator(
-            api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback
-        )
-        response = await component.run_async(chat_messages)
-
-        # check we called the streaming callback
-        assert streaming_callback_called
-
-        # check that the component still returns the correct response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert "Hello" in response["replies"][0].text  # see openai_mock_chat_completion_chunk
-
     def test_run_with_streaming_callback_in_run_method(self, chat_messages, openai_mock_chat_completion_chunk):
         streaming_callback_called = False
 
@@ -410,30 +352,6 @@ class TestOpenAIChatGenerator:
 
         component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
         response = component.run(chat_messages, streaming_callback=streaming_callback)
-
-        # check we called the streaming callback
-        assert streaming_callback_called
-
-        # check that the component still returns the correct response
-        assert isinstance(response, dict)
-        assert "replies" in response
-        assert isinstance(response["replies"], list)
-        assert len(response["replies"]) == 1
-        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
-        assert "Hello" in response["replies"][0].text  # see openai_mock_chat_completion_chunk
-
-    @pytest.mark.asyncio
-    async def test_run_with_streaming_callback_in_run_method_async(
-        self, chat_messages, openai_mock_async_chat_completion_chunk
-    ):
-        streaming_callback_called = False
-
-        def streaming_callback(chunk: StreamingChunk) -> None:
-            nonlocal streaming_callback_called
-            streaming_callback_called = True
-
-        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
-        response = await component.run_async(chat_messages, streaming_callback=streaming_callback)
 
         # check we called the streaming callback
         assert streaming_callback_called

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import AsyncMock, patch
+
+from openai import AsyncOpenAI, OpenAIError
+import pytest
+from datetime import datetime
+import os
+
+from openai.types.chat import ChatCompletion, ChatCompletionMessage, ChatCompletionMessageToolCall, ChatCompletionChunk
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message_tool_call import Function
+from openai.types.chat import chat_completion_chunk
+
+from haystack.dataclasses import StreamingChunk
+from haystack.utils.auth import Secret
+from haystack.dataclasses import ChatMessage, ToolCall
+from haystack.tools import Tool
+from haystack.components.generators.chat.openai import OpenAIChatGenerator
+
+
+@pytest.fixture
+def chat_messages():
+    return [
+        ChatMessage.from_system("You are a helpful assistant"),
+        ChatMessage.from_user("What's the capital of France"),
+    ]
+
+
+@pytest.fixture
+def mock_chat_completion_chunk_with_tools(openai_mock_stream_async):
+    """
+    Mock the OpenAI API completion chunk response and reuse it for tests
+    """
+
+    with patch(
+        "openai.resources.chat.completions.AsyncCompletions.create", new_callable=AsyncMock
+    ) as mock_chat_completion_create:
+        completion = ChatCompletionChunk(
+            id="foo",
+            model="gpt-4",
+            object="chat.completion.chunk",
+            choices=[
+                chat_completion_chunk.Choice(
+                    finish_reason="tool_calls",
+                    logprobs=None,
+                    index=0,
+                    delta=chat_completion_chunk.ChoiceDelta(
+                        role="assistant",
+                        tool_calls=[
+                            chat_completion_chunk.ChoiceDeltaToolCall(
+                                index=0,
+                                id="123",
+                                type="function",
+                                function=chat_completion_chunk.ChoiceDeltaToolCallFunction(
+                                    name="weather", arguments='{"city": "Paris"}'
+                                ),
+                            )
+                        ],
+                    ),
+                )
+            ],
+            created=int(datetime.now().timestamp()),
+            usage={"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+        )
+        mock_chat_completion_create.return_value = openai_mock_stream_async(completion)
+        yield mock_chat_completion_create
+
+
+@pytest.fixture
+def tools():
+    tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+    tool = Tool(
+        name="weather",
+        description="useful to determine the weather in a given location",
+        parameters=tool_parameters,
+        function=lambda x: x,
+    )
+    return [tool]
+
+
+class TestOpenAIChatGeneratorAsync:
+    def test_init_should_also_create_async_client_with_same_args(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            api_base_url="test-base-url",
+            organization="test-organization",
+            timeout=30,
+            max_retries=5,
+        )
+
+        assert isinstance(component.async_client, AsyncOpenAI)
+        assert component.async_client.api_key == "test-api-key"
+        assert component.async_client.organization == "test-organization"
+        assert component.async_client.base_url == "test-base-url/"
+        assert component.async_client.timeout == 30
+        assert component.async_client.max_retries == 5
+
+    @pytest.mark.asyncio
+    async def test_run_async(self, chat_messages, openai_mock_async_chat_completion):
+        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
+        response = await component.run_async(chat_messages)
+
+        # check that the component returns the correct ChatMessage response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.asyncio
+    async def test_run_with_params_async(self, chat_messages, openai_mock_async_chat_completion):
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"), generation_kwargs={"max_tokens": 10, "temperature": 0.5}
+        )
+        response = await component.run_async(chat_messages)
+
+        # check that the component calls the OpenAI API with the correct parameters
+        _, kwargs = openai_mock_async_chat_completion.call_args
+        assert kwargs["max_tokens"] == 10
+        assert kwargs["temperature"] == 0.5
+
+        # check that the tools are not passed to the OpenAI API (the generator is initialized without tools)
+        assert "tools" not in kwargs
+
+        # check that the component returns the correct response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+    @pytest.mark.asyncio
+    async def test_run_with_params_streaming_async(self, chat_messages, openai_mock_async_chat_completion_chunk):
+        streaming_callback_called = False
+
+        def streaming_callback(chunk: StreamingChunk) -> None:
+            nonlocal streaming_callback_called
+            streaming_callback_called = True
+
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback
+        )
+        response = await component.run_async(chat_messages)
+
+        # check we called the streaming callback
+        assert streaming_callback_called
+
+        # check that the component still returns the correct response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert "Hello" in response["replies"][0].text  # see openai_mock_chat_completion_chunk
+
+    @pytest.mark.asyncio
+    async def test_run_with_streaming_callback_in_run_method_async(
+        self, chat_messages, openai_mock_async_chat_completion_chunk
+    ):
+        streaming_callback_called = False
+
+        def streaming_callback(chunk: StreamingChunk) -> None:
+            nonlocal streaming_callback_called
+            streaming_callback_called = True
+
+        component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))
+        response = await component.run_async(chat_messages, streaming_callback=streaming_callback)
+
+        # check we called the streaming callback
+        assert streaming_callback_called
+
+        # check that the component still returns the correct response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+        assert "Hello" in response["replies"][0].text  # see openai_mock_chat_completion_chunk
+
+    @pytest.mark.asyncio
+    async def test_run_with_tools_async(self, tools):
+        with patch(
+            "openai.resources.chat.completions.AsyncCompletions.create", new_callable=AsyncMock
+        ) as mock_chat_completion_create:
+            completion = ChatCompletion(
+                id="foo",
+                model="gpt-4",
+                object="chat.completion",
+                choices=[
+                    Choice(
+                        finish_reason="tool_calls",
+                        logprobs=None,
+                        index=0,
+                        message=ChatCompletionMessage(
+                            role="assistant",
+                            tool_calls=[
+                                ChatCompletionMessageToolCall(
+                                    id="123",
+                                    type="function",
+                                    function=Function(name="weather", arguments='{"city": "Paris"}'),
+                                )
+                            ],
+                        ),
+                    )
+                ],
+                created=int(datetime.now().timestamp()),
+                usage={"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+            )
+
+            mock_chat_completion_create.return_value = completion
+
+            component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"), tools=tools, tools_strict=True)
+            response = await component.run_async([ChatMessage.from_user("What's the weather like in Paris?")])
+
+        # ensure that the tools are passed to the OpenAI API
+        assert mock_chat_completion_create.call_args[1]["tools"] == [
+            {"type": "function", "function": {**tools[0].tool_spec, "strict": True}}
+        ]
+
+        assert len(response["replies"]) == 1
+        message = response["replies"][0]
+
+        assert not message.texts
+        assert not message.text
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_run_with_tools_streaming_async(self, mock_chat_completion_chunk_with_tools, tools):
+        streaming_callback_called = False
+
+        def streaming_callback(chunk: StreamingChunk) -> None:
+            nonlocal streaming_callback_called
+            streaming_callback_called = True
+
+        component = OpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"), streaming_callback=streaming_callback
+        )
+        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        response = await component.run_async(chat_messages, tools=tools)
+
+        # check we called the streaming callback
+        assert streaming_callback_called
+
+        # check that the component still returns the correct response
+        assert isinstance(response, dict)
+        assert "replies" in response
+        assert isinstance(response["replies"], list)
+        assert len(response["replies"]) == 1
+        assert [isinstance(reply, ChatMessage) for reply in response["replies"]]
+
+        message = response["replies"][0]
+
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_async(self):
+        chat_messages = [ChatMessage.from_user("What's the capital of France")]
+        component = OpenAIChatGenerator(generation_kwargs={"n": 1})
+        results = await component.run_async(chat_messages)
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+        assert "gpt-4o" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_wrong_model_async(self, chat_messages):
+        component = OpenAIChatGenerator(model="something-obviously-wrong")
+        with pytest.raises(OpenAIError):
+            await component.run_async(chat_messages)
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_streaming_async(self):
+        class Callback:
+            def __init__(self):
+                self.responses = ""
+                self.counter = 0
+
+            def __call__(self, chunk: StreamingChunk) -> None:
+                self.counter += 1
+                self.responses += chunk.content if chunk.content else ""
+
+        callback = Callback()
+        component = OpenAIChatGenerator(streaming_callback=callback)
+        results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
+
+        assert len(results["replies"]) == 1
+        message: ChatMessage = results["replies"][0]
+        assert "Paris" in message.text
+
+        assert "gpt-4o" in message.meta["model"]
+        assert message.meta["finish_reason"] == "stop"
+
+        assert callback.counter > 1
+        assert "Paris" in callback.responses
+
+        # check that the completion_start_time is set and valid ISO format
+        assert "completion_start_time" in message.meta
+        assert datetime.fromisoformat(message.meta["completion_start_time"]) < datetime.now()
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY", None),
+        reason="Export an env var called OPENAI_API_KEY containing the OpenAI API key to run this test.",
+    )
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_live_run_with_tools_async(self, tools):
+        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
+        component = OpenAIChatGenerator(tools=tools)
+        results = await component.run_async(chat_messages)
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+
+        assert not message.texts
+        assert not message.text
+        assert message.tool_calls
+        tool_call = message.tool_call
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -136,7 +136,7 @@ class TestOpenAIChatGeneratorAsync:
     async def test_run_with_params_streaming_async(self, chat_messages, openai_mock_async_chat_completion_chunk):
         streaming_callback_called = False
 
-        def streaming_callback(chunk: StreamingChunk) -> None:
+        async def streaming_callback(chunk: StreamingChunk) -> None:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
@@ -162,7 +162,7 @@ class TestOpenAIChatGeneratorAsync:
     ):
         streaming_callback_called = False
 
-        def streaming_callback(chunk: StreamingChunk) -> None:
+        async def streaming_callback(chunk: StreamingChunk) -> None:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
@@ -237,7 +237,7 @@ class TestOpenAIChatGeneratorAsync:
     async def test_run_with_tools_streaming_async(self, mock_chat_completion_chunk_with_tools, tools):
         streaming_callback_called = False
 
-        def streaming_callback(chunk: StreamingChunk) -> None:
+        async def streaming_callback(chunk: StreamingChunk) -> None:
             nonlocal streaming_callback_called
             streaming_callback_called = True
 
@@ -300,16 +300,15 @@ class TestOpenAIChatGeneratorAsync:
     @pytest.mark.integration
     @pytest.mark.asyncio
     async def test_live_run_streaming_async(self):
-        class Callback:
-            def __init__(self):
-                self.responses = ""
-                self.counter = 0
+        counter = 0
+        responses = ""
 
-            def __call__(self, chunk: StreamingChunk) -> None:
-                self.counter += 1
-                self.responses += chunk.content if chunk.content else ""
+        async def callback(chunk: StreamingChunk):
+            nonlocal counter
+            nonlocal responses
+            counter += 1
+            responses += chunk.content if chunk.content else ""
 
-        callback = Callback()
         component = OpenAIChatGenerator(streaming_callback=callback)
         results = await component.run_async([ChatMessage.from_user("What's the capital of France?")])
 
@@ -320,8 +319,8 @@ class TestOpenAIChatGeneratorAsync:
         assert "gpt-4o" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
 
-        assert callback.counter > 1
-        assert "Paris" in callback.responses
+        assert counter > 1
+        assert "Paris" in responses
 
         # check that the completion_start_time is set and valid ISO format
         assert "completion_start_time" in message.meta

--- a/test/components/generators/conftest.py
+++ b/test/components/generators/conftest.py
@@ -65,6 +65,14 @@ def openai_mock_stream():
 
 
 @pytest.fixture
+def openai_mock_stream_async():
+    """
+    Fixture that returns a function to create AsyncMockStream instances with custom chunks
+    """
+    return OpenAIAsyncMockStream
+
+
+@pytest.fixture
 def openai_mock_chat_completion():
     """
     Mock the OpenAI API completion response and reuse it for tests


### PR DESCRIPTION
### Related Issues

- fixes #8859

### Proposed Changes:

This adds `run_async` to `OpenAIChatGenerator`. It uses internally the async version of OpenAI client (which has the same methods, but ofc they return awaitable coroutines).

### How did you test it?

unit tests, integration tests, manual verification

### Notes for the reviewer

- I've basically duplicated all the relevant tests in `test_openai_async` and make them run `run_async`. 
- The `streaming_callback` is still a `Callable[[StreamingChunk], None]`. I've tried make it support also an `Awaitable` but it breaks since `run_async` of components expects the same exact params of `run`.
- The sync and async client instances are created at init time. We may decide to create a factory method to get the correct client instance (using lru_cache on the output) as an alternative.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
