### PR TITLE
chore: update EvalRunResult deprecation warning to 2.12

### DIFF
--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -223,21 +223,21 @@ class EvaluationRunResult:
 
     def score_report(self) -> "DataFrame":
         """Generates a DataFrame report with aggregated scores for each metric."""
-        msg = "The `score_report` method is deprecated and will be changed to `aggregated_report` in Haystack 2.12.0."
+        msg = "The `score_report` method is deprecated and will be removed in Haystack 2.12.0. Use `aggregated_report` instead."
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.aggregated_report(output_format="df")
 
     def to_pandas(self) -> "DataFrame":
         """Generates a DataFrame report with detailed scores for each metric."""
-        msg = "The `to_pandas` method is deprecated and will be changed to `detailed_report` in Haystack 2.12.0."
+        msg = "The `to_pandas` method is deprecated and will be removed in Haystack 2.12.0. Use `detailed_report` instead."
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.detailed_report(output_format="df")
 
     def comparative_individual_scores_report(self, other: "EvaluationRunResult") -> "DataFrame":
         """Generates a DataFrame report with detailed scores for each metric from two evaluation runs for comparison."""
         msg = (
-            "The `comparative_individual_scores_report` method is deprecated and will be changed to "
-            "`comparative_detailed_report` in Haystack 2.12.0."
+            "The `comparative_individual_scores_report` method is deprecated will be removed in Haystack 2.12.0. "
+            "Use `comparative_detailed_report` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.comparative_detailed_report(other, output_format="df")

--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -223,13 +223,13 @@ class EvaluationRunResult:
 
     def score_report(self) -> "DataFrame":
         """Generates a DataFrame report with aggregated scores for each metric."""
-        msg = "The `score_report` method is deprecated and will be changed to `aggregated_report` in Haystack 2.11.0."
+        msg = "The `score_report` method is deprecated and will be changed to `aggregated_report` in Haystack 2.12.0."
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.aggregated_report(output_format="df")
 
     def to_pandas(self) -> "DataFrame":
         """Generates a DataFrame report with detailed scores for each metric."""
-        msg = "The `to_pandas` method is deprecated and will be changed to `detailed_report` in Haystack 2.11.0."
+        msg = "The `to_pandas` method is deprecated and will be changed to `detailed_report` in Haystack 2.12.0."
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.detailed_report(output_format="df")
 
@@ -237,7 +237,7 @@ class EvaluationRunResult:
         """Generates a DataFrame report with detailed scores for each metric from two evaluation runs for comparison."""
         msg = (
             "The `comparative_individual_scores_report` method is deprecated and will be changed to "
-            "`comparative_detailed_report` in Haystack 2.11.0."
+            "`comparative_detailed_report` in Haystack 2.12.0."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.comparative_detailed_report(other, output_format="df")

--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -223,21 +223,27 @@ class EvaluationRunResult:
 
     def score_report(self) -> "DataFrame":
         """Generates a DataFrame report with aggregated scores for each metric."""
-        msg = "The `score_report` method is deprecated and will be removed in Haystack 2.12.0. Use `aggregated_report` instead."
+        msg = (
+            "The `score_report` method is deprecated and will be removed in Haystack 2.12.0. Use "
+            "`aggregated_report` instead."
+        )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.aggregated_report(output_format="df")
 
     def to_pandas(self) -> "DataFrame":
         """Generates a DataFrame report with detailed scores for each metric."""
-        msg = "The `to_pandas` method is deprecated and will be removed in Haystack 2.12.0. Use `detailed_report` instead."
+        msg = (
+            "The `to_pandas` method is deprecated and will be removed in Haystack 2.12.0. Use `detailed_report` "
+            "instead."
+        )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.detailed_report(output_format="df")
 
     def comparative_individual_scores_report(self, other: "EvaluationRunResult") -> "DataFrame":
         """Generates a DataFrame report with detailed scores for each metric from two evaluation runs for comparison."""
         msg = (
-            "The `comparative_individual_scores_report` method is deprecated will be removed in Haystack 2.12.0. "
-            "Use `comparative_detailed_report` instead."
+            "The `comparative_individual_scores_report` method is deprecated will be removed in Haystack 2.12.0. Use "
+            "`comparative_detailed_report` instead."
         )
         warn(msg, DeprecationWarning, stacklevel=2)
         return self.comparative_detailed_report(other, output_format="df")


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack/issues/8955

### Proposed Changes:

- Update the DeprecationWarning to warn about the removal of the deprecated methods in 2.12 because the warning was not part of the 2.10 release as Stefano pointed out: https://github.com/deepset-ai/haystack/blob/v2.10.x/haystack/evaluation/eval_run_result.py

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
