### PR TITLE
ci: make `lint` workflow check pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,6 +223,7 @@ jobs:
         with:
           files: |
             **/*.py
+            pyproject.toml
           files_ignore: |
             test/**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "jsonschema",             # JsonSchemaValidator, Tool
   "haystack-experimental",
 ]
-
+# trigger
 [tool.hatch.envs.default]
 installer = "uv"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "jsonschema",             # JsonSchemaValidator, Tool
   "haystack-experimental",
 ]
-# trigger
+
 [tool.hatch.envs.default]
 installer = "uv"
 dependencies = [


### PR DESCRIPTION
### Related Issues
When changing dependencies, the `lint` workflow (including mypy) should run appropriately to find type issues.
This did not happen, for example, in #9178.

### Proposed Changes:
- make the `lint` workflow also monitor pyproject.toml

### How did you test it?
I tested this in this PR, triggering `lint` with a change to pyproject.toml. Mypy ran: https://github.com/deepset-ai/haystack/actions/runs/14353439800/job/40237681508


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
