### PR TITLE
feat: add run_async for OpenAITextEmbedder

### DIFF
--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -5,7 +5,8 @@
 import os
 from typing import Any, Dict, List, Optional
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
+from openai.types import CreateEmbeddingResponse
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.utils import Secret, deserialize_secrets_inplace
@@ -101,6 +102,13 @@ class OpenAITextEmbedder:
             timeout=timeout,
             max_retries=max_retries,
         )
+        self.async_client = AsyncOpenAI(
+            api_key=api_key.resolve_value(),
+            organization=organization,
+            base_url=api_base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """
@@ -139,6 +147,27 @@ class OpenAITextEmbedder:
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
         return default_from_dict(cls, data)
 
+    def _prepare_input(self, text: str) -> Dict[str, Any]:
+        if not isinstance(text, str):
+            raise TypeError(
+                "OpenAITextEmbedder expects a string as an input."
+                "In case you want to embed a list of Documents, please use the OpenAIDocumentEmbedder."
+            )
+
+        text_to_embed = self.prefix + text + self.suffix
+
+        # copied from OpenAI embedding_utils (https://github.com/openai/openai-python/blob/main/openai/embeddings_utils.py)
+        # replace newlines, which can negatively affect performance.
+        text_to_embed = text_to_embed.replace("\n", " ")
+
+        kwargs = {"model": self.model, "input": text}
+        if self.dimensions is not None:
+            kwargs["dimensions"] = self.dimensions
+        return kwargs
+
+    def _prepare_output(self, result: CreateEmbeddingResponse) -> Dict[str, Any]:
+        return {"embedding": result.data[0].embedding, "meta": {"model": result.model, "usage": dict(result.usage)}}
+
     @component.output_types(embedding=List[float], meta=Dict[str, Any])
     def run(self, text: str):
         """
@@ -152,23 +181,26 @@ class OpenAITextEmbedder:
             - `embedding`: The embedding of the input text.
             - `meta`: Information about the usage of the model.
         """
-        if not isinstance(text, str):
-            raise TypeError(
-                "OpenAITextEmbedder expects a string as an input."
-                "In case you want to embed a list of Documents, please use the OpenAIDocumentEmbedder."
-            )
+        create_kwargs = self._prepare_input(text=text)
+        response = self.client.embeddings.create(**create_kwargs)
+        return self._prepare_output(result=response)
 
-        text_to_embed = self.prefix + text + self.suffix
+    @component.output_types(embedding=List[float], meta=Dict[str, Any])
+    async def run_async(self, text: str):
+        """
+        Asynchronously embed a single string.
 
-        # copied from OpenAI embedding_utils (https://github.com/openai/openai-python/blob/main/openai/embeddings_utils.py)
-        # replace newlines, which can negatively affect performance.
-        text_to_embed = text_to_embed.replace("\n", " ")
+        This is the asynchronous version of the `run` method. It has the same parameters and return values
+        but can be used with `await` in async code.
 
-        if self.dimensions is not None:
-            response = self.client.embeddings.create(model=self.model, dimensions=self.dimensions, input=text_to_embed)
-        else:
-            response = self.client.embeddings.create(model=self.model, input=text_to_embed)
+        :param text:
+            Text to embed.
 
-        meta = {"model": response.model, "usage": dict(response.usage)}
-
-        return {"embedding": response.data[0].embedding, "meta": meta}
+        :returns:
+            A dictionary with the following keys:
+            - `embedding`: The embedding of the input text.
+            - `meta`: Information about the usage of the model.
+        """
+        create_kwargs = self._prepare_input(text=text)
+        response = await self.async_client.embeddings.create(**create_kwargs)
+        return self._prepare_output(result=response)

--- a/test/components/embedders/test_openai_text_embedder.py
+++ b/test/components/embedders/test_openai_text_embedder.py
@@ -135,3 +135,21 @@ class TestOpenAITextEmbedder:
         )
 
         assert result["meta"]["usage"] == {"prompt_tokens": 6, "total_tokens": 6}, "Usage information does not match"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.environ.get("OPENAI_API_KEY", "") == "", reason="OPENAI_API_KEY is not set")
+    @pytest.mark.integration
+    async def test_run_async(self):
+        model = "text-embedding-ada-002"
+
+        embedder = OpenAITextEmbedder(model=model, prefix="prefix ", suffix=" suffix")
+        result = await embedder.run_async(text="The food was delicious")
+
+        assert len(result["embedding"]) == 1536
+        assert all(isinstance(x, float) for x in result["embedding"])
+
+        assert "text" in result["meta"]["model"] and "ada" in result["meta"]["model"], (
+            "The model name does not contain 'text' and 'ada'"
+        )
+
+        assert result["meta"]["usage"] == {"prompt_tokens": 6, "total_tokens": 6}, "Usage information does not match"


### PR DESCRIPTION
### Related Issues

- fixes #9021

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
I refactored into some function to avoid repetition between `run` and `run_async`.

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
I have added an integration test. All the unit tests are passing locally.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
