### PR TITLE
chore: removing `EvalRunResult` deprecation warnings

### DIFF
--- a/haystack/evaluation/eval_run_result.py
+++ b/haystack/evaluation/eval_run_result.py
@@ -220,30 +220,3 @@ class EvaluationRunResult:
         # combine both detailed reports
         combined_results = {**renamed_detailed_a, **filtered_detailed_b}
         return self._handle_output(combined_results, output_format, csv_file)
-
-    def score_report(self) -> "DataFrame":
-        """Generates a DataFrame report with aggregated scores for each metric."""
-        msg = (
-            "The `score_report` method is deprecated and will be removed in Haystack 2.12.0. Use "
-            "`aggregated_report` instead."
-        )
-        warn(msg, DeprecationWarning, stacklevel=2)
-        return self.aggregated_report(output_format="df")
-
-    def to_pandas(self) -> "DataFrame":
-        """Generates a DataFrame report with detailed scores for each metric."""
-        msg = (
-            "The `to_pandas` method is deprecated and will be removed in Haystack 2.12.0. Use `detailed_report` "
-            "instead."
-        )
-        warn(msg, DeprecationWarning, stacklevel=2)
-        return self.detailed_report(output_format="df")
-
-    def comparative_individual_scores_report(self, other: "EvaluationRunResult") -> "DataFrame":
-        """Generates a DataFrame report with detailed scores for each metric from two evaluation runs for comparison."""
-        msg = (
-            "The `comparative_individual_scores_report` method is deprecated will be removed in Haystack 2.12.0. Use "
-            "`comparative_detailed_report` instead."
-        )
-        warn(msg, DeprecationWarning, stacklevel=2)
-        return self.comparative_detailed_report(other, output_format="df")

--- a/releasenotes/notes/removing-deprecated-EvalRunResult-d28c2eb407da0051.yaml
+++ b/releasenotes/notes/removing-deprecated-EvalRunResult-d28c2eb407da0051.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    `to_pandas`, `comparative_individual_scores_report` and `score_report` were removed from `EvaluationRunResult`, please use now `detailed_report`, `comparative_detailed_report` and `aggregated_report` instead.


### PR DESCRIPTION
### Related Issues

- fixes #8955 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
