### PR TITLE
feat: Add option to split by number of tokens to RecursiveDocumentSplitter

### DIFF
--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -370,7 +370,6 @@ class RecursiveDocumentSplitter:
             A list of text chunks.
         """
         chunks = []
-        step = self.split_length - self.split_overlap
 
         if split_units == "word":
             words = re.findall(r"\S+|\s+", text)
@@ -381,7 +380,7 @@ class RecursiveDocumentSplitter:
                 if word != " ":
                     current_chunk.append(word)
                     current_length += 1
-                    if current_length == step and current_chunk:
+                    if current_length == self.split_length and current_chunk:
                         chunks.append("".join(current_chunk))
                         current_chunk = []
                         current_length = 0
@@ -391,12 +390,12 @@ class RecursiveDocumentSplitter:
             if current_chunk:
                 chunks.append("".join(current_chunk))
         elif split_units == "char":
-            for i in range(0, self._chunk_length(text), step):
+            for i in range(0, self._chunk_length(text), self.split_length):
                 chunks.append(text[i : i + self.split_length])
         else:  # token
             assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
             tokens = self.tiktoken_tokenizer.encode(text)
-            for i in range(0, len(tokens), step):
+            for i in range(0, len(tokens), self.split_length):
                 chunk_tokens = tokens[i : i + self.split_length]
                 chunks.append(self.tiktoken_tokenizer.decode(chunk_tokens))
         return chunks

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -7,6 +7,10 @@ from copy import deepcopy
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from haystack import Document, component, logging
+from haystack.lazy_imports import LazyImport
+
+with LazyImport("Run 'pip install tiktoken'") as tiktoken_imports:
+    import tiktoken
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +27,10 @@ class RecursiveDocumentSplitter:
     applied in a specific order, being the last separator the most specific one.
 
     Each separator is applied to the text, it then checks each of the resulting chunks, it keeps the chunks that
-    are within the chunk_size, for the ones that are larger than the chunk_size, it applies the next separator in the
+    are within the split_length, for the ones that are larger than the split_length, it applies the next separator in the
     list to the remaining text.
 
-    This is done until all chunks are smaller than the chunk_size parameter.
+    This is done until all chunks are smaller than the split_length parameter.
 
     Example:
 
@@ -57,17 +61,18 @@ class RecursiveDocumentSplitter:
         *,
         split_length: int = 200,
         split_overlap: int = 0,
-        split_unit: Literal["word", "char"] = "word",
+        split_unit: Literal["word", "char", "token"] = "word",
         separators: Optional[List[str]] = None,
         sentence_splitter_params: Optional[Dict[str, Any]] = None,
     ):
         """
         Initializes a RecursiveDocumentSplitter.
 
-        :param split_length: The maximum length of each chunk by default in words, but can be in characters.
+        :param split_length: The maximum length of each chunk by default in words, but can be in characters or tokens.
             See the `split_units` parameter.
         :param split_overlap: The number of characters to overlap between consecutive chunks.
-        :param split_unit: The unit of the split_length parameter. It can be either "word" or "char".
+        :param split_unit: The unit of the split_length parameter. It can be either "word", "char", or "token".
+            If "token" is selected, the text will be split into tokens using the tiktoken tokenizer (o200k_base).
         :param separators: An optional list of separator strings to use for splitting the text. The string
             separators will be treated as regular expressions unless the separator is "sentence", in that case the
             text will be split into sentences using a custom sentence tokenizer based on NLTK.
@@ -88,12 +93,19 @@ class RecursiveDocumentSplitter:
         self.sentence_splitter_params = (
             {"keep_white_spaces": True} if sentence_splitter_params is None else sentence_splitter_params
         )
+        self.tiktoken_tokenizer: Optional["tiktoken.Encoding"] = None
+        self._is_warmed_up = False
 
     def warm_up(self) -> None:
         """
-        Warm up the sentence tokenizer.
+        Warm up the sentence tokenizer and tiktoken tokenizer if needed.
         """
