### PR TITLE
fix: in OpenAIChatGenerator set additionalProperties to False when tools_strict=True

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -373,16 +373,13 @@ class OpenAIChatGenerator:
 
         openai_tools = {}
         if tools:
-            tool_definitions = [
-                {
-                    "type": "function",
-                    "function": {
-                        **t.tool_spec,
-                        **({"strict": tools_strict, "additionalProperties": False} if tools_strict else {}),
-                    },
-                }
-                for t in tools
-            ]
+            tool_definitions = []
+            for t in tools:
+                function_spec = {**t.tool_spec}
+                if tools_strict:
+                    function_spec["strict"] = True
+                    function_spec["parameters"]["additionalProperties"] = False
+                tool_definitions.append({"type": "function", "function": function_spec})
             openai_tools = {"tools": tool_definitions}
 
         is_streaming = streaming_callback is not None

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -374,7 +374,13 @@ class OpenAIChatGenerator:
         openai_tools = {}
         if tools:
             tool_definitions = [
-                {"type": "function", "function": {**t.tool_spec, **({"strict": tools_strict} if tools_strict else {})}}
+                {
+                    "type": "function",
+                    "function": {
+                        **t.tool_spec,
+                        **({"strict": tools_strict, "additionalProperties": False} if tools_strict else {}),
+                    },
+                }
                 for t in tools
             ]
             openai_tools = {"tools": tool_definitions}

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -209,7 +209,7 @@ class ComponentTool(Tool):
             if socket.is_mandatory:
                 required.append(input_name)
 
-        parameters_schema = {"type": "object", "properties": properties}
+        parameters_schema = {"type": "object", "properties": properties, "additionalProperties": False}
 
         if required:
             parameters_schema["required"] = required

--- a/haystack/tools/component_tool.py
+++ b/haystack/tools/component_tool.py
@@ -209,7 +209,7 @@ class ComponentTool(Tool):
             if socket.is_mandatory:
                 required.append(input_name)
 
-        parameters_schema = {"type": "object", "properties": properties, "additionalProperties": False}
+        parameters_schema = {"type": "object", "properties": properties}
 
         if required:
             parameters_schema["required"] = required

--- a/releasenotes/notes/fix-componenttool-for-openai-tools_strict-998e5cd7ebc6ec19.yaml
+++ b/releasenotes/notes/fix-componenttool-for-openai-tools_strict-998e5cd7ebc6ec19.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the `ComponentTool` for OpenAI tools strict mode. This sets `additionalProperties` to `false` for the function schema.

--- a/releasenotes/notes/fix-componenttool-for-openai-tools_strict-998e5cd7ebc6ec19.yaml
+++ b/releasenotes/notes/fix-componenttool-for-openai-tools_strict-998e5cd7ebc6ec19.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix the `ComponentTool` for OpenAI tools strict mode. This sets `additionalProperties` to `false` for the function schema.
+    Make sure that `OpenAIChatGenerator` sets `additionalProperties: False` in the tool schema when `tool_strict` is set to `True`.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -426,7 +426,7 @@ class TestOpenAIChatGenerator:
         # ensure that the tools are passed to the OpenAI API
         function_spec = {**tools[0].tool_spec}
         function_spec["strict"] = True
-        function_spec["properties"]["additionalProperties"] = False
+        function_spec["parameters"]["additionalProperties"] = False
         assert mock_chat_completion_create.call_args[1]["tools"] == [{"type": "function", "function": function_spec}]
 
         assert len(response["replies"]) == 1

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -424,9 +424,10 @@ class TestOpenAIChatGenerator:
             response = component.run([ChatMessage.from_user("What's the weather like in Paris?")])
 
         # ensure that the tools are passed to the OpenAI API
-        assert mock_chat_completion_create.call_args[1]["tools"] == [
-            {"type": "function", "function": {**tools[0].tool_spec, "strict": True}}
-        ]
+        function_spec = {**tools[0].tool_spec}
+        function_spec["strict"] = True
+        function_spec["properties"]["additionalProperties"] = False
+        assert mock_chat_completion_create.call_args[1]["tools"] == [{"type": "function", "function": function_spec}]
 
         assert len(response["replies"]) == 1
         message = response["replies"][0]

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -216,9 +216,10 @@ class TestOpenAIChatGeneratorAsync:
             response = await component.run_async([ChatMessage.from_user("What's the weather like in Paris?")])
 
         # ensure that the tools are passed to the OpenAI API
-        assert mock_chat_completion_create.call_args[1]["tools"] == [
-            {"type": "function", "function": {**tools[0].tool_spec, "strict": True}}
-        ]
+        function_spec = {**tools[0].tool_spec}
+        function_spec["strict"] = True
+        function_spec["properties"]["additionalProperties"] = False
+        assert mock_chat_completion_create.call_args[1]["tools"] == [{"type": "function", "function": function_spec}]
 
         assert len(response["replies"]) == 1
         message = response["replies"][0]

--- a/test/components/generators/chat/test_openai_async.py
+++ b/test/components/generators/chat/test_openai_async.py
@@ -218,7 +218,7 @@ class TestOpenAIChatGeneratorAsync:
         # ensure that the tools are passed to the OpenAI API
         function_spec = {**tools[0].tool_spec}
         function_spec["strict"] = True
-        function_spec["properties"]["additionalProperties"] = False
+        function_spec["parameters"]["additionalProperties"] = False
         assert mock_chat_completion_create.call_args[1]["tools"] == [{"type": "function", "function": function_spec}]
 
         assert len(response["replies"]) == 1

--- a/test/tools/test_component_tool.py
+++ b/test/tools/test_component_tool.py
@@ -134,7 +134,6 @@ class TestToolComponent:
             "type": "object",
             "properties": {"text": {"type": "string", "description": "user's name"}},
             "required": ["text"],
-            "additionalProperties": False,
         }
 
         # Test tool invocation
@@ -166,7 +165,6 @@ class TestToolComponent:
                 }
             },
             "required": ["user"],
-            "additionalProperties": False,
         }
 
         assert tool.name == "user_greeter"
@@ -195,7 +193,6 @@ class TestToolComponent:
                 }
             },
             "required": ["texts"],
-            "additionalProperties": False,
         }
 
         # Test tool invocation
@@ -229,7 +226,6 @@ class TestToolComponent:
                 }
             },
             "required": ["person"],
-            "additionalProperties": False,
         }
 
         # Test tool invocation
@@ -298,7 +294,6 @@ class TestToolComponent:
                 "top_k": {"description": "The number of top documents to concatenate", "type": "integer"},
             },
             "required": ["documents"],
-            "additionalProperties": False,
         }
 
         # Test tool invocation


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8912

### Proposed Changes:
- always set `additionalProperties: false` for function schema

### How did you test it?
- added integration test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
