### PR TITLE
feat: support rest-style docstrings when loading tools from function

### DIFF
--- a/releasenotes/notes/tool-from-function-with-rest-docstring-fa2728ec718db524.yaml
+++ b/releasenotes/notes/tool-from-function-with-rest-docstring-fa2728ec718db524.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Supports ReST-style docstrings for functions when generating a tool from a function.
+    The ReST-style docstring will be automatically parsed to infer the tool's description and
+    argument descriptions.

--- a/test/tools/test_from_function.py
+++ b/test/tools/test_from_function.py
@@ -10,6 +10,19 @@ def function_with_docstring(city: str) -> str:
     return f"Weather report for {city}: 20°C, sunny"
 
 
+def function_with_rest_docstring(city: str) -> str:
+    """
+    Get weather report for a city.
+
+    :param city: The city for which to get the weather.
+    :return: The weather report for the city.
+    :raises ValueError: If the city is not found.
+    """
+    if city == "":
+        raise ValueError("City not found.")
+    return f"Weather report for {city}: 20°C, sunny"
+
+
 def test_from_function_description_from_docstring():
     tool = create_tool_from_function(function=function_with_docstring)
 
@@ -17,6 +30,23 @@ def test_from_function_description_from_docstring():
     assert tool.description == "Get weather report for a city."
     assert tool.parameters == {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
     assert tool.function == function_with_docstring
+
+
+def test_from_function_description_from_rest_docstring():
+    tool = create_tool_from_function(function=function_with_rest_docstring)
+
+    assert tool.name == "function_with_rest_docstring"
+    assert tool.description == (
+        "Get weather report for a city.\n\n"
+        "Returns: The weather report for the city.\n\n"
+        "Raises:\n- ValueError: If the city is not found."
+    )
+    assert tool.parameters == {
+        "type": "object",
+        "properties": {"city": {"type": "string", "description": "The city for which to get the weather."}},
+        "required": ["city"],
+    }
+    assert tool.function == function_with_rest_docstring
 
 
 def test_from_function_with_empty_description():


### PR DESCRIPTION
### Related Issues

N/A

### Proposed Changes:

Supports ReST-style docstrings when loading a tool from function.
The docstring will be automatically parsed for function-level descriptions and parameter descriptions.

### How did you test it?

Added a new unit test for it.

### Notes for the reviewer

N/A

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
