### PR TITLE
feat: Agent checks that its chat_generator supports tools

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 from typing import Any, Dict, List, Optional
 
 from haystack import component, default_from_dict, default_to_dict, logging
@@ -76,7 +77,16 @@ class Agent:
         :param raise_on_tool_invocation_failure: Should the agent raise an exception when a tool invocation fails?
             If set to False, the exception will be turned into a chat message and passed to the LLM.
         :param streaming_callback: A callback that will be invoked when a response is streamed from the LLM.
+        :raises TypeError: If the chat_generator does not support tools parameter in its run method.
         """
+        # Check if chat_generator supports tools parameter
+        chat_generator_run_method = inspect.signature(chat_generator.run)
+        if "tools" not in chat_generator_run_method.parameters:
+            raise TypeError(
+                f"{type(chat_generator).__name__} does not accept tools parameter in its run method. "
+                "The Agent component requires a chat generator that supports tools."
+            )
+
         valid_exits = ["text"] + [tool.name for tool in tools or []]
         if exit_conditions is None:
             exit_conditions = ["text"]

--- a/releasenotes/notes/check-chatgenerator-tools-support-f684c1ad0d9ad108.yaml
+++ b/releasenotes/notes/check-chatgenerator-tools-support-f684c1ad0d9ad108.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The Agent component checks that the ChatGenerator it is initialized with supports tools. If it doesn't, the Agent raises a TypeError.


### PR DESCRIPTION
### Related Issues

- fixes #9133 

### Proposed Changes:

- Raise an error in the init of the Agent if the run method of the chat_generator does not have a tools input parameter
- Added a unit test with a ChatGenerator that implements the protocol but doesn't accept tools in its run method

### How did you test it?

new unit test

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
