### PR TITLE
docs: fixing docstrings

### DIFF
--- a/haystack/components/audio/whisper_local.py
+++ b/haystack/components/audio/whisper_local.py
@@ -113,12 +113,12 @@ class LocalWhisperTranscriber:
         """
         Transcribes a list of audio files into a list of documents.
 
-        For the supported audio formats, languages, and other parameters, see the
-        [Whisper API documentation](https://platform.openai.com/docs/guides/speech-to-text) and the official Whisper
-        [GitHup repo](https://github.com/openai/whisper).
-
         :param sources:
             A list of paths or binary streams to transcribe.
+        :param whisper_params:
+            For the supported audio formats, languages, and other parameters, see the
+            [Whisper API documentation](https://platform.openai.com/docs/guides/speech-to-text) and the official Whisper
+            [GitHup repo](https://github.com/openai/whisper).
 
         :returns: A dictionary with the following keys:
             - `documents`: A list of documents where each document is a transcribed audio file. The content of


### PR DESCRIPTION
### Proposed Changes:

- adding missing parameter in whisper local docstrings

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
