### PR TITLE
feat: make `AzureOpenAITexttEmbedder` inherit from `OpenAITextEmbedder` - async support 

### DIFF
--- a/haystack/components/embedders/openai_text_embedder.py
+++ b/haystack/components/embedders/openai_text_embedder.py
@@ -160,14 +160,14 @@ class OpenAITextEmbedder:
 
         text_to_embed = self.prefix + text + self.suffix
 
-        # copied from OpenAI embedding_utils (https://github.com/openai/openai-python/blob/main/openai/embeddings_utils.py)
-        # replace newlines, which can negatively affect performance.
+        # Replace newlines, which can negatively affect performance, as recommended by OpenAI.
         text_to_embed = text_to_embed.replace("\n", " ")
 
+        api_params: Dict[str, Any] = {"model": self.model, "input": text_to_embed}
         if self.dimensions is not None:
-            response = self.client.embeddings.create(model=self.model, dimensions=self.dimensions, input=text_to_embed)
-        else:
-            response = self.client.embeddings.create(model=self.model, input=text_to_embed)
+            api_params["dimensions"] = self.dimensions
+
+        response = self.client.embeddings.create(**api_params)
 
         meta = {"model": response.model, "usage": dict(response.usage)}
 

--- a/releasenotes/notes/azure-text-embedder-inherit-ea230e61cba3a90f.yaml
+++ b/releasenotes/notes/azure-text-embedder-inherit-ea230e61cba3a90f.yaml
@@ -1,0 +1,6 @@
+---
+
+features:
+  - |
+    The `AzureOpenAITextEmbedder` component now inherits from the `OpenAITextEmbedder` component,
+    enabling asynchronous usage.

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -14,7 +14,7 @@ class TestAzureOpenAITextEmbedder:
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
         embedder = AzureOpenAITextEmbedder(azure_endpoint="https://example-resource.azure.openai.com/")
 
-        assert embedder._client.api_key == "fake-api-key"
+        assert embedder.client.api_key == "fake-api-key"
         assert embedder.azure_deployment == "text-embedding-ada-002"
         assert embedder.dimensions is None
         assert embedder.organization is None
@@ -29,7 +29,7 @@ class TestAzureOpenAITextEmbedder:
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
         embedder = AzureOpenAITextEmbedder(azure_endpoint="https://example-resource.azure.openai.com/", max_retries=0)
 
-        assert embedder._client.api_key == "fake-api-key"
+        assert embedder.client.api_key == "fake-api-key"
         assert embedder.azure_deployment == "text-embedding-ada-002"
         assert embedder.dimensions is None
         assert embedder.organization is None
@@ -194,4 +194,5 @@ class TestAzureOpenAITextEmbedder:
 
         assert len(result["embedding"]) == 1536
         assert all(isinstance(x, float) for x in result["embedding"])
-        assert result["meta"] == {"model": "text-embedding-ada-002", "usage": {"prompt_tokens": 6, "total_tokens": 6}}
+        assert result["meta"]["usage"] == {"prompt_tokens": 6, "total_tokens": 6}
+        assert "ada" in result["meta"]["model"]

--- a/test/components/embedders/test_azure_text_embedder.py
+++ b/test/components/embedders/test_azure_text_embedder.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 
+import httpx
 import pytest
 
 from haystack.components.embedders import AzureOpenAITextEmbedder
@@ -16,6 +17,7 @@ class TestAzureOpenAITextEmbedder:
 
         assert embedder.client.api_key == "fake-api-key"
         assert embedder.azure_deployment == "text-embedding-ada-002"
+        assert embedder.model == "text-embedding-ada-002"
         assert embedder.dimensions is None
         assert embedder.organization is None
         assert embedder.prefix == ""
@@ -31,6 +33,7 @@ class TestAzureOpenAITextEmbedder:
 
         assert embedder.client.api_key == "fake-api-key"
         assert embedder.azure_deployment == "text-embedding-ada-002"
+        assert embedder.model == "text-embedding-ada-002"
         assert embedder.dimensions is None
         assert embedder.organization is None
         assert embedder.prefix == ""
@@ -121,6 +124,7 @@ class TestAzureOpenAITextEmbedder:
         }
         component = AzureOpenAITextEmbedder.from_dict(data)
         assert component.azure_deployment == "text-embedding-ada-002"
+        assert component.model == "text-embedding-ada-002"
         assert component.azure_endpoint == "https://example-resource.azure.openai.com/"
         assert component.api_version == "2023-05-15"
         assert component.max_retries == 5
@@ -154,6 +158,7 @@ class TestAzureOpenAITextEmbedder:
         }
         component = AzureOpenAITextEmbedder.from_dict(data)
         assert component.azure_deployment == "text-embedding-ada-002"
+        assert component.model == "text-embedding-ada-002"
         assert component.azure_endpoint == "https://example-resource.azure.openai.com/"
         assert component.api_version == "2023-05-15"
         assert component.max_retries == 10
@@ -163,6 +168,21 @@ class TestAzureOpenAITextEmbedder:
         assert component.default_headers == {"x-custom-header": "custom-value"}
         assert component.azure_ad_token_provider is not None
         assert component.http_client_kwargs == {"proxy": "http://example.com:3128", "verify": False}
+
+    def test_init_http_client(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://test.openai.azure.com")
+
+        embedder = AzureOpenAITextEmbedder()
+        client = embedder._init_http_client()
+        assert client is None
+
+        embedder.http_client_kwargs = {"proxy": "http://example.com:3128"}
+        client = embedder._init_http_client(async_client=False)
+        assert isinstance(client, httpx.Client)
+
+        client = embedder._init_http_client(async_client=True)
+        assert isinstance(client, httpx.AsyncClient)
 
     def test_http_client_kwargs_type_validation(self, monkeypatch):
         monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-api-key")


### PR DESCRIPTION
### Related Issues

- fixes #9017
- twin PR of #9189

### Proposed Changes:
- make `AzureOpenAITexttEmbedder` inherit from `OpenAITextEmbedder`
- get `run_async` implementation for free!

### How did you test it?
- CI
- I did not remove or add new tests for `AzureOpenAITexttEmbedder` (I tested `run_async locally` and works as expected)

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
