### PR TITLE
fix: set tracing tags before context manager exits

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -212,29 +212,29 @@ class AsyncPipeline(PipelineBase):
                         loop = asyncio.get_running_loop()
                         outputs = await loop.run_in_executor(None, lambda: instance.run(**component_inputs))
 
-                component_visits[component_name] += 1
+                    component_visits[component_name] += 1
 
-                if not isinstance(outputs, dict):
-                    raise PipelineRuntimeError(
-                        f"Component '{component_name}' returned an invalid output type. "
-                        f"Expected a dict, but got {type(outputs).__name__} instead. "
+                    if not isinstance(outputs, dict):
+                        raise PipelineRuntimeError(
+                            f"Component '{component_name}' returned an invalid output type. "
+                            f"Expected a dict, but got {type(outputs).__name__} instead. "
+                        )
+
+                    span.set_tag("haystack.component.visits", component_visits[component_name])
+                    span.set_content_tag("haystack.component.outputs", deepcopy(outputs))
+
+                    # Distribute outputs to downstream inputs; also prune outputs based on `include_outputs_from`
+                    pruned = self._write_component_outputs(
+                        component_name=component_name,
+                        component_outputs=outputs,
+                        inputs=inputs_state,
+                        receivers=cached_receivers[component_name],
+                        include_outputs_from=include_outputs_from,
                     )
+                    if pruned:
+                        pipeline_outputs[component_name] = pruned
 
-                span.set_tag("haystack.component.visits", component_visits[component_name])
-                span.set_content_tag("haystack.component.outputs", deepcopy(outputs))
-
-                # Distribute outputs to downstream inputs; also prune outputs based on `include_outputs_from`
-                pruned = self._write_component_outputs(
-                    component_name=component_name,
-                    component_outputs=outputs,
-                    inputs=inputs_state,
-                    receivers=cached_receivers[component_name],
-                    include_outputs_from=include_outputs_from,
-                )
-                if pruned:
-                    pipeline_outputs[component_name] = pruned
-
-                return pruned
+                    return pruned
 
             async def _run_highest_in_isolation(component_name: str) -> AsyncIterator[Dict[str, Any]]:
                 """


### PR DESCRIPTION
### Related Issues

- partial resolution of https://github.com/deepset-ai/haystack/issues/8864 but not a full fix


### Proposed Changes:

Any operations on the span (set_tag) should be performed before the context manager exits.

To keep the reference to the parent span, we actually need to implement async support for our tracers since the context managers context is not carried over to co-routines. There are also issues with how we handle `parent_span` (we just ignore it in most (all?) of our tracers).
 
### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

Ignoring for release notes to wait for the full fix.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
