### PR TITLE
Avoid mutating self.routes in ConditionalRouter to_dict method

### DIFF
--- a/haystack/components/routers/conditional_router.py
+++ b/haystack/components/routers/conditional_router.py
@@ -241,13 +241,14 @@ class ConditionalRouter:
         :returns:
             Dictionary with serialized data.
         """
+        serialized_routes = []
         for route in self.routes:
             # output_type needs to be serialized to a string
-            route["output_type"] = serialize_type(route["output_type"])
+            serialized_routes.append({**route, "output_type": serialize_type(route["output_type"])})
         se_filters = {name: serialize_callable(filter_func) for name, filter_func in self.custom_filters.items()}
         return default_to_dict(
             self,
-            routes=self.routes,
+            routes=serialized_routes,
             custom_filters=se_filters,
             unsafe=self._unsafe,
             validate_output_type=self._validate_output_type,

--- a/releasenotes/notes/fix-conditional-router-to-dict-5af887da50effe11.yaml
+++ b/releasenotes/notes/fix-conditional-router-to-dict-5af887da50effe11.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug where the `output_type` of a `ConditionalRouter` was not being serialized correctly.
+    This would cause the router to not work correctly after being serialized and deserialized.

--- a/releasenotes/notes/fix-conditional-router-to-dict-5af887da50effe11.yaml
+++ b/releasenotes/notes/fix-conditional-router-to-dict-5af887da50effe11.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Fix a bug where the `output_type` of a `ConditionalRouter` was not being serialized correctly.
-    This would cause the router to not work correctly after being serialized and deserialized.
+    This would cause the router to work incorrectly after being serialized and deserialized.

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -542,3 +542,29 @@ class TestRouter:
         # Verify router still works normally
         result = router.run(question="What?", mode="chat")
         assert result == {"chat": "What?"}
+
+    def test_router_to_dict_does_not_mutate_routes(self):
+        routes = [
+            {"condition": "{{streams|length < 2}}", "output": "{{query}}", "output_type": str, "output_name": "query"}
+        ]
+
+        router = ConditionalRouter(routes)
+
+        # Store the original output_type before serializing
+        original_output_type = router.routes[0]["output_type"]
+        assert original_output_type is str
+
+        router_dict = router.to_dict()
+
+        # Verify that the original routes are not mutated
+        assert router.routes[0]["output_type"] is str
+        assert router.routes[0]["output_type"] is original_output_type
+
+        # Verify that the serialized output_type is a string
+        assert isinstance(router_dict["init_parameters"]["routes"][0]["output_type"], str), (
+            "Serialized output_type should be a string"
+        )
+
+        # Verify that the router still works correctly after to_dict()
+        result = router.run(streams=[1], query="test")
+        assert result == {"query": "test"}, "Router should still work correctly after to_dict()"

--- a/test/components/routers/test_conditional_router.py
+++ b/test/components/routers/test_conditional_router.py
@@ -568,3 +568,9 @@ class TestRouter:
         # Verify that the router still works correctly after to_dict()
         result = router.run(streams=[1], query="test")
         assert result == {"query": "test"}, "Router should still work correctly after to_dict()"
+
+        # Double check on another ConditionalRouter instance
+        new_router = ConditionalRouter.from_dict(router_dict)
+        assert new_router.routes == router.routes
+        assert new_router.routes[0]["output_type"] is str
+        assert new_router.routes[0]["output_type"] is original_output_type


### PR DESCRIPTION
### Related Issues

- fixes #8904 

### Proposed Changes:

This PR includes changes to ensure that the `to_dict` method in the `ConditionalRouter` class does not mutate the original `routes` and adds a corresponding test to verify this behavior.

### How did you test it?

unit tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
