### PR TITLE
feat: Add warning to ChatPromptBuilder and PromptBuilder if they have variables, but `required_variables` is not set

### DIFF
--- a/haystack/components/builders/chat_prompt_builder.py
+++ b/haystack/components/builders/chat_prompt_builder.py
@@ -136,6 +136,15 @@ class ChatPromptBuilder:
                     variables += list(template_variables)
         self.variables = variables
 
+        if len(self.variables) > 0 and required_variables is None:
+            logger.warning(
+                "ChatPromptBuilder has {length} prompt variables, but `required_variables` is not set. "
+                "By default, all prompt variables are treated as optional, which may lead to unintended behavior in "
+                "multi-branch pipelines. To avoid unexpected execution, ensure that variables intended to be required "
+                "are explicitly set in `required_variables`.",
+                length=len(self.variables),
+            )
+
         # setup inputs
         for var in self.variables:
             if self.required_variables == "*" or var in self.required_variables:

--- a/haystack/components/builders/prompt_builder.py
+++ b/haystack/components/builders/prompt_builder.py
@@ -7,8 +7,10 @@ from typing import Any, Dict, List, Literal, Optional, Set, Union
 from jinja2 import meta
 from jinja2.sandbox import SandboxedEnvironment
 
-from haystack import component, default_to_dict
+from haystack import component, default_to_dict, logging
 from haystack.utils import Jinja2TimeExtension
+
+logger = logging.getLogger(__name__)
 
 
 @component
@@ -179,6 +181,15 @@ class PromptBuilder:
             variables = list(template_variables)
         variables = variables or []
         self.variables = variables
+
+        if len(self.variables) > 0 and required_variables is None:
+            logger.warning(
+                "PromptBuilder has {length} prompt variables, but `required_variables` is not set. "
+                "By default, all prompt variables are treated as optional, which may lead to unintended behavior in "
+                "multi-branch pipelines. To avoid unexpected execution, ensure that variables intended to be required "
+                "are explicitly set in `required_variables`.",
+                length=len(self.variables),
+            )
 
         # setup inputs
         for var in self.variables:

--- a/releasenotes/notes/warning-chat-and-prompt-builder-ca42295df9c1b770.yaml
+++ b/releasenotes/notes/warning-chat-and-prompt-builder-ca42295df9c1b770.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Added a warning to ChatPromptBuilder and PromptBuilder when prompt variables are present and `required_variables` is unset to help users avoid unexpected execution in multi-branch pipelines. The warning recommends users to set `required_variables`.

--- a/test/components/builders/test_prompt_builder.py
+++ b/test/components/builders/test_prompt_builder.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
 import arrow
+import logging
 import pytest
 from jinja2 import TemplateSyntaxError
 
@@ -330,3 +331,8 @@ class TestPromptBuilder:
         # Expect ValueError for invalid offset
         with pytest.raises(ValueError, match="Invalid offset or operator"):
             builder.run()
+
+    def test_warning_no_required_variables(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _ = PromptBuilder(template="This is a {{ variable }}")
+            assert "but `required_variables` is not set." in caplog.text


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/8901

Related to https://github.com/deepset-ai/haystack/issues/8903

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add warning to ChatPromptBuilder and PromptBuilder if they have variables, but `required_variables` is not set

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
