### PR TITLE
build: drop Python 3.8 support

### DIFF
--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -4,14 +4,13 @@
 
 import ast
 import contextlib
-from typing import Any, Callable, Dict, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set, TypeAlias
 from warnings import warn
 
 import jinja2.runtime
 from jinja2 import Environment, TemplateSyntaxError, meta
 from jinja2.nativetypes import NativeEnvironment
 from jinja2.sandbox import SandboxedEnvironment
-from typing_extensions import TypeAlias
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import deserialize_callable, deserialize_type, serialize_callable, serialize_type

--- a/haystack/components/converters/output_adapter.py
+++ b/haystack/components/converters/output_adapter.py
@@ -4,13 +4,14 @@
 
 import ast
 import contextlib
-from typing import Any, Callable, Dict, Optional, Set, TypeAlias
+from typing import Any, Callable, Dict, Optional, Set
 from warnings import warn
 
 import jinja2.runtime
 from jinja2 import Environment, TemplateSyntaxError, meta
 from jinja2.nativetypes import NativeEnvironment
 from jinja2.sandbox import SandboxedEnvironment
+from typing_extensions import TypeAlias
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import deserialize_callable, deserialize_type, serialize_callable, serialize_type

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -70,7 +70,6 @@ method decorated with `@component.input`. This dataclass contains:
 """
 
 import inspect
-import sys
 from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -157,11 +157,7 @@ class Component(Protocol):
     # arguments. Even defining here a method with `**kwargs` doesn't work as the
     # expected signature must be identical.
     # This makes most Language Servers and type checkers happy and shows less errors.
-    # NOTE: This check can be removed when we drop Python 3.8 support.
-    if sys.version_info >= (3, 9):
-        run: Callable[..., Dict[str, Any]]
-    else:
-        run: Callable
+    run: Callable[..., Dict[str, Any]]
 
 
 class ComponentMeta(type):

--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field
-from typing import Any, Iterable, List, Type, TypeVar, get_args
-
-from typing_extensions import Annotated, TypeAlias  # Python 3.8 compatibility
+from typing import Annotated, Any, Iterable, List, Type, TypeAlias, TypeVar, get_args
 
 HAYSTACK_VARIADIC_ANNOTATION = "__haystack__variadic_t"
 HAYSTACK_GREEDY_VARIADIC_ANNOTATION = "__haystack__greedy_variadic_t"

--- a/haystack/core/component/types.py
+++ b/haystack/core/component/types.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Iterable, List, Type, TypeAlias, TypeVar, get_args
+from typing import Annotated, Any, Iterable, List, Type, TypeVar, get_args
+
+from typing_extensions import TypeAlias  # Python 3.9 compatibility
 
 HAYSTACK_VARIADIC_ANNOTATION = "__haystack__variadic_t"
 HAYSTACK_GREEDY_VARIADIC_ANNOTATION = "__haystack__greedy_variadic_t"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,6 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
 exclude = [".github", "proposals"]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
   "pyyaml",
   "more-itertools",         # TextDocumentSplitter
   "networkx",               # Pipeline graphs
+  "typing_extensions>=4.7", # typing support for Python 3.9
   "requests",
   "numpy",
   "python-dateutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LLM framework to build customizable, production-ready LLM applications. Connect components (models, vector DBs, file converters) to pipelines or agents that can interact with your data."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [{ name = "deepset.ai", email = "malte.pietsch@deepset.ai" }]
 keywords = [
   "BERT",
@@ -34,7 +34,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -53,7 +52,6 @@ dependencies = [
   "pyyaml",
   "more-itertools",         # TextDocumentSplitter
   "networkx",               # Pipeline graphs
-  "typing_extensions>=4.7", # typing support for Python 3.8
   "requests",
   "numpy",
   "python-dateutil",
@@ -289,7 +287,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 exclude = [".github", "proposals"]
 
 [tool.ruff.format]

--- a/releasenotes/notes/drop-python-3.8-868710963e794c83.yaml
+++ b/releasenotes/notes/drop-python-3.8-868710963e794c83.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Starting from Haystack 2.11.0, Python 3.8 is no longer supported.
+    Python 3.8 reached its end of life on October 2024.

--- a/releasenotes/notes/drop-python-3.8-868710963e794c83.yaml
+++ b/releasenotes/notes/drop-python-3.8-868710963e794c83.yaml
@@ -1,5 +1,5 @@
 ---
 upgrade:
   - |
-    Starting from Haystack 2.11.0, Python 3.8 is no longer supported.
+    Starting from Haystack 2.11.0 Python 3.8 is no longer supported.
     Python 3.8 reached its end of life on October 2024.

--- a/test/components/converters/test_markdown_to_document.py
+++ b/test/components/converters/test_markdown_to_document.py
@@ -54,8 +54,9 @@ class TestMarkdownToDocument:
 
         converter = MarkdownToDocument()
 
-        with patch("haystack.components.converters.markdown.normalize_metadata") as normalize_metadata, patch(
-            "haystack.components.converters.markdown.MarkdownIt"
+        with (
+            patch("haystack.components.converters.markdown.normalize_metadata") as normalize_metadata,
+            patch("haystack.components.converters.markdown.MarkdownIt"),
         ):
             converter.run(sources=[bytestream, test_files_path / "markdown" / "sample.md"], meta={"language": "it"})
 

--- a/test/core/component/test_component.py
+++ b/test/core/component/test_component.py
@@ -496,8 +496,9 @@ def test_pre_init_hooking_variadic_positional_args():
     assert c.kwarg1 is None
     assert c.kwarg2 == "string"
 
-    with pytest.raises(ComponentError), _hook_component_init(
-        partial(pre_init_hook, expected_params={"args": (1, 2), "kwarg1": None})
+    with (
+        pytest.raises(ComponentError),
+        _hook_component_init(partial(pre_init_hook, expected_params={"args": (1, 2), "kwarg1": None})),
     ):
         _ = MockComponent(1, 2, kwarg1=None)
 

--- a/test/tools/test_from_function.py
+++ b/test/tools/test_from_function.py
@@ -2,12 +2,7 @@ import pytest
 
 from haystack.tools.from_function import create_tool_from_function, _remove_title_from_schema, tool
 from haystack.tools.errors import SchemaGenerationError
-from typing import Literal, Optional
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
+from typing import Annotated, Literal, Optional
 
 
 def function_with_docstring(city: str) -> str:


### PR DESCRIPTION
### Related Issues

- fixes #8894

### Proposed Changes:
- drop support for Python 3.8

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
