### PR TITLE
enhancement: add detailed error message for failed component run

### DIFF
--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -76,7 +76,15 @@ class Pipeline(PipelineBase):
             # when we delete them in case they're sent to other Components
             span.set_content_tag("haystack.component.input", deepcopy(component_inputs))
             logger.info("Running component {component_name}", component_name=component_name)
-            component_output = instance.run(**component_inputs)
+            try:
+                component_output = instance.run(**component_inputs)
+            except Exception as error:
+                raise PipelineRuntimeError(
+                    f"The following component failed to run:\n"
+                    f"Component name: '{component_name}'\n"
+                    f"Component type: '{instance.__class__.__name__}'\n"
+                    f"Error: {str(error)}"
+                ) from error
             component_visits[component_name] += 1
 
             if not isinstance(component_output, Mapping):

--- a/releasenotes/notes/add-error-message-component-run-failure-b956852263d41c3c.yaml
+++ b/releasenotes/notes/add-error-message-component-run-failure-b956852263d41c3c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Improved error handling for component `run` failures by raising a runtime error that includes the component's name and type.

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -84,7 +84,7 @@ class TestPipeline:
 
         assert "didn't return a dictionary" in str(exc_info.value)
 
-    def test__run_component_error(self):
+    def test_run_component_error(self):
         """Test error when component fails to run"""
 
         @component

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -84,6 +84,29 @@ class TestPipeline:
 
         assert "didn't return a dictionary" in str(exc_info.value)
 
+    def test__run_component_error(self):
+        """Test error when component fails to run"""
+
+        @component
+        class ErroringComponent:
+            @component.output_types(output=str)
+            def run(self):
+                raise ValueError("Test error")
+
+        erroring_component = ErroringComponent()
+        pp = Pipeline()
+        pp.add_component("erroring_component", erroring_component)
+
+        inputs = {"wrong": {"value": [{"sender": None, "value": "test_value"}]}}
+
+        with pytest.raises(PipelineRuntimeError) as exc_info:
+            pp._run_component(
+                component=pp._get_component_with_graph_metadata_and_visits("erroring_component", 0),
+                inputs=inputs,
+                component_visits={"erroring_component": 0},
+            )
+        assert "Component name: 'erroring_component'" in str(exc_info.value)
+
     def test_run(self):
         joiner_1 = BranchJoiner(type_=str)
         joiner_2 = BranchJoiner(type_=str)


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack-private/issues/115

### Proposed Changes:

Enhance error handling by raising a detailed runtime error when a component fails, including the component's `name` and `type` in the error message for better debugging.

### How did you test it?

Added a test
Existing tests
### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
