### PR TITLE
fix ResourceWarning: unclosed file when using telemetry

### DIFF
--- a/haystack/telemetry/_environment.py
+++ b/haystack/telemetry/_environment.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 _IS_DOCKER_CACHE = None
 
 
+def _str_in_any_line_of_file(s: str, path: str) -> bool:
+    with open(path) as f:
+        return any(s in line for line in f)
+
+
 def _in_podman() -> bool:
     """
     Check if the code is running in a Podman container.
@@ -41,7 +46,7 @@ def _has_docker_cgroup_v1() -> bool:
     This only works with cgroups v1.
     """
     path = "/proc/self/cgroup"  # 'self' should be always symlinked to the actual PID
-    return os.path.isfile(path) and any("docker" in line for line in open(path))
+    return os.path.isfile(path) and _str_in_any_line_of_file("docker", path)
 
 
 def _has_docker_cgroup_v2() -> bool:
@@ -51,7 +56,7 @@ def _has_docker_cgroup_v2() -> bool:
     inspired from: https://github.com/jenkinsci/docker-workflow-plugin/blob/master/src/main/java/org/jenkinsci/plugins/docker/workflow/client/DockerClient.java
     """
     path = "/proc/self/mountinfo"  # 'self' should be always symlinked to the actual PID
-    return os.path.isfile(path) and any("/docker/containers/" in line for line in open(path))
+    return os.path.isfile(path) and _str_in_any_line_of_file("/docker/containers/", path)
 
 
 def _is_containerized() -> Optional[bool]:


### PR DESCRIPTION
### Related Issues

i did not report an issue but directly fix it
Our company had to disable telemetry, as it caused out CI pipelines to fail with the following trace:

`
a/b/c/__init__.py::mypy - pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
Traceback (most recent call last):
  File "/builds/mlbase/air/rag/search-api/.venv/lib/python3.12/site-packages/haystack/telemetry/_environment.py", line 54, in _has_docker_cgroup_v2
    return os.path.isfile(path) and any("/docker/containers/" in line for line in open(path))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
`
### Proposed Changes:

open the file in a contextmanager

### How did you test it?

manually

### Notes for the reviewer

i did not implement unit tests, as the issue is quite trivial

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
