### PR TITLE
enhancement: Add attributes to PipelineRuntimeError

### DIFF
--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -42,6 +42,18 @@ class PipelineRuntimeError(Exception):
         return cls(component_name, component_type, message)
 
 
+class PipelineComponentsBlockedError(PipelineRuntimeError):
+    def __init__(self) -> None:
+        message = (
+            "Cannot run pipeline - all components are blocked. "
+            "This typically happens when:\n"
+            "1. There is no valid entry point for the pipeline\n"
+            "2. There is a circular dependency preventing the pipeline from running\n"
+            "Check the connections between these components and ensure all required inputs are provided."
+        )
+        super().__init__(None, None, message)
+
+
 class PipelineConnectError(PipelineError):
     pass
 

--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -37,7 +37,8 @@ class PipelineRuntimeError(Exception):
             f"The following component returned an invalid output:\n"
             f"Component name: '{component_name}'\n"
             f"Component type: '{component_type.__name__}'\n"
-            f"Expected a dict, but got {type(output).__name__} instead."
+            f"Expected a dictionary, but got {type(output).__name__} instead.\n"
+            f"Check the component's output and ensure it is a valid dictionary."
         )
         return cls(component_name, component_type, message)
 

--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Type
+from typing import Any, Optional, Type
 
 
 class PipelineError(Exception):
@@ -10,32 +10,36 @@ class PipelineError(Exception):
 
 
 class PipelineRuntimeError(Exception):
-    def __init__(self, component_name: str, component_type: Type, detail: str) -> None:
+    def __init__(self, component_name: Optional[str], component_type: Optional[Type], message: str) -> None:
         self.component_name = component_name
         self.component_type = component_type
-        self.detail = detail
-
-    def __str__(self):
-        return (
-            f"PipelineRuntimeError:\n"
-            f"Component name: '{self.component_name}'\n"
-            f"Component type: '{self.component_type.__name__}'\n"
-            f"Details: {self.detail}"
-        )
+        super().__init__(message)
 
     @classmethod
     def from_exception(cls, component_name: str, component_type: Type, error: Exception):
         """
         Create a PipelineRuntimeError from an exception.
         """
-        return cls(component_name, component_type, f"Failed to run component. Error: {str(error)}")
+        message = (
+            f"The following component failed to run:\n"
+            f"Component name: '{component_name}'\n"
+            f"Component type: '{component_type.__name__}'\n"
+            f"Error: {str(error)}"
+        )
+        return cls(component_name, component_type, message)
 
     @classmethod
     def from_invalid_output(cls, component_name: str, component_type: Type, output: Any):
         """
         Create a PipelineRuntimeError from an invalid output.
         """
-        return cls(component_name, component_type, f"Invalid output type: {type(output)}. Expected a dictionary.")
+        message = (
+            f"The following component returned an invalid output:\n"
+            f"Component name: '{component_name}'\n"
+            f"Component type: '{component_type.__name__}'\n"
+            f"Expected a dict, but got {type(output).__name__} instead."
+        )
+        return cls(component_name, component_type, message)
 
 
 class PipelineConnectError(PipelineError):

--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -13,14 +13,14 @@ class PipelineRuntimeError(Exception):
     def __init__(self, component_name: str, component_type: Type, detail: str) -> None:
         self.component_name = component_name
         self.component_type = component_type
-        super().__init__(detail)
+        self.detail = detail
 
     def __str__(self):
         return (
             f"PipelineRuntimeError:\n"
             f"Component name: '{self.component_name}'\n"
             f"Component type: '{self.component_type.__name__}'\n"
-            f"Details: {self.args[0]}"
+            f"Details: {self.detail}"
         )
 
     @classmethod

--- a/haystack/core/errors.py
+++ b/haystack/core/errors.py
@@ -2,13 +2,40 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any, Type
+
 
 class PipelineError(Exception):
     pass
 
 
 class PipelineRuntimeError(Exception):
