### PR TITLE
refactor!: `ChatMessage` serialization-deserialization updates

### DIFF
--- a/haystack/dataclasses/chat_message.py
+++ b/haystack/dataclasses/chat_message.py
@@ -354,12 +354,8 @@ class ChatMessage:
         :returns:
             The created object.
         """
-        init_params: Dict[str, Any] = {}
-
         if "content" in data:
-            init_params["_role"] = ChatRole(data["role"])
-            init_params["_name"] = data["name"]
-            init_params["_meta"] = data["meta"]
+            init_params = {"_role": ChatRole(data["role"]), "_name": data["name"], "_meta": data["meta"]}
 
             if isinstance(data["content"], list):
                 # current format - the serialized `content` field is a list of dictionaries
@@ -373,11 +369,12 @@ class ChatMessage:
 
         if "_content" in data:
             # format for versions >=2.9.0 and <2.12.0 - the serialized `_content` field is a list of dictionaries
-            init_params["_role"] = ChatRole(data["_role"])
-            init_params["_content"] = _deserialize_content(data["_content"])
-            init_params["_name"] = data["_name"]
-            init_params["_meta"] = data["_meta"]
-            return cls(**init_params)
+            return cls(
+                _role=ChatRole(data["_role"]),
+                _content=_deserialize_content(data["_content"]),
+                _name=data["_name"],
+                _meta=data["_meta"],
+            )
 
         raise ValueError(f"Missing 'content' or '_content' in serialized ChatMessage: `{data}`")
 

--- a/releasenotes/notes/chatmessage-serde-updates-f211c930e59c59b6.yaml
+++ b/releasenotes/notes/chatmessage-serde-updates-f211c930e59c59b6.yaml
@@ -1,6 +1,9 @@
 ---
-enhancements:
+upgrade:
   - |
-    Updates to `ChatMessage` serialization and deserialization.
+    Updated `ChatMessage` serialization and deserialization.
     `ChatMessage.to_dict()` now returns a dictionary with the keys: `role`, `content`, `meta`, and `name`.
     `ChatMessage.from_dict()` supports this format and maintains compatibility with older formats.
+
+    If your application consumes the result of `ChatMessage.to_dict()`, update your code to handle the new format.
+    No changes are needed if you're using `ChatPromptBuilder` in a Pipeline.

--- a/releasenotes/notes/chatmessage-serde-updates-f211c930e59c59b6.yaml
+++ b/releasenotes/notes/chatmessage-serde-updates-f211c930e59c59b6.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Updates to `ChatMessage` serialization and deserialization.
+    `ChatMessage.to_dict()` now returns a dictionary with the keys: `role`, `content`, `meta`, and `name`.
+    `ChatMessage.from_dict()` supports this format and maintains compatibility with older formats.

--- a/test/components/builders/test_chat_prompt_builder.py
+++ b/test/components/builders/test_chat_prompt_builder.py
@@ -542,13 +542,8 @@ class TestChatPromptBuilderDynamic:
             "type": "haystack.components.builders.chat_prompt_builder.ChatPromptBuilder",
             "init_parameters": {
                 "template": [
-                    {"_content": [{"text": "text and {var}"}], "_role": "user", "_meta": {}, "_name": None},
-                    {
-                        "_content": [{"text": "content {required_var}"}],
-                        "_role": "assistant",
-                        "_meta": {},
-                        "_name": None,
-                    },
+                    {"content": [{"text": "text and {var}"}], "role": "user", "meta": {}, "name": None},
+                    {"content": [{"text": "content {required_var}"}], "role": "assistant", "meta": {}, "name": None},
                 ],
                 "variables": ["var", "required_var"],
                 "required_variables": ["required_var"],
@@ -561,12 +556,12 @@ class TestChatPromptBuilderDynamic:
                 "type": "haystack.components.builders.chat_prompt_builder.ChatPromptBuilder",
                 "init_parameters": {
                     "template": [
-                        {"_content": [{"text": "text and {var}"}], "_role": "user", "_meta": {}, "_name": None},
+                        {"content": [{"text": "text and {var}"}], "role": "user", "meta": {}, "name": None},
                         {
-                            "_content": [{"text": "content {required_var}"}],
-                            "_role": "assistant",
-                            "_meta": {},
-                            "_name": None,
+                            "content": [{"text": "content {required_var}"}],
+                            "role": "assistant",
+                            "meta": {},
+                            "name": None,
                         },
                     ],
                     "variables": ["var", "required_var"],


### PR DESCRIPTION
### Related Issues

- fixes #9009, fixes #8740

### Proposed Changes:
- modify `ChatMessage.to_dict()` to return a dictionary with the keys: `role`, `content`, `meta`, and `name` (instead of `_role`, ...)

- make `ChatMessage.to_dict()` support and deserialize these formats:
  - current format (`role`, `content`, ...) - 2.12.0
  - previous format (`_role`, `_content`, ...) - >=2.9.0, <2.12.0 
  - pre 2.9.0 format (`content` is a string) - <2.9.0

### How did you test it?
CI; new tests

### Notes for the reviewer
If users explicitly consume `ChatMessage.to_dict()` output, this is a breaking change -> communicated in the release note. 

For pipeline users, I don't expect this to break anything.

However, please review this PR carefully in case I missed something.

Once this is merged, I will coordinate with @dfokina to remove the last 2 sections from 2.12.0 [`ChatMessage` docs](https://docs.haystack.deepset.ai/docs/chatmessage).

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
