### PR TITLE
chore: pin `ddtrace<3.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ extra-dependencies = [
 
   # Tracing
   "opentelemetry-sdk",
-  "ddtrace",
+  "ddtrace<3.0.0",  # Haystack is not compatible with ddtrace>=3.0.0. https://github.com/deepset-ai/haystack/issues/8896
 
   # Structured logging
   "structlog",


### PR DESCRIPTION
### Related Issues

- part of #8896
- (failing tests: https://github.com/deepset-ai/haystack/actions/runs/13443883797/job/37565096377?pr=8878)

### Proposed Changes:
- pin `ddtrace<3.0.0`

### How did you test it?
CI

### Notes for the reviewer
As explained in #8896, at some point we should make Haystack compatible with `ddtrace>=3.0.0`

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
