### PR TITLE
feat: Allow OpenAI client config in `OpenAIChatGenerator` and `AzureOpenAIChatGenerator`

### DIFF
--- a/releasenotes/notes/add-openai-client-config-generators-59a66f69c0733013.yaml
+++ b/releasenotes/notes/add-openai-client-config-generators-59a66f69c0733013.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    `OpenAIChatGenerator` and `AzureOpenAIChatGenerator` now support custom HTTP client config via `http_client_kwargs`, enabling proxy and SSL setup.

--- a/test/components/generators/chat/test_openai.py
+++ b/test/components/generators/chat/test_openai.py
@@ -101,6 +101,7 @@ class TestOpenAIChatGenerator:
         assert component.client.max_retries == 5
         assert component.tools is None
         assert not component.tools_strict
+        assert component.http_client_kwargs is None
 
     def test_init_fail_wo_api_key(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -129,6 +130,7 @@ class TestOpenAIChatGenerator:
             max_retries=1,
             tools=[tool],
             tools_strict=True,
+            http_client_kwargs={"proxy": "http://example.com:8080", "verify": False},
         )
         assert component.client.api_key == "test-api-key"
         assert component.model == "gpt-4o-mini"
@@ -138,6 +140,7 @@ class TestOpenAIChatGenerator:
         assert component.client.max_retries == 1
         assert component.tools == [tool]
         assert component.tools_strict
+        assert component.http_client_kwargs == {"proxy": "http://example.com:8080", "verify": False}
 
     def test_init_with_parameters_and_env_vars(self, monkeypatch):
         monkeypatch.setenv("OPENAI_TIMEOUT", "100")
@@ -173,6 +176,7 @@ class TestOpenAIChatGenerator:
                 "tools_strict": False,
                 "max_retries": None,
                 "timeout": None,
+                "http_client_kwargs": None,
             },
         }
 
@@ -190,6 +194,7 @@ class TestOpenAIChatGenerator:
             tools_strict=True,
             max_retries=10,
             timeout=100.0,
+            http_client_kwargs={"proxy": "http://example.com:8080", "verify": False},
         )
         data = component.to_dict()
 
@@ -219,6 +224,7 @@ class TestOpenAIChatGenerator:
                     }
                 ],
                 "tools_strict": True,
+                "http_client_kwargs": {"proxy": "http://example.com:8080", "verify": False},
             },
         }
 
@@ -246,6 +252,7 @@ class TestOpenAIChatGenerator:
                     }
                 ],
                 "tools_strict": True,
+                "http_client_kwargs": {"proxy": "http://example.com:8080", "verify": False},
             },
         }
         component = OpenAIChatGenerator.from_dict(data)
@@ -262,6 +269,7 @@ class TestOpenAIChatGenerator:
         assert component.tools_strict
         assert component.client.timeout == 100.0
         assert component.client.max_retries == 10
+        assert component.http_client_kwargs == {"proxy": "http://example.com:8080", "verify": False}
 
     def test_from_dict_fail_wo_env_var(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -279,6 +287,14 @@ class TestOpenAIChatGenerator:
         }
         with pytest.raises(ValueError):
             OpenAIChatGenerator.from_dict(data)
+
+    def test_http_client_kwargs_type_validation(self):
+        with pytest.raises(TypeError, match="The parameter 'http_client_kwargs' must be a dictionary."):
+            OpenAIChatGenerator(http_client_kwargs="invalid_argument")
+
+    def test_http_client_kwargs_with_invalid_params(self):
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            OpenAIChatGenerator(http_client_kwargs={"invalid_key": "invalid_value"})
 
     def test_run(self, chat_messages, openai_mock_chat_completion):
         component = OpenAIChatGenerator(api_key=Secret.from_token("test-api-key"))


### PR DESCRIPTION
### Related Issues

- fixes #9169 

### Proposed Changes:

Currently, users cannot configure the HTTP client used in these chat generators. We can't expose an `http_client` parameter directly, as the client instance is not serializable and cannot be restored during deserialization.

To solve this, I propose adding a new parameter to store HTTP client configuration options. These options will be used in the `init` method to construct the client and can be safely serialized and deserialized.

### How did you test it?

Added new tests 
### Notes for the reviewer

Similar to t[his PR](https://github.com/deepset-ai/haystack/pull/9136)
### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