-        self.nltk_tokenizer = self._get_custom_sentence_tokenizer(self.sentence_splitter_params)
+        if "sentence" in self.separators:
+            self.nltk_tokenizer = self._get_custom_sentence_tokenizer(self.sentence_splitter_params)
+        if self.split_units == "token":
+            tiktoken_imports.check()
+            self.tiktoken_tokenizer = tiktoken.get_encoding("o200k_base")
+        self._is_warmed_up = True
 
     def _check_params(self) -> None:
         if self.split_length < 1:
@@ -117,20 +129,24 @@ class RecursiveDocumentSplitter:
 
         :param current_chunk: The current chunk to be split.
         :returns:
-            A tuple containing the current chunk and the remaining words or characters.
+            A tuple containing the current chunk and the remaining chunk.
         """
-
         if self.split_units == "word":
             words = current_chunk.split()
             current_chunk = " ".join(words[: self.split_length])
             remaining_words = words[self.split_length :]
             return current_chunk, " ".join(remaining_words)
-
-        # split by characters
-        text = current_chunk
-        current_chunk = text[: self.split_length]
-        remaining_chars = text[self.split_length :]
-        return current_chunk, remaining_chars
+        elif self.split_units == "char":
+            text = current_chunk
+            current_chunk = text[: self.split_length]
+            remaining_chars = text[self.split_length :]
+            return current_chunk, remaining_chars
+        else:  # token
+            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
+            tokens = self.tiktoken_tokenizer.encode(current_chunk)
+            current_tokens = tokens[: self.split_length]
+            remaining_tokens = tokens[self.split_length :]
+            return self.tiktoken_tokenizer.decode(current_tokens), self.tiktoken_tokenizer.decode(remaining_tokens)
 
     def _apply_overlap(self, chunks: List[str]) -> List[str]:
         """
@@ -159,8 +175,7 @@ class RecursiveDocumentSplitter:
                     "Consider increasing the `split_length` parameter or decreasing the `split_overlap` parameter."
                 )
 
-            # create a new chunk starting with the overlap
-            current_chunk = overlap + " " + chunk if self.split_units == "word" else overlap + chunk
+            current_chunk = self._create_chunk_starting_with_overlap(chunk, overlap)
 
             # if this new chunk exceeds 'split_length', trim it and move the remaining text to the next chunk
             # if this is the last chunk, another new chunk will contain the trimmed text preceded by the overlap
@@ -168,13 +183,22 @@ class RecursiveDocumentSplitter:
             if self._chunk_length(current_chunk) > self.split_length:
                 current_chunk, remaining_text = self._split_chunk(current_chunk)
                 if idx < len(chunks) - 1:
-                    chunks[idx + 1] = remaining_text + (" " if self.split_units == "word" else "") + chunks[idx + 1]
+                    if self.split_units == "word":
+                        chunks[idx + 1] = remaining_text + " " + chunks[idx + 1]
+                    elif self.split_units == "token":
+                        # For token-based splitting, combine at token level
+                        assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
+                        remaining_tokens = self.tiktoken_tokenizer.encode(remaining_text)
+                        next_chunk_tokens = self.tiktoken_tokenizer.encode(chunks[idx + 1])
+                        chunks[idx + 1] = self.tiktoken_tokenizer.decode(remaining_tokens + next_chunk_tokens)
+                    else:  # char
+                        chunks[idx + 1] = remaining_text + chunks[idx + 1]
                 elif remaining_text:
                     # create a new chunk with the trimmed text preceded by the overlap of the last chunk
                     overlapped_chunks.append(current_chunk)
                     chunk = remaining_text
                     overlap, _ = self._get_overlap(overlapped_chunks)
-                    current_chunk = overlap + " " + chunk if self.split_units == "word" else overlap + chunk
+                    current_chunk = self._create_chunk_starting_with_overlap(chunk, overlap)
 
             overlapped_chunks.append(current_chunk)
 
@@ -188,7 +212,7 @@ class RecursiveDocumentSplitter:
                 while remaining_chunk:
                     # combine overlap with remaining chunk
                     overlap, _ = self._get_overlap(overlapped_chunks)
-                    current = overlap + (" " if self.split_units == "word" else "") + remaining_chunk
+                    current = self._create_chunk_starting_with_overlap(remaining_chunk, overlap)
 
                     # if it fits within split_length we are done
                     if self._chunk_length(current) <= self.split_length:
