### PR TITLE
build: support python 3.13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,8 @@ next contribution!
 
 ### Setting up your development environment
 
+*Currently, to contribute to Haystack, you must use a version of Python >=3.9 and <3.13.*
+
 Haystack makes heavy use of [Hatch](https://hatch.pypa.io/latest/), a Python project manager that we use to set up the
 virtual environments, build the project, and publish packages. As you can imagine, the first step towards becoming a
 Haystack contributor is installing Hatch. There are a variety of installation methods depending on your operating system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,9 @@ next contribution!
 
 ### Setting up your development environment
 
-*Currently, to contribute to Haystack, you must use a version of Python >=3.9 and <3.13.*
+*To run Haystack tests locally, ensure your development environment uses Python >=3.9 and <3.13.*
+Some optional dependencies are not yet compatible with Python 3.13
+(see [this PR](https://github.com/deepset-ai/haystack/pull/8965) for details).
 
 Haystack makes heavy use of [Hatch](https://hatch.pypa.io/latest/), a Python project manager that we use to set up the
 virtual environments, build the project, and publish packages. As you can imagine, the first step towards becoming a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LLM framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pipelines or agents that can interact with your data."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8"
 authors = [{ name = "deepset.ai", email = "malte.pietsch@deepset.ai" }]
 keywords = [
   "BERT",
@@ -39,6 +39,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [

--- a/releasenotes/notes/python-3.13-support-68d6f52887611eac.yaml
+++ b/releasenotes/notes/python-3.13-support-68d6f52887611eac.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Haystack now officially supports Python 3.13.
+    Some components and integrations may not yet be compatible.
+    Specifically, the `NamedEntityExtractor` does not work with Python 3.13 when using the `spacy` backend.
+    Additionally, you may encounter issues installing `openai-whisper`, which is required by the
+    `LocalWhisperTranscriber` component, if you use `uv` or `poetry` for installation.
+    In this case, we recommend using `pip` for installation.


### PR DESCRIPTION
### Related Issues

- fixes #8825

I experimented with Python 3.13 locally (Ubuntu) and in a draft PR (https://github.com/deepset-ai/haystack/pull/8959; Ubuntu, MacOs, Windows).

**What I found**
- our core dependencies work well with Python 3.13 except for Spacy (and, to some extent, Whisper).
- Spacy (used in the `NamedEntityExtractor`) is not yet compatible: https://github.com/explosion/spaCy/issues/13658.
- Whisper has some installation issues with `uv` (but works with `pip`): https://github.com/astral-sh/uv/issues/6852
- **Contributors** using Python 3.13 will encounter errors when installing test dependencies due to Spacy and Whisper.
- In my opinion, this shouldn't prevent **final users** from using Python 3.13.

### Proposed Changes:
- support Python 3.13 and communicate it

### How did you test it?
CI; if you are curious, check also tests in https://github.com/deepset-ai/haystack/pull/8959.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
