### PR TITLE
Chat Generatol Protocol POC

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -2,53 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-from typing import TYPE_CHECKING
-
-from lazy_imports import LazyImporter
-
-# These imports need to be loaded eagerly:
-# - they configure essential services (logging, tracing)
-# - they define core classes which should be accessible through the haystack namespace
 import haystack.logging
 import haystack.tracing
 from haystack.core.component import component
+from haystack.core.errors import ComponentError, DeserializationError
+from haystack.core.pipeline import AsyncPipeline, Pipeline, PredefinedPipeline
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.dataclasses import Answer, Document, ExtractedAnswer, GeneratedAnswer
 from haystack.version import __version__
-
-_import_structure = {
-    "core.errors": ["ComponentError", "DeserializationError"],
-    "core.pipeline": ["AsyncPipeline", "Pipeline", "PredefinedPipeline"],
-    "core.serialization": ["default_from_dict", "default_to_dict"],
-    "dataclasses": ["Answer", "Document", "ExtractedAnswer", "GeneratedAnswer"],
-}
-
-if TYPE_CHECKING:
-    from .core.errors import ComponentError, DeserializationError
-    from .core.pipeline import AsyncPipeline, Pipeline, PredefinedPipeline
-    from .core.serialization import default_from_dict, default_to_dict
-    from .dataclasses import Answer, Document, ExtractedAnswer, GeneratedAnswer
-
-else:
-    sys.modules[__name__] = LazyImporter(
-        name=__name__,
-        module_file=__file__,
-        import_structure=_import_structure,
-        # These modules were imported eagerly above,
-        # but must also be added to extra_objects so LazyImporter exposes them
-        # through the haystack namespace.
-        extra_objects={
-            "__version__": __version__,
-            "logging": haystack.logging,
-            "tracing": haystack.tracing,
-            "component": component,
-            # haystack.core requires special handling:
-            # - It has an empty __init__.py to avoid circular imports.
-            # - For this reason, it does not play well with LazyImporter.
-            # - We pass it directly in extra_objects to preserve the module reference.
-            # - This preserves the ability to monkey-patch the module in tests.
-            "core": haystack.core,
-        },
-    )
 
 # Initialize the logging configuration
 # This is a no-op unless `structlog` is installed
@@ -56,3 +17,18 @@ haystack.logging.configure_logging()
 
 # Same for tracing (no op if `opentelemetry` or `ddtrace` is not installed)
 haystack.tracing.auto_enable_tracing()
+
+__all__ = [
+    "Answer",
+    "AsyncPipeline",
+    "ComponentError",
+    "DeserializationError",
+    "Document",
+    "ExtractedAnswer",
+    "GeneratedAnswer",
+    "Pipeline",
+    "PredefinedPipeline",
+    "component",
+    "default_from_dict",
+    "default_to_dict",
+]

--- a/haystack/components/extractors/llm_metadata_extractor.py
+++ b/haystack/components/extractors/llm_metadata_extractor.py
@@ -205,6 +205,8 @@ class LLMMetadataExtractor:
         init_parameters = data.get("init_parameters", {})
 
         chat_generator_class = import_class_by_name(data["init_parameters"]["chat_generator"]["type"])
+        assert hasattr(chat_generator_class, "from_dict")  # we know but mypy doesn't
+
         chat_generator_instance = chat_generator_class.from_dict(init_parameters["chat_generator"])
 
         init_parameters["chat_generator"] = chat_generator_instance

--- a/haystack/components/generators/chat/types.py
+++ b/haystack/components/generators/chat/types.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, List, Protocol, TypeVar
+
+from haystack.dataclasses import ChatMessage
+
+T = TypeVar("T", bound="ChatGenerator")
+
+
+class ChatGenerator(Protocol):
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize this component to a dictionary.
+
+        :returns:
+            The serialized component as a dictionary.
+        """
+        ...
+
+    @classmethod
+    def from_dict(cls: type[T], data: Dict[str, Any]) -> T:
+        """
+        Deserialize this component from a dictionary.
+
+        Returns an instance of the specific implementing class.
+        """
+        ...
+
+    def run(self, messages: List[ChatMessage]) -> Dict[str, Any]:
+        """
+        Run the chat generator.
+        """
+        ...

--- a/haystack/components/generators/chat/types.py
+++ b/haystack/components/generators/chat/types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, List, Protocol, TypeVar
 
 from haystack.dataclasses import ChatMessage

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -461,6 +461,14 @@ class _Component:
         """
 
         def output_types_decorator(run_method: Callable[P, R]) -> Callable[P, R]:
+            """
+            Decorator that sets the output types of the decorated method.
+
+            This happens at class creation time, and since we don't have the decorated
+            class available here, we temporarily store the output types as an attribute of
+            the decorated method. The ComponentMeta metaclass will use this data to create
+            sockets at instance creation time.
+            """
             method_name = run_method.__name__
             if method_name not in ("run", "run_async"):
                 raise ComponentError("'output_types' decorator can only be used on 'run' and 'run_async' methods")

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -76,7 +76,9 @@ from contextvars import ContextVar
 from copy import deepcopy
 from dataclasses import dataclass
 from types import new_class