@@ -201,30 +225,53 @@ class RecursiveDocumentSplitter:
 
         return overlapped_chunks
 
+    def _create_chunk_starting_with_overlap(self, chunk, overlap):
+        if self.split_units == "word":
+            current_chunk = overlap + " " + chunk
+        elif self.split_units == "token":
+            # For token-based splitting, combine at token level
+            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
+            overlap_tokens = self.tiktoken_tokenizer.encode(overlap)
+            chunk_tokens = self.tiktoken_tokenizer.encode(chunk)
+            current_chunk = self.tiktoken_tokenizer.decode(overlap_tokens + chunk_tokens)
+        else:  # char
+            current_chunk = overlap + chunk
+        return current_chunk
+
     def _get_overlap(self, overlapped_chunks: List[str]) -> Tuple[str, str]:
         """Get the previous overlapped chunk instead of the original chunk."""
         prev_chunk = overlapped_chunks[-1]
         overlap_start = max(0, self._chunk_length(prev_chunk) - self.split_overlap)
+
         if self.split_units == "word":
             word_chunks = prev_chunk.split()
             overlap = " ".join(word_chunks[overlap_start:])
-        else:
+        elif self.split_units == "token":
+            # For token-based splitting, handle overlap at token level
+            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
+            tokens = self.tiktoken_tokenizer.encode(prev_chunk)
+            overlap_tokens = tokens[overlap_start:]
+            overlap = self.tiktoken_tokenizer.decode(overlap_tokens)
+        else:  # char
             overlap = prev_chunk[overlap_start:]
+
         return overlap, prev_chunk
 
     def _chunk_length(self, text: str) -> int:
         """
-        Split the text by whitespace and count non-empty elements.
+        Get the length of the chunk in the specified units (words, characters, or tokens).
 
-        :param: The text to be split.
-        :return: The number of words in the text.
+        :param text: The text to measure.
+        :returns: The length of the text in the specified units.
         """
-
         if self.split_units == "word":
             words = [word for word in text.split(" ") if word]
             return len(words)
-
-        return len(text)
+        elif self.split_units == "char":
+            return len(text)
+        else:  # token
+            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
+            return len(self.tiktoken_tokenizer.encode(text))
 
     def _chunk_text(self, text: str) -> List[str]:
         """
@@ -284,7 +331,7 @@ class RecursiveDocumentSplitter:
                     # recursively handle splits that are too large
                     if self._chunk_length(split_text) > self.split_length:
                         if curr_separator == self.separators[-1]:
-                            # tried last separator, can't split further, do a fixed-split based on word/character
+                            # tried last separator, can't split further, do a fixed-split based on word/character/token
                             fall_back_chunks = self._fall_back_to_fixed_chunking(split_text, self.split_units)
                             chunks.extend(fall_back_chunks)
                         else:
@@ -310,15 +357,15 @@ class RecursiveDocumentSplitter:
         # if no separator worked, fall back to word- or character-level chunking
         return self._fall_back_to_fixed_chunking(text, self.split_units)
 
-    def _fall_back_to_fixed_chunking(self, text: str, split_units: Literal["word", "char"]) -> List[str]:
+    def _fall_back_to_fixed_chunking(self, text: str, split_units: Literal["word", "char", "token"]) -> List[str]:
         """
         Fall back to a fixed chunking approach if no separator works for the text.
 
-        Splits the text into smaller chunks based on the split_length and split_units attributes, either by words or
-        characters. It splits into words using whitespace as a separator.
+        Splits the text into smaller chunks based on the split_length and split_units attributes, either by words,
+        characters, or tokens.
 
         :param text: The text to be split into chunks.
