### PR TITLE
chore: Rename deserialize_tools_inplace -> deserialize_tools_or_toolset_inplace

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -11,7 +11,7 @@ from haystack.components.tools import ToolInvoker
 from haystack.dataclasses import ChatMessage
 from haystack.dataclasses.state import State, _schema_from_dict, _schema_to_dict, _validate_schema
 from haystack.dataclasses.streaming_chunk import SyncStreamingCallbackT
-from haystack.tools import Tool, deserialize_tools_inplace
+from haystack.tools import Tool, deserialize_tools_or_toolset_inplace
 from haystack.utils.callable_serialization import deserialize_callable, serialize_callable
 from haystack.utils.deserialization import deserialize_chatgenerator_inplace
 
@@ -168,7 +168,7 @@ class Agent:
         if init_params.get("streaming_callback") is not None:
             init_params["streaming_callback"] = deserialize_callable(init_params["streaming_callback"])
 
-        deserialize_tools_inplace(init_params, key="tools")
+        deserialize_tools_or_toolset_inplace(init_params, key="tools")
 
         return default_from_dict(cls, data)
 

--- a/haystack/components/generators/chat/azure.py
+++ b/haystack/components/generators/chat/azure.py
@@ -14,7 +14,7 @@ from haystack.tools import (
     Tool,
     Toolset,
     _check_duplicate_tool_names,
-    deserialize_tools_inplace,
+    deserialize_tools_or_toolset_inplace,
     serialize_tools_or_toolset,
 )
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
@@ -218,7 +218,7 @@ class AzureOpenAIChatGenerator(OpenAIChatGenerator):
             The deserialized component instance.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key", "azure_ad_token"])
-        deserialize_tools_inplace(data["init_parameters"], key="tools")
+        deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:

--- a/haystack/components/generators/chat/hugging_face_api.py
+++ b/haystack/components/generators/chat/hugging_face_api.py
@@ -13,7 +13,7 @@ from haystack.tools import (
     Tool,
     Toolset,
     _check_duplicate_tool_names,
-    deserialize_tools_inplace,
+    deserialize_tools_or_toolset_inplace,
     serialize_tools_or_toolset,
 )
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
@@ -213,7 +213,7 @@ class HuggingFaceAPIChatGenerator:
         Deserialize this component from a dictionary.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
-        deserialize_tools_inplace(data["init_parameters"], key="tools")
+        deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:

--- a/haystack/components/generators/chat/hugging_face_local.py
+++ b/haystack/components/generators/chat/hugging_face_local.py
@@ -16,7 +16,7 @@ from haystack.tools import (
     Tool,
     Toolset,
     _check_duplicate_tool_names,
-    deserialize_tools_inplace,
+    deserialize_tools_or_toolset_inplace,
     serialize_tools_or_toolset,
 )
 from haystack.utils import (
@@ -309,7 +309,7 @@ class HuggingFaceLocalChatGenerator:
         """
         torch_and_transformers_import.check()  # leave this, cls method
         deserialize_secrets_inplace(data["init_parameters"], keys=["token"])
-        deserialize_tools_inplace(data["init_parameters"], key="tools")
+        deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:

--- a/haystack/components/generators/chat/openai.py
+++ b/haystack/components/generators/chat/openai.py
@@ -26,7 +26,7 @@ from haystack.tools import (
     Tool,
     Toolset,
     _check_duplicate_tool_names,
-    deserialize_tools_inplace,
+    deserialize_tools_or_toolset_inplace,
     serialize_tools_or_toolset,
 )
 from haystack.utils import Secret, deserialize_callable, deserialize_secrets_inplace, serialize_callable
@@ -207,7 +207,7 @@ class OpenAIChatGenerator:
             The deserialized component instance.
         """
         deserialize_secrets_inplace(data["init_parameters"], keys=["api_key"])
-        deserialize_tools_inplace(data["init_parameters"], key="tools")
+        deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
         init_params = data.get("init_parameters", {})
         serialized_callback_handler = init_params.get("streaming_callback")
         if serialized_callback_handler:

--- a/haystack/components/tools/tool_invoker.py
+++ b/haystack/components/tools/tool_invoker.py
@@ -14,7 +14,7 @@ from haystack.tools import (
     Tool,
     Toolset,
     _check_duplicate_tool_names,
-    deserialize_tools_inplace,
+    deserialize_tools_or_toolset_inplace,
     serialize_tools_or_toolset,
 )
 from haystack.tools.errors import ToolInvocationError
@@ -458,5 +458,5 @@ class ToolInvoker:
         :returns:
             The deserialized component.
         """
-        deserialize_tools_inplace(data["init_parameters"], key="tools")
+        deserialize_tools_or_toolset_inplace(data["init_parameters"], key="tools")
         return default_from_dict(cls, data)

--- a/haystack/tools/__init__.py
+++ b/haystack/tools/__init__.py
@@ -8,14 +8,14 @@
 from .from_function import create_tool_from_function, tool
 from .tool import Tool, _check_duplicate_tool_names
 from .component_tool import ComponentTool
-from .serde_utils import deserialize_tools_inplace, serialize_tools_or_toolset
+from .serde_utils import deserialize_tools_or_toolset_inplace, serialize_tools_or_toolset
 from .toolset import Toolset
 
 __all__ = [
     "_check_duplicate_tool_names",
     "ComponentTool",
     "create_tool_from_function",
-    "deserialize_tools_inplace",
+    "deserialize_tools_or_toolset_inplace",
     "serialize_tools_or_toolset",
     "Tool",
     "Toolset",

--- a/haystack/tools/serde_utils.py
+++ b/haystack/tools/serde_utils.py
@@ -26,7 +26,7 @@ def serialize_tools_or_toolset(
     return [tool.to_dict() for tool in tools]
 
 
-def deserialize_tools_inplace(data: Dict[str, Any], key: str = "tools"):
+def deserialize_tools_or_toolset_inplace(data: Dict[str, Any], key: str = "tools"):
     """
     Deserialize a list of Tools or a Toolset in a dictionary inplace.
 

--- a/releasenotes/notes/rename-deserialize_tools_inplace-f10d72127be54bed.yaml
+++ b/releasenotes/notes/rename-deserialize_tools_inplace-f10d72127be54bed.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Utility function `deserialize_tools_inplace` has been renamed to `deserialize_tools_or_toolset_inplace` to reflect that it can deserialize both `Toolset` and `Tool` objects.

--- a/test/tools/test_serde_utils.py
+++ b/test/tools/test_serde_utils.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from haystack.tools import Tool, deserialize_tools_inplace, Toolset, serialize_tools_or_toolset
+from haystack.tools import Tool, deserialize_tools_or_toolset_inplace, Toolset, serialize_tools_or_toolset
 
 
 def get_weather_report(city: str) -> str:
@@ -41,38 +41,38 @@ class TestToolSerdeUtils:
         )
 
         data = {"tools": [tool.to_dict()]}
