### PR TITLE
feat: Improve type validation for bare types

### DIFF
--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -66,37 +66,15 @@ def _strict_types_are_compatible(sender, receiver):  # pylint: disable=too-many-
     sender_args = get_args(sender)
     receiver_args = get_args(receiver)
 
-    # Handle Callable types
-    if sender_origin == receiver_origin == collections.abc.Callable:
-        return _check_callable_compatibility(sender_args, receiver_args)
-
     # Handle bare types
     if not sender_args and sender_origin:
         sender_args = (Any,)
     if not receiver_args and receiver_origin:
         receiver_args = (Any,) * (len(sender_args) if sender_args else 1)
-
-    return not (len(sender_args) > len(receiver_args)) and all(
-        _strict_types_are_compatible(*args) for args in zip(sender_args, receiver_args)
-    )
-
-
-def _check_callable_compatibility(sender_args, receiver_args):
-    """Helper function to check compatibility of Callable types"""
-    if not receiver_args:
-        return True
-    if not sender_args:
-        sender_args = ([Any] * len(receiver_args[0]), Any)
-    # Standard Callable has two elements in args: argument list and return type
-    if len(sender_args) != 2 or len(receiver_args) != 2:
+    if len(sender_args) > len(receiver_args):
         return False
-    # Return types must be compatible
-    if not _strict_types_are_compatible(sender_args[1], receiver_args[1]):
-        return False
-    # Input Arguments must be of same length
-    if len(sender_args[0]) != len(receiver_args[0]):
-        return False
-    return all(_strict_types_are_compatible(sender_args[0][i], receiver_args[0][i]) for i in range(len(sender_args[0])))
+
+    return all(_strict_types_are_compatible(*args) for args in zip(sender_args, receiver_args))
 
 
 def _type_name(type_):

--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import collections.abc
 from typing import Any, TypeVar, Union, get_args, get_origin
 
 from haystack import logging

--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Set, Tuple, TypeVar, Union, get_args, get_origin
+from typing import Any, TypeVar, Union, get_args, get_origin
 
 from haystack import logging
 

--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import collections.abc
 from typing import Any, TypeVar, Union, get_args, get_origin
 
 from haystack import logging
@@ -65,16 +66,37 @@ def _strict_types_are_compatible(sender, receiver):  # pylint: disable=too-many-
     sender_args = get_args(sender)
     receiver_args = get_args(receiver)
 
+    # Handle Callable types
+    if sender_origin == receiver_origin == collections.abc.Callable:
+        return _check_callable_compatibility(sender_args, receiver_args)
+
     # Handle bare types
     if not sender_args and sender_origin:
         sender_args = (Any,)
     if not receiver_args and receiver_origin:
         receiver_args = (Any,) * (len(sender_args) if sender_args else 1)
 
-    if len(sender_args) > len(receiver_args):
-        return False
+    return not (len(sender_args) > len(receiver_args)) and all(
+        _strict_types_are_compatible(*args) for args in zip(sender_args, receiver_args)
+    )
 
-    return all(_strict_types_are_compatible(*args) for args in zip(sender_args, receiver_args))
+
+def _check_callable_compatibility(sender_args, receiver_args):
+    """Helper function to check compatibility of Callable types"""
+    if not receiver_args:
+        return True
+    if not sender_args:
+        sender_args = ([Any] * len(receiver_args[0]), Any)
+    # Standard Callable has two elements in args: argument list and return type
+    if len(sender_args) != 2 or len(receiver_args) != 2:
+        return False
+    # Return types must be compatible
+    if not _strict_types_are_compatible(sender_args[1], receiver_args[1]):
+        return False
+    # Input Arguments must be of same length
+    if len(sender_args[0]) != len(receiver_args[0]):
+        return False
+    return all(_strict_types_are_compatible(sender_args[0][i], receiver_args[0][i]) for i in range(len(sender_args[0])))
 
 
 def _type_name(type_):

--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, TypeVar, Union, get_args, get_origin
+from typing import Any, Dict, List, Set, Tuple, TypeVar, Union, get_args, get_origin
 
 from haystack import logging
 
@@ -64,6 +64,13 @@ def _strict_types_are_compatible(sender, receiver):  # pylint: disable=too-many-
     # Compare generic type arguments
     sender_args = get_args(sender)
     receiver_args = get_args(receiver)
