### PR TITLE
fix: Fix content tag name to match one we use in Pipeline

### DIFF
--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -230,7 +230,7 @@ class AsyncPipeline(PipelineBase):
                         )
 
                     span.set_tag("haystack.component.visits", component_visits[component_name])
-                    span.set_content_tag("haystack.component.outputs", deepcopy(outputs))
+                    span.set_content_tag("haystack.component.output", deepcopy(outputs))
 
                     # Distribute outputs to downstream inputs; also prune outputs based on `include_outputs_from`
                     pruned = self._write_component_outputs(

--- a/releasenotes/notes/fix-content-tag-name-async-pipeline-efda4b6298ccd11c.yaml
+++ b/releasenotes/notes/fix-content-tag-name-async-pipeline-efda4b6298ccd11c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    In AsyncPipline the span tag name is updated from `hasytack.component.outputs` to `haystack.component.output`. This matches the tag name used in Pipeline and is the tag name expected by our tracers.


### PR DESCRIPTION
### Related Issues

- fixes https://github.com/deepset-ai/haystack/issues/9139

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Updates the tag name to be `haystack.component.output` instead of `haystack.component.outputs` (so drop the `s`). Our tracers expect the tag name to be `haystack.component.output` and this typo is what caused all component outputs to not be logged when using AsyncPipeline in Langfuse.

E.g. Here is what it looks like with the misnamed tag
<img width="839" alt="Screenshot 2025-04-03 at 10 55 23" src="https://github.com/user-attachments/assets/7e1ad34a-577f-4296-a8e1-74f188d2658b" />

And with the correctly named tag
<img width="855" alt="Screenshot 2025-04-03 at 10 56 36" src="https://github.com/user-attachments/assets/f28be4ab-738a-4825-ab9c-cd17e4efdf26" />


### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Tested locally using langfuse integration

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
