### PR TITLE
refactor: reorganize Tool serde utility functions

### DIFF
--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -10,7 +10,7 @@ from openai.lib.azure import AsyncAzureADTokenProvider, AsyncAzureOpenAI, AzureA
 from haystack import component, default_from_dict, default_to_dict
 from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.dataclasses.streaming_chunk import StreamingCallbackT
-from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 
 

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -9,7 +9,7 @@ from haystack import component, default_from_dict, default_to_dict
 from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall, select_streaming_callback
 from haystack.dataclasses.streaming_chunk import StreamingCallbackT
 from haystack.lazy_imports import LazyImport
-from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
 from haystack.utils.hf import HFGenerationAPIType, HFModelType, check_valid_model, convert_message_to_hf_format
 from haystack.utils.url_validation import is_valid_http_url

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -12,8 +12,13 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Union
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.dataclasses import ChatMessage, StreamingChunk, ToolCall, select_streaming_callback
 from haystack.lazy_imports import LazyImport
-from haystack.tools import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
-from haystack.tools.toolset import Toolset
+from haystack.tools import (
+    Tool,
+    Toolset,
+    _check_duplicate_tool_names,
+    deserialize_tools_inplace,
+    serialize_tools_or_toolset,
+)
 from haystack.utils import (
     ComponentDevice,
     Secret,
@@ -21,7 +26,6 @@ from haystack.utils import (
     deserialize_secrets_inplace,
     serialize_callable,
 )
-from haystack.utils.misc import serialize_tools_or_toolset
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -22,10 +22,14 @@ from haystack.dataclasses import (
     ToolCall,
     select_streaming_callback,
 )
-from haystack.tools.tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
-from haystack.tools.toolset import Toolset
+from haystack.tools import (
+    Tool,
+    Toolset,
+    _check_duplicate_tool_names,
+    deserialize_tools_inplace,
+    serialize_tools_or_toolset,
+)
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
-from haystack.utils.misc import serialize_tools_or_toolset
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -9,10 +9,15 @@ from typing import Any, Dict, List, Optional, Union
 from haystack import component, default_from_dict, default_to_dict, logging
 from haystack.core.component.sockets import Sockets
 from haystack.dataclasses import ChatMessage, State, ToolCall
-from haystack.tools.component_tool import ComponentTool
-from haystack.tools.tool import Tool, ToolInvocationError, _check_duplicate_tool_names, deserialize_tools_inplace
-from haystack.tools.toolset import Toolset
-from haystack.utils.misc import serialize_tools_or_toolset
+from haystack.tools import (
+    ComponentTool,
+    Tool,
+    Toolset,
+    _check_duplicate_tool_names,
+    deserialize_tools_inplace,
+    serialize_tools_or_toolset,
+)
+from haystack.tools.errors import ToolInvocationError
 
 logger = logging.getLogger(__name__)
 

--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -6,17 +6,18 @@
 
 # ruff: noqa: I001 (ignore import order as we need to import Tool before ComponentTool)
 from .from_function import create_tool_from_function, tool
-from .tool import Tool, _check_duplicate_tool_names, deserialize_tools_inplace
+from .tool import Tool, _check_duplicate_tool_names
 from .component_tool import ComponentTool
+from .serde_utils import deserialize_tools_inplace, serialize_tools_or_toolset
 from .toolset import Toolset
 
-
 __all__ = [
-    "Tool",
     "_check_duplicate_tool_names",
-    "deserialize_tools_inplace",
-    "create_tool_from_function",
-    "tool",
     "ComponentTool",
+    "create_tool_from_function",
+    "deserialize_tools_inplace",
+    "serialize_tools_or_toolset",
+    "Tool",
     "Toolset",
+    "tool",
 ]

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, List, Union
 
 from haystack.core.errors import DeserializationError

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -1,0 +1,69 @@
+from typing import Any, Dict, List, Union
+
+from haystack.core.errors import DeserializationError
+from haystack.core.serialization import import_class_by_name
+from haystack.tools.tool import Tool
+from haystack.tools.toolset import Toolset
+
+
+def serialize_tools_or_toolset(
+    tools: Union[Toolset, List[Tool], None],
+) -> Union[Dict[str, Any], List[Dict[str, Any]], None]:
+    """
+    Serialize a Toolset or a list of Tools to a dictionary or a list of tool dictionaries.
+
+    :param tools: A Toolset, a list of Tools, or None
+    :returns: A dictionary, a list of tool dictionaries, or None if tools is None
+    """
+    if tools is None:
+        return None
+    if isinstance(tools, Toolset):
+        return tools.to_dict()
+    return [tool.to_dict() for tool in tools]
+
+
+def deserialize_tools_inplace(data: Dict[str, Any], key: str = "tools"):
+    """
+    Deserialize a list of Tools or a Toolset in a dictionary inplace.
+
+    :param data:
+        The dictionary with the serialized data.
+    :param key:
+        The key in the dictionary where the list of Tools or Toolset is stored.
+    """
+    if key in data:
+        serialized_tools = data[key]
+
+        if serialized_tools is None:
+            return
+
+        # Check if it's a serialized Toolset (a dict with "type" and "data" keys)
+        if isinstance(serialized_tools, dict) and all(k in serialized_tools for k in ["type", "data"]):
+            toolset_class_name = serialized_tools.get("type")
+            if not toolset_class_name:
+                raise DeserializationError("The 'type' key is missing or None in the serialized toolset data")
+
+            toolset_class = import_class_by_name(toolset_class_name)
+
+            if not issubclass(toolset_class, Toolset):
+                raise TypeError(f"Class '{toolset_class}' is not a subclass of Toolset")
+
+            data[key] = toolset_class.from_dict(serialized_tools)
+            return
+
+        if not isinstance(serialized_tools, list):
+            raise TypeError(f"The value of '{key}' is not a list or a dictionary")
+
+        deserialized_tools = []
+        for tool in serialized_tools:
+            if not isinstance(tool, dict):
+                raise TypeError(f"Serialized tool '{tool}' is not a dictionary")
+
+            # different classes are allowed: Tool, ComponentTool, etc.
+            tool_class = import_class_by_name(tool["type"])
+            if not issubclass(tool_class, Tool):
+                raise TypeError(f"Class '{tool_class}' is not a subclass of Tool")
+
+            deserialized_tools.append(tool_class.from_dict(tool))
+
+        data[key] = deserialized_tools

--- a/haystack/utils/misc.py
+++ b/haystack/utils/misc.py
@@ -2,11 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Union
+from typing import List, Union
 
 from numpy import exp
-
-from haystack.tools import Tool, Toolset
 
 
 def expand_page_range(page_range: List[Union[str, int]]) -> List[int]:

--- a/haystack/utils/misc.py
+++ b/haystack/utils/misc.py
@@ -54,19 +54,3 @@ def expit(x) -> float:
     :param x: input value. Can be a scalar or a numpy array.
     """
     return 1 / (1 + exp(-x))
-
-
-def serialize_tools_or_toolset(
-    tools: Union[Toolset, List[Tool], None],
-) -> Union[Dict[str, Any], List[Dict[str, Any]], None]:
-    """
-    Serialize a Toolset or a list of Tools to a dictionary or a list of tool dictionaries.
-
-    :param tools: A Toolset, a list of Tools, or None
-    :returns: A dictionary, a list of tool dictionaries, or None if tools is None
-    """
-    if tools is None:
-        return None
-    if isinstance(tools, Toolset):
-        return tools.to_dict()
-    return [tool.to_dict() for tool in tools]

--- a/test/tools/test_serde_utils.py
+++ b/test/tools/test_serde_utils.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from haystack.tools import Tool, deserialize_tools_inplace, Toolset, serialize_tools_or_toolset
+
+
+def get_weather_report(city: str) -> str:
+    return f"Weather report for {city}: 20°C, sunny"
+
+
+parameters = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+
+
+class TestToolSerdeUtils:
+    def test_serialize_toolset(self):
+        toolset = Toolset(
+            tools=[
+                Tool(
+                    name="weather", description="Get weather report", parameters=parameters, function=get_weather_report
+                )
+            ]
+        )
+
+        data = serialize_tools_or_toolset(toolset)
+        assert data == toolset.to_dict()
+
+    def test_serialize_tool(self):
+        tool = Tool(
+            name="weather", description="Get weather report", parameters=parameters, function=get_weather_report
+        )
+
+        data = serialize_tools_or_toolset([tool])
+        assert data == [tool.to_dict()]
+
+    def test_deserialize_tools_inplace(self):
+        tool = Tool(
+            name="weather", description="Get weather report", parameters=parameters, function=get_weather_report
+        )
+
+        data = {"tools": [tool.to_dict()]}
+        deserialize_tools_inplace(data)
+        assert data["tools"] == [tool]
+
+        data = {"mytools": [tool.to_dict()]}
+        deserialize_tools_inplace(data, key="mytools")
+        assert data["mytools"] == [tool]
+
+        data = {"no_tools": 123}
+        deserialize_tools_inplace(data)
+        assert data == {"no_tools": 123}
+
+    def test_deserialize_tools_inplace_failures(self):
+        data = {"key": "value"}
+        deserialize_tools_inplace(data)
+        assert data == {"key": "value"}
+
+        data = {"tools": None}
+        deserialize_tools_inplace(data)
+        assert data == {"tools": None}
+
+        data = {"tools": "not a list"}
+        with pytest.raises(TypeError):
+            deserialize_tools_inplace(data)
+
+        data = {"tools": ["not a dictionary"]}
+        with pytest.raises(TypeError):
+            deserialize_tools_inplace(data)
+
+        # not a subclass of Tool
+        data = {"tools": [{"type": "haystack.dataclasses.ChatMessage", "data": {"irrelevant": "irrelevant"}}]}
+        with pytest.raises(TypeError):
+            deserialize_tools_inplace(data)
+
+    def test_deserialize_toolset_inplace(self):
+        tool = Tool(
+            name="weather", description="Get weather report", parameters=parameters, function=get_weather_report
+        )
+        toolset = Toolset(tools=[tool])
+
+        data = {"tools": toolset.to_dict()}
+
+        deserialize_tools_inplace(data)
+
+        assert data["tools"] == toolset
+        assert isinstance(data["tools"], Toolset)
+        assert data["tools"][0] == tool
+
+    def test_deserialize_toolset_inplace_failures(self):
+        data = {"tools": {"key": "value"}}
+        with pytest.raises(TypeError):
+            deserialize_tools_inplace(data)
+
+        data = {"tools": {"type": "haystack.tools.Tool", "data": "some_data"}}
+        with pytest.raises(TypeError):
+            deserialize_tools_inplace(data)

--- a/test/tools/test_tool.py
+++ b/test/tools/test_tool.py
@@ -5,7 +5,8 @@
 import re
 import pytest
 
-from haystack.tools.tool import Tool, ToolInvocationError, deserialize_tools_inplace, _check_duplicate_tool_names
+from haystack.tools import Tool, _check_duplicate_tool_names
+from haystack.tools.errors import ToolInvocationError
 
 
 def get_weather_report(city: str) -> str:
@@ -119,45 +120,6 @@ class TestTool:
         assert tool.function == get_weather_report
         assert tool.outputs_to_state["documents"]["source"] == "docs"
         assert tool.outputs_to_state["documents"]["handler"] == get_weather_report
-
-
-def test_deserialize_tools_inplace():
-    tool = Tool(name="weather", description="Get weather report", parameters=parameters, function=get_weather_report)
-
-    data = {"tools": [tool.to_dict()]}
-    deserialize_tools_inplace(data)
-    assert data["tools"] == [tool]
-
-    data = {"mytools": [tool.to_dict()]}
-    deserialize_tools_inplace(data, key="mytools")
-    assert data["mytools"] == [tool]
-
-    data = {"no_tools": 123}
-    deserialize_tools_inplace(data)
-    assert data == {"no_tools": 123}
-
-
-def test_deserialize_tools_inplace_failures():
-    data = {"key": "value"}
-    deserialize_tools_inplace(data)
-    assert data == {"key": "value"}
-
-    data = {"tools": None}
-    deserialize_tools_inplace(data)
-    assert data == {"tools": None}
-
-    data = {"tools": "not a list"}
-    with pytest.raises(TypeError):
-        deserialize_tools_inplace(data)
-
-    data = {"tools": ["not a dictionary"]}
-    with pytest.raises(TypeError):
-        deserialize_tools_inplace(data)
-
-    # not a subclass of Tool
-    data = {"tools": [{"type": "haystack.dataclasses.ChatMessage", "data": {"irrelevant": "irrelevant"}}]}
-    with pytest.raises(TypeError):
-        deserialize_tools_inplace(data)
 
 
 def test_check_duplicate_tool_names():


### PR DESCRIPTION
### Related Issues

In #9161, a new utility function `serialize_tools_or_toolset` was introduced in utils/misc.py.
The corresponding deserialization function `deserialize_tools_inplace` is in tools/tool.py.

### Proposed Changes:
- move all Tool serde utility functions in tools/serde_utils.py
- add unit tests for uncovered cases

### How did you test it?
CI

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
