### PR TITLE
refactor!: use Chat Generator in LLM evaluators

### DIFF
--- a/haystack/components/evaluators/llm_evaluator.py
+++ b/haystack/components/evaluators/llm_evaluator.py
@@ -206,7 +206,6 @@ class LLMEvaluator:
         for input_names_to_values in tqdm(list_of_input_names_to_values, disable=not self.progress_bar):
             prompt = self.builder.run(**input_names_to_values)
             messages = [ChatMessage.from_user(prompt["prompt"])]
-            print(messages)
             try:
                 result = self._chat_generator.run(messages=messages)
             except Exception as e:

--- a/releasenotes/notes/llm-evaluators-chat-generator-bf930fa6db019714.yaml
+++ b/releasenotes/notes/llm-evaluators-chat-generator-bf930fa6db019714.yaml
@@ -3,4 +3,4 @@ upgrade:
   - |
     `LLMEvaluator`, `ContextRelevanceEvaluator`, and `FaithfulnessEvaluator` now internally use a
     `ChatGenerator` instance instead of a `Generator` instance.
-    The public attribute `generator` has been removed and replaced with `_chat_generator`.
+    The public attribute `generator` has been replaced with `_chat_generator`.

--- a/releasenotes/notes/llm-evaluators-chat-generator-bf930fa6db019714.yaml
+++ b/releasenotes/notes/llm-evaluators-chat-generator-bf930fa6db019714.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    `LLMEvaluator`, `ContextRelevanceEvaluator`, and `FaithfulnessEvaluator` now internally use a
+    `ChatGenerator` instance instead of a `Generator` instance.
+    The public attribute `generator` has been removed and replaced with `_chat_generator`.

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -19,7 +19,7 @@ class TestContextRelevanceEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator()
         assert component.api == "openai"
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.instructions == (
             "Please extract only sentences from the provided context which are absolutely relevant and "
             "required to answer the following question. If no relevant sentences are found, or if you "
@@ -66,7 +66,7 @@ class TestContextRelevanceEvaluator:
                 {"inputs": {"questions": "Football is the most popular sport."}, "outputs": {"custom_score": 0}},
             ],
         )
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.api == "openai"
         assert component.examples == [
             {"inputs": {"questions": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
@@ -108,7 +108,7 @@ class TestContextRelevanceEvaluator:
         }
         component = ContextRelevanceEvaluator.from_dict(data)
         assert component.api == "openai"
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.examples == [{"inputs": {"questions": "What is football?"}, "outputs": {"score": 0}}]
 
         pipeline = Pipeline()
@@ -119,13 +119,13 @@ class TestContextRelevanceEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator()
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             if "Football" in kwargs["messages"][0].text:
                 return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["a", "b"], "score": 1}')]}
             else:
                 return {"replies": [ChatMessage.from_assistant('{"relevant_statements": [], "score": 0}')]}
 
-        monkeypatch.setattr("haystack.components.generators.chat.openai.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -153,13 +153,13 @@ class TestContextRelevanceEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator()
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             if "Football" in kwargs["messages"][0].text:
                 return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["a", "b"], "score": 1}')]}
             else:
                 return {"replies": [ChatMessage.from_assistant('{"relevant_statements": [], "score": 0}')]}
 
-        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -189,13 +189,13 @@ class TestContextRelevanceEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = ContextRelevanceEvaluator(raise_on_failure=False)
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             if "Python" in kwargs["messages"][0].text:
                 raise Exception("OpenAI API request failed.")
             else:
                 return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["c", "d"], "score": 1}')]}
 
-        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [

--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -11,6 +11,7 @@ import pytest
 from haystack import Pipeline
 from haystack.components.evaluators import ContextRelevanceEvaluator
 from haystack.utils.auth import Secret
+from haystack.dataclasses.chat_message import ChatMessage
 
 
 class TestContextRelevanceEvaluator:
@@ -119,12 +120,12 @@ class TestContextRelevanceEvaluator:
         component = ContextRelevanceEvaluator()
 
         def generator_run(self, *args, **kwargs):
-            if "Football" in kwargs["prompt"]:
-                return {"replies": ['{"relevant_statements": ["a", "b"], "score": 1}']}
+            if "Football" in kwargs["messages"][0].text:
+                return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["a", "b"], "score": 1}')]}
             else:
-                return {"replies": ['{"relevant_statements": [], "score": 0}']}
+                return {"replies": [ChatMessage.from_assistant('{"relevant_statements": [], "score": 0}')]}
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.generators.chat.openai.OpenAIChatGenerator.run", generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -153,12 +154,12 @@ class TestContextRelevanceEvaluator:
         component = ContextRelevanceEvaluator()
 
         def generator_run(self, *args, **kwargs):
