### PR TITLE
Add MCPTool

### DIFF
--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -8,6 +8,16 @@
 from .from_function import create_tool_from_function, tool
 from .tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from .component_tool import ComponentTool
+from .mcp_tool import (
+    MCPTool,
+    MCPError,
+    MCPConnectionError,
+    MCPToolNotFoundError,
+    MCPInvocationError,
+    MCPServerInfo,
+    HttpMCPServerInfo,
+    StdioMCPServerInfo,
+)
 
 
 __all__ = [
@@ -17,4 +27,12 @@ __all__ = [
     "create_tool_from_function",
     "tool",
     "ComponentTool",
+    "MCPTool",
+    "MCPError",
+    "MCPConnectionError",
+    "MCPToolNotFoundError",
+    "MCPInvocationError",
+    "MCPServerInfo",
+    "HttpMCPServerInfo",
+    "StdioMCPServerInfo",
 ]

--- a/haystack/tools/mcp_tool.py
+++ b/haystack/tools/mcp_tool.py
@@ -343,6 +343,7 @@ class MCPTool(Tool):
 
         # Store connection parameters for serialization
         self._server_info = server_info
+        client = None
 
         # Initialize the connection
         try:
@@ -376,7 +377,8 @@ class MCPTool(Tool):
             )
 
         except Exception as e:
-            self._run_sync(client.close())
+            if client is not None:
+                self._run_sync(client.close())
             raise MCPError(f"Failed to initialize MCPTool: {e}") from e
 
     def _invoke_tool(self, **kwargs: Any) -> Any:

