### PR TITLE
fix: updating end2end evaluation tests

### DIFF
--- a/e2e/pipelines/test_evaluation_pipeline.py
+++ b/e2e/pipelines/test_evaluation_pipeline.py
@@ -220,7 +220,7 @@ def test_evaluation_pipeline(samples_path):
     }
     results_a = built_input_for_results_eval(results_rag_a)
     evaluation_result_a = EvaluationRunResult(run_name="rag_pipeline_a", results=results_a, inputs=inputs_a)
-    df_score_report = evaluation_result_a.score_report()
+    df_score_report = evaluation_result_a.aggregated_report()
 
     # assert the score report has all the metrics
     assert len(df_score_report) == 7
@@ -236,7 +236,7 @@ def test_evaluation_pipeline(samples_path):
     ]
 
     # assert the evaluation result has all the metrics, inputs and questions
-    df = evaluation_result_a.to_pandas()
+    df = evaluation_result_a.detailed_report()
     assert list(df.columns) == [
         "question",
         "contexts",
@@ -266,7 +266,7 @@ def test_evaluation_pipeline(samples_path):
     }
     results_b = built_input_for_results_eval(results_rag_b)
     evaluation_result_b = EvaluationRunResult(run_name="rag_pipeline_b", results=results_b, inputs=inputs_b)
-    df_comparative = evaluation_result_a.comparative_individual_scores_report(evaluation_result_b)
+    df_comparative = evaluation_result_a.comparative_detailed_report(evaluation_result_b)
 
     # assert the comparative score report has all the metrics, inputs and questions
     assert len(df_comparative) == 3


### PR DESCRIPTION
### Proposed Changes:

- find end2end evaluation tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
