### PR TITLE
test: remove duplicate test on OpenAIChatGenerator

### DIFF
--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -151,23 +151,6 @@ class TestOpenAIChatGenerator:
         assert component.client.timeout == 100.0
         assert component.client.max_retries == 10
 
-    def test_init_should_also_create_async_client_with_same_args(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
-        component = OpenAIChatGenerator(
-            api_key=Secret.from_token("test-api-key"),
-            api_base_url="test-base-url",
-            organization="test-organization",
-            timeout=30,
-            max_retries=5,
-        )
-
-        assert isinstance(component.async_client, AsyncOpenAI)
-        assert component.async_client.api_key == "test-api-key"
-        assert component.async_client.organization == "test-organization"
-        assert component.async_client.base_url == "test-base-url/"
-        assert component.async_client.timeout == 30
-        assert component.async_client.max_retries == 5
-
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = OpenAIChatGenerator()


### PR DESCRIPTION
### Proposed Changes:

Test `test_init_should_also_create_async_client_with_same_args` was present both in `test_openai.py` and `test_openai_async.py`.

### How did you test it?

CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