-    pass
+    def __init__(self, component_name: str, component_type: Type, detail: str) -> None:
+        self.component_name = component_name
+        self.component_type = component_type
+        super().__init__(detail)
+
+    def __str__(self):
+        return (
+            f"PipelineRuntimeError:\n"
+            f"Component name: '{self.component_name}'\n"
+            f"Component type: '{self.component_type.__name__}'\n"
+            f"Details: {self.args[0]}"
+        )
+
+    @classmethod
+    def from_exception(cls, component_name: str, component_type: Type, error: Exception):
+        """
+        Create a PipelineRuntimeError from an exception.
+        """
+        return cls(component_name, component_type, f"Failed to run component. Error: {str(error)}")
+
+    @classmethod
+    def from_invalid_output(cls, component_name: str, component_type: Type, output: Any):
+        """
+        Create a PipelineRuntimeError from an invalid output.
+        """
+        return cls(component_name, component_type, f"Invalid output type: {type(output)}. Expected a dictionary.")
 
 
 class PipelineConnectError(PipelineError):

--- a/haystack/core/pipeline/async_pipeline.py
+++ b/haystack/core/pipeline/async_pipeline.py
@@ -211,11 +211,8 @@ class AsyncPipeline(PipelineBase):
                         try:
                             outputs = await instance.run_async(**component_inputs)  # type: ignore
                         except Exception as error:
