### PR TITLE
fix: right tracer import path

### DIFF
--- a/haystack/tracing/tracer.py
+++ b/haystack/tracing/tracer.py
@@ -224,7 +224,7 @@ def _auto_configured_opentelemetry_tracer() -> Optional[Tracer]:
 def _auto_configured_datadog_tracer() -> Optional[Tracer]:
     # we implement this here and not in the `datadog` module to avoid import warnings when Datadog is not installed
     try:
-        from ddtrace import tracer
+        from ddtrace.trace import tracer
 
         from haystack.tracing.datadog import DatadogTracer
 


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

- pretty sure the old import path is invalid when I look at the code here: https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/__init__.py

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
