### PR TITLE
fix: improve `component.output_types` decorator type hinting to support `run_async` methods

### DIFF
--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -454,11 +454,25 @@ class _Component:
     ) -> Callable[[Callable[RunParamsT, RunReturnT]], Callable[RunParamsT, RunReturnT]]:
         """
         Decorator factory that specifies the output types of a component.
+
+        Use as:
+        ```python
+        @component
+        class MyComponent:
+            @component.output_types(output_1=int, output_2=str)
+            def run(self, value: int):
+                return {"output_1": 1, "output_2": "2"}
+        ```
         """
 
         def output_types_decorator(run_method: Callable[RunParamsT, RunReturnT]) -> Callable[RunParamsT, RunReturnT]:
             """
             Decorator that sets the output types of the decorated method.
+
+            This happens at class creation time, and since we don't have the decorated
+            class available here, we temporarily store the output types as an attribute of
+            the decorated method. The ComponentMeta metaclass will use this data to create
+            sockets at instance creation time.
             """
             method_name = run_method.__name__
             if method_name not in ("run", "run_async"):

--- a/haystack/core/component/component.py
+++ b/haystack/core/component/component.py
@@ -91,7 +91,7 @@ logger = logging.getLogger(__name__)
 RunParamsT = ParamSpec("RunParamsT")
 SyncRunReturnT = TypeVar("SyncRunReturnT", bound=Dict[str, Any])
 AsyncRunReturnT = TypeVar("AsyncRunReturnT", bound=Coroutine[Any, Any, Dict[str, Any]])
-ComponentRunReturnT = Union[SyncRunReturnT, AsyncRunReturnT]
+RunReturnT = Union[SyncRunReturnT, AsyncRunReturnT]
 
 
 @dataclass
@@ -451,14 +451,12 @@ class _Component:
 
     def output_types(
         self, **types: Any
-    ) -> Callable[[Callable[RunParamsT, ComponentRunReturnT]], Callable[RunParamsT, ComponentRunReturnT]]:
+    ) -> Callable[[Callable[RunParamsT, RunReturnT]], Callable[RunParamsT, RunReturnT]]:
         """
         Decorator factory that specifies the output types of a component.
         """
 
-        def output_types_decorator(
-            run_method: Callable[RunParamsT, ComponentRunReturnT],
-        ) -> Callable[RunParamsT, ComponentRunReturnT]:
+        def output_types_decorator(run_method: Callable[RunParamsT, RunReturnT]) -> Callable[RunParamsT, RunReturnT]:
             """
             Decorator that sets the output types of the decorated method.
             """

--- a/releasenotes/notes/output-types-decorator-better-type-hinting-51bb3f28f55954b4.yaml
+++ b/releasenotes/notes/output-types-decorator-better-type-hinting-51bb3f28f55954b4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improved type hinting for the `component.output_types` decorator. The type hinting for the decorator was originally
+    introduced  to avoid overshadowing the type hinting of the `run` method and allow proper static type checking.
+    This update extends support to asynchronous `run_async` methods.


### PR DESCRIPTION
### Related Issues

- type hinting for the `component.output_types` decorator was introduced in https://github.com/deepset-ai/haystack/pull/9074
- I forgot to explicitly support `run_async` methods which have a different type and now we have mypy failures: https://github.com/deepset-ai/haystack/actions/runs/14040072535/job/39308204626


### Proposed Changes:
- extend type hinting to support `run_async` methods
- choose more expressive names for the `TypeVar`s and `ParamSpec`

### How did you test it?
- CI
- locally run mypy on all Haystack
- checked that the `ChatGenerator` protocol still works (we are not overshadowing `run` methods types). I used the following code.

```python
from haystack.components.extractors.llm_metadata_extractor import LLMMetadataExtractor, LLMProvider
from haystack.components.generators.chat.openai import OpenAIChatGenerator
from haystack.components.generators.chat.types import ChatGenerator

def do_something(generator: ChatGenerator):
    print(generator.to_dict())

chat_generator = OpenAIChatGenerator(model="gpt-4o-mini", generation_kwargs={"temperature": 0.5})
do_something(chat_generator) # mypy ok

extractor = LLMMetadataExtractor(prompt="some prompt that was used with the LLM {{document.content}}", generator_api=LLMProvider.OPENAI)
do_something(extractor) # mypy error
```

### Notes for the reviewer
Currently, we are only running mypy on the changed files of a PR.
https://github.com/deepset-ai/haystack/blob/dae8c7babaf28d2ffab4f2a8dedecd63e2394fb4/.github/workflows/tests.yml#L249

This means that if we make types changes in core classes, mypy is not checking them across the codebase.

Even if we probably do that because mypy is slow, I would revisit this choice. WDYT? https://github.com/deepset-ai/haystack/pull/9103

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