-        :param split_units: The unit of the split_length parameter. It can be either "word" or "char".
+        :param split_units: The unit of the split_length parameter. It can be either "word", "char", or "token".
         :returns:
             A list of text chunks.
         """
@@ -343,11 +390,15 @@ class RecursiveDocumentSplitter:
 
             if current_chunk:
                 chunks.append("".join(current_chunk))
-
-        else:
+        elif split_units == "char":
             for i in range(0, self._chunk_length(text), step):
                 chunks.append(text[i : i + self.split_length])
-
+        else:  # token
+            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
+            tokens = self.tiktoken_tokenizer.encode(text)
+            for i in range(0, len(tokens), step):
+                chunk_tokens = tokens[i : i + self.split_length]
+                chunks.append(self.tiktoken_tokenizer.decode(chunk_tokens))
         return chunks
 
     def _add_overlap_info(self, curr_pos: int, new_doc: Document, new_docs: List[Document]) -> None:
@@ -410,7 +461,14 @@ class RecursiveDocumentSplitter:
         :returns:
             A dictionary containing a key "documents" with a List of Documents with smaller chunks of text corresponding
             to the input documents.
+
+        :raises RuntimeError: If the component wasn't warmed up but requires it for sentence splitting or tokenization.
         """
+        if not self._is_warmed_up and ("sentence" in self.separators or self.split_units == "token"):
+            raise RuntimeError(
+                "The component RecursiveDocumentSplitter wasn't warmed up but requires it "
+                "for sentence splitting or tokenization. Call 'warm_up()' before calling 'run()'."
+            )
         docs = []
         for doc in documents:
             if not doc.content or doc.content == "":

--- a/haystack/components/preprocessors/recursive_splitter.py
+++ b/haystack/components/preprocessors/recursive_splitter.py
@@ -142,11 +142,11 @@ class RecursiveDocumentSplitter:
             remaining_chars = text[self.split_length :]
             return current_chunk, remaining_chars
         else:  # token
-            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
-            tokens = self.tiktoken_tokenizer.encode(current_chunk)
+            # at this point we know that the tokenizer is already initialized
+            tokens = self.tiktoken_tokenizer.encode(current_chunk)  # type: ignore
             current_tokens = tokens[: self.split_length]
             remaining_tokens = tokens[self.split_length :]
-            return self.tiktoken_tokenizer.decode(current_tokens), self.tiktoken_tokenizer.decode(remaining_tokens)
+            return self.tiktoken_tokenizer.decode(current_tokens), self.tiktoken_tokenizer.decode(remaining_tokens)  # type: ignore
 
     def _apply_overlap(self, chunks: List[str]) -> List[str]:
         """
@@ -187,10 +187,10 @@ class RecursiveDocumentSplitter:
                         chunks[idx + 1] = remaining_text + " " + chunks[idx + 1]
                     elif self.split_units == "token":
                         # For token-based splitting, combine at token level
-                        assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
-                        remaining_tokens = self.tiktoken_tokenizer.encode(remaining_text)
-                        next_chunk_tokens = self.tiktoken_tokenizer.encode(chunks[idx + 1])
-                        chunks[idx + 1] = self.tiktoken_tokenizer.decode(remaining_tokens + next_chunk_tokens)
+                        # at this point we know that the tokenizer is already initialized
+                        remaining_tokens = self.tiktoken_tokenizer.encode(remaining_text)  # type: ignore
+                        next_chunk_tokens = self.tiktoken_tokenizer.encode(chunks[idx + 1])  # type: ignore
+                        chunks[idx + 1] = self.tiktoken_tokenizer.decode(remaining_tokens + next_chunk_tokens)  # type: ignore
                     else:  # char
                         chunks[idx + 1] = remaining_text + chunks[idx + 1]
                 elif remaining_text:
@@ -230,10 +230,10 @@ class RecursiveDocumentSplitter:
             current_chunk = overlap + " " + chunk
         elif self.split_units == "token":
             # For token-based splitting, combine at token level
-            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
-            overlap_tokens = self.tiktoken_tokenizer.encode(overlap)
-            chunk_tokens = self.tiktoken_tokenizer.encode(chunk)
-            current_chunk = self.tiktoken_tokenizer.decode(overlap_tokens + chunk_tokens)
+            # at this point we know that the tokenizer is already initialized
+            overlap_tokens = self.tiktoken_tokenizer.encode(overlap)  # type: ignore
+            chunk_tokens = self.tiktoken_tokenizer.encode(chunk)  # type: ignore
+            current_chunk = self.tiktoken_tokenizer.decode(overlap_tokens + chunk_tokens)  # type: ignore
         else:  # char
             current_chunk = overlap + chunk
         return current_chunk
@@ -248,10 +248,10 @@ class RecursiveDocumentSplitter:
             overlap = " ".join(word_chunks[overlap_start:])
         elif self.split_units == "token":
             # For token-based splitting, handle overlap at token level
-            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
-            tokens = self.tiktoken_tokenizer.encode(prev_chunk)
+            # at this point we know that the tokenizer is already initialized
+            tokens = self.tiktoken_tokenizer.encode(prev_chunk)  # type: ignore
             overlap_tokens = tokens[overlap_start:]
-            overlap = self.tiktoken_tokenizer.decode(overlap_tokens)
+            overlap = self.tiktoken_tokenizer.decode(overlap_tokens)  # type: ignore
         else:  # char
             overlap = prev_chunk[overlap_start:]
 
@@ -270,8 +270,8 @@ class RecursiveDocumentSplitter:
         elif self.split_units == "char":
             return len(text)
         else:  # token
-            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
-            return len(self.tiktoken_tokenizer.encode(text))
+            # at this point we know that the tokenizer is already initialized
+            return len(self.tiktoken_tokenizer.encode(text))  # type: ignore
 
     def _chunk_text(self, text: str) -> List[str]:
         """
