### PR TITLE
ci: apply explicit `timeout` to Datadog actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
         api-url: https://api.datadoghq.eu
+        timeout: 30000
         events: |
           - title: "${{ github.workflow }} workflow"
             text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           api-key: ${{ env.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.job }} in ${{ github.workflow }} workflow"
               text: "License compliance check: direct dependencies only."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
@@ -119,6 +120,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
@@ -192,6 +194,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
@@ -270,6 +273,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
@@ -338,6 +342,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
@@ -403,6 +408,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"
@@ -461,6 +467,7 @@ jobs:
         with:
           api-key: ${{ secrets.CORE_DATADOG_API_KEY }}
           api-url: https://api.datadoghq.eu
+          timeout: 30000
           events: |
             - title: "${{ github.workflow }} workflow"
               text: "Job ${{ github.job }} in branch ${{ github.ref_name }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
+# trigger
+
 [project]
 name = "haystack-ai"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
 
-# trigger
-
 [project]
 name = "haystack-ai"
 dynamic = ["version"]


### PR DESCRIPTION
### Related Issues
[Some workflows are failing in PRs](https://github.com/deepset-ai/haystack/actions/runs/13658319778/job/38183109511?pr=8965).
This happens because a [new version of the Datadog action](https://github.com/masci/datadog/releases/tag/v1.9.0) was released, with an extremely low default timeout (30milliseconds instead of 30 seconds).

### Proposed Changes:
- apply an explicit timeout of 30 seconds to Datadog actions

### How did you test it?
CI: compare this [workflow](https://github.com/deepset-ai/haystack/actions/runs/13658602930/job/38184082285) with the failing one above.
e2e tests are failing for unrelated reasons.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
