### PR TITLE
test: monkeypatch OpenAI API key in some unit tests

### DIFF
--- a/test/components/evaluators/test_context_relevance_evaluator.py
+++ b/test/components/evaluators/test_context_relevance_evaluator.py
@@ -80,7 +80,8 @@ class TestContextRelevanceEvaluator:
         assert component._chat_generator.client.api_key == "test-api-key"
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
-    def test_init_with_chat_generator(self):
+    def test_init_with_chat_generator(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         chat_generator = OpenAIChatGenerator(generation_kwargs={"response_format": {"type": "json_object"}, "seed": 42})
         component = ContextRelevanceEvaluator(chat_generator=chat_generator)
 

--- a/test/components/evaluators/test_faithfulness_evaluator.py
+++ b/test/components/evaluators/test_faithfulness_evaluator.py
@@ -100,7 +100,8 @@ class TestFaithfulnessEvaluator:
         assert component._chat_generator.client.api_key == "test-api-key"
         assert component._chat_generator.generation_kwargs == {"response_format": {"type": "json_object"}, "seed": 42}
 
-    def test_init_with_chat_generator(self):
+    def test_init_with_chat_generator(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         chat_generator = OpenAIChatGenerator(generation_kwargs={"response_format": {"type": "json_object"}, "seed": 42})
         component = FaithfulnessEvaluator(chat_generator=chat_generator)
 

--- a/test/utils/test_deserialization.py
+++ b/test/utils/test_deserialization.py
@@ -98,7 +98,8 @@ class TestDeserializeDocumentStoreInInitParamsInplace:
 
 
 class TestDeserializeChatGeneratorInplace:
-    def test_deserialize_chatgenerator_inplace(self):
+    def test_deserialize_chatgenerator_inplace(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
         chat_generator = OpenAIChatGenerator()
         data = {"chat_generator": chat_generator.to_dict()}
 


### PR DESCRIPTION
### Related Issues

- tests failing in PRs from forks: https://github.com/deepset-ai/haystack/actions/runs/14262118726/job/39975878667
- similar to #9168

### Proposed Changes:
- monkeypatch the OpenAI API key where appropriate

### How did you test it?
- CI
- local test: I ran the unit tests in a local environment without OpenAI API key


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
