### PR TITLE
chore: ignore mypy issue due to Sentence Transformers 4.0.1 release

### DIFF
--- a/haystack/components/embedders/backends/sentence_transformers_backend.py
+++ b/haystack/components/embedders/backends/sentence_transformers_backend.py
@@ -68,7 +68,8 @@ class _SentenceTransformersEmbeddingBackend:
     ):
         sentence_transformers_import.check()
 
-        self.model = SentenceTransformer(
+        self.model = SentenceTransformer(  # type: ignore[call-overload, misc]
+            # type issues with sentence-transformers 4.0.1 - https://github.com/UKPLab/sentence-transformers/issues/3290
             model_name_or_path=model,
             device=device,
             token=auth_token.resolve_value() if auth_token else None,


### PR DESCRIPTION
### Related Issues

- mypy is failing in our CI: https://github.com/deepset-ai/haystack/actions/runs/14086071654/job/39450754410
- Sentence Transformers 4.0.1, recently released, has some type issues: https://github.com/UKPLab/sentence-transformers/issues/3290

### Proposed Changes:
- temporarily ignore this specific mypy error to unblock the CI

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
