### PR TITLE
ci: improve release notes format checking

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -13,6 +13,7 @@ on:
       - "**.py"
       - "pyproject.toml"
       - "!.github/**/*.py"
+      - "releasenotes/notes/*.yaml"
 
 jobs:
   reno:

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -45,4 +45,5 @@ jobs:
       - name: Verify release notes formatting
         if: steps.changed-files.outputs.any_changed == 'true' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
         run: |
-          yamllint -d "{extends: default, rules: {line-length: {max: 1200}}}" ${{ steps.changed-files.outputs.all_changed_files }}
+          pip install "reno<5"
+          reno lint .

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -47,4 +47,4 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true' && !contains( github.event.pull_request.labels.*.name, 'ignore-for-release-notes')
         run: |
           pip install "reno<5"
-          reno lint .
+          reno lint .  # it is not possible to pass a list of files to reno lint

--- a/.github/workflows/release_notes_skipper.yml
+++ b/.github/workflows/release_notes_skipper.yml
@@ -13,6 +13,7 @@ on:
       - "**.py"
       - "pyproject.toml"
       - "!.github/**/*.py"
+      - "releasenotes/notes/*.yaml"
 
 jobs:
   reno:

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -37,7 +37,7 @@ template: |
       Add normal bug fixes here, or remove this section.
 
 sections:
-  # The prelude section is implicitly included.
+  # The highlights section is implicitly included.
   - [upgrade, Upgrade Notes]
   - [features, New Features]
   - [enhancements, Enhancement Notes]
@@ -45,3 +45,6 @@ sections:
   - [deprecations, Deprecation Notes]
   - [security, Security Notes]
   - [fixes, Bug Fixes]
+  # DO NOT REMOVE. The following sections are no longer used, but were used in the past. Keeping them here avoids reno linting errors.
+  - [prelude, prelude]
+  - [preview, preview]

--- a/releasenotes/notes/add-batch_size_faiss_init-5e97c1fb9409f873.yaml
+++ b/releasenotes/notes/add-batch_size_faiss_init-5e97c1fb9409f873.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-  Add batch_size to the __init__ method of FAISS Document Store. This works as the default value for all methods of
-  FAISS Document Store that support batch_size.
+    Add batch_size to the __init__ method of FAISS Document Store. This works as the default value for all methods of
+    FAISS Document Store that support batch_size.

--- a/releasenotes/notes/run-async-azure-54450f0c2495f5c8.yaml
+++ b/releasenotes/notes/run-async-azure-54450f0c2495f5c8.yaml
@@ -1,5 +1,4 @@
 ---
----
 features:
   - |
     Add `run_async` method to `AzureOpenAIChatGenerator`. This method uses `AsyncAzureOpenAI`


### PR DESCRIPTION
### Related Issues

While releasing 2.11.0, an incorrectly formatted release note caused errors.
Currently, our release notes linting is based on `yamllint`, which is too permissive and does not check reno format.

### Proposed Changes:
- use [`reno lint`](https://docs.openstack.org/reno/latest/user/usage.html#checking-notes)
- fix incorrect release notes

### How did you test it?
CI; problematic release notes were found -> https://github.com/deepset-ai/haystack/actions/runs/13680619540/job/38251779192

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
