### PR TITLE
feat: Update agent exit condition check

### DIFF
--- a/releasenotes/notes/check-all-llm-messages-for-exit-4bac0a38011b9e03.yaml
+++ b/releasenotes/notes/check-all-llm-messages-for-exit-4bac0a38011b9e03.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    In Agent we check all messages from the LLM when doing an exit condition check.
+    For example, it's possible the LLM returns multiple messages such as multiple tool calls or includes messages with reasoning.
+    Now we check all messages to before assessing if we should exit the loop.


### PR DESCRIPTION
### Related Issues

- fixes #issue-number

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates the exit condition checks in Agent to properly check all messages before deciding to exit. It's possible for the LLM to return multiple messages such as requesting multiple different tool calls or sometimes including reasoning messages in addition to the tool call request. 

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Added unit tests.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
