### PR TITLE
chore: remove unused logger from several modules

### DIFF
--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union, get_args
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.dataclasses import ByteStream
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice
@@ -14,8 +14,6 @@ from haystack.utils import ComponentDevice
 with LazyImport("Run 'pip install \"openai-whisper>=20231106\"' to install whisper.") as whisper_import:
     import whisper
 
-
-logger = logging.getLogger(__name__)
 WhisperLocalModel = Literal[
     "base",
     "base.en",

--- a/haystack/components/caching/cache_checker.py
+++ b/haystack/components/caching/cache_checker.py
@@ -4,11 +4,9 @@
 
 from typing import Any, Dict, List
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import DocumentStore
 from haystack.utils import deserialize_document_store_in_init_params_inplace
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/classifiers/zero_shot_document_classifier.py
+++ b/haystack/components/classifiers/zero_shot_document_classifier.py
@@ -4,13 +4,10 @@
 
 from typing import Any, Dict, List, Optional
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
 from haystack.utils.hf import deserialize_hf_model_kwargs, resolve_hf_pipeline_kwargs, serialize_hf_model_kwargs
-
-logger = logging.getLogger(__name__)
-
 
 with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     from transformers import pipeline

--- a/haystack/components/connectors/openapi.py
+++ b/haystack/components/connectors/openapi.py
@@ -4,14 +4,12 @@
 
 from typing import Any, Dict, Optional
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
 
 with LazyImport("Run 'pip install openapi-llm'") as openapi_llm_imports:
     from openapi_llm.client.openapi import OpenAPIClient
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/connectors/openapi_service.py
+++ b/haystack/components/connectors/openapi_service.py
@@ -7,11 +7,9 @@ from collections import defaultdict
 from copy import copy
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage, ChatRole
 from haystack.lazy_imports import LazyImport
-
-logger = logging.getLogger(__name__)
 
 with LazyImport("Run 'pip install openapi3'") as openapi_imports:
     import requests

--- a/haystack/components/embedders/hugging_face_api_document_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_document_embedder.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from tqdm import tqdm
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import Document
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -16,8 +16,6 @@ from haystack.utils.url_validation import is_valid_http_url
 
 with LazyImport(message="Run 'pip install \"huggingface_hub>=0.27.0\"'") as huggingface_hub_import:
     from huggingface_hub import InferenceClient
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/embedders/hugging_face_api_text_embedder.py
+++ b/haystack/components/embedders/hugging_face_api_text_embedder.py
@@ -5,7 +5,7 @@
 import warnings
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_secrets_inplace
 from haystack.utils.hf import HFEmbeddingAPIType, HFModelType, check_valid_model
@@ -13,8 +13,6 @@ from haystack.utils.url_validation import is_valid_http_url
 
 with LazyImport(message="Run 'pip install \"huggingface_hub>=0.27.0\"'") as huggingface_hub_import:
     from huggingface_hub import InferenceClient
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -7,12 +7,10 @@ from typing import Any, Callable, Dict, Optional
 
 from openai.lib.azure import AzureADTokenProvider, AzureOpenAI
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators import OpenAIGenerator
 from haystack.dataclasses import StreamingChunk
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -7,13 +7,11 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from openai.lib.azure import AsyncAzureADTokenProvider, AsyncAzureOpenAI, AzureADTokenProvider, AzureOpenAI
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses import StreamingChunk
 from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 from typing import Any, AsyncIterable, Callable, Dict, Iterable, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall, select_streaming_callback
 from haystack.lazy_imports import LazyImport
 from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
@@ -22,9 +22,6 @@ with LazyImport(message="Run 'pip install \"huggingface_hub[inference]>=0.27.0\"
         ChatCompletionStreamOutput,
         InferenceClient,
     )
-
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/generators/hugging_face_api.py
+++ b/haystack/components/generators/hugging_face_api.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union, cast
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import StreamingChunk
 from haystack.lazy_imports import LazyImport
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
@@ -20,9 +20,6 @@ with LazyImport(message="Run 'pip install \"huggingface_hub>=0.27.0\"'") as hugg
         TextGenerationStreamOutput,
         TextGenerationStreamOutputToken,
     )
