### PR TITLE
test: temporarily skip `test_to_mermaid_image` integration test

### DIFF
--- a/test/core/pipeline/test_draw.py
+++ b/test/core/pipeline/test_draw.py
@@ -12,7 +12,7 @@ from haystack.core.pipeline.draw import _to_mermaid_image, _to_mermaid_text
 from haystack.testing.sample_components import AddFixedValue, Double
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=5)
+@pytest.mark.skip(reason="Temporarily skipped due to mermaid.ink issues")
 @pytest.mark.integration
 def test_to_mermaid_image():
     pipe = Pipeline()


### PR DESCRIPTION
### Related Issues

- https://github.com/deepset-ai/haystack/issues/9107
- today this test keeps failing: https://github.com/deepset-ai/haystack/actions/runs/14104890422/job/39510021594?pr=9120

### Proposed Changes:
- temporarily skip `test_to_mermaid_image` integration test

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
