### PR TITLE
test: stop drawing pipelines in e2e tests

### DIFF
--- a/e2e/pipelines/test_dense_doc_search.py
+++ b/e2e/pipelines/test_dense_doc_search.py
@@ -42,9 +42,6 @@ def test_dense_doc_search_pipeline(tmp_path, samples_path):
     indexing_pipeline.connect("splitter.documents", "embedder.documents")
     indexing_pipeline.connect("embedder.documents", "writer.documents")
 
-    # Draw the indexing pipeline
-    indexing_pipeline.draw(tmp_path / "test_dense_doc_search_indexing_pipeline.png")
-
     # Serialize the indexing pipeline to YAML.
     with open(tmp_path / "test_dense_doc_search_indexing_pipeline.yaml", "w") as f:
         indexing_pipeline.dump(f)
@@ -71,9 +68,6 @@ def test_dense_doc_search_pipeline(tmp_path, samples_path):
 
     querying_result = query_pipeline.run({"text_embedder": {"text": "Who lives in Rome?"}})
     assert querying_result["embedding_retriever"]["documents"][0].content == "My name is Giorgio and I live in Rome."
-
-    # Draw the querying pipeline
-    query_pipeline.draw(tmp_path / "test_dense_doc_search_query_pipeline.png")
 
     # Serialize the querying pipeline to JSON
     with open(tmp_path / "test_dense_doc_search_query_pipeline.json", "w") as f:

--- a/e2e/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/pipelines/test_extractive_qa_pipeline.py
@@ -17,9 +17,6 @@ def test_extractive_qa_pipeline(tmp_path):
     qa_pipeline.add_component(instance=ExtractiveReader(model="deepset/tinyroberta-squad2"), name="reader")
     qa_pipeline.connect("retriever", "reader")
 
-    # Draw the pipeline
-    qa_pipeline.draw(tmp_path / "test_extractive_qa_pipeline.png")
-
     # Serialize the pipeline to YAML
     with open(tmp_path / "test_bm25_rag_pipeline.yaml", "w") as f:
         qa_pipeline.dump(f)

--- a/e2e/pipelines/test_hybrid_doc_search_pipeline.py
+++ b/e2e/pipelines/test_hybrid_doc_search_pipeline.py
@@ -30,9 +30,6 @@ def test_hybrid_doc_search_pipeline(tmp_path):
     hybrid_pipeline.connect("embedding_retriever", "joiner")
     hybrid_pipeline.connect("joiner", "ranker")
 
-    # Draw the pipeline
-    hybrid_pipeline.draw(tmp_path / "test_hybrid_doc_search_pipeline.png")
-
     # Serialize the pipeline to YAML
     with open(tmp_path / "test_hybrid_doc_search_pipeline.yaml", "w") as f:
         hybrid_pipeline.dump(f)

--- a/e2e/pipelines/test_preprocessing_pipeline.py
+++ b/e2e/pipelines/test_preprocessing_pipeline.py
@@ -36,9 +36,6 @@ def test_preprocessing_pipeline(tmp_path):
     preprocessing_pipeline.connect("splitter.documents", "embedder.documents")
     preprocessing_pipeline.connect("embedder.documents", "writer.documents")
 
-    # Draw the pipeline
-    preprocessing_pipeline.draw(tmp_path / "test_preprocessing_pipeline.png")
-
     # Serialize the pipeline to YAML
     with open(tmp_path / "test_preprocessing_pipeline.yaml", "w") as f:
         preprocessing_pipeline.dump(f)

--- a/e2e/pipelines/test_rag_pipelines_e2e.py
+++ b/e2e/pipelines/test_rag_pipelines_e2e.py
@@ -43,9 +43,6 @@ def test_bm25_rag_pipeline(tmp_path):
     rag_pipeline.connect("llm.meta", "answer_builder.meta")
     rag_pipeline.connect("retriever", "answer_builder.documents")
 
-    # Draw the pipeline
-    rag_pipeline.draw(tmp_path / "test_bm25_rag_pipeline.png")
-
     # Serialize the pipeline to YAML
     with open(tmp_path / "test_bm25_rag_pipeline.yaml", "w") as f:
         rag_pipeline.dump(f)
@@ -114,9 +111,6 @@ def test_embedding_retrieval_rag_pipeline(tmp_path):
     rag_pipeline.connect("llm.replies", "answer_builder.replies")
     rag_pipeline.connect("llm.meta", "answer_builder.meta")
     rag_pipeline.connect("retriever", "answer_builder.documents")
-
-    # Draw the pipeline
-    rag_pipeline.draw(tmp_path / "test_embedding_rag_pipeline.png")
 
     # Serialize the pipeline to JSON
     with open(tmp_path / "test_embedding_rag_pipeline.json", "w") as f:


### PR DESCRIPTION
### Related Issues

- e2e nightly test fail due to Mermaid timeouts: https://github.com/deepset-ai/haystack/actions/runs/14232107561/job/39890226888
- investigated in #9107

### Proposed Changes:
- do not draw pipelines in e2e tests

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