-
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/generators/openai_dalle.py
+++ b/haystack/components/generators/openai_dalle.py
@@ -8,10 +8,8 @@ from typing import Any, Dict, List, Literal, Optional
 from openai import OpenAI
 from openai.types.image import Image
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/joiners/answer_joiner.py
+++ b/haystack/components/joiners/answer_joiner.py
@@ -7,13 +7,11 @@ from enum import Enum
 from math import inf
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.core.component.types import Variadic
 from haystack.dataclasses.answer import ExtractedAnswer, GeneratedAnswer
 
 AnswerType = Union[GeneratedAnswer, ExtractedAnswer]
-
-logger = logging.getLogger(__name__)
 
 
 class JoinMode(Enum):

--- a/haystack/components/joiners/branch.py
+++ b/haystack/components/joiners/branch.py
@@ -4,11 +4,9 @@
 
 from typing import Any, Dict, Type
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.core.component.types import GreedyVariadic
 from haystack.utils import deserialize_type, serialize_type
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/joiners/string_joiner.py
+++ b/haystack/components/joiners/string_joiner.py
@@ -4,10 +4,8 @@
 
 from typing import List
 
-from haystack import component, logging
+from haystack import component
 from haystack.core.component.types import Variadic
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/rankers/meta_field_grouping_ranker.py
+++ b/haystack/components/rankers/meta_field_grouping_ranker.py
@@ -5,9 +5,7 @@
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, cast
 
-from haystack import Document, component, logging
-
-logger = logging.getLogger(__name__)
+from haystack import Document, component
 
 
 @component

--- a/haystack/components/rankers/sentence_transformers_diversity.py
+++ b/haystack/components/rankers/sentence_transformers_diversity.py
@@ -5,13 +5,10 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
 from haystack.utils.hf import deserialize_hf_model_kwargs, serialize_hf_model_kwargs
-
-logger = logging.getLogger(__name__)
-
 
 with LazyImport(message="Run 'pip install \"sentence-transformers>=3.0.0\"'") as torch_and_sentence_transformers_import:
     import torch

--- a/haystack/components/rankers/transformers_similarity.py
+++ b/haystack/components/rankers/transformers_similarity.py
@@ -5,13 +5,10 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, DeviceMap, Secret, deserialize_secrets_inplace
 from haystack.utils.hf import deserialize_hf_model_kwargs, resolve_hf_device_map, serialize_hf_model_kwargs
-
-logger = logging.getLogger(__name__)
-
 
 with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     import accelerate  # pylint: disable=unused-import # the library is used but not directly referenced

--- a/haystack/components/retrievers/filter_retriever.py
+++ b/haystack/components/retrievers/filter_retriever.py
@@ -4,11 +4,9 @@
 
 from typing import Any, Dict, List, Optional
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import DocumentStore
 from haystack.utils import deserialize_document_store_in_init_params_inplace
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/components/routers/file_type_router.py
+++ b/haystack/components/routers/file_type_router.py
@@ -8,12 +8,9 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.components.converters.utils import get_bytestream_from_source, normalize_metadata
 from haystack.dataclasses import ByteStream
