### PR TITLE
ci: fix lint job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,11 +221,12 @@ jobs:
         id: files
         uses: tj-actions/changed-files@v46
         with:
-          files: |
-            **/*.py
-            pyproject.toml
-          files_ignore: |
-            test/**
+          files_yaml: |
+            python:
+              - '**/*.py'
+              - '!test/**'
+            pyproject:
+              - 'pyproject.toml'
 
       - uses: actions/setup-python@v5
         with:
@@ -250,9 +251,10 @@ jobs:
           hatch run test:types
 
       - name: Pylint
-        if: steps.files.outputs.any_changed == 'true'
+        # Running pylint on pyproject.toml causes errors, so we only run it on python files.
+        if: steps.files.outputs.python_any_changed == 'true'
         run: |
-          hatch run test:lint ${{ steps.files.outputs.all_changed_files }}
+          hatch run test:lint ${{ steps.files.outputs.python_all_changed_files }}
 
       - name: Calculate alert data
         id: calculator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
-# trigger
+
 [project]
 name = "haystack-ai"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["hatchling>=1.8.0"]
 build-backend = "hatchling.build"
-
+# trigger
 [project]
 name = "haystack-ai"
 dynamic = ["version"]


### PR DESCRIPTION
### Related Issues

- In https://github.com/deepset-ai/haystack/pull/9199, I made the `lint` job trigger when pyproject.toml is changed (to check type issues with mypy)
- The `lint` job includes mypy and pylint. Pylint runs on the changed files.
- Doing `pylint pyproject.toml` is not expected and causes errors. See an example: https://github.com/deepset-ai/haystack/actions/runs/14381662538/job/40327103358

### Proposed Changes:
- change the `lint` job to trigger when pyproject.toml is changed but do not pass pyproject.toml to pylint

### How did you test it?
CI; made a change in pyproject in https://github.com/deepset-ai/haystack/pull/9217/commits/f1313dc537c068a0b0664336bbafba0ad3ef240a to trigger the job -> https://github.com/deepset-ai/haystack/actions/runs/14399118142/job/40381073183 no errors


### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
