### PR TITLE
fix: removing for `HuggingFaceTextEmbedder` async test for non-existant model

### DIFF
--- a/test/components/embedders/test_hugging_face_api_text_embedder.py
+++ b/test/components/embedders/test_hugging_face_api_text_embedder.py
@@ -317,28 +317,3 @@ class TestHuggingFaceAPITextEmbedderAsync:
             assert isinstance(result["embedding"], list)
             assert all(isinstance(x, float) for x in result["embedding"])
             assert len(result["embedding"]) == 384  # MiniLM-L6-v2 has 384 dimensions
-
-    @pytest.mark.integration
-    @pytest.mark.asyncio
-    @pytest.mark.skipif(os.environ.get("HF_API_TOKEN", "") == "", reason="HF_API_TOKEN is not set")
-    async def test_run_async_error_handling_with_real_api(self):
-        """
-        Integration test that verifies error handling with a real API.
-        This test requires a valid Hugging Face API token.
-        """
-        # Use an invalid model name to trigger an error
-        invalid_model_name = "invalid-model-name-that-does-not-exist"
-
-        embedder = HuggingFaceAPITextEmbedder(
-            api_type=HFEmbeddingAPIType.SERVERLESS_INFERENCE_API, api_params={"model": invalid_model_name}
-        )
-
-        # Test with a simple text
-        text = "This is a test sentence for embedding."
-
-        # The request should fail with an appropriate error
-        with pytest.raises(Exception) as excinfo:
-            await embedder.run_async(text=text)
-
-        # Verify that the error message contains information about the invalid model
-        assert invalid_model_name in str(excinfo.value) or "model" in str(excinfo.value).lower()


### PR DESCRIPTION
### Proposed Changes:

- removing some of the async tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
