### PR TITLE
fix: manage max_retries=0 in AzureOpenAIGenerator, AzureOpenAIChatGenerator, AzureOpenAITextEmbedder, AzureOpenAIDocumentEmbedder

### DIFF
--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -128,7 +128,7 @@ class AzureOpenAIDocumentEmbedder:
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider
 

--- a/haystack/components/embedders/azure_text_embedder.py
+++ b/haystack/components/embedders/azure_text_embedder.py
@@ -108,7 +108,7 @@ class AzureOpenAITextEmbedder:
         self.dimensions = dimensions
         self.organization = organization
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.prefix = prefix
         self.suffix = suffix
         self.default_headers = default_headers or {}

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -140,7 +140,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         self.organization = organization
         self.model: str = azure_deployment or "gpt-4o-mini"
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider
 

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -148,7 +148,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         self.organization = organization
         self.model = azure_deployment or "gpt-4o-mini"
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider
 

--- a/releasenotes/notes/fix-9127-a16104e9efd4b8f2.yaml
+++ b/releasenotes/notes/fix-9127-a16104e9efd4b8f2.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Fixes issue 9127

--- a/releasenotes/notes/fix-9127-a16104e9efd4b8f2.yaml
+++ b/releasenotes/notes/fix-9127-a16104e9efd4b8f2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes issue 9127

--- a/releasenotes/notes/fix-max-retries-azure-open-ai-a16104e9efd4b8f2.yaml
+++ b/releasenotes/notes/fix-max-retries-azure-open-ai-a16104e9efd4b8f2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Ensure that the max_retries initialization parameter is correctly set when equal 0 in AzureOpenAIGenerator, AzureOpenAIChatGenerator, AzureOpenAITextEmbedder and AzureOpenAIDocumentEmbedder.

--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -30,6 +30,25 @@ class TestAzureOpenAIDocumentEmbedder:
         assert embedder.default_headers == {}
         assert embedder.azure_ad_token_provider is None
 
+    def test_init_with_0_max_retries(self, monkeypatch):
+        """Tests that the max_retries init param is set correctly if equal 0"""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        embedder = AzureOpenAIDocumentEmbedder(
+            azure_endpoint="https://example-resource.azure.openai.com/", max_retries=0
+        )
+        assert embedder.azure_deployment == "text-embedding-ada-002"
+        assert embedder.dimensions is None
+        assert embedder.organization is None
+        assert embedder.prefix == ""
+        assert embedder.suffix == ""
+        assert embedder.batch_size == 32
+        assert embedder.progress_bar is True
+        assert embedder.meta_fields_to_embed == []
+        assert embedder.embedding_separator == "\n"
+        assert embedder.default_headers == {}
+        assert embedder.azure_ad_token_provider is None
+        assert embedder.max_retries == 0
+
     def test_to_dict(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
         component = AzureOpenAIDocumentEmbedder(azure_endpoint="https://example-resource.azure.openai.com/")

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -23,6 +23,21 @@ class TestAzureOpenAITextEmbedder:
         assert embedder.default_headers == {}
         assert embedder.azure_ad_token_provider is None
 
+    def test_init_with_zero_max_retries(self, monkeypatch):
+        """Tests that the max_retries init param is set correctly if equal 0"""
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        embedder = AzureOpenAITextEmbedder(azure_endpoint="https://example-resource.azure.openai.com/", max_retries=0)
+
+        assert embedder._client.api_key == "fake-api-key"
+        assert embedder.azure_deployment == "text-embedding-ada-002"
+        assert embedder.dimensions is None
+        assert embedder.organization is None
+        assert embedder.prefix == ""
+        assert embedder.suffix == ""
+        assert embedder.default_headers == {}
+        assert embedder.azure_ad_token_provider is None
+        assert embedder.max_retries == 0
+
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
         component = AzureOpenAITextEmbedder(azure_endpoint="https://example-resource.azure.openai.com/")

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -60,6 +60,27 @@ class TestAzureOpenAIChatGenerator:
         assert component.tools == tools
         assert component.tools_strict
         assert component.azure_ad_token_provider is not None
+        assert component.max_retries == 5
+
+    def test_init_with_0_max_retries(self, tools):
+        component = AzureOpenAIChatGenerator(
+            api_key=Secret.from_token("test-api-key"),
+            azure_endpoint="some-non-existing-endpoint",
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            tools=tools,
+            tools_strict=True,
+            azure_ad_token_provider=default_azure_ad_token_provider,
+            max_retries=0,
+        )
+        assert component.client.api_key == "test-api-key"
+        assert component.azure_deployment == "gpt-4o-mini"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.tools == tools
+        assert component.tools_strict
+        assert component.azure_ad_token_provider is not None
+        assert component.max_retries == 0
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -63,6 +63,7 @@ class TestAzureOpenAIChatGenerator:
         assert component.max_retries == 5
 
     def test_init_with_0_max_retries(self, tools):
+        """Tests that the max_retries init param is set correctly if equal 0"""
         component = AzureOpenAIChatGenerator(
             api_key=Secret.from_token("test-api-key"),
             azure_endpoint="some-non-existing-endpoint",

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -44,6 +44,25 @@ class TestAzureOpenAIGenerator:
         assert component.timeout == 30.0
         assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
         assert component.azure_ad_token_provider is not None
+        assert component.max_retries == 5
+
+    def test_init_with_0_max_retries(self):
+        component = AzureOpenAIGenerator(
+            api_key=Secret.from_token("fake-api-key"),
+            azure_endpoint="some-non-existing-endpoint",
+            azure_deployment="gpt-4o-mini",
+            streaming_callback=print_streaming_chunk,
+            generation_kwargs={"max_tokens": 10, "some_test_param": "test-params"},
+            azure_ad_token_provider=default_azure_ad_token_provider,
+            max_retries=0,
+        )
+        assert component.client.api_key == "fake-api-key"
+        assert component.azure_deployment == "gpt-4o-mini"
+        assert component.streaming_callback is print_streaming_chunk
+        assert component.timeout == 30.0
+        assert component.generation_kwargs == {"max_tokens": 10, "some_test_param": "test-params"}
+        assert component.azure_ad_token_provider is not None
+        assert component.max_retries == 0
 
     def test_to_dict_default(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-api-key")

--- a/test/components/generators/test_azure.py
+++ b/test/components/generators/test_azure.py
@@ -47,6 +47,7 @@ class TestAzureOpenAIGenerator:
         assert component.max_retries == 5
 
     def test_init_with_0_max_retries(self):
+        """Tests that the max_retries init param is set correctly if equal 0"""
         component = AzureOpenAIGenerator(
             api_key=Secret.from_token("fake-api-key"),
             azure_endpoint="some-non-existing-endpoint",


### PR DESCRIPTION
### Related Issues

- fixes #9127

### Proposed Changes:

Check is max_retries is None and only in that case check env var.

### How did you test it?

Unit tests

### Notes for the reviewer

None

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
