### PR TITLE
refactor: Update how we look for finish_reason

### DIFF
--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -498,8 +498,10 @@ class OpenAIChatGenerator:
                     _arguments=call_data["arguments"],
                 )
 
-        # finish_reason is in the last chunk if usage is not included, and in the second last chunk if usage is included
-        finish_reason = (chunks[-2] if chunk.usage and len(chunks) >= 2 else chunks[-1]).meta.get("finish_reason")
+        # finish_reason can appear in different places so we look for the last one
+        finish_reason = [
+            chunk.meta.get("finish_reason") for chunk in chunks if chunk.meta.get("finish_reason") is not None
+        ][-1]
 
         meta = {
             "model": chunk.model,

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -499,9 +499,10 @@ class OpenAIChatGenerator:
                 )
 
         # finish_reason can appear in different places so we look for the last one
-        finish_reason = [
+        finish_reasons = [
             chunk.meta.get("finish_reason") for chunk in chunks if chunk.meta.get("finish_reason") is not None
-        ][-1]
+        ]
+        finish_reason = finish_reasons[-1] if finish_reasons else None
 
         meta = {
             "model": chunk.model,
@@ -588,6 +589,11 @@ class OpenAIChatGenerator:
         """
         chunk_message = StreamingChunk(content="")
         chunk_message.meta.update(
-            {"model": chunk.model, "usage": chunk.usage, "received_at": datetime.now().isoformat()}
+            {
+                "model": chunk.model,
+                "usage": chunk.usage,
+                "received_at": datetime.now().isoformat(),
+                "finish_reason": chunk.choices[0].finish_reason,
+            }
         )
         return chunk_message

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -405,7 +405,6 @@ class OpenAIChatGenerator:
             # choices is an empty array for usage_chunk when include_usage is set to True
             if chunk.usage is not None:
                 chunk_delta = self._convert_usage_chunk_to_streaming_chunk(chunk)
-
             else:
                 assert len(chunk.choices) == 1, "Streaming responses should have only one choice."
                 chunk_delta = self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
@@ -589,11 +588,9 @@ class OpenAIChatGenerator:
         """
         chunk_message = StreamingChunk(content="")
         chunk_message.meta.update(
-            {
-                "model": chunk.model,
-                "usage": chunk.usage,
-                "received_at": datetime.now().isoformat(),
-                "finish_reason": chunk.choices[0].finish_reason,
-            }
+            {"model": chunk.model, "usage": chunk.usage, "received_at": datetime.now().isoformat()}
         )
+        # choices can be empty so only add if finish_reason if not empty
+        if len(chunk.choices) > 0 and hasattr(chunk.choices[0], "finish_reason"):
+            chunk_message.meta["finish_reason"] = chunk.choices[0].finish_reason
         return chunk_message

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -402,14 +402,9 @@ class OpenAIChatGenerator:
         chunk_delta: StreamingChunk
 
         for chunk in chat_completion:  # pylint: disable=not-an-iterable
-            # choices is an empty array for usage_chunk when include_usage is set to True
-            if chunk.usage is not None:
-                chunk_delta = self._convert_usage_chunk_to_streaming_chunk(chunk)
-            else:
-                assert len(chunk.choices) == 1, "Streaming responses should have only one choice."
-                chunk_delta = self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
+            assert len(chunk.choices) <= 1, "Streaming responses should have at most one choice."
+            chunk_delta = self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
             chunks.append(chunk_delta)
-
             callback(chunk_delta)
         return [self._convert_streaming_chunks_to_chat_message(chunk, chunks)]
 
@@ -421,15 +416,9 @@ class OpenAIChatGenerator:
         chunk_delta: StreamingChunk
 
         async for chunk in chat_completion:  # pylint: disable=not-an-iterable
-            # choices is an empty array for usage_chunk when include_usage is set to True
-            if chunk.usage is not None:
-                chunk_delta = self._convert_usage_chunk_to_streaming_chunk(chunk)
-
-            else:
-                assert len(chunk.choices) == 1, "Streaming responses should have only one choice."
-                chunk_delta = self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
+            assert len(chunk.choices) <= 1, "Streaming responses should have at most one choice."
+            chunk_delta = self._convert_chat_completion_chunk_to_streaming_chunk(chunk)
             chunks.append(chunk_delta)
-
             await callback(chunk_delta)
         return [self._convert_streaming_chunks_to_chat_message(chunk, chunks)]
 
@@ -449,12 +438,12 @@ class OpenAIChatGenerator:
             )
 
     def _convert_streaming_chunks_to_chat_message(
-        self, chunk: ChatCompletionChunk, chunks: List[StreamingChunk]
+        self, last_chunk: ChatCompletionChunk, chunks: List[StreamingChunk]
     ) -> ChatMessage:
         """
         Connects the streaming chunks into a single ChatMessage.
 
-        :param chunk: The last chunk returned by the OpenAI API.
+        :param last_chunk: The last chunk returned by the OpenAI API.
         :param chunks: The list of all `StreamingChunk` objects.
 
         :returns: The ChatMessage.
@@ -504,11 +493,11 @@ class OpenAIChatGenerator:
         finish_reason = finish_reasons[-1] if finish_reasons else None
 
         meta = {
-            "model": chunk.model,
+            "model": last_chunk.model,
             "index": 0,
             "finish_reason": finish_reason,
             "completion_start_time": chunks[0].meta.get("received_at"),  # first chunk received
-            "usage": chunk.usage or {},
+            "usage": dict(last_chunk.usage or {}),  # last chunk has the final usage data if available
         }
 
         return ChatMessage.from_assistant(text=text or None, tool_calls=tool_calls, meta=meta)
@@ -560,6 +549,10 @@ class OpenAIChatGenerator:
         :returns:
             The StreamingChunk.
         """