+
+    # Handle bare types
+    if not sender_args and sender_origin:
+        sender_args = (Any,)
+    if not receiver_args and receiver_origin:
+        receiver_args = (Any,) * (len(sender_args) if sender_args else 1)
+
     if len(sender_args) > len(receiver_args):
         return False
 

--- a/releasenotes/notes/add-bare-type-validation-a4720bc66ccaf5ef.yaml
+++ b/releasenotes/notes/add-bare-type-validation-a4720bc66ccaf5ef.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Treat bare types (e.g., List, Dict) as generic types with Any arguments during type compatibility checks.

--- a/test/core/pipeline/test_type_utils.py
+++ b/test/core/pipeline/test_type_utils.py
@@ -361,7 +361,7 @@ def test_partially_overlapping_unions_are_not_compatible_strict(sender_type, rec
         pytest.param(Dict[str, int], Dict, id="dict-of-primitive-to-bare-dict"),
         pytest.param(Set[float], Set, id="set-of-primitive-to-bare-set"),
         pytest.param(Tuple[int, str], Tuple, id="tuple-of-primitive-to-bare-tuple"),
-        pytest.param(Callable[[int, str], bool], Callable, id="callable-to-bare-callable"),
+        pytest.param((List[int]), list, id="list-of-primitive-to-list-object"),
     ],
 )
 def test_container_of_primitive_to_bare_container_strict(sender_type, receiver_type):
@@ -377,6 +377,7 @@ def test_container_of_primitive_to_bare_container_strict(sender_type, receiver_t
         pytest.param(Dict[Any, Any], Dict, id="dict-of-any-to-bare-dict"),
         pytest.param(Set[Any], Set, id="set-of-any-to-bare-set"),
         pytest.param(Tuple[Any], Tuple, id="tuple-of-any-to-bare-tuple"),
+        pytest.param(Callable[[Any], Any], Callable, id="callable-of-any-to-bare-callable"),
     ],
 )
 def test_container_of_any_to_bare_container_strict(sender_type, receiver_type):
@@ -388,12 +389,58 @@ def test_container_of_any_to_bare_container_strict(sender_type, receiver_type):
 @pytest.mark.parametrize(
     "sender_type,receiver_type",
     [
+        pytest.param(Callable[[int, str], bool], Callable, id="callable-to-bare-callable"),
+        pytest.param(Callable[[List], int], Callable[[List], Any], id="callable-list-int-to-any"),
+    ],
+)
+def test_callable_compatibility(sender_type, receiver_type):
+    assert _types_are_compatible(sender_type, receiver_type)
+    assert not _types_are_compatible(receiver_type, sender_type)
+
+
+@pytest.mark.parametrize(
+    "sender_type,receiver_type",
+    [
         pytest.param(Literal["test"], Literal, id="literal-to-bare-literal"),
         pytest.param(Union[str, int], Union, id="union-to-bare-union"),
-        pytest.param(Optional[str], Optional, id="union-to-bare-union"),
+        pytest.param(Optional[str], Optional, id="optional-to-bare-optional"),
     ],
 )
 def test_always_incompatible_bare_types(sender_type, receiver_type):
     # Neither are compatible
     assert not _types_are_compatible(sender_type, receiver_type)
