### PR TITLE
fix: cleaning up `InMemoryDocumentStore` executor when created inside the class

### DIFF
--- a/test/document_stores/test_in_memory.py
+++ b/test/document_stores/test_in_memory.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import logging
 from unittest.mock import patch
 
@@ -572,3 +573,11 @@ class TestMemoryDocumentStore(DocumentStoreBaseTests):  # pylint: disable=R0904
         for i, result in enumerate(results):
             assert len(result) == 1
             assert result[0].content == f"Document {i * 10} content"
+
+    def test_executor_shutdown(self):
+        doc_store = InMemoryDocumentStore()
+        executor = doc_store.executor
+        with patch.object(executor, "shutdown", wraps=executor.shutdown) as mock_shutdown:
+            del doc_store
+            gc.collect()
+            mock_shutdown.assert_called_once_with(wait=True)


### PR DESCRIPTION
### Proposed Changes:

- keep track of whether the class itself created the thread executor and if so we clean up when the class is destroyed

### How did you test it?

- unit tests, integration tests, manual verification, instructions for manual tests -->


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
