### PR TITLE
Revert "test: skip HF API live integration tests (#8889)"

### DIFF
--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -358,7 +358,10 @@ class TestHuggingFaceAPIDocumentEmbedder:
 
     @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
     def test_live_run_serverless(self):
         docs = [
             Document(content="I love cheese", meta={"topic": "Cuisine"}),

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -187,7 +187,10 @@ class TestHuggingFaceAPITextEmbedder:
 
     @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
     def test_live_run_serverless(self):
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -526,7 +526,10 @@ class TestHuggingFaceAPIChatGenerator:
         }
 
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run_serverless(self):
         generator = HuggingFaceAPIChatGenerator(
@@ -547,7 +550,10 @@ class TestHuggingFaceAPIChatGenerator:
         assert "completion_tokens" in response["replies"][0].meta["usage"]
 
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
     @pytest.mark.flaky(reruns=3, reruns_delay=10)
     def test_live_run_serverless_streaming(self):
         generator = HuggingFaceAPIChatGenerator(
@@ -573,7 +579,13 @@ class TestHuggingFaceAPIChatGenerator:
         assert "completion_tokens" in response_meta["usage"]
 
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
+    @pytest.mark.xfail(
+        reason="The Hugging Face API can be unstable and this test may fail intermittently", strict=False
+    )
     def test_live_run_with_tools(self, tools):
         """
         We test the round trip: generate tool call, pass tool message, generate response.

--- a/test/components/generators/test_hugging_face_api.py
+++ b/test/components/generators/test_hugging_face_api.py
@@ -324,12 +324,12 @@ class TestHuggingFaceAPIGenerator:
     def test_live_run_streaming_check_completion_start_time(self):
         generator = HuggingFaceAPIGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "HuggingFaceTB/SmolLM2-1.7B-Instruct"},
-            generation_kwargs={"max_new_tokens": 20},
+            api_params={"model": "HuggingFaceH4/zephyr-7b-beta"},
+            generation_kwargs={"max_new_tokens": 30},
             streaming_callback=streaming_callback_handler,
         )
 
-        results = generator.run("What is the capital of France?")
+        results = generator.run("You are a helpful agent that answers questions. What is the capital of France?")
 
         assert len(results["replies"]) == 1
         assert "Paris" in results["replies"][0]

--- a/test/components/generators/test_hugging_face_api.py
+++ b/test/components/generators/test_hugging_face_api.py
@@ -315,6 +315,7 @@ class TestHuggingFaceAPIGenerator:
         assert len(response["meta"]) > 0
         assert [isinstance(meta, dict) for meta in response["meta"]]
 
+    @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.environ.get("HF_API_TOKEN", None),
@@ -323,7 +324,8 @@ class TestHuggingFaceAPIGenerator:
     def test_live_run_streaming_check_completion_start_time(self):
         generator = HuggingFaceAPIGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "HuggingFaceH4/zephyr-7b-beta"},
+            api_params={"model": "HuggingFaceTB/SmolLM2-1.7B-Instruct"},
+            generation_kwargs={"max_new_tokens": 20},
             streaming_callback=streaming_callback_handler,
         )
 

--- a/test/components/generators/test_hugging_face_api.py
+++ b/test/components/generators/test_hugging_face_api.py
@@ -291,7 +291,10 @@ class TestHuggingFaceAPIGenerator:
 
     @pytest.mark.flaky(reruns=5, reruns_delay=5)
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
     def test_run_serverless(self):
         generator = HuggingFaceAPIGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
@@ -313,7 +316,10 @@ class TestHuggingFaceAPIGenerator:
         assert [isinstance(meta, dict) for meta in response["meta"]]
 
     @pytest.mark.integration
-    @pytest.mark.skip(reason="Temporarily skipped due to limits on HF API requests.")
+    @pytest.mark.skipif(
+        not os.environ.get("HF_API_TOKEN", None),
+        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
+    )
     def test_live_run_streaming_check_completion_start_time(self):
         generator = HuggingFaceAPIGenerator(
             api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,


### PR DESCRIPTION
This reverts commit 56a3a9bd61b7391ae91e3d8179b3b33918ef4932.

### Related Issues

- fixes #8890 

### Proposed Changes:

I upgraded Haystack Bot to a PRO subscription on HuggingFace. It's token should now have a higher API limit, which is why we can re-enable the HF API live integration tests that were temporarily skipped.

### How did you test it?

CI, for example https://github.com/deepset-ai/haystack/actions/runs/13500630092/job/37718234502?pr=8914#step:8:98

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
