### PR TITLE
Improve state resuming mechanism

### DIFF
--- a/examples/resume_breakpoints.py
+++ b/examples/resume_breakpoints.py
@@ -87,34 +87,12 @@ def hybrid_retrieval(doc_store):
     return rag_pipeline
 
 
-def load_json(file_path: str) -> dict:
-    """
-    Loads a JSON file into a dictionary.
-
-    :param file_path: Path to the JSON file
-    :return: The loaded JSON as a dictionary
-    :raises FileNotFoundError: If the file doesn't exist
-    :raises json.JSONDecodeError: If the file contains invalid JSON
-    :raises IOError: If there's an issue reading the file
-    """
-    try:
-        with open(file_path, "r") as file:
-            data = json.load(file)
-        return data
-    except FileNotFoundError:
-        raise FileNotFoundError(f"File not found: {file_path}")
-    except json.JSONDecodeError as e:
-        raise json.JSONDecodeError(f"Invalid JSON in file {file_path}: {str(e)}", e.doc, e.pos)
-    except IOError as e:
-        raise IOError(f"Error reading file {file_path}: {str(e)}")
-
-
 def main():
     """blah"""
     doc_store = indexing()
     pipeline = hybrid_retrieval(doc_store)
 
-    resume_state = load_json(sys.argv[1])
+    resume_state = pipeline.load_state((sys.argv[1]))
 
     pipeline.run(data={}, resume_state=resume_state)
 

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import json
 import sys
 from copy import deepcopy
@@ -330,6 +331,7 @@ class Pipeline(PipelineBase):
 
         return value
 
+    @staticmethod
     def save_state(
         inputs: Dict[str, Any],
         component_name: str,
@@ -375,24 +377,11 @@ class Pipeline(PipelineBase):
             logger.error(f"Failed to save pipeline state: {str(e)}")
             raise
 
-    def resume_from_state(self, state: Dict[str, Any], validate_components: bool = True) -> Dict[str, Any]:
+    def resume_from_state(self, state: Dict[str, Any]):
         """
         Resume pipeline execution from a saved state.
 
-        Args:
-            state: Loaded pipeline state
-            validate_components: Whether to validate component compatibility before resuming
-
-        Returns:
-            Dict containing the pipeline outputs
         """
-        try:
-            self._validate_components_state(state)
-            return self.run(data=state["pipeline_state"]["original_input_data"], resume_state=state)
-
-        except Exception as e:
-            logger.error(f"Failed to resume pipeline: {str(e)}")
-            raise
 
     def load_state(self, file_path: Union[str, Path]) -> Dict[str, Any]:
         """
@@ -431,7 +420,7 @@ class Pipeline(PipelineBase):
 
         :param resume_state: The saved state to validate.
         """
-        # Check for the presence of the 'pipeline_state' key.
+        # This can be removed if we always load the state using the load_state method
         if "pipeline_state" not in resume_state:
             raise PipelineRuntimeError("Invalid resume state: missing 'pipeline_state' key.")
 
@@ -479,11 +468,6 @@ class Pipeline(PipelineBase):
         Validates the loaded pipeline state.
 
         Ensures that the state contains required keys: "metadata", "breakpoint", and "pipeline_state".
-        Also checks that the sets of component names in:
-        - pipeline_state["inputs"],
-        - state["input_data"], and
-        - pipeline_state["ordered_component_names"]
-        are identical.
 
         Raises:
             ValueError: If required keys are missing or the component sets are inconsistent.

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -390,8 +390,7 @@ class Pipeline(PipelineBase):
         from datetime import datetime
 
         dt = datetime.now()
-        state_id = f"{component_name}_state_{dt.strftime('%Y_%m_%d_%H_%M_%S')}"
-        file_name = f"{state_id}.json"
+        file_name = f"{component_name}_state_{dt.strftime('%Y_%m_%d_%H_%M_%S')}.json"
 
         state = {
             "input_data": self.original_input_data,

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -7,7 +7,7 @@ import sys
 from copy import deepcopy
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Callable, Dict, Mapping, Optional, Set, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
 
 from haystack import logging, tracing
 from haystack.core.component import Component
@@ -336,9 +336,9 @@ class Pipeline(PipelineBase):
         inputs: Dict[str, Any],
         component_name: str,
         component_visits: Dict[str, int],
-        ordered_component_names: Optional[Set[str]],
+        ordered_component_names: Optional[List[str]],
         original_input_data,
-        callback_fun: Callable = None,
+        callback_fun: Optional[Callable[..., Any]] = None,
     ) -> None:
         """
         Saves the state of the pipeline at a given component visit count.
@@ -370,7 +370,7 @@ class Pipeline(PipelineBase):
             logger.info(f"Pipeline state saved at: {file_name}")
 
             # pass the state to some user-defined callback function
-            if callback_fun:
+            if callback_fun is not None:
                 callback_fun(state)
 
         except Exception as e:

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -25,8 +25,10 @@ class Pipeline(PipelineBase):
     Orchestrates component execution according to the execution graph, one after the other.
     """
 
-    ordered_component_names: Optional[list[str]] = None
-    original_input_data: Optional[dict[str, Any]] = (None,)
+    def __init__(self):
+        super().__init__()
+        self.ordered_component_names: Optional[List[str]] = None
+        self.original_input_data: Optional[Dict[str, Any]] = None
 
     def _run_component(
         self,
@@ -71,14 +73,14 @@ class Pipeline(PipelineBase):
                     msg = f"Breaking at component: {component_name}"
                     logger.info(msg)
                     self.save_state(inputs, component_name, component_visits)
-                    sys.exit()  # ToDo: do this in a more graceful way
+                    sys.exit()
 
                 # check if the visit count is the same
                 elif bp[1] == component_visits[component_name]:
                     msg = f"nBreaking at component: {component_name} visit count: {component_visits[component_name]}"
                     logger.info(msg)
                     self.save_state(inputs, component_name, component_visits)
-            sys.exit()  # ToDo: do this in a more graceful way
+                    sys.exit()  # ToDo: do this in a more graceful way
 
         with tracing.tracer.trace(
             "haystack.component.run",
@@ -302,6 +304,7 @@ class Pipeline(PipelineBase):
                         component_name, component_visits[component_name]
                     )
 
+                self.original_input_data = data
                 component_outputs = self._run_component(
                     component, inputs, component_visits, breakpoints, parent_span=span
                 )


### PR DESCRIPTION

### Proposed Changes:

- Add a new `load_state` function in pipeline logic
- add a metadata key in `resume_state` and store state_id
- add `validate_state` to validate the `debug_state` has all the required high level keys
- add `validate_component_state` to validate if components passed in `debug_state` are in pipeline

### How did you test it?

Manual testing
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