-
-logger = logging.getLogger(__name__)
-
 
 CUSTOM_MIMETYPES = {
     # we add markdown because it is not added by the mimetypes module

--- a/haystack/components/routers/transformers_text_router.py
+++ b/haystack/components/routers/transformers_text_router.py
@@ -4,12 +4,9 @@
 
 from typing import Any, Dict, List, Optional
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
-
-logger = logging.getLogger(__name__)
-
 
 with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     from transformers import AutoConfig, pipeline

--- a/haystack/components/routers/zero_shot_text_router.py
+++ b/haystack/components/routers/zero_shot_text_router.py
@@ -4,12 +4,9 @@
 
 from typing import Any, Dict, List, Optional
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.lazy_imports import LazyImport
 from haystack.utils import ComponentDevice, Secret, deserialize_secrets_inplace
-
-logger = logging.getLogger(__name__)
-
 
 with LazyImport(message="Run 'pip install transformers[torch,sentencepiece]'") as torch_and_transformers_import:
     from transformers import pipeline

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -5,11 +5,9 @@
 import json
 from typing import Any, Dict, List
 
-from haystack import component, default_from_dict, default_to_dict, logging
+from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses.chat_message import ChatMessage, ToolCall
 from haystack.tools.tool import Tool, ToolInvocationError, _check_duplicate_tool_names, deserialize_tools_inplace
-
-logger = logging.getLogger(__name__)
 
 _TOOL_INVOCATION_FAILURE = "Tool invocation failed with error: {error}."
 _TOOL_NOT_FOUND = "Tool {tool_name} not found in the list of tools. Available tools are: {available_tools}."

--- a/haystack/components/writers/document_writer.py
+++ b/haystack/components/writers/document_writer.py
@@ -4,11 +4,9 @@
 
 from typing import Any, Dict, List, Optional
 
-from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack import Document, component, default_from_dict, default_to_dict
 from haystack.document_stores.types import DocumentStore, DuplicatePolicy
 from haystack.utils import deserialize_document_store_in_init_params_inplace
-
-logger = logging.getLogger(__name__)
 
 
 @component

--- a/haystack/core/component/sockets.py
+++ b/haystack/core/component/sockets.py
@@ -4,12 +4,9 @@
 
 from typing import Dict, Optional, Type, Union
 
-from haystack import logging
 from haystack.core.type_utils import _type_name
 
 from .types import InputSocket, OutputSocket
-
-logger = logging.getLogger(__name__)
 
 SocketsDict = Dict[str, Union[InputSocket, OutputSocket]]
 SocketsIOType = Union[Type[InputSocket], Type[OutputSocket]]

--- a/haystack/core/pipeline/descriptions.py
+++ b/haystack/core/pipeline/descriptions.py
@@ -6,11 +6,8 @@ from typing import Dict, List
 
 import networkx  # type:ignore
 
-from haystack import logging
 from haystack.core.component.types import InputSocket, OutputSocket
 from haystack.core.type_utils import _type_name
-
-logger = logging.getLogger(__name__)
 
 
 def find_pipeline_inputs(

--- a/haystack/core/type_utils.py
+++ b/haystack/core/type_utils.py
@@ -4,10 +4,6 @@
 
 from typing import Any, TypeVar, Union, get_args, get_origin
 
-from haystack import logging
-
-logger = logging.getLogger(__name__)
-
 T = TypeVar("T")
 
 

--- a/haystack/dataclasses/document.py
+++ b/haystack/dataclasses/document.py
@@ -8,11 +8,8 @@ from typing import Any, Dict, List, Optional
 
 from numpy import ndarray
 
-from haystack import logging
 from haystack.dataclasses.byte_stream import ByteStream
 from haystack.dataclasses.sparse_embedding import SparseEmbedding
-
-logger = logging.getLogger(__name__)
 
 LEGACY_FIELDS = ["content_type", "id_hash_keys", "dataframe"]
 

--- a/haystack/document_stores/types/protocol.py
+++ b/haystack/document_stores/types/protocol.py
@@ -4,14 +4,11 @@
 
 from typing import Any, Dict, List, Optional, Protocol
 
-from haystack import logging
 from haystack.dataclasses import Document
 from haystack.document_stores.types.policy import DuplicatePolicy
 
 # Ellipsis are needed for the type checker, it's safe to disable module-wide
 # pylint: disable=unnecessary-ellipsis
-
-logger = logging.getLogger(__name__)
 
 
 class DocumentStore(Protocol):

--- a/haystack/telemetry/_environment.py
+++ b/haystack/telemetry/_environment.py
@@ -7,10 +7,7 @@ import platform
 import sys
 from typing import Any, Dict, Optional
 
-from haystack import logging
 from haystack.version import __version__
-
-logger = logging.getLogger(__name__)
 
 # This value cannot change during the lifetime of the process
 _IS_DOCKER_CACHE = None

--- a/haystack/utils/device.py
+++ b/haystack/utils/device.py
@@ -7,10 +7,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple, Union
 
-from haystack import logging
 from haystack.lazy_imports import LazyImport
-
-logger = logging.getLogger(__name__)
 
 with LazyImport(
     message="PyTorch must be installed to use torch.device or use GPU support in HuggingFace transformers. "


### PR DESCRIPTION
### Related Issues

I noticed that in several modules we initialize a logger, but we don't use it.

### Proposed Changes:
- remove all unused loggers (and related imports)

### How did you test it?
CI

### Notes for the reviewer
I think that this is just the effect of copy-pasting components.
If I am wrong and creating loggers serve any purpose, this PR would be easy to revert.
 
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