@@ -393,11 +393,11 @@ class RecursiveDocumentSplitter:
             for i in range(0, self._chunk_length(text), self.split_length):
                 chunks.append(text[i : i + self.split_length])
         else:  # token
-            assert self.tiktoken_tokenizer is not None  # mypy doesn't know that warm_up() is called
-            tokens = self.tiktoken_tokenizer.encode(text)
+            # at this point we know that the tokenizer is already initialized
+            tokens = self.tiktoken_tokenizer.encode(text)  # type: ignore
             for i in range(0, len(tokens), self.split_length):
                 chunk_tokens = tokens[i : i + self.split_length]
-                chunks.append(self.tiktoken_tokenizer.decode(chunk_tokens))
+                chunks.append(self.tiktoken_tokenizer.decode(chunk_tokens))  # type: ignore
         return chunks
 
     def _add_overlap_info(self, curr_pos: int, new_doc: Document, new_docs: List[Document]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ extra-dependencies = [
   "tabulate",                         # XLSXToDocument
   "python-oxmsg",                     # MSGToDocument
 
-  "nltk>=3.9.1", # NLTKDocumentSplitter
+  "nltk>=3.9.1", # NLTKDocumentSplitter, RecursiveDocumentSplitter
+  "tiktoken", # RecursiveDocumentSplitter
 
   # OpenAPI
   "jsonref",              # OpenAPIServiceConnector, OpenAPIServiceToFunctions

--- a/releasenotes/notes/recursive-splitter-token-df56428887ac45bd.yaml
+++ b/releasenotes/notes/recursive-splitter-token-df56428887ac45bd.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    RecursiveDocumentSplitter supports splitting by number of tokens.
+    The `RecursiveDocumentSplitter` now supports splitting by number of tokens.
     Setting "split_unit" to "token" will use a hard-coded tiktoken tokenizer (o200k_base) and requires having tiktoken installed.

--- a/releasenotes/notes/recursive-splitter-token-df56428887ac45bd.yaml
+++ b/releasenotes/notes/recursive-splitter-token-df56428887ac45bd.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    RecursiveDocumentSplitter supports splitting by number of tokens.
+    Setting "split_unit" to "token" will use a hard-coded tiktoken tokenizer (o200k_base) and requires having tiktoken installed.

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -401,6 +401,25 @@ def test_run_split_document_with_overlap_character_unit():
     assert doc_chunks[4].meta["_split_overlap"] == [{"doc_id": doc_chunks[3].id, "range": (10, 20)}]
 
 
+def test_run_split_document_with_overlap_and_fallback_character_unit():
+    splitter = RecursiveDocumentSplitter(split_length=8, split_overlap=4, separators=["."], split_unit="char")
+    text = "A simple sentence1. Short. Short."
+
+    doc = Document(content=text)
+    doc_chunks = splitter.run([doc])
+    doc_chunks = doc_chunks["documents"]
+
+    assert len(doc_chunks) == 8
+    assert doc_chunks[0].content == "A simple"
+    assert doc_chunks[1].content == "mple sen"
+    assert doc_chunks[2].content == " sentenc"
+    assert doc_chunks[3].content == "tence1. "
+    assert doc_chunks[4].content == "e1. Shor"
+    assert doc_chunks[5].content == "Short. S"
+    assert doc_chunks[6].content == "t. Short"
+    assert doc_chunks[7].content == "hort."
+
+
 def test_run_separator_exists_but_split_length_too_small_fall_back_to_character_chunking():
     splitter = RecursiveDocumentSplitter(separators=[" "], split_length=2, split_unit="char")
     doc = Document(content="This is some text")
@@ -882,6 +901,25 @@ def test_run_split_by_token_with_fallback():
     assert len(chunks) > 1
     for chunk in chunks:
         assert splitter._chunk_length(chunk.content) <= 2
+
+
+def test_run_split_by_token_with_overlap_and_fallback():
+    splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=2, separators=["."], split_unit="token")
+    splitter.warm_up()
+
+    text = "This is a test. This is another test. This is the final test."
+    doc = Document(content=text)
+    chunks = splitter.run([doc])["documents"]
+
+    assert len(chunks) == 8
+    assert chunks[0].content == "This is a test"
+    assert chunks[1].content == " a test."
+    assert chunks[2].content == " test. This is"
+    assert chunks[3].content == " This is another test"
+    assert chunks[4].content == " another test. This"
+    assert chunks[5].content == ". This is the"
+    assert chunks[6].content == " is the final test"
+    assert chunks[7].content == " final test."
 
 
 def test_run_without_warm_up_raises_error():

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -816,3 +816,87 @@ def test_run_serialization_in_pipeline():
     pipeline_dict = pipeline.dumps()
     new_pipeline = Pipeline.loads(pipeline_dict)
     assert pipeline_dict == new_pipeline.dumps()
+
+
+def test_run_split_by_token_count():
+    splitter = RecursiveDocumentSplitter(split_length=5, separators=["."], split_unit="token")
+    splitter.warm_up()
+
+    text = "This is a test. This is another test. This is the final test."
+    doc = Document(content=text)
+    chunks = splitter.run([doc])["documents"]
+
+    assert len(chunks) == 4
+    assert chunks[0].content == "This is a test."
+    assert chunks[1].content == " This is another test."
+    assert chunks[2].content == " This is the final test"
+    assert chunks[3].content == "."
+
+
+def test_run_split_by_token_count_with_html_tags():
+    splitter = RecursiveDocumentSplitter(split_length=4, separators=["."], split_unit="token")
+    splitter.warm_up()
+
+    text = "This is a test. <h><a><y><s><t><a><c><k><c><o><r><e> This is the final test."
+    doc = Document(content=text)
+    chunks = splitter.run([doc])["documents"]
+
+    assert len(chunks) == 10
+
+
+def test_run_split_by_token_with_sentence_tokenizer():
+    splitter = RecursiveDocumentSplitter(split_length=4, separators=["sentence"], split_unit="token")
+    splitter.warm_up()
+
+    text = "This is sentence one. This is sentence two."
+    doc = Document(content=text)
+    chunks = splitter.run([doc])["documents"]
+
+    assert len(chunks) == 4
+    assert chunks[0].content == "This is sentence one"
+    assert chunks[1].content == ". "
+    assert chunks[2].content == "This is sentence two"
+    assert chunks[3].content == "."
+
+
+def test_run_split_by_token_with_empty_document(caplog: LogCaptureFixture):
+    splitter = RecursiveDocumentSplitter(split_length=4, separators=["."], split_unit="token")
+    splitter.warm_up()
+
+    empty_doc = Document(content="")
+    doc_chunks = splitter.run([empty_doc])
+    doc_chunks = doc_chunks["documents"]
+
+    assert len(doc_chunks) == 0
+    assert "has an empty content. Skipping this document." in caplog.text
+
+
+def test_run_split_by_token_with_fallback():
+    splitter = RecursiveDocumentSplitter(split_length=2, separators=["."], split_unit="token")
+    splitter.warm_up()
+
+    text = "This is a very long sentence that will need to be split into smaller chunks."
+    doc = Document(content=text)
+    chunks = splitter.run([doc])["documents"]
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert splitter._chunk_length(chunk.content) <= 2
+
+
+def test_run_without_warm_up_raises_error():
+    docs = [Document(content="text")]
+
+    splitter_token = RecursiveDocumentSplitter(split_unit="token")
+    with pytest.raises(RuntimeError, match="warmed up"):
+        splitter_token.run(docs)
+
+    splitter_sentence = RecursiveDocumentSplitter(separators=["sentence"])
+    with pytest.raises(RuntimeError, match="warmed up"):
+        splitter_sentence.run(docs)
+
+    # Test that no error is raised when warm_up is not required
+    splitter_no_warmup = RecursiveDocumentSplitter(separators=["."])
+    result = splitter_no_warmup.run(docs)
+    assert len(result["documents"]) == 1
+    assert result["documents"][0].content == "text"

--- a/test/components/preprocessors/test_recursive_splitter.py
+++ b/test/components/preprocessors/test_recursive_splitter.py
@@ -837,6 +837,7 @@ def test_run_serialization_in_pipeline():
     assert pipeline_dict == new_pipeline.dumps()
 
 
+@pytest.mark.integration
 def test_run_split_by_token_count():
     splitter = RecursiveDocumentSplitter(split_length=5, separators=["."], split_unit="token")
     splitter.warm_up()
@@ -852,6 +853,7 @@ def test_run_split_by_token_count():
     assert chunks[3].content == "."
 
 
+@pytest.mark.integration
 def test_run_split_by_token_count_with_html_tags():
     splitter = RecursiveDocumentSplitter(split_length=4, separators=["."], split_unit="token")
     splitter.warm_up()
@@ -863,6 +865,7 @@ def test_run_split_by_token_count_with_html_tags():
     assert len(chunks) == 10
 
 
+@pytest.mark.integration
 def test_run_split_by_token_with_sentence_tokenizer():
     splitter = RecursiveDocumentSplitter(split_length=4, separators=["sentence"], split_unit="token")
     splitter.warm_up()
@@ -878,6 +881,7 @@ def test_run_split_by_token_with_sentence_tokenizer():
     assert chunks[3].content == "."
 
 
+@pytest.mark.integration
 def test_run_split_by_token_with_empty_document(caplog: LogCaptureFixture):
     splitter = RecursiveDocumentSplitter(split_length=4, separators=["."], split_unit="token")
     splitter.warm_up()
@@ -890,6 +894,7 @@ def test_run_split_by_token_with_empty_document(caplog: LogCaptureFixture):
     assert "has an empty content. Skipping this document." in caplog.text
 
 
+@pytest.mark.integration
 def test_run_split_by_token_with_fallback():
     splitter = RecursiveDocumentSplitter(split_length=2, separators=["."], split_unit="token")
     splitter.warm_up()
@@ -903,6 +908,7 @@ def test_run_split_by_token_with_fallback():
         assert splitter._chunk_length(chunk.content) <= 2
 
 
+@pytest.mark.integration
 def test_run_split_by_token_with_overlap_and_fallback():
     splitter = RecursiveDocumentSplitter(split_length=4, split_overlap=2, separators=["."], split_unit="token")
     splitter.warm_up()


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/deepset-ai/haystack-private/issues/117

### Proposed Changes:

- Add `"token"` as `split_unit` with hardcoded tiktoken tokenizer
- Add tiktoken as extra dependency
- Fix bug in fallback logic when `split_overlap` is not 0
- Update warmup method to only load nltk if needed

### How did you test it?

Added new tests, ran locally

### Notes for the reviewer

I am convinced I found a bug in the RecursiveDocumentSplitter's logic that handles overlap in the fallback implementation. What I need to better understand is the expected behavior and if the fix that I propose results in that behavior.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
