### PR TITLE
feat: add run_async for HuggingFaceAPITextEmbedder

### DIFF
--- a/releasenotes/notes/adding-async-huggingface-api-text-embedder-ad68e201fcef09bb.yaml
+++ b/releasenotes/notes/adding-async-huggingface-api-text-embedder-ad68e201fcef09bb.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The `HuggingFaceAPITextEmbedder` now also has support for a run() method in an asynchronous way, i.e., run_async.

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import random
@@ -11,6 +12,9 @@ from numpy import array
 from haystack.components.embedders import HuggingFaceAPITextEmbedder
 from haystack.utils.auth import Secret
 from haystack.utils.hf import HFEmbeddingAPIType
+from haystack import Pipeline
+from haystack.components.retrievers import InMemoryBM25Retriever
+from haystack.document_stores import InMemoryDocumentStore
 
 
 @pytest.fixture
@@ -227,3 +231,127 @@ class TestHuggingFaceAPITextEmbedder:
 
         assert len(result["embedding"]) == 384
         assert all(isinstance(x, float) for x in result["embedding"])
+
+
+class TestHuggingFaceAPITextEmbedderAsync:
+    """
+    Integration tests for HuggingFaceAPITextEmbedder that verify the async functionality with a real API.
+    These tests require a valid Hugging Face API token.
+    """
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.environ.get("HF_API_TOKEN", "") == "", reason="HF_API_TOKEN is not set")
+    async def test_run_async_with_real_api(self):
+        """
+        Integration test that verifies the async functionality with a real API.
+        This test requires a valid Hugging Face API token.
+        """
+        # Use a small, reliable model for testing
+        model_name = "sentence-transformers/all-MiniLM-L6-v2"
+
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": model_name}
+        )
+
+        # Test with a simple text
+        text = "This is a test sentence for embedding."
+        result = await embedder.run_async(text=text)
+
+        # Verify the result
+        assert "embedding" in result
+        assert isinstance(result["embedding"], list)
+        assert all(isinstance(x, float) for x in result["embedding"])
+        assert len(result["embedding"]) == 384  # MiniLM-L6-v2 has 384 dimensions
+
+        # Test with a longer text
+        long_text = "This is a longer test sentence for embedding. " * 10
+        result = await embedder.run_async(text=long_text)
+
+        # Verify the result
+        assert "embedding" in result
+        assert isinstance(result["embedding"], list)
+        assert all(isinstance(x, float) for x in result["embedding"])
+        assert len(result["embedding"]) == 384
+
+        # Test with prefix and suffix
+        embedder_with_prefix_suffix = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API,
+            api_params={"model": model_name},
+            prefix="prefix: ",
+            suffix=" :suffix",
+        )
+
+        result = await embedder_with_prefix_suffix.run_async(text=text)
+
+        # Verify the result
+        assert "embedding" in result
+        assert isinstance(result["embedding"], list)
+        assert all(isinstance(x, float) for x in result["embedding"])
+        assert len(result["embedding"]) == 384
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.environ.get("HF_API_TOKEN", "") == "", reason="HF_API_TOKEN is not set")
+    async def test_run_async_concurrent_requests(self):
+        """
+        Integration test that verifies the async functionality with concurrent requests.
+        This test requires a valid Hugging Face API token.
+        """
+        # Use a small, reliable model for testing
+        model_name = "sentence-transformers/all-MiniLM-L6-v2"
+
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": model_name}
+        )
+
+        # Test with multiple concurrent requests
+        texts = [
+            "This is the first test sentence.",
+            "This is the second test sentence.",
+            "This is the third test sentence.",
+            "This is the fourth test sentence.",
+            "This is the fifth test sentence.",
+        ]
+
+        # Run concurrent requests
+        tasks = [embedder.run_async(text=text) for text in texts]
+        results = await asyncio.gather(*tasks)
+
+        # Verify the results
+        for i, result in enumerate(results):
+            assert "embedding" in result
+            assert isinstance(result["embedding"], list)
+            assert all(isinstance(x, float) for x in result["embedding"])
+            assert len(result["embedding"]) == 384  # MiniLM-L6-v2 has 384 dimensions
+
+            # Verify that the embeddings are different
+            if i > 0:
+                prev_embedding = results[i - 1]["embedding"]
+                curr_embedding = result["embedding"]
+                assert prev_embedding != curr_embedding  # Different texts should have different embeddings
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(os.environ.get("HF_API_TOKEN", "") == "", reason="HF_API_TOKEN is not set")
+    async def test_run_async_error_handling_with_real_api(self):
+        """
+        Integration test that verifies error handling with a real API.
+        This test requires a valid Hugging Face API token.
+        """
+        # Use an invalid model name to trigger an error
+        invalid_model_name = "invalid-model-name-that-does-not-exist"
+
+        embedder = HuggingFaceAPITextEmbedder(
+            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": invalid_model_name}
+        )
+
+        # Test with a simple text
+        text = "This is a test sentence for embedding."
+
+        # The request should fail with an appropriate error
+        with pytest.raises(Exception) as excinfo:
+            await embedder.run_async(text=text)
+
+        # Verify that the error message contains information about the invalid model
+        assert invalid_model_name in str(excinfo.value) or "model" in str(excinfo.value).lower()

--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -12,9 +12,6 @@ from numpy import array
 from haystack.components.embedders import HuggingFaceAPITextEmbedder
 from haystack.utils.auth import Secret
 from haystack.utils.hf import HFEmbeddingAPIType
-from haystack import Pipeline
-from haystack.components.retrievers import InMemoryBM25Retriever
-from haystack.document_stores import InMemoryDocumentStore
 
 
 @pytest.fixture
@@ -298,14 +295,11 @@ class TestHuggingFaceAPITextEmbedderAsync:
         Integration test that verifies the async functionality with concurrent requests.
         This test requires a valid Hugging Face API token.
         """
-        # Use a small, reliable model for testing
         model_name = "sentence-transformers/all-MiniLM-L6-v2"
-
         embedder = HuggingFaceAPITextEmbedder(
             api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": model_name}
         )
 
-        # Test with multiple concurrent requests
         texts = [
             "This is the first test sentence.",
             "This is the second test sentence.",
@@ -318,18 +312,11 @@ class TestHuggingFaceAPITextEmbedderAsync:
         tasks = [embedder.run_async(text=text) for text in texts]
         results = await asyncio.gather(*tasks)
 
-        # Verify the results
         for i, result in enumerate(results):
             assert "embedding" in result
             assert isinstance(result["embedding"], list)
             assert all(isinstance(x, float) for x in result["embedding"])
             assert len(result["embedding"]) == 384  # MiniLM-L6-v2 has 384 dimensions
-
-            # Verify that the embeddings are different
-            if i > 0:
-                prev_embedding = results[i - 1]["embedding"]
-                curr_embedding = result["embedding"]
-                assert prev_embedding != curr_embedding  # Different texts should have different embeddings
 
     @pytest.mark.integration
     @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues

- fixes #9019 

### Proposed Changes:

I have added run_async method for HuggingFaceAPITextEmbedder and unit test for it

### How did you test it?

I have added an integration test. All the unit tests are passing locally.

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
