### PR TITLE
fix: add chat message name field

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -371,6 +371,10 @@ class ChatMessage:
 
         openai_msg: Dict[str, Any] = {"role": self._role.value}
 
+        # Add name field if present
+        if self._name is not None:
+            openai_msg["name"] = self._name
+
         if tool_call_results:
             result = tool_call_results[0]
             if result.origin.id is None:

--- a/test/dataclasses/test_chat_message.py
+++ b/test/dataclasses/test_chat_message.py
@@ -257,6 +257,12 @@ def test_to_openai_dict_format():
     )
     assert message.to_openai_dict_format() == {"role": "tool", "content": tool_result, "tool_call_id": "123"}
 
+    message = ChatMessage.from_user(text="I have a question", name="John")
+    assert message.to_openai_dict_format() == {"role": "user", "content": "I have a question", "name": "John"}
+
+    message = ChatMessage.from_assistant(text="I have an answer", name="Assistant1")
+    assert message.to_openai_dict_format() == {"role": "assistant", "content": "I have an answer", "name": "Assistant1"}
+
 
 def test_to_openai_dict_format_invalid():
     message = ChatMessage(_role=ChatRole.ASSISTANT, _content=[])


### PR DESCRIPTION
### Related Issues

- fixes #8964 

### Proposed Changes:

- Include name field in OpenAI dictionary format when present 
- Aligns with OpenAI's chat API format
 <!--- In case of a feature: Describe what did you add and how it works -->

### How did you test it?

-  unit tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
