### PR TITLE
feat: Add async run to DocumentWriter

### DIFF
--- a/releasenotes/notes/async-document-writer-9458ced66c1c38c7.yaml
+++ b/releasenotes/notes/async-document-writer-9458ced66c1c38c7.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add `run_async` method to `DocumentWriter`. This method supports the same parameters as
+    the `run` method and relies on the DocumentStore to implement `write_documents_async`.
+    It returns a coroutine that can be awaited.

--- a/test/components/writers/test_document_writer.py
+++ b/test/components/writers/test_document_writer.py
@@ -92,3 +92,43 @@ class TestDocumentWriter:
 
         result = writer.run(documents=documents)
         assert result["documents_written"] == 0
+
+    @pytest.mark.asyncio
+    async def test_run_async_invalid_docstore(self):
+        document_store = document_store_class("MockedDocumentStore")
+
+        writer = DocumentWriter(document_store)
+        documents = [
+            Document(content="This is the text of a document."),
+            Document(content="This is the text of another document."),
+        ]
+
+        with pytest.raises(TypeError, match="does not provide async support"):
+            await writer.run_async(documents=documents)
+
+    @pytest.mark.asyncio
+    async def test_run_async(self):
+        document_store = InMemoryDocumentStore()
+        writer = DocumentWriter(document_store)
+        documents = [
+            Document(content="This is the text of a document."),
+            Document(content="This is the text of another document."),
+        ]
+
+        result = await writer.run_async(documents=documents)
+        assert result["documents_written"] == 2
+
+    @pytest.mark.asyncio
+    async def test_run_async_skip_policy(self):
+        document_store = InMemoryDocumentStore()
+        writer = DocumentWriter(document_store, policy=DuplicatePolicy.SKIP)
+        documents = [
+            Document(content="This is the text of a document."),
+            Document(content="This is the text of another document."),
+        ]
+
+        result = await writer.run_async(documents=documents)
+        assert result["documents_written"] == 2
+
+        result = await writer.run_async(documents=documents)
+        assert result["documents_written"] == 0


### PR DESCRIPTION
### Related Issues

- fixes #8961 

### Proposed Changes:

- Add run_async implementation to DocumentWriter from haystack-experimental including tests. Compared to the implementation in haystack-experimental I only changed docstrings.

### How did you test it?

Tests require an InMemoryDocumentStore with write_documents_async to pass. Open issue: https://github.com/deepset-ai/haystack/issues/8960

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
