### PR TITLE
ci: run mypy across the codebase

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -246,7 +246,7 @@ jobs:
         if: steps.files.outputs.any_changed == 'true'
         run: |
           mkdir .mypy_cache
-          hatch run test:types ${{ steps.files.outputs.all_changed_files }}
+          hatch run test:types
 
       - name: Pylint
         if: steps.files.outputs.any_changed == 'true'

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -7,6 +7,8 @@
 # - they make this module more complicated and hard to maintain
 # - they offer minimal performance gains in this case.
 
+# A NICE TRIGGER
+
 import haystack.logging
 import haystack.tracing
 from haystack.core.component import component

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -7,7 +7,6 @@
 # - they make this module more complicated and hard to maintain
 # - they offer minimal performance gains in this case.
 
-# A NICE TRIGGER
 
 import haystack.logging
 import haystack.tracing

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -7,7 +7,6 @@
 # - they make this module more complicated and hard to maintain
 # - they offer minimal performance gains in this case.
 
-
 import haystack.logging
 import haystack.tracing
 from haystack.core.component import component


### PR DESCRIPTION
### Related Issues

- happened that in #9074 we changed some types in core classes
- since mypy is currently configured to run only on the changed python files of a PR, it did not catch errors
https://github.com/deepset-ai/haystack/blob/dae8c7babaf28d2ffab4f2a8dedecd63e2394fb4/.github/workflows/tests.yml#L249

### Proposed Changes:
- whenever at least one python file is changed, make mypy run across all the codebase

### How did you test it?
CI; triggered a run by temporarily changing a python file (https://github.com/deepset-ai/haystack/pull/9103/commits/9b5457a543c001c02572f23bb6ea056633806527) -> [mypy run](https://github.com/deepset-ai/haystack/actions/runs/14042523294/job/39316170468) (failures in the logs are related to #9102)

In this case, mypy spent 1m22s (for comparison, in #9099, mypy ran on a single file and took 1m5s).

### Notes for the reviewer
Perhaps we have not done this in the past because mypy is slow...
However, the `lint` job (including mypy) depends on unit tests and runs concurrently with integration tests (which are slower), so all in all I don't think this change would make people wait any longer.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
