### PR TITLE
fix: use eager imports in `haystack/__init__.py`

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -2,53 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-from typing import TYPE_CHECKING
+# We avoid lazy imports here because:
+# - they create potential static type checking issues which are hard to debug
+# - they make this module more complicated and hard to maintain
+# - they offer minimal performance gains in this case.
 
-from lazy_imports import LazyImporter
-
-# These imports need to be loaded eagerly:
-# - they configure essential services (logging, tracing)
-# - they define core classes which should be accessible through the haystack namespace
 import haystack.logging
 import haystack.tracing
 from haystack.core.component import component
+from haystack.core.errors import ComponentError, DeserializationError
+from haystack.core.pipeline import AsyncPipeline, Pipeline, PredefinedPipeline
+from haystack.core.serialization import default_from_dict, default_to_dict
+from haystack.dataclasses import Answer, Document, ExtractedAnswer, GeneratedAnswer
 from haystack.version import __version__
-
-_import_structure = {
-    "core.errors": ["ComponentError", "DeserializationError"],
-    "core.pipeline": ["AsyncPipeline", "Pipeline", "PredefinedPipeline"],
-    "core.serialization": ["default_from_dict", "default_to_dict"],
-    "dataclasses": ["Answer", "Document", "ExtractedAnswer", "GeneratedAnswer"],
-}
-
-if TYPE_CHECKING:
-    from .core.errors import ComponentError, DeserializationError
-    from .core.pipeline import AsyncPipeline, Pipeline, PredefinedPipeline
-    from .core.serialization import default_from_dict, default_to_dict
-    from .dataclasses import Answer, Document, ExtractedAnswer, GeneratedAnswer
-
-else:
-    sys.modules[__name__] = LazyImporter(
-        name=__name__,
-        module_file=__file__,
-        import_structure=_import_structure,
-        # These modules were imported eagerly above,
-        # but must also be added to extra_objects so LazyImporter exposes them
-        # through the haystack namespace.
-        extra_objects={
-            "__version__": __version__,
-            "logging": haystack.logging,
-            "tracing": haystack.tracing,
-            "component": component,
-            # haystack.core requires special handling:
-            # - It has an empty __init__.py to avoid circular imports.
-            # - For this reason, it does not play well with LazyImporter.
-            # - We pass it directly in extra_objects to preserve the module reference.
-            # - This preserves the ability to monkey-patch the module in tests.
-            "core": haystack.core,
-        },
-    )
 
 # Initialize the logging configuration
 # This is a no-op unless `structlog` is installed
@@ -56,3 +22,18 @@ haystack.logging.configure_logging()
 
 # Same for tracing (no op if `opentelemetry` or `ddtrace` is not installed)
 haystack.tracing.auto_enable_tracing()
+
+__all__ = [
+    "Answer",
+    "AsyncPipeline",
+    "ComponentError",
+    "DeserializationError",
+    "Document",
+    "ExtractedAnswer",
+    "GeneratedAnswer",
+    "Pipeline",
+    "PredefinedPipeline",
+    "component",
+    "default_from_dict",
+    "default_to_dict",
+]

--- a/releasenotes/notes/haystack-init-eager-imports-b0aa339bf8845186.yaml
+++ b/releasenotes/notes/haystack-init-eager-imports-b0aa339bf8845186.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Replace lazy imports with eager imports in `haystack/__init__.py` to avoid potential static type checking issues
+    and simplify maintenance.


### PR DESCRIPTION
### Related Issues
While working on #9037, I ran into a very strange type checking issue:
I added type hints to the `@component.output_types` decorator but I could not get mypy to check the type of the underlying `run` method.

After a while debugging, it turned out that `from haystack import component` had some issues, while `from haystack.core.component import component` worked perfectly in terms of static type checking.

If we revert to eager imports in `haystack/__init__.py`, this problem goes away.

### Proposed Changes:
- use eager imports in `haystack/__init__.py`
  - no strange type checking issues
  - code is much simpler, to read and maintain

### How did you test it?
CI

### Notes for the reviewer
Ofc, this comes at a (small) cost in terms of performance.

 `import haystack` (full Haystack installation, CPU import times in milliseconds - User time + System time):
- before this PR: 163ms
- after this PR: 250 ms
- Haystack 2.10.0: 3620ms

I would say this is still acceptable.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
