### PR TITLE
Consolidate the use of `select_streaming_callback` utility in OpenAI and Azure ChatGenerators

### DIFF
--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from openai.lib.azure import AsyncAzureADTokenProvider, AsyncAzureOpenAI, AzureADTokenProvider, AzureOpenAI
 
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
-from haystack.dataclasses import StreamingChunk
+from haystack.dataclasses.streaming_chunk import StreamingCallbackT
 from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
@@ -68,7 +68,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
         api_key: Optional[Secret] = Secret.from_env_var("AZURE_OPENAI_API_KEY", strict=False),
         azure_ad_token: Optional[Secret] = Secret.from_env_var("AZURE_OPENAI_AD_TOKEN", strict=False),
         organization: Optional[str] = None,
-        streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
+        streaming_callback: Optional[StreamingCallbackT] = None,
         timeout: Optional[float] = None,
         max_retries: Optional[int] = None,
         generation_kwargs: Optional[Dict[str, Any]] = None,

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -242,7 +242,9 @@ class OpenAIChatGenerator:
         if len(messages) == 0:
             return {"replies": []}
 
-        streaming_callback = streaming_callback or self.streaming_callback
+        streaming_callback = select_streaming_callback(
+            init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=False
+        )
 
         api_args = self._prepare_api_call(
             messages=messages,
@@ -314,7 +316,9 @@ class OpenAIChatGenerator:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
         # validate and select the streaming callback
-        streaming_callback = select_streaming_callback(self.streaming_callback, streaming_callback, requires_async=True)  # type: ignore
+        streaming_callback = select_streaming_callback(
+            init_callback=self.streaming_callback, runtime_callback=streaming_callback, requires_async=True
+        )
 
         if len(messages) == 0:
             return {"replies": []}

--- a/releasenotes/notes/use-select-streaming-callback-utility-740949185fb5c1fa.yaml
+++ b/releasenotes/notes/use-select-streaming-callback-utility-740949185fb5c1fa.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Consolidate the use of `select_streaming_callback` utility in OpenAI and Azure ChatGenerators,
+    which checks the compatibility of `streaming_callback` with the async or non-async `run` method.


### PR DESCRIPTION
### Related Issues

- fixes #8953 

### Proposed Changes:

Use `select_streaming_callback` in `OpenAIChatGenerator.run` ; Remove some unneeded `# type: ignore` ; Update types

### How did you test it?

unit tests, manual verification

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