-            if "Football" in kwargs["prompt"]:
-                return {"replies": ['{"relevant_statements": ["a", "b"], "score": 1}']}
+            if "Football" in kwargs["messages"][0].text:
+                return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["a", "b"], "score": 1}')]}
             else:
-                return {"replies": ['{"relevant_statements": [], "score": 0}']}
+                return {"replies": [ChatMessage.from_assistant('{"relevant_statements": [], "score": 0}')]}
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -189,12 +190,12 @@ class TestContextRelevanceEvaluator:
         component = ContextRelevanceEvaluator(raise_on_failure=False)
 
         def generator_run(self, *args, **kwargs):
-            if "Python" in kwargs["prompt"]:
+            if "Python" in kwargs["messages"][0].text:
                 raise Exception("OpenAI API request failed.")
             else:
-                return {"replies": ['{"relevant_statements": ["c", "d"], "score": 1}']}
+                return {"replies": [ChatMessage.from_assistant('{"relevant_statements": ["c", "d"], "score": 1}')]}
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -18,7 +18,7 @@ class TestFaithfulnessEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator()
         assert component.api == "openai"
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.instructions == (
             "Your task is to judge the faithfulness or groundedness of statements based "
             "on context information. First, please extract statements from a provided predicted "
@@ -85,7 +85,7 @@ class TestFaithfulnessEvaluator:
                 },
             ],
         )
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.api == "openai"
         assert component.examples == [
             {"inputs": {"predicted_answers": "Damn, this is straight outta hell!!!"}, "outputs": {"custom_score": 1}},
@@ -133,7 +133,7 @@ class TestFaithfulnessEvaluator:
         }
         component = FaithfulnessEvaluator.from_dict(data)
         assert component.api == "openai"
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.examples == [
             {"inputs": {"predicted_answers": "Football is the most popular sport."}, "outputs": {"score": 0}}
         ]
@@ -146,7 +146,7 @@ class TestFaithfulnessEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator()
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             if "Football" in kwargs["messages"][0].text:
                 return {
                     "replies": [ChatMessage.from_assistant('{"statements": ["a", "b"], "statement_scores": [1, 0]}')]
@@ -156,7 +156,7 @@ class TestFaithfulnessEvaluator:
                     "replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]
                 }
 
-        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -191,7 +191,7 @@ class TestFaithfulnessEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator()
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             if "Football" in kwargs["messages"][0].text:
                 return {
                     "replies": [ChatMessage.from_assistant('{"statements": ["a", "b"], "statement_scores": [1, 0]}')]
@@ -199,7 +199,7 @@ class TestFaithfulnessEvaluator:
             else:
                 return {"replies": [ChatMessage.from_assistant('{"statements": [], "statement_scores": []}')]}
 
-        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -236,7 +236,7 @@ class TestFaithfulnessEvaluator:
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = FaithfulnessEvaluator(raise_on_failure=False)
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             if "Python" in kwargs["messages"][0].text:
                 raise Exception("OpenAI API request failed.")
             else:
@@ -244,7 +244,7 @@ class TestFaithfulnessEvaluator:
                     "replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]
                 }
 
-        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -10,6 +10,7 @@ import pytest
 from haystack import Pipeline
 from haystack.components.evaluators import FaithfulnessEvaluator
 from haystack.utils.auth import Secret
+from haystack.dataclasses.chat_message import ChatMessage
 
 
 class TestFaithfulnessEvaluator:
@@ -146,12 +147,16 @@ class TestFaithfulnessEvaluator:
         component = FaithfulnessEvaluator()
 
         def generator_run(self, *args, **kwargs):
-            if "Football" in kwargs["prompt"]:
-                return {"replies": ['{"statements": ["a", "b"], "statement_scores": [1, 0]}']}
+            if "Football" in kwargs["messages"][0].text:
+                return {
+                    "replies": [ChatMessage.from_assistant('{"statements": ["a", "b"], "statement_scores": [1, 0]}')]
+                }
             else:
-                return {"replies": ['{"statements": ["c", "d"], "statement_scores": [1, 1]}']}
+                return {
+                    "replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]
+                }
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -187,12 +192,14 @@ class TestFaithfulnessEvaluator:
         component = FaithfulnessEvaluator()
 
         def generator_run(self, *args, **kwargs):
-            if "Football" in kwargs["prompt"]:
-                return {"replies": ['{"statements": ["a", "b"], "statement_scores": [1, 0]}']}
+            if "Football" in kwargs["messages"][0].text:
+                return {
+                    "replies": [ChatMessage.from_assistant('{"statements": ["a", "b"], "statement_scores": [1, 0]}')]
+                }
             else:
-                return {"replies": ['{"statements": [], "statement_scores": []}']}
+                return {"replies": [ChatMessage.from_assistant('{"statements": [], "statement_scores": []}')]}
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [
@@ -230,12 +237,14 @@ class TestFaithfulnessEvaluator:
         component = FaithfulnessEvaluator(raise_on_failure=False)
 
         def generator_run(self, *args, **kwargs):
-            if "Python" in kwargs["prompt"]:
+            if "Python" in kwargs["messages"][0].text:
                 raise Exception("OpenAI API request failed.")
             else:
-                return {"replies": ['{"statements": ["c", "d"], "statement_scores": [1, 1]}']}
+                return {
+                    "replies": [ChatMessage.from_assistant('{"statements": ["c", "d"], "statement_scores": [1, 1]}')]
+                }
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", generator_run)
 
         questions = ["Which is the most popular global sport?", "Who created the Python language?"]
         contexts = [

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -24,7 +24,7 @@ class TestLLMEvaluator:
             ],
         )
         assert component.api == "openai"
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.api_params == {"generation_kwargs": {"response_format": {"type": "json_object"}, "seed": 42}}
         assert component.instructions == "test-instruction"
         assert component.inputs == [("predicted_answers", List[str])]
@@ -65,7 +65,7 @@ class TestLLMEvaluator:
                 },
             ],
         )
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.api_params == {"generation_kwargs": {"response_format": {"type": "json_object"}, "seed": 43}}
         assert component.api == "openai"
         assert component.examples == [
@@ -240,7 +240,7 @@ class TestLLMEvaluator:
         }
         component = LLMEvaluator.from_dict(data)
         assert component.api == "openai"
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.api_params == {"generation_kwargs": {"response_format": {"type": "json_object"}, "seed": 42}}
         assert component.instructions == "test-instruction"
         assert component.inputs == [("predicted_answers", List[str])]
@@ -318,10 +318,10 @@ class TestLLMEvaluator:
             ],
         )
 
-        def generator_run(self, *args, **kwargs):
-            return {"replies": ['{"score": 0.5}']}
+        def chat_generator_run(self, *args, **kwargs):
+            return {"replies": [ChatMessage.from_assistant('{"score": 0.5}')]}
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         with pytest.raises(ValueError):
             component.run(questions=["What is the capital of Germany?"], predicted_answers=[["Berlin"], ["Paris"]])
@@ -343,10 +343,10 @@ class TestLLMEvaluator:
             ],
         )
 
-        def generator_run(self, *args, **kwargs):
+        def chat_generator_run(self, *args, **kwargs):
             return {"replies": [ChatMessage.from_assistant('{"score": 0.5}')]}
 
-        monkeypatch.setattr("haystack.components.generators.chat.openai.OpenAIChatGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.evaluators.llm_evaluator.OpenAIChatGenerator.run", chat_generator_run)
 
         results = component.run(questions=["What is the capital of Germany?"], predicted_answers=["Berlin"])
         assert results == {"results": [{"score": 0.5}], "meta": None}
@@ -472,7 +472,7 @@ class TestLLMEvaluator:
                 },
             ],
         )
-        assert component.generator.client.api_key == "test-api-key"
+        assert component._chat_generator.client.api_key == "test-api-key"
         assert component.api_params == {
             "generation_kwargs": {"response_format": {"type": "json_object"}, "seed": 42},
             "api_base_url": "http://127.0.0.1:11434/v1",

--- a/test/components/evaluators/test_llm_evaluator.py
+++ b/test/components/evaluators/test_llm_evaluator.py
@@ -9,6 +9,7 @@ import pytest
 from haystack import Pipeline
 from haystack.components.evaluators import LLMEvaluator
 from haystack.utils.auth import Secret
+from haystack.dataclasses.chat_message import ChatMessage
 
 
 class TestLLMEvaluator:
@@ -343,9 +344,9 @@ class TestLLMEvaluator:
         )
 
         def generator_run(self, *args, **kwargs):
-            return {"replies": ['{"score": 0.5}']}
+            return {"replies": [ChatMessage.from_assistant('{"score": 0.5}')]}
 
-        monkeypatch.setattr("haystack.components.generators.openai.OpenAIGenerator.run", generator_run)
+        monkeypatch.setattr("haystack.components.generators.chat.openai.OpenAIChatGenerator.run", generator_run)
 
         results = component.run(questions=["What is the capital of Germany?"], predicted_answers=["Berlin"])
         assert results == {"results": [{"score": 0.5}], "meta": None}


### PR DESCRIPTION
### Related Issues

- part of #9062 (I decided to split the work to keep PRs small)

### Proposed Changes:
- refactor `LLMEvaluator` and child classes (`ContextRelevanceEvaluator` and `FaithfulnessEvaluator`) to use a Chat Generator instead of a Generator

- breaking: replace the public attribute `self.generator` with `self._chat_generator`
  This would not be strictly required but:
    - in a future PR we will allow users to pass a `chat_generator` instance and I think exposing a `generator` attribute would be confusing
    - I believe that the `generator`/`_chat_generator` attribute should not be part of the public API of this component

### How did you test it?
CI; adapted tests


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