-from typing import Any, Dict, Optional, ParamSpec, Protocol, Type, TypeVar, runtime_checkable
+from typing import Any, Dict, Optional, Protocol, Type, TypeVar, runtime_checkable
+
+from typing_extensions import ParamSpec
 
 from haystack import logging
 from haystack.core.errors import ComponentError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 installer = "uv"
 dependencies = [
   "pre-commit",
-  "ruff",
+  "ruff<0.10.0",
   "toml",
   "reno",
   # dulwich is a reno dependency, they pin it at >=0.15.0 so pip takes ton of time to resolve the dependency tree.

--- a/try_chatgenerator_protcol.py
+++ b/try_chatgenerator_protcol.py
@@ -1,0 +1,52 @@
+# ruff: noqa: E501
+
+from haystack.components.converters import DOCXToDocument
+from haystack.components.embedders import OpenAITextEmbedder
+from haystack.components.extractors import NamedEntityExtractor
+from haystack.components.generators.chat.hugging_face_api import HuggingFaceAPIChatGenerator
+from haystack.components.generators.chat.hugging_face_local import HuggingFaceLocalChatGenerator
+from haystack.components.generators.chat.openai import OpenAIChatGenerator
+from haystack.components.generators.chat.types import ChatGenerator
+
+
+class ChatGeneratorEncapsulator:
+    def __init__(self, chat_generator: ChatGenerator):
+        self.chat_generator = chat_generator
+
+    def show(self):
+        """
+        Print the dictionary representation of the chat generator.
+        """
+        print(self.chat_generator.to_dict())
+
+
+my_chat_generator = ChatGeneratorEncapsulator(OpenAIChatGenerator())  # mypy: OK
+my_chat_generator.show()  # works
+
+another_chat_generator = ChatGeneratorEncapsulator(DOCXToDocument())  # mypy: Error
+# error: Argument 1 to "ChatGeneratorEncapsulator" has incompatible type "DOCXToDocument"; expected "ChatGenerator"  [arg-type]
+# note: Following member(s) of "DOCXToDocument" have conflicts:
+# note:     Expected:
+# note:         def run(self, messages: list[ChatMessage]) -> dict[str, Any]
+# note:     Got:
+# note:         def run(sources: list[str | Path | ByteStream], meta: dict[str, Any] | list[dict[str, Any]] | None = ...) -> Any
+
+another_chat_generator.show()  # works
+
+
+another_cg2 = ChatGeneratorEncapsulator(OpenAITextEmbedder())  # mypy: Error
+another_cg2.show()  # works
+
+
+another_cg3 = ChatGeneratorEncapsulator(HuggingFaceLocalChatGenerator())  # mypy: OK
+another_cg3.show()  # works
+
+
+another_cg4 = ChatGeneratorEncapsulator(NamedEntityExtractor(backend="spacy", model="en_core_web_sm"))  # mypy: error
+another_cg4.show()  # works
+
+
+another_cg5 = ChatGeneratorEncapsulator(
+    HuggingFaceAPIChatGenerator(api_type="something", api_params={"model": "some-model"})
+)  # mypy: OK
+another_cg5.show()  # works

--- a/try_chatgenerator_protcol.py
+++ b/try_chatgenerator_protcol.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ruff: noqa: E501
 
 from haystack.components.converters import DOCXToDocument

--- a/try_chatgenerator_protcol.py
+++ b/try_chatgenerator_protcol.py
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# the following lines avoid errors in the CI
 # ruff: noqa: E501
+# mypy: ignore-errors
 
 from haystack.components.converters import DOCXToDocument
 from haystack.components.embedders import OpenAITextEmbedder


### PR DESCRIPTION
As discussed in https://github.com/deepset-ai/haystack-experimental/issues/218, I propose introducing a `ChatGenerator` Protocol to qualify `ChatGenerator` components from a static type-checking perspective.

The current PR outlines a POC demonstrating how this could work and the benefits it provides.

### Why
- Chat Generators are central components in Haystack. They are used directly and often incorporated into more complex components like `LLMMetadataExtractor`, `Agent`, and `Summarizer`. Even `LLMEvaluator` could fit, though it currently uses a Generator.

- Using them inside other components has been handled in various ways. For example, see the [`LLMMetadataExtractor` implementation](https://github.com/deepset-ai/haystack/blob/main/haystack/components/extractors/llm_metadata_extractor.py). This often results in several lazy imports, support for limited set of Chat Generators, inconsistent user experience.
- Introducing a shallow abstraction to qualify Chat Generators would improve flexibility, reduce code duplication and standardize the integration in other components.

### Pros
- Introducing a Protocol for Chat Generator would give us **static type checking** (mypy/pyright), also providing better guidance for users.
- This could simplify existing components and introduce a consistent way of defining components based on Chat Generators.

### No Runtime Checking
While the Protocol ensures static type safety, it does not provide strong runtime guarantees.
- If we mark the protocol as `@runtime_checkable`, runtime checks would only verify method existence—not their signatures (see [mypy docs](https://mypy.readthedocs.io/en/stable/protocols.html#using-isinstance-with-protocols)).
- For this reason, I propose avoiding `@runtime_checkable` entirely and handling runtime validation where needed.


### Protocol vs Abstract Class
- An abstract class would offer stronger guarantees both statically and dynamically, but at the cost of flexibility.

- A Protocol, on the other hand, requires little to no changes to our codebase.
  - Chat Generators wouldn't need to inherit from a base class.
  - Most Chat Generators (including community ones) would already implement the protocol.

---

For more details on the implementation, look at comments in this PR.