### PR TITLE
test: change model to test HF API embedders

### DIFF
--- a/test/components/embedders/test_hugging_face_api_document_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_document_embedder.py
@@ -370,7 +370,7 @@ class TestHuggingFaceAPIDocumentEmbedder:
 
         embedder = HuggingFaceAPIDocumentEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
+            api_params={"model": "BAAI/bge-small-en-v1.5"},
             meta_fields_to_embed=["topic"],
             embedding_separator=" | ",
         )

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -193,8 +193,7 @@ class TestHuggingFaceAPITextEmbedder:
     )
     def test_live_run_serverless(self):
         embedder = HuggingFaceAPITextEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "sentence-transformers/all-MiniLM-L6-v2"},
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": "BAAI/bge-small-en-v1.5"}
         )
         result = embedder.run(text="The food was delicious")
 


### PR DESCRIPTION
### Related Issues

- starting from `huggingface_hub==0.30.0`, some Sentence Transformers models cannot be used for feature extraction.
- test failures: https://github.com/deepset-ai/haystack/actions/runs/14172873416/job/39701047266
- reported in https://github.com/huggingface/huggingface_hub/issues/2967

### Proposed Changes:
- just a workaround: change the model we use for testing (which is also aligned with docstrings)

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
