### PR TITLE
chore: cleaning up unused imports in tests

### DIFF
--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -5,7 +5,7 @@ import pytest
 from haystack.components.builders.chat_prompt_builder import ChatPromptBuilder
 from haystack import component
 from haystack.core.pipeline.pipeline import Pipeline
-from haystack.dataclasses.chat_message import ChatMessage, ChatRole
+from haystack.dataclasses.chat_message import ChatMessage
 from haystack.dataclasses.document import Document
 
 

--- a/test/components/converters/test_csv_to_document.py
+++ b/test/components/converters/test_csv_to_document.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
-from unittest.mock import patch
-import pandas as pd
-from pathlib import Path
 import os
 
 import pytest

--- a/test/core/pipeline/test_component_checks.py
+++ b/test/core/pipeline/test_component_checks.py
@@ -4,7 +4,23 @@
 
 import pytest
 
-from haystack.core.pipeline.component_checks import *
+from haystack.core.pipeline.component_checks import (
+    all_predecessors_executed,
+    all_socket_predecessors_executed,
+    any_predecessors_provided_input,
+    any_socket_input_received,
+    any_socket_value_from_predecessor_received,
+    are_all_lazy_variadic_sockets_resolved,
+    are_all_sockets_ready,
+    can_component_run,
+    can_not_receive_inputs_from_pipeline,
+    has_any_trigger,
+    has_lazy_variadic_socket_received_all_inputs,
+    has_socket_received_all_inputs,
+    has_user_input,
+    is_any_greedy_socket_ready,
+    is_socket_lazy_variadic,
+)
 from haystack.core.pipeline.component_checks import _NO_OUTPUT_PRODUCED
 from haystack.core.component.types import InputSocket, OutputSocket, Variadic, GreedyVariadic
 

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import datetime
-
 import sys
 from unittest.mock import Mock
 

--- a/test/evaluation/test_eval_run_result.py
+++ b/test/evaluation/test_eval_run_result.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import json
 
 from haystack.evaluation import EvaluationRunResult
 import pytest


### PR DESCRIPTION
### Proposed Changes:

- I've noticed a few unused imports and unneeded imports with wildcards

- Suggestion: we could think about a set of lighter lint rules for the tests, e.g.: unused imports, unused variables - currently it seems nothing is being checked

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
