### PR TITLE
chore: Update default output type of list joiner to be correct

### DIFF
--- a/haystack/components/joiners/list_joiner.py
+++ b/haystack/components/joiners/list_joiner.py
@@ -77,7 +77,7 @@ class ListJoiner:
         if list_type_ is not None:
             component.set_output_types(self, values=list_type_)
         else:
-            component.set_output_types(self, values=List)
+            component.set_output_types(self, values=List[Any])
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/test/components/joiners/test_list_joiner.py
+++ b/test/components/joiners/test_list_joiner.py
@@ -101,7 +101,8 @@ class TestListJoiner:
         pipe = Pipeline()
         pipe.add_component("joiner", joiner)
         pipe.add_component("llm", llm)
-        pipe.connect("joiner.values", "llm.messages")
+        with pytest.raises(PipelineConnectError):
+            pipe.connect("joiner.values", "llm.messages")
         assert pipe is not None
 
     def test_pipeline_connection_validation_list_chatmessage(self):


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Default output type was `List` and should be `List[Any]`.  This is a fix for a change that is not yet in a Haystack release so it's not a breaking change. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated test to reflect this. 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
