### PR TITLE
fix: `DALLEImageGenerator` - ensure `max_retries` is correctly set when 0

### DIFF
--- a/haystack/components/embedders/azure_document_embedder.py
+++ b/haystack/components/embedders/azure_document_embedder.py
@@ -127,7 +127,7 @@ class AzureOpenAIDocumentEmbedder:
         self.progress_bar = progress_bar
         self.meta_fields_to_embed = meta_fields_to_embed or []
         self.embedding_separator = embedding_separator
-        self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
+        self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider

--- a/haystack/components/embedders/azure_text_embedder.py
+++ b/haystack/components/embedders/azure_text_embedder.py
@@ -107,7 +107,7 @@ class AzureOpenAITextEmbedder:
         self.azure_deployment = azure_deployment
         self.dimensions = dimensions
         self.organization = organization
-        self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
+        self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.prefix = prefix
         self.suffix = suffix

--- a/haystack/components/generators/azure.py
+++ b/haystack/components/generators/azure.py
@@ -139,7 +139,7 @@ class AzureOpenAIGenerator(OpenAIGenerator):
         self.azure_deployment = azure_deployment
         self.organization = organization
         self.model: str = azure_deployment or "gpt-4o-mini"
-        self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
+        self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -147,7 +147,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         self.azure_deployment = azure_deployment
         self.organization = organization
         self.model = azure_deployment or "gpt-4o-mini"
-        self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
+        self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
         self.default_headers = default_headers or {}
         self.azure_ad_token_provider = azure_ad_token_provider

--- a/haystack/components/generators/openai_dalle.py
+++ b/haystack/components/generators/openai_dalle.py
@@ -70,7 +70,7 @@ class DALLEImageGenerator:
         self.organization = organization
 
         self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
-        self.max_retries = max_retries or int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
+        self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
 
         self.client: Optional[OpenAI] = None
 

--- a/haystack/components/generators/openai_dalle.py
+++ b/haystack/components/generators/openai_dalle.py
@@ -69,7 +69,7 @@ class DALLEImageGenerator:
         self.api_base_url = api_base_url
         self.organization = organization
 
-        self.timeout = timeout or float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
+        self.timeout = timeout if timeout is not None else float(os.environ.get("OPENAI_TIMEOUT", "30.0"))
         self.max_retries = max_retries if max_retries is not None else int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
 
         self.client: Optional[OpenAI] = None

--- a/releasenotes/notes/dalle-fix-max-retries-703c36ce354a2e45.yaml
+++ b/releasenotes/notes/dalle-fix-max-retries-703c36ce354a2e45.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    In `DALLEImageGenerator`, ensure that the `max_retries` initialization parameter is correctly set when it is equal
+    to 0.

--- a/test/components/generators/test_openai_dalle.py
+++ b/test/components/generators/test_openai_dalle.py
@@ -56,7 +56,7 @@ class TestDALLEImageGenerator:
 
     def test_init_max_retries_0(self, monkeypatch):
         """
-        Test that the max_retries parameter is taken into account also if it is 0.
+        Test that the max_retries parameter is taken into account even if it is 0.
         """
         component = DALLEImageGenerator(max_retries=0)
         assert component.max_retries == 0

--- a/test/components/generators/test_openai_dalle.py
+++ b/test/components/generators/test_openai_dalle.py
@@ -54,6 +54,13 @@ class TestDALLEImageGenerator:
         assert pytest.approx(component.timeout) == 60.0
         assert component.max_retries == 10
 
+    def test_init_max_retries_0(self, monkeypatch):
+        """
+        Test that the max_retries parameter is taken into account also if it is 0.
+        """
+        component = DALLEImageGenerator(max_retries=0)
+        assert component.max_retries == 0
+
     def test_warm_up(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         component = DALLEImageGenerator()


### PR DESCRIPTION
### Related Issues

- similar to #9127: when the initialization parameter is provided and is equal to 0, `max_retries` was incorrectly set to an env var value or 5

### Proposed Changes:
- same fix as #9128: if the initialization parameter is not `None`, take it into account
- I also made the same fix to `timeout` in some components for the sake of consistency: in this case, 0 is not a very meaningful value

### How did you test it?
CI; small new test


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
