### PR TITLE
chore: make `openapi-llm` an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ extra-dependencies = [
   "openapi3",
   "openapi-llm>=0.4.1",   # OpenAPIConnector
 
-
   # Tracing
   "opentelemetry-sdk",
   "ddtrace",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "numpy",
   "python-dateutil",
   "jsonschema",             # JsonSchemaValidator, Tool
-  "openapi-llm>=0.4.1",            # OpenAPIConnector
   "haystack-experimental",
 ]
 
@@ -119,8 +118,10 @@ extra-dependencies = [
   "nltk>=3.9.1", # NLTKDocumentSplitter
 
   # OpenAPI
-  "jsonref",  # OpenAPIServiceConnector, OpenAPIServiceToFunctions
+  "jsonref",              # OpenAPIServiceConnector, OpenAPIServiceToFunctions
   "openapi3",
+  "openapi-llm>=0.4.1",   # OpenAPIConnector
+
 
   # Tracing
   "opentelemetry-sdk",


### PR DESCRIPTION
### Related Issues

`openapi-llm` dependency was introduced in https://github.com/deepset-ai/haystack/pull/8808.
Probably due to an oversight, it was introduced as a required dependency instead of an optional one.


### Proposed Changes:
- Make `openapi-llm` an optional dependency

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
