### PR TITLE
fix: don't break on IndexError in logging

### DIFF
--- a/haystack/logging.py
+++ b/haystack/logging.py
@@ -192,7 +192,7 @@ def patch_make_records_to_use_kwarg_string_interpolation(original_make_records: 
         safe_extra = extra or {}
         try:
             interpolated_msg = msg.format(**safe_extra)
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, IndexError):
             interpolated_msg = msg
         return original_make_records(name, level, fn, lno, interpolated_msg, (), exc_info, func, extra, sinfo)
 

--- a/releasenotes/notes/fix-logging-index-error-c58691db633542c5.yaml
+++ b/releasenotes/notes/fix-logging-index-error-c58691db633542c5.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix an index error in the logging module when arbitrary strings are logged.
+    Fixed an index error in the logging module when arbitrary strings are logged.

--- a/releasenotes/notes/fix-logging-index-error-c58691db633542c5.yaml
+++ b/releasenotes/notes/fix-logging-index-error-c58691db633542c5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an index error in the logging module when arbitrary strings are logged.


### PR DESCRIPTION
### Related Issues

- fixes haystack logging raising another error when logging exceptions

We've seen this for a production pipeline:
```
IndexError: Replacement index 0 out of range for positional args tuple
```

Here's the logline that caused this error:
```python
except Exception as e:
            logger.error(
                f"Component {component.__class__.__name__} with prefix '{prefix}' failed with exception: {str(e)}",
                exc_info=True,
            )
```

relevant stacktrace:
```
  File "/home/haystackd/.local/lib/python3.12/site-packages/haystack/logging.py", line 144, in _log_only_with_kwargs
    return func(
           ^^^^^
  File "/home/haystackd/.pyenv/versions/3.12.8/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/home/haystackd/.pyenv/versions/3.12.8/lib/python3.12/logging/__init__.py", line 1682, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/haystackd/.local/lib/python3.12/site-packages/haystack/logging.py", line 194, in _wrapper
    interpolated_msg = msg.format(**safe_extra)
                       ^^^^^^^^^^^^^^^^^^^^^^^^
IndexError: Replacement index 0 out of range for positional args tuple
```

### Proposed Changes:
- catch IndexError

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->

### Notes for the reviewer
- a general catch all would be even safer I guess

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
