### PR TITLE
fix: improve error message for incorrect component types

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -197,12 +197,15 @@ class PipelineBase:
                         # ...then try again
                         if component_data["type"] not in component.registry:
                             raise PipelineError(
-                                f"Successfully imported module {module} but can't find it in the component registry."
-                                "This is unexpected and most likely a bug."
+                                f"Successfully imported module '{module}' but couldn't find"
+                                f"'{component_data['type']}' in the component registry.\n"
+                                f"The component might be registered under a different path."
+                                f"Here are the components registered:\n {component.registry.keys()}\n"
                             )
                     except (ImportError, PipelineError, ValueError) as e:
                         raise PipelineError(
-                            f"Component '{component_data['type']}' (name: '{name}') not imported."
+                            f"Component '{component_data['type']}' (name: '{name}') not imported. Please"
+                            f"check that the package is installed and the component path is correct."
                         ) from e
 
                 # Create a new one

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -197,14 +197,14 @@ class PipelineBase:
                         # ...then try again
                         if component_data["type"] not in component.registry:
                             raise PipelineError(
-                                f"Successfully imported module '{module}' but couldn't find"
+                                f"Successfully imported module '{module}' but couldn't find "
                                 f"'{component_data['type']}' in the component registry.\n"
-                                f"The component might be registered under a different path."
+                                f"The component might be registered under a different path. "
                                 f"Here are the registered components:\n {list(component.registry.keys())}\n"
                             )
                     except (ImportError, PipelineError, ValueError) as e:
                         raise PipelineError(
-                            f"Component '{component_data['type']}' (name: '{name}') not imported. Please"
+                            f"Component '{component_data['type']}' (name: '{name}') not imported. Please "
                             f"check that the package is installed and the component path is correct."
                         ) from e
 

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -200,7 +200,7 @@ class PipelineBase:
                                 f"Successfully imported module '{module}' but couldn't find"
                                 f"'{component_data['type']}' in the component registry.\n"
                                 f"The component might be registered under a different path."
-                                f"Here are the components registered:\n {list(component.registry.keys())}\n"
+                                f"Here are the registered components:\n {list(component.registry.keys())}\n"
                             )
                     except (ImportError, PipelineError, ValueError) as e:
                         raise PipelineError(

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -200,7 +200,7 @@ class PipelineBase:
                                 f"Successfully imported module '{module}' but couldn't find"
                                 f"'{component_data['type']}' in the component registry.\n"
                                 f"The component might be registered under a different path."
-                                f"Here are the components registered:\n {component.registry.keys()}\n"
+                                f"Here are the components registered:\n {list(component.registry.keys())}\n"
                             )
                     except (ImportError, PipelineError, ValueError) as e:
                         raise PipelineError(

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -606,7 +606,30 @@ class TestPipelineBase:
         with pytest.raises(PipelineError) as err:
             PipelineBase.from_dict(data)
 
-        err.match(r"Component '' \(name: 'add_two'\) not imported.")
+        err.match(
+            r"Component '' \(name: 'add_two'\) not imported. Please check that the package is installed and the component path is correct."
+        )
+
+    def test_from_dict_with_correct_import_but_invalid_type(self):
+        # Test case: Module imports but component not found in registry.
+        data_registry_error = {
+            "metadata": {"test": "test"},
+            "components": {"add_two": {"type": "haystack.testing.NonExistentComponent", "init_parameters": {"add": 2}}},
+            "connections": [],
+        }
+
+        # Patch thread_safe_import so it doesn't raise an ImportError.
+        with patch("haystack.utils.type_serialization.thread_safe_import") as mock_import:
+            mock_import.return_value = None
+            with pytest.raises(PipelineError) as err_info:
+                PipelineBase.from_dict(data_registry_error)
+            outer_message = str(err_info.value)
+            inner_message = str(err_info.value.__cause__)
+
+            assert "Component 'haystack.testing.NonExistentComponent' (name: 'add_two') not imported." in outer_message
+            assert "Successfully imported module 'haystack.testing' but couldn't find" in inner_message
+            assert "in the component registry." in inner_message
+            assert "registered under a different path." in inner_message
 
     # UNIT
     def test_from_dict_without_connection_sender(self):


### PR DESCRIPTION
### Related Issues

- fixes #9002

### Proposed Changes:

The current error message is misleading. Improve it and show registry for imported components.

### How did you test it?

Existing tests
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
