### PR TITLE
fix: removing unused imports in e2e tests

### DIFF
--- a/e2e/pipelines/test_extractive_qa_pipeline.py
+++ b/e2e/pipelines/test_extractive_qa_pipeline.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-
 from haystack import Document, Pipeline
 from haystack.components.readers import ExtractiveReader
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever


### PR DESCRIPTION
### Proposed Changes:

- removing unused import

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
