### PR TITLE
chore: Use thread safe import in `import_class_by_name` utility function

### DIFF
--- a/haystack/core/serialization.py
+++ b/haystack/core/serialization.py
@@ -255,9 +255,7 @@ def import_class_by_name(fully_qualified_name: str) -> Type[object]:
     try:
         module_path, class_name = fully_qualified_name.rsplit(".", 1)
         logger.debug(
-            "Attempting to import class '{class_name}' from module '{module_path}'",
-            cls_name=class_name,
-            md_path=module_path,
+            "Attempting to import class '{cls_name}' from module '{md_path}'", cls_name=class_name, md_path=module_path
         )
         module = thread_safe_import(module_path)
         return getattr(module, class_name)


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- We missed a import module call when first moving over to a thread safe version so I updated it
- Also updated logger calls to use the correct syntax and remove f-strings

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Existing tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
