### PR TITLE
feat: Add Toolset support in ChatGenerator(s)

### DIFF
--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -179,7 +179,7 @@ class HuggingFaceLocalChatGenerator:
 
         if tools and streaming_callback is not None:
             raise ValueError("Using tools and streaming at the same time is not supported. Please choose one.")
-        _check_duplicate_tool_names(tools)
+        _check_duplicate_tool_names(list(tools or []))
 
         huggingface_pipeline_kwargs = huggingface_pipeline_kwargs or {}
         generation_kwargs = generation_kwargs or {}

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -13,6 +13,7 @@ from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall, select_streaming_callback
 from haystack.lazy_imports import LazyImport
 from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+from haystack.tools.toolset import Toolset
 from haystack.utils import (
     ComponentDevice,
     Secret,
@@ -20,6 +21,7 @@ from haystack.utils import (
     deserialize_secrets_inplace,
     serialize_callable,
 )
+from haystack.utils.misc import serialize_tools_or_toolset
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +125,7 @@ class HuggingFaceLocalChatGenerator:
         huggingface_pipeline_kwargs: Optional[Dict[str, Any]] = None,
         stop_words: Optional[List[str]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
         tool_parsing_function: Optional[Callable[[str], Optional[List[ToolCall]]]] = None,
         async_executor: Optional[ThreadPoolExecutor] = None,
     ):
@@ -164,7 +166,8 @@ class HuggingFaceLocalChatGenerator:
             For some chat models, the output includes both the new text and the original prompt.
             In these cases, make sure your prompt has no stop words.
         :param streaming_callback: An optional callable for handling streaming responses.
-        :param tools: A list of tools for which the model can prepare calls.
+        :param tools: A list of tools or a Toolset for which the model can prepare calls.
+            This parameter can accept either a list of `Tool` objects or a `Toolset` instance.
         :param tool_parsing_function:
             A callable that takes a string and returns a list of ToolCall objects or None.
             If None, the default_tool_parser will be used which extracts tool calls using a predefined pattern.
@@ -273,7 +276,6 @@ class HuggingFaceLocalChatGenerator:
             Dictionary with serialized data.
         """
         callback_name = serialize_callable(self.streaming_callback) if self.streaming_callback else None
-        serialized_tools = [tool.to_dict() for tool in self.tools] if self.tools else None
         serialization_dict = default_to_dict(
             self,
             huggingface_pipeline_kwargs=self.huggingface_pipeline_kwargs,
@@ -281,7 +283,7 @@ class HuggingFaceLocalChatGenerator:
             streaming_callback=callback_name,
             token=self.token.to_dict() if self.token else None,
             chat_template=self.chat_template,
-            tools=serialized_tools,
+            tools=serialize_tools_or_toolset(self.tools),
             tool_parsing_function=serialize_callable(self.tool_parsing_function),
         )
 
@@ -323,7 +325,7 @@ class HuggingFaceLocalChatGenerator:
         messages: List[ChatMessage],
         generation_kwargs: Optional[Dict[str, Any]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
     ):
         """
         Invoke text generation inference based on the provided messages and generation parameters.
@@ -332,8 +334,9 @@ class HuggingFaceLocalChatGenerator:
         :param generation_kwargs: Additional keyword arguments for text generation.
         :param streaming_callback: An optional callable for handling streaming responses.
         :param tools:
-            A list of tools for which the model can prepare calls. If set, it will override the `tools` parameter
-            provided during initialization.
+            A list of tools or a Toolset for which the model can prepare calls. If set, it will override
+            the `tools` parameter provided during initialization. This parameter can accept either a list
+            of `Tool` objects or a `Toolset` instance.
         :returns:
             A list containing the generated responses as ChatMessage instances.
         """
@@ -377,6 +380,10 @@ class HuggingFaceLocalChatGenerator:
 
         # convert messages to HF format
         hf_messages = [convert_message_to_hf_format(message) for message in messages]
+
+        if isinstance(tools, Toolset):
+            tools = list(tools)
+
         prepared_prompt = tokenizer.apply_chat_template(
             hf_messages,
             tokenize=False,
@@ -480,7 +487,7 @@ class HuggingFaceLocalChatGenerator:
         messages: List[ChatMessage],
         generation_kwargs: Optional[Dict[str, Any]] = None,
         streaming_callback: Optional[Callable[[StreamingChunk], None]] = None,
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
     ):
         """
         Asynchronously invokes text generation inference based on the provided messages and generation parameters.
@@ -491,7 +498,8 @@ class HuggingFaceLocalChatGenerator:
         :param messages: A list of ChatMessage objects representing the input messages.
         :param generation_kwargs: Additional keyword arguments for text generation.
         :param streaming_callback: An optional callable for handling streaming responses.
-        :param tools: A list of tools for which the model can prepare calls.
+        :param tools: A list of tools or a Toolset for which the model can prepare calls.
+            This parameter can accept either a list of `Tool` objects or a `Toolset` instance.
         :returns: A dictionary with the following keys:
             - `replies`: A list containing the generated responses as ChatMessage instances.
         """
@@ -576,13 +584,17 @@ class HuggingFaceLocalChatGenerator:
         tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
         generation_kwargs: Dict[str, Any],
         stop_words: Optional[List[str]],
-        tools: Optional[List[Tool]] = None,
+        tools: Optional[Union[List[Tool], Toolset]] = None,
     ):
         """
         Handles async non-streaming generation of responses.
         """
         # convert messages to HF format
         hf_messages = [convert_message_to_hf_format(message) for message in messages]
+
+        if isinstance(tools, Toolset):
+            tools = list(tools)
+
         prepared_prompt = tokenizer.apply_chat_template(
             hf_messages,
             tokenize=False,

--- a/releasenotes/notes/support-toolset-initialization-1ccbc174abf16bd2.yaml
+++ b/releasenotes/notes/support-toolset-initialization-1ccbc174abf16bd2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Add support for initializing chat generators with a Toolset, allowing for more flexible tool management. The tools parameter can now accept either a list of Tool objects or a Toolset instance.

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -16,6 +16,11 @@ from haystack.utils.auth import Secret
 from haystack.utils.azure import default_azure_ad_token_provider
 
 
+def get_weather(city: str) -> str:
+    """Get weather information for a city."""
+    return f"Weather info for {city}"
+
+
 @pytest.fixture
 def tools():
     tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
@@ -23,7 +28,7 @@ def tools():
         name="weather",
         description="useful to determine the weather in a given location",
         parameters=tool_parameters,
-        function=lambda x: x,
+        function=get_weather,
     )
 
     return [tool]

--- a/test/components/generators/chat/test_azure.py
+++ b/test/components/generators/chat/test_azure.py
@@ -263,32 +263,6 @@ class TestAzureOpenAIChatGenerator:
             "the Azure OpenAI endpoint URL to run this test."
         ),
     )
-    def test_live_run_with_toolset(self, tools):
-        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        toolset = Toolset(tools)
-        component = AzureOpenAIChatGenerator(tools=toolset, organization="HaystackCI")
-        results = component.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert not message.texts
-        assert not message.text
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.tool_name == "weather"
-        assert tool_call.arguments == {"city": "Paris"}
-        assert message.meta["finish_reason"] == "tool_calls"
-
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("AZURE_OPENAI_API_KEY", None) or not os.environ.get("AZURE_OPENAI_ENDPOINT", None),
-        reason=(
-            "Please export env variables called AZURE_OPENAI_API_KEY containing "
-            "the Azure OpenAI key, AZURE_OPENAI_ENDPOINT containing "
-            "the Azure OpenAI endpoint URL to run this test."
-        ),
-    )
     def test_live_run(self):
         chat_messages = [ChatMessage.from_user("What's the capital of France")]
         component = AzureOpenAIChatGenerator(organization="HaystackCI")

--- a/test/components/generators/chat/test_hugging_face_api.py
+++ b/test/components/generators/chat/test_hugging_face_api.py
@@ -880,36 +880,6 @@ class TestHuggingFaceAPIChatGenerator:
         assert len(deserialized_component.tools) == len(tools)
         assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
 
-    @pytest.mark.integration
-    @pytest.mark.skipif(
-        not os.environ.get("HF_API_TOKEN", None),
-        reason="Export an env var called HF_API_TOKEN containing the Hugging Face token to run this test.",
-    )
-    @pytest.mark.xfail(
-        reason="The Hugging Face API can be unstable and this test may fail intermittently", strict=False
-    )
-    def test_live_run_with_toolset(self, tools):
-        chat_messages = [ChatMessage.from_user("What's the weather like in Paris?")]
-        toolset = Toolset(tools)
-        generator = HuggingFaceAPIChatGenerator(
-            api_type=HFGenerationAPIType.SERVERLESS_INFERENCE_API,
-            api_params={"model": "NousResearch/Hermes-3-Llama-3.1-8B"},
-            generation_kwargs={"temperature": 0.5},
-            tools=toolset,
-        )
-
-        results = generator.run(chat_messages)
-        assert len(results["replies"]) == 1
-        message = results["replies"][0]
-
-        assert message.tool_calls
-        tool_call = message.tool_call
-        assert isinstance(tool_call, ToolCall)
-        assert tool_call.tool_name == "weather"
-        assert "city" in tool_call.arguments
-        assert "Paris" in tool_call.arguments["city"]
-        assert message.meta["finish_reason"] == "stop"
-
     def test_to_dict_with_toolset(self, mock_check_valid_model, tools):
         """Test that the HuggingFaceAPIChatGenerator can be serialized to a dictionary with a Toolset."""
         toolset = Toolset(tools)

--- a/test/components/generators/chat/test_hugging_face_local.py
+++ b/test/components/generators/chat/test_hugging_face_local.py
@@ -16,6 +16,7 @@ from haystack.dataclasses.streaming_chunk import StreamingChunk
 from haystack.tools import Tool
 from haystack.utils import ComponentDevice
 from haystack.utils.auth import Secret
+from haystack.tools.toolset import Toolset
 
 
 # used to test serialization of streaming_callback
@@ -553,3 +554,87 @@ class TestHuggingFaceLocalChatGenerator:
                 del generator
                 gc.collect()
                 mock_shutdown.assert_called_once_with(wait=True)
+
+    def test_live_run_with_tools(self, tools):
+        """Test that the model can be run with tools to generate tool calls."""
+        generator = HuggingFaceLocalChatGenerator(tools=tools)
+
+        # Mock pipeline and tokenizer
+        mock_pipeline = Mock(return_value=[{"generated_text": '{"name": "weather", "arguments": {"city": "Paris"}}'}])
+        mock_tokenizer = Mock(spec=PreTrainedTokenizer)
+        mock_tokenizer.encode.return_value = ["some", "tokens"]
+        mock_tokenizer.pad_token_id = 100
+        mock_tokenizer.apply_chat_template.return_value = "test prompt"
+        mock_pipeline.tokenizer = mock_tokenizer
+        generator.pipeline = mock_pipeline
+
+        messages = [ChatMessage.from_user("What's the weather in Paris?")]
+        results = generator.run(messages=messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+        assert message.tool_calls
+        tool_call = message.tool_calls[0]
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+    def test_hugging_face_local_generator_with_toolset_initialization(self, model_info_mock, tools):
+        """Test that the HuggingFaceLocalChatGenerator can be initialized with a Toolset."""
+        toolset = Toolset(tools)
+        generator = HuggingFaceLocalChatGenerator(tools=toolset)
+        assert generator.tools == toolset
+
+    def test_from_dict_with_toolset(self, model_info_mock, tools):
+        """Test that the HuggingFaceLocalChatGenerator can be deserialized from a dictionary with a Toolset."""
+        toolset = Toolset(tools)
+        component = HuggingFaceLocalChatGenerator(tools=toolset)
+        data = component.to_dict()
+
+        deserialized_component = HuggingFaceLocalChatGenerator.from_dict(data)
+
+        assert isinstance(deserialized_component.tools, Toolset)
+        assert len(deserialized_component.tools) == len(tools)
+        assert all(isinstance(tool, Tool) for tool in deserialized_component.tools)
+
+    def test_run_with_toolset(self, model_info_mock):
+        """Test running the model with a Toolset."""
+        # Create a toolset with a weather tool
+        tool_parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+        tool = Tool(
+            name="weather",
+            description="useful to determine the weather in a given location",
+            parameters=tool_parameters,
+            function=get_weather,
+        )
+        toolset = Toolset([tool])
+
+        generator = HuggingFaceLocalChatGenerator(tools=toolset)
+
+        # Mock pipeline and tokenizer
+        mock_pipeline = Mock(return_value=[{"generated_text": '{"name": "weather", "arguments": {"city": "Paris"}}'}])
+        mock_tokenizer = Mock(spec=PreTrainedTokenizer)
+        mock_tokenizer.encode.return_value = ["some", "tokens"]
+        mock_tokenizer.pad_token_id = 100
+        mock_tokenizer.apply_chat_template.return_value = "test prompt with toolset"
+        mock_pipeline.tokenizer = mock_tokenizer
+        generator.pipeline = mock_pipeline
+
+        messages = [ChatMessage.from_user("What's the weather in Paris?")]
+        results = generator.run(messages=messages)
+
+        assert len(results["replies"]) == 1
+        message = results["replies"][0]
+        assert message.tool_calls
+        tool_call = message.tool_calls[0]
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.tool_name == "weather"
+        assert tool_call.arguments == {"city": "Paris"}
+        assert message.meta["finish_reason"] == "tool_calls"
+
+        # Check that the tools were properly extracted from the toolset in the apply_chat_template call
+        _, kwargs = mock_tokenizer.apply_chat_template.call_args
+        assert "tools" in kwargs
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["tools"][0]["function"]["name"] == "weather"

--- a/test/components/generators/chat/test_hugging_face_local.py
+++ b/test/components/generators/chat/test_hugging_face_local.py
@@ -79,7 +79,7 @@ def custom_tool_parser(text: str) -> Optional[List[ToolCall]]:
 
 
 class TestHuggingFaceLocalChatGenerator:
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def mock_model_info(self, monkeypatch):
         """Mock the model_info function to prevent real HTTP requests."""
 
@@ -104,7 +104,7 @@ class TestHuggingFaceLocalChatGenerator:
         assert generator.generation_kwargs == {**generation_kwargs, **{"stop_sequences": ["stop"]}}
         assert generator.streaming_callback == streaming_callback
 
-    def test_init_custom_token(self):
+    def test_init_custom_token(self, model_info_mock):
         generator = HuggingFaceLocalChatGenerator(
             model="mistralai/Mistral-7B-Instruct-v0.2",
             task="text2text-generation",
@@ -119,7 +119,7 @@ class TestHuggingFaceLocalChatGenerator:
             "device": "cpu",
         }
 
-    def test_init_custom_device(self):
+    def test_init_custom_device(self, model_info_mock):
         generator = HuggingFaceLocalChatGenerator(
             model="mistralai/Mistral-7B-Instruct-v0.2",
             task="text2text-generation",
@@ -134,7 +134,7 @@ class TestHuggingFaceLocalChatGenerator:
             "device": "cpu",
         }
 
-    def test_init_task_parameter(self):
+    def test_init_task_parameter(self, model_info_mock):
         generator = HuggingFaceLocalChatGenerator(
             task="text2text-generation", device=ComponentDevice.from_str("cpu"), token=None
         )
@@ -146,7 +146,7 @@ class TestHuggingFaceLocalChatGenerator:
             "device": "cpu",
         }
 
-    def test_init_task_in_huggingface_pipeline_kwargs(self):
+    def test_init_task_in_huggingface_pipeline_kwargs(self, model_info_mock):
         generator = HuggingFaceLocalChatGenerator(
             huggingface_pipeline_kwargs={"task": "text2text-generation"},
             device=ComponentDevice.from_str("cpu"),

--- a/test/components/generators/chat/test_hugging_face_local.py
+++ b/test/components/generators/chat/test_hugging_face_local.py
@@ -79,15 +79,6 @@ def custom_tool_parser(text: str) -> Optional[List[ToolCall]]:
 
 
 class TestHuggingFaceLocalChatGenerator:
-    @pytest.fixture
-    def mock_model_info(self, monkeypatch):
-        """Mock the model_info function to prevent real HTTP requests."""
-
-        def mock_model_info(*args, **kwargs):
-            return {"pipeline_tag": "text2text-generation"}
-
-        monkeypatch.setattr("huggingface_hub.HfApi.model_info", mock_model_info)
-
     def test_initialize_with_valid_model_and_generation_parameters(self, model_info_mock):
         model = "HuggingFaceH4/zephyr-7b-alpha"
         generation_kwargs = {"n": 1}


### PR DESCRIPTION
### Why:
Update ChatGenerators to support initialization with a Toolset. 

### What:
- Modified the `tools` parameter to accept either a list of `Tool` objects or a `Toolset` instance 
- Added new serialization logic to handle `Toolset` in the `to_dict()` methods across relevant classes.
- Updated tests to validate the initialization and usage of `Toolset` in existing generators.

### How can it be used:
The updated chat generators can now be instantiated with a `Toolset`, enhancing tool management:
```python
toolset = Toolset(tools)  # where tools is a list of Tool objects
generator = AzureOpenAIChatGenerator(azure_endpoint="your-endpoint", tools=toolset)
```
Users can seamlessly pass a `Toolset` instead of a list of Tool instances

### How did you test it:
Test cases were added to ensure that the chat generators can be initialized with a `Toolset` correctly and that the generated calls utilize the tools defined within the `Toolset`. Tests also cover serialization and deserialization processes of generators containing a `Toolset`.

### Notes for the reviewer:
Focus on ensuring that the changes to support `Toolset` do not break existing functionality. Pay special attention to the new tests added for validating Toolset integration in both generators. Verify that documentation is updated to reflect these changes.