### PR TITLE
fix:  converting methods to `staticmethod` and fixing docstrings in `DocumentRecallEvaluator`

### DIFF
--- a/haystack/components/evaluators/document_recall.py
+++ b/haystack/components/evaluators/document_recall.py
@@ -76,18 +76,23 @@ class DocumentRecallEvaluator:
         if isinstance(mode, str):
             mode = RecallMode.from_str(mode)
 
-        mode_functions = {RecallMode.SINGLE_HIT: self._recall_single_hit, RecallMode.MULTI_HIT: self._recall_multi_hit}
+        mode_functions = {
+            RecallMode.SINGLE_HIT: DocumentRecallEvaluator._recall_single_hit,
+            RecallMode.MULTI_HIT: DocumentRecallEvaluator._recall_multi_hit,
+        }
         self.mode_function = mode_functions[mode]
         self.mode = mode
 
-    def _recall_single_hit(self, ground_truth_documents: List[Document], retrieved_documents: List[Document]) -> float:
+    @staticmethod
+    def _recall_single_hit(ground_truth_documents: List[Document], retrieved_documents: List[Document]) -> float:
         unique_truths = {g.content for g in ground_truth_documents}
         unique_retrievals = {p.content for p in retrieved_documents}
         retrieved_ground_truths = unique_truths.intersection(unique_retrievals)
 
         return float(len(retrieved_ground_truths) > 0)
 
-    def _recall_multi_hit(self, ground_truth_documents: List[Document], retrieved_documents: List[Document]) -> float:
+    @staticmethod
+    def _recall_multi_hit(ground_truth_documents: List[Document], retrieved_documents: List[Document]) -> float:
         unique_truths = {g.content for g in ground_truth_documents}
         unique_retrievals = {p.content for p in retrieved_documents}
         retrieved_ground_truths = unique_truths.intersection(unique_retrievals)
@@ -109,7 +114,7 @@ class DocumentRecallEvaluator:
             A list of retrieved documents for each question.
         A dictionary with the following outputs:
             - `score` - The average of calculated scores.
-            - `invididual_scores` - A list of numbers from 0.0 to 1.0 that represents the proportion of matching
+            - `individual_scores` - A list of numbers from 0.0 to 1.0 that represents the proportion of matching
                 documents retrieved. If the mode is `single_hit`, the individual scores are 0 or 1.
         """
         if len(ground_truth_documents) != len(retrieved_documents):


### PR DESCRIPTION
### Proposed Changes:

- fix:  converting methods to `staticmethod`
- docs: typo

### How did you test it?

- unit tests, integration tests, manual verification, instructions for manual tests -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
