### PR TITLE
test: make sure no extra modules are being imported due to `__init__` definitions

### DIFF
--- a/test/core/test_importing.py
+++ b/test/core/test_importing.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+import sys
+from unittest.mock import patch
+
+
+def test_lazy_import():
+    # Save the original state of the module if it exists
+    original_imported = sys.modules.get("haystack.components.generators.chat.azure")
+
+    with patch.dict(sys.modules):
+        # Remove the module from sys.modules if it was already imported
+        if original_imported:
+            del sys.modules["haystack.components.generators.chat.azure"]
+
+    from haystack.components.generators.chat import OpenAIChatGenerator  # Import the intended class
+
+    should_not_be_there = [
+        "haystack.components.generators.chat.azure"
+        # "haystack.components.generators.chat.hugging_face_local",
+        # "haystack.components.generators.chat.hugging_face_api"
+    ]
+
+    should_be_there = ["haystack.components.generators.chat.openai"]
+
+    for module in should_be_there:
+        if module not in sys.modules.keys():
+            print(f"Module {module} not found in sys.modules")
+            break
+
+    for modules in sys.modules.keys():
+        for module in should_not_be_there:
+            if module in modules:
+                print(f"Found {module} in sys.modules")
+                break
+
+    # Restore the module if it was previously imported (preserves test isolation)
+    if original_imported:
+        sys.modules["haystack.components.generators.chat.azure"] = original_imported


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
