### PR TITLE
test: OpenAIChatGenerator - relax flaky test

### DIFF
--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -886,7 +886,7 @@ class TestOpenAIChatGenerator:
 
         # check that the completion_start_time is set and valid ISO format
         assert "completion_start_time" in message.meta
-        assert datetime.fromisoformat(message.meta["completion_start_time"]) < datetime.now()
+        assert datetime.fromisoformat(message.meta["completion_start_time"]) <= datetime.now()
 
         assert isinstance(message.meta["usage"], dict)
         assert message.meta["usage"]["prompt_tokens"] > 0


### PR DESCRIPTION
### Related Issues

- this test sometimes fails because the two times do not differ : https://github.com/deepset-ai/haystack/actions/runs/13952175226/job/39054633236?pr=9067

### Proposed Changes:
- relax the flaky test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