+    assert not _types_are_compatible(receiver_type, sender_type)
+
+
+@pytest.mark.parametrize(
+    "sender_type,receiver_type",
+    [
+        # Nested Lists
+        pytest.param(List[List[int]], List[List], id="nested-list-to-partially-bare-list"),
+        pytest.param(List[List[int]], List, id="nested-list-to-bare-list"),
+        # Nested Dicts
+        pytest.param(Dict[str, Dict[str, int]], Dict[str, Dict], id="nested-dict-to-partially-bare-dict"),
+        pytest.param(Dict[str, Dict[str, int]], Dict, id="nested-dict-to-bare-dict"),
+        # Nested Sets
+        pytest.param(Set[Set[int]], Set[Set], id="nested-set-to-partially-bare-set"),
+        pytest.param(Set[Set[int]], Set, id="nested-set-to-bare-set"),
+        # Nested Tuples
+        pytest.param(Tuple[Tuple[int, str], bool], Tuple[Tuple, bool], id="nested-tuple-to-partially-bare-tuple"),
+        pytest.param(Tuple[Tuple[int, str], bool], Tuple, id="nested-tuple-to-bare-tuple"),
+        # Mixed nesting
+        pytest.param(List[Dict[str, int]], List[Dict], id="list-of-dict-to-list-of-bare-dict"),
+        pytest.param(Dict[str, List[int]], Dict[str, List], id="dict-with-list-to-dict-with-bare-list"),
+        pytest.param(Set[Tuple[int, str]], Set[Tuple], id="set-of-tuple-to-set-of-bare-tuple"),
+        pytest.param(
+            Tuple[List[int], Dict[str, bool]], Tuple[List, Dict], id="tuple-of-containers-to-tuple-of-bare-containers"
+        ),
+        # Triple nesting
+        pytest.param(List[List[List[int]]], List[List[List]], id="triple-nested-list-to-partially-bare"),
+        pytest.param(List[List[List[int]]], List[List], id="triple-nested-list-to-double-bare"),
+        pytest.param(List[List[List[int]]], List, id="triple-nested-list-to-completely-bare"),
+    ],
+)
+def test_nested_container_compatibility(sender_type, receiver_type):
+    assert _types_are_compatible(sender_type, receiver_type)
+    # Bare container types should not be compatible with their typed counterparts
     assert not _types_are_compatible(receiver_type, sender_type)

--- a/test/core/pipeline/test_type_utils.py
+++ b/test/core/pipeline/test_type_utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import pytest
 
@@ -355,13 +355,20 @@ def test_partially_overlapping_unions_are_not_compatible_strict(sender_type, rec
 
 
 @pytest.mark.parametrize(
+    "sender_type,receiver_type", [pytest.param((List[int]), list, id="list-of-primitive-to-list-object")]
+)
+def test_list_of_primitive_to_list(sender_type, receiver_type):
+    """This currently doesn't work because we don't handle primitive types."""
+    assert not _types_are_compatible(sender_type, receiver_type)
+
+
+@pytest.mark.parametrize(
     "sender_type,receiver_type",
     [
         pytest.param(List[int], List, id="list-of-primitive-to-bare-list"),
         pytest.param(Dict[str, int], Dict, id="dict-of-primitive-to-bare-dict"),
         pytest.param(Set[float], Set, id="set-of-primitive-to-bare-set"),
         pytest.param(Tuple[int, str], Tuple, id="tuple-of-primitive-to-bare-tuple"),
-        pytest.param((List[int]), list, id="list-of-primitive-to-list-object"),
     ],
 )
 def test_container_of_primitive_to_bare_container_strict(sender_type, receiver_type):
@@ -377,25 +384,12 @@ def test_container_of_primitive_to_bare_container_strict(sender_type, receiver_t
         pytest.param(Dict[Any, Any], Dict, id="dict-of-any-to-bare-dict"),
         pytest.param(Set[Any], Set, id="set-of-any-to-bare-set"),
         pytest.param(Tuple[Any], Tuple, id="tuple-of-any-to-bare-tuple"),
-        pytest.param(Callable[[Any], Any], Callable, id="callable-of-any-to-bare-callable"),
     ],
 )
 def test_container_of_any_to_bare_container_strict(sender_type, receiver_type):
     # Both are compatible
     assert _types_are_compatible(sender_type, receiver_type)
     assert _types_are_compatible(receiver_type, sender_type)
-
-
-@pytest.mark.parametrize(
-    "sender_type,receiver_type",
-    [
-        pytest.param(Callable[[int, str], bool], Callable, id="callable-to-bare-callable"),
-        pytest.param(Callable[[List], int], Callable[[List], Any], id="callable-list-int-to-any"),
-    ],
-)
-def test_callable_compatibility(sender_type, receiver_type):
-    assert _types_are_compatible(sender_type, receiver_type)
-    assert not _types_are_compatible(receiver_type, sender_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues

- fixes #8874 

### Proposed Changes:

- Treat bare types (e.g., List, Dict) as generic types with Any arguments during type compatibility checks.

### How did you test it?

 - added unit tests 

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
