### PR TITLE
fix: Set `messages` in state_schema at init time of Agent

### DIFF
--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -156,6 +156,7 @@ class Agent:
             tools=[t.to_dict() for t in self.tools],
             system_prompt=self.system_prompt,
             exit_conditions=self.exit_conditions,
+            # We serialize the original state schema, not the resolved one to reflect the original user input
             state_schema=_schema_to_dict(self._state_schema),
             max_agent_steps=self.max_agent_steps,
             raise_on_tool_invocation_failure=self.raise_on_tool_invocation_failure,

--- a/haystack/components/agents/agent.py
+++ b/haystack/components/agents/agent.py
@@ -99,10 +99,12 @@ class Agent:
                 "Ensure that each exit condition corresponds to either 'text' or a valid tool name."
             )
 
-        # Handle state schema
+        # Validate state schema if provided
         if state_schema is not None:
             _validate_schema(state_schema)
         self._state_schema = state_schema or {}
+
+        # Initialize state schema
         resolved_state_schema = deepcopy(self._state_schema)
         if resolved_state_schema.get("messages") is None:
             resolved_state_schema["messages"] = {"type": List[ChatMessage], "handler": merge_lists}

--- a/haystack/dataclasses/state.py
+++ b/haystack/dataclasses/state.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional
 
 from haystack.dataclasses import ChatMessage
@@ -93,13 +94,13 @@ class State:
         :param data: Optional dictionary of initial data to populate the state
         """
         _validate_schema(schema)
-        self.schema = schema
+        self.schema = deepcopy(schema)
         if self.schema.get("messages") is None:
             self.schema["messages"] = {"type": List[ChatMessage], "handler": merge_lists}
         self._data = data or {}
 
         # Set default handlers if not provided in schema
-        for definition in schema.values():
+        for definition in self.schema.values():
             # Skip if handler is already defined and not None
             if definition.get("handler") is not None:
                 continue

--- a/haystack/dataclasses/state.py
+++ b/haystack/dataclasses/state.py
@@ -118,7 +118,7 @@ class State:
         :param default: Value to return if key is not found
         :returns: Value associated with key or default if not found
         """
-        return self._data.get(key, default)
+        return deepcopy(self._data.get(key, default))
 
     def set(self, key: str, value: Any, handler_override: Optional[Callable[[Any, Any], Any]] = None) -> None:
         """

--- a/releasenotes/notes/fix-agent-output-messages-550404a95199bb67.yaml
+++ b/releasenotes/notes/fix-agent-output-messages-550404a95199bb67.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    In Agent we make sure state_schema is always initialized to have 'messages'. Previously this was only happening at run time which is why pipeline.connect failed because output types are set at init time.
+    Now the Agent correctly sets everything in state_schema (including messages by default) at init time.

--- a/test/dataclasses/test_state.py
+++ b/test/dataclasses/test_state.py
@@ -178,3 +178,12 @@ def test_schema_from_dict_with_handlers(complex_schema):
     }
     result = _schema_from_dict(schema_dict)
     assert result == complex_schema
+
+
+def test_state_mutability():
+    state = State({"my_list": {"type": list}}, {"my_list": [1, 2]})
+
+    my_list = state.get("my_list")
+    my_list.append(3)
+
+    assert state.get("my_list") == [1, 2]


### PR DESCRIPTION
### Related Issues

- fixes #9193 

### Proposed Changes:

 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
- Set `messages` in state_schema at init time of Agent. This is needed to properly set `messages` as an output type of Agent and was the original intent of this PR https://github.com/deepset-ai/haystack/pull/9150

### How did you test it?

<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
- Added tests
- Also added more tests for State

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

Most of the line changes come from adding tests.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