--- a/haystack/tools/mcp_tool.py
+++ b/haystack/tools/mcp_tool.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import os
+from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, fields
+from typing import Any, Coroutine, Dict, List, Optional, Tuple
+
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp import ClientSession, types
+from mcp.client.sse import sse_client
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from haystack import logging
+from haystack.core.serialization import generate_qualified_class_name, import_class_by_name
+from haystack.tools import Tool
+from haystack.tools.errors import ToolInvocationError
+
+logger = logging.getLogger(__name__)
+
+
+class MCPError(Exception):
+    """Base class for MCP-related errors."""
+
+    pass
+
+
+class MCPConnectionError(MCPError):
+    """Error connecting to MCP server."""
+
+    pass
+
+
+class MCPToolNotFoundError(MCPError):
+    """Error when a tool is not found on the server."""
+
+    pass
+
+
+class MCPInvocationError(ToolInvocationError):
+    """Error during tool invocation."""
+
+    pass
+
+
+class MCPClient(ABC):
+    """
+    Abstract base class for MCP clients.
+
+    This class defines the common interface and shared functionality for all MCP clients,
+    regardless of the transport mechanism used.
+    """
+
+    def __init__(self) -> None:
+        self.session: Optional[ClientSession] = None
+        self.exit_stack: AsyncExitStack = AsyncExitStack()
+        self.stdio: Optional[MemoryObjectReceiveStream[types.JSONRPCMessage | Exception]] = None
+        self.write: Optional[MemoryObjectSendStream[types.JSONRPCMessage]] = None
+
+    @abstractmethod
+    async def connect(self) -> List[types.Tool]:
+        """
+        Connect to an MCP server.
+
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        pass
+
+    async def call_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
+        """
+        Call a tool on the connected MCP server.
+
+        :param tool_name: Name of the tool to call
+        :param tool_args: Arguments to pass to the tool
+        :returns: Result of the tool invocation
+        :raises MCPError: If not connected to an MCP server
+        :raises MCPInvocationError: If tool invocation fails
+        """
+        if not self.session:
+            raise MCPError("Not connected to an MCP server")
+
+        try:
+            result = await self.session.call_tool(tool_name, tool_args)
+            return result
+        except Exception as e:
+            raise MCPInvocationError(f"Failed to invoke tool '{tool_name}'") from e
+
+    async def close(self) -> None:
+        """
+        Close the connection and clean up resources.
+        """
+        try:
+            await self.exit_stack.aclose()
+            self.session = None
+            self.stdio = None
+            self.write = None
+        except Exception:
+            # Best effort cleanup
+            pass
+
+    async def _initialize_session_with_transport(
+        self,
+        transport_tuple: Tuple[
+            MemoryObjectReceiveStream[types.JSONRPCMessage | Exception], MemoryObjectSendStream[types.JSONRPCMessage]
+        ],
+        connection_type: str,
+    ) -> List[types.Tool]:
+        """
+        Common session initialization logic for all transports.
+
+        :param transport_tuple: Tuple containing (stdio, write) from the transport
+        :param connection_type: String describing the connection type for error messages
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        try:
+            self.stdio, self.write = transport_tuple
+            self.session = await self.exit_stack.enter_async_context(ClientSession(self.stdio, self.write))
+
+            await self.session.initialize()
+
+            # List available tools
+            response = await self.session.list_tools()
+            return response.tools
+
+        except Exception as e:
+            await self.close()
+            raise MCPConnectionError(f"Failed to connect to {connection_type}: {e}") from e
+
+
+class StdioMCPClient(MCPClient):
+    """
+    MCP client that connects to servers using stdio transport.
+    """
+
+    def __init__(self, command: str, args: Optional[List[str]] = None, env: Optional[Dict[str, str]] = None) -> None:
+        """
+        Initialize a stdio MCP client.
+
+        :param command: Command to run (e.g., "python", "node")
+        :param args: Arguments to pass to the command
+        :param env: Environment variables for the command
+        """
+        super().__init__()
+        self.command: str = command
+        self.args: List[str] = args or []
+        self.env: Optional[Dict[str, str]] = env
+
+    async def connect(self) -> List[types.Tool]:
+        """
+        Connect to an MCP server using stdio transport.
+
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
+        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
+        return await self._initialize_session_with_transport(stdio_transport, f"stdio server (command: {self.command})")
+
+
+class HttpMCPClient(MCPClient):
+    """
+    MCP client that connects to servers using HTTP transport.
+    """
+
+    def __init__(self, base_url: str, token: Optional[str] = None, timeout: int = 5) -> None:
+        """
+        Initialize an HTTP MCP client.
+
+        :param base_url: Base URL of the server
+        :param token: Authentication token for the server (optional)
+        :param timeout: Connection timeout in seconds
+        """
+        super().__init__()
+        self.base_url: str = base_url.rstrip("/")  # Remove any trailing slashes
+        self.token: Optional[str] = token
+        self.timeout: int = timeout
+
+    async def connect(self) -> List[types.Tool]:
+        """
+        Connect to an MCP server using HTTP transport.
+
+        :returns: List of available tools on the server
+        :raises MCPConnectionError: If connection to the server fails
+        """
+        sse_url = f"{self.base_url}/sse"
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else None
+        sse_transport = await self.exit_stack.enter_async_context(
+            sse_client(sse_url, headers=headers, timeout=self.timeout)
+        )
+        return await self._initialize_session_with_transport(sse_transport, f"HTTP server at {self.base_url}")
+
+
+@dataclass
+class MCPServerInfo(ABC):
+    """
+    Abstract base class for MCP server connection parameters.
+
+    This class defines the common interface for all MCP server connection types.
+    """
+
+    @abstractmethod
+    def create_client(self) -> MCPClient:
+        """
+        Create an appropriate MCP client for this server info.
+
+        :returns: An instance of MCPClient configured with this server info
+        """
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this server info to a dictionary.
+
+        :returns: Dictionary representation of this server info
+        """
+        # Store the fully qualified class name for deserialization
+        result = {"type": generate_qualified_class_name(type(self))}
+
+        # Add all fields from the dataclass
+        for field in fields(self):
+            result[field.name] = getattr(self, field.name)
+
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MCPServerInfo":
+        """
+        Deserialize server info from a dictionary.
+
+        :param data: Dictionary containing serialized server info
+        :returns: Instance of the appropriate server info class
+        """
+        # Remove the type field as it's not a constructor parameter
+        data_copy = data.copy()
+        data_copy.pop("type", None)
+
+        # Create an instance of the class with the remaining fields
+        return cls(**data_copy)
+
+
+@dataclass
+class HttpMCPServerInfo(MCPServerInfo):
+    """
+    Data class that encapsulates HTTP MCP server connection parameters.
+
+    :param base_url: Base URL of the MCP server
+    :param token: Authentication token for the server (optional)
+    :param timeout: Connection timeout in seconds
+    """
+
+    base_url: str
+    token: Optional[str] = None
+    timeout: int = 30
+
+    def create_client(self) -> MCPClient:
+        """
+        Create an HTTP MCP client.
+
+        :returns: Configured HttpMCPClient instance
+        """
+        return HttpMCPClient(self.base_url, self.token, self.timeout)
+
+
+@dataclass
+class StdioMCPServerInfo(MCPServerInfo):
+    """
+    Data class that encapsulates stdio MCP server connection parameters.
+
+    :param command: Command to run (e.g., "python", "node")
+    :param args: Arguments to pass to the command
+    :param env: Environment variables for the command
+    """
+
+    command: str
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
+
+    def create_client(self) -> MCPClient:
+        """
+        Create a stdio MCP client.
+
+        :returns: Configured StdioMCPClient instance
+        """
+        return StdioMCPClient(self.command, self.args, self.env)
+
+
+class MCPTool(Tool):
+    """
+    A Tool that represents a single tool from an MCP server.
+
+    This implementation uses the official MCP SDK for protocol handling while maintaining
+    compatibility with the Haystack tool ecosystem.
+
+    Example using HTTP:
+    ```python
+    from haystack.tools import MCPTool, HttpMCPServerInfo
+
+    # Create tool instance
+    tool = MCPTool(
+        name="add",
+        server_info=HttpMCPServerInfo(base_url="http://localhost:8000")
+    )
+
+    # Use the tool
+    result = tool.invoke(a=5, b=3)
+    ```
+
+    Example using stdio:
+    ```python
+    from haystack.tools import MCPTool, StdioMCPServerInfo
+
+    # Create tool instance
+    tool = MCPTool(
+        name="get_current_time",
+        server_info=StdioMCPServerInfo(command="python", args=["path/to/server.py"])
+    )
+
+    # Use the tool
+    result = tool.invoke(timezone="America/New_York")
+    ```
+    """
+
+    # Shared thread pool with optimal sizing
+    _executor = ThreadPoolExecutor(max_workers=min(32, (os.cpu_count() or 1) + 4))
+    _loop_policy = None
+
+    def __init__(self, name: str, server_info: MCPServerInfo, description: Optional[str] = None):
+        """
+        Initialize the MCP tool.
+
+        :param name: Name of the tool to use
+        :param server_info: Server connection information
+        :param description: Custom description (if None, server description will be used)
+        :raises MCPConnectionError: If connection to the server fails
+        :raises MCPToolNotFoundError: If no tools are available or the requested tool is not found
+        """
+
+        # Store connection parameters for serialization
+        self._server_info = server_info
+
+        # Initialize the connection
+        try:
+            # Create the appropriate client using the factory method
+            client = server_info.create_client()
+
+            # Connect and get available tools
+            tools = self._run_sync(client.connect())
+
+            # Handle no tools case
+            if not tools:
+                raise MCPToolNotFoundError("No tools available on server")
+
+            # Find the specified tool
+            tool_info = next((t for t in tools if t.name == name), None)
+            if not tool_info:
+                raise MCPToolNotFoundError(f"Tool '{name}' not found on server")
+
+            # Store the client for later use
+            self._client = client
+
+            # Initialize the parent class with the final values
+            logger.debug(f"Initializing MCPTool with name: {name}")
+
+            # Hook into the Tool base class
+            super().__init__(
+                name=name,
+                description=description or tool_info.description,
+                parameters=tool_info.inputSchema,
+                function=self._invoke_tool,
+            )
+
+        except Exception as e:
+            self._run_sync(client.close())
+            raise MCPError(f"Failed to initialize MCPTool: {e}") from e
+
+    def _invoke_tool(self, **kwargs: Any) -> Any:
+        """
+        Synchronous tool invocation.
+
+        This method is called by the Tool base class's invoke() method.
+
+        :param kwargs: Arguments to pass to the tool
+        :returns: Result of the tool invocation
+        :raises: Any exception that might occur during tool invocation
+        """
+        try:
+            return self._run_sync(self._client.call_tool(self.name, kwargs))
+        except Exception:
+            # Preserve the original exception
+            raise
+
+    async def ainvoke(self, **kwargs: Any) -> Any:
+        """
+        Asynchronous tool invocation.
+
+        :param kwargs: Arguments to pass to the tool
+        :returns: Result of the tool invocation
+        :raises: Any exception that might occur during tool invocation
+        """
+        return await self._client.call_tool(self.name, kwargs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the MCPTool to a dictionary.
+
+        Note: The active connection is not serialized. A new connection will need to be
+        established when deserializing.
+        """
+        return {
+            "type": generate_qualified_class_name(type(self)),
+            "data": {"name": self.name, "description": self.description, "server_info": self._server_info.to_dict()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Tool":
+        """
+        Deserializes the MCPTool from a dictionary.
+
+        Note: This will establish a new connection to the MCP server.
+        """
+        inner_data = data["data"]
+        server_info_dict = inner_data.get("server_info", {})
+
+        # Import the server info class by name
+        server_info_class = import_class_by_name(server_info_dict["type"])
+
+        # Create an instance of the server info class
+        server_info = server_info_class.from_dict(server_info_dict)
+
+        return cls(name=inner_data["name"], description=inner_data.get("description"), server_info=server_info)
+
+    @classmethod
+    def _get_loop_policy(cls):
+        """
+        Get the event loop policy with caching for better performance.
+
+        :returns: The cached event loop policy
+        """
+        if cls._loop_policy is None:
+            cls._loop_policy = asyncio.get_event_loop_policy()
+        return cls._loop_policy
+
+    def _run_sync(self, coro: Coroutine, timeout: Optional[float] = 30) -> Any:
+        """
+        Run a coroutine in a synchronous context with improved handling.
+
+        :param coro: Coroutine to run
+        :param timeout: Optional timeout in seconds
+        :returns: Result of the coroutine
+        :raises TimeoutError: If the operation times out
+        :raises Exception: Any exception that might occur during execution
+        """
+        try:
+            try:
+                # Try to get the current event loop
+                running_loop = self._get_loop_policy().get_event_loop()
+
+                if running_loop.is_running():
+                    # We're in an async context, use the shared thread pool
+                    future = self._executor.submit(lambda: asyncio.run(asyncio.wait_for(coro, timeout)))
+                    return future.result()
+                else:
+                    # We have an event loop but it's not running
+                    return running_loop.run_until_complete(asyncio.wait_for(coro, timeout))
+            except RuntimeError:
+                # No event loop exists, create one
+                return asyncio.run(asyncio.wait_for(coro, timeout))
+        except asyncio.TimeoutError:
+            raise TimeoutError(f"Operation timed out after {timeout} seconds") from None
+        except Exception:
+            # Preserve the original exception type and traceback
+            raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ extra-dependencies = [
   # ComponentTool
   "docstring-parser",
 
+  # MCP integration
+  "mcp",
+
   # Test
   "pytest",
   "pytest-bdd",
@@ -147,6 +150,7 @@ extra-dependencies = [
   "pip",                     # mypy needs pip to install missing stub packages
   "pylint",
   "ipython",
+  "mcp_server_time" # used in mcp tool tests
 ]
 
 [tool.hatch.envs.test.scripts]

--- a/releasenotes/notes/add-mcp-tool-a69518537e35f63a.yaml
+++ b/releasenotes/notes/add-mcp-tool-a69518537e35f63a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added MCPTool for interacting with MCP servers over HTTP and stdio to the Haystack tooling ecosystem.

--- a/test/tools/test_mcp_tool.py
+++ b/test/tools/test_mcp_tool.py
@@ -1,0 +1,264 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from haystack.tools import MCPTool, HttpMCPServerInfo, StdioMCPServerInfo, MCPError
+from haystack.components.generators.chat import OpenAIChatGenerator
+from haystack.dataclasses import ChatMessage, ChatRole
+from haystack.components.tools import ToolInvoker
+from haystack import Pipeline
+from haystack.tools.from_function import tool
+
+
+@tool
+def echo(name: str) -> str:
+    """Echo a name"""
+    return f"Hello, {name}!"
+
+
+class TestMCPToolWithMockedServer:
+    """Tests for MCPTool with a mocked server."""
+
+    @patch("haystack.tools.mcp_tool.HttpMCPClient")
+    def test_http_mcp_tool_invoke(self, mock_client_class):
+        """Test invoking an HTTP MCPTool."""
+        # Setup mocks
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.connect = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value=10)
+
+        # Create a mock tool
+        mock_tool = MagicMock()
+        mock_tool.name = "add"
+        mock_tool.description = "Add two numbers"
+        mock_tool.inputSchema = {
+            "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+            "required": ["a", "b"],
+            "type": "object",
+        }
+
+        # Set up the connect method to return our mock tool
+        mock_client.connect.return_value = [mock_tool]
+
+        # Create server info and tool
+        server_info = HttpMCPServerInfo(base_url="http://localhost:8000")
+        tool = MCPTool(name="add", server_info=server_info)
+
+        # Invoke the tool
+        result = tool.invoke(a=7, b=3)
+
+        # Assertions
+        assert result == 10
+        mock_client.call_tool.assert_called_once_with("add", {"a": 7, "b": 3})
+
+    @patch("haystack.tools.mcp_tool.StdioMCPClient")
+    def test_stdio_mcp_tool_invoke(self, mock_client_class):
+        """Test invoking a stdio MCPTool."""
+        # Setup mocks
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.connect = AsyncMock()
+        mock_client.call_tool = AsyncMock(return_value="2023-01-01T12:00:00Z")
+
+        # Create a mock tool
+        mock_tool = MagicMock()
+        mock_tool.name = "get_current_time"
+        mock_tool.description = "Get current time in a specific timezone"
+        mock_tool.inputSchema = {
+            "properties": {"timezone": {"type": "string"}},
+            "required": ["timezone"],
+            "type": "object",
+        }
+
+        # Set up the connect method to return our mock tool
+        mock_client.connect.return_value = [mock_tool]
+
+        # Create server info and tool
+        server_info = StdioMCPServerInfo(command="python", args=["server.py"])
+        tool = MCPTool(name="get_current_time", server_info=server_info)
+
+        # Invoke the tool
+        result = tool.invoke(timezone="America/New_York")
+
+        # Assertions
+        assert result == "2023-01-01T12:00:00Z"
+        mock_client.call_tool.assert_called_once_with("get_current_time", {"timezone": "America/New_York"})
+
+
+@pytest.mark.integration
+class TestMCPToolInPipelineWithOpenAI:
+    """Integration tests for MCPTool in Haystack pipelines with OpenAI."""
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_mcp_tool_with_http_server(self):
+        """Test using an MCPTool with a real HTTP server."""
+        import tempfile
+        import os
+        import subprocess
+        import time
+        import socket
+        from urllib.error import URLError
+        import logging
+
+        # Find an available port
+        def find_free_port():
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                return s.getsockname()[1]
+
+        port = find_free_port()
+
+        # Create a temporary file for the server script
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+            temp_file.write(
+                f"""
+from mcp.server.fastmcp import FastMCP
+mcp = FastMCP("MCP Calculator", host="127.0.0.1", port={port})
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    \"\"\"Add two numbers\"\"\"
+    return a + b
+
+# Add a subtraction tool
+@mcp.tool()
+def subtract(a: int, b: int) -> int:
+    \"\"\"Subtract b from a\"\"\"
+    return a - b
+
+if __name__ == "__main__":
+    try:
+        mcp.run(transport="sse")
+    except Exception as e:
+        sys.exit(1)
+""".encode()
+            )
+            server_script_path = temp_file.name
+
+        server_process = None
+        try:
+            # Start the server in a separate process
+            server_process = subprocess.Popen(
+                ["python", server_script_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+
+            # Give the server a moment to start
+            time.sleep(5)
+            # Create an MCPTool that connects to the HTTP server
+            server_info = HttpMCPServerInfo(base_url=f"http://127.0.0.1:{port}")
+
+            # Create the tool
+            tool = MCPTool(name="add", server_info=server_info)
+
+            # Invoke the tool
+            result = tool.invoke(a=5, b=3)
+
+            # Verify the result
+            assert not result.isError
+            assert len(result.content) == 1
+            assert result.content[0].text == "8"
+
+            # Try another tool from the same server
+            subtract_tool = MCPTool(name="subtract", server_info=server_info)
+            result = subtract_tool.invoke(a=10, b=4)
+
+            # Verify the result
+            assert not result.isError
+            assert len(result.content) == 1
+            assert result.content[0].text == "6"
+
+        except Exception as e:
+            # Check server output for clues
+            if server_process and server_process.poll() is None:
+                server_process.terminate()
+            raise
+
+        finally:
+            # Clean up
+            if server_process:
+                if server_process.poll() is None:  # Process is still running
+                    server_process.terminate()
+                    try:
+                        server_process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        server_process.kill()
+                        server_process.wait(timeout=5)
+
+            # Remove the temporary file
+            if os.path.exists(server_script_path):
+                os.remove(server_script_path)
+
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY") and not os.environ.get("BRAVE_API_KEY"),
+        reason="OPENAI_API_KEY or BRAVE_API_KEY not set",
+    )
+    def test_mcp_brave_search(self):
+        """Test using an MCPTool in a pipeline with OpenAI."""
+
+        # Create an MCPTool for the brave_web_search operation
+        server_info = StdioMCPServerInfo(
+            command="docker",
+            args=["run", "-i", "--rm", "-e", f"BRAVE_API_KEY={os.environ.get('BRAVE_API_KEY')}", "mcp/brave-search"],
+            env=None,
+        )
+        tool = MCPTool(name="brave_web_search", server_info=server_info)
+
+        # Create pipeline with OpenAIChatGenerator and ToolInvoker
+        pipeline = Pipeline()
+        pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[tool]))
+        pipeline.add_component("tool_invoker", ToolInvoker(tools=[tool]))
+
+        # Connect components
+        pipeline.connect("llm.replies", "tool_invoker.messages")
+
+        # Create a message that should trigger tool use
+        message = ChatMessage.from_user(text="Use brave_web_search to search for the latest German elections news")
+
+        result = pipeline.run({"llm": {"messages": [message]}})
+
+        tool_messages = result["tool_invoker"]["tool_messages"]
+        assert len(tool_messages) == 1
+
+        tool_message = tool_messages[0]
+        assert tool_message.is_from(ChatRole.TOOL)
+        assert any(term in tool_message.tool_call_result.result for term in ["Bundestag", "elections"])
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_mcp_tool_in_pipeline_with_multiple_tools(self):
+        """Test using multiple MCPTools in a pipeline with OpenAI."""
+
+        # Mix mcp tool with a simple echo tool
+        time_server_info = StdioMCPServerInfo(
+            command="python", args=["-m", "mcp_server_time", "--local-timezone=America/New_York"]
+        )
+        time_tool = MCPTool(name="get_current_time", server_info=time_server_info)
+
+        # Create pipeline with OpenAIChatGenerator and ToolInvoker
+        pipeline = Pipeline()
+        pipeline.add_component("llm", OpenAIChatGenerator(model="gpt-4o-mini", tools=[echo, time_tool]))
+        pipeline.add_component("tool_invoker", ToolInvoker(tools=[echo, time_tool]))
+
+        pipeline.connect("llm.replies", "tool_invoker.messages")
+
+        # Create a message that should trigger tool use
+        message = ChatMessage.from_user(text="What is the current time in New York?")
+
+        result = pipeline.run({"llm": {"messages": [message]}})
+
+        tool_messages = result["tool_invoker"]["tool_messages"]
+        assert len(tool_messages) == 1
+
+        tool_message = tool_messages[0]
+        assert tool_message.is_from(ChatRole.TOOL)
+        assert "timezone" in tool_message.tool_call_result.result
+        assert "datetime" in tool_message.tool_call_result.result
+        assert "New_York" in tool_message.tool_call_result.result
+
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+    def test_mcp_tool_error_handling(self):
+        """Test error handling with MCPTool in a pipeline."""
+
+        # Create a custom server info for a server that might return errors
+        server_info = HttpMCPServerInfo(base_url="http://localhost:8000")
+        with pytest.raises(MCPError):
+            tool = MCPTool(name="divide", server_info=server_info)


### PR DESCRIPTION
### Why:
Adds MCPTool (Model Context Protocol), enabling tools to connect and interact with MCP servers via HTTP and stdio transports.

### What:
- Added a new module `mcp_tool` that includes classes to handle the MCP client implementation for HTTP and stdio transports.
- Updated `__init__.py` to export MCP-related classes for external use.
- Incorporated MCP dependency into `pyproject.toml`.

### How can it be used:
MCP tools can be created and invoked through HTTP or stdio server configurations:
```python
from haystack.tools import MCPTool, HttpMCPServerInfo

server_info = HttpMCPServerInfo(base_url="http://localhost:8000")
tool = MCPTool(name="add", server_info=server_info)
result = tool.invoke(a=5, b=3)

# Using stdio
from haystack.tools import MCPTool, StdioMCPServerInfo

server_info = StdioMCPServerInfo(command="python", args=["server.py"])
tool = MCPTool(name="get_current_time", server_info=server_info)
result = tool.invoke(timezone="America/New_York")
```

### How did you test it:
Implemented unit tests using `pytest` and `unittest.mock` to simulate MCP server behaviors. Additionally, integration tests were conducted with actual server instances to validate interactions across network protocols.

### Notes for the reviewer:
Focus on the implementation details of the `MCPTool` class in `mcp_tool.py`, and ensure tests effectively mock server responses and include proper cleanup routines. Check integration with the new MCP server dependencies in `pyproject.toml`.
