### PR TITLE
feat: In FileTypeRouter add `.msg` to "application/vnd.ms-outlook" mapping

### DIFF
--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -15,9 +15,14 @@ from haystack.dataclasses import ByteStream
 logger = logging.getLogger(__name__)
 
 
-# we add markdown because it is not added by the mimetypes module
-# see https://github.com/python/cpython/pull/17995
-CUSTOM_MIMETYPES = {".md": "text/markdown", ".markdown": "text/markdown"}
+CUSTOM_MIMETYPES = {
+    # we add markdown because it is not added by the mimetypes module
+    # see https://github.com/python/cpython/pull/17995
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    # we add msg because it is not added by the mimetypes module
+    ".msg": "application/vnd.ms-outlook",
+}
 
 
 @component

--- a/releasenotes/notes/add-msg-mime-type-file-router-b33d8916caaf5976.yaml
+++ b/releasenotes/notes/add-msg-mime-type-file-router-b33d8916caaf5976.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    In the FileTypeRouter add explicit support for classifying .msg files with mimetype "application/vnd.ms-outlook" since the mimetypes module returns None for .msg files by default.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -288,6 +288,15 @@ class TestFileTypeRouter:
         with pytest.raises(ValueError, match="Unsupported data source type:"):
             router.run(sources=[{"unsupported": "type"}])
 
+    def test_msg_mime_type(self, test_files_path):
+        """
+        Test that the component correctly classifies MSG files.
+        """
+        file_paths = [test_files_path / "msg" / "sample.msg"]
+        router = FileTypeRouter(mime_types=["application/vnd.ms-outlook"])
+        output = router.run(sources=file_paths)
+        assert len(output["application/vnd.ms-outlook"]) == 1
+
     def test_invalid_regex_pattern(self):
         """
         Test that the component raises a ValueError for invalid regex patterns.

--- a/test/components/routers/test_file_router.py
+++ b/test/components/routers/test_file_router.py
@@ -87,14 +87,16 @@ class TestFileTypeRouter:
             test_files_path / "txt" / "doc_2.txt",
             test_files_path / "audio" / "the context for this answer is here.wav",
             test_files_path / "images" / "apple.jpg",
+            test_files_path / "msg" / "sample.msg",
         ]
 
-        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg"])
+        router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg", "application/vnd.ms-outlook"])
         output = router.run(sources=file_paths)
         assert output
         assert len(output[r"text/plain"]) == 2
         assert len(output[r"audio/x-wav"]) == 1
         assert len(output[r"image/jpeg"]) == 1
+        assert len(output["application/vnd.ms-outlook"]) == 1
         assert not output.get("unclassified")
 
     def test_run_with_single_meta(self, test_files_path):
@@ -287,15 +289,6 @@ class TestFileTypeRouter:
         router = FileTypeRouter(mime_types=[r"text/plain", r"audio/x-wav", r"image/jpeg"])
         with pytest.raises(ValueError, match="Unsupported data source type:"):
             router.run(sources=[{"unsupported": "type"}])
-
-    def test_msg_mime_type(self, test_files_path):
-        """
-        Test that the component correctly classifies MSG files.
-        """
-        file_paths = [test_files_path / "msg" / "sample.msg"]
-        router = FileTypeRouter(mime_types=["application/vnd.ms-outlook"])
-        output = router.run(sources=file_paths)
-        assert len(output["application/vnd.ms-outlook"]) == 1
 
     def test_invalid_regex_pattern(self):
         """


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
In the FileTypeRouter add explicit support for classifying .msg files with mimetype "application/vnd.ms-outlook" since the mimetypes module returns None for .msg files by default.

I did this by updating the `CUSTOM_MIMETYPES` dict.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added a unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