-                            raise PipelineRuntimeError(
-                                f"The following component failed to run:\n"
-                                f"Component name: '{component_name}'\n"
-                                f"Component type: '{instance.__class__.__name__}'\n"
-                                f"Error: {str(error)}"
+                            raise PipelineRuntimeError.from_exception(
+                                component_name, instance.__class__, error
                             ) from error
                     else:
                         loop = asyncio.get_running_loop()
@@ -224,10 +221,7 @@ class AsyncPipeline(PipelineBase):
                     component_visits[component_name] += 1
 
                     if not isinstance(outputs, dict):
-                        raise PipelineRuntimeError(
-                            f"Component '{component_name}' returned an invalid output type. "
-                            f"Expected a dict, but got {type(outputs).__name__} instead. "
-                        )
+                        raise PipelineRuntimeError.from_invalid_output(component_name, instance.__class__, outputs)
 
                     span.set_tag("haystack.component.visits", component_visits[component_name])
                     span.set_content_tag("haystack.component.output", deepcopy(outputs))

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -20,6 +20,7 @@ from haystack.core.errors import (
     PipelineDrawingError,
     PipelineError,
     PipelineMaxComponentRuns,
+    PipelineRuntimeError,
     PipelineUnmarshalError,
     PipelineValidationError,
 )
@@ -1195,19 +1196,22 @@ class PipelineBase:
         Validate the pipeline to check if it is blocked or has no valid entry point.
 
         :param priority_queue: Priority queue of component names.
+        :raises PipelineRuntimeError:
+            If the pipeline is blocked or has no valid entry point.
         """
         if len(priority_queue) == 0:
             return
 
         candidate = priority_queue.peek()
         if candidate is not None and candidate[0] == ComponentPriority.BLOCKED:
-            raise PipelineValidationError(
+            message = (
                 "Cannot run pipeline - all components are blocked. "
                 "This typically happens when:\n"
                 "1. There is no valid entry point for the pipeline\n"
                 "2. There is a circular dependency preventing the pipeline from running\n"
                 "Check the connections between these components and ensure all required inputs are provided."
             )
+            raise PipelineRuntimeError(None, None, message)
 
 
 def _connections_status(

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -16,11 +16,11 @@ from haystack import logging
 from haystack.core.component import Component, InputSocket, OutputSocket, component
 from haystack.core.errors import (
     DeserializationError,
+    PipelineComponentsBlockedError,
     PipelineConnectError,
     PipelineDrawingError,
     PipelineError,
     PipelineMaxComponentRuns,
-    PipelineRuntimeError,
     PipelineUnmarshalError,
     PipelineValidationError,
 )
@@ -1204,14 +1204,7 @@ class PipelineBase:
 
         candidate = priority_queue.peek()
         if candidate is not None and candidate[0] == ComponentPriority.BLOCKED:
-            message = (
-                "Cannot run pipeline - all components are blocked. "
-                "This typically happens when:\n"
-                "1. There is no valid entry point for the pipeline\n"
-                "2. There is a circular dependency preventing the pipeline from running\n"
-                "Check the connections between these components and ensure all required inputs are provided."
-            )
-            raise PipelineRuntimeError(None, None, message)
+            raise PipelineComponentsBlockedError()
 
 
 def _connections_status(

--- a/haystack/core/pipeline/base.py
+++ b/haystack/core/pipeline/base.py
@@ -20,7 +20,6 @@ from haystack.core.errors import (
     PipelineDrawingError,
     PipelineError,
     PipelineMaxComponentRuns,
-    PipelineRuntimeError,
     PipelineUnmarshalError,
     PipelineValidationError,
 )
@@ -1202,7 +1201,7 @@ class PipelineBase:
 
         candidate = priority_queue.peek()
         if candidate is not None and candidate[0] == ComponentPriority.BLOCKED:
-            raise PipelineRuntimeError(
+            raise PipelineValidationError(
                 "Cannot run pipeline - all components are blocked. "
                 "This typically happens when:\n"
                 "1. There is no valid entry point for the pipeline\n"

--- a/haystack/core/pipeline/pipeline.py
+++ b/haystack/core/pipeline/pipeline.py
@@ -79,19 +79,11 @@ class Pipeline(PipelineBase):
             try:
                 component_output = instance.run(**component_inputs)
             except Exception as error:
-                raise PipelineRuntimeError(
-                    f"The following component failed to run:\n"
-                    f"Component name: '{component_name}'\n"
-                    f"Component type: '{instance.__class__.__name__}'\n"
-                    f"Error: {str(error)}"
-                ) from error
+                raise PipelineRuntimeError.from_exception(component_name, instance.__class__, error) from error
             component_visits[component_name] += 1
 
             if not isinstance(component_output, Mapping):
-                raise PipelineRuntimeError(
-                    f"Component '{component_name}' didn't return a dictionary. "
-                    "Components must always return dictionaries: check the documentation."
-                )
+                raise PipelineRuntimeError.from_invalid_output(component_name, instance.__class__, component_output)
 
             span.set_tag("haystack.component.visits", component_visits[component_name])
             span.set_content_tag("haystack.component.output", component_output)

--- a/releasenotes/notes/add-attributes-to-pipeline-runtime-error-03941943aaf89880.yaml
+++ b/releasenotes/notes/add-attributes-to-pipeline-runtime-error-03941943aaf89880.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Added component_name and component_type attributes to PipelineRuntimeError.
+    - Moved error message creation to within PipelineRuntimeError
+    - Created a new subclass of PipelineRuntimeError called PipelineComponentsBlockedError for the specific case where the pipeline cannot run since no components are unblocked.

--- a/test/core/pipeline/features/pipeline_run.feature
+++ b/test/core/pipeline/features/pipeline_run.feature
@@ -67,4 +67,4 @@ Feature: Pipeline running
         | kind | exception |
         | that has an infinite loop | PipelineMaxComponentRuns |
         | that has a component that doesn't return a dictionary | PipelineRuntimeError |
-        | that has a cycle that would get it stuck | PipelineRuntimeError |
+        | that has a cycle that would get it stuck | PipelineComponentsBlockedError |

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -82,7 +82,7 @@ class TestPipeline:
                 component_visits={"wrong": 0},
             )
 
-        assert "didn't return a dictionary" in str(exc_info.value)
+        assert "Invalid output type:" in str(exc_info.value)
 
     def test_run_component_error(self):
         """Test error when component fails to run"""
@@ -106,13 +106,3 @@ class TestPipeline:
                 component_visits={"erroring_component": 0},
             )
         assert "Component name: 'erroring_component'" in str(exc_info.value)
-
-    def test_run(self):
-        joiner_1 = BranchJoiner(type_=str)
-        joiner_2 = BranchJoiner(type_=str)
-        pp = Pipeline()
-        pp.add_component("joiner_1", joiner_1)
-        pp.add_component("joiner_2", joiner_2)
-        pp.connect("joiner_1", "joiner_2")
-
-        outputs = pp.run({"value": "test_value"})

--- a/test/core/pipeline/test_pipeline.py
+++ b/test/core/pipeline/test_pipeline.py
@@ -82,7 +82,7 @@ class TestPipeline:
                 component_visits={"wrong": 0},
             )
 
-        assert "Invalid output type:" in str(exc_info.value)
+        assert "Expected a dict" in str(exc_info.value)
 
     def test_run_component_error(self):
         """Test error when component fails to run"""


### PR DESCRIPTION
### Related Issues

- fixes #9166 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Adds attributes `component_type`, and `component_name` to `PipelineRuntimeError`
- Adds class methods for constructing `PipelineRuntimeError` from two different scenarios (`from_exception` and `from_invalid_output`)

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Updated tests

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
