### PR TITLE
test: skip/remove some `Pipeline.draw` integration tests

### DIFF
--- a/test/core/pipeline/test_draw.py
+++ b/test/core/pipeline/test_draw.py
@@ -111,6 +111,7 @@ def test_to_mermaid_text_does_not_edit_graph():
     assert expected_pipe == pipe.to_dict()
 
 
+@pytest.mark.skip(reason="This is a nice to have, but frequently fails due to mermaid.ink issues")
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "params",
@@ -140,20 +141,6 @@ def test_to_mermaid_image_invalid_format():
 
     with pytest.raises(ValueError, match="Invalid image format:"):
         _to_mermaid_image(pipe.graph, params={"format": "invalid_format"})
-
-
-@pytest.mark.integration
-def test_to_mermaid_image_missing_theme():
-    # Test default theme (neutral)
-    pipe = Pipeline()
-    pipe.add_component("comp1", Double())
-    pipe.add_component("comp2", Double())
-    pipe.connect("comp1", "comp2")
-
-    params = {"format": "img"}
-    image_data = _to_mermaid_image(pipe.graph, params=params)
-
-    assert image_data  # Ensure some data is returned
 
 
 def test_to_mermaid_image_invalid_scale():


### PR DESCRIPTION
### Related Issues

- related to #9107 

### Proposed Changes:
- skip/remove some `Pipeline.draw` integration tests (better explained in the comments)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
