### PR TITLE
docs: updating docstring `BranchJoiner`

### DIFF
--- a/haystack/components/joiners/branch.py
+++ b/haystack/components/joiners/branch.py
@@ -60,7 +60,7 @@ class BranchJoiner:
     pipe.add_component('joiner', BranchJoiner(List[ChatMessage]))
     pipe.add_component('generator', OpenAIChatGenerator(model="gpt-4o-mini"))
     pipe.add_component('validator', JsonSchemaValidator(json_schema=person_schema))
-    pipe.add_component('adapter', OutputAdapter("{{chat_message}}", List[ChatMessage]))
+    pipe.add_component('adapter', OutputAdapter("{{chat_message}}", List[ChatMessage], unsafe=True))
 
     # And connect them
     pipe.connect("adapter", "joiner")
@@ -74,7 +74,7 @@ class BranchJoiner:
         "adapter": {"chat_message": [ChatMessage.from_user("Create json from Peter Parker")]}}
     )
 
-    print(json.loads(result["validator"]["validated"][0].content))
+    print(json.loads(result["validator"]["validated"][0].text))
 
 
     >> {'first_name': 'Peter', 'last_name': 'Parker', 'nationality': 'American', 'name': 'Spider-Man', 'occupation':


### PR DESCRIPTION
### Proposed Changes:

- update docstring, OutputAdapter needs to be initialised with `unsafe=True` and .text instead of .content for the ChatMessage

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
