### PR TITLE
ci: pin blis for python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ extra-dependencies = [
   "spacy>=3.8,<3.9",
   "spacy-curated-transformers>=0.2,<=0.3",
   "en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.8.0/en_core_web_trf-3.8.0-py3-none-any.whl",
+  # spacy requires thinc, which depends on blis. We pin blis because version 1.2.1 does not have wheels for python 3.9
+  # and compiling it from source takes much time.
+  "blis<1.2.1; python_version < '3.10'",
 
   # Converters
   "pypdf",                            # PyPDFToDocument


### PR DESCRIPTION
### Related Issues

- fixes  #9159

### Proposed Changes:
- pin `blis<1.2.1` for python 3.9, as proposed in the issue

### How did you test it?
CI.
Unit tests times seem to have acceptable values now.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