+        # if there are no choices, return an empty chunk
+        if len(chunk.choices) == 0:
+            return StreamingChunk(content="", meta={"model": chunk.model, "received_at": datetime.now().isoformat()})
+
         # we stream the content of the chunk if it's not a tool or function call
         choice: ChunkChoice = chunk.choices[0]
         content = choice.delta.content or ""
@@ -575,22 +568,4 @@ class OpenAIChatGenerator:
                 "received_at": datetime.now().isoformat(),
             }
         )
-        return chunk_message
-
-    def _convert_usage_chunk_to_streaming_chunk(self, chunk: ChatCompletionChunk) -> StreamingChunk:
-        """
-        Converts the usage chunk received from the OpenAI API when `include_usage` is set to `True` to a StreamingChunk.
-
-        :param chunk: The usage chunk returned by the OpenAI API.
-
-        :returns:
-            The StreamingChunk.
-        """
-        chunk_message = StreamingChunk(content="")
-        chunk_message.meta.update(
-            {"model": chunk.model, "usage": chunk.usage, "received_at": datetime.now().isoformat()}
-        )
-        # choices can be empty so only add if finish_reason if not empty
-        if len(chunk.choices) > 0 and hasattr(chunk.choices[0], "finish_reason"):
-            chunk_message.meta["finish_reason"] = chunk.choices[0].finish_reason
         return chunk_message

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -803,13 +803,10 @@ class TestOpenAIChatGenerator:
                 prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0),
             ),
         )
-        result = component._convert_usage_chunk_to_streaming_chunk(chunk)
+        result = component._convert_chat_completion_chunk_to_streaming_chunk(chunk)
         assert result.content == ""
         assert result.meta["model"] == "gpt-4o-mini-2024-07-18"
-        assert isinstance(result.meta["usage"], CompletionUsage)
-        assert result.meta["usage"].completion_tokens == 8
-        assert result.meta["usage"].prompt_tokens == 13
-        assert result.meta["usage"].total_tokens == 21
+        assert result.meta["received_at"] is not None
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -825,6 +822,7 @@ class TestOpenAIChatGenerator:
         assert "Paris" in message.text
         assert "gpt-4o" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
+        assert message.meta["usage"]["prompt_tokens"] > 0
 
     @pytest.mark.skipif(
         not os.environ.get("OPENAI_API_KEY", None),
@@ -926,6 +924,6 @@ class TestOpenAIChatGenerator:
         assert "Paris" in message.text
         assert "gpt-4o" in message.meta["model"]
         assert message.meta["finish_reason"] == "stop"
-        assert isinstance(message.meta["usage"], CompletionUsage)
-        assert message.meta["usage"].prompt_tokens > 0
+        assert isinstance(message.meta["usage"], dict)
+        assert message.meta["usage"]["prompt_tokens"] > 0
         assert "completion_start_time" in message.meta


### PR DESCRIPTION
### Related Issues

- fixes failing Mistral [tests](https://github.com/deepset-ai/haystack-core-integrations/actions/runs/13888924382) in core-integrations

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Changes how we look for the `finish_reason` when processing streaming chunks. OpenAI and Mistral put the finish_reason in different chunks so we just now look for the last one that is not None.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested manually for mistral and ensured existing OpenAI tests still work.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