-        deserialize_tools_inplace(data)
+        deserialize_tools_or_toolset_inplace(data)
         assert data["tools"] == [tool]
 
         data = {"mytools": [tool.to_dict()]}
-        deserialize_tools_inplace(data, key="mytools")
+        deserialize_tools_or_toolset_inplace(data, key="mytools")
         assert data["mytools"] == [tool]
 
         data = {"no_tools": 123}
-        deserialize_tools_inplace(data)
+        deserialize_tools_or_toolset_inplace(data)
         assert data == {"no_tools": 123}
 
     def test_deserialize_tools_inplace_failures(self):
         data = {"key": "value"}
-        deserialize_tools_inplace(data)
+        deserialize_tools_or_toolset_inplace(data)
         assert data == {"key": "value"}
 
         data = {"tools": None}
-        deserialize_tools_inplace(data)
+        deserialize_tools_or_toolset_inplace(data)
         assert data == {"tools": None}
 
         data = {"tools": "not a list"}
         with pytest.raises(TypeError):
-            deserialize_tools_inplace(data)
+            deserialize_tools_or_toolset_inplace(data)
 
         data = {"tools": ["not a dictionary"]}
         with pytest.raises(TypeError):
-            deserialize_tools_inplace(data)
+            deserialize_tools_or_toolset_inplace(data)
 
         # not a subclass of Tool
         data = {"tools": [{"type": "haystack.dataclasses.ChatMessage", "data": {"irrelevant": "irrelevant"}}]}
         with pytest.raises(TypeError):
-            deserialize_tools_inplace(data)
+            deserialize_tools_or_toolset_inplace(data)
 
     def test_deserialize_toolset_inplace(self):
         tool = Tool(
@@ -82,7 +82,7 @@ class TestToolSerdeUtils:
 
         data = {"tools": toolset.to_dict()}
 
-        deserialize_tools_inplace(data)
+        deserialize_tools_or_toolset_inplace(data)
 
         assert data["tools"] == toolset
         assert isinstance(data["tools"], Toolset)
@@ -91,8 +91,8 @@ class TestToolSerdeUtils:
     def test_deserialize_toolset_inplace_failures(self):
         data = {"tools": {"key": "value"}}
         with pytest.raises(TypeError):
-            deserialize_tools_inplace(data)
+            deserialize_tools_or_toolset_inplace(data)
 
         data = {"tools": {"type": "haystack.tools.Tool", "data": "some_data"}}
         with pytest.raises(TypeError):
-            deserialize_tools_inplace(data)
+            deserialize_tools_or_toolset_inplace(data)


### PR DESCRIPTION
Rename `deserialize_tools_inplace` serde util method to `deserialize_tools_or_toolset_inplace` to have better symmetry with the companion method `serialize_tools_or_toolset`