### PR TITLE
test: adding `Pipeline` component name checks - cannot have `.` (dot characters)

### DIFF
--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -339,7 +339,7 @@ class PipelineBase:
 
         # Component names can't have "."
         if "." in name:
-            raise ValueError("Component names cannot contain '.' (dot) characters.")
+            raise ValueError(f"{name} is an invalid component name, cannot contain '.' (dot) characters.")
 
         # Component instances must be components
         if not isinstance(instance, Component):

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -337,6 +337,10 @@ class PipelineBase:
         if name == "_debug":
             raise ValueError("'_debug' is a reserved name for debug output. Choose another name.")
 
+        # Component names can't have "."
+        if "." in name:
+            raise ValueError("Component names cannot contain '.' (dot) characters.")
+
         # Component instances must be components
         if not isinstance(instance, Component):
             raise PipelineValidationError(

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -176,6 +176,13 @@ class TestPipelineBase:
         assert image_path.read_bytes() == mock_to_mermaid_image.return_value
 
     # UNIT
+    def test_add_invalid_component_name(self):
+        pipe = PipelineBase()
+        with pytest.raises(ValueError):
+            pipe.add_component("this.is.not.a.valida.name", FakeComponent)
+        with pytest.raises(ValueError):
+            pipe.add_component("debug", FakeComponent)
+
     def test_add_component_to_different_pipelines(self):
         first_pipe = PipelineBase()
         second_pipe = PipelineBase()

--- a/test/core/pipeline/test_pipeline_base.py
+++ b/test/core/pipeline/test_pipeline_base.py
@@ -181,7 +181,7 @@ class TestPipelineBase:
         with pytest.raises(ValueError):
             pipe.add_component("this.is.not.a.valida.name", FakeComponent)
         with pytest.raises(ValueError):
-            pipe.add_component("debug", FakeComponent)
+            pipe.add_component("_debug", FakeComponent)
 
     def test_add_component_to_different_pipelines(self):
         first_pipe = PipelineBase()


### PR DESCRIPTION
### Proposed Changes:

- add a check that a component name cannot contain `.` (dot) 

### How did you test it?

- unit tests, integration tests, manual verification, instructions for manual tests 

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
