### PR TITLE
test: make Azure embedders tests correctly run on PRs from forks

### DIFF
--- a/test/components/embedders/test_azure_document_embedder.py
+++ b/test/components/embedders/test_azure_document_embedder.py
@@ -212,6 +212,18 @@ class TestAzureOpenAIDocumentEmbedder:
         assert len(caplog.records) == 1
         assert "Failed embedding of documents 1, 2 caused by Mocked error" in caplog.text
 
+    def test_http_client_kwargs_type_validation(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test.openai.azure.com")
+        with pytest.raises(TypeError, match="The parameter 'http_client_kwargs' must be a dictionary."):
+            AzureOpenAIDocumentEmbedder(http_client_kwargs="invalid_argument")
+
+    def test_http_client_kwargs_with_invalid_params(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test.openai.azure.com")
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            AzureOpenAIDocumentEmbedder(http_client_kwargs={"invalid_key": "invalid_value"})
+
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.environ.get("AZURE_OPENAI_API_KEY", None) and not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
@@ -246,11 +258,3 @@ class TestAzureOpenAIDocumentEmbedder:
             assert len(doc.embedding) == 1536
             assert all(isinstance(x, float) for x in doc.embedding)
         assert metadata == {"model": "text-embedding-ada-002", "usage": {"prompt_tokens": 15, "total_tokens": 15}}
-
-    def test_http_client_kwargs_type_validation(self):
-        with pytest.raises(TypeError, match="The parameter 'http_client_kwargs' must be a dictionary."):
-            AzureOpenAIDocumentEmbedder(http_client_kwargs="invalid_argument")
-
-    def test_http_client_kwargs_with_invalid_params(self):
-        with pytest.raises(TypeError, match="unexpected keyword argument"):
-            AzureOpenAIDocumentEmbedder(http_client_kwargs={"invalid_key": "invalid_value"})

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -164,6 +164,18 @@ class TestAzureOpenAITextEmbedder:
         assert component.azure_ad_token_provider is not None
         assert component.http_client_kwargs == {"proxy": "http://example.com:3128", "verify": False}
 
+    def test_http_client_kwargs_type_validation(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test.openai.azure.com")
+        with pytest.raises(TypeError, match="The parameter 'http_client_kwargs' must be a dictionary."):
+            AzureOpenAITextEmbedder(http_client_kwargs="invalid_argument")
+
+    def test_http_client_kwargs_with_invalid_params(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test.openai.azure.com")
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            AzureOpenAITextEmbedder(http_client_kwargs={"invalid_key": "invalid_value"})
+
     @pytest.mark.integration
     @pytest.mark.skipif(
         not os.environ.get("AZURE_OPENAI_API_KEY", None) and not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
@@ -183,11 +195,3 @@ class TestAzureOpenAITextEmbedder:
         assert len(result["embedding"]) == 1536
         assert all(isinstance(x, float) for x in result["embedding"])
         assert result["meta"] == {"model": "text-embedding-ada-002", "usage": {"prompt_tokens": 6, "total_tokens": 6}}
-
-    def test_http_client_kwargs_type_validation(self):
-        with pytest.raises(TypeError, match="The parameter 'http_client_kwargs' must be a dictionary."):
-            AzureOpenAITextEmbedder(http_client_kwargs="invalid_argument")
-
-    def test_http_client_kwargs_with_invalid_params(self):
-        with pytest.raises(TypeError, match="unexpected keyword argument"):
-            AzureOpenAITextEmbedder(http_client_kwargs={"invalid_key": "invalid_value"})


### PR DESCRIPTION
### Related Issues

- new tests for these components have been introduced in #9136
- since they do not monkeypatch the required environment variables, these tests fail in PR from forks (where these env var are not set) - see #9140

### Proposed Changes:
- monkeypatch the specific environment variables

### How did you test it?
- CI
- local test: I ran the unit tests in a local environment without the required environment variables

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
